### PR TITLE
test(notebook): decouple redirect trust from probe timing

### DIFF
--- a/src/main/notebook/mirror-probe.test.ts
+++ b/src/main/notebook/mirror-probe.test.ts
@@ -138,12 +138,10 @@ describe('pickFastestMirror', () => {
     await expect(pickFastestMirror({ candidates: [ustc, official] })).resolves.toEqual(
       official.mirror
     )
+    // Verify trust acceptance without assuming it also wins a wall-clock latency race.
     await expect(
       pickFastestMirror({
-        candidates: [
-          { ...ustc, trustedDomains: [...ustc.trustedDomains, 'mirrors.nju.edu.cn'] },
-          official
-        ]
+        candidates: [{ ...ustc, trustedDomains: [...ustc.trustedDomains, 'mirrors.nju.edu.cn'] }]
       })
     ).resolves.toEqual(ustc.mirror)
     expect(vi.mocked(netFetchStandard).mock.calls.map(([url]) => String(url))).toEqual(


### PR DESCRIPTION
## Problem

PR #2226's Ubuntu full-suite shard failed the existing USTC-to-NJU redirect trust test. The test expected USTC to be selected even when the equally valid official mirror completed faster. Coverage aggregation inherited the same failure. This test entered main in #2217; it is unrelated to the Specialist implementation.

## Proposed change

Test accepted redirects with USTC as the sole candidate. Retain the untrusted-redirect fallback assertion and existing dedicated fastest-mirror tests. Production behavior is unchanged.

## Acceptance criteria and validation

Reproduced the exact CI mismatch deterministically by making mocked USTC requests advance a controlled `Date.now` clock while official requests did not: original assertion selected the official mirror and failed. The corrected assertion passed under the same clock. The clock instrumentation was then removed because acceptance no longer depends on relative latency.

Final test-only diff -> `npm test -- src/main/notebook/mirror-probe.test.ts` -> all 14 tests passed. `npm run lint`, targeted Prettier and `git diff --check` passed after the material edit. No production interfaces, consumers, persistence, UI, or data compatibility changed; no full local test run. Final-head PR Gate and independent review remain required.

## Review focus

Ensure trust rejection/fallback remains covered and the accepted-redirect assertion no longer assumes wall-clock ordering. No latency policy or timeout changes.
