### PR TITLE
fix(preview): translate TIFF page navigation buttons

### DIFF
--- a/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx
@@ -238,14 +238,14 @@ describe('TiffPreviewContent', () => {
 
     await vi.waitFor(() => expect(container.textContent).toContain('Page 1 of 2'))
     expect(
-      container.querySelector<HTMLButtonElement>('[aria-label="Previous TIFF page"]')?.disabled
+      container.querySelector<HTMLButtonElement>('[aria-label="Previous page"]')?.disabled
     ).toBe(true)
-    expect(
-      container.querySelector<HTMLButtonElement>('[aria-label="Next TIFF page"]')?.disabled
-    ).toBe(false)
+    expect(container.querySelector<HTMLButtonElement>('[aria-label="Next page"]')?.disabled).toBe(
+      false
+    )
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('[aria-label="Next TIFF page"]')?.click()
+      container.querySelector<HTMLButtonElement>('[aria-label="Next page"]')?.click()
     })
 
     await vi.waitFor(() => expect(container.textContent).toContain('Page 2 of 2'))
@@ -289,7 +289,7 @@ describe('TiffPreviewContent', () => {
 
     await vi.waitFor(() => expect(container.textContent).toContain('Page 1 of 2'))
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('[aria-label="Next TIFF page"]')?.click()
+      container.querySelector<HTMLButtonElement>('[aria-label="Next page"]')?.click()
     })
 
     await vi.waitFor(() =>
@@ -299,7 +299,7 @@ describe('TiffPreviewContent', () => {
     expect(window.api.previewResources.release).not.toHaveBeenCalled()
 
     await act(async () => {
-      container.querySelector<HTMLButtonElement>('[aria-label="Previous TIFF page"]')?.click()
+      container.querySelector<HTMLButtonElement>('[aria-label="Previous page"]')?.click()
     })
 
     await vi.waitFor(() => expect(container.textContent).toContain('Page 1 of 2'))

--- a/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.tsx
@@ -61,13 +61,13 @@ const TiffPageControls = ({
   const { t } = useTranslation()
   const actions = [
     {
-      label: 'Previous TIFF page',
+      label: t('Previous page'),
       icon: ChevronLeft,
       disabled: pageIndex === 0,
       onClick: () => onPageChange(pageIndex - 1)
     },
     {
-      label: 'Next TIFF page',
+      label: t('Next page'),
       icon: ChevronRight,
       disabled: pageIndex === pageCount - 1,
       onClick: () => onPageChange(pageIndex + 1)


### PR DESCRIPTION
## Summary
- Multi-page TIFF preview pager buttons used hardcoded English labels (`Previous TIFF page` / `Next TIFF page`) for both tooltip and `aria-label`, so they stayed English in every non-English locale.
- Reuse the existing `Previous page` / `Next page` translation keys already consumed by `SourcePreview.tsx` — present in all 8 translated locales, so no catalog changes were needed.
- Update `TiffPreview.test.tsx` aria-label selectors to match.

## Testing
- `npx vitest run src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx` — 7 passed
- `npx vitest run src/renderer/src/i18n/resources.test.ts` — i18n guard suite passed (no missing/orphaned keys)