### PR TITLE
fix(notifications): restore unread visibility and expire orphaned requests

### DIFF
--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -1,0 +1,70 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import type { PlaywrightTestConfig } from '@playwright/test'
+import type { JSONReport } from '@playwright/test/reporter'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const loadConfig = async (platform: NodeJS.Platform): Promise<PlaywrightTestConfig> => {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { value: platform })
+  try {
+    vi.resetModules()
+    return (await import('./playwright.config')).default
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original })
+  }
+}
+
+describe('Electron Playwright concurrency', () => {
+  it('runs one Windows journey at a time even with the CI two-worker CLI budget', async () => {
+    const config = await loadConfig('win32')
+    const root = mkdtempSync(join(tmpdir(), 'open-science-playwright-config-'))
+    try {
+      const configPath = join(root, 'playwright.config.cjs')
+      writeFileSync(
+        configPath,
+        `module.exports = ${JSON.stringify({ ...config, testDir: root, outputDir: join(root, 'results') })}`
+      )
+      writeFileSync(
+        join(root, 'concurrency.spec.cjs'),
+        `const { test } = require(${JSON.stringify(require.resolve('@playwright/test'))});
+         for (let i = 0; i < 4; i++) test('journey ' + i, async () => {});`
+      )
+      const run = spawnSync(
+        process.execPath,
+        [
+          require.resolve('@playwright/test/cli'),
+          'test',
+          '-c',
+          configPath,
+          '--workers=2',
+          '--fully-parallel',
+          '--retries=0',
+          '--reporter=json'
+        ],
+        { encoding: 'utf8', timeout: 15_000 }
+      )
+      expect(run.status, run.stderr).toBe(0)
+      const report = JSON.parse(run.stdout) as JSONReport
+      const results = report.suites.flatMap((suite) =>
+        suite.specs.flatMap((spec) => spec.tests.flatMap((test) => test.results))
+      )
+      expect(results).toHaveLength(4)
+      expect([...new Set(results.map((result) => result.workerIndex))]).toEqual([0])
+    } finally {
+      rmSync(root, { recursive: true, force: true })
+    }
+  }, 20_000)
+
+  it.each(['darwin', 'linux'] as const)(
+    'preserves the CLI worker choice on %s',
+    async (platform) => {
+      expect((await loadConfig(platform)).projects).toBeUndefined()
+    }
+  )
+})

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
   snapshotPathTemplate: '{testDir}/{testFilePath}-snapshots/{arg}-darwin{ext}',
   fullyParallel: false,
   workers: 1,
+  // Keep Windows Electron journeys from sharing a desktop, including when CI raises the global
+  // worker budget. The unnamed project preserves existing test IDs and test-level sharding.
+  projects: process.platform === 'win32' ? [{ workers: 1 }] : undefined,
   retries: process.env.CI ? 1 : 0,
   timeout: 120_000,
   expect: {

--- a/src/main/notifications/notification-inbox-controller.test.ts
+++ b/src/main/notifications/notification-inbox-controller.test.ts
@@ -12,7 +12,7 @@ const repository = (
       unreadCount: 0,
       latestSequence: 0
     })),
-    expireTransientPendingAuthorizations: vi.fn(async () => ({
+    expireTransientPendingActions: vi.fn(async () => ({
       changed: false,
       unreadCount: 0,
       latestSequence: 0
@@ -90,7 +90,7 @@ describe('createNotificationInboxController', () => {
     await inbox.restore()
 
     expect(db.migrateLegacyUnread).toHaveBeenCalledWith(expect.any(Function), 1500)
-    expect(db.expireTransientPendingAuthorizations).toHaveBeenCalledWith(1500)
+    expect(db.expireTransientPendingActions).toHaveBeenCalledWith(1500)
     expect(db.snapshot).toHaveBeenCalledWith(1)
   })
 

--- a/src/main/notifications/notification-inbox-controller.ts
+++ b/src/main/notifications/notification-inbox-controller.ts
@@ -142,7 +142,7 @@ export const createNotificationInboxController = (
     try {
       const restoredAt = now()
       await dependencies.repository.migrateLegacyUnread(createId, restoredAt)
-      await dependencies.repository.expireTransientPendingAuthorizations(restoredAt)
+      await dependencies.repository.expireTransientPendingActions(restoredAt)
       const snapshot = await dependencies.repository.snapshot(1)
       unreadCount = snapshot.unreadCount
       latestSequence = snapshot.latestSequence

--- a/src/main/notifications/notification-inbox-repository.test.ts
+++ b/src/main/notifications/notification-inbox-repository.test.ts
@@ -6,6 +6,8 @@ import type { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { CredentialRequestBroker } from '../connectors/credential-request-broker'
+import { createNotificationInboxController } from './notification-inbox-controller'
 import {
   MAX_NOTIFICATION_INBOX_ITEMS,
   NotificationInboxDbRepository,
@@ -44,6 +46,106 @@ afterEach(async () => {
 })
 
 describe('NotificationInboxDbRepository', () => {
+  it('N01: exposes an unread failure behind 50 read outcomes through the default controller snapshot', async () => {
+    const repository = await createRepository()
+    const inbox = createNotificationInboxController({
+      headless: false,
+      repository,
+      onChanged: vi.fn()
+    })
+    inbox.configureDesktop({
+      isAppFocused: () => true,
+      confirmSessionVisible: async (sessionId) => sessionId === 'visible-session',
+      badge: { setCount: vi.fn() }
+    })
+    await inbox.record({
+      dedupeKey: 'task:old-failure',
+      kind: 'task.failed',
+      sessionId: 'background-session',
+      originId: 'old-failure',
+      title: 'Task failed',
+      summary: 'The background task failed.'
+    })
+    for (let index = 0; index < 50; index += 1) {
+      await inbox.record({
+        dedupeKey: `task:new-${index}`,
+        kind: 'task.completed',
+        sessionId: 'visible-session',
+        originId: `new-${index}`,
+        title: 'Task completed',
+        summary: 'The visible task finished.'
+      })
+    }
+
+    const stored = await client!.notificationInboxItem.findUnique({
+      where: { dedupeKey: 'task:old-failure' }
+    })
+    expect(stored).toMatchObject({ kind: 'task.failed', readAt: null })
+    const snapshot = await inbox.getSnapshot()
+    expect(snapshot.unreadCount).toBe(1)
+    expect(snapshot.items.filter((item) => item.readAt !== undefined)).toHaveLength(50)
+    expect(snapshot.items.filter((item) => item.readAt === undefined)).toEqual([
+      expect.objectContaining({ originId: 'old-failure', kind: 'task.failed' })
+    ])
+  })
+
+  it('N02: expires an orphaned credential request after reopening SQLite while retaining a plan approval', async () => {
+    const repository = await createRepository()
+    await repository.record({
+      id: 'credential-1',
+      dedupeKey: 'input:connector-credential:credential-1',
+      kind: 'task.needs-attention',
+      source: 'connector',
+      attentionReason: 'waiting-for-user',
+      sessionId: 'existing-session',
+      originId: 'credential-1',
+      title: 'Response needed',
+      summary: 'A task needs your response.',
+      actionState: 'pending'
+    })
+    for (const source of ['connector', 'session-plan'] as const) {
+      await repository.record({
+        id: `approval-${source}`,
+        dedupeKey: `authorization:${source}:approval-${source}`,
+        kind: 'authorization.required',
+        source,
+        sessionId: 'existing-session',
+        originId: `approval-${source}`,
+        title: 'Approval needed',
+        summary: 'A request needs approval.',
+        actionState: 'pending'
+      })
+    }
+
+    // Model an unclean exit: persisted rows survive, but no broker settlement runs.
+    await client!.$disconnect()
+    client = createProjectDbClient(storageRoot!)
+    const restored = createNotificationInboxController({
+      headless: true,
+      repository: new NotificationInboxDbRepository(() => Promise.resolve(client!)),
+      onChanged: vi.fn(),
+      now: () => 3000
+    })
+    const broker = new CredentialRequestBroker({ broadcast: vi.fn(), generateId: () => 'new-id' })
+    await restored.restore()
+    await restored.reconcileSessionCatalog(['existing-session'])
+
+    expect(broker.getPending('credential-1')).toBeNull()
+    const snapshot = await restored.getSnapshot()
+    expect(snapshot.items.find((item) => item.id === 'approval-connector')).toMatchObject({
+      actionState: 'expired',
+      settledAt: 3000
+    })
+    expect(snapshot.items.find((item) => item.id === 'approval-session-plan')).toMatchObject({
+      actionState: 'pending'
+    })
+    const credential = snapshot.items.find((item) => item.id === 'credential-1')
+    expect(credential).not.toHaveProperty('targetInvalidatedAt')
+    expect(credential).not.toHaveProperty('readAt')
+    expect(credential?.actionState).toBe('expired')
+    expect(credential?.settledAt).toBe(3000)
+  })
+
   it('records each dedupe key once and returns newest-first snapshots', async () => {
     const repository = await createRepository()
 
@@ -88,6 +190,83 @@ describe('NotificationInboxDbRepository', () => {
     expect(snapshot.items.find((item) => item.originId === 'oldest')).toMatchObject({
       actionState: 'pending'
     })
+  })
+
+  it('includes every unread outcome and read pending action without duplicate rows', async () => {
+    const repository = await createRepository()
+    for (const kind of ['task.failed', 'task.completed', 'task.needs-attention'] as const) {
+      await repository.record({
+        id: kind,
+        dedupeKey: kind,
+        kind,
+        originId: kind,
+        title: 'Task update',
+        summary: 'A task needs attention.'
+      })
+    }
+    await repository.record({
+      id: 'read-pending',
+      dedupeKey: 'authorization:connector:pending',
+      kind: 'authorization.required',
+      source: 'connector',
+      originId: 'pending',
+      title: 'Approval needed',
+      summary: 'Approval needed',
+      actionState: 'pending',
+      readAt: 1000
+    })
+    for (let index = 0; index < 50; index += 1) {
+      await record(repository, `recent-${index}`)
+    }
+    const snapshot = await repository.snapshot()
+    expect(snapshot.items).toHaveLength(54)
+    expect(new Set(snapshot.items.map((item) => item.id)).size).toBe(54)
+    expect(snapshot.unreadCount).toBe(53)
+    for (const kind of ['task.failed', 'task.completed', 'task.needs-attention']) {
+      expect(snapshot.items.find((item) => item.id === kind)).toMatchObject({ kind })
+    }
+    expect(snapshot.items.find((item) => item.id === 'read-pending')).toMatchObject({
+      actionState: 'pending',
+      readAt: 1000
+    })
+  })
+
+  it('leaves unrelated input requests and settled credentials unchanged during restore', async () => {
+    const repository = await createRepository()
+    for (const [id, source, dedupeKey, actionState] of [
+      ['other-connector', 'connector', 'input:other:1', 'pending'],
+      ['agent-question', 'agent-question', 'input:agent-question:1', 'pending'],
+      ['settled-credential', 'connector', 'input:connector-credential:1', 'resolved']
+    ] as const) {
+      await repository.record({
+        id,
+        source,
+        dedupeKey,
+        actionState: 'pending',
+        kind: 'task.needs-attention',
+        attentionReason: 'waiting-for-user',
+        originId: id,
+        title: 'Response needed',
+        summary: 'A task needs your response.'
+      })
+      if (actionState !== 'pending') await repository.settle(dedupeKey, actionState, 1000)
+    }
+    const result = await repository.expireTransientPendingActions(3000)
+    expect(result.changed).toBe(false)
+    const snapshot = await repository.snapshot()
+    expect(snapshot.items.find((item) => item.id === 'other-connector')?.actionState).toBe(
+      'pending'
+    )
+    expect(snapshot.items.find((item) => item.id === 'agent-question')?.actionState).toBe('pending')
+    expect(snapshot.items.find((item) => item.id === 'settled-credential')?.actionState).toBe(
+      'resolved'
+    )
+    expect(snapshot.items.find((item) => item.id === 'settled-credential')?.settledAt).toBe(1000)
+    expect(
+      snapshot.items
+        .filter((item) => item.actionState === 'pending')
+        .every((item) => item.settledAt === undefined)
+    ).toBe(true)
   })
 
   it('marks all only through the caller snapshot boundary', async () => {
@@ -157,7 +336,7 @@ describe('NotificationInboxDbRepository', () => {
     })
     await record(repository, 'task')
 
-    await repository.expireTransientPendingAuthorizations(2250)
+    await repository.expireTransientPendingActions(2250)
 
     const snapshot = await repository.snapshot()
     expect(snapshot.unreadCount).toBe(4)
@@ -264,9 +443,14 @@ describe('NotificationInboxDbRepository', () => {
 
     const snapshot = await repository.snapshot(MAX_NOTIFICATION_INBOX_ITEMS)
     await expect(client!.notificationInboxItem.count()).resolves.toBe(MAX_NOTIFICATION_INBOX_ITEMS)
-    expect(snapshot.items).toHaveLength(200)
-    expect(snapshot.items.at(-1)?.originId).toBe('801')
+    expect(snapshot.items).toHaveLength(MAX_NOTIFICATION_INBOX_ITEMS)
+    expect(snapshot.items.at(-1)?.originId).toBe('1')
     expect(snapshot.items[0]?.originId).toBe(String(MAX_NOTIFICATION_INBOX_ITEMS))
+
+    await repository.markAllRead(snapshot.latestSequence, 3000)
+    const readHistory = await repository.snapshot(MAX_NOTIFICATION_INBOX_ITEMS)
+    expect(readHistory.items).toHaveLength(200)
+    expect(readHistory.items.at(-1)?.originId).toBe('801')
   })
 
   it('allows active pending actions to exceed the retained history limit', async () => {

--- a/src/main/notifications/notification-inbox-repository.ts
+++ b/src/main/notifications/notification-inbox-repository.ts
@@ -164,9 +164,9 @@ export class NotificationInboxDbRepository {
     )
     return this.enqueue(async () => {
       const client = await this.getClient()
-      const [pendingRows, historyRows, metadata] = await Promise.all([
+      const [attentionRows, historyRows, metadata] = await Promise.all([
         client.notificationInboxItem.findMany({
-          where: ACTIVE_PENDING_WHERE,
+          where: { OR: [ACTIVE_PENDING_WHERE, { readAt: null }] },
           orderBy: { sequence: 'desc' }
         }),
         client.notificationInboxItem.findMany({
@@ -176,9 +176,10 @@ export class NotificationInboxDbRepository {
         }),
         stateFor(client, false)
       ])
-      const rows = [...pendingRows, ...historyRows].sort(
-        (left, right) => right.sequence - left.sequence
-      )
+      // The history window must never hide a row counted by the unread badge.
+      const rows = [
+        ...new Map([...attentionRows, ...historyRows].map((row) => [row.id, row])).values()
+      ].sort((left, right) => right.sequence - left.sequence)
       return { ...metadata, items: rows.map(toInboxItem) }
     })
   }
@@ -235,15 +236,22 @@ export class NotificationInboxDbRepository {
     })
   }
 
-  expireTransientPendingAuthorizations(settledAt: number): Promise<NotificationRepositoryState> {
+  expireTransientPendingActions(settledAt: number): Promise<NotificationRepositoryState> {
     return this.enqueue(async () => {
       const client = await this.getClient()
       return client.$transaction(async (transaction) => {
         const result = await transaction.notificationInboxItem.updateMany({
           where: {
-            kind: 'authorization.required',
             actionState: 'pending',
-            source: { not: 'session-plan' }
+            OR: [
+              { kind: 'authorization.required', source: { not: 'session-plan' } },
+              {
+                kind: 'task.needs-attention',
+                source: 'connector',
+                attentionReason: 'waiting-for-user',
+                dedupeKey: { startsWith: 'input:connector-credential:' }
+              }
+            ]
           },
           data: { actionState: 'expired', settledAt: new Date(settledAt) }
         })

--- a/src/renderer/src/components/NotificationLiveToast.test.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.test.tsx
@@ -109,6 +109,115 @@ afterEach(() => {
 })
 
 describe('NotificationLiveToast', () => {
+  it('N03: shows a sessionless connector approval on the foreground Home page', async () => {
+    await act(async () => root.render(<NotificationLiveToast />))
+    const approval = item(2, {
+      kind: 'authorization.required',
+      source: 'connector',
+      attentionReason: 'waiting-permission',
+      actionState: 'pending',
+      sessionId: undefined,
+      title: 'Approval needed'
+    })
+    await act(async () => {
+      useNotificationInboxStore.setState({ latestSequence: 2, items: [approval, item(1)] })
+    })
+    await flushToastPosition()
+
+    const toast = container.querySelector<HTMLElement>('[data-testid="notification-live-toast"]')
+    expect(toast).not.toBeNull()
+    expect(toast?.textContent).toContain('Approval needed')
+    expect(toast?.classList.contains('invisible')).toBe(false)
+  })
+
+  it('N04: removes the shown toast when its target is invalidated without a new sequence', async () => {
+    const openSessionById = vi.fn(() => true)
+    const originalOpen = useNavigationStore.getState().openSessionById
+    useNavigationStore.setState({ openSessionById })
+    try {
+      await act(async () => root.render(<NotificationLiveToast />))
+      await act(async () => {
+        useNotificationInboxStore.setState({ latestSequence: 2, items: [item(2), item(1)] })
+      })
+      await flushToastPosition()
+      expect(container.querySelector('[data-testid="notification-live-toast"]')).not.toBeNull()
+
+      await act(async () => {
+        useNotificationInboxStore.setState({
+          revision: 3,
+          latestSequence: 2,
+          items: [item(2, { readAt: 3000, targetInvalidatedAt: 3000 }), item(1)]
+        })
+      })
+      const openButton = [...container.querySelectorAll<HTMLButtonElement>('button')].find(
+        (button) => button.textContent === 'Open'
+      )
+      await act(async () => openButton?.click())
+      expect(openSessionById).not.toHaveBeenCalled()
+      expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+    } finally {
+      useNavigationStore.setState({ openSessionById: originalOpen })
+    }
+  })
+
+  it('still suppresses an active-session notification without replaying it on Home', async () => {
+    useNavigationStore.setState({ view: 'workspace' })
+    useSessionStore.setState({ selectedSessionId: 'session-1' })
+    await act(async () => root.render(<NotificationLiveToast />))
+    await act(async () => {
+      useNotificationInboxStore.setState({ latestSequence: 2, items: [item(2), item(1)] })
+    })
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+    await act(async () => useNavigationStore.setState({ view: 'home' }))
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+  })
+
+  it('withdraws a removed lead and does not carry its count into the next arrival', async () => {
+    await act(async () => root.render(<NotificationLiveToast />))
+    await act(async () => {
+      useNotificationInboxStore.setState({ latestSequence: 2, items: [item(2), item(1)] })
+    })
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).not.toBeNull()
+    await act(async () => {
+      useNotificationInboxStore.setState({ items: [item(1)] })
+    })
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+    // A refresh that restores the row must not replay an already-withdrawn arrival.
+    await act(async () => {
+      useNotificationInboxStore.setState({ items: [item(2), item(1)] })
+    })
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+    await act(async () => {
+      useNotificationInboxStore.setState({ latestSequence: 3, items: [item(3), item(1)] })
+    })
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).not.toBeNull()
+    expect(container.textContent).not.toContain('more message')
+  })
+
+  it('refreshes a settled lead without restarting its dismissal timer', async () => {
+    vi.useFakeTimers()
+    await act(async () => root.render(<NotificationLiveToast />))
+    const approval = item(2, {
+      kind: 'authorization.required',
+      source: 'connector',
+      actionState: 'pending'
+    })
+    await act(async () => {
+      useNotificationInboxStore.setState({ latestSequence: 2, items: [approval, item(1)] })
+    })
+    act(() => vi.advanceTimersByTime(3000))
+    await act(async () => {
+      useNotificationInboxStore.setState({
+        items: [{ ...approval, actionState: 'expired', title: 'Approval needed' }, item(1)]
+      })
+    })
+    const toast = container.querySelector('[data-testid="notification-live-toast"]')
+    expect(toast?.textContent).toContain('Approval needed')
+    expect(toast?.querySelector('.bg-bg-300')).not.toBeNull()
+    act(() => vi.advanceTimersByTime(3000))
+    expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()
+  })
+
   it('does not replay existing messages and anchors a newly arrived message above the bell', async () => {
     await act(async () => root.render(<NotificationLiveToast />))
     expect(container.querySelector('[data-testid="notification-live-toast"]')).toBeNull()

--- a/src/renderer/src/components/NotificationLiveToast.tsx
+++ b/src/renderer/src/components/NotificationLiveToast.tsx
@@ -27,10 +27,7 @@ import {
   notificationEventToneClasses,
   resolveNotificationEventVisual
 } from './notification-event-visual'
-import {
-  presentNotificationInbox,
-  type PresentedNotificationInboxItem
-} from './notification-inbox-presentation'
+import { presentNotificationInbox } from './notification-inbox-presentation'
 import { runNotificationTask } from './notification-safety'
 
 const AUTO_DISMISS_MS = 6000
@@ -39,7 +36,7 @@ const VIEWPORT_MARGIN = 8
 const TOAST_MAX_WIDTH = 320
 
 type LiveNotice = Readonly<{
-  lead: PresentedNotificationInboxItem
+  leadId: string
   count: number
 }>
 
@@ -92,6 +89,15 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
   const [position, setPosition] = useState<ToastPosition>()
   const baselineSequenceRef = useRef<number | undefined>(undefined)
   const toastRef = useRef<HTMLDivElement>(null)
+  const leadNotification = items.find(
+    (item) => item.id === notice?.leadId && item.targetInvalidatedAt === undefined
+  )
+
+  // Mutations do not allocate a new sequence. Withdraw stale content before it can be clicked.
+  if (notice && !leadNotification) {
+    setNotice(undefined)
+    setPaused(false)
+  }
 
   useEffect(() => {
     if (status !== 'ready') return
@@ -116,17 +122,20 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
         item.sequence > previousSequence &&
         item.readAt === undefined &&
         item.targetInvalidatedAt === undefined &&
-        item.sessionId !== activeSessionId
+        (!activeSessionId || item.sessionId !== activeSessionId)
     )
     if (added.length === 0) return
 
     setNotice((current) => {
-      const candidates = current ? [current.lead.notification, ...added] : added
+      const currentLead = items.find(
+        (item) => item.id === current?.leadId && item.targetInvalidatedAt === undefined
+      )
+      const candidates = currentLead ? [currentLead, ...added] : added
       const lead = presentNotificationInbox(candidates, sessions, projects)[0]?.items[0]
       if (!lead) return current
       return {
-        lead,
-        count: (current?.count ?? 0) + added.length
+        leadId: lead.notification.id,
+        count: (currentLead ? (current?.count ?? 0) : 0) + added.length
       }
     })
   }, [items, latestSequence, projects, selectedSessionId, sessions, status, view])
@@ -189,9 +198,13 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
     }
   }, [notice, updatePosition])
 
-  if (!notice) return null
+  if (!notice || !leadNotification) return null
 
-  const { notification, projectName, sessionTitle, detailPreview } = notice.lead
+  const { notification, projectName, sessionTitle, detailPreview } = presentNotificationInbox(
+    [leadNotification],
+    sessions,
+    projects
+  )[0].items[0]
   const openLead = async (): Promise<void> => {
     let completed = false
     const completeOpen = (): void => {
@@ -200,9 +213,7 @@ const NotificationLiveToastContent = (): React.JSX.Element | null => {
       if (notification.readAt === undefined) {
         runNotificationTask(() => markRead([notification.id]))
       }
-      setNotice((current) =>
-        current?.lead.notification.id === notification.id ? undefined : current
-      )
+      setNotice((current) => (current?.leadId === notification.id ? undefined : current))
     }
     let opened = true
     try {


### PR DESCRIPTION
## Problem

The inbox can report unread history that its snapshot does not expose. An unclean restart also leaves connector credential prompts pending after their in-memory broker is gone. Foreground toasts suppress sessionless requests on Home and retain stale navigation after their target is invalidated.

## Proposed change

- Return all unread rows and all active pending actions alongside the existing recent-history window, deduplicated by ID.
- Expire orphaned connector credential prompts during startup using their existing source, kind, wait reason, and credential-request identity. Preserve persistent plan approvals, unrelated pending inputs, and settled requests.
- Suppress foreground toasts only for an actual matching active session.
- Store the toast lead ID and derive its content and actionability from the current inbox row; withdraw removed or invalidated leads without replaying them.
- Run one Electron journey at a time on each Windows CI runner while retaining two independent shards. Keep every existing assertion, timeout, retry rule, and fail-on-flaky check.

## Scope and non-goals

No database schema, persisted field, enum, renderer API, or new dependency. Startup recovery updates existing matching credential notifications from `pending` to the existing `expired` state and writes `settledAt`; it does not mark them read. Expired requests become eligible for the existing history retention policy. This intentionally covers already-persisted orphan prompts without a migration or broker replay.

The existing 1000-row history retention and 50-row default recent-history window remain. All retained unread notifications are accessible; older read history still has no paging UI. Cursor pagination is explicitly deferred under the approved minimal scope.

## Acceptance criteria and validation

Four new regressions failed twice on unchanged production code, for the reported behavior: the default controller snapshot omitted its sole unread failure; restored credentials remained pending; a sessionless Home approval produced no toast; an invalidated toast still invoked its old session navigation. The two affected files' 20 existing tests passed both times. SQLite tests use real migrated databases and a real controller, including disconnect/reopen recovery; React tests mount the real components with their existing stores. No production test seam was added.

After the last material source/test edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Snapshot membership, deduplication, retention and startup expiration | `notification-inbox-repository.test.ts` and `notification-inbox-controller.test.ts` | Passed |
| Native/runtime and transport consumers | Remaining `src/main/notifications` suites | Passed |
| Credential settlement and persisted notification contract | `credential-request-broker.test.ts`, `notifications.contract.test.ts` | Passed |
| Refresh, grouping, visual state and foreground navigation | Inbox store, bell, toast, presentation and event-visual suites | Passed |
| Additional unread completions reaching Home | `HomePage.render.test.tsx` | Passed |
| Main and renderer types | `npm run typecheck:node`, `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |

The targeted Vitest command covers 17 files / 301 passing tests. CodeGraph identified the controller, renderer store, Home, bell and toast consumer paths; its shared index reports a worktree mismatch, so final modified source and explicit transport/lifecycle tests were checked directly. The repository impact classifier requests the full plan because notifications has no registered Module owner. Per maintainer direction, the complete portable and platform suites are deferred to PR CI rather than run locally. No path handling, native delivery code, protocol translation, or persisted format changed, so no new platform or migration test is introduced.

Visual verification passed in the Codex in-app browser at 1280×720 with the real HomePage, NotificationBell, NotificationLiveToast, CSS, and stores against isolated fixture data: the old unread failure appears above 50 read completions; a sessionless Home approval shows a toast; invalidating the shown task target withdraws its toast and Open action. Screenshots are delivered in the task. Backend persistence remains covered separately by real SQLite tests. [Independent review](https://github.com/aipoch/open-science/pull/2237#issuecomment-5557814948) found no actionable findings at the final head `0163ccede07274deda5d841176f1652121cd6fc3`. The [final PR Gate run](https://github.com/aipoch/open-science/actions/runs/34019620588) provides complete portable and platform validation; local checks are not release certification.

## CI follow-up

Rebased onto `d9b21b904da7698da9d36723522c644f85eb612c` without conflicts; the notification patch is byte-for-byte unchanged. The 301 notification/consumer tests, full typecheck, and lint passed again after rebase. The original Windows failure was a graceful-close timeout in the Memory restart test; its retry passed. Five local repetitions with two workers passed, so no speculative shutdown or timeout change was made.

The existing [Windows E2E dry-run](https://github.com/aipoch/open-science/actions/runs/34017258927) exposed first-turn stalls and a frame-sampling failure with two workers. The [single-worker dry-run](https://github.com/aipoch/open-science/actions/runs/34018123489) passed all 53 journeys without retries, in 13m33s and 19m57s, within the unchanged 25-minute budget. This follows [Playwright's CI recommendation](https://playwright.dev/docs/ci#workers); it does not claim to prove the cause of the original shutdown timeout.

The final implementation uses the standard [per-project worker cap](https://playwright.dev/docs/api/class-testproject#test-project-workers) in `playwright.config.ts`, only on Windows. The single unnamed project preserves test identities and sharding; other platforms retain the CLI worker choice. Protected workflows and integrity rules are unchanged, and the actual trusted integrity evaluator passes for the final commit.

A new real-CLI regression failed twice on the old config because `--workers=2 --fully-parallel` started workers 0 and 1. With the Windows project cap, the same CLI runs all four probe tests on worker 0. The two other platform cases and 77 related fixture/workflow/integrity tests pass (80 total); Node typecheck and config lint pass. The four affected local Electron journeys also passed without retries. Final PR CI checks the project-cap implementation with the existing, unmodified workflow commands.

## Review focus

- Unread badge/list consistency without weakening retention or hiding read pending actions.
- Narrow startup expiration, including historical orphan rows while preserving recoverable plan approvals and read-state independence.
- Existing toast lifecycle behavior: new-arrival detection, stale-row withdrawal, original expiry timer, and deferred navigation completion.
