### PR TITLE
fix(preview): preserve active reads during resource revocation

### DIFF
--- a/e2e/fixtures/renderer-failure-gate.ts
+++ b/e2e/fixtures/renderer-failure-gate.ts
@@ -16,7 +16,9 @@ class RendererFailureGate {
       if (message.type() !== 'error') return
       const text = message.text()
       if (this.allowedConsoleErrors.has(text)) return
-      this.failures.set(`console:${text}`, new Error(`[renderer console] ${text}`))
+      const { url, lineNumber, columnNumber } = message.location()
+      const location = url ? ` (${url}:${lineNumber + 1}:${columnNumber + 1})` : ''
+      this.failures.set(`console:${text}`, new Error(`[renderer console] ${text}${location}`))
     }
     const recordPageError = (error: Error): void => {
       this.failures.set(

--- a/src/main/managed-preview-protocol.test.ts
+++ b/src/main/managed-preview-protocol.test.ts
@@ -340,6 +340,68 @@ describe('managed preview protocol', () => {
     expect(fileHandle.close).toHaveBeenCalled()
   })
 
+  it.each(['complete', 'cancel', 'read failure'])(
+    'settles an in-flight read before closing its revoked lease (%s)',
+    async (outcome) => {
+      let beginRead!: () => void
+      let finishRead!: () => void
+      const started = new Promise<void>((resolve) => {
+        beginRead = resolve
+      })
+      const pending = new Promise<void>((resolve) => {
+        finishRead = resolve
+      })
+      let closed = false
+      const close = vi.fn(async () => {
+        closed = true
+      })
+      const verifyUnchanged = vi.fn(async () => {
+        if (closed) throw new Error('Version file read lease is closed.')
+      })
+      const resources = new (await import('./managed-preview-resources')).ManagedPreviewResources({
+        resolvePath: vi.fn(),
+        openLatestManagedFile: vi.fn().mockResolvedValue({
+          path: '/managed/pinned.md',
+          size: 1,
+          versionToken: 1,
+          snapshot: { dev: 1n, ino: 2n, size: 1n, mtimeNs: 1n },
+          read: async (buffer: Uint8Array) => {
+            beginRead()
+            await pending
+            if (closed) throw new Error('Version file read lease is closed.')
+            if (outcome === 'read failure') throw new Error('read failed')
+            buffer[0] = 65
+            return { bytesRead: 1 }
+          },
+          verifyUnchanged,
+          close
+        })
+      })
+      const resource = await resources.acquire(17, {
+        source: 'upload',
+        projectId: 'project-1',
+        fileId: 'file-1'
+      })
+      const response = await createManagedPreviewProtocolHandler(resources)(
+        new Request(resource.url)
+      )
+      await started
+      resources.release(17, { resourceId: resource.id })
+      const completed =
+        outcome === 'cancel'
+          ? response.body!.cancel()
+          : outcome === 'read failure'
+            ? expect(response.text()).rejects.toThrow('read failed')
+            : expect(response.text()).resolves.toBe('A')
+      expect(close).not.toHaveBeenCalled()
+      finishRead()
+      await completed
+      expect(close).toHaveBeenCalledOnce()
+      if (outcome === 'cancel') expect(verifyUnchanged).not.toHaveBeenCalled()
+      else if (outcome === 'complete') expect(verifyUnchanged).toHaveBeenCalledOnce()
+    }
+  )
+
   it('returns the load-error page when an invalid Range header rejects the strict response setup', async () => {
     const source = Buffer.from('strict-range-error-path')
     const fileHandle = {

--- a/src/main/managed-preview-protocol.test.ts
+++ b/src/main/managed-preview-protocol.test.ts
@@ -402,6 +402,93 @@ describe('managed preview protocol', () => {
     }
   )
 
+  it.each([false, true])(
+    'releases an unconsumed response on request abort (buffered: %s)',
+    async (buffered) => {
+      let finishRead!: () => void
+      let beginRead!: () => void
+      const started = new Promise<void>((resolve) => {
+        beginRead = resolve
+      })
+      const pending = new Promise<void>((resolve) => {
+        finishRead = resolve
+      })
+      const close = vi.fn()
+      const resources = new (await import('./managed-preview-resources')).ManagedPreviewResources({
+        resolvePath: vi.fn(),
+        openLatestManagedFile: vi.fn().mockResolvedValue({
+          path: '/managed/large.txt',
+          size: 128 * 1024,
+          versionToken: 1,
+          snapshot: { dev: 1n, ino: 2n, size: 131072n, mtimeNs: 1n },
+          read: async (_buffer: Uint8Array, _offset: number, length: number) => {
+            beginRead()
+            await pending
+            return { bytesRead: length }
+          },
+          verifyUnchanged: vi.fn(),
+          close
+        })
+      })
+      const resource = await resources.acquire(17, {
+        source: 'upload',
+        projectId: 'project-1',
+        fileId: 'file-1'
+      })
+      const abort = new AbortController()
+      const response = await createManagedPreviewProtocolHandler(resources)(
+        new Request(resource.url, { signal: abort.signal })
+      )
+      await started
+      if (buffered) {
+        finishRead()
+        await new Promise<void>((resolve) => setImmediate(resolve))
+      }
+      resources.releaseOwner(17)
+      abort.abort(new Error('preview abandoned'))
+      expect(close).not.toHaveBeenCalled()
+      finishRead()
+      // No response reader/cancel callback is involved in releasing the lease.
+      await vi.waitFor(() => expect(close).toHaveBeenCalledOnce())
+      await expect(response.text()).rejects.toThrow('preview abandoned')
+    }
+  )
+
+  it('cancels an opened stream when response header construction fails', async () => {
+    let finishRead!: () => void
+    let beginRead!: () => void
+    const started = new Promise<void>((resolve) => {
+      beginRead = resolve
+    })
+    const pending = new Promise<void>((resolve) => {
+      finishRead = resolve
+    })
+    const close = vi.fn()
+    const resources = {
+      resolveProtocolResource: vi.fn().mockResolvedValue({
+        fileHandle: {
+          read: async (_buffer: Uint8Array, _offset: number, length: number) => {
+            beginRead()
+            await pending
+            return { bytesRead: length }
+          },
+          close
+        },
+        size: 128 * 1024,
+        mimeType: 'text/plain\ninvalid-header',
+        verifyUnchanged: vi.fn()
+      })
+    } as unknown as ManagedPreviewResources
+    const response = createManagedPreviewProtocolHandler(resources)(
+      new Request('open-science-preview://resource-1/report.txt')
+    )
+    await started
+    expect(close).not.toHaveBeenCalled()
+    finishRead()
+    expect((await response).status).toBe(404)
+    expect(close).toHaveBeenCalledOnce()
+  })
+
   it('returns the load-error page when an invalid Range header rejects the strict response setup', async () => {
     const source = Buffer.from('strict-range-error-path')
     const fileHandle = {

--- a/src/main/managed-preview-protocol.ts
+++ b/src/main/managed-preview-protocol.ts
@@ -82,10 +82,23 @@ const createStrictFileResponse = async (
   request: Request
 ): Promise<Response> => {
   let closed = false
+  let onAbort: (() => void) | undefined
   const closeHandle = async (): Promise<void> => {
     if (closed) return
     closed = true
+    if (onAbort) request.signal.removeEventListener('abort', onAbort)
     await resource.fileHandle.close()
+  }
+  let canceled = false
+  let reading: Promise<void> | undefined
+  const cancelReading = async (): Promise<void> => {
+    canceled = true
+    // Cancellation can arrive while an asynchronous read still owns the handle.
+    try {
+      await reading
+    } finally {
+      await closeHandle()
+    }
   }
 
   try {
@@ -107,9 +120,18 @@ const createStrictFileResponse = async (
     }
 
     let position = range.start
-    let canceled = false
-    let reading: Promise<void> | undefined
     const body = new ReadableStream<Uint8Array>({
+      start: (controller) => {
+        // An abandoned response may never be consumed or receive a stream cancel callback.
+        onAbort = () => {
+          controller.error(
+            request.signal.reason ?? new DOMException('Preview read aborted', 'AbortError')
+          )
+          void cancelReading().catch(() => undefined)
+        }
+        request.signal.addEventListener('abort', onAbort, { once: true })
+        if (request.signal.aborted) onAbort()
+      },
       pull: (controller) => {
         reading = (async () => {
           try {
@@ -149,16 +171,11 @@ const createStrictFileResponse = async (
         })()
         return reading
       },
-      cancel: async () => {
-        canceled = true
-        // Cancellation can arrive while an asynchronous read still owns the handle.
-        await reading
-        await closeHandle()
-      }
+      cancel: cancelReading
     })
     return new Response(body, { status: isPartial ? 206 : 200, headers })
   } catch (error) {
-    await closeHandle()
+    await cancelReading().catch(() => undefined)
     throw error
   }
 }
@@ -170,13 +187,14 @@ const createManagedPreviewProtocolHandler = (
   options: ManagedPreviewProtocolOptions = {}
 ): ((request: Request) => Promise<Response>) => {
   return async (request) => {
+    let fileResponse: Response | undefined
     try {
       const url = new URL(request.url)
       if (options.isResourceAllowed && !options.isResourceAllowed(url.hostname)) {
         throw new Error('Managed preview resource is not assigned to this session.')
       }
       const resource = await resources.resolveProtocolResource(url.hostname)
-      const fileResponse =
+      fileResponse =
         'fileHandle' in resource
           ? await createStrictFileResponse(resource, request)
           : await fetchFile(resource.filePath, request)
@@ -197,6 +215,8 @@ const createManagedPreviewProtocolHandler = (
         headers
       })
     } catch {
+      // Header/response construction can fail after the resource stream has been opened.
+      await fileResponse?.body?.cancel().catch(() => undefined)
       return createLoadErrorResponse()
     }
   }

--- a/src/main/managed-preview-protocol.ts
+++ b/src/main/managed-preview-protocol.ts
@@ -107,42 +107,52 @@ const createStrictFileResponse = async (
     }
 
     let position = range.start
+    let canceled = false
+    let reading: Promise<void> | undefined
     const body = new ReadableStream<Uint8Array>({
-      pull: async (controller) => {
-        try {
-          if (request.signal.aborted) {
-            throw request.signal.reason ?? new DOMException('Preview read aborted', 'AbortError')
-          }
-          const length = Math.min(64 * 1024, range.end - position + 1)
-          const buffer = new Uint8Array(length)
-          let chunkOffset = 0
-          while (chunkOffset < length) {
-            const { bytesRead } = await resource.fileHandle.read(
-              buffer,
-              chunkOffset,
-              length - chunkOffset,
-              position + chunkOffset
-            )
-            if (bytesRead === 0) {
-              throw new Error('Managed preview file changed during streaming.')
+      pull: (controller) => {
+        reading = (async () => {
+          try {
+            if (request.signal.aborted) {
+              throw request.signal.reason ?? new DOMException('Preview read aborted', 'AbortError')
             }
-            chunkOffset += bytesRead
-          }
+            const length = Math.min(64 * 1024, range.end - position + 1)
+            const buffer = new Uint8Array(length)
+            let chunkOffset = 0
+            while (chunkOffset < length) {
+              const { bytesRead } = await resource.fileHandle.read(
+                buffer,
+                chunkOffset,
+                length - chunkOffset,
+                position + chunkOffset
+              )
+              if (canceled) return
+              if (bytesRead === 0) {
+                throw new Error('Managed preview file changed during streaming.')
+              }
+              chunkOffset += bytesRead
+            }
 
-          position += chunkOffset
-          const complete = position > range.end
-          if (complete) await resource.verifyUnchanged()
-          controller.enqueue(buffer)
-          if (complete) {
-            await closeHandle()
-            controller.close()
+            position += chunkOffset
+            const complete = position > range.end
+            if (complete) await resource.verifyUnchanged()
+            if (canceled) return
+            controller.enqueue(buffer)
+            if (complete) {
+              await closeHandle()
+              controller.close()
+            }
+          } catch (error) {
+            await closeHandle().catch(() => undefined)
+            if (!canceled) controller.error(error)
           }
-        } catch (error) {
-          await closeHandle().catch(() => undefined)
-          controller.error(error)
-        }
+        })()
+        return reading
       },
       cancel: async () => {
+        canceled = true
+        // Cancellation can arrive while an asynchronous read still owns the handle.
+        await reading
         await closeHandle()
       }
     })

--- a/src/main/managed-preview-resources.test.ts
+++ b/src/main/managed-preview-resources.test.ts
@@ -187,6 +187,63 @@ describe('ManagedPreviewResources', () => {
     expect(close).toHaveBeenCalledOnce()
   })
 
+  it.each(['release', 'owner teardown', 'read failure'])(
+    'keeps admitted protocol and IPC reads alive through %s, while rejecting new reads',
+    async (reason) => {
+      let finishRead!: () => void
+      const pending = new Promise<void>((resolve) => {
+        finishRead = resolve
+      })
+      let closed = false
+      const close = vi.fn(async () => {
+        closed = true
+      })
+      const resources = new ManagedPreviewResources({
+        resolvePath: vi.fn(),
+        openLatestManagedFile: vi.fn().mockResolvedValue({
+          path: '/managed/pinned.txt',
+          size: 1,
+          versionToken: 1,
+          snapshot: { dev: 1n, ino: 2n, size: 1n, mtimeNs: 1n },
+          read: vi.fn(),
+          readRange: async () => {
+            await pending
+            if (closed) throw new Error('Version file read lease is closed.')
+            if (reason === 'read failure') throw new Error('read failed')
+            return new Uint8Array([65])
+          },
+          verifyUnchanged: vi.fn(),
+          close
+        })
+      })
+      const resource = await resources.acquire(17, {
+        source: 'upload',
+        projectId: 'project-1',
+        fileId: 'file-1'
+      })
+      const protocol = await resources.resolveProtocolResource(resource.id)
+      if (!('fileHandle' in protocol)) throw new Error('Expected a pinned protocol lease')
+      const range = { resourceId: resource.id, begin: 0, end: 1 }
+      const reading = resources.readRange(17, range)
+      const result =
+        reason === 'read failure'
+          ? expect(reading).rejects.toThrow('read failed')
+          : expect(reading).resolves.toMatchObject({ data: new Uint8Array([65]) })
+
+      if (reason === 'owner teardown') resources.releaseOwner(17)
+      else resources.release(17, { resourceId: resource.id })
+      await expect(resources.resolveProtocolResource(resource.id)).rejects.toThrow('not available')
+      await expect(resources.readRange(17, range)).rejects.toThrow('not available')
+      expect(close).not.toHaveBeenCalled()
+      finishRead()
+      await result
+      expect(close).not.toHaveBeenCalled()
+      await protocol.fileHandle.close()
+      await protocol.fileHandle.close()
+      expect(close).toHaveBeenCalledOnce()
+    }
+  )
+
   it('keeps a Notebook input Version lease open for capability reads instead of resolving a path', async () => {
     const trustedBytes = Buffer.from('staged through a live lease')
     const close = vi.fn().mockResolvedValue(undefined)

--- a/src/main/managed-preview-resources.ts
+++ b/src/main/managed-preview-resources.ts
@@ -106,6 +106,7 @@ type ResourceEntry = ManagedPreviewResource & {
   ownerId: number
   filePath: string
   trustedLease?: ManagedPreviewTrustedLease
+  activeReaders?: number
   strictSnapshot?: {
     dev: bigint
     ino: bigint
@@ -414,8 +415,13 @@ class ManagedPreviewResources {
     }
 
     if (resource.trustedLease) {
-      const data = await resource.trustedLease.readRange(begin, end)
-      return { begin, end, total: resource.size, data: new Uint8Array(data) }
+      const releaseRead = this.retainTrustedLease(resource)
+      try {
+        const data = await resource.trustedLease.readRange(begin, end)
+        return { begin, end, total: resource.size, data: new Uint8Array(data) }
+      } finally {
+        await releaseRead()
+      }
     }
 
     const buffer = Buffer.allocUnsafe(end - begin)
@@ -465,13 +471,13 @@ class ManagedPreviewResources {
     }
 
     if (resource.trustedLease) {
+      const releaseRead = this.retainTrustedLease(resource)
       return {
         fileHandle: {
           read: (buffer, offset, length, position) =>
             resource.trustedLease!.read(buffer, offset, length, position),
-          // One capability may serve several concurrent HTTP range requests. The resource owner,
-          // not an individual response, closes the pinned handle.
-          close: async () => undefined
+          // Each admitted response pins the shared lease until completion or cancellation.
+          close: releaseRead
         },
         mimeType: resource.mimeType,
         size: resource.size,
@@ -573,12 +579,28 @@ class ManagedPreviewResources {
   private revokeResource(resourceId: string, ownerId: number): void {
     const resource = this.resources.get(resourceId)
     this.resources.delete(resourceId)
-    if (resource?.trustedLease) void resource.trustedLease.close().catch(() => undefined)
+    if (resource?.trustedLease && !resource.activeReaders) {
+      void resource.trustedLease.close().catch(() => undefined)
+    }
     this.releasedOwners.set(resourceId, ownerId)
     while (this.releasedOwners.size > MAX_RELEASED_RESOURCE_TOMBSTONES) {
       const oldestResourceId = this.releasedOwners.keys().next().value
       if (oldestResourceId === undefined) break
       this.releasedOwners.delete(oldestResourceId)
+    }
+  }
+
+  private retainTrustedLease(resource: ResourceEntry): () => Promise<void> {
+    resource.activeReaders = (resource.activeReaders ?? 0) + 1
+    let released = false
+    return async () => {
+      if (released) return
+      released = true
+      resource.activeReaders! -= 1
+      // Revocation removes access immediately; only already-admitted reads may finish.
+      if (!resource.activeReaders && this.resources.get(resource.id) !== resource) {
+        await resource.trustedLease!.close().catch(() => undefined)
+      }
     }
   }
 

--- a/test/renderer-failure-gate.test.ts
+++ b/test/renderer-failure-gate.test.ts
@@ -31,10 +31,39 @@ describe('RendererFailureGate', () => {
     const observed = observablePage()
     await gate.observe(observed.page as never)
 
-    observed.emit('console', { type: () => 'error', text: () => 'broken renderer' })
+    observed.emit('console', {
+      type: () => 'error',
+      text: () => 'broken renderer',
+      location: () => ({ url: '', lineNumber: 0, columnNumber: 0 })
+    })
     observed.emit('pageerror', new Error('uncaught renderer failure'))
 
     expect(() => gate.assertNoFailures()).toThrow(/Renderer emitted errors/)
+  })
+
+  it('includes the failing resource location without allowing the error', async () => {
+    const gate = new RendererFailureGate()
+    const observed = observablePage()
+    await gate.observe(observed.page as never)
+    observed.emit('console', {
+      type: () => 'error',
+      text: () => 'Failed to load resource: net::ERR_FAILED',
+      location: () => ({
+        url: 'open-science-preview://resource-id',
+        lineNumber: 2,
+        columnNumber: 4
+      })
+    })
+
+    let failure: AggregateError | undefined
+    try {
+      gate.assertNoFailures()
+    } catch (error) {
+      failure = error as AggregateError
+    }
+    expect(failure?.errors[0].message).toBe(
+      '[renderer console] Failed to load resource: net::ERR_FAILED (open-science-preview://resource-id:3:5)'
+    )
   })
 
   it('ignores non-error console messages', async () => {
@@ -56,7 +85,11 @@ describe('RendererFailureGate', () => {
     observed.emit('console', { type: () => 'error', text: () => 'expected failed resource' })
     expect(() => gate.assertNoFailures()).not.toThrow()
 
-    observed.emit('console', { type: () => 'error', text: () => 'unexpected renderer failure' })
+    observed.emit('console', {
+      type: () => 'error',
+      text: () => 'unexpected renderer failure',
+      location: () => ({ url: '', lineNumber: 0, columnNumber: 0 })
+    })
     expect(() => gate.assertNoFailures()).toThrow(/Renderer emitted errors/)
   })
 
@@ -64,7 +97,11 @@ describe('RendererFailureGate', () => {
     const gate = new RendererFailureGate()
     const observed = observablePage()
     observed.page.consoleMessages.mockResolvedValue([
-      { type: () => 'error', text: () => 'early console failure' }
+      {
+        type: () => 'error',
+        text: () => 'early console failure',
+        location: () => ({ url: '', lineNumber: 0, columnNumber: 0 })
+      }
     ])
     observed.page.pageErrors.mockResolvedValue([new Error('early page failure')])
 


### PR DESCRIPTION
## Problem

Follow-up to merged #2225 and #2224. Their macOS jobs failed the Markdown version/diff journey with `net::ERR_FAILED`; #2225 completed in 15 minutes, below the existing 20-minute job budget. A local baseline reproduced the same console failure in 1 of 3 runs. The failing URL is an internal `open-science-preview` capability, not an external download.

Revoking a preview capability currently closes its trusted file lease while an admitted protocol or IPC read can still be pending. Slow-read experiments and a deterministic owner/protocol regression reproduce `Version file read lease is closed`. Renderer cancellation can reach Main after revocation, so the pending response can fail instead of finishing cancellation. The console gate also drops resource locations, making unrelated resources' load errors hard to identify.

## Proposed change

- Remove revoked capabilities from admission immediately, but retain their trusted lease until all admitted readers release it. Share this rule across protocol responses and IPC range reads, including renderer-owner teardown.
- Wait for the current stream pull before releasing its handle on cancellation, and stop delivering bytes once cancelled. Bind stream cleanup to request abort as well, including responses that are never consumed, and cancel an opened response when header construction fails. Keep integrity failures and unexpected renderer errors blocking.
- Include the original console resource URL and line/column in E2E failures.

## Scope and non-goals

- Historical data compatibility: none required; no migrations or backfill.
- Persistence/data model: no database fields, persisted formats, or storage changes. The only new owner field is the private in-memory `ResourceEntry.activeReaders` counter; release callbacks and streams use local idempotence/cancellation flags and a pending-read Promise. No new enum values or public state variants.
- Architecture/API/UI: existing resource owner and protocol/IPC interfaces remain in place. This adjusts internal lease lifetime; no page, interaction, or renderer implementation changes.
- Keep the 20-minute macOS timeout, runner topology, caches, retries, and all selected checks unchanged. A successful sampled job already took 14m48s, largely in serial E2E. Additional runners/caches or another timeout increase would not repair the reproduced race. The expected benefit is fewer failing/repeated runs, not a claimed speedup of a successful run.

## Acceptance criteria and validation

The original implementation failed all 5 initial lifecycle regressions. Independent review identified abandoned responses as another cleanup path; an additional failing regression reproduced it before the follow-up fix. After the final material edit:

| Behavior | Check | Result |
| --- | --- | --- |
| Revocation, owner teardown, concurrent protocol/IPC reads, read failures, cancellation, integrity and consumers | Focused Vitest command below | 13 files / 210 tests passed |
| File versions/diff navigation, PDF reading context, image preview and dividers | `npx playwright test e2e/workspace-files.spec.ts --retries=0` | 10 passed (44.9s) |
| Previously flaky Markdown journey, no retries | `npx playwright test e2e/workspace-files.spec.ts --grep 'edits uploaded Markdown' --repeat-each=5 --retries=0` | 5/5 passed (37.7s) |
| Main, preload and E2E types | `npm run typecheck:node` (includes sandbox types) | Passed |
| Lint and formatting | `npm run lint`, touched-file Prettier, `git diff --check` | Passed |
| Real Electron build | `npm run build:e2e` | Passed |

```sh
npx vitest run src/main/managed-preview-resources.test.ts src/main/managed-preview-protocol.test.ts src/main/managed-preview-ipc.test.ts src/main/office-preview src/main/managed-file-versions/version-file-operator.test.ts src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx src/renderer/src/pages/workspace/previews/useManagedPreviewResource.test.tsx src/renderer/src/pages/workspace/previews/managed-pdf-document.test.ts test/renderer-failure-gate.test.ts scripts/electron-app-fixture.test.ts --maxWorkers=1
```

The Test Impact Set includes the resource owner, protocol/IPC adapters, Office and PDF consumers, text preview hooks, immutable-file integrity, and E2E failure reporting. CodeGraph's existing root index informed consumer discovery; it is not a worktree-local index, so current worktree imports/call sites and tests were checked directly. Shared interfaces and renderer code do not change; Node/preload/E2E typechecks cover the changed implementation. No full local suite was run per maintainer instruction. The final `test:affected -- --base 9719e5b9 --head HEAD --explain` selects full CI because the E2E failure-gate fixture/test are unknown to the existing classifier. The maintainer explicitly excludes a full local suite; the scoped evidence above does not claim full verification. Windows/Linux execution is covered by exact-head PR CI, with results and remaining limitations below.

## Exact-head CI and independent review

Final source head: `c01dcd1664f482324ddf5d5a4735022678a1fee9`.

- [PR Gate, attempt 1](https://github.com/aipoch/open-science/actions/runs/34002296864/attempts/1): macOS native/build/functional/workspace/accessibility/visual checks passed in **13m02s**. All three Ubuntu portable shards and merged coverage passed: **1,396 files / 24,148 tests passed**, 16 files / 264 tests skipped under the existing platform selection. Static checks, Linux Notebook isolation, Windows core, and Windows E2E shard 2/2 passed.
- Windows E2E shard 1/2 encountered an unchanged scrolling-journey flake (`message-tool-layout-stability.spec.ts`, paced-tool bottom-follow): a 20px upward overshoot exceeded the 2px assertion on the first try; its built-in retry passed, and the existing flaky-test gate correctly failed the job. No preview-resource failure occurred. A [single rerun of only that failed shard and its dependent gate](https://github.com/aipoch/open-science/actions/runs/34002296864/attempts/2) passed (Windows shard: 10m50s), and PR Gate is green. The original failure remains part of the evidence and is not claimed fixed by this PR.
- [Independent review](https://github.com/aipoch/open-science/pull/2230#issuecomment-5555914283) inspected this exact head: **mergeable, no actionable findings**. This is static inspection, separate from executed test evidence.
- The initial source head had a separate Ubuntu cleanup flake in unchanged `remote-access/service.test.ts` (`ENOTEMPTY`); that test passed in the complete final-head run. Neither unrelated area was changed by this PR.
- CI Integrity and CodeQL passed. The initial final-head CI Integrity execution was cancelled by the workflow concurrency group when the PR description was edited; its single rerun passed.
- Two macOS CI executions (initial and final source heads) passed. This supports the lifecycle fix but does not establish a long-term flake rate or a guaranteed successful-run speedup.

## Review focus

Immediate rejection of new access after revocation, one final close across simultaneous readers and repeated release, cancellation during an asynchronous read, request abort before response consumption (including a buffered unread response), header-construction failure cleanup, and preservation of real integrity/renderer failures. The retention is confined to already-admitted reads; there is no grace-period access, new queue, retry policy or cache.
