### PR TITLE
fix(provider-protocol): preserve tool content and response semantics

### DIFF
--- a/src/main/settings/chat-provider-compatibility.test.ts
+++ b/src/main/settings/chat-provider-compatibility.test.ts
@@ -156,7 +156,7 @@ describe('ChatProviderCompatibilityBridge', () => {
     const body = await response.text()
     expect(body).toContain('"content":"ready"')
     expect(body).toContain('"name":"search"')
-    expect(body).toContain('"prompt_tokens":11')
+    expect(body).toContain('"prompt_tokens":16')
     expect(body).toContain('data: [DONE]')
     const request = JSON.parse(String(upstream.mock.calls[0]?.[1]?.body))
     expect(request).toMatchObject({

--- a/src/main/settings/chat-provider-compatibility.ts
+++ b/src/main/settings/chat-provider-compatibility.ts
@@ -149,6 +149,14 @@ const chatToAnthropic = (body: Json, model: string): Json => {
 }
 
 const anthropicToChat = (message: Json, model: string): Json => {
+  if (
+    message.stop_reason != null &&
+    !['end_turn', 'stop_sequence', 'tool_use', 'max_tokens', 'refusal'].includes(
+      String(message.stop_reason)
+    )
+  ) {
+    throw new Error('Unsupported upstream Messages stop reason.')
+  }
   const content = Array.isArray(message.content) ? message.content.filter(object) : []
   const toolCalls = content
     .filter((part) => part.type === 'tool_use' && typeof part.name === 'string')
@@ -166,7 +174,10 @@ const anthropicToChat = (message: Json, model: string): Json => {
     .map((part) => part.thinking)
     .join('')
   const usage = object(message.usage) ? message.usage : {}
-  const promptTokens = Number(usage.input_tokens ?? 0)
+  const promptTokens =
+    Number(usage.input_tokens ?? 0) +
+    Number(usage.cache_read_input_tokens ?? 0) +
+    Number(usage.cache_creation_input_tokens ?? 0)
   const completionTokens = Number(usage.output_tokens ?? 0)
   return {
     id: message.id ?? `chatcmpl_${Date.now()}`,
@@ -182,7 +193,14 @@ const anthropicToChat = (message: Json, model: string): Json => {
           ...(reasoning ? { reasoning_content: reasoning } : {}),
           ...(toolCalls.length > 0 ? { tool_calls: toolCalls } : {})
         },
-        finish_reason: toolCalls.length > 0 ? 'tool_calls' : 'stop'
+        finish_reason:
+          message.stop_reason === 'max_tokens'
+            ? 'length'
+            : message.stop_reason === 'refusal'
+              ? 'content_filter'
+              : toolCalls.length > 0
+                ? 'tool_calls'
+                : 'stop'
       }
     ],
     usage: {
@@ -191,6 +209,9 @@ const anthropicToChat = (message: Json, model: string): Json => {
       total_tokens: promptTokens + completionTokens,
       ...(typeof usage.cache_read_input_tokens === 'number'
         ? { prompt_tokens_details: { cached_tokens: usage.cache_read_input_tokens } }
+        : {}),
+      ...(typeof usage.cache_creation_input_tokens === 'number'
+        ? { cache_creation_input_tokens: usage.cache_creation_input_tokens }
         : {})
     }
   }
@@ -216,7 +237,9 @@ const writeChatStream = (response: ServerResponse, completion: Json): void => {
     role: 'assistant',
     content: message.content,
     ...(message.reasoning_content ? { reasoning_content: message.reasoning_content } : {}),
-    ...(message.tool_calls ? { tool_calls: message.tool_calls } : {})
+    ...(Array.isArray(message.tool_calls)
+      ? { tool_calls: message.tool_calls.map((call, index) => ({ ...call, index })) }
+      : {})
   })
   chunk({}, choice.finish_reason, completion.usage)
   response.end('data: [DONE]\n\n')

--- a/src/main/settings/native-responses-compatibility.ts
+++ b/src/main/settings/native-responses-compatibility.ts
@@ -454,20 +454,35 @@ const streamSummaryObserver = (
   }
 }
 
-const rewriteSseLine = (
-  line: string,
+const rewriteSseEvent = (
+  lines: readonly string[],
   aliases: NativeResponsesToolAliases,
   observe: (value: unknown) => void
 ): string => {
-  if (!line.startsWith('data:')) return line
-  const data = line.slice('data:'.length).trimStart()
-  if (!data || data === '[DONE]') return line
+  const dataLines = lines.filter((line) => line.startsWith('data:'))
+  const data = dataLines
+    .map((line) =>
+      line
+        .replace(/\r?\n$/, '')
+        .slice(5)
+        .replace(/^ /, '')
+    )
+    .join('\n')
+  if (!data || data === '[DONE]') return lines.join('')
   try {
     const payload = JSON.parse(data) as unknown
     observe(payload)
-    return `data: ${JSON.stringify(restoreNativeResponsesPayload(payload, aliases))}`
+    const restored = JSON.stringify(restoreNativeResponsesPayload(payload, aliases))
+    const firstDataIndex = lines.findIndex((line) => line.startsWith('data:'))
+    return lines
+      .map((line, index) => {
+        if (!line.startsWith('data:')) return line
+        if (index !== firstDataIndex) return ''
+        return `data: ${restored}${line.match(/\r?\n$/)?.[0] ?? ''}`
+      })
+      .join('')
   } catch {
-    return line
+    return lines.join('')
   }
 }
 
@@ -495,7 +510,7 @@ const streamResponse = async (
   const flushEvent = (): void => {
     if (pendingEvent.length === 0) return
     writeHeaders()
-    response.write(pendingEvent.join(''))
+    response.write(rewriteSseEvent(pendingEvent, aliases, observer.observe))
     pendingEvent = []
     eventBytes = 0
   }
@@ -511,7 +526,7 @@ const streamResponse = async (
         throw new ResponseBodyLimitError('Native Responses upstream SSE event', limits.eventBytes)
       }
     }
-    pendingEvent.push(rewriteSseLine(line, aliases, observer.observe) + (newline ? '\n' : ''))
+    pendingEvent.push(line + (newline ? '\n' : ''))
     if (boundary) flushEvent()
   }
 

--- a/src/main/settings/provider-protocol-regressions.test.ts
+++ b/src/main/settings/provider-protocol-regressions.test.ts
@@ -1,0 +1,671 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ChatProviderCompatibilityBridge } from './chat-provider-compatibility'
+import { NativeResponsesCompatibilityProxy } from './native-responses-compatibility'
+import { normalizeOpenAiChatModelStepUsage } from './openai-chat-usage'
+import {
+  CAPTURED_TOOL_IMAGE_PNG_BASE64,
+  CLAUDE_CODE_TOOL_IMAGE_REQUEST_FIXTURE,
+  CODEX_NATIVE_TOOL_IMAGE_REQUEST_FIXTURE
+} from './provider-tool-image-wire.test-fixtures'
+import { ResponsesBridge } from './responses-bridge'
+import { responsesToChatRequest } from './responses-request-adapter'
+import { streamChatToResponses } from './responses-response-adapter'
+import { createXaiOAuthProviderBridge } from './xai-oauth-provider-bridge'
+import { anthropicToResponses, chatToResponses, sanitizeXaiResponsesRequest } from './xai-protocol'
+
+type Json = Record<string, unknown>
+const bridges: { close(): Promise<void> }[] = []
+afterEach(async () => {
+  await Promise.all(bridges.splice(0).map((bridge) => bridge.close()))
+})
+
+const post = async (
+  bridge: { start(): Promise<{ baseUrl: string; token: string }>; close(): Promise<void> },
+  path: string,
+  body: Json
+): Promise<Response> => {
+  if (!bridges.includes(bridge)) bridges.push(bridge)
+  const connection = await bridge.start()
+  return fetch(`${connection.baseUrl}${path}`, {
+    method: 'POST',
+    headers: { authorization: `Bearer ${connection.token}`, 'content-type': 'application/json' },
+    body: JSON.stringify(body)
+  })
+}
+const sse = (body: string): ReturnType<typeof JSON.parse>[] =>
+  body.split(/\r?\n\r?\n/).flatMap((event) => {
+    const data = event
+      .split(/\r?\n/)
+      .filter((line) => line.startsWith('data:'))
+      .map((line) => line.slice(5).replace(/^ /, ''))
+      .join('\n')
+    return !data || data === '[DONE]' ? [] : [JSON.parse(data)]
+  })
+const responsePayload = {
+  id: 'resp_report',
+  status: 'completed',
+  output: [{ type: 'message', content: [{ type: 'output_text', text: 'partial' }] }],
+  usage: { input_tokens: 12, input_tokens_details: { cached_tokens: 5 }, output_tokens: 2 }
+}
+const xai = (
+  wire: 'anthropic' | 'openai',
+  upstream: typeof fetch
+): ReturnType<typeof createXaiOAuthProviderBridge> =>
+  createXaiOAuthProviderBridge(
+    [{ id: 'active', model: 'grok-test' }],
+    'active',
+    wire,
+    async () => 'test-token',
+    upstream
+  )
+const chat = (payload: Json): ChatProviderCompatibilityBridge =>
+  new ChatProviderCompatibilityBridge(
+    { wire: 'anthropic', endpoint: 'https://provider.example/v1/messages', model: 'test-model' },
+    async () => Response.json(payload)
+  )
+const textRequest = { messages: [{ role: 'user', content: 'Continue' }] }
+
+// Only traverse structured values: a base64 string hidden inside JSON text is not an image part.
+const imageParts = (value: unknown): Json[] => {
+  if (Array.isArray(value)) return value.flatMap(imageParts)
+  if (value === null || typeof value !== 'object') return []
+  const part = value as Json
+  return part.type === 'input_image' || part.type === 'image_url'
+    ? [part]
+    : Object.values(part).flatMap(imageParts)
+}
+
+describe('provider protocol report regressions', () => {
+  it('R01a preserves a captured Codex tool image as a multimodal part over HTTP', async () => {
+    const upstream = vi.fn<typeof fetch>(async () =>
+      Response.json({
+        id: 'chat-report',
+        choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }]
+      })
+    )
+    const bridge = new ResponsesBridge(
+      { baseUrl: 'https://provider.example/v1', model: 'test' },
+      upstream
+    )
+    const response = await post(bridge, '/responses', {
+      ...CODEX_NATIVE_TOOL_IMAGE_REQUEST_FIXTURE,
+      stream: false
+    })
+    expect(response.status).toBe(200)
+    await response.text()
+    const sent = JSON.parse(String(upstream.mock.calls[0]?.[1]?.body))
+    expect(imageParts(sent)).toHaveLength(1)
+    expect(JSON.stringify(imageParts(sent))).toContain(CAPTURED_TOOL_IMAGE_PNG_BASE64)
+    expect(sent.messages).toContainEqual(
+      expect.objectContaining({ role: 'tool', tool_call_id: 'call_fixture_1' })
+    )
+    expect(
+      sent.messages
+        .filter((message: Json) => message.role === 'tool')
+        .some((message: Json) => String(message.content).includes(CAPTURED_TOOL_IMAGE_PNG_BASE64))
+    ).toBe(false)
+  })
+
+  it('R01b preserves a captured Claude tool image through the xAI HTTP bridge', async () => {
+    const upstream = vi.fn<typeof fetch>(async () => Response.json(responsePayload))
+    const response = await post(xai('anthropic', upstream), '/v1/messages', {
+      ...CLAUDE_CODE_TOOL_IMAGE_REQUEST_FIXTURE,
+      max_tokens: 128
+    })
+    expect(response.status).toBe(200)
+    await response.text()
+    const sent = JSON.parse(String(upstream.mock.calls[0]?.[1]?.body))
+    expect(imageParts(sent)).toHaveLength(1)
+    expect(JSON.stringify(imageParts(sent))).toContain(CAPTURED_TOOL_IMAGE_PNG_BASE64)
+    expect(sent.input).toContainEqual(
+      expect.objectContaining({ type: 'function_call_output', call_id: 'toolu_fixture_1' })
+    )
+  })
+
+  it.each([false, true])(
+    'R02 Chat length preserves truncation through Responses HTTP (stream=%s)',
+    async (stream) => {
+      const completion = {
+        id: 'chat-length',
+        choices: [{ message: { content: 'partial' }, finish_reason: 'length' }]
+      }
+      const upstream = vi.fn<typeof fetch>(async () =>
+        stream
+          ? new Response(
+              `data: ${JSON.stringify({ choices: [{ delta: { content: 'partial' }, finish_reason: 'length' }] })}\n\ndata: [DONE]\n\n`,
+              { headers: { 'content-type': 'text/event-stream' } }
+            )
+          : Response.json(completion)
+      )
+      const response = await post(
+        new ResponsesBridge({ baseUrl: 'https://provider.example/v1', model: 'test' }, upstream),
+        '/responses',
+        { input: 'continue', stream }
+      )
+      expect(response.status).toBe(200)
+      const result = stream ? sse(await response.text()).at(-1)?.response : await response.json()
+      expect(result).toMatchObject({ status: 'incomplete' })
+    }
+  )
+
+  it.each(['anthropic', 'openai'] as const)(
+    'R02 Responses incomplete preserves truncation for %s',
+    async (wire) => {
+      const response = await post(
+        xai(wire, async () =>
+          Response.json({
+            ...responsePayload,
+            status: 'incomplete',
+            incomplete_details: { reason: 'max_output_tokens' }
+          })
+        ),
+        wire === 'anthropic' ? '/v1/messages' : '/v1/chat/completions',
+        textRequest
+      )
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(wire === 'anthropic' ? payload.stop_reason : payload.choices[0].finish_reason).toBe(
+        wire === 'anthropic' ? 'max_tokens' : 'length'
+      )
+    }
+  )
+
+  it('R02 Messages max_tokens preserves truncation in the Chat HTTP output', async () => {
+    const response = await post(
+      chat({ content: [{ type: 'text', text: 'partial' }], stop_reason: 'max_tokens' }),
+      '/v1/chat/completions',
+      textRequest
+    )
+    expect(response.status).toBe(200)
+    expect((await response.json()).choices[0].finish_reason).toBe('length')
+  })
+
+  it('R03 preserves cached input totals and normalizable cache read/write usage over HTTP', async () => {
+    const response = await post(
+      chat({
+        content: [],
+        stop_reason: 'end_turn',
+        usage: {
+          input_tokens: 3,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 4,
+          output_tokens: 2
+        }
+      }),
+      '/v1/chat/completions',
+      textRequest
+    )
+    expect(response.status).toBe(200)
+    const payload = await response.json()
+    expect
+      .soft(payload.usage)
+      .toMatchObject({ prompt_tokens: 17, total_tokens: 19, completion_tokens: 2 })
+    expect(normalizeOpenAiChatModelStepUsage(payload.usage)).toEqual({
+      inputTokens: 3,
+      cachedReadTokens: 10,
+      cachedWriteTokens: 4,
+      cacheTokens: 14,
+      outputTokens: 2
+    })
+  })
+
+  it('R04 emits requested SSE usage matching the same xAI JSON response', async () => {
+    const bridge = xai('openai', async () => Response.json(responsePayload))
+    const json = await post(bridge, '/v1/chat/completions', textRequest)
+    expect(json.status).toBe(200)
+    const payload = await json.json()
+    expect(payload.usage).toMatchObject({
+      prompt_tokens: 12,
+      prompt_tokens_details: { cached_tokens: 5 }
+    })
+    const response = await post(bridge, '/v1/chat/completions', {
+      ...textRequest,
+      stream: true,
+      stream_options: { include_usage: true }
+    })
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    expect(body).toContain('data: [DONE]')
+    expect(sse(body).filter((chunk) => chunk.usage)).toEqual([
+      expect.objectContaining({ choices: [], usage: payload.usage })
+    ])
+  })
+
+  it('R05 preserves two tool calls when Chat HTTP SSE is consumed by the existing adapter', async () => {
+    const response = await post(
+      chat({
+        content: [
+          { type: 'tool_use', id: 'call_a', name: 'first', input: { a: 1 } },
+          { type: 'tool_use', id: 'call_b', name: 'second', input: { b: 2 } }
+        ],
+        stop_reason: 'tool_use'
+      }),
+      '/v1/chat/completions',
+      { ...textRequest, stream: true }
+    )
+    expect(response.status).toBe(200)
+    const body = await response.text()
+    const calls = sse(body).flatMap((chunk) => chunk.choices?.[0]?.delta?.tool_calls ?? [])
+    expect.soft(calls.map((call) => call.index)).toEqual([0, 1])
+    let converted = ''
+    await streamChatToResponses(
+      new Response(body, { headers: { 'content-type': 'text/event-stream' } }),
+      {
+        writeHead: vi.fn(),
+        write: (chunk) => {
+          converted += chunk
+          return true
+        },
+        end: vi.fn()
+      },
+      'test-model'
+    )
+    expect(
+      sse(converted)
+        .at(-1)
+        ?.response.output.filter((item: Json) => item.type === 'function_call')
+    ).toMatchObject([
+      { call_id: 'call_a', name: 'first', arguments: '{"a":1}' },
+      { call_id: 'call_b', name: 'second', arguments: '{"b":2}' }
+    ])
+  })
+
+  it.each(['incomplete', 'completed'])(
+    'R06 rejects invalid tool arguments instead of emitting an empty call (%s)',
+    async (status) => {
+      const response = await post(
+        xai('anthropic', async () =>
+          Response.json({
+            ...responsePayload,
+            status,
+            incomplete_details: status === 'incomplete' ? { reason: 'max_output_tokens' } : null,
+            output: [
+              {
+                type: 'function_call',
+                call_id: 'call_bad',
+                name: 'read_file',
+                arguments: '{"path":'
+              }
+            ]
+          })
+        ),
+        '/v1/messages',
+        textRequest
+      )
+      const payload = await response.json()
+      expect
+        .soft(payload.content?.filter((part: Json) => part.type === 'tool_use') ?? [])
+        .toEqual([])
+      expect(response.status).toBe(502)
+      expect(payload).toHaveProperty('error')
+    }
+  )
+
+  it('R06 control preserves a legitimate empty-object call', async () => {
+    const response = await post(
+      xai('anthropic', async () =>
+        Response.json({
+          ...responsePayload,
+          output: [{ type: 'function_call', call_id: 'call_ok', name: 'get_time', arguments: '{}' }]
+        })
+      ),
+      '/v1/messages',
+      textRequest
+    )
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      content: [{ type: 'tool_use', input: {} }],
+      stop_reason: 'tool_use'
+    })
+  })
+
+  it.each([
+    { multiline: false, crlf: false },
+    { multiline: true, crlf: false },
+    { multiline: true, crlf: true }
+  ])(
+    'R07 restores tool identity in a complete SSE event ($multiline, crlf=$crlf)',
+    async ({ multiline, crlf }) => {
+      const upstream = vi.fn<typeof fetch>(async (_, init) => {
+        const request = JSON.parse(String(init?.body))
+        const item = {
+          type: 'function_call',
+          id: 'fc_a',
+          call_id: 'call_a',
+          name: request.tools[0].name,
+          arguments: '{}'
+        }
+        const prefix = '{"type":"response.output_item.done",'
+        const suffix = `"output_index":0,"item":${JSON.stringify(item)}}`
+        const body = `: heartbeat\nevent: response.output_item.done\nid: event-1\nretry: 1500\ndata: ${prefix}${multiline ? '\ndata: ' : ''}${suffix}\n\nevent: unknown\ndata: not-json\n\ndata: [DONE]\n\n`
+        const bytes = new TextEncoder().encode(crlf ? body.replaceAll('\n', '\r\n') : body)
+        return new Response(
+          new ReadableStream({
+            start(controller) {
+              // Split inside field names and CRLF boundaries, not only at event boundaries.
+              for (let index = 0; index < bytes.length; index += 7)
+                controller.enqueue(bytes.slice(index, index + 7))
+              controller.close()
+            }
+          }),
+          { headers: { 'content-type': 'text/event-stream' } }
+        )
+      })
+      const response = await post(
+        new NativeResponsesCompatibilityProxy(
+          { baseUrl: 'https://provider.example/v1', model: 'test' },
+          upstream
+        ),
+        '/responses',
+        {
+          input: 'lookup',
+          stream: true,
+          tools: [
+            {
+              type: 'namespace',
+              name: 'mcp__audit',
+              tools: [
+                { type: 'function', name: 'lookup', parameters: { type: 'object', properties: {} } }
+              ]
+            }
+          ]
+        }
+      )
+      expect(response.status).toBe(200)
+      const body = await response.text()
+      expect(body).toContain(': heartbeat')
+      expect(body).toContain('id: event-1')
+      expect(body).toContain('retry: 1500')
+      expect(body).toContain(
+        crlf ? 'event: unknown\r\ndata: not-json\r\n\r\n' : 'event: unknown\ndata: not-json\n\n'
+      )
+      expect(sse(body.split('event: unknown')[0])[0].item).toMatchObject({
+        name: 'lookup',
+        namespace: 'mcp__audit',
+        call_id: 'call_a'
+      })
+    }
+  )
+
+  it.each(['native', 'anthropic', 'chat'])(
+    'R08 preserves business schema names and null constraints (%s)',
+    (wire) => {
+      const schema = {
+        type: 'object',
+        properties: {
+          safety_identifier: { type: 'string' },
+          external_web_access: { type: 'boolean' },
+          prompt_cache_retention: { type: 'string' },
+          nullable: { const: null }
+        },
+        required: ['safety_identifier', 'nullable'],
+        additionalProperties: false
+      }
+      const original = structuredClone(schema)
+      const request =
+        wire === 'native'
+          ? sanitizeXaiResponsesRequest({
+              safety_identifier: 'metadata',
+              tools: [{ type: 'function', name: 'audit', parameters: schema }]
+            })
+          : wire === 'anthropic'
+            ? anthropicToResponses(
+                { messages: [], tools: [{ name: 'audit', input_schema: schema }] },
+                'test'
+              )
+            : chatToResponses(
+                {
+                  messages: [],
+                  tools: [{ type: 'function', function: { name: 'audit', parameters: schema } }]
+                },
+                'test'
+              )
+      expect(request).not.toHaveProperty('safety_identifier')
+      expect(schema).toEqual(original)
+      expect(request.tools).toEqual([expect.objectContaining({ parameters: original })])
+    }
+  )
+})
+
+describe('provider protocol regression edge contracts', () => {
+  it('R01 keeps parallel Codex results together and associates images without mutating replay', () => {
+    const image = {
+      type: 'input_image',
+      image_url: 'https://example.test/image.png',
+      detail: 'high'
+    }
+    const body = {
+      input: [
+        { type: 'function_call', call_id: 'call_parallel_alpha', name: 'first', arguments: '{}' },
+        { type: 'function_call', call_id: 'call_parallel_beta', name: 'second', arguments: '{}' },
+        {
+          type: 'function_call_output',
+          call_id: 'call_parallel_alpha',
+          output: [{ type: 'input_text', text: 'first result' }, image]
+        },
+        {
+          type: 'function_call_output',
+          call_id: 'call_parallel_beta',
+          output: [{ type: 'input_text', text: 'second result' }, image]
+        },
+        { type: 'message', role: 'assistant', content: 'I see both images.' }
+      ]
+    }
+    const original = structuredClone(body)
+    const result = responsesToChatRequest(body, 'test')
+    expect(result.messages.slice(0, 3)).toMatchObject([
+      {
+        role: 'assistant',
+        tool_calls: [{ id: 'call_parallel_alpha' }, { id: 'call_parallel_beta' }]
+      },
+      { role: 'tool', tool_call_id: 'call_parallel_alpha', content: 'first result' },
+      { role: 'tool', tool_call_id: 'call_parallel_beta', content: 'second result' }
+    ])
+    const media = result.messages.slice(3, -1)
+    expect(imageParts(media)).toEqual([
+      { type: 'image_url', image_url: { url: image.image_url, detail: 'high' } },
+      { type: 'image_url', image_url: { url: image.image_url, detail: 'high' } }
+    ])
+    expect(JSON.stringify(media)).toContain('call_parallel_alpha')
+    expect(JSON.stringify(media)).toContain('call_parallel_beta')
+    expect(body).toEqual(original)
+    expect(responsesToChatRequest(body, 'test')).toEqual(result)
+  })
+
+  it('R01 preserves URL images in Claude tool results and their call association', () => {
+    const result = anthropicToResponses(
+      {
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'tool_result',
+                tool_use_id: 'url_call',
+                content: [
+                  { type: 'text', text: 'image result' },
+                  { type: 'image', source: { type: 'url', url: 'https://example.test/tool.png' } }
+                ]
+              },
+              { type: 'tool_result', tool_use_id: 'other_call', content: 'other result' }
+            ]
+          }
+        ]
+      },
+      'test'
+    )
+    expect((result.input as Json[]).slice(0, 2)).toEqual([
+      { type: 'function_call_output', call_id: 'url_call', output: 'image result' },
+      { type: 'function_call_output', call_id: 'other_call', output: 'other result' }
+    ])
+    expect(imageParts(result)).toEqual([
+      { type: 'input_image', image_url: 'https://example.test/tool.png' }
+    ])
+    expect(JSON.stringify((result.input as Json[]).slice(2))).toContain('url_call')
+  })
+
+  it.each([false, true])(
+    'R02 truncation overrides tool-call completion (Messages stream=%s)',
+    async (stream) => {
+      const response = await post(
+        xai('anthropic', async () =>
+          Response.json({
+            ...responsePayload,
+            status: 'incomplete',
+            incomplete_details: { reason: 'max_output_tokens' },
+            output: [
+              { type: 'function_call', call_id: 'truncated', name: 'get_time', arguments: '{}' }
+            ]
+          })
+        ),
+        '/v1/messages',
+        { ...textRequest, stream }
+      )
+      expect(response.status).toBe(200)
+      const stopReason = stream
+        ? sse(await response.text()).find((event) => event.type === 'message_delta')?.delta
+            .stop_reason
+        : (await response.json()).stop_reason
+      expect(stopReason).toBe('max_tokens')
+    }
+  )
+
+  it.each(['failed', 'cancelled', 'in_progress', 'unrecognized'])(
+    'R02 rejects an explicit %s Responses result',
+    async (status) => {
+      const response = await post(
+        xai('openai', async () => Response.json({ ...responsePayload, status })),
+        '/v1/chat/completions',
+        textRequest
+      )
+      expect(response.status).toBe(502)
+      expect(await response.json()).toHaveProperty('error')
+    }
+  )
+
+  it.each([false, true])('R02 normalizes the Chat length reason (stream=%s)', async (stream) => {
+    const upstream = async (): Promise<Response> =>
+      stream
+        ? new Response(
+            'data: {"choices":[{"delta":{"content":"partial"},"finish_reason":"length"}]}\n\ndata: [DONE]\n\n',
+            { headers: { 'content-type': 'text/event-stream' } }
+          )
+        : Response.json({ choices: [{ message: { content: 'partial' }, finish_reason: 'length' }] })
+    const response = await post(
+      new ResponsesBridge({ baseUrl: 'https://provider.example/v1', model: 'test' }, upstream),
+      '/responses',
+      { input: 'continue', stream }
+    )
+    expect(response.status).toBe(200)
+    const payload = stream ? sse(await response.text()).at(-1)?.response : await response.json()
+    expect(payload).toMatchObject({
+      status: 'incomplete',
+      incomplete_details: { reason: 'max_output_tokens' },
+      output: [{ status: 'incomplete' }]
+    })
+  })
+
+  it.each([undefined, false])('R04 keeps usage opt-in (include_usage=%s)', async (includeUsage) => {
+    const response = await post(
+      xai('openai', async () => Response.json(responsePayload)),
+      '/v1/chat/completions',
+      {
+        ...textRequest,
+        stream: true,
+        ...(includeUsage === undefined ? {} : { stream_options: { include_usage: includeUsage } })
+      }
+    )
+    expect(response.status).toBe(200)
+    expect(sse(await response.text()).filter((chunk) => chunk.usage)).toEqual([])
+  })
+
+  it.each(['null', '[]', '42', '"text"', undefined])(
+    'R06 rejects non-object or missing arguments before SSE (%s)',
+    async (arguments_) => {
+      const response = await post(
+        xai('anthropic', async () =>
+          Response.json({
+            ...responsePayload,
+            output: [{ type: 'function_call', call_id: 'bad', name: 'run', arguments: arguments_ }]
+          })
+        ),
+        '/v1/messages',
+        { ...textRequest, stream: true }
+      )
+      expect(response.status).toBe(502)
+      expect(response.headers.get('content-type')).toContain('application/json')
+      expect(await response.json()).toHaveProperty('error')
+    }
+  )
+
+  it('R08 leaves schema defaults, enums, metadata and tool output business values opaque', () => {
+    const data = {
+      safety_identifier: null,
+      external_web_access: false,
+      prompt_cache_retention: 'business'
+    }
+    const body = {
+      prompt_cache_retention: '24h',
+      safety_identifier: 'wire',
+      external_web_access: true,
+      previous_response_id: null,
+      metadata: data,
+      input: [{ type: 'function_call_output', call_id: 'a', output: data }],
+      additional_tools: [
+        {
+          type: 'function',
+          name: 'audit',
+          parameters: {
+            type: 'object',
+            properties: { value: { enum: [null, 'present'], default: null } }
+          }
+        }
+      ]
+    }
+    const expected = structuredClone(body)
+    const result = sanitizeXaiResponsesRequest(body)
+    expect(result).toEqual({
+      metadata: expected.metadata,
+      input: expected.input,
+      tools: expected.additional_tools
+    })
+    expect(body).toEqual(expected)
+  })
+})
+
+describe('provider termination rejection contracts', () => {
+  it.each([false, true])(
+    'R02 does not turn an unknown Messages stop reason into success (stream=%s)',
+    async (stream) => {
+      const response = await post(
+        chat({ content: [{ type: 'text', text: 'partial' }], stop_reason: 'unexpected' }),
+        '/v1/chat/completions',
+        { ...textRequest, stream }
+      )
+      expect(response.status).toBe(502)
+      expect(await response.json()).toHaveProperty('error')
+    }
+  )
+
+  it.each(['anthropic', 'openai'] as const)(
+    'R02 retains content filtering for %s',
+    async (wire) => {
+      const response = await post(
+        xai(wire, async () =>
+          Response.json({
+            ...responsePayload,
+            status: 'incomplete',
+            incomplete_details: { reason: 'content_filter' }
+          })
+        ),
+        wire === 'anthropic' ? '/v1/messages' : '/v1/chat/completions',
+        textRequest
+      )
+      expect(response.status).toBe(200)
+      const payload = await response.json()
+      expect(wire === 'anthropic' ? payload.stop_reason : payload.choices[0].finish_reason).toBe(
+        wire === 'anthropic' ? 'refusal' : 'content_filter'
+      )
+    }
+  )
+})

--- a/src/main/settings/responses-bridge.test.ts
+++ b/src/main/settings/responses-bridge.test.ts
@@ -1925,7 +1925,7 @@ describe('Responses-compatible bridge conversion', () => {
       const output = await response.text()
       // [DONE] is present but the answer was cut off by length: incomplete wins over a clean complete.
       expect(output).toContain('response.incomplete')
-      expect(output).toContain('length')
+      expect(output).toContain('"incomplete_details":{"reason":"max_output_tokens"}')
       expect(output).not.toContain('response.completed')
     } finally {
       await bridge.close()

--- a/src/main/settings/responses-request-adapter.test.ts
+++ b/src/main/settings/responses-request-adapter.test.ts
@@ -89,7 +89,7 @@ describe('Responses request protocol adapter', () => {
     })
   })
 
-  it('stringifies function-call image output, documenting why the Codex Chat bridge stays disabled', () => {
+  it('keeps function-call images in associated user content', () => {
     const imageOutput = [
       { type: 'input_text', text: '{"status":"completed"}' },
       { type: 'input_image', image_url: 'data:image/png;base64,aW1hZ2U=' }
@@ -110,9 +110,9 @@ describe('Responses request protocol adapter', () => {
     expect(request.messages).toContainEqual({
       role: 'tool',
       tool_call_id: 'call-1',
-      content: JSON.stringify(imageOutput)
+      content: '{"status":"completed"}'
     })
-    expect(request.messages).not.toContainEqual(
+    expect(request.messages).toContainEqual(
       expect.objectContaining({
         content: expect.arrayContaining([expect.objectContaining({ type: 'image_url' })])
       })

--- a/src/main/settings/responses-request-adapter.ts
+++ b/src/main/settings/responses-request-adapter.ts
@@ -184,6 +184,12 @@ export const inputToMessages = (
 
   const droppedItemTypes = new Set<string>()
   let pendingToolCalls: JsonObject[] = []
+  let pendingToolImages: JsonObject[] = []
+  const flushToolImages = (): void => {
+    if (pendingToolImages.length === 0) return
+    messages.push({ role: 'user', content: pendingToolImages })
+    pendingToolImages = []
+  }
   let pendingReasoning: string | undefined
   const flushToolCalls = (): void => {
     if (pendingToolCalls.length === 0) return
@@ -199,6 +205,7 @@ export const inputToMessages = (
   for (const item of input) {
     if (!item || typeof item !== 'object') throw new Error('Responses input items must be objects')
     if (item.type === 'function_call') {
+      flushToolImages()
       const callId = item.call_id ?? item.id
       const reasoning = reasoningByCallId?.get(String(callId))
       if (reasoning && !pendingReasoning) pendingReasoning = reasoning
@@ -209,6 +216,7 @@ export const inputToMessages = (
       })
     } else if (item.type === 'message') {
       flushToolCalls()
+      flushToolImages()
       const role = item.role === 'developer' ? 'system' : (item.role ?? 'user')
       if (!['system', 'user', 'assistant'].includes(role)) {
         throw new Error(`Unsupported Responses message role: ${String(item.role)}`)
@@ -216,11 +224,29 @@ export const inputToMessages = (
       messages.push({ role, content: textFromContent(item.content) })
     } else if (item.type === 'function_call_output') {
       flushToolCalls()
+      const content = Array.isArray(item.output) ? textFromContent(item.output) : item.output
       messages.push({
         role: 'tool',
         tool_call_id: item.call_id,
-        content: typeof item.output === 'string' ? item.output : JSON.stringify(item.output)
+        content: Array.isArray(content)
+          ? content
+              .filter((part) => part.type === 'text')
+              .map((part) => part.text)
+              .join('')
+          : typeof content === 'string'
+            ? content
+            : JSON.stringify(content)
       })
+      if (Array.isArray(content)) {
+        const images = content.filter((part) => part.type === 'image_url')
+        if (images.length > 0) {
+          // Keep all parallel tool results adjacent before attaching their associated media.
+          pendingToolImages.push(
+            { type: 'text', text: `Images from tool call ${String(item.call_id)}:` },
+            ...images
+          )
+        }
+      }
     } else if (KNOWN_SKIPPABLE_ITEM_TYPES.has(String(item.type))) {
       droppedItemTypes.add(String(item.type))
     } else {
@@ -228,6 +254,7 @@ export const inputToMessages = (
     }
   }
   flushToolCalls()
+  flushToolImages()
 
   if (droppedItemTypes.size > 0) {
     log.info('bridge dropped non-representable input items', {

--- a/src/main/settings/responses-response-adapter.ts
+++ b/src/main/settings/responses-response-adapter.ts
@@ -172,11 +172,33 @@ const chatUsageToResponsesUsage = (usage: unknown): JsonObject | undefined => {
   }
 }
 
+const chatTerminalDetails = (
+  finishReason: unknown
+): { status: 'completed' | 'incomplete'; incomplete_details: { reason: string } | null } => {
+  if (finishReason == null || finishReason === 'stop' || finishReason === 'tool_calls') {
+    return { status: 'completed', incomplete_details: null }
+  }
+  if (finishReason === 'length' || finishReason === 'content_filter') {
+    return {
+      status: 'incomplete',
+      incomplete_details: {
+        reason: finishReason === 'length' ? 'max_output_tokens' : 'content_filter'
+      }
+    }
+  }
+  throw new ResponsesProtocolError(
+    'Unsupported upstream finish reason',
+    502,
+    'unsupported_upstream_output'
+  )
+}
+
 export const completionToResponse = (
   completion: JsonObject,
   namespacedTools: readonly ResponsesBridgeNamespacedTool[] = []
 ): JsonObject => {
   const message = completion.choices?.[0]?.message ?? {}
+  const terminal = chatTerminalDetails(completion.choices?.[0]?.finish_reason)
   const output: JsonObject[] = []
   if (hasUpstreamImageField(message)) throw unsupportedUpstreamImageOutput()
   const contentText = upstreamTextFromContent(message.content)
@@ -190,7 +212,7 @@ export const completionToResponse = (
     output.push({
       id: `msg_${completion.id}`,
       type: 'message',
-      status: 'completed',
+      status: terminal.status,
       role: 'assistant',
       content: [{ type: 'output_text', text, annotations: [] }]
     })
@@ -200,18 +222,22 @@ export const completionToResponse = (
     output.push({
       id: `fc_${tool.id}`,
       type: 'function_call',
-      status: 'completed',
+      status: terminal.status,
       call_id: tool.id,
       ...identity,
       arguments: tool.function?.arguments ?? '{}'
     })
   }
-  return responseEnvelope(
-    completion.id ?? `resp_${randomBytes(6).toString('hex')}`,
-    completion.model,
-    output,
-    chatUsageToResponsesUsage(completion.usage)
-  )
+  return {
+    ...responseEnvelope(
+      completion.id ?? `resp_${randomBytes(6).toString('hex')}`,
+      completion.model,
+      output,
+      chatUsageToResponsesUsage(completion.usage),
+      terminal.status
+    ),
+    ...terminal
+  }
 }
 
 const writeEvent = (
@@ -356,6 +382,7 @@ export const streamChatToResponses = async (
   }
 
   let streamError: unknown
+  let terminal = chatTerminalDetails(undefined)
   try {
     await consumeBoundedResponseBody(
       upstream,
@@ -370,6 +397,7 @@ export const streamChatToResponses = async (
     )
     buffered += decoder.decode()
     if (buffered.trim()) handleRecord(buffered)
+    terminal = chatTerminalDetails(terminalFinishReason)
   } catch (error) {
     streamError = error
   }
@@ -377,7 +405,8 @@ export const streamChatToResponses = async (
   for (const index of toolItems.keys()) ensureToolItem(index)
 
   for (const item of output) {
-    item.status = 'completed'
+    item.status =
+      streamError || (!terminalFinishReason && !sawDone) ? 'incomplete' : terminal.status
     const outputIndex = output.indexOf(item)
     if (item.type === 'message') {
       const text = item.content.map((part: JsonObject) => part.text).join('')
@@ -425,7 +454,7 @@ export const streamChatToResponses = async (
         message: 'Upstream stream ended before completion'
       })
     })
-  } else if (terminalFinishReason === 'stop' || terminalFinishReason === 'tool_calls') {
+  } else if (terminal.status === 'completed' && terminalFinishReason) {
     writeEvent(response, 'response.completed', sequence++, {
       response: responseEnvelope(responseId, model, output, usage)
     })
@@ -434,7 +463,7 @@ export const streamChatToResponses = async (
     writeEvent(response, 'response.incomplete', sequence++, {
       response: {
         ...responseEnvelope(responseId, model, output, usage, 'incomplete'),
-        incomplete_details: { reason: terminalFinishReason }
+        incomplete_details: terminal.incomplete_details
       }
     })
   } else if (sawDone) {

--- a/src/main/settings/xai-oauth-provider-bridge.ts
+++ b/src/main/settings/xai-oauth-provider-bridge.ts
@@ -184,7 +184,15 @@ export class XaiOAuthProviderBridge {
     if (!wantsStream) return json(response, 200, translated)
     response.writeHead(200, { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' })
     if (this.wire === 'anthropic') this.writeAnthropicStream(response, translated)
-    else this.writeChatStream(response, translated)
+    else
+      this.writeChatStream(
+        response,
+        translated,
+        typeof body.stream_options === 'object' &&
+          body.stream_options !== null &&
+          'include_usage' in body.stream_options &&
+          body.stream_options.include_usage === true
+      )
   }
 
   private advertise(id: string): void {
@@ -285,18 +293,27 @@ export class XaiOAuthProviderBridge {
     response.end()
   }
 
-  private writeChatStream(response: ServerResponse, completion: Record<string, unknown>): void {
+  private writeChatStream(
+    response: ServerResponse,
+    completion: Record<string, unknown>,
+    includeUsage: boolean
+  ): void {
     const choices = Array.isArray(completion.choices) ? completion.choices : []
     const first = choices[0] as Record<string, unknown> | undefined
     const message =
       first && typeof first.message === 'object' ? (first.message as Record<string, unknown>) : {}
     const chunk = (delta: unknown, finishReason: unknown = null): void => {
       response.write(
-        `data: ${JSON.stringify({ id: completion.id, object: 'chat.completion.chunk', created: completion.created, model: completion.model, choices: [{ index: 0, delta, finish_reason: finishReason }] })}\n\n`
+        `data: ${JSON.stringify({ id: completion.id, object: 'chat.completion.chunk', created: completion.created, model: completion.model, choices: [{ index: 0, delta, finish_reason: finishReason }], ...(includeUsage ? { usage: null } : {}) })}\n\n`
       )
     }
     chunk({ role: 'assistant', content: message.content, tool_calls: message.tool_calls })
     chunk({}, first?.finish_reason)
+    if (includeUsage) {
+      response.write(
+        `data: ${JSON.stringify({ id: completion.id, object: 'chat.completion.chunk', created: completion.created, model: completion.model, choices: [], usage: completion.usage })}\n\n`
+      )
+    }
     response.end('data: [DONE]\n\n')
   }
 }

--- a/src/main/settings/xai-protocol.test.ts
+++ b/src/main/settings/xai-protocol.test.ts
@@ -124,9 +124,11 @@ describe('xAI protocol projection', () => {
       sanitizeXaiResponsesRequest({
         prompt_cache_retention: '24h',
         safety_identifier: 'secret',
-        input: [{ external_web_access: true, content: null }]
+        external_web_access: true,
+        previous_response_id: null,
+        input: [{ role: 'user', content: 'hello' }]
       })
-    ).toEqual({ input: [{}] })
+    ).toEqual({ input: [{ role: 'user', content: 'hello' }] })
     expect(
       countAnthropicInputTokens({ messages: [{ role: 'user', content: 'hello world' }] })
     ).toBeGreaterThan(0)

--- a/src/main/settings/xai-protocol.ts
+++ b/src/main/settings/xai-protocol.ts
@@ -30,6 +30,9 @@ const contentParts = (content: unknown): unknown => {
     if (part.type === 'image_url' && object(part.image_url)) {
       return { type: 'input_image', image_url: part.image_url.url }
     }
+    if (part.type === 'image' && object(part.source) && part.source.type === 'url') {
+      return { type: 'input_image', image_url: part.source.url }
+    }
     if (part.type === 'image' && object(part.source) && part.source.type === 'base64') {
       return {
         type: 'input_image',
@@ -41,22 +44,16 @@ const contentParts = (content: unknown): unknown => {
 }
 
 export const sanitizeXaiResponsesRequest = (body: Json): Json => {
-  const clean = (value: unknown): unknown => {
-    if (Array.isArray(value)) return value.map(clean)
-    if (!object(value)) return value
-    return Object.fromEntries(
-      Object.entries(value)
-        .filter(
-          ([key, child]) =>
-            child !== null &&
-            key !== 'prompt_cache_retention' &&
-            key !== 'safety_identifier' &&
-            key !== 'external_web_access'
-        )
-        .map(([key, child]) => [key, clean(child)])
+  // Unsupported request metadata is top-level. Schemas and tool output are opaque business data.
+  const sanitized = Object.fromEntries(
+    Object.entries(body).filter(
+      ([key, value]) =>
+        value !== null &&
+        key !== 'prompt_cache_retention' &&
+        key !== 'safety_identifier' &&
+        key !== 'external_web_access'
     )
-  }
-  const sanitized = clean(body) as Json
+  )
   if (Array.isArray(sanitized.additional_tools)) {
     sanitized.tools = [
       ...(Array.isArray(sanitized.tools) ? sanitized.tools : []),
@@ -107,6 +104,29 @@ export const anthropicToResponses = (body: Json, model: string): Json => {
           call_id: part.tool_use_id,
           output: textOf(part.content)
         })
+        if (Array.isArray(part.content)) {
+          const media: unknown[] = []
+          for (const resultPart of part.content) {
+            if (!object(resultPart)) throw new Error('Unsupported tool result content.')
+            if (resultPart.type === 'text' || resultPart.type === 'input_text') continue
+            const converted = contentParts([resultPart])
+            const image = Array.isArray(converted) ? converted[0] : undefined
+            if (
+              !object(image) ||
+              image.type !== 'input_image' ||
+              typeof image.image_url !== 'string'
+            ) {
+              throw new Error('Unsupported tool result image content.')
+            }
+            media.push(image)
+          }
+          if (media.length > 0) {
+            messageContent.push(
+              { type: 'input_text', text: `Images from tool call ${String(part.tool_use_id)}:` },
+              ...media
+            )
+          }
+        }
       } else {
         const converted = contentParts([part])
         messageContent.push(Array.isArray(converted) ? converted[0] : part)
@@ -232,17 +252,35 @@ const responseCalls = (response: Json): Json[] =>
 
 const usage = (response: Json): Json => (object(response.usage) ? response.usage : {})
 
+const responseFinishReason = (response: Json): 'length' | 'content_filter' | undefined => {
+  if (response.status === 'incomplete') {
+    const reason = object(response.incomplete_details)
+      ? response.incomplete_details.reason
+      : undefined
+    if (reason === 'max_output_tokens') return 'length'
+    if (reason === 'content_filter') return 'content_filter'
+    throw new Error('Upstream response is incomplete for an unsupported reason.')
+  }
+  // Older compatible providers omit status. Explicit nonterminal/failed statuses are not success.
+  if (response.status != null && response.status !== 'completed') {
+    throw new Error('Upstream response did not complete successfully.')
+  }
+  return undefined
+}
+
 export const responsesToAnthropic = (response: Json, model: string): Json => {
+  const finishReason = responseFinishReason(response)
   const content: Json[] = []
   const text = responseText(response)
   if (text) content.push({ type: 'text', text })
   for (const call of responseCalls(response)) {
-    let input: unknown = {}
+    let input: unknown
     try {
-      input = typeof call.arguments === 'string' ? JSON.parse(call.arguments) : {}
+      input = typeof call.arguments === 'string' ? JSON.parse(call.arguments) : undefined
     } catch {
-      input = {}
+      throw new Error('Upstream tool arguments must be a valid JSON object.')
     }
+    if (!object(input)) throw new Error('Upstream tool arguments must be a valid JSON object.')
     content.push({ type: 'tool_use', id: call.call_id ?? call.id, name: call.name, input })
   }
   const counts = usage(response)
@@ -252,7 +290,14 @@ export const responsesToAnthropic = (response: Json, model: string): Json => {
     role: 'assistant',
     model,
     content,
-    stop_reason: responseCalls(response).length > 0 ? 'tool_use' : 'end_turn',
+    stop_reason:
+      finishReason === 'length'
+        ? 'max_tokens'
+        : finishReason === 'content_filter'
+          ? 'refusal'
+          : responseCalls(response).length > 0
+            ? 'tool_use'
+            : 'end_turn',
     stop_sequence: null,
     usage: {
       input_tokens: counts.input_tokens ?? 0,
@@ -262,6 +307,7 @@ export const responsesToAnthropic = (response: Json, model: string): Json => {
 }
 
 export const responsesToChat = (response: Json, model: string): Json => {
+  const finishReason = responseFinishReason(response)
   const calls = responseCalls(response)
   const counts = usage(response)
   const inputDetails = object(counts.input_tokens_details) ? counts.input_tokens_details : {}
@@ -288,7 +334,7 @@ export const responsesToChat = (response: Json, model: string): Json => {
               }
             : {})
         },
-        finish_reason: calls.length ? 'tool_calls' : 'stop'
+        finish_reason: finishReason ?? (calls.length ? 'tool_calls' : 'stop')
       }
     ],
     usage: {


### PR DESCRIPTION
## Problem

Provider protocol conversion can silently change tool results and completion semantics: tool images become text or disappear, truncated answers look complete, cached input is undercounted, xAI Chat SSE omits requested usage, parallel tools have no stream index, malformed tool arguments become `{}`, multiline native SSE loses tool identity, and request sanitization removes legitimate schema fields and null constraints.

## Proposed change

- Preserve tool-result text/call IDs and attach typed images in associated upstream user content, keeping parallel Chat tool results adjacent.
- Map truncation/filter reasons consistently in JSON and SSE; reject explicit failed/nonterminal or unsupported termination values while retaining compatibility with omitted status fields.
- Sum uncached input, cache reads and cache writes; retain the existing `cache_creation_input_tokens` compatibility extension. Emit requested xAI SSE usage with empty `choices` before `[DONE]` and add stable parallel tool indexes at Chat serialization.
- Reject malformed or non-object Responses tool arguments before publishing Messages tool calls, including before downstream SSE starts; valid `{}` remains allowed.
- Join native SSE data lines at the existing event boundary before restoring tool identity, preserving limits, comments and unknown events. Strip unsupported request-level metadata without recursively modifying business schemas or tool data.

## Scope and non-goals

Six existing production files, no new production module or public export. No database/schema migration, application enum, persisted format, historical backfill, UI component, dependency or subscription owner. Correct future usage can flow through existing persistence consumers. Existing unknown/omitted-status compatibility is covered separately from explicit failure handling.

Images use supported upstream content parts; this does not enable new models or change the application's saved user messages. No automatic continuation/retry or tool execution is added. No UI screenshots apply because renderer pages and error presentation are unchanged; HTTP error behavior is tested, not claimed as a UI reproduction.

## Acceptance criteria and validation

The final regression suite contains 41 cases. Against the unchanged base production files, **36 cases failed and 5 controls passed on each of two runs**. Failures were behavioral assertions matching R01–R08, not startup errors. The same suite passes **41/41** after the fix. Existing captured Codex/Claude image requests and real loopback HTTP bridges are used; no production test seam was introduced.

All checks below ran after the last material edit. The worktree reused the root installation for Vitest:

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| R01–R08 HTTP/adapters; parallel image association, malformed arguments, LF/CRLF fragmented SSE, unknown reasons, opaque schema values | `node ../../node_modules/vitest/vitest.mjs run src/main/settings/provider-protocol-regressions.test.ts src/main/settings/chat-provider-compatibility.test.ts src/main/acp/codebuddy-turn-adapter.test.ts src/main/agent-framework/codebuddy.test.ts src/shared/settings.test.ts --maxWorkers=2` | 74 passed, including all 41 regressions |
| Settings transport owners, request/result architecture boundaries, native SSE limits/cancellation/diagnostics, same-protocol image fixtures, OAuth refresh/retarget/cleanup, framework contracts and representative ACP/CLI/reviewer/artifact consumers | `npm run test:module -- settings_backend_resolution` | 741 passed, 4 skipped; 38 files passed, 1 skipped |
| Main, preload/shared and renderer typing | `npm run typecheck` | Passed, including sandbox-package typecheck |
| Repository lint | `npm run lint` | Passed |
| Changed-file formatting and whitespace | `prettier --check <11 changed files>`; `git diff --check` | Passed |
| Final impact explanation | `npm run test:affected:explain -- --base f4897533d853740320dbbf29b4e0aa7dd92c9d68 --head HEAD` | Full CI fallback: Chat compatibility/new regression ownership is not declared; no classifier rules changed |

The module set covers Claude Code, OpenCode, Codex Responses and Codex Chat routes; supplemental checks cover CodeBuddy. No local full `npm test` was run, per maintainer instruction. The exact-head PR Gate remains authoritative for full and platform-risk lanes. Independent AI review is pending CI; local checks are not a claim of completed independent review.

Limitations: deterministic upstream fixtures establish wire contracts, not real-provider acceptance, real CLI tool execution, UI billing, or historical data recovery. The R05 consumer composition demonstrates the index contract and is not presented as a real CodeBuddy-to-Responses production chain. Four module tests remain skipped under their existing environment gates.

## Review focus

Image association and parallel-result ordering; completion versus truncation/error semantics; cache totals and the additive cache-write field; no fabricated tool arguments; SSE metadata/limits preservation; sanitization boundaries. Local planning files and raw evidence are excluded from the PR.
