### PR TITLE
fix(literature): preserve retrieval evidence and document scope

### DIFF
--- a/src/main/literature/document-reader.test.ts
+++ b/src/main/literature/document-reader.test.ts
@@ -2,6 +2,9 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+
 import { PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -10,6 +13,8 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import { extractPdfText } from '../uploads/attachment-media'
 import { LiteratureDocumentReader } from './document-reader'
 import { LiteratureFullTextIndex, literatureIndexPath } from './full-text-index'
+
+import { createLiteratureMcpServer, LITERATURE_READ_DOCUMENT_TOOL_NAME } from './mcp-server'
 
 vi.mock('../uploads/attachment-media', () => ({ extractPdfText: vi.fn() }))
 
@@ -115,6 +120,96 @@ describe('LiteratureDocumentReader', () => {
   afterEach(async () => {
     await rm(root, { recursive: true, force: true })
     vi.restoreAllMocks()
+  })
+
+  it.each([
+    { query: 'DNA', pages: [1] },
+    { query: '修复机制', pages: [2] },
+    { query: 'DNA 修复机制', pages: [1, 2] }
+  ])(
+    'retrieves the matching pages for "$query" in the same bilingual PDF',
+    async ({ query, pages }) => {
+      vi.mocked(extractPdfText).mockResolvedValue({
+        text: '--- Page 1 ---\nDNA background discussion.\n--- Page 2 ---\n本研究的主要结论是修复机制显著提高可靠性。',
+        pageCount: 2,
+        truncated: false
+      })
+      const reader = new LiteratureDocumentReader({
+        storageRoot: root,
+        sessions: { loadSessionForContinuation: vi.fn(async () => session()) },
+        inputs: {
+          resolveVersion: vi.fn(async () => input),
+          resolveContent: vi.fn(async () => join(root, 'paper.pdf'))
+        }
+      })
+      const result = (await reader.readCurrent({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        promptMessageId: 'message-1',
+        input: { documentIds: ['binding-1'], query }
+      })) as { passages: Array<{ documentId: string; pageStart: number }> }
+
+      expect(result.passages.every(({ documentId }) => documentId === 'binding-1')).toBe(true)
+      expect(result.passages.map(({ pageStart }) => pageStart).sort()).toEqual(pages)
+    }
+  )
+
+  it('does not silently broaden a singular document search through the MCP boundary', async () => {
+    vi.mocked(extractPdfText).mockImplementation(async (path) => ({
+      text:
+        path === join(root, 'second.pdf')
+          ? '--- Page 1 ---\nneedle\n--- Page 2 ---\nconclusion'
+          : '--- Page 1 ---\nbackground\n--- Page 2 ---\nunrelated',
+      pageCount: 2,
+      truncated: false
+    }))
+    const reader = new LiteratureDocumentReader({
+      storageRoot: root,
+      sessions: { loadSessionForContinuation: vi.fn(async () => session()) },
+      inputs: {
+        resolveVersion: vi.fn(async ({ inputFileVersionId }) =>
+          inputFileVersionId === 'version-2' ? secondInput : input
+        ),
+        resolveContent: vi.fn(async (resolved) =>
+          join(root, resolved.inputFileVersionId === 'version-2' ? 'second.pdf' : 'paper.pdf')
+        )
+      }
+    })
+    const server = createLiteratureMcpServer({
+      readDocument: (request) =>
+        reader.readCurrent({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          promptMessageId: 'message-1',
+          input: request
+        })
+    })
+    const client = new Client({ name: 'literature-scope-test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+    try {
+      const scoped = await client.callTool({
+        name: LITERATURE_READ_DOCUMENT_TOOL_NAME,
+        arguments: { documentIds: ['binding-1'], query: 'needle' }
+      })
+      expect(scoped.structuredContent).toMatchObject({ passages: [] })
+      const all = await client.callTool({
+        name: LITERATURE_READ_DOCUMENT_TOOL_NAME,
+        arguments: { query: 'needle' }
+      })
+      expect(all.structuredContent).toMatchObject({
+        documents: [{ id: 'binding-1' }, { id: 'binding-2' }],
+        passages: [expect.objectContaining({ documentId: 'binding-2' })]
+      })
+      const ambiguous = await client.callTool({
+        name: LITERATURE_READ_DOCUMENT_TOOL_NAME,
+        arguments: { documentId: 'binding-1', query: 'needle' }
+      })
+      expect(ambiguous).toMatchObject({ isError: true })
+    } finally {
+      await client.close()
+      await server.close()
+    }
   })
 
   it('reads only the current message PDF snapshot and uses BM25 for a query', async () => {

--- a/src/main/literature/document-reader.ts
+++ b/src/main/literature/document-reader.ts
@@ -384,7 +384,7 @@ class LiteratureDocumentReader {
       }
     }
     const descriptors = [...descriptorByExtractionId.values()]
-    const fallbackResponse = (reason: 'empty-bm25' | 'bm25-error'): unknown => {
+    const fallbackResponse = (reason: 'empty-bm25' | 'bm25-error' | 'cjk-query'): unknown => {
       const passages = fallbackSearch(descriptors, query)
       log.info('Literature retrieval completed', {
         retrievalMode: 'fallback',
@@ -425,6 +425,9 @@ class LiteratureDocumentReader {
         })
       }
     }
+    // unicode61 cannot match concepts embedded in unsegmented CJK sentences. Route the
+    // entire query through lexical retrieval even when an English term would match FTS.
+    if (CJK_CHARACTER.test(query)) return fallbackResponse('cjk-query')
     let index: LiteratureFullTextIndex | undefined
     try {
       index = await LiteratureFullTextIndex.open(this.options.storageRoot)

--- a/src/main/literature/full-text-index.test.ts
+++ b/src/main/literature/full-text-index.test.ts
@@ -5,7 +5,11 @@ import { join } from 'node:path'
 import { PrismaClient } from '@prisma/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { LiteratureFullTextIndex, literatureIndexPath } from './full-text-index'
+import {
+  LiteratureFullTextIndex,
+  literatureIndexPath,
+  type LiteratureIndexChunk
+} from './full-text-index'
 import { migrationSqlExecutor } from '../database/migration-sql-executor'
 
 const HASH_A = 'a'.repeat(64)
@@ -49,6 +53,38 @@ describe('LiteratureFullTextIndex', () => {
     await client.$disconnect()
     return Number(rows[0]?.value ?? 0)
   }
+
+  it('retains selected matches when unrelated documents enter or leave the shared index', async () => {
+    const chunks = (contents: string[]): LiteratureIndexChunk[] =>
+      contents.map((content, index) => ({
+        pageStart: index + 1,
+        pageEnd: index + 1,
+        textStart: index * 100,
+        textEnd: index * 100 + content.length,
+        content
+      }))
+    await index.replace({
+      extractionId: 'selected',
+      documentChecksum: HASH_A,
+      extractorFingerprint: HASH_B,
+      chunks: chunks(['alpha', 'beta'])
+    })
+    const query = { extractionIds: ['selected'], query: 'alpha beta' }
+    const before = await index.search(query)
+    expect(before.map(({ content }) => content).sort()).toEqual(['alpha', 'beta'])
+    await index.replace({
+      extractionId: 'unselected',
+      documentChecksum: HASH_B,
+      extractorFingerprint: HASH_B,
+      chunks: chunks(Array.from({ length: 30 }, () => 'alpha'))
+    })
+    const during = await index.search(query)
+    expect(during.every(({ extractionId }) => extractionId === 'selected')).toBe(true)
+    expect.soft(during.map(({ content }) => content).sort()).toEqual(['alpha', 'beta'])
+    await index.deleteExtraction('unselected')
+    const after = await index.search(query)
+    expect(after.map(({ content }) => content).sort()).toEqual(['alpha', 'beta'])
+  })
 
   it('replaces PDF chunks and retrieves matching passages with page locators', async () => {
     await index.replace({
@@ -304,7 +340,7 @@ describe('LiteratureFullTextIndex', () => {
     expect(flush).toHaveBeenCalledTimes(5)
   })
 
-  it('filters weak matches relative to the best BM25 candidate', async () => {
+  it('ranks weaker matches after stronger evidence without excluding them', async () => {
     await index.replace({
       extractionId: 'extraction-1',
       documentChecksum: HASH_A,
@@ -343,7 +379,8 @@ describe('LiteratureFullTextIndex', () => {
       expect.objectContaining({
         pageStart: 1,
         relativeScore: 1
-      })
+      }),
+      expect.objectContaining({ pageStart: 2 })
     ])
   })
 

--- a/src/main/literature/full-text-index.ts
+++ b/src/main/literature/full-text-index.ts
@@ -52,7 +52,6 @@ const MAX_SECTION_TITLE_CHARS = 1_024
 const MAX_QUERY_TERMS = 16
 const MAX_SEARCH_RESULTS = 20
 const SEARCH_CANDIDATE_MULTIPLIER = 3
-const MIN_RELATIVE_BM25_SCORE = 0.25
 const MAX_RESULT_OVERLAP_RATIO = 0.5
 const INDEX_IDLE_RETENTION = '-1 day'
 const INDEX_ACCESS_FLUSH_INTERVAL_MS = 60 * 60 * 1000
@@ -421,12 +420,11 @@ class LiteratureFullTextIndex {
           rows[0]?.rank ?? 0
         )
       )
-      const qualified = candidates.filter(
-        ({ relativeScore }, index) => index === 0 || relativeScore >= MIN_RELATIVE_BM25_SCORE
-      )
+      // BM25 statistics cover the shared index, so relative scores must not exclude
+      // matching evidence merely because unselected documents were indexed or removed.
       const results: LiteratureSearchResult[] = []
       let overlapFilteredCount = 0
-      for (const candidate of qualified) {
+      for (const candidate of candidates) {
         const overlapsSelected = results.some(
           (selected) => resultOverlapRatio(candidate, selected) >= MAX_RESULT_OVERLAP_RATIO
         )
@@ -443,8 +441,6 @@ class LiteratureFullTextIndex {
         limit,
         candidateLimit,
         candidateCount: candidates.length,
-        relativeScoreThreshold: MIN_RELATIVE_BM25_SCORE,
-        qualityFilteredCount: candidates.length - qualified.length,
         overlapFilteredCount,
         bestRank: candidates[0]?.rank ?? null,
         lowestReturnedRelativeScore: results.at(-1)?.relativeScore ?? null,

--- a/src/main/literature/mcp-server.test.ts
+++ b/src/main/literature/mcp-server.test.ts
@@ -40,6 +40,59 @@ describe('Literature MCP server', () => {
     }
   })
 
+  it.each([
+    { query: 'needle', documentId: 'binding-1' },
+    { query: 'needle', cursor: 'cursor' },
+    { query: 'needle', documentIds: ['binding-1'], documentId: 'binding-1' },
+    { query: 'needle', documentIds: ['binding-1'], documentId: 'binding-2' },
+    { documentIds: ['binding-1'] },
+    { documentId: 'binding-1', documentIds: ['binding-2'], cursor: 'cursor' }
+  ])('rejects mode-incompatible fields before dispatch: %j', async (input) => {
+    const readDocument = vi.fn().mockResolvedValue({ scope: 'unused' })
+    const server = createLiteratureMcpServer({ readDocument })
+    const client = new Client({ name: 'literature-mode-test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+    try {
+      const result = await client.callTool({
+        name: LITERATURE_READ_DOCUMENT_TOOL_NAME,
+        arguments: input
+      })
+      expect(result).toMatchObject({ isError: true })
+      expect(readDocument).not.toHaveBeenCalled()
+      expect(JSON.stringify(result.content)).toContain(input.query ? 'Search' : 'Sequential')
+    } finally {
+      await client.close()
+      await server.close()
+    }
+  })
+
+  it.each([
+    {},
+    { documentId: 'binding-1' },
+    { cursor: 'cursor' },
+    { documentId: 'binding-1', cursor: 'cursor' },
+    { query: 'needle' },
+    { query: 'needle', documentIds: ['binding-1', 'binding-2'] }
+  ])('preserves valid reading and search inputs: %j', async (input) => {
+    const readDocument = vi.fn().mockResolvedValue({ scope: 'valid' })
+    const server = createLiteratureMcpServer({ readDocument })
+    const client = new Client({ name: 'literature-valid-mode-test', version: '1.0.0' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    await Promise.all([server.connect(serverTransport), client.connect(clientTransport)])
+    try {
+      const result = await client.callTool({
+        name: LITERATURE_READ_DOCUMENT_TOOL_NAME,
+        arguments: input
+      })
+      expect(result.isError).not.toBe(true)
+      expect(readDocument).toHaveBeenCalledExactlyOnceWith(input)
+    } finally {
+      await client.close()
+      await server.close()
+    }
+  })
+
   it('emits bounded presentation metadata before a large passage result', async () => {
     const readDocument = vi.fn().mockResolvedValue({
       scope: 'relevant-passages',

--- a/src/main/literature/mcp-server.ts
+++ b/src/main/literature/mcp-server.ts
@@ -74,13 +74,34 @@ const createLiteratureMcpServer = (handler: LiteratureMcpHandler): ModelContextP
     {
       title: 'Read linked literature',
       description:
-        'Read one to three multi-page PDFs explicitly linked to the current Open Science message. Omit query and provide documentId to read one document in bounded sequential batches, following nextCursor until null. Provide query to retrieve relevant passages across documentIds, or all linked documents when documentIds is omitted. Use this instead of Notebook, shell, filesystem, or Python for linked-PDF reading.',
-      inputSchema: {
-        documentId: z.string().trim().min(1).max(512).optional(),
-        documentIds: z.array(z.string().trim().min(1).max(512)).min(1).max(3).optional(),
-        query: z.string().trim().min(1).max(2_000).optional(),
-        cursor: z.string().trim().min(1).max(128).optional()
-      }
+        'Read one to three multi-page PDFs explicitly linked to the current Open Science message. Omit query and provide documentId to read one document in bounded sequential batches, following nextCursor until null. Provide query to retrieve relevant passages across documentIds, or all linked documents when documentIds is omitted. Search requests must not include documentId or cursor; sequential requests must not include documentIds. Use this instead of Notebook, shell, filesystem, or Python for linked-PDF reading.',
+      inputSchema: z
+        .object({
+          documentId: z.string().trim().min(1).max(512).optional(),
+          documentIds: z.array(z.string().trim().min(1).max(512)).min(1).max(3).optional(),
+          query: z.string().trim().min(1).max(2_000).optional(),
+          cursor: z.string().trim().min(1).max(128).optional()
+        })
+        .superRefine((request, context) => {
+          if (request.query !== undefined) {
+            for (const field of ['documentId', 'cursor'] as const) {
+              if (request[field] !== undefined)
+                context.addIssue({
+                  code: 'custom',
+                  path: [field],
+                  message:
+                    'Search requests accept query and documentIds only; omit documentId and cursor.'
+                })
+            }
+          } else if (request.documentIds !== undefined) {
+            context.addIssue({
+              code: 'custom',
+              path: ['documentIds'],
+              message:
+                'Sequential requests accept documentId and cursor only; omit documentIds or provide query.'
+            })
+          }
+        })
     },
     async (request) => {
       try {

--- a/src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx
+++ b/src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx
@@ -1,15 +1,85 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import type { ProjectFileItem } from '../../../../shared/project-files'
 
 import { ReadingContextPicker } from './ReadingContextPicker'
 
 afterEach(() => {
+  cleanup()
   vi.unstubAllGlobals()
   document.body.replaceChildren()
 })
 
 describe('ReadingContextPicker', () => {
+  it('hides stale project PDFs and prevents selection while the next project loads', async () => {
+    const file = (projectId: string): ProjectFileItem => ({
+      id: projectId,
+      source: 'upload',
+      sourceFileId: `upload-${projectId}`,
+      sourceVersionId: `version-${projectId}`,
+      projectId,
+      sessionId: 'source-session',
+      name: `${projectId}-only.pdf`,
+      path: `${projectId}.pdf`,
+      mimeType: 'application/pdf',
+      size: 20,
+      sortAtMs: 1
+    })
+    const first = { items: [file('A')], totalCount: 1 }
+    const second = { items: [file('B')], totalCount: 1 }
+    let resolveSecond!: (value: typeof second) => void
+    const loadingSecond = new Promise<typeof second>((resolve) => {
+      resolveSecond = resolve
+    })
+    const listFiles = vi.fn().mockResolvedValueOnce(first).mockReturnValueOnce(loadingSecond)
+    vi.stubGlobal('api', {
+      projectFiles: { listFiles },
+      sessions: { filterPdfContextCandidates: vi.fn(async ({ sources }) => ({ sources })) }
+    })
+    const selectFirst = vi.fn().mockResolvedValue(undefined)
+    const selectSecond = vi.fn().mockRejectedValue(new Error('keep picker open'))
+    const picker = (projectId: string, onSelect: typeof selectFirst): React.JSX.Element => (
+      <ReadingContextPicker
+        projectId={projectId}
+        linkedSources={[]}
+        atLimit={false}
+        onSelect={onSelect}
+      >
+        <button type="button">Reading</button>
+      </ReadingContextPicker>
+    )
+    const view = render(picker('A', selectFirst))
+    fireEvent.click(screen.getByRole('button', { name: 'Reading' }))
+    await screen.findByRole('option', { name: 'A-only.pdf' })
+
+    view.rerender(picker('B', selectSecond))
+    await waitFor(() => expect(listFiles).toHaveBeenCalledTimes(2))
+    const stale = screen.queryByRole('option', { name: 'A-only.pdf' })
+    expect.soft(stale).toBeNull()
+    expect.soft(screen.queryByText('Checking PDFs…')).not.toBeNull()
+    if (stale)
+      await act(async () => {
+        fireEvent.click(stale)
+      })
+    expect.soft(selectSecond).not.toHaveBeenCalled()
+    expect(selectFirst).not.toHaveBeenCalled()
+
+    selectSecond.mockClear().mockResolvedValue(undefined)
+    await act(async () => {
+      resolveSecond(second)
+    })
+    fireEvent.click(await screen.findByRole('option', { name: 'B-only.pdf' }))
+    await waitFor(() =>
+      expect(selectSecond).toHaveBeenCalledWith({
+        sourceKind: 'upload-version',
+        sourceFileId: 'upload-B',
+        sourceVersionId: 'version-B'
+      })
+    )
+  })
+
   it('retries project PDF discovery after a transient load failure', async () => {
     const listFiles = vi
       .fn()

--- a/src/renderer/src/pages/workspace/ReadingContextPicker.tsx
+++ b/src/renderer/src/pages/workspace/ReadingContextPicker.tsx
@@ -98,8 +98,10 @@ export const ReadingContextPicker = ({
     }
   }, [atLimit, loadRevision, open, projectId])
 
+  const isCurrentProject = result.projectId === projectId
   const linked = useMemo(() => new Set(linkedSources.map(sourceKey)), [linkedSources])
   const items = useMemo(() => {
+    if (!isCurrentProject) return []
     const needle = query.trim()
     return result.items
       .filter(({ source }) => !linked.has(sourceKey(source)))
@@ -107,9 +109,10 @@ export const ReadingContextPicker = ({
       .filter(({ match }) => match !== null)
       .sort((a, b) => (b.match?.score ?? 0) - (a.match?.score ?? 0))
       .map(({ item }) => item)
-  }, [linked, query, result.items])
+  }, [isCurrentProject, linked, query, result.items])
 
   const select = async (item: EligiblePdf): Promise<void> => {
+    if (!isCurrentProject || result.status !== 'loaded') return
     const key = sourceKey(item.source)
     setPendingKey(key)
     try {
@@ -160,7 +163,7 @@ export const ReadingContextPicker = ({
           <p className="px-2 py-2 text-sm text-text-300">
             {t('A conversation can link up to 3 PDFs.')}
           </p>
-        ) : result.status === 'loading' || result.status === 'idle' ? (
+        ) : !isCurrentProject || result.status === 'loading' || result.status === 'idle' ? (
           <p role="status" className="flex items-center gap-2 px-2 py-2 text-sm text-text-300">
             <Loader2 className="size-4 animate-spin" aria-hidden="true" />
             {t('Checking PDFs…')}

--- a/src/renderer/src/pages/workspace/literature-tool-presentation.ts
+++ b/src/renderer/src/pages/workspace/literature-tool-presentation.ts
@@ -138,7 +138,6 @@ const buildLiteratureToolSummary = (
   const presentation = outputs.map(presentationRecord).find(Boolean)
   const output = outputs.find(isLiteratureOutputRecord)
   const query = asString(input.query)
-  const presentedQuery = query && !/\p{Script=Han}/u.test(query) ? query : undefined
   const action: LiteratureToolAction = query ? 'search' : 'read'
   const presentationNames = Array.isArray(presentation?.documentNames)
     ? presentation.documentNames.flatMap((name) =>
@@ -173,7 +172,7 @@ const buildLiteratureToolSummary = (
 
   return {
     action,
-    ...(presentedQuery ? { query: presentedQuery } : {}),
+    ...(query ? { query } : {}),
     documentNames,
     documentCount: documentNames.length || requestedIds.length,
     ...(passageCount !== undefined ? { passageCount } : {}),

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -148,32 +148,22 @@ describe('workspace tool activity details', () => {
     expect(JSON.stringify(details)).not.toContain('binding-secret-id')
   })
 
-  it('keeps a CJK retrieval query out of the Literature presentation', () => {
-    const activity = createActivity({
-      providerToolName: 'mcp__open-science-literature__read_document',
-      rawInput: {
-        documentId: 'binding-secret-id',
-        query: '梳理这篇论文的核心贡献'
-      }
-    })
-
-    const details = buildToolActivityDetails(activity)
-
-    expect(details).toMatchObject({
-      displayName: 'Reading',
-      subtitle: undefined,
-      sections: [
-        {
-          kind: 'literature',
-          summary: {
-            action: 'search',
-            documentCount: 1
-          }
-        }
-      ]
-    })
-    expect(JSON.stringify(details)).not.toContain('梳理这篇论文的核心贡献')
-  })
+  it.each(['DNA repair', '修复机制', '修復機制', 'DNA 修复机制', 'DNA修復の仕組み'])(
+    'preserves the original Literature query "%s" in the tool card summary',
+    (query) => {
+      const details = buildToolActivityDetails(
+        createActivity({
+          providerToolName: 'mcp__open-science-literature__read_document',
+          rawInput: { documentIds: ['binding-secret-id'], query }
+        })
+      )
+      expect(details).toMatchObject({
+        displayName: 'Reading',
+        sections: [{ kind: 'literature', summary: { action: 'search', query, documentCount: 1 } }]
+      })
+      expect(JSON.stringify(details)).not.toContain('binding-secret-id')
+    }
+  )
 
   it('uses the shared Literature presentation block when OpenCode truncates the full result', () => {
     const activity = createActivity({


### PR DESCRIPTION
## Problem

Mixed English/CJK queries can return only the English background passage, and unrelated documents in the shared FTS corpus can remove matching evidence through a relative-score cutoff. `read_document` also silently ignores mode-incompatible selection fields. The Reading picker can expose the previous project's PDF during a project switch, while the tool card hides queries containing Han characters.

## Proposed change

- Route CJK queries through the existing bounded lexical/bigram search; retain BM25 for English.
- Validate search versus sequential parameters at the MCP schema boundary. Reject ignored fields with actionable SDK validation errors.
- Remove the global relative-score exclusion while retaining ranking, limits and overlap deduplication.
- Require current-project results for picker rendering and selection, retaining cancellation of stale requests.
- Preserve every query language in the existing tool-card summary and line clamp.

## Scope and non-goals

No dependencies, architecture changes, persisted fields, database schema changes, migrations or historical-call rewriting. Existing indexes remain usable. Valid MCP calls retain their behavior; previously ignored invalid combinations now fail. Public retrieval modes and picker statuses are unchanged; `cjk-query` is only an internal log routing reason.

BM25 ranking and top-limit membership can still vary with corpus statistics. This change removes inappropriate hard exclusion; it does not introduce corpus-independent ranking or a new retrieval engine.

## Acceptance criteria and validation

Reproduced all five reports before production edits through actual SQLite, the SDK Client/InMemoryTransport/server/reader, a mounted picker with a deferred next-project response, and the existing activity-summary consumer. Two identical baseline runs each had 85 passing controls/existing cases and 8 expected failures (four query-language variants). Additional invalid-mode cases also failed on unchanged code. No test-only production seam or report numbers in test names.

Checks ran after the last material behavior edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Retrieval, filtering, parameter validation, picker and query summaries | `npx vitest run src/main/literature src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts` | 108 passed |
| Real MCP HTTP endpoint and runtime consumer | `npx vitest run src/main/acp/runtime.test.ts src/main/acp/mcp-http-host.test.ts` | 602 passed; rerun outside sandbox because local port binding is blocked inside it |
| Capability/snapshot authority, cards, permissions and project-switch consumers | Consumer command below | 388 passed |
| Main, sandbox and renderer types | `npm run typecheck` | passed |
| Lint and whitespace | `npm run lint`; `git diff --check` | passed |

```sh
npx vitest run \
  src/main/acp/session-capability-owner.test.ts \
  src/main/session-persistence/pdf-context-owner.test.ts \
  src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx \
  src/renderer/src/pages/workspace/WorkspaceMessageScroller.render.test.tsx \
  src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx \
  src/renderer/src/pages/workspace/permission-request-presentation.test.ts \
  src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx \
  src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
```

1,098 distinct local cases passed. The module-impact helper does not yet own Literature and recommends full fallback. Per maintainer instruction, local validation uses the explicit owner/consumer slices above; PR CI owns complete and platform validation. No ownership-manifest change is included. Consumers were selected from CodeGraph and public call paths. Provider adapters share the unchanged MCP endpoint; this patch changes no subscription, replay or provider-specific transport logic. Live provider behavior and packaged OS lanes are not established by these local tests.

UI screenshots are pending ego lite first-run setup. The prepared local fixture mounts the real components with controlled test data. Independent verification remains pending PR review and CI.

## Review focus

Confirm the strict mode errors preserve valid requests; the mixed query includes both pages; unselected corpus changes no longer hard-filter selected matches; the project-switch window cannot submit an old PDF; and CJK queries appear in the existing card without exposing document identities.
