### PR TITLE
fix(skills): preserve package integrity across edits and imports

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -422,7 +422,9 @@
           "src/main/skills/user-skill-compatibility-index.test.ts",
           "src/main/skills/user-skill-repository.architecture.test.ts",
           "src/main/skills/user-skill-repository.atomic.test.ts",
-          "src/main/skills/user-skill-repository.test.ts"
+          "src/main/skills/user-skill-repository.test.ts",
+          "src/main/skills/user-skill-integrity.regression.test.ts",
+          "src/main/skills/materializer-integrity.regression.test.ts"
         ],
         "contract": [
           "src/main/skills/host-skills-service.test.ts",
@@ -440,7 +442,9 @@
           "src/main/specialist/package/service.test.ts",
           "src/preload/index.test.ts",
           "src/renderer/src/pages/settings/SkillsPanel.render.test.tsx",
-          "src/renderer/src/stores/settings-skills-slice.test.ts"
+          "src/renderer/src/stores/settings-skills-slice.test.ts",
+          "src/renderer/src/pages/settings/SkillUploadView.render.test.tsx",
+          "src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx"
         ]
       },
       "capabilityOverlays": ["windows_sensitive"],

--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -288,7 +288,13 @@ describe('Settings integration application commands', () => {
     await router.dispatcher.invoke(
       settingsIntegrationApplicationCommands.updateSkill,
       invocation([
-        { id: 'personal-skill', name: 'Skill', description: 'Updated', body: 'Body' }
+        {
+          id: 'personal-skill',
+          name: 'Skill',
+          expectedCompatibility: 'version',
+          description: 'Updated',
+          body: 'Body'
+        }
       ] as const)
     )
     await router.dispatcher.invoke(
@@ -324,6 +330,7 @@ describe('Settings integration application commands', () => {
     })
     expect(skillMethod('updateSkill')).toHaveBeenCalledWith({
       id: 'personal-skill',
+      expectedCompatibility: 'version',
       name: 'Skill',
       description: 'Updated',
       body: 'Body'

--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -291,7 +291,7 @@ describe('Settings integration application commands', () => {
         {
           id: 'personal-skill',
           name: 'Skill',
-          expectedCompatibility: 'version',
+          etag: 'version',
           description: 'Updated',
           body: 'Body'
         }
@@ -330,7 +330,7 @@ describe('Settings integration application commands', () => {
     })
     expect(skillMethod('updateSkill')).toHaveBeenCalledWith({
       id: 'personal-skill',
-      expectedCompatibility: 'version',
+      etag: 'version',
       name: 'Skill',
       description: 'Updated',
       body: 'Body'

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4032,6 +4032,7 @@ describe('SettingsService: skills', () => {
 
     skills = await service.updateSkill({
       id: 'personal-my-skill',
+      expectedCompatibility: detail.compatibility!,
       description: 'Edited.',
       body: '# Edited',
       metadata: detail.metadata
@@ -4139,6 +4140,7 @@ describe('SettingsService: skills', () => {
     // Editing keeps one file, drops one, and adds one.
     await service.updateSkill({
       id: 'personal-ref-skill-id',
+      expectedCompatibility: detail.compatibility!,
       description: 'd',
       body: '# body',
       references: [{ path: 'keep.py' }, { path: 'new.py', dataBase64: b64('new') }]

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4032,7 +4032,7 @@ describe('SettingsService: skills', () => {
 
     skills = await service.updateSkill({
       id: 'personal-my-skill',
-      expectedCompatibility: detail.compatibility!,
+      etag: detail.etag!,
       description: 'Edited.',
       body: '# Edited',
       metadata: detail.metadata
@@ -4140,7 +4140,7 @@ describe('SettingsService: skills', () => {
     // Editing keeps one file, drops one, and adds one.
     await service.updateSkill({
       id: 'personal-ref-skill-id',
-      expectedCompatibility: detail.compatibility!,
+      etag: detail.etag!,
       description: 'd',
       body: '# body',
       references: [{ path: 'keep.py' }, { path: 'new.py', dataBase64: b64('new') }]

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -1326,3 +1326,39 @@ it('returns an opaque etag with the detail and changes it after an unconditional
   } as never)
   expect((await catalog.getSkillDetail(before.id)).body).toBe('Fresh')
 })
+
+// Windows cannot represent these historical POSIX basenames as ordinary files.
+it.skipIf(process.platform === 'win32').each(['CON.csv', 'trailing.'])(
+  'preserves a historical reference named %s through an editor save',
+  async (name) => {
+    const catalog = await createCatalog()
+    await catalog.createSkill({ name: 'legacy', description: 'Original', body: 'Original body' })
+    const refsDir = join(userSkillSourceDir(catalog, 'personal'), 'legacy', 'references')
+    await mkdir(refsDir)
+    await writeFile(join(refsDir, name), 'historical bytes')
+    const detail = await catalog.getSkillDetail('personal-legacy')
+    expect(detail.references).toEqual([{ path: name, sizeBytes: 16 }])
+
+    await catalog.updateSkill({
+      id: detail.id,
+      etag: detail.etag,
+      description: detail.description,
+      body: 'Edited body',
+      references: detail.references.map(({ path }) => ({ path }))
+    })
+    const updated = await catalog.getSkillDetail(detail.id)
+    expect(updated.body).toContain('Edited body')
+    expect(updated.references).toEqual(detail.references)
+    expect(await readFile(join(refsDir, name), 'utf8')).toBe('historical bytes')
+
+    await catalog.updateSkill({
+      id: updated.id,
+      etag: updated.etag,
+      description: updated.description,
+      body: updated.body,
+      references: []
+    })
+    expect((await catalog.getSkillDetail(detail.id)).references).toEqual([])
+    await expect(readFile(join(refsDir, name))).rejects.toMatchObject({ code: 'ENOENT' })
+  }
+)

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -1190,7 +1190,11 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
       references: [{ path: 'old.csv', dataBase64: Buffer.from('old').toString('base64') }]
     })
     const old = await catalog.getSkillDetail('personal-draft')
+    const oldCompatibility = (await catalog.listUserSkills()).find(
+      (skill) => skill.id === old.id
+    )!.compatibility!
     await catalog.updateSkill({
+      ...{ expectedCompatibility: oldCompatibility },
       id: old.id,
       description: 'Newer description',
       body: 'Newer body',
@@ -1201,6 +1205,7 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
     })
     const result = await catalog
       .updateSkill({
+        ...{ expectedCompatibility: oldCompatibility },
         id: old.id,
         description: old.description,
         body: 'Old editor body edit',
@@ -1221,5 +1226,72 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
         'utf8'
       )
     ).resolves.toBe('new')
+  })
+})
+
+describe('SK06 optimistic editor boundary', () => {
+  it('accepts one of two saves with the same precondition, then accepts a freshly read edit', async () => {
+    const catalog = await createCatalog()
+    await catalog.createSkill({ name: 'concurrent', description: 'Initial', body: 'Initial' })
+    const expectedCompatibility = (await catalog.listUserSkills())[0].compatibility!
+    const request = {
+      id: 'personal-concurrent',
+      expectedCompatibility,
+      description: 'First',
+      body: 'First'
+    }
+    const results = await Promise.allSettled([
+      catalog.updateSkill(request),
+      catalog.updateSkill({ ...request, description: 'Second', body: 'Second' })
+    ])
+    expect(results.map((result) => result.status).sort()).toEqual(['fulfilled', 'rejected'])
+    const current = await catalog.getSkillDetail(request.id)
+    const next = {
+      ...request,
+      expectedCompatibility: (await catalog.listUserSkills())[0].compatibility!,
+      body: 'Fresh edit'
+    }
+    await catalog.updateSkill(next)
+    expect((await catalog.getSkillDetail(current.id)).body).toBe('Fresh edit')
+  })
+
+  it('rejects a missing precondition without mutating the package', async () => {
+    const catalog = await createCatalog()
+    await catalog.createSkill({ name: 'missing-token', description: 'Original', body: 'Original' })
+    await expect(
+      catalog.updateSkill({
+        id: 'personal-missing-token',
+        description: 'Changed',
+        body: 'Changed'
+      } as never)
+    ).rejects.toThrow(/reload|version/i)
+    expect((await catalog.getSkillDetail('personal-missing-token')).body).toBe('Original')
+  })
+
+  it('detects attachment-only changes even when SKILL.md is unchanged', async () => {
+    const catalog = await createCatalog()
+    await catalog.createSkill({
+      name: 'attachment',
+      description: 'Original',
+      body: 'Original',
+      references: [{ path: 'data.csv', dataBase64: Buffer.from('before').toString('base64') }]
+    })
+    const expectedCompatibility = (await catalog.listUserSkills())[0].compatibility!
+    const file = join(
+      userSkillSourceDir(catalog, 'personal'),
+      'attachment',
+      'references',
+      'data.csv'
+    )
+    await writeFile(file, 'after')
+    const request = {
+      id: 'personal-attachment',
+      expectedCompatibility,
+      description: 'Changed',
+      body: 'Changed'
+    }
+    await expect(catalog.updateSkill(request)).rejects.toThrow(/changed|reload/i)
+    expect(await readFile(file, 'utf8')).toBe('after')
+    expect((await catalog.getSkillDetail(request.id)).body).toBe('Original')
   })
 })

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -814,6 +814,7 @@ describe('SkillCatalogModule', () => {
       (
         await catalog.updateSkill({
           id: 'personal-my-skill',
+          expectedCompatibility: (await catalog.getSkillDetail('personal-my-skill')).compatibility!,
           description: 'Edited.',
           body: '# Edited'
         })

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -1140,3 +1140,86 @@ describe('SkillCatalogModule', () => {
     ])
   })
 })
+
+describe('reported Skill integrity regressions through Settings APIs', () => {
+  it('SK03 importing wrapped metadata cannot make an existing personal skill unavailable', async () => {
+    const catalog = await createCatalog()
+    await catalog.createSkill({ name: 'victim', description: 'Victim', body: 'Original victim' })
+    const file = join(userSkillSourceDir(catalog, 'personal'), 'victim', 'SKILL.md')
+    const original = await readFile(file, 'utf8')
+    const bytes = zipSync({
+      'wrapped/SKILL.md': strToU8('---\nname: external\ndescription: External\n---\nExternal body'),
+      'wrapped/.specialist-package.json': strToU8(
+        JSON.stringify({
+          id: 'personal-victim',
+          version: '1.0.0',
+          contentHash: 'external',
+          standalone: false,
+          ownerIds: ['absent-owner']
+        })
+      )
+    })
+    const result = await catalog
+      .importSkillZip({ dataBase64: Buffer.from(bytes).toString('base64') })
+      .then(
+        (outcome) => ({ outcome }),
+        (error: unknown) => ({ error })
+      )
+    // The reported attack corrupts identity, not the original file bytes.
+    expect(await readFile(file, 'utf8')).toBe(original)
+    const skills = await catalog.listSkills()
+    expect
+      .soft(skills.find((skill) => skill.name === 'victim'))
+      .toMatchObject({ id: 'personal-victim', available: true })
+    if ('outcome' in result)
+      expect
+        .soft(skills.find((skill) => skill.name === 'external'))
+        .toMatchObject({ id: result.outcome.id, available: true })
+    else expect(String(result.error)).toMatch(/reserved|metadata/i)
+    await expect(catalog.getSkillDetail('personal-victim')).resolves.toMatchObject({
+      body: expect.stringContaining('Original victim')
+    })
+  })
+
+  it('SK06 an old detail snapshot cannot overwrite a later save and delete its new attachment', async () => {
+    const catalog = await createCatalog()
+    await catalog.createSkill({
+      name: 'draft',
+      description: 'Original description',
+      body: 'Original body',
+      references: [{ path: 'old.csv', dataBase64: Buffer.from('old').toString('base64') }]
+    })
+    const old = await catalog.getSkillDetail('personal-draft')
+    await catalog.updateSkill({
+      id: old.id,
+      description: 'Newer description',
+      body: 'Newer body',
+      references: [
+        { path: 'old.csv' },
+        { path: 'new.csv', dataBase64: Buffer.from('new').toString('base64') }
+      ]
+    })
+    const result = await catalog
+      .updateSkill({
+        id: old.id,
+        description: old.description,
+        body: 'Old editor body edit',
+        metadata: old.metadata,
+        references: old.references.map(({ path }) => ({ path }))
+      })
+      .then(
+        () => 'saved',
+        () => 'rejected'
+      )
+    expect.soft(result).toBe('rejected')
+    const latest = await catalog.getSkillDetail(old.id)
+    expect.soft(latest.description).toBe('Newer description')
+    expect.soft(latest.references.map(({ path }) => path)).toContain('new.csv')
+    await expect(
+      readFile(
+        join(userSkillSourceDir(catalog, 'personal'), 'draft', 'references', 'new.csv'),
+        'utf8'
+      )
+    ).resolves.toBe('new')
+  })
+})

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -1143,7 +1143,7 @@ describe('SkillCatalogModule', () => {
 })
 
 describe('reported Skill integrity regressions through Settings APIs', () => {
-  it('SK03 importing wrapped metadata cannot make an existing personal skill unavailable', async () => {
+  it('importing wrapped metadata cannot make an existing personal skill unavailable', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({ name: 'victim', description: 'Victim', body: 'Original victim' })
     const file = join(userSkillSourceDir(catalog, 'personal'), 'victim', 'SKILL.md')
@@ -1182,7 +1182,7 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
     })
   })
 
-  it('SK06 an old detail snapshot cannot overwrite a later save and delete its new attachment', async () => {
+  it('an old detail snapshot cannot overwrite a later save and delete its new attachment', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({
       name: 'draft',
@@ -1230,7 +1230,7 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
   })
 })
 
-describe('SK06 optimistic editor boundary', () => {
+describe('optimistic editor boundary', () => {
   it('accepts one of two saves with the same precondition, then accepts a freshly read edit', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({ name: 'concurrent', description: 'Initial', body: 'Initial' })

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -814,7 +814,7 @@ describe('SkillCatalogModule', () => {
       (
         await catalog.updateSkill({
           id: 'personal-my-skill',
-          expectedCompatibility: (await catalog.getSkillDetail('personal-my-skill')).compatibility!,
+          etag: (await catalog.getSkillDetail('personal-my-skill')).etag!,
           description: 'Edited.',
           body: '# Edited'
         })
@@ -1191,11 +1191,9 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
       references: [{ path: 'old.csv', dataBase64: Buffer.from('old').toString('base64') }]
     })
     const old = await catalog.getSkillDetail('personal-draft')
-    const oldCompatibility = (await catalog.listUserSkills()).find(
-      (skill) => skill.id === old.id
-    )!.compatibility!
+    const oldEtag = old.etag!
     await catalog.updateSkill({
-      ...{ expectedCompatibility: oldCompatibility },
+      ...{ etag: oldEtag },
       id: old.id,
       description: 'Newer description',
       body: 'Newer body',
@@ -1206,7 +1204,7 @@ describe('reported Skill integrity regressions through Settings APIs', () => {
     })
     const result = await catalog
       .updateSkill({
-        ...{ expectedCompatibility: oldCompatibility },
+        ...{ etag: oldEtag },
         id: old.id,
         description: old.description,
         body: 'Old editor body edit',
@@ -1234,10 +1232,10 @@ describe('optimistic editor boundary', () => {
   it('accepts one of two saves with the same precondition, then accepts a freshly read edit', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({ name: 'concurrent', description: 'Initial', body: 'Initial' })
-    const expectedCompatibility = (await catalog.listUserSkills())[0].compatibility!
+    const etag = (await catalog.getSkillDetail('personal-concurrent')).etag!
     const request = {
       id: 'personal-concurrent',
-      expectedCompatibility,
+      etag,
       description: 'First',
       body: 'First'
     }
@@ -1249,14 +1247,14 @@ describe('optimistic editor boundary', () => {
     const current = await catalog.getSkillDetail(request.id)
     const next = {
       ...request,
-      expectedCompatibility: (await catalog.listUserSkills())[0].compatibility!,
+      etag: (await catalog.getSkillDetail(request.id)).etag!,
       body: 'Fresh edit'
     }
     await catalog.updateSkill(next)
     expect((await catalog.getSkillDetail(current.id)).body).toBe('Fresh edit')
   })
 
-  it('rejects a missing precondition without mutating the package', async () => {
+  it('preserves unconditional updates for clients that omit the etag', async () => {
     const catalog = await createCatalog()
     await catalog.createSkill({ name: 'missing-token', description: 'Original', body: 'Original' })
     await expect(
@@ -1265,8 +1263,8 @@ describe('optimistic editor boundary', () => {
         description: 'Changed',
         body: 'Changed'
       } as never)
-    ).rejects.toThrow(/reload|version/i)
-    expect((await catalog.getSkillDetail('personal-missing-token')).body).toBe('Original')
+    ).resolves.toBeDefined()
+    expect((await catalog.getSkillDetail('personal-missing-token')).body).toBe('Changed')
   })
 
   it('detects attachment-only changes even when SKILL.md is unchanged', async () => {
@@ -1277,7 +1275,7 @@ describe('optimistic editor boundary', () => {
       body: 'Original',
       references: [{ path: 'data.csv', dataBase64: Buffer.from('before').toString('base64') }]
     })
-    const expectedCompatibility = (await catalog.listUserSkills())[0].compatibility!
+    const etag = (await catalog.getSkillDetail('personal-attachment')).etag!
     const file = join(
       userSkillSourceDir(catalog, 'personal'),
       'attachment',
@@ -1287,7 +1285,7 @@ describe('optimistic editor boundary', () => {
     await writeFile(file, 'after')
     const request = {
       id: 'personal-attachment',
-      expectedCompatibility,
+      etag,
       description: 'Changed',
       body: 'Changed'
     }
@@ -1295,4 +1293,36 @@ describe('optimistic editor boundary', () => {
     expect(await readFile(file, 'utf8')).toBe('after')
     expect((await catalog.getSkillDetail(request.id)).body).toBe('Original')
   })
+})
+
+it.each(['', null, 17])('rejects an invalid supplied etag %s without writing', async (etag) => {
+  const catalog = await createCatalog()
+  await catalog.createSkill({ name: 'invalid-etag', description: 'Original', body: 'Original' })
+  await expect(
+    catalog.updateSkill({
+      id: 'personal-invalid-etag',
+      description: 'Changed',
+      body: 'Changed',
+      etag
+    } as never)
+  ).rejects.toThrow(/etag/i)
+  expect((await catalog.getSkillDetail('personal-invalid-etag')).body).toBe('Original')
+})
+
+it('returns an opaque etag with the detail and changes it after an unconditional save', async () => {
+  const catalog = await createCatalog()
+  await catalog.createSkill({ name: 'etag', description: 'Original', body: 'Original' })
+  const before = await catalog.getSkillDetail('personal-etag')
+  expect(before).toHaveProperty('etag', expect.stringMatching(/^".+"$/))
+  expect(before).not.toHaveProperty('compatibility')
+  await catalog.updateSkill({ id: before.id, description: 'New', body: 'New' } as never)
+  const after = await catalog.getSkillDetail(before.id)
+  expect(after.etag).not.toBe(before.etag)
+  await catalog.updateSkill({
+    id: before.id,
+    description: 'Fresh',
+    body: 'Fresh',
+    etag: after.etag
+  } as never)
+  expect((await catalog.getSkillDetail(before.id)).body).toBe('Fresh')
 })

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -537,7 +537,7 @@ class SkillCatalogModule {
       const { fields, body } = await readSkillFile(lockedSkill.sourceDir)
       return {
         ...this.toSkillView(lockedSkill, disabled),
-        compatibility: lockedSkill.compatibility,
+        etag: JSON.stringify(lockedSkill.compatibility),
         body,
         metadata: Object.fromEntries(
           Object.entries(fields).filter(([key]) => key !== 'name' && key !== 'description')
@@ -589,8 +589,8 @@ class SkillCatalogModule {
 
   async updateSkill(request: UpdateSkillRequest): Promise<SkillView[]> {
     if ('name' in request) throw new Error('Skill name is immutable.')
-    if (typeof request.expectedCompatibility !== 'string' || !request.expectedCompatibility) {
-      throw new Error('Reload this Skill before saving to obtain its current version.')
+    if (request.etag !== undefined && (typeof request.etag !== 'string' || !request.etag)) {
+      throw new Error('Invalid Skill etag.')
     }
     const skill = (await this.managedCatalog()).find((entry) => entry.id === request.id)
     if (!skill || skill.source !== 'personal') {
@@ -605,7 +605,7 @@ class SkillCatalogModule {
         metadata: request.metadata,
         references: request.references
       },
-      request.expectedCompatibility
+      request.etag
     )
     await this.refreshRegisteredHelpers()
     return this.listSkills()

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -537,6 +537,7 @@ class SkillCatalogModule {
       const { fields, body } = await readSkillFile(lockedSkill.sourceDir)
       return {
         ...this.toSkillView(lockedSkill, disabled),
+        compatibility: lockedSkill.compatibility,
         body,
         metadata: Object.fromEntries(
           Object.entries(fields).filter(([key]) => key !== 'name' && key !== 'description')
@@ -588,17 +589,24 @@ class SkillCatalogModule {
 
   async updateSkill(request: UpdateSkillRequest): Promise<SkillView[]> {
     if ('name' in request) throw new Error('Skill name is immutable.')
+    if (typeof request.expectedCompatibility !== 'string' || !request.expectedCompatibility) {
+      throw new Error('Reload this Skill before saving to obtain its current version.')
+    }
     const skill = (await this.managedCatalog()).find((entry) => entry.id === request.id)
     if (!skill || skill.source !== 'personal') {
       throw new Error(`Not a personal skill id: ${request.id}`)
     }
-    await this.userSkills.updatePersonal(request.id, {
-      name: skill.name,
-      description: request.description,
-      body: request.body,
-      metadata: request.metadata,
-      references: request.references
-    })
+    await this.userSkills.updatePersonal(
+      request.id,
+      {
+        name: skill.name,
+        description: request.description,
+        body: request.body,
+        metadata: request.metadata,
+        references: request.references
+      },
+      request.expectedCompatibility
+    )
     await this.refreshRegisteredHelpers()
     return this.listSkills()
   }

--- a/src/main/skills/agent-home-skill-owner.ts
+++ b/src/main/skills/agent-home-skill-owner.ts
@@ -1,14 +1,13 @@
 import { createHash } from 'node:crypto'
 import { cp, lstat, readFile, readdir, stat } from 'node:fs/promises'
-import { basename, join, resolve } from 'node:path'
+import { basename, join, relative } from 'node:path'
 
 import type { AgentHomeSkillRef, AgentHomeSkillSource } from '../../shared/settings'
-import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
+import { SKILL_IMPORT_LIMITS, isAppOwnedSkillRootFile } from '../../shared/skill-import-limits'
 import { parseSkillDocument } from './frontmatter'
-import {
-  SOURCE_MANIFEST,
-  type SkillPackageTransactionOwner,
-  type StagedSkillPackage
+import type {
+  SkillPackageTransactionOwner,
+  StagedSkillPackage
 } from './skill-package-transaction-owner'
 import type { ImportOutcome, ParsedSkillPreview } from './user-skill-import-contracts'
 import { assertUsableSkillName, isUsableSkillName, type UserSkillStore } from './user-skill-store'
@@ -271,9 +270,9 @@ class AgentHomeSkillOwner {
         if (!entryStat.isFile()) {
           throw new Error(`Agent-home Skill contains an unsupported filesystem entry.`)
         }
-        if (relativePath === SOURCE_MANIFEST) {
+        if (isAppOwnedSkillRootFile(relativePath)) {
           if (options.skipSourceManifest) continue
-          throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
+          throw new Error(`Skill import may not include the reserved file ${relativePath}.`)
         }
         if (fileCount >= SKILL_IMPORT_LIMITS.maxFiles) {
           throw new Error(`Agent-home Skill has more than ${SKILL_IMPORT_LIMITS.maxFiles} files.`)
@@ -361,8 +360,10 @@ class AgentHomeSkillOwner {
         force: false,
         errorOnExist: true,
         filter: async (entry) => {
-          if (resolve(entry) === resolve(sourcePath, SOURCE_MANIFEST)) {
-            throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
+          if (isAppOwnedSkillRootFile(relative(sourcePath, entry))) {
+            throw new Error(
+              `Skill import may not include the reserved file ${relative(sourcePath, entry)}.`
+            )
           }
           if ((await lstat(entry)).isSymbolicLink()) {
             throw new Error(`Refusing to import an agent-home Skill containing a symbolic link.`)
@@ -540,11 +541,29 @@ class AgentHomeSkillOwner {
           : null
         const identityUnchanged =
           existing?.agentHome && agentHomeKey(existing.agentHome) === agentHomeKey(skill)
+        let installedSignature: string | undefined
         if (existingDirectoryName && identityUnchanged && existing.signature === staged.signature) {
+          try {
+            installedSignature = await this.signatureOfAgentHomeSkill(
+              this.store.skillDirectory('imported', existingDirectoryName),
+              { skipSourceManifest: true }
+            )
+          } catch {
+            // A broken live tree is repaired from the validated staging copy.
+          }
+        }
+        if (
+          existingDirectoryName &&
+          identityUnchanged &&
+          existing.signature === staged.signature &&
+          installedSignature === staged.signature
+        ) {
           await this.transactions.discard(staged)
           return { status: 'unchanged', id: `imported-${existingDirectoryName}` }
         }
 
+        if (existingDirectoryName)
+          await this.store.assertOrdinaryReplacement('imported', existingDirectoryName)
         await this.transactions.promote(staged)
         return {
           status: existingDirectoryName ? 'updated' : 'imported',

--- a/src/main/skills/materializer-integrity.regression.test.ts
+++ b/src/main/skills/materializer-integrity.regression.test.ts
@@ -1,0 +1,102 @@
+import * as fs from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ClaudeCodeSkillMaterializer } from './materializer'
+import { UserSkillRepository } from './user-skill-repository'
+import { catalogFingerprint } from './user-skill-catalog-observer'
+
+// Scope failure injection to one filesystem call, with real I/O for everything else.
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, rm: vi.fn(actual.rm) }
+})
+const roots: string[] = []
+afterEach(async () => {
+  vi.mocked(fs.rm).mockReset()
+  const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  vi.mocked(fs.rm).mockImplementation(actual.rm)
+  for (const root of roots.splice(0)) {
+    // Runtime copies are read-only; restore only temporary test directories before cleanup.
+    const writable = async (directory: string): Promise<void> => {
+      await fs.chmod(directory, 0o755)
+      for (const entry of await fs.readdir(directory, { withFileTypes: true })) {
+        const path = join(directory, entry.name)
+        if (entry.isDirectory()) await writable(path)
+        else await fs.chmod(path, 0o644)
+      }
+    }
+    await writable(root)
+    await actual.rm(root, { recursive: true, force: true })
+  }
+})
+const fixture = async (): Promise<{
+  root: string
+  repo: UserSkillRepository
+  configDir: string
+  materializer: ClaudeCodeSkillMaterializer
+}> => {
+  const root = await fs.mkdtemp(join(tmpdir(), 'skill-runtime-integrity-'))
+  roots.push(root)
+  const repo = new UserSkillRepository(root)
+  await repo.createPersonal({ name: 'demo', description: 'Demo', body: 'Body' })
+  return {
+    root,
+    repo,
+    configDir: join(root, 'runtime'),
+    materializer: new ClaudeCodeSkillMaterializer()
+  }
+}
+
+describe('reported runtime Skill integrity regressions', () => {
+  it('SK04 reports failed withdrawal, retains tracking and allows a later successful retry', async () => {
+    const { repo, configDir, materializer } = await fixture()
+    await materializer.sync(configDir, await repo.list(), { directoryLayout: 'app-owned' })
+    const target = join(configDir, 'skills', 'os-personal-demo')
+    const manifest = join(configDir, 'skills', '.os-versions.json')
+    const before = await fs.readFile(manifest, 'utf8')
+    expect(await fs.readFile(join(target, 'SKILL.md'), 'utf8')).toContain('Body')
+    const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let blocked = true
+    const busy = Object.assign(new Error('Injected target EBUSY'), { code: 'EBUSY' })
+    vi.mocked(fs.rm).mockImplementation(async (path, options) => {
+      if (String(path) === target && blocked) throw busy
+      return actual.rm(path, options)
+    })
+    const result = await materializer.sync(configDir, [], { directoryLayout: 'app-owned' }).then(
+      () => 'success',
+      () => 'failure'
+    )
+    expect.soft(result).toBe('failure')
+    expect.soft(await fs.readFile(manifest, 'utf8')).toBe(before)
+    expect(await fs.readFile(join(target, 'SKILL.md'), 'utf8')).toContain('Body')
+    blocked = false
+    await materializer.sync(configDir, [], { directoryLayout: 'app-owned' })
+    await expect(fs.stat(target)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(JSON.parse(await fs.readFile(manifest, 'utf8'))).toEqual({})
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'SK05 propagates a chmod-only executable change into the existing runtime copy',
+    async () => {
+      const { root, repo, configDir, materializer } = await fixture()
+      const scripts = join(root, 'skills', 'personal', 'demo', 'scripts')
+      await fs.mkdir(scripts)
+      const source = join(scripts, 'run.sh')
+      await fs.writeFile(source, '#!/bin/sh\necho demo\n', { mode: 0o644 })
+      const before = await repo.list()
+      await materializer.sync(configDir, before)
+      const target = join(configDir, 'skills', 'os-personal-demo', 'scripts', 'run.sh')
+      expect((await fs.stat(target)).mode & 0o111).toBe(0)
+      await fs.chmod(source, 0o755)
+      expect((await fs.stat(source)).mode & 0o111).toBe(0o111)
+      const after = await repo.list()
+      expect(after[0].updatedAt).toBe(before[0].updatedAt)
+      expect.soft(after[0].compatibility).not.toBe(before[0].compatibility)
+      expect.soft(catalogFingerprint(after)).not.toBe(catalogFingerprint(before))
+      await materializer.sync(configDir, after)
+      expect((await fs.stat(target)).mode & 0o111).toBe(0o111)
+    }
+  )
+})

--- a/src/main/skills/materializer-integrity.regression.test.ts
+++ b/src/main/skills/materializer-integrity.regression.test.ts
@@ -50,7 +50,7 @@ const fixture = async (): Promise<{
 }
 
 describe('reported runtime Skill integrity regressions', () => {
-  it('SK04 reports failed withdrawal, retains tracking and allows a later successful retry', async () => {
+  it('reports failed withdrawal, retains tracking and allows a later successful retry', async () => {
     const { repo, configDir, materializer } = await fixture()
     await materializer.sync(configDir, await repo.list(), { directoryLayout: 'app-owned' })
     const target = join(configDir, 'skills', 'os-personal-demo')
@@ -78,7 +78,7 @@ describe('reported runtime Skill integrity regressions', () => {
   })
 
   it.skipIf(process.platform === 'win32')(
-    'SK05 propagates a chmod-only executable change into the existing runtime copy',
+    'propagates a chmod-only executable change into the existing runtime copy',
     async () => {
       const { root, repo, configDir, materializer } = await fixture()
       const scripts = join(root, 'skills', 'personal', 'demo', 'scripts')

--- a/src/main/skills/materializer-integrity.regression.test.ts
+++ b/src/main/skills/materializer-integrity.regression.test.ts
@@ -97,6 +97,12 @@ describe('reported runtime Skill integrity regressions', () => {
       expect.soft(catalogFingerprint(after)).not.toBe(catalogFingerprint(before))
       await materializer.sync(configDir, after)
       expect((await fs.stat(target)).mode & 0o111).toBe(0o111)
+      // A restarted reader and the reverse chmod transition must invalidate the same projection.
+      const restarted = new UserSkillRepository(root)
+      expect((await restarted.list())[0].compatibility).toBe(after[0].compatibility)
+      await fs.chmod(source, 0o644)
+      await materializer.sync(configDir, await restarted.list())
+      expect((await fs.stat(target)).mode & 0o111).toBe(0)
     }
   )
 })

--- a/src/main/skills/materializer.ts
+++ b/src/main/skills/materializer.ts
@@ -174,6 +174,7 @@ class ClaudeCodeSkillMaterializer implements SkillMaterializer {
           await rm(stale, { recursive: true, force: true })
         } catch (error) {
           log.warn('failed to remove stale skill dir', { name, error })
+          throw error
         }
         delete versions[name]
       }

--- a/src/main/skills/skill-bundle-import-owner.ts
+++ b/src/main/skills/skill-bundle-import-owner.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname, join, resolve, sep } from 'node:path'
 
 import type {
@@ -7,7 +7,7 @@ import type {
   SkillBundlePreviewResult,
   SkippedSkill
 } from '../../shared/settings'
-import { SKILL_IMPORT_LIMITS } from '../../shared/skill-import-limits'
+import { SKILL_IMPORT_LIMITS, isAppOwnedSkillRootFile } from '../../shared/skill-import-limits'
 import {
   fetchSkillFiles,
   fetchSkillPreview,
@@ -22,16 +22,30 @@ import {
 import { parseSkillDocument } from './frontmatter'
 import { canonicalSkillDocument } from './skill-document-name'
 import { selectSkillManifestRoots } from './skill-bundle-paths'
+import { inspectSkillPackage } from './skill-package-inspection'
 import { extractZip, extractZipLenient } from './zip-extract'
-import {
-  SOURCE_MANIFEST,
-  type SkillPackageTransactionOwner
-} from './skill-package-transaction-owner'
+import type { SkillPackageTransactionOwner } from './skill-package-transaction-owner'
 import type { ImportOutcome, ParsedSkillPreview } from './user-skill-import-contracts'
 import { UserSkillStore, normalizeSkillName, parseUserSkillId } from './user-skill-store'
 
 type SkillRoot = { subPath: string; files: FetchedSkillFile[] }
 type SkillDiscovery = { roots: SkillRoot[]; skipped: SkippedSkill[] }
+
+// Installation identity excludes the pinned revision; package paths remain case-sensitive.
+const githubSourceKey = (url: string): string | undefined => {
+  const location = parseGitHubSkillUrl(url)
+  return location
+    ? JSON.stringify([location.owner.toLowerCase(), location.repo.toLowerCase(), location.path])
+    : undefined
+}
+
+const assertOrdinarySkillFiles = (files: readonly FetchedSkillFile[]): void => {
+  for (const file of files) {
+    if (isAppOwnedSkillRootFile(file.relativePath)) {
+      throw new Error(`Skill import may not include the reserved file ${file.relativePath}.`)
+    }
+  }
+}
 
 const signatureOf = (files: FetchedSkillFile[]): string => {
   const hash = createHash('sha256')
@@ -204,6 +218,7 @@ export class SkillBundleImportOwner {
     if (!fetcher) throw new Error('No fetch implementation available.')
 
     const files = await fetchSkillFiles(location, fetcher, options)
+    assertOrdinarySkillFiles(files)
     const signature = signatureOf(files)
     const preview = parsedSkillPreview(
       files
@@ -218,7 +233,10 @@ export class SkillBundleImportOwner {
       const existingDirectoryName = await this.findImportedDirectoryNameByUrl(url)
       if (existingDirectoryName) {
         const existing = await this.transactions.readImportedSource(existingDirectoryName)
-        if (existing?.signature === signature) {
+        if (
+          existing?.signature === signature &&
+          (await this.installedMatches(existingDirectoryName, files))
+        ) {
           return { status: 'unchanged', id: `imported-${existingDirectoryName}` }
         }
         await this.writeImported(existingDirectoryName, files, url, signature)
@@ -265,9 +283,10 @@ export class SkillBundleImportOwner {
             continue
           }
 
-          const alreadyImported = Boolean(
-            await this.findImportedDirectoryNameBySignature(signatureOf(root.files))
-          )
+          assertOrdinarySkillFiles(root.files)
+          const existing = await this.findImportedDirectoryNameBySignature(signatureOf(root.files))
+          const alreadyImported =
+            existing !== undefined && (await this.installedMatches(existing, root.files))
           const replaceableId = alreadyImported ? undefined : await this.replaceableImportedId(name)
 
           if (!previewContentUnavailable) previewContentBytes += skillMd.content.length
@@ -340,7 +359,7 @@ export class SkillBundleImportOwner {
     repoInput: string,
     fetchImpl?: FetchLike,
     options: GitHubFetchOptions = {}
-  ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
+  ): Promise<(ScannedSkill & { alreadyImported: boolean; installedId?: string })[]> {
     const repo = parseGitHubRepo(repoInput)
     if (!repo) throw new Error('Not a recognizable GitHub repo (owner/repo or a github.com URL).')
 
@@ -351,19 +370,29 @@ export class SkillBundleImportOwner {
       scanRepoForSkills(repo, fetcher, options),
       this.transactions.runRecovered(() => this.importedIndex())
     ])
-    return found.map((skill) => ({
-      ...skill,
-      alreadyImported:
-        index.urls.has(skill.url) || index.directoryNames.has(normalizeSkillName(skill.name))
-    }))
+    return found.map((skill) => {
+      const matches = index.filter((entry) => entry.sourceKey === githubSourceKey(skill.url))
+      const installed = matches.length === 1 ? matches[0] : undefined
+      return {
+        ...skill,
+        alreadyImported:
+          installed !== undefined &&
+          parseGitHubSkillUrl(installed.url)?.ref === parseGitHubSkillUrl(skill.url)?.ref,
+        ...(installed ? { installedId: `imported-${installed.directoryName}` } : {})
+      }
+    })
   }
 
   private async findImportedDirectoryNameByUrl(url: string): Promise<string | undefined> {
-    for (const directoryName of await this.store.listDirectoryNames('imported')) {
-      const source = await this.transactions.readImportedSource(directoryName)
-      if (source?.url === url) return directoryName
+    const matches = (await this.importedIndex()).filter(
+      (entry) => entry.sourceKey === githubSourceKey(url)
+    )
+    if (matches.length > 1) {
+      throw new Error(
+        'Multiple installed Skills match this GitHub source. Resolve the duplicate imports before updating.'
+      )
     }
-    return undefined
+    return matches[0]?.directoryName
   }
 
   private async replaceableImportedId(name: string): Promise<string | undefined> {
@@ -392,6 +421,7 @@ export class SkillBundleImportOwner {
     reservedNames: readonly string[] = []
   ): Promise<ImportOutcome> {
     const files = root.files
+    assertOrdinarySkillFiles(files)
     const skillMd = files.find((file) => file.relativePath.toLowerCase() === 'skill.md')!
     const signature = signatureOf(files)
 
@@ -410,7 +440,12 @@ export class SkillBundleImportOwner {
 
     const existingDirectoryName = await this.findImportedDirectoryNameBySignature(signature)
     if (existingDirectoryName) {
-      return { status: 'unchanged', id: `imported-${existingDirectoryName}` }
+      if (await this.installedMatches(existingDirectoryName, files)) {
+        return { status: 'unchanged', id: `imported-${existingDirectoryName}` }
+      }
+      const existing = await this.transactions.readImportedSource(existingDirectoryName)
+      await this.writeImported(existingDirectoryName, files, existing?.url ?? '', signature)
+      return { status: 'updated', id: `imported-${existingDirectoryName}` }
     }
 
     const name = parseSkillDocument(skillMd.content.toString('utf8')).name?.trim()
@@ -430,15 +465,47 @@ export class SkillBundleImportOwner {
     return undefined
   }
 
-  private async importedIndex(): Promise<{ urls: Set<string>; directoryNames: Set<string> }> {
-    const urls = new Set<string>()
-    const directoryNames = new Set<string>()
+  private async importedIndex(): Promise<
+    Array<{ directoryName: string; url: string; sourceKey: string }>
+  > {
+    const entries: Array<{ directoryName: string; url: string; sourceKey: string }> = []
     for (const directoryName of await this.store.listDirectoryNames('imported')) {
-      directoryNames.add(directoryName)
       const source = await this.transactions.readImportedSource(directoryName)
-      if (source?.url) urls.add(source.url)
+      const sourceKey = source?.url ? githubSourceKey(source.url) : undefined
+      if (source?.url && sourceKey) entries.push({ directoryName, url: source.url, sourceKey })
     }
-    return { urls, directoryNames }
+    return entries
+  }
+
+  // Compare the actual normalized installation, not its historical source receipt. Inspection
+  // bounds reads and rejects symlinks/unsupported entries; a broken copy is repairable by reimport.
+  private async installedMatches(
+    directoryName: string,
+    files: readonly FetchedSkillFile[]
+  ): Promise<boolean> {
+    try {
+      const installed = await inspectSkillPackage(
+        this.store.skillDirectory('imported', directoryName)
+      )
+      if (installed.length !== files.length) return false
+      const byPath = new Map(installed.map((file) => [file.relativePath, file]))
+      for (const file of files) {
+        const target = byPath.get(file.relativePath)
+        if (!target) return false
+        const expected =
+          file.relativePath.toLowerCase() === 'skill.md'
+            ? canonicalImportedSkillDocument(file.content, directoryName)
+            : file.content
+        if (
+          target.size !== expected.length ||
+          !(await readFile(target.absolutePath)).equals(expected)
+        )
+          return false
+      }
+      return true
+    } catch {
+      return false
+    }
   }
 
   private async writeImported(
@@ -447,17 +514,17 @@ export class SkillBundleImportOwner {
     url: string,
     signature: string
   ): Promise<void> {
+    await this.store.assertOrdinaryReplacement('imported', directoryName)
     const dir = this.store.skillDirectory('imported', directoryName)
     const root = resolve(dir)
-    const manifestTarget = resolve(dir, SOURCE_MANIFEST)
     const seen = new Set<string>()
     for (const file of files) {
       const target = resolve(dir, file.relativePath)
       if (target === root || !target.startsWith(root + sep)) {
         throw new Error(`Refusing to write skill file outside its directory: ${file.relativePath}`)
       }
-      if (target === manifestTarget) {
-        throw new Error(`Skill import may not include the reserved file ${SOURCE_MANIFEST}.`)
+      if (isAppOwnedSkillRootFile(file.relativePath)) {
+        throw new Error(`Skill import may not include the reserved file ${file.relativePath}.`)
       }
       if (seen.has(target)) {
         throw new Error(`Duplicate file path in skill import: ${file.relativePath}`)

--- a/src/main/skills/user-skill-compatibility-index.test.ts
+++ b/src/main/skills/user-skill-compatibility-index.test.ts
@@ -181,7 +181,7 @@ describe('UserSkillCompatibilityIndex', () => {
 
     expect(result).toMatchObject({
       sourceDir,
-      compatibility: expect.stringMatching(/^sha256-tree-v2:[a-f0-9]{64}$/)
+      compatibility: expect.stringMatching(/^sha256-tree-v3:[a-f0-9]{64}$/)
     })
   })
 
@@ -215,4 +215,30 @@ describe('UserSkillCompatibilityIndex', () => {
     expect(mutatingHash).toHaveBeenCalledTimes(3)
     expect(restartedHash).not.toHaveBeenCalled()
   })
+})
+
+it('rebuilds a historical v1 cache instead of trusting its old file metadata', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'legacy-skill-cache-'))
+  try {
+    const source = join(root, 'skills', 'personal', 'demo')
+    await mkdir(source, { recursive: true })
+    await writeFile(join(source, 'SKILL.md'), '---\nname: demo\n---\nBody')
+    await new UserSkillCompatibilityIndex(root).scan([source])
+    const path = join(root, 'runtime-support', 'user-skill-compatibility-v1.json')
+    const legacy = JSON.parse(await readFile(path, 'utf8'))
+    legacy.version = 1
+    for (const pkg of Object.values(legacy.packages) as Array<{
+      files: Record<string, { executable?: boolean }>
+    }>) {
+      for (const file of Object.values(pkg.files)) delete file.executable
+    }
+    await writeFile(path, JSON.stringify(legacy))
+    const hashFile = vi.fn(hashFileContents)
+    const result = await new UserSkillCompatibilityIndex(root, { hashFile }).scan([source])
+    expect(hashFile).toHaveBeenCalledOnce()
+    expect(result[0]).toMatchObject({ compatibility: expect.stringMatching(/^sha256-tree-v3:/) })
+    expect(JSON.parse(await readFile(path, 'utf8')).version).toBe(2)
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
 })

--- a/src/main/skills/user-skill-compatibility-index.ts
+++ b/src/main/skills/user-skill-compatibility-index.ts
@@ -6,13 +6,14 @@ import { dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { createLogger, diagnosticErrorFields } from '../logger'
 
 const log = createLogger('skills')
-const CACHE_VERSION = 1
-const COMPATIBILITY_VERSION = 'sha256-tree-v2'
+const CACHE_VERSION = 2
+const COMPATIBILITY_VERSION = 'sha256-tree-v3'
 const SHA256_HEX = /^[a-f0-9]{64}$/
 const NON_NEGATIVE_INTEGER = /^\d+$/
 const INTEGER = /^-?\d+$/
 
 type FileMetadata = {
+  executable: boolean
   size: string
   mtimeNs: string
   ctimeNs: string
@@ -55,7 +56,10 @@ const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)
 
 const sameMetadata = (left: FileMetadata | undefined, right: FileMetadata): boolean =>
-  left?.size === right.size && left.mtimeNs === right.mtimeNs && left.ctimeNs === right.ctimeNs
+  left?.size === right.size &&
+  left.mtimeNs === right.mtimeNs &&
+  left.ctimeNs === right.ctimeNs &&
+  left.executable === right.executable
 
 const streamFileHash: HashFile = async (path) => {
   const hash = createHash('sha256')
@@ -171,6 +175,8 @@ class UserSkillCompatibilityIndex {
     for (const [path, file] of Object.entries(files)) {
       compatibilityHash.update(path)
       compatibilityHash.update('\0')
+      compatibilityHash.update(file.executable ? 'x' : '-')
+      compatibilityHash.update('\0')
       compatibilityHash.update(file.sha256)
       compatibilityHash.update('\0')
     }
@@ -185,6 +191,7 @@ class UserSkillCompatibilityIndex {
     const metadata = await lstat(path, { bigint: true })
     return metadata.isFile()
       ? {
+          executable: (metadata.mode & 0o111n) !== 0n,
           size: metadata.size.toString(),
           mtimeNs: metadata.mtimeNs.toString(),
           ctimeNs: metadata.ctimeNs.toString()
@@ -205,6 +212,7 @@ class UserSkillCompatibilityIndex {
         for (const [path, fileValue] of Object.entries(packageValue.files)) {
           if (
             isRecord(fileValue) &&
+            typeof fileValue.executable === 'boolean' &&
             typeof fileValue.size === 'string' &&
             NON_NEGATIVE_INTEGER.test(fileValue.size) &&
             typeof fileValue.mtimeNs === 'string' &&
@@ -215,6 +223,7 @@ class UserSkillCompatibilityIndex {
             SHA256_HEX.test(fileValue.sha256)
           ) {
             files[path] = {
+              executable: fileValue.executable,
               size: fileValue.size,
               mtimeNs: fileValue.mtimeNs,
               ctimeNs: fileValue.ctimeNs,

--- a/src/main/skills/user-skill-integrity.regression.test.ts
+++ b/src/main/skills/user-skill-integrity.regression.test.ts
@@ -57,7 +57,7 @@ const githubFetch =
       const name = url.split('/').pop()!
       if (!(name in files)) throw new Error(`Unexpected GitHub file: ${url}`)
       content = files[name]
-    } else if (/^https:\/\/api.github.com\/repos\/[^/]+\/[^/]+$/.test(url))
+    } else if (/^https:\/\/api\.github\.com\/repos\/[^/]+\/[^/]+$/.test(url))
       payload = { default_branch: 'main' }
     else throw new Error(`Unexpected GitHub request: ${url}`)
     return {

--- a/src/main/skills/user-skill-integrity.regression.test.ts
+++ b/src/main/skills/user-skill-integrity.regression.test.ts
@@ -70,7 +70,7 @@ const githubFetch =
 
 describe('reported Skill integrity regressions through UserSkillRepository', () => {
   it.each(['数据.csv', 'my data.csv'])(
-    'SK01 saves a new reference named %s without losing it',
+    'saves a new reference named %s without losing it',
     async (name) => {
       const { root, repo } = await fixture()
       expect(await repo.createPersonal({ ...baseInput, references: [reference(name)] })).toBe(
@@ -83,7 +83,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
   )
 
   it.each(['数据.csv', 'my data.csv'])(
-    'SK01 preserves an existing name-only reference %s on body save',
+    'preserves an existing name-only reference %s on body save',
     async (name) => {
       const { root, repo } = await fixture()
       const id = await repo.createPersonal(baseInput)
@@ -104,7 +104,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
     }
   )
 
-  it('SK01 control: explicitly removing a reference still removes only that file', async () => {
+  it('explicitly removing a reference still removes only that file', async () => {
     const { root, repo } = await fixture()
     const id = await repo.createPersonal({
       ...baseInput,
@@ -115,7 +115,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
   })
 
   it.each(['agent-home', 'zip', 'github'] as const)(
-    'SK02 repairs a missing installed file when reimporting %s',
+    'repairs a missing installed file when reimporting %s',
     async (source) => {
       const { root, repo } = await fixture()
       const home = join(root, 'external', 'demo')
@@ -152,7 +152,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
   )
 
   it.each(['foreign-id', 'personal-victim'])(
-    'SK03 ordinary wrapped ZIP cannot adopt external installation ID %s',
+    'ordinary wrapped ZIP cannot adopt external installation ID %s',
     async (externalId) => {
       const { repo } = await fixture()
       const victim = await repo.createPersonal({ ...baseInput, name: 'victim' })
@@ -185,7 +185,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
     }
   )
 
-  it('SK03 control: archive-root metadata is already filtered', async () => {
+  it('archive-root metadata is already filtered', async () => {
     const { repo } = await fixture()
     const result = await repo.importFromZip(
       zip({
@@ -203,7 +203,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
     await expect(repo.delete(result.id)).resolves.toBeUndefined()
   })
 
-  it('SK07 preserves local identity when the same GitHub source advances to another pinned commit', async () => {
+  it('preserves local identity when the same GitHub source advances to another pinned commit', async () => {
     const { repo } = await fixture()
     const firstFetch = githubFetch('a'.repeat(40), 'revision A')
     const [firstCandidate] = await repo.scanRepo('acme/skills', firstFetch)
@@ -219,7 +219,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
     expect(await repo.body(first.id)).toContain('revision B')
   })
 
-  it('SK07 does not label a same-named skill from another GitHub repository as already imported', async () => {
+  it('does not label a same-named skill from another GitHub repository as already imported', async () => {
     const { repo } = await fixture()
     const fetch = githubFetch('a'.repeat(40), 'revision A')
     const [candidate] = await repo.scanRepo('acme/skills', fetch)
@@ -231,7 +231,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
 
 describe('Skill integrity boundary controls', () => {
   it.each(['../evil.csv', 'C:\\evil.csv', '.', '..', 'CON.csv', 'bad:name.csv', 'trailing.'])(
-    'SK01 rejects unsafe reference %s without changing the live package',
+    'rejects unsafe reference %s without changing the live package',
     async (path) => {
       const { root, repo } = await fixture()
       const id = await repo.createPersonal({ ...baseInput, references: [reference('keep.csv')] })
@@ -247,7 +247,7 @@ describe('Skill integrity boundary controls', () => {
   )
 
   it.each(['agent-home', 'publish', 'github'] as const)(
-    'SK03 rejects reserved metadata via %s before replacing existing data',
+    'rejects reserved metadata via %s before replacing existing data',
     async (source) => {
       const { root, repo } = await fixture()
       await repo.createPersonal(baseInput)
@@ -278,7 +278,7 @@ describe('Skill integrity boundary controls', () => {
   )
 
   it.each(['zip', 'github'] as const)(
-    'SK02 repairs a renamed %s installation and recognizes its normalized healthy copy',
+    'repairs a renamed %s installation and recognizes its normalized healthy copy',
     async (source) => {
       const { root, repo } = await fixture()
       await repo.createPersonal(baseInput)
@@ -303,7 +303,7 @@ describe('Skill integrity boundary controls', () => {
     }
   )
 
-  it('SK07 refuses to choose between historical copies of the same GitHub source', async () => {
+  it('refuses to choose between historical copies of the same GitHub source', async () => {
     const { root, repo } = await fixture()
     for (const [name, sha] of [
       ['demo', 'a'],

--- a/src/main/skills/user-skill-integrity.regression.test.ts
+++ b/src/main/skills/user-skill-integrity.regression.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, mkdir, readFile, readdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { zipSync } from 'fflate'
@@ -366,5 +366,67 @@ it.each(['agent-home', 'zip', 'github'] as const)(
     await expect(importSkill()).rejects.toThrow(/Specialist/)
     expect(await readFile(join(dir, '.specialist-package.json'), 'utf8')).toBe(metadata)
     expect(await readFile(join(dir, 'data.csv'), 'utf8')).toBe('changed locally')
+  }
+)
+
+describe('existing nonportable reference names', () => {
+  it.skipIf(process.platform === 'win32').each(['CON.csv', 'trailing.'])(
+    'allows a published package with %s to be edited without renaming its reference',
+    async (name) => {
+      const { root, repo } = await fixture()
+      const source = join(root, 'draft')
+      await mkdir(join(source, 'references'), { recursive: true })
+      await writeFile(join(source, 'SKILL.md'), document())
+      await writeFile(join(source, 'references', name), 'published bytes')
+      const id = await repo.publishPersonalDirectory('demo', source)
+
+      await repo.updatePersonal(id, {
+        ...baseInput,
+        body: 'edited after publishing',
+        references: [{ path: name }]
+      })
+      expect(await repo.body(id)).toContain('edited after publishing')
+      const file = join(root, 'skills', 'personal', 'demo', 'references', name)
+      expect(await readFile(file, 'utf8')).toBe('published bytes')
+
+      await expect(
+        repo.updatePersonal(id, { ...baseInput, references: [reference(name, 'replacement')] })
+      ).rejects.toThrow('Unsafe Skill reference filename')
+      expect(await readFile(file, 'utf8')).toBe('published bytes')
+      expect(await repo.body(id)).toContain('edited after publishing')
+    }
+  )
+
+  it.each(['CON.csv', 'trailing.', '../SKILL.md', 'nested/file.csv'])(
+    'does not accept an unproven name-only reference %s',
+    async (name) => {
+      const { root, repo } = await fixture()
+      const id = await repo.createPersonal(baseInput)
+      // A name-only request is not proof that a file already exists in references/.
+      await expect(
+        repo.updatePersonal(id, { ...baseInput, body: 'changed', references: [{ path: name }] })
+      ).rejects.toThrow('Unsafe Skill reference filename')
+      expect(await repo.body(id)).toContain('original')
+      expect(await readdir(join(root, 'skills', 'personal', 'demo'))).toEqual(['SKILL.md'])
+    }
+  )
+})
+
+it.skipIf(process.platform === 'win32').each(['directory', 'symlink'] as const)(
+  'does not treat an existing %s as a retained legacy reference file',
+  async (kind) => {
+    const { root, repo } = await fixture()
+    const id = await repo.createPersonal(baseInput)
+    const refsDir = join(root, 'skills', 'personal', 'demo', 'references')
+    await mkdir(refsDir)
+    const outside = join(root, 'outside.csv')
+    await writeFile(outside, 'untouched')
+    if (kind === 'directory') await mkdir(join(refsDir, 'CON.csv'))
+    else await symlink(outside, join(refsDir, 'CON.csv'))
+    await expect(
+      repo.updatePersonal(id, { ...baseInput, body: 'changed', references: [{ path: 'CON.csv' }] })
+    ).rejects.toThrow(/Unsafe Skill reference filename|symbolic link/)
+    expect(await repo.body(id)).toContain('original')
+    expect(await readFile(outside, 'utf8')).toBe('untouched')
   }
 )

--- a/src/main/skills/user-skill-integrity.regression.test.ts
+++ b/src/main/skills/user-skill-integrity.regression.test.ts
@@ -333,3 +333,38 @@ describe('Skill integrity boundary controls', () => {
     expect(await repo.body('imported-demo')).toContain('historical a')
   })
 })
+
+it.each(['agent-home', 'zip', 'github'] as const)(
+  'preserves historical Specialist metadata when %s reimport would repair the package',
+  async (source) => {
+    const { root, repo } = await fixture()
+    const home = join(root, 'external')
+    await mkdir(home)
+    await writeFile(join(home, 'SKILL.md'), document())
+    await writeFile(join(home, 'data.csv'), 'original data')
+    const bytes = zip({ 'wrapped/SKILL.md': document(), 'wrapped/data.csv': 'original data' })
+    const importSkill = (): Promise<ImportOutcome> =>
+      source === 'agent-home'
+        ? repo.importAgentHomeSkill(home, { source: 'agents', slug: 'demo' })
+        : source === 'zip'
+          ? repo.importFromZip(bytes)
+          : repo.importFromGitHub(
+              'https://github.com/acme/skills/tree/main/demo',
+              githubFetch('a'.repeat(40), 'original')
+            )
+    await importSkill()
+    const dir = join(root, 'skills/imported/demo')
+    const metadata = JSON.stringify({
+      id: 'imported-demo',
+      version: '1',
+      contentHash: 'owned',
+      standalone: true,
+      ownerIds: ['legitimate-owner']
+    })
+    await writeFile(join(dir, '.specialist-package.json'), metadata)
+    await writeFile(join(dir, 'data.csv'), 'changed locally')
+    await expect(importSkill()).rejects.toThrow(/Specialist/)
+    expect(await readFile(join(dir, '.specialist-package.json'), 'utf8')).toBe(metadata)
+    expect(await readFile(join(dir, 'data.csv'), 'utf8')).toBe('changed locally')
+  }
+)

--- a/src/main/skills/user-skill-integrity.regression.test.ts
+++ b/src/main/skills/user-skill-integrity.regression.test.ts
@@ -1,0 +1,228 @@
+import { mkdtemp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { zipSync } from 'fflate'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { FetchLike } from './github-import'
+import { UserSkillRepository, type ImportOutcome } from './user-skill-repository'
+import type { SkillReference } from '../../shared/settings'
+
+const roots: string[] = []
+const fixture = async (): Promise<{ root: string; repo: UserSkillRepository }> => {
+  const root = await mkdtemp(join(tmpdir(), 'skill-integrity-'))
+  roots.push(root)
+  return { root, repo: new UserSkillRepository(root) }
+}
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const document = (name = 'demo', body = 'original'): string =>
+  `---\nname: ${name}\ndescription: Original description\n---\n${body}\n`
+const zip = (files: Record<string, string>): Buffer =>
+  Buffer.from(
+    zipSync(
+      Object.fromEntries(Object.entries(files).map(([path, text]) => [path, Buffer.from(text)]))
+    )
+  )
+const baseInput = { name: 'demo', description: 'Original description', body: 'original' }
+const reference = (path: string, text = 'a,b\n1,2\n'): SkillReference => ({
+  path,
+  dataBase64: Buffer.from(text).toString('base64')
+})
+
+// Only the external GitHub transport is controlled. Both scan and import run their real owners.
+const githubFetch =
+  (sha: string, body: string): FetchLike =>
+  async (url) => {
+    const files: Record<string, string> = {
+      'SKILL.md': document('demo', body),
+      'data.csv': 'a,b\n1,2\n'
+    }
+    let payload: unknown
+    let content = ''
+    if (url.includes('/commits/')) payload = { sha }
+    else if (url.includes('/git/trees/'))
+      payload = { tree: [{ path: 'demo/SKILL.md', type: 'blob' }] }
+    else if (url.includes('/contents/'))
+      payload = Object.keys(files).map((name) => ({
+        type: 'file',
+        name,
+        path: `demo/${name}`,
+        download_url: `https://raw.githubusercontent.com/acme/skills/${sha}/demo/${name}`
+      }))
+    else if (url.startsWith('https://raw.githubusercontent.com/')) {
+      const name = url.split('/').pop()!
+      if (!(name in files)) throw new Error(`Unexpected GitHub file: ${url}`)
+      content = files[name]
+    } else if (/^https:\/\/api.github.com\/repos\/[^/]+\/[^/]+$/.test(url))
+      payload = { default_branch: 'main' }
+    else throw new Error(`Unexpected GitHub request: ${url}`)
+    return {
+      ok: true,
+      status: 200,
+      json: async () => payload,
+      arrayBuffer: async () => new TextEncoder().encode(content).buffer
+    }
+  }
+
+describe('reported Skill integrity regressions through UserSkillRepository', () => {
+  it.each(['数据.csv', 'my data.csv'])(
+    'SK01 saves a new reference named %s without losing it',
+    async (name) => {
+      const { root, repo } = await fixture()
+      expect(await repo.createPersonal({ ...baseInput, references: [reference(name)] })).toBe(
+        'personal-demo'
+      )
+      await expect(
+        readFile(join(root, 'skills/personal/demo/references', name), 'utf8')
+      ).resolves.toBe('a,b\n1,2\n')
+    }
+  )
+
+  it.each(['数据.csv', 'my data.csv'])(
+    'SK01 preserves an existing name-only reference %s on body save',
+    async (name) => {
+      const { root, repo } = await fixture()
+      const id = await repo.createPersonal(baseInput)
+      const references = join(root, 'skills/personal/demo/references')
+      await mkdir(references)
+      await writeFile(join(references, name), 'keep me')
+      const names = await repo.withSkillReadLock(id, (skill) =>
+        readdir(join(skill.sourceDir, 'references'))
+      )
+      expect(names).toEqual([name])
+      await repo.updatePersonal(id, {
+        ...baseInput,
+        body: 'body edited',
+        references: names!.map((path) => ({ path }))
+      })
+      expect(await repo.body(id)).toContain('body edited')
+      await expect(readFile(join(references, name), 'utf8')).resolves.toBe('keep me')
+    }
+  )
+
+  it('SK01 control: explicitly removing a reference still removes only that file', async () => {
+    const { root, repo } = await fixture()
+    const id = await repo.createPersonal({
+      ...baseInput,
+      references: [reference('keep.csv'), reference('delete.csv')]
+    })
+    await repo.updatePersonal(id, { ...baseInput, references: [{ path: 'keep.csv' }] })
+    expect(await readdir(join(root, 'skills/personal/demo/references'))).toEqual(['keep.csv'])
+  })
+
+  it.each(['agent-home', 'zip', 'github'] as const)(
+    'SK02 repairs a missing installed file when reimporting %s',
+    async (source) => {
+      const { root, repo } = await fixture()
+      const home = join(root, 'external', 'demo')
+      await mkdir(home, { recursive: true })
+      await writeFile(join(home, 'SKILL.md'), document())
+      await writeFile(join(home, 'data.csv'), 'a,b\n1,2\n')
+      const bytes = zip({ 'demo/SKILL.md': document(), 'demo/data.csv': 'a,b\n1,2\n' })
+      const identity = { source: 'agents' as const, slug: 'demo' }
+      const importSkill = (): Promise<ImportOutcome> =>
+        source === 'agent-home'
+          ? repo.importAgentHomeSkill(home, identity)
+          : source === 'zip'
+            ? repo.importFromZip(bytes)
+            : repo.importFromGitHub(
+                'https://github.com/acme/skills/tree/main/demo',
+                githubFetch('a'.repeat(40), 'original')
+              )
+      const first = await importSkill()
+      expect(first).toEqual({ status: 'imported', id: 'imported-demo' })
+      const installedFile = join(root, 'skills/imported/demo/data.csv')
+      expect(await readFile(installedFile, 'utf8')).toBe('a,b\n1,2\n')
+      expect((await importSkill()).status).toBe('unchanged')
+      await rm(installedFile)
+      if (source === 'agent-home') {
+        const [match] = await repo.matchImportedAgentHomeSkills([
+          { sourcePath: home, canonical: identity, aliases: [identity] }
+        ])
+        expect(match.identityImported).toBe(false)
+      }
+      const repaired = await importSkill()
+      expect.soft(repaired).toEqual({ status: 'updated', id: first.id })
+      await expect(readFile(installedFile, 'utf8')).resolves.toBe('a,b\n1,2\n')
+    }
+  )
+
+  it.each(['foreign-id', 'personal-victim'])(
+    'SK03 ordinary wrapped ZIP cannot adopt external installation ID %s',
+    async (externalId) => {
+      const { repo } = await fixture()
+      const victim = await repo.createPersonal({ ...baseInput, name: 'victim' })
+      const result = await repo
+        .importFromZip(
+          zip({
+            'wrapped/SKILL.md': document('external'),
+            'wrapped/.specialist-package.json': JSON.stringify({
+              id: externalId,
+              version: '1.0.0',
+              contentHash: 'external',
+              standalone: false,
+              ownerIds: ['absent-owner']
+            })
+          })
+        )
+        .then(
+          (outcome) => ({ outcome }),
+          (error: unknown) => ({ error })
+        )
+      const catalog = await repo.list()
+      expect(await repo.body(victim)).toContain('original')
+      // Either rejecting reserved metadata or stripping it is acceptable; accepting its identity is not.
+      expect.soft(catalog.filter((skill) => skill.id === victim)).toHaveLength(1)
+      if ('outcome' in result) {
+        expect.soft(catalog.find((skill) => skill.name === 'external')?.id).toBe(result.outcome.id)
+        await expect(repo.delete(result.outcome.id)).resolves.toBeUndefined()
+      } else expect(String(result.error)).toMatch(/reserved|metadata/i)
+      expect(await repo.body(victim)).toContain('original')
+    }
+  )
+
+  it('SK03 control: archive-root metadata is already filtered', async () => {
+    const { repo } = await fixture()
+    const result = await repo.importFromZip(
+      zip({
+        'SKILL.md': document('external'),
+        '.specialist-package.json': JSON.stringify({
+          id: 'foreign-id',
+          version: '1',
+          contentHash: 'external',
+          standalone: false,
+          ownerIds: ['absent-owner']
+        })
+      })
+    )
+    expect((await repo.list())[0].id).toBe(result.id)
+    await expect(repo.delete(result.id)).resolves.toBeUndefined()
+  })
+
+  it('SK07 preserves local identity when the same GitHub source advances to another pinned commit', async () => {
+    const { repo } = await fixture()
+    const firstFetch = githubFetch('a'.repeat(40), 'revision A')
+    const [firstCandidate] = await repo.scanRepo('acme/skills', firstFetch)
+    expect(firstCandidate.url).toContain('a'.repeat(40))
+    const first = await repo.importFromGitHub(firstCandidate.url, firstFetch)
+    const secondFetch = githubFetch('b'.repeat(40), 'revision B')
+    const [secondCandidate] = await repo.scanRepo('acme/skills', secondFetch)
+    expect(secondCandidate.url).toContain('b'.repeat(40))
+    const second = await repo.importFromGitHub(secondCandidate.url, secondFetch)
+    expect.soft(second).toEqual({ status: 'updated', id: first.id })
+    expect.soft(await repo.list()).toHaveLength(1)
+    expect(await repo.body(first.id)).toContain('revision B')
+  })
+
+  it('SK07 does not label a same-named skill from another GitHub repository as already imported', async () => {
+    const { repo } = await fixture()
+    const fetch = githubFetch('a'.repeat(40), 'revision A')
+    const [candidate] = await repo.scanRepo('acme/skills', fetch)
+    await repo.importFromGitHub(candidate.url, fetch)
+    const [other] = await repo.scanRepo('other/skills', fetch)
+    expect(other.alreadyImported).toBe(false)
+  })
+})

--- a/src/main/skills/user-skill-integrity.regression.test.ts
+++ b/src/main/skills/user-skill-integrity.regression.test.ts
@@ -34,11 +34,12 @@ const reference = (path: string, text = 'a,b\n1,2\n'): SkillReference => ({
 
 // Only the external GitHub transport is controlled. Both scan and import run their real owners.
 const githubFetch =
-  (sha: string, body: string): FetchLike =>
+  (sha: string, body: string, extraFiles: Record<string, string> = {}): FetchLike =>
   async (url) => {
     const files: Record<string, string> = {
       'SKILL.md': document('demo', body),
-      'data.csv': 'a,b\n1,2\n'
+      'data.csv': 'a,b\n1,2\n',
+      ...extraFiles
     }
     let payload: unknown
     let content = ''
@@ -211,6 +212,7 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
     const secondFetch = githubFetch('b'.repeat(40), 'revision B')
     const [secondCandidate] = await repo.scanRepo('acme/skills', secondFetch)
     expect(secondCandidate.url).toContain('b'.repeat(40))
+    expect.soft(secondCandidate.alreadyImported).toBe(false)
     const second = await repo.importFromGitHub(secondCandidate.url, secondFetch)
     expect.soft(second).toEqual({ status: 'updated', id: first.id })
     expect.soft(await repo.list()).toHaveLength(1)
@@ -224,5 +226,110 @@ describe('reported Skill integrity regressions through UserSkillRepository', () 
     await repo.importFromGitHub(candidate.url, fetch)
     const [other] = await repo.scanRepo('other/skills', fetch)
     expect(other.alreadyImported).toBe(false)
+  })
+})
+
+describe('Skill integrity boundary controls', () => {
+  it.each(['../evil.csv', 'C:\\evil.csv', '.', '..', 'CON.csv', 'bad:name.csv', 'trailing.'])(
+    'SK01 rejects unsafe reference %s without changing the live package',
+    async (path) => {
+      const { root, repo } = await fixture()
+      const id = await repo.createPersonal({ ...baseInput, references: [reference('keep.csv')] })
+      const before = await repo.body(id)
+      await expect(
+        repo.updatePersonal(id, { ...baseInput, body: 'changed', references: [reference(path)] })
+      ).rejects.toThrow()
+      expect(await repo.body(id)).toBe(before)
+      expect(await readFile(join(root, 'skills/personal/demo/references/keep.csv'), 'utf8')).toBe(
+        'a,b\n1,2\n'
+      )
+    }
+  )
+
+  it.each(['agent-home', 'publish', 'github'] as const)(
+    'SK03 rejects reserved metadata via %s before replacing existing data',
+    async (source) => {
+      const { root, repo } = await fixture()
+      await repo.createPersonal(baseInput)
+      const home = join(root, 'external')
+      await mkdir(home)
+      await writeFile(join(home, 'SKILL.md'), document())
+      const metadata = JSON.stringify({
+        id: 'foreign-id',
+        version: '1',
+        contentHash: 'untrusted',
+        standalone: false,
+        ownerIds: ['absent-owner']
+      })
+      await writeFile(join(home, '.specialist-package.json'), metadata)
+      const transport = githubFetch('a'.repeat(40), 'original', {
+        '.specialist-package.json': metadata
+      })
+      const operation =
+        source === 'agent-home'
+          ? repo.importAgentHomeSkill(home, { source: 'agents', slug: 'demo' })
+          : source === 'publish'
+            ? repo.publishPersonalDirectory('demo', home, true)
+            : repo.importFromGitHub('https://github.com/acme/skills/tree/main/demo', transport)
+      await expect(operation).rejects.toThrow(/reserved/i)
+      expect((await repo.list()).map((skill) => skill.id)).toEqual(['personal-demo'])
+      expect(await repo.body('personal-demo')).toContain('original')
+    }
+  )
+
+  it.each(['zip', 'github'] as const)(
+    'SK02 repairs a renamed %s installation and recognizes its normalized healthy copy',
+    async (source) => {
+      const { root, repo } = await fixture()
+      await repo.createPersonal(baseInput)
+      const bytes = zip({ 'wrapped/SKILL.md': document(), 'wrapped/data.csv': 'data' })
+      const importSkill = (): Promise<ImportOutcome> =>
+        source === 'zip'
+          ? repo.importFromZip(bytes)
+          : repo.importFromGitHub(
+              'https://github.com/acme/skills/tree/main/demo',
+              githubFetch('a'.repeat(40), 'original')
+            )
+      const first = await importSkill()
+      expect(first.id).toBe('imported-demo-2')
+      const dir = join(root, 'skills/imported/demo-2')
+      const original = await readFile(join(dir, 'data.csv'), 'utf8')
+      expect(await readFile(join(dir, 'SKILL.md'), 'utf8')).toContain('name: demo-2')
+      expect((await importSkill()).status).toBe('unchanged')
+      await writeFile(join(dir, 'data.csv'), 'corrupted')
+      expect.soft(await importSkill()).toEqual({ status: 'updated', id: first.id })
+      expect(await readFile(join(dir, 'data.csv'), 'utf8')).toBe(original)
+      expect((await importSkill()).status).toBe('unchanged')
+    }
+  )
+
+  it('SK07 refuses to choose between historical copies of the same GitHub source', async () => {
+    const { root, repo } = await fixture()
+    for (const [name, sha] of [
+      ['demo', 'a'],
+      ['demo-2', 'b']
+    ]) {
+      const dir = join(root, 'skills/imported', name)
+      await mkdir(dir, { recursive: true })
+      await writeFile(join(dir, 'SKILL.md'), document(name, `historical ${sha}`))
+      await writeFile(
+        join(dir, '.source.json'),
+        JSON.stringify({
+          url: `https://github.com/acme/skills/tree/${sha.repeat(40)}/demo`,
+          signature: sha.repeat(64)
+        })
+      )
+    }
+    await expect(
+      repo.importFromGitHub(
+        `https://github.com/acme/skills/tree/${'c'.repeat(40)}/demo`,
+        githubFetch('c'.repeat(40), 'next')
+      )
+    ).rejects.toThrow(/multiple|ambiguous/i)
+    expect((await repo.list()).map((skill) => skill.id).sort()).toEqual([
+      'imported-demo',
+      'imported-demo-2'
+    ])
+    expect(await repo.body('imported-demo')).toContain('historical a')
   })
 })

--- a/src/main/skills/user-skill-repository.architecture.test.ts
+++ b/src/main/skills/user-skill-repository.architecture.test.ts
@@ -278,7 +278,9 @@ describe('User Skill repository architecture', () => {
           'src/main/skills/user-skill-compatibility-index.test.ts',
           'src/main/skills/user-skill-repository.architecture.test.ts',
           'src/main/skills/user-skill-repository.atomic.test.ts',
-          'src/main/skills/user-skill-repository.test.ts'
+          'src/main/skills/user-skill-repository.test.ts',
+          'src/main/skills/user-skill-integrity.regression.test.ts',
+          'src/main/skills/materializer-integrity.regression.test.ts'
         ],
         contract: [
           'src/main/skills/host-skills-service.test.ts',
@@ -296,7 +298,9 @@ describe('User Skill repository architecture', () => {
           'src/main/specialist/package/service.test.ts',
           'src/preload/index.test.ts',
           'src/renderer/src/pages/settings/SkillsPanel.render.test.tsx',
-          'src/renderer/src/stores/settings-skills-slice.test.ts'
+          'src/renderer/src/stores/settings-skills-slice.test.ts',
+          'src/renderer/src/pages/settings/SkillUploadView.render.test.tsx',
+          'src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx'
         ]
       },
       capabilityOverlays: ['windows_sensitive'],

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -520,7 +520,7 @@ describe('UserSkillRepository', () => {
       name: 'foo',
       source: 'imported',
       license: 'MIT',
-      compatibility: expect.stringMatching(/^sha256-tree-v2:/)
+      compatibility: expect.stringMatching(/^sha256-tree-v3:/)
     })
   })
 
@@ -1605,7 +1605,7 @@ describe('UserSkillRepository', () => {
     expect((await restarted.previewZip(zip)).previews[0].alreadyImported).toBe(true)
   })
 
-  it('marks scanned candidates already imported by URL or by same name', async () => {
+  it('does not mark same-named candidates from another repository as imported', async () => {
     const repo = new UserSkillRepository(await makeStorage())
     const skillMd = ['---', 'name: Foo', 'description: An imported skill.', '---', 'body'].join(
       '\n'
@@ -1635,8 +1635,8 @@ describe('UserSkillRepository', () => {
 
     const scanned = await repo.scanRepo('other/repo', treeFetch)
     const byName = Object.fromEntries(scanned.map((skill) => [skill.name, skill.alreadyImported]))
-    // "foo" is a different repo (different URL) but the same folder name -> flagged by name.
-    expect(byName).toEqual({ foo: true, bar: false })
+    // A directory name collision is not a matching source identity.
+    expect(byName).toEqual({ foo: false, bar: false })
   })
 
   it('writes frontmatter that the reader can parse back', async () => {

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -116,12 +116,8 @@ class UserSkillRepository {
   }
 
   // Replaces an existing personal skill through the shared staged package transaction.
-  async updatePersonal(
-    id: string,
-    input: WriteSkillInput,
-    expectedCompatibility?: string
-  ): Promise<void> {
-    return this.store.updatePersonal(id, input, expectedCompatibility)
+  async updatePersonal(id: string, input: WriteSkillInput, expectedEtag?: string): Promise<void> {
+    return this.store.updatePersonal(id, input, expectedEtag)
   }
 
   // Deletes a personal or imported skill directory.

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -116,8 +116,12 @@ class UserSkillRepository {
   }
 
   // Replaces an existing personal skill through the shared staged package transaction.
-  async updatePersonal(id: string, input: WriteSkillInput): Promise<void> {
-    return this.store.updatePersonal(id, input)
+  async updatePersonal(
+    id: string,
+    input: WriteSkillInput,
+    expectedCompatibility?: string
+  ): Promise<void> {
+    return this.store.updatePersonal(id, input, expectedCompatibility)
   }
 
   // Deletes a personal or imported skill directory.
@@ -165,7 +169,7 @@ class UserSkillRepository {
     repoInput: string,
     fetchImpl?: FetchLike,
     options: GitHubFetchOptions = {}
-  ): Promise<(ScannedSkill & { alreadyImported: boolean })[]> {
+  ): Promise<(ScannedSkill & { alreadyImported: boolean; installedId?: string })[]> {
     return this.bundleImports.scanRepo(repoInput, fetchImpl, options)
   }
 

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -77,7 +77,10 @@ const packageFileSizeError = (): Error => new Error('Skill package contains an o
 
 const packageTotalSizeError = (): Error => new Error('Skill package exceeds the total size limit.')
 
-const prepareSkillWrite = (input: WriteSkillInput): PreparedSkillWrite => {
+const prepareSkillWrite = (
+  input: WriteSkillInput,
+  existingReferences?: ReadonlySet<string>
+): PreparedSkillWrite => {
   const document = serializePersonalSkillDocument(input)
   const documentBytes = Buffer.byteLength(document, 'utf8')
   if (documentBytes > SKILL_IMPORT_LIMITS.maxFileBytes) throw packageFileSizeError()
@@ -86,7 +89,9 @@ const prepareSkillWrite = (input: WriteSkillInput): PreparedSkillWrite => {
   const references = new Map<string, SkillReference>()
   for (const reference of input.references) {
     const name = reference.path
-    if (!isSafeSkillReferenceName(name)) {
+    // Historical/published POSIX names may be retained, but never introduced or overwritten.
+    const retained = reference.dataBase64 === undefined && existingReferences?.has(name)
+    if (!isSafeSkillReferenceName(name) && !retained) {
       throw new Error(`Unsafe Skill reference filename: ${name}`)
     }
     references.set(name, reference)
@@ -317,7 +322,6 @@ export class UserSkillStore {
     const parsed = parseUserSkillId(id)
     if (!parsed || parsed.source !== 'personal') throw new Error(`Not a personal skill id: ${id}`)
     const name = parsed.directoryName
-    const prepared = prepareSkillWrite(input)
 
     await this.transactions.runMutationRecovered(async () => {
       const live = this.skillDirectory('personal', name)
@@ -339,6 +343,21 @@ export class UserSkillStore {
             return true
           }
         })
+        // Read exact regular-file names from the staged, symlink-free copy under the write lock.
+        const entries = input.references?.some(
+          (reference) => !isSafeSkillReferenceName(reference.path)
+        )
+          ? await readdir(join(staging, 'references'), { withFileTypes: true }).catch(
+              (error: NodeJS.ErrnoException) => {
+                if (error.code === 'ENOENT') return []
+                throw error
+              }
+            )
+          : []
+        const existingReferences = new Set(
+          entries.filter((entry) => entry.isFile()).map((entry) => entry.name)
+        )
+        const prepared = prepareSkillWrite(input, existingReferences)
         await this.writeSkillDirectory(staging, prepared)
         await inspectSkillPackage(staging)
       })

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -313,11 +313,7 @@ export class UserSkillStore {
     }, ['personal'])
   }
 
-  async updatePersonal(
-    id: string,
-    input: WriteSkillInput,
-    expectedCompatibility?: string
-  ): Promise<void> {
+  async updatePersonal(id: string, input: WriteSkillInput, expectedEtag?: string): Promise<void> {
     const parsed = parseUserSkillId(id)
     if (!parsed || parsed.source !== 'personal') throw new Error(`Not a personal skill id: ${id}`)
     const name = parsed.directoryName
@@ -325,9 +321,9 @@ export class UserSkillStore {
 
     await this.transactions.runMutationRecovered(async () => {
       const live = this.skillDirectory('personal', name)
-      if (expectedCompatibility !== undefined) {
+      if (expectedEtag !== undefined) {
         const current = (await this.listSkillsLocked()).find((skill) => skill.id === id)
-        if (!current || current.compatibility !== expectedCompatibility) {
+        if (!current || JSON.stringify(current.compatibility) !== expectedEtag) {
           throw new Error('This Skill changed. Reload it before saving.')
         }
       }

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -1,6 +1,8 @@
 import { cp, lstat, mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
-import { dirname, join, resolve } from 'node:path'
+import { dirname, join, relative } from 'node:path'
 
+import { isSafeSkillReferenceName } from '../../shared/skill-reference-name'
+import { isAppOwnedSkillRootFile } from '../../shared/skill-import-limits'
 import type { SkillReference, SkillSource } from '../../shared/settings'
 import {
   frontmatterBlock,
@@ -15,11 +17,11 @@ import {
   SKILL_IMPORT_LIMITS
 } from './import-limits'
 import { inspectSkillPackage } from './skill-package-inspection'
+import type { SkillPackageTransactionOwner } from './skill-package-transaction-owner'
 import {
-  SOURCE_MANIFEST,
-  type SkillPackageTransactionOwner
-} from './skill-package-transaction-owner'
-import { readSpecialistPackageSkillMetadata } from './specialist-package-adapter'
+  readSpecialistPackageSkillMetadata,
+  SPECIALIST_PACKAGE_SKILL_METADATA
+} from './specialist-package-adapter'
 import type { UserSkillCompatibilityIndex } from './user-skill-compatibility-index'
 import { SAFE_SKILL_NAME, SKILL_NAME_MAX_LENGTH, assertUsableSkillName } from './skill-name'
 import { readSkillHelperDescriptors } from './registered-helper-catalog'
@@ -83,8 +85,10 @@ const prepareSkillWrite = (input: WriteSkillInput): PreparedSkillWrite => {
 
   const references = new Map<string, SkillReference>()
   for (const reference of input.references) {
-    const name = reference.path.split(/[\\/]/).pop() ?? ''
-    if (!name || !/^[A-Za-z0-9._-]+$/.test(name)) continue
+    const name = reference.path
+    if (!isSafeSkillReferenceName(name)) {
+      throw new Error(`Unsafe Skill reference filename: ${name}`)
+    }
     references.set(name, reference)
   }
 
@@ -284,6 +288,7 @@ export class UserSkillStore {
         throw new Error(`A skill named "${normalizedName}" already exists.`)
       }
 
+      await this.assertOrdinaryReplacement('personal', normalizedName)
       const staged = await this.transactions.stage('personal', normalizedName, async (staging) => {
         await cp(sourcePath, staging, {
           recursive: true,
@@ -293,8 +298,10 @@ export class UserSkillStore {
             if ((await lstat(entry)).isSymbolicLink()) {
               throw new Error('Refusing to publish a Skill containing a symbolic link.')
             }
-            if (resolve(entry) === resolve(sourcePath, SOURCE_MANIFEST)) {
-              throw new Error(`Skill publish may not include the reserved file ${SOURCE_MANIFEST}.`)
+            if (isAppOwnedSkillRootFile(relative(sourcePath, entry))) {
+              throw new Error(
+                `Skill publish may not include the reserved file ${relative(sourcePath, entry)}.`
+              )
             }
             return true
           }
@@ -306,7 +313,11 @@ export class UserSkillStore {
     }, ['personal'])
   }
 
-  async updatePersonal(id: string, input: WriteSkillInput): Promise<void> {
+  async updatePersonal(
+    id: string,
+    input: WriteSkillInput,
+    expectedCompatibility?: string
+  ): Promise<void> {
     const parsed = parseUserSkillId(id)
     if (!parsed || parsed.source !== 'personal') throw new Error(`Not a personal skill id: ${id}`)
     const name = parsed.directoryName
@@ -314,6 +325,12 @@ export class UserSkillStore {
 
     await this.transactions.runMutationRecovered(async () => {
       const live = this.skillDirectory('personal', name)
+      if (expectedCompatibility !== undefined) {
+        const current = (await this.listSkillsLocked()).find((skill) => skill.id === id)
+        if (!current || current.compatibility !== expectedCompatibility) {
+          throw new Error('This Skill changed. Reload it before saving.')
+        }
+      }
       const staged = await this.transactions.stage('personal', name, async (staging) => {
         await cp(live, staging, {
           recursive: true,
@@ -348,6 +365,23 @@ export class UserSkillStore {
         force: true
       })
     })
+  }
+
+  // Ordinary repair/import must not erase historical installation identity or Specialist ownership.
+  // The Specialist package transaction remains the only owner of that metadata, even if malformed.
+  async assertOrdinaryReplacement(source: UserSkillSource, directoryName: string): Promise<void> {
+    let entries: string[]
+    try {
+      entries = await readdir(this.skillDirectory(source, directoryName))
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return
+      throw error
+    }
+    if (entries.some((name) => name.toLowerCase() === SPECIALIST_PACKAGE_SKILL_METADATA)) {
+      throw new Error(
+        'Use the Specialist package workflow to update a Skill with installation metadata.'
+      )
+    }
   }
 
   async uniqueImportedName(

--- a/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
@@ -99,3 +99,43 @@ describe('SkillEditLoader', () => {
     expect(onDone).toHaveBeenCalledOnce()
   })
 })
+
+it('SK06 submits the loaded compatibility and retains the draft on a stale-save rejection', async () => {
+  const onDone = vi.fn()
+  const updateSkill = vi
+    .fn()
+    .mockRejectedValue(new Error('This Skill changed. Reload it before saving.'))
+  useSettingsStore.setState({ updateSkill })
+  ;(window as unknown as { api: unknown }).api = {
+    settings: {
+      getSkillDetail: vi.fn().mockResolvedValue({ ...detail, compatibility: 'loaded-version' })
+    }
+  }
+  await act(async () => {
+    root.render(<SkillEditLoader skillId={detail.id} onDone={onDone} />)
+  })
+  const body = container.querySelector<HTMLTextAreaElement>('[aria-label="Skill body"]')!
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+      body,
+      'My unsaved draft'
+    )
+    body.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  const save = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+    (button) => button.textContent?.trim() === 'Save'
+  )!
+  expect(save).toBeDefined()
+  await act(async () => {
+    save.click()
+  })
+  expect
+    .soft(updateSkill)
+    .toHaveBeenCalledWith(
+      expect.objectContaining({ expectedCompatibility: 'loaded-version', body: 'My unsaved draft' })
+    )
+  expect(body.value).toBe('My unsaved draft')
+  expect(container.textContent).toContain('This Skill changed. Reload it before saving.')
+  expect(onDone).not.toHaveBeenCalled()
+  expect(save.disabled).toBe(false)
+})

--- a/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
@@ -100,7 +100,7 @@ describe('SkillEditLoader', () => {
   })
 })
 
-it('SK06 submits the loaded compatibility and retains the draft on a stale-save rejection', async () => {
+it('submits the loaded compatibility and retains the draft on a stale-save rejection', async () => {
   const onDone = vi.fn()
   const updateSkill = vi
     .fn()

--- a/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
@@ -135,7 +135,9 @@ it('SK06 submits the loaded compatibility and retains the draft on a stale-save 
       expect.objectContaining({ expectedCompatibility: 'loaded-version', body: 'My unsaved draft' })
     )
   expect(body.value).toBe('My unsaved draft')
-  expect(container.textContent).toContain('This Skill changed. Reload it before saving.')
+  expect(container.textContent).toContain(
+    'This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.'
+  )
   expect(onDone).not.toHaveBeenCalled()
   expect(save.disabled).toBe(false)
 })

--- a/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillEditLoader.render.test.tsx
@@ -11,6 +11,7 @@ let root: Root
 
 const detail = {
   id: 'personal-alpha',
+  etag: 'loaded-version',
   name: 'alpha',
   displayName: 'Alpha',
   description: 'Alpha description.',
@@ -100,7 +101,7 @@ describe('SkillEditLoader', () => {
   })
 })
 
-it('submits the loaded compatibility and retains the draft on a stale-save rejection', async () => {
+it('submits the loaded etag and retains the draft on a stale-save rejection', async () => {
   const onDone = vi.fn()
   const updateSkill = vi
     .fn()
@@ -108,7 +109,7 @@ it('submits the loaded compatibility and retains the draft on a stale-save rejec
   useSettingsStore.setState({ updateSkill })
   ;(window as unknown as { api: unknown }).api = {
     settings: {
-      getSkillDetail: vi.fn().mockResolvedValue({ ...detail, compatibility: 'loaded-version' })
+      getSkillDetail: vi.fn().mockResolvedValue({ ...detail, etag: 'loaded-version' })
     }
   }
   await act(async () => {
@@ -132,12 +133,144 @@ it('submits the loaded compatibility and retains the draft on a stale-save rejec
   expect
     .soft(updateSkill)
     .toHaveBeenCalledWith(
-      expect.objectContaining({ expectedCompatibility: 'loaded-version', body: 'My unsaved draft' })
+      expect.objectContaining({ etag: 'loaded-version', body: 'My unsaved draft' })
     )
   expect(body.value).toBe('My unsaved draft')
-  expect(container.textContent).toContain(
-    'This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.'
-  )
+  expect(document.querySelector('[role=dialog]')?.textContent).toContain('Review Skill changes')
   expect(onDone).not.toHaveBeenCalled()
   expect(save.disabled).toBe(false)
+})
+
+const clickButton = async (label: string): Promise<void> => {
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('button')).find(
+    (item) => item.textContent?.trim() === label
+  )
+  expect(button, label).toBeDefined()
+  await act(async () => {
+    button!.click()
+  })
+}
+
+const editBody = async (value: string): Promise<void> => {
+  const input = container.querySelector<HTMLTextAreaElement>('[aria-label="Skill body"]')!
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+const latest = {
+  ...detail,
+  etag: 'latest-version',
+  body: 'Newer body',
+  description: 'Newer description',
+  references: [{ path: 'new.csv', sizeBytes: 10 }]
+}
+const conflictError = new Error('This Skill changed. Reload it before saving.')
+
+const mountConflict = async (): Promise<{
+  getSkillDetail: ReturnType<typeof vi.fn>
+  updateSkill: ReturnType<typeof vi.fn>
+  onDone: ReturnType<typeof vi.fn>
+}> => {
+  const getSkillDetail = vi.fn().mockResolvedValueOnce(detail).mockResolvedValue(latest)
+  const updateSkill = vi.fn().mockRejectedValueOnce(conflictError).mockResolvedValue(undefined)
+  const onDone = vi.fn()
+  useSettingsStore.setState({ updateSkill })
+  ;(window as unknown as { api: unknown }).api = { settings: { getSkillDetail } }
+  await act(async () => {
+    root.render(<SkillEditLoader skillId={detail.id} onDone={onDone} />)
+  })
+  await editBody('My draft')
+  await clickButton('Save')
+  return { getSkillDetail, updateSkill, onDone }
+}
+
+it('shows both versions and reference names without replacing the draft on conflict', async () => {
+  const { updateSkill, onDone } = await mountConflict()
+  const dialog = document.querySelector('[role=dialog]')!
+  expect(dialog?.textContent).toContain('My draft')
+  expect(dialog?.textContent).toContain('Newer body')
+  expect(dialog?.textContent).toContain('new.csv')
+  await clickButton('Keep editing')
+  expect(document.querySelector('[role=dialog]')).toBeNull()
+  expect(container.querySelector<HTMLTextAreaElement>('[aria-label="Skill body"]')!.value).toBe(
+    'My draft'
+  )
+  expect(updateSkill).toHaveBeenCalledOnce()
+  expect(onDone).not.toHaveBeenCalled()
+})
+
+it('overwrites only after explicit review using the latest etag', async () => {
+  const { updateSkill, onDone } = await mountConflict()
+  await clickButton('Overwrite with my draft')
+  expect(updateSkill).toHaveBeenLastCalledWith(
+    expect.objectContaining({ etag: 'latest-version', body: 'My draft', references: [] })
+  )
+  expect(onDone).toHaveBeenCalledOnce()
+})
+
+it('loads the reviewed latest version only on explicit choice', async () => {
+  const { updateSkill } = await mountConflict()
+  await clickButton('Load latest version')
+  expect(container.querySelector<HTMLTextAreaElement>('[aria-label="Skill body"]')!.value).toBe(
+    'Newer body'
+  )
+  expect(container.textContent).toContain('new.csv')
+  await clickButton('Save')
+  expect(updateSkill).toHaveBeenLastCalledWith(
+    expect.objectContaining({
+      etag: 'latest-version',
+      body: 'Newer body',
+      references: [{ path: 'new.csv', dataBase64: undefined }]
+    })
+  )
+})
+
+it('requires review again when the resource changes after the overwrite review', async () => {
+  const { getSkillDetail, updateSkill, onDone } = await mountConflict()
+  updateSkill.mockRejectedValueOnce(conflictError)
+  getSkillDetail.mockResolvedValueOnce({ ...latest, etag: 'third-version', body: 'Changed again' })
+  await clickButton('Overwrite with my draft')
+  expect(document.querySelector('[role=dialog]')?.textContent).toContain('Changed again')
+  expect(onDone).not.toHaveBeenCalled()
+  await clickButton('Overwrite with my draft')
+  expect(updateSkill).toHaveBeenLastCalledWith(
+    expect.objectContaining({ etag: 'third-version', body: 'My draft' })
+  )
+  expect(onDone).toHaveBeenCalledOnce()
+})
+
+it('retains the draft when loading the latest version fails and permits another save attempt', async () => {
+  const getSkillDetail = vi
+    .fn()
+    .mockResolvedValueOnce(detail)
+    .mockRejectedValueOnce(new Error('read failed'))
+    .mockResolvedValue(latest)
+  useSettingsStore.setState({ updateSkill: vi.fn().mockRejectedValue(conflictError) })
+  ;(window as unknown as { api: unknown }).api = { settings: { getSkillDetail } }
+  await act(async () => {
+    root.render(<SkillEditLoader skillId={detail.id} onDone={vi.fn()} />)
+  })
+  await editBody('My draft')
+  await clickButton('Save')
+  expect(container.querySelector<HTMLTextAreaElement>('[aria-label="Skill body"]')!.value).toBe(
+    'My draft'
+  )
+  expect(container.querySelector('[role=alert]')?.textContent).toContain('read failed')
+  await clickButton('Save')
+  expect(document.querySelector('[role=dialog]')?.textContent).toContain('Newer body')
+})
+
+it('does not let the editor fall back to an unconditional save when detail has no etag', async () => {
+  const updateSkill = vi.fn()
+  useSettingsStore.setState({ updateSkill })
+  ;(window as unknown as { api: unknown }).api = {
+    settings: { getSkillDetail: vi.fn().mockResolvedValue({ ...detail, etag: undefined }) }
+  }
+  await act(async () => {
+    root.render(<SkillEditLoader skillId={detail.id} onDone={vi.fn()} />)
+  })
+  expect(container.textContent).toContain('Open Science could not load this Skill.')
+  expect(updateSkill).not.toHaveBeenCalled()
 })

--- a/src/renderer/src/pages/settings/SkillEditor.tsx
+++ b/src/renderer/src/pages/settings/SkillEditor.tsx
@@ -15,6 +15,7 @@ import { parseSkillDocument } from '../../../../shared/skill-frontmatter'
 import { ErrorNotice } from '@/components/error-notice'
 import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { Button } from '@/components/ui/button'
+import { isSafeSkillReferenceName } from '../../../../shared/skill-reference-name'
 import { Input } from '@/components/ui/input'
 import { Textarea } from '@/components/ui/textarea'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
@@ -24,6 +25,7 @@ import { SettingsIconAction, SettingsLoadNotice } from './SettingsLayout'
 type SkillEditorReference = SkillReference & { sizeBytes?: number }
 
 export type SkillDraft = {
+  compatibility?: string
   id?: string
   name: string
   description: string
@@ -349,6 +351,10 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
     if (addingReferences || files.length === 0) return
 
     setReferenceError(null)
+    if (files.some((file) => !isSafeSkillReferenceName(file.name))) {
+      setReferenceError(t('Use a safe filename without path separators or reserved characters.'))
+      return
+    }
     const selected = new Map<string, File>()
     for (const file of files) selected.set(file.name, file)
     const retained = references.filter((reference) => !selected.has(reference.path))
@@ -413,6 +419,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
     try {
       await onSave({
         id: initial.id,
+        compatibility: initial.compatibility,
         name: currentName,
         description: description.trim(),
         body: persistedBody,
@@ -421,7 +428,13 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
       })
     } catch (error) {
       setSaveError(
-        error instanceof Error && error.message ? error.message : t('Unable to save this skill.')
+        error instanceof Error && error.message.includes('This Skill changed.')
+          ? t(
+              'This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.'
+            )
+          : error instanceof Error && error.message
+            ? error.message
+            : t('Unable to save this skill.')
       )
     } finally {
       setSaving(false)
@@ -727,6 +740,7 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
           if (loadRequestRef.current !== requestId) return
           setDraft({
             id: detail.id,
+            compatibility: detail.compatibility,
             name: detail.name,
             description: detail.description,
             body: detail.body,
@@ -795,6 +809,7 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
       onSave={async (next) => {
         await updateSkill({
           id: next.id ?? skillId,
+          expectedCompatibility: next.compatibility ?? '',
           description: next.description,
           body: next.body,
           metadata: next.metadata,

--- a/src/renderer/src/pages/settings/SkillEditor.tsx
+++ b/src/renderer/src/pages/settings/SkillEditor.tsx
@@ -1,11 +1,15 @@
 /* Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V4 */
 import type { TFunction } from 'i18next'
 import { AlertTriangle, ChevronDown, FileUp, Upload, X } from 'lucide-react'
-import { RadioGroup } from 'radix-ui'
+import { Dialog, RadioGroup } from 'radix-ui'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
-import type { SkillPackageFileInfo, SkillReference } from '../../../../shared/settings'
+import type {
+  SkillDetailView,
+  SkillPackageFileInfo,
+  SkillReference
+} from '../../../../shared/settings'
 import { serializePersonalSkillDocument } from '../../../../shared/personal-skill-document'
 import {
   isSkillPackageBudgetedPath,
@@ -17,6 +21,15 @@ import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { Button } from '@/components/ui/button'
 import { isSafeSkillReferenceName } from '../../../../shared/skill-reference-name'
 import { Input } from '@/components/ui/input'
+import {
+  dialogBodyClassName,
+  dialogDescriptionClassName,
+  dialogFooterClassName,
+  dialogHeaderClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
 import { Textarea } from '@/components/ui/textarea'
 import { useFileDropZone } from '@/hooks/useFileDropZone'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -25,7 +38,7 @@ import { SettingsIconAction, SettingsLoadNotice } from './SettingsLayout'
 type SkillEditorReference = SkillReference & { sizeBytes?: number }
 
 export type SkillDraft = {
-  compatibility?: string
+  etag?: string
   id?: string
   name: string
   description: string
@@ -419,7 +432,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
     try {
       await onSave({
         id: initial.id,
-        compatibility: initial.compatibility,
+        etag: initial.etag,
         name: currentName,
         description: description.trim(),
         body: persistedBody,
@@ -428,13 +441,7 @@ const SkillEditor = ({ initial, onCancel, onSave }: SkillEditorProps): React.JSX
       })
     } catch (error) {
       setSaveError(
-        error instanceof Error && error.message.includes('This Skill changed.')
-          ? t(
-              'This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.'
-            )
-          : error instanceof Error && error.message
-            ? error.message
-            : t('Unable to save this skill.')
+        error instanceof Error && error.message ? error.message : t('Unable to save this skill.')
       )
     } finally {
       setSaving(false)
@@ -725,11 +732,28 @@ type SkillEditLoaderProps = {
   onDone: () => void
 }
 
+const toSkillDraft = (detail: SkillDetailView): SkillDraft => ({
+  id: detail.id,
+  etag: detail.etag,
+  name: detail.name,
+  description: detail.description,
+  body: detail.body,
+  metadata: detail.metadata,
+  references: detail.references.map((reference) => ({
+    path: reference.path,
+    sizeBytes: reference.sizeBytes
+  })),
+  packageFiles: detail.packageFiles
+})
+
 // Loads an existing personal skill's content, then renders the editor pre-filled.
 const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.Element => {
   const { t } = useTranslation()
   const updateSkill = useSettingsStore((state) => state.updateSkill)
   const [draft, setDraft] = useState<SkillDraft | null>(null)
+  const [conflict, setConflict] = useState<{ draft: SkillDraft; latest: SkillDraft } | null>(null)
+  const [resolving, setResolving] = useState(false)
+  const [conflictError, setConflictError] = useState<string | null>(null)
   const [loadState, setLoadState] = useState<'loading' | 'ready' | 'error' | 'not-found'>('loading')
   const loadRequestRef = useRef(0)
 
@@ -738,19 +762,11 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
       void window.api.settings.getSkillDetail(skillId).then(
         (detail) => {
           if (loadRequestRef.current !== requestId) return
-          setDraft({
-            id: detail.id,
-            compatibility: detail.compatibility,
-            name: detail.name,
-            description: detail.description,
-            body: detail.body,
-            metadata: detail.metadata,
-            references: detail.references.map((ref) => ({
-              path: ref.path,
-              sizeBytes: ref.sizeBytes
-            })),
-            packageFiles: detail.packageFiles
-          })
+          if (!detail.etag) {
+            setLoadState('error')
+            return
+          }
+          setDraft(toSkillDraft(detail))
           setLoadState('ready')
         },
         (error) => {
@@ -802,22 +818,134 @@ const SkillEditLoader = ({ skillId, onDone }: SkillEditLoaderProps): React.JSX.E
     )
   }
 
+  const saveDraft = async (next: SkillDraft): Promise<void> => {
+    // Optional API preconditions preserve old clients; the editor never performs a blind write.
+    if (!next.etag) throw new Error(t('Open Science could not load this Skill.'))
+    try {
+      await updateSkill({
+        id: next.id ?? skillId,
+        etag: next.etag,
+        description: next.description,
+        body: next.body,
+        metadata: next.metadata,
+        references: next.references
+      })
+    } catch (error) {
+      if (!(error instanceof Error) || !error.message.includes('This Skill changed.')) throw error
+      const detail = await window.api.settings.getSkillDetail(skillId)
+      if (!detail.etag) throw new Error(t('Open Science could not load this Skill.'))
+      setConflict({ draft: next, latest: toSkillDraft(detail) })
+      setConflictError(null)
+      return
+    }
+    setConflict(null)
+    onDone()
+  }
+
+  const overwrite = async (): Promise<void> => {
+    if (!conflict || resolving) return
+    setResolving(true)
+    setConflictError(null)
+    try {
+      // Recheck the version that was reviewed; a later change needs another explicit decision.
+      await saveDraft({ ...conflict.draft, etag: conflict.latest.etag })
+    } catch (error) {
+      setConflictError(error instanceof Error ? error.message : t('Unable to save this skill.'))
+    } finally {
+      setResolving(false)
+    }
+  }
+
   return (
-    <SkillEditor
-      initial={draft}
-      onCancel={onDone}
-      onSave={async (next) => {
-        await updateSkill({
-          id: next.id ?? skillId,
-          expectedCompatibility: next.compatibility ?? '',
-          description: next.description,
-          body: next.body,
-          metadata: next.metadata,
-          references: next.references
-        })
-        onDone()
-      }}
-    />
+    <>
+      <SkillEditor key={draft.etag} initial={draft} onCancel={onDone} onSave={saveDraft} />
+      <Dialog.Root
+        open={conflict !== null}
+        onOpenChange={(open) => {
+          if (!open && !resolving) setConflict(null)
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className={dialogOverlayClassName} />
+          <Dialog.Content
+            className={dialogPanelClassName(
+              'flex max-h-[85vh] w-[min(900px,calc(100vw-2rem))] flex-col p-0'
+            )}
+            onEscapeKeyDown={(event) => {
+              if (resolving) event.preventDefault()
+            }}
+            onInteractOutside={(event) => event.preventDefault()}
+          >
+            <div className={dialogHeaderClassName}>
+              <div>
+                <Dialog.Title className={dialogTitleClassName}>
+                  {t('Review Skill changes')}
+                </Dialog.Title>
+                <Dialog.Description className={dialogDescriptionClassName}>
+                  {t('This Skill changed while you were editing. Your draft is preserved.')}
+                </Dialog.Description>
+              </div>
+            </div>
+            {conflict ? (
+              <div className={`${dialogBodyClassName} min-h-0 overflow-y-auto`}>
+                <div className="grid gap-4 md:grid-cols-2">
+                  {[
+                    { label: t('Your draft'), value: conflict.draft },
+                    { label: t('Latest version'), value: conflict.latest }
+                  ].map(({ label, value }) => (
+                    <section
+                      key={label}
+                      aria-label={label}
+                      className="min-w-0 rounded-lg border border-border p-3"
+                    >
+                      <h3 className="mb-3 text-sm font-medium">{label}</h3>
+                      <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words text-xs">
+                        {serializePersonalSkillDocument(value)}
+                      </pre>
+                      <h4 className="mb-1 mt-4 text-sm font-medium">{t('References')}</h4>
+                      {value.references?.length ? (
+                        <ul className="space-y-1 break-all font-mono text-xs">
+                          {value.references.map((reference) => (
+                            <li key={reference.path}>{reference.path}</li>
+                          ))}
+                        </ul>
+                      ) : (
+                        <p className="text-xs text-muted-foreground">{t('No reference files')}</p>
+                      )}
+                    </section>
+                  ))}
+                </div>
+                <p className="mt-4 text-sm text-muted-foreground">
+                  {t(
+                    'Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.'
+                  )}
+                </p>
+                {conflictError ? <SkillEditorAlert message={conflictError} /> : null}
+              </div>
+            ) : null}
+            <div className={`${dialogFooterClassName} flex-wrap`}>
+              <Button variant="ghost" disabled={resolving} onClick={() => setConflict(null)}>
+                {t('Keep editing')}
+              </Button>
+              <Button
+                variant="outline"
+                disabled={resolving}
+                onClick={() => {
+                  if (!conflict) return
+                  setDraft(conflict.latest)
+                  setConflict(null)
+                }}
+              >
+                {t('Load latest version')}
+              </Button>
+              <Button disabled={resolving} onClick={() => void overwrite()}>
+                {resolving ? t('Saving…') : t('Overwrite with my draft')}
+              </Button>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </>
   )
 }
 

--- a/src/renderer/src/pages/settings/SkillImportView.tsx
+++ b/src/renderer/src/pages/settings/SkillImportView.tsx
@@ -460,9 +460,9 @@ const SkillImportView = ({
                         {skill.path}
                       </span>
                     </span>
-                    {skill.alreadyImported ? (
+                    {skill.alreadyImported || skill.installedId ? (
                       <span className="shrink-0 rounded-full bg-muted px-2 py-0.5 text-xs text-muted-foreground">
-                        {t('Imported')}
+                        {skill.alreadyImported ? t('Imported') : t('Update available')}
                       </span>
                     ) : null}
                   </button>

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -409,7 +409,7 @@ describe('SkillUploadView (batch upload)', () => {
   })
 })
 
-describe('SK08 same-named upload selection regressions', () => {
+describe('same-named upload selection regressions', () => {
   it.each(['zip', 'md'])(
     'submits exactly one selected %s file when names collide',
     async (extension) => {

--- a/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.render.test.tsx
@@ -408,3 +408,66 @@ describe('SkillUploadView (batch upload)', () => {
     )
   })
 })
+
+describe('SK08 same-named upload selection regressions', () => {
+  it.each(['zip', 'md'])(
+    'submits exactly one selected %s file when names collide',
+    async (extension) => {
+      const alphaBase64 = btoa('alpha zip')
+      useSettingsStore.setState({
+        previewSkillZip: vi.fn().mockImplementation(async (base64: string) => ({
+          previews: [
+            {
+              subPath: 'demo',
+              name: base64 === alphaBase64 ? 'alpha' : 'beta',
+              description: '',
+              metadata: {},
+              body: base64,
+              files: ['SKILL.md'],
+              alreadyImported: false
+            }
+          ],
+          skipped: []
+        })),
+        importSkillZipBatch: vi.fn().mockResolvedValue({
+          results: [{ subPath: 'demo', status: 'imported', id: 'imported-demo' }],
+          skills: []
+        })
+      })
+      act(() => root.render(<SkillUploadView onUploaded={vi.fn()} onWriteInstead={vi.fn()} />))
+      await dropFiles(
+        ['alpha', 'beta'].map(
+          (name) =>
+            new File(
+              [extension === 'zip' ? `${name} zip` : `---\nname: ${name}\n---\n${name} body`],
+              `pack.${extension}`,
+              { type: extension === 'zip' ? 'application/zip' : 'text/markdown' }
+            )
+        )
+      )
+      const alpha = document.body.querySelector<HTMLInputElement>('[aria-label="Select alpha"]')
+      const beta = document.body.querySelector<HTMLInputElement>('[aria-label="Select beta"]')
+      expect(alpha).not.toBeNull()
+      expect(beta).not.toBeNull()
+      expect(alpha!.checked).toBe(false)
+      expect(beta!.checked).toBe(false)
+      act(() => alpha!.click())
+      expect.soft(beta!.checked).toBe(false)
+      expect(document.body.textContent).toContain('Import selected (1)')
+      clickButton('Import selected')
+      await flush()
+      const state = useSettingsStore.getState()
+      if (extension === 'zip') {
+        expect.soft(state.importSkillZipBatch).toHaveBeenCalledTimes(1)
+        expect(state.importSkillZipBatch).toHaveBeenCalledWith(alphaBase64, [
+          { subPath: 'demo', replaceId: undefined }
+        ])
+      } else {
+        expect.soft(state.createSkill).toHaveBeenCalledTimes(1)
+        expect(state.createSkill).toHaveBeenCalledWith(
+          expect.objectContaining({ name: 'alpha', body: 'alpha body' })
+        )
+      }
+    }
+  )
+})

--- a/src/renderer/src/pages/settings/SkillUploadView.tsx
+++ b/src/renderer/src/pages/settings/SkillUploadView.tsx
@@ -146,6 +146,7 @@ const SkillUploadView = ({
 
   // Parses one picked file into its candidates, capturing a per-file error instead of throwing.
   const parseFile = async (file: File): Promise<ParseResult> => {
+    const sourceId = crypto.randomUUID()
     const name = file.name.toLowerCase()
     const isBundle = name.endsWith('.zip') || name.endsWith('.skill')
 
@@ -185,7 +186,7 @@ const SkillUploadView = ({
         return {
           candidates: previews.map((preview) => ({
             kind: 'bundle',
-            key: `${file.name}::${preview.subPath}`,
+            key: `${sourceId}::${preview.subPath}`,
             fileName: file.name,
             base64,
             subPath: preview.subPath,
@@ -228,7 +229,7 @@ const SkillUploadView = ({
         candidates: [
           {
             kind: 'markdown',
-            key: file.name,
+            key: sourceId,
             fileName: file.name,
             name: parsed.name,
             description: parsed.description ?? '',

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -899,7 +899,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
-          compatibility: 'version',
+          etag: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -933,7 +933,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      expectedCompatibility: 'version',
+      etag: 'version',
       description: 'Custom',
       body: '# Body',
       metadata: { author: 'Ada', license: 'MIT', category: 'research' },
@@ -946,7 +946,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
-          compatibility: 'version',
+          etag: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -989,7 +989,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      expectedCompatibility: 'version',
+      etag: 'version',
       description: 'Custom',
       body: '# New body',
       metadata: { author: 'Grace', tags: 'analysis, writing' },
@@ -1002,7 +1002,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
-          compatibility: 'version',
+          etag: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1032,7 +1032,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      expectedCompatibility: 'version',
+      etag: 'version',
       description: 'Custom',
       body: '# New body',
       metadata: { author: 'Ada', license: 'MIT' },
@@ -1045,7 +1045,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
-          compatibility: 'version',
+          etag: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1082,7 +1082,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
-      expectedCompatibility: 'version',
+      etag: 'version',
       description: 'Custom',
       body: '# Plain replacement',
       metadata: { author: 'Old author', license: 'MIT' },
@@ -1095,7 +1095,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
-          compatibility: 'version',
+          etag: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1385,7 +1385,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
-          compatibility: 'version',
+          etag: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1428,6 +1428,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-budgeted',
+          etag: 'version',
           name: 'budgeted',
           description: 'Custom',
           source: 'personal',

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -2359,7 +2359,7 @@ describe('SkillsPanel (sub-views)', () => {
   })
 })
 
-it('SK07 distinguishes a selected update from an already installed revision', async () => {
+it('distinguishes a selected update from an already installed revision', async () => {
   useSettingsStore.setState({
     scanRepoSkills: vi.fn().mockResolvedValue({
       skills: [

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -899,6 +899,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
+          compatibility: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -932,6 +933,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
+      expectedCompatibility: 'version',
       description: 'Custom',
       body: '# Body',
       metadata: { author: 'Ada', license: 'MIT', category: 'research' },
@@ -944,6 +946,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
+          compatibility: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -986,6 +989,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
+      expectedCompatibility: 'version',
       description: 'Custom',
       body: '# New body',
       metadata: { author: 'Grace', tags: 'analysis, writing' },
@@ -998,6 +1002,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
+          compatibility: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1027,6 +1032,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
+      expectedCompatibility: 'version',
       description: 'Custom',
       body: '# New body',
       metadata: { author: 'Ada', license: 'MIT' },
@@ -1039,6 +1045,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
+          compatibility: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1075,6 +1082,7 @@ describe('SkillsPanel (sub-views)', () => {
 
     expect(useSettingsStore.getState().updateSkill).toHaveBeenCalledWith({
       id: 'personal-mine',
+      expectedCompatibility: 'version',
       description: 'Custom',
       body: '# Plain replacement',
       metadata: { author: 'Old author', license: 'MIT' },
@@ -1087,6 +1095,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
+          compatibility: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -1376,6 +1385,7 @@ describe('SkillsPanel (sub-views)', () => {
       settings: {
         getSkillDetail: vi.fn().mockResolvedValue({
           id: 'personal-mine',
+          compatibility: 'version',
           name: 'Mine',
           description: 'Custom',
           source: 'personal',
@@ -2347,4 +2357,42 @@ describe('SkillsPanel (sub-views)', () => {
     expect(document.body.textContent).toContain('Name exists')
     expect(useSettingsStore.getState().createSkill).not.toHaveBeenCalled()
   })
+})
+
+it('SK07 distinguishes a selected update from an already installed revision', async () => {
+  useSettingsStore.setState({
+    scanRepoSkills: vi.fn().mockResolvedValue({
+      skills: [
+        {
+          name: 'update-me',
+          path: 'update-me',
+          url: 'https://github.com/acme/skills/tree/pinned/update-me',
+          installedId: 'imported-update-me',
+          alreadyImported: false
+        },
+        {
+          name: 'current',
+          path: 'current',
+          url: 'https://github.com/acme/skills/tree/pinned/current',
+          installedId: 'imported-current',
+          alreadyImported: true
+        }
+      ]
+    })
+  })
+  act(() => root.render(<SkillsPanel view={{ kind: 'import' }} onNavigate={vi.fn()} />))
+  setValue('GitHub keyword or repository', 'acme/skills')
+  await act(async () => {
+    Array.from(document.body.querySelectorAll<HTMLButtonElement>('button'))
+      .find((button) => button.textContent?.trim() === 'Find skills')!
+      .click()
+  })
+  expect(document.body.textContent).toContain('Update available')
+  expect(
+    document.body.querySelector<HTMLInputElement>('[aria-label="Select update-me"]')?.checked
+  ).toBe(true)
+  expect(
+    document.body.querySelector<HTMLInputElement>('[aria-label="Select current"]')?.checked
+  ).toBe(false)
+  expect(document.body.textContent).toContain('Import selected (1)')
 })

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -249,7 +249,7 @@ describe('settings Skills slice', () => {
     [
       'updateSkill',
       'updateSkill',
-      { id: 'target', name: 'Updated', expectedCompatibility: 'version', description: '', body: '' }
+      { id: 'target', name: 'Updated', etag: 'version', description: '', body: '' }
     ],
     ['deleteSkill', 'deleteSkill', 'target']
   ] as const)('reconciles the catalog after %s', async (_label, actionName, input) => {

--- a/src/renderer/src/stores/settings-skills-slice.test.ts
+++ b/src/renderer/src/stores/settings-skills-slice.test.ts
@@ -246,7 +246,11 @@ describe('settings Skills slice', () => {
 
   it.each([
     ['createSkill', 'createSkill', { name: 'New', description: '', body: '' }],
-    ['updateSkill', 'updateSkill', { id: 'target', name: 'Updated', description: '', body: '' }],
+    [
+      'updateSkill',
+      'updateSkill',
+      { id: 'target', name: 'Updated', expectedCompatibility: 'version', description: '', body: '' }
+    ],
     ['deleteSkill', 'deleteSkill', 'target']
   ] as const)('reconciles the catalog after %s', async (_label, actionName, input) => {
     const commandName = actionName as 'createSkill' | 'updateSkill' | 'deleteSkill'

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1248,7 +1248,7 @@ describe('settings store: refreshProviderModels', () => {
 
     await useSettingsStore.getState().updateSkill({
       id: created.id,
-      expectedCompatibility: 'version',
+      etag: 'version',
       description: '',
       body: '# Demo'
     })

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -1246,9 +1246,12 @@ describe('settings store: refreshProviderModels', () => {
     await useSettingsStore.getState().createSkill({ name: 'Demo', description: '', body: '# Demo' })
     expect(useSettingsStore.getState().skills).toEqual([created])
 
-    await useSettingsStore
-      .getState()
-      .updateSkill({ id: created.id, description: '', body: '# Demo' })
+    await useSettingsStore.getState().updateSkill({
+      id: created.id,
+      expectedCompatibility: 'version',
+      description: '',
+      body: '# Demo'
+    })
     expect(useSettingsStore.getState().skills).toEqual([updated])
 
     await useSettingsStore.getState().deleteSkill(created.id)

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4252,6 +4252,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "Löscht den Speicher des Kernels der ausgewählten Sprache. Andere Kernel bleiben unverändert.",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "Die Änderungen an den Zugangsdaten wurden gespeichert, aber die Konnektoren konnten nicht aktualisiert werden. Versuchen Sie es unter Einstellungen > Konnektoren erneut.",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Ein Argument pro Zeile. Leerzeichen und Leerzeilen bleiben erhalten. Leeren Sie das Feld, um alle Argumente zu entfernen.",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Die gespeicherten Argumente enthalten interne Zeilenumbrüche. Beim Bearbeiten dieses Felds wird die Liste mit einem Argument pro Zeile ersetzt."
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Die gespeicherten Argumente enthalten interne Zeilenumbrüche. Beim Bearbeiten dieses Felds wird die Liste mit einem Argument pro Zeile ersetzt.",
+    "Use a safe filename without path separators or reserved characters.": "Verwenden Sie einen sicheren Dateinamen ohne Pfadtrennzeichen oder reservierte Zeichen.",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Diese Fähigkeit wurde geändert. Ihr Entwurf bleibt erhalten. Öffnen Sie den Editor erneut, um vor dem Speichern die neueste Version zu laden."
   }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4254,6 +4254,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Ein Argument pro Zeile. Leerzeichen und Leerzeilen bleiben erhalten. Leeren Sie das Feld, um alle Argumente zu entfernen.",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Die gespeicherten Argumente enthalten interne Zeilenumbrüche. Beim Bearbeiten dieses Felds wird die Liste mit einem Argument pro Zeile ersetzt.",
     "Use a safe filename without path separators or reserved characters.": "Verwenden Sie einen sicheren Dateinamen ohne Pfadtrennzeichen oder reservierte Zeichen.",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Diese Fähigkeit wurde geändert. Ihr Entwurf bleibt erhalten. Öffnen Sie den Editor erneut, um vor dem Speichern die neueste Version zu laden."
+    "Review Skill changes": "Änderungen an der Fähigkeit prüfen",
+    "This Skill changed while you were editing. Your draft is preserved.": "Diese Fähigkeit wurde während Ihrer Bearbeitung geändert. Ihr Entwurf bleibt erhalten.",
+    "Your draft": "Ihr Entwurf",
+    "Latest version": "Neueste Version",
+    "No reference files": "Keine Referenzdateien",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "Beim Laden der neuesten Version wird Ihr Entwurf verworfen. Beim Überschreiben werden die bearbeitbaren Inhalte ersetzt und Referenzdateien gelöscht, die in Ihrem Entwurf fehlen.",
+    "Keep editing": "Weiter bearbeiten",
+    "Load latest version": "Neueste Version laden",
+    "Overwrite with my draft": "Mit meinem Entwurf überschreiben"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4409,6 +4409,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Un argumento por línea. Se conservan los espacios y las líneas vacías. Vacíe el campo para eliminar todos los argumentos.",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Los argumentos guardados contienen saltos de línea internos. Al editar este campo, se sustituye la lista con un argumento por línea.",
     "Use a safe filename without path separators or reserved characters.": "Utilice un nombre de archivo seguro sin separadores de ruta ni caracteres reservados.",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Esta Habilidad ha cambiado. Su borrador se conserva. Vuelva a abrir el editor para cargar la versión más reciente antes de guardar."
+    "Review Skill changes": "Revisar los cambios de la habilidad",
+    "This Skill changed while you were editing. Your draft is preserved.": "Esta habilidad cambió durante la edición. Su borrador se conserva.",
+    "Your draft": "Su borrador",
+    "Latest version": "Última versión",
+    "No reference files": "Sin archivos de referencia",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "Cargar la última versión descarta su borrador. Sobrescribir reemplaza el contenido editable y elimina los archivos de referencia que no estén en su borrador.",
+    "Keep editing": "Continuar editando",
+    "Load latest version": "Cargar la última versión",
+    "Overwrite with my draft": "Sobrescribir con mi borrador"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4407,6 +4407,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "Borra la memoria del kernel del lenguaje seleccionado. Los demás kernels no se ven afectados.",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "Se guardaron los cambios de credenciales, pero no se pudieron actualizar los Conectores. Vuelva a intentarlo desde Configuración > Conectores.",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Un argumento por línea. Se conservan los espacios y las líneas vacías. Vacíe el campo para eliminar todos los argumentos.",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Los argumentos guardados contienen saltos de línea internos. Al editar este campo, se sustituye la lista con un argumento por línea."
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Los argumentos guardados contienen saltos de línea internos. Al editar este campo, se sustituye la lista con un argumento por línea.",
+    "Use a safe filename without path separators or reserved characters.": "Utilice un nombre de archivo seguro sin separadores de ruta ni caracteres reservados.",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Esta Habilidad ha cambiado. Su borrador se conserva. Vuelva a abrir el editor para cargar la versión más reciente antes de guardar."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4407,6 +4407,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "Efface la mémoire du noyau du langage sélectionné. Les autres noyaux ne sont pas affectés.",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "Les modifications des identifiants ont été enregistrées, mais les Connecteurs n’ont pas pu être actualisés. Réessayez depuis Paramètres > Connecteurs.",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Un argument par ligne. Les espaces et les lignes vides sont conservés. Videz le champ pour supprimer tous les arguments.",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Les arguments enregistrés contiennent des sauts de ligne internes. Modifier ce champ remplace la liste avec un argument par ligne."
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Les arguments enregistrés contiennent des sauts de ligne internes. Modifier ce champ remplace la liste avec un argument par ligne.",
+    "Use a safe filename without path separators or reserved characters.": "Utilisez un nom de fichier sûr, sans séparateurs de chemin ni caractères réservés.",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Cette Compétence a été modifiée. Votre brouillon est conservé. Rouvrez l’éditeur pour charger la dernière version avant d’enregistrer."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4409,6 +4409,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Un argument par ligne. Les espaces et les lignes vides sont conservés. Videz le champ pour supprimer tous les arguments.",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Les arguments enregistrés contiennent des sauts de ligne internes. Modifier ce champ remplace la liste avec un argument par ligne.",
     "Use a safe filename without path separators or reserved characters.": "Utilisez un nom de fichier sûr, sans séparateurs de chemin ni caractères réservés.",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Cette Compétence a été modifiée. Votre brouillon est conservé. Rouvrez l’éditeur pour charger la dernière version avant d’enregistrer."
+    "Review Skill changes": "Examiner les modifications de la compétence",
+    "This Skill changed while you were editing. Your draft is preserved.": "Cette compétence a été modifiée pendant votre édition. Votre brouillon est conservé.",
+    "Your draft": "Votre brouillon",
+    "Latest version": "Dernière version",
+    "No reference files": "Aucun fichier de référence",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "Charger la dernière version supprime votre brouillon. Écraser remplace le contenu modifiable et supprime les fichiers de référence absents de votre brouillon.",
+    "Keep editing": "Continuer la modification",
+    "Load latest version": "Charger la dernière version",
+    "Overwrite with my draft": "Écraser avec mon brouillon"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4097,6 +4097,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "選択した言語のカーネルのメモリを消去します。他のカーネルには影響しません。",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "認証情報の変更は保存されましたが、コネクタを更新できませんでした。設定 > コネクタから再試行してください。",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "1 行に 1 つの引数を入力します。空白と空行は保持されます。欄を空にすると、すべての引数が削除されます。",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "保存済みの引数には引数内の改行が含まれています。この欄を編集すると、1 行に 1 つの引数としてリスト全体が置き換えられます。"
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "保存済みの引数には引数内の改行が含まれています。この欄を編集すると、1 行に 1 つの引数としてリスト全体が置き換えられます。",
+    "Use a safe filename without path separators or reserved characters.": "パス区切り文字や予約文字を含まない安全なファイル名を使用してください。",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "このスキルは変更されました。下書きは保持されています。保存する前にエディターを開き直して最新バージョンを読み込んでください。"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4099,6 +4099,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "1 行に 1 つの引数を入力します。空白と空行は保持されます。欄を空にすると、すべての引数が削除されます。",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "保存済みの引数には引数内の改行が含まれています。この欄を編集すると、1 行に 1 つの引数としてリスト全体が置き換えられます。",
     "Use a safe filename without path separators or reserved characters.": "パス区切り文字や予約文字を含まない安全なファイル名を使用してください。",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "このスキルは変更されました。下書きは保持されています。保存する前にエディターを開き直して最新バージョンを読み込んでください。"
+    "Review Skill changes": "スキルの変更を確認",
+    "This Skill changed while you were editing. Your draft is preserved.": "編集中にこのスキルが変更されました。下書きは保持されています。",
+    "Your draft": "下書き",
+    "Latest version": "最新バージョン",
+    "No reference files": "参照ファイルはありません",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "最新バージョンを読み込むと下書きは破棄されます。上書きすると編集可能な内容が置き換わり、下書きにない参照ファイルは削除されます。",
+    "Keep editing": "編集を続ける",
+    "Load latest version": "最新バージョンを読み込む",
+    "Overwrite with my draft": "下書きで上書き"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4097,6 +4097,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "한 줄에 인수 하나를 입력합니다. 공백과 빈 줄은 유지됩니다. 입력란을 비우면 모든 인수가 제거됩니다.",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "저장된 인수 내부에 줄 바꿈이 포함되어 있습니다. 이 입력란을 편집하면 한 줄에 인수 하나씩 전체 목록이 교체됩니다.",
     "Use a safe filename without path separators or reserved characters.": "경로 구분자나 예약 문자가 없는 안전한 파일 이름을 사용하세요.",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "이 스킬이 변경되었습니다. 초안은 유지됩니다. 저장하기 전에 편집기를 다시 열어 최신 버전을 불러오세요."
+    "Review Skill changes": "스킬 변경 사항 검토",
+    "This Skill changed while you were editing. Your draft is preserved.": "편집하는 동안 이 스킬이 변경되었습니다. 초안은 유지됩니다.",
+    "Your draft": "내 초안",
+    "Latest version": "최신 버전",
+    "No reference files": "참조 파일 없음",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "최신 버전을 불러오면 초안이 삭제됩니다. 덮어쓰면 편집 가능한 내용이 교체되고 초안에 없는 참조 파일이 삭제됩니다.",
+    "Keep editing": "계속 편집",
+    "Load latest version": "최신 버전 불러오기",
+    "Overwrite with my draft": "내 초안으로 덮어쓰기"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4095,6 +4095,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "선택한 언어 커널의 메모리를 지웁니다. 다른 커널에는 영향을 주지 않습니다.",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "자격 증명 변경 사항은 저장되었지만 커넥터를 새로 고치지 못했습니다. 설정 > 커넥터에서 다시 시도하세요.",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "한 줄에 인수 하나를 입력합니다. 공백과 빈 줄은 유지됩니다. 입력란을 비우면 모든 인수가 제거됩니다.",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "저장된 인수 내부에 줄 바꿈이 포함되어 있습니다. 이 입력란을 편집하면 한 줄에 인수 하나씩 전체 목록이 교체됩니다."
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "저장된 인수 내부에 줄 바꿈이 포함되어 있습니다. 이 입력란을 편집하면 한 줄에 인수 하나씩 전체 목록이 교체됩니다.",
+    "Use a safe filename without path separators or reserved characters.": "경로 구분자나 예약 문자가 없는 안전한 파일 이름을 사용하세요.",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "이 스킬이 변경되었습니다. 초안은 유지됩니다. 저장하기 전에 편집기를 다시 열어 최신 버전을 불러오세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4537,6 +4537,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "Очищает память ядра выбранного языка. Другие ядра не затрагиваются.",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "Изменения учётных данных сохранены, но обновить Коннекторы не удалось. Повторите попытку в разделе Настройки > Коннекторы.",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Один аргумент на строку. Пробелы и пустые строки сохраняются. Очистите поле, чтобы удалить все аргументы.",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Сохранённые аргументы содержат внутренние переводы строк. При редактировании этого поля список заменяется: каждая строка становится отдельным аргументом."
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Сохранённые аргументы содержат внутренние переводы строк. При редактировании этого поля список заменяется: каждая строка становится отдельным аргументом.",
+    "Use a safe filename without path separators or reserved characters.": "Используйте безопасное имя файла без разделителей пути и зарезервированных символов.",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Этот Навык изменён. Ваш черновик сохранён. Перед сохранением снова откройте редактор, чтобы загрузить последнюю версию."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4539,6 +4539,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "Один аргумент на строку. Пробелы и пустые строки сохраняются. Очистите поле, чтобы удалить все аргументы.",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "Сохранённые аргументы содержат внутренние переводы строк. При редактировании этого поля список заменяется: каждая строка становится отдельным аргументом.",
     "Use a safe filename without path separators or reserved characters.": "Используйте безопасное имя файла без разделителей пути и зарезервированных символов.",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "Этот Навык изменён. Ваш черновик сохранён. Перед сохранением снова откройте редактор, чтобы загрузить последнюю версию."
+    "Review Skill changes": "Проверить изменения навыка",
+    "This Skill changed while you were editing. Your draft is preserved.": "Этот навык был изменён во время редактирования. Ваш черновик сохранён.",
+    "Your draft": "Ваш черновик",
+    "Latest version": "Последняя версия",
+    "No reference files": "Нет справочных файлов",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "Загрузка последней версии удалит ваш черновик. Перезапись заменит редактируемое содержимое и удалит справочные файлы, которых нет в вашем черновике.",
+    "Keep editing": "Продолжить редактирование",
+    "Load latest version": "Загрузить последнюю версию",
+    "Overwrite with my draft": "Перезаписать моим черновиком"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4097,6 +4097,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "清空所选语言内核的内存，不影响其他内核。",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "凭据变更已保存，但连接器刷新失败。请前往设置 > 连接器重试。",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "每行一个参数。空格和空行会保留。清空输入框可移除所有参数。",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "已保存的参数内部含有换行。编辑此输入框将按每行一个参数替换整个列表。"
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "已保存的参数内部含有换行。编辑此输入框将按每行一个参数替换整个列表。",
+    "Use a safe filename without path separators or reserved characters.": "请使用不含路径分隔符或保留字符的安全文件名。",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "此技能已更改，您的草稿已保留。请重新打开编辑器，加载最新版本后再保存。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4099,6 +4099,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "每行一个参数。空格和空行会保留。清空输入框可移除所有参数。",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "已保存的参数内部含有换行。编辑此输入框将按每行一个参数替换整个列表。",
     "Use a safe filename without path separators or reserved characters.": "请使用不含路径分隔符或保留字符的安全文件名。",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "此技能已更改，您的草稿已保留。请重新打开编辑器，加载最新版本后再保存。"
+    "Review Skill changes": "查看技能更改",
+    "This Skill changed while you were editing. Your draft is preserved.": "此技能在您编辑时发生了更改。您的草稿已保留。",
+    "Your draft": "您的草稿",
+    "Latest version": "最新版本",
+    "No reference files": "没有参考文件",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "加载最新版本将丢弃您的草稿。覆盖将替换可编辑内容，并删除草稿中没有的参考文件。",
+    "Keep editing": "继续编辑",
+    "Load latest version": "加载最新版本",
+    "Overwrite with my draft": "用我的草稿覆盖"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4097,6 +4097,8 @@
     "Clears memory in the selected language kernel. Other kernels are unaffected.": "清空所選語言核心的記憶體，不影響其他核心。",
     "Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.": "憑證變更已儲存，但連接器重新整理失敗。請前往設定 > 連接器重試。",
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "每行一個參數。空格和空行會保留。清空輸入框可移除所有參數。",
-    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "已儲存的參數內部含有換行。編輯此輸入框將按每行一個參數取代整個清單。"
+    "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "已儲存的參數內部含有換行。編輯此輸入框將按每行一個參數取代整個清單。",
+    "Use a safe filename without path separators or reserved characters.": "請使用不含路徑分隔符號或保留字元的安全檔案名稱。",
+    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "此技能已變更，您的草稿已保留。請重新開啟編輯器，載入最新版本後再儲存。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4099,6 +4099,14 @@
     "One argument per line. Spaces and blank lines are preserved. Clear the field to remove all arguments.": "每行一個參數。空格和空行會保留。清空輸入框可移除所有參數。",
     "The saved arguments contain embedded line breaks. Editing this field replaces the list using one argument per line.": "已儲存的參數內部含有換行。編輯此輸入框將按每行一個參數取代整個清單。",
     "Use a safe filename without path separators or reserved characters.": "請使用不含路徑分隔符號或保留字元的安全檔案名稱。",
-    "This Skill changed. Your draft is preserved. Reopen the editor to load the latest version before saving.": "此技能已變更，您的草稿已保留。請重新開啟編輯器，載入最新版本後再儲存。"
+    "Review Skill changes": "檢視技能變更",
+    "This Skill changed while you were editing. Your draft is preserved.": "此技能在您編輯時發生了變更。您的草稿已保留。",
+    "Your draft": "您的草稿",
+    "Latest version": "最新版本",
+    "No reference files": "沒有參考檔案",
+    "Loading the latest version discards your draft. Overwriting replaces the editable content and removes reference files absent from your draft.": "載入最新版本將捨棄您的草稿。覆寫將取代可編輯內容，並刪除草稿中沒有的參考檔案。",
+    "Keep editing": "繼續編輯",
+    "Load latest version": "載入最新版本",
+    "Overwrite with my draft": "以我的草稿覆寫"
   }
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1124,6 +1124,8 @@ export type SkillView = {
 // A skill view plus its SKILL.md body (frontmatter stripped) and the names of any files under its
 // `references/` directory, for the detail/edit view.
 export type SkillDetailView = SkillView & {
+  // Read-time precondition for personal editor saves; not a stored revision counter.
+  compatibility?: string
   body: string
   metadata?: Record<string, string>
   references: SkillReferenceInfo[]
@@ -1191,6 +1193,7 @@ export type CreateSkillRequest = {
 // Update an existing personal skill through a staged package replacement.
 export type UpdateSkillRequest = {
   id: string
+  expectedCompatibility: string
   description: string
   body: string
   metadata?: Record<string, string>
@@ -1391,6 +1394,7 @@ export type ImportAgentHomeSkillsResult = {
 
 // One skill directory found by a repo scan, with an importable URL and whether it's already imported.
 export type ScannedSkillView = {
+  installedId?: string
   name: string
   path: string
   url: string

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1124,8 +1124,8 @@ export type SkillView = {
 // A skill view plus its SKILL.md body (frontmatter stripped) and the names of any files under its
 // `references/` directory, for the detail/edit view.
 export type SkillDetailView = SkillView & {
-  // Read-time precondition for personal editor saves; not a stored revision counter.
-  compatibility?: string
+  // Opaque read-time validator for conditional saves; not a stored revision counter.
+  etag?: string
   body: string
   metadata?: Record<string, string>
   references: SkillReferenceInfo[]
@@ -1193,7 +1193,8 @@ export type CreateSkillRequest = {
 // Update an existing personal skill through a staged package replacement.
 export type UpdateSkillRequest = {
   id: string
-  expectedCompatibility: string
+  // Omit for an unconditional update; supplied etags are checked before any write.
+  etag?: string
   description: string
   body: string
   metadata?: Record<string, string>

--- a/src/shared/skill-import-limits.ts
+++ b/src/shared/skill-import-limits.ts
@@ -1,9 +1,12 @@
 const APP_OWNED_ROOT_FILES = new Set(['.source.json', '.specialist-package.json'])
 
+export const isAppOwnedSkillRootFile = (relativePath: string): boolean =>
+  APP_OWNED_ROOT_FILES.has(relativePath.toLowerCase())
+
 // App-owned root metadata travels with a Skill package but is not part of the user-authored package
 // budget. Nested files with the same names remain ordinary package content.
 export const isSkillPackageBudgetedPath = (relativePath: string): boolean =>
-  !APP_OWNED_ROOT_FILES.has(relativePath)
+  !isAppOwnedSkillRootFile(relativePath)
 
 // Resource caps that bound a skill import from any source (a .zip/.skill bundle or a recursive
 // GitHub download). Without them a zip bomb or a very large repository could exhaust memory or freeze

--- a/src/shared/skill-reference-name.ts
+++ b/src/shared/skill-reference-name.ts
@@ -1,0 +1,8 @@
+// References edited by the form are portable basenames, never paths. Keep Unicode and spaces
+// intact while rejecting Windows aliases/separators even when the current OS would accept them.
+export const isSafeSkillReferenceName = (name: string): boolean =>
+  name.length > 0 &&
+  !/[<>:"/\\|?*]/.test(name) &&
+  !Array.from(name).some((character) => character.charCodeAt(0) < 32) &&
+  !/[. ]$/.test(name) &&
+  !/^(con|prn|aux|nul|com[1-9¹²³]|lpt[1-9¹²³])(?:\.|$)/i.test(name)


### PR DESCRIPTION
## Problem

SK01–SK08 reproduce data loss on ordinary Skill edits, untrusted installation identity, ineffective reimport repairs, false runtime-sync success, stale executable permissions, duplicate GitHub updates, and coupled selection of same-named uploads.

## Proposed change

| Report | Trigger and consequence | Minimum correction |
| --- | --- | --- |
| SK01 | Saving Chinese/space attachment names silently drops new files or deletes existing references. | Share portable basename validation; preserve supported names and reject unsafe new input before live mutation. Already-existing regular-file basenames from historical/published POSIX packages can be retained without replacement bytes, including CON.csv and trailing.; explicit removal still works. |
| SK02 | A damaged imported copy retains its historical source signature, so reimport cannot repair it. | Compare the actual installed inventory/normalized content before returning unchanged; repair Agent Home, ZIP and GitHub copies under the existing ID. |
| SK03 | Wrapped ordinary imports can install Specialist metadata and make existing IDs unavailable. | Reject app-owned metadata at the resolved Skill root on ordinary ingress; preserve legitimate historical installation metadata. |
| SK04 | Removing a disabled app-owned runtime Skill fails but sync reports success. | Propagate deletion failure and retain tracking until removal succeeds; a later sync can retry. |
| SK05 | chmod-only changes leave runtime scripts without the requested executable mode. | Include the executable property in compatibility and invalidate the rebuildable cache. |
| SK06 | An old editor overwrites newer content and deletes subsequently added attachments. | Carry an optional opaque etag in the update request and compare under the mutation lock. The editor always sends it and offers review, keep editing, load latest, or an explicit conditional overwrite. |
| SK07 | A new pinned GitHub revision becomes a second local Skill, separating existing references/settings. | Derive stable owner/repo/root identity independently of revision, update the original ID, and show update availability. |
| SK08 | Two same-named uploads share selection identity and can both be submitted when one is selected. | Allocate an in-memory identity per file occurrence for ZIP and Markdown. |

## Scope and non-goals

All eight fixes address reproduced failures; no new architecture layer, dependency, database table/column, product enum, automatic merge system, history storage or persistent retry queue.

**Interface:** `UpdateSkillRequest.etag` is optional. Omitted etags retain legacy unconditional-update behavior; supplied invalid/stale etags fail before mutation. Detail responses return an opaque etag derived from the existing content fingerprint, with no stored revision counter. The editor always supplies the read-time etag. On conflict it preserves the draft and shows both versions and reference lists. Loading latest discards the draft only on explicit choice; overwrite rechecks the reviewed latest etag, so another intervening update requires another review. No force flag, automatic merge, or partial-update redesign. This follows the optional validator pattern in [Google AIP-154](https://google.aip.dev/154) and explicit save-conflict choices in [VS Code](https://code.visualstudio.com/updates/v1_42#_save-conflict-resolution). `ScannedSkillView.installedId` is optional and transient. Repository consumers retain the stable facade.

**Persistence/history:** existing Skill files and `.source.json` are rewritten only through existing save/import transactions. Derived compatibility cache content advances from version 1 to 2 and stores an executable boolean; tree hashes advance from v2 to v3, rebuilding old caches and refreshing runtime projections. Authoritative Skill data needs no migration. Historical/published nonportable reference names remain unchanged on body edits: the exception requires an exact regular file in the symlink-free staging copy and a name-only request. New names and replacement uploads retain strict validation; directories and symbolic links do not qualify. Existing Specialist sidecars are never blindly stripped: ordinary replacement refuses such installations. One unambiguous historical GitHub source updates in place; multiple historical matches are refused without merging identities or rebinding relationships. Already lost files cannot be recovered by this change. Intentional same-root multi-ref coexistence is outside this minimum policy.

## Acceptance criteria and validation

Regressions precede production fixes in `e0a55ed5` and `24976d6`. On unmodified baseline production, the expanded boundary suite ran twice: **32 expected failures and 53 passing controls**, with identical failure names and report-consistent observations. Fixtures use real temporary files and public repository/catalog/component boundaries; only external GitHub transport and a targeted `rm` EBUSY are controlled. No production test seam was added.

The optional-etag and conflict-resolution adjustment was also tested before implementation: two runs each produced **15 failures and 39 passing controls**, with identical failing names. This includes contract adaptation as well as observable unconditional-update, draft preservation, conflict review and conditional-overwrite cases. After implementation all 54 pass. Test names describe behavior without report-number prefixes.

Final local Test Impact Set: **34 test files, 2,021 passed, zero failed**, after the last material source edit. It combines the declared `user_skills_repository` module with explicit interface/runtime consumers and registered-helper refresh coverage; only testFiles changed in its manifest, not ownership/routing. Typecheck and lint also passed after rebasing onto main at 47cfebd74c5efd4b927cef8e64760ef04b267906. Final head: 78e1cb38. Only translation insertion conflicts required resolution; a redundant French formatting commit was skipped. Semantic comparison confirms all latest-main locale entries and all final Skill changes are present, and the Skill implementation/tests are byte-identical to the pre-rebase state. The three-count difference from the prior 2,024 run comes from dynamically enumerated i18n guard cases on latest main, not removed Skill regression tests. No code changed after this final test run.

| Behavior / risk | Project-owned checks (run via `npm test -- <paths>`) | Final result |
| --- | --- | --- |
| SK01/02/03/07 filesystem ingress and identity | `user-skill-integrity.regression.test.ts`, repository/atomic tests, `skill-catalog.test.ts` | Passed |
| SK04/05 runtime removal and chmod | `materializer-integrity.regression.test.ts`, `materializer.test.ts`, compatibility-index/catalog-observer tests | Passed |
| SK06 competing/stale/optional etags and explicit conflict resolution | `skill-catalog.test.ts`, `SkillEditLoader.render.test.tsx`, `SkillsPanel.render.test.tsx` | Passed |
| SK07/08 actual selection/submission | `SkillsPanel.render.test.tsx`, `SkillUploadView.render.test.tsx` | Passed |
| Repository consumers / boundary contracts | Module's Notebook RPC, host/conversation import, Specialist package, Settings service/slice, preload tests; additional backend-resolver, agent-runtime-manager, integration-application-commands and settings-store tests | Passed |
| Cache history / stable facade / module declaration | compatibility-index and repository architecture tests; module-test-impact and validate-module-impact tests | Passed |
| All eight translated locales | i18n resources guard, editor/upload i18n render tests | Passed |
| Main/preload/renderer types and source lint | `npm run typecheck`, `npm run lint` | Passed |

Exact-head `test:affected --explain` selects the full CI plan because the existing classifier treats the module manifest as a global gate input. Only its testFiles changed; per CONTRIBUTING, local validation uses the module plus explicit consumers and manifest tests. No complete local `npm test` run. The manifest's owner/contract tests and explicit consumers establish the local impact map; PR Gate remains authoritative for complete and cross-platform lanes. POSIX chmod assertions run on macOS/Linux and skip Windows; portable basename/path and real-filesystem cases remain in the Windows lane. Framework resolver/runtime consumers cover claude-code, opencode, codex-response and codex-bridge. No real model invocation of a leftover disabled Skill or Windows ACL behavior is claimed.

Electron/Playwright interaction checks using actual renderer components/styles and isolated API/store fixtures passed with no page errors. Local screenshots demonstrate distinct same-named selection, stale-save comparison with Chinese/space reference names, loading the latest version, and GitHub update availability. Four additional Electron interaction checks passed: both versions are visible; keep editing retains the draft; loading latest adopts its etag; explicit overwrite uses the reviewed etag. The component suite additionally covers another concurrent write during review and failed latest-version reads. This is component interaction verification, not full packaged-app E2E; screenshots/planning artifacts remain local as required.

The latest P2 review finding about historical reference names was reproduced on unmodified e79cf444 production twice: **4 identical failures, 78 passing controls**. Both Settings detail/save and publishPersonalDirectory/updatePersonal paths failed with `Unsafe Skill reference filename` for CON.csv and trailing. The fix adds no test seam or public interface. Regression coverage verifies byte/name preservation, explicit deletion, rejection of replacement bytes, absent references, directories and symlinks. POSIX-only real-file cases skip Windows; portable rejection controls run everywhere. The final impact set above includes this follow-up.

## Review focus

Please confirm that the final owner/contract/consumer evidence covers the changed interfaces and persistence boundaries, especially normalized imported content, legitimate Specialist metadata preservation, stale-write lock placement and explicit conflict choices, and GitHub revision-independent identity. The previous-head AI review identified the history regression addressed above. Independent review and exact-head CI for this follow-up are pending; local passing checks alone are not the final verification claim.
