### PR TITLE
docs(remote): align remote control guide with current pairing UI labels

### DIFF
--- a/REMOTE_CONTROL.md
+++ b/REMOTE_CONTROL.md
@@ -51,7 +51,7 @@ Keeping these services separate prevents Browser access from changing the behavi
 ## 3. Enable App access
 
 1. Select **App access**.
-2. If Open Science reports that setup is incomplete, select **Detect and set up**.
+2. If Open Science reports that setup is incomplete, select **Detect again**.
 3. Approve the operating-system prompt if service creation or repair requires administrator access.
 4. Wait until the page reports **Connected**.
 5. Open the Remote.It mobile app and sign in to the same account.
@@ -59,25 +59,25 @@ Keeping these services separate prevents Browser access from changing the behavi
 7. Select **Connect** or **Launch**.
 8. Compare the six-digit code with the request shown in **Pairing requests**.
 9. Approve the request from the Open Science desktop window or an already trusted browser.
-10. Choose **Allow once** for temporary access or **Always trust this browser** for later visits to the same remote address.
+10. Choose **Allow for up to 12 hours** for temporary access or **Trust this browser for 180 days** for later visits to the same remote address.
 
 Remote.It account access opens the private route, but it is not an Open Science credential. The six-digit confirmation prevents a local process from impersonating that route with forged HTTP headers.
 
 ## 4. Enable Browser access
 
 1. Select **Browser access**.
-2. If needed, select **Detect and set up** and approve the operating-system prompt.
+2. If needed, select **Detect again** and approve the operating-system prompt.
 3. Wait until the page reports **Connected** and shows the persistent browser link.
 4. Open the link with **Open**, copy it to another device, or scan the displayed QR code.
 5. On the new browser, compare its six-digit code with the request shown in **Pairing requests**.
 6. Approve the request from the Open Science desktop window or from an already trusted browser.
-7. Choose **Allow once** for temporary access or **Always trust this browser** for later visits to the same remote address.
+7. Choose **Allow for up to 12 hours** for temporary access or **Trust this browser for 180 days** for later visits to the same remote address.
 
 Browser trust belongs to the browser profile, not to the physical device. Private browsing, cleared site data, a different browser, or a different browser profile requires verification again.
 
 ### Manage trusted browsers
 
-The **Trusted browsers** section lists browser profiles with permanent access through either remote mode. Revoke an entry to deny it on its next HTTP request or WebSocket reconnect.
+The **Trusted browsers** section lists browser profiles trusted for 180 days through either remote mode. Revoke an entry to deny it on its next HTTP request or WebSocket reconnect.
 
 The **Pairing requests** section lists browsers currently waiting for two-step verification. Approve only when the six-digit code matches the code on the requesting browser.
 
@@ -91,11 +91,11 @@ The **Pairing requests** section lists browsers currently waiting for two-step v
 
 ### Remote.It is installed but Open Science says sign-in is required
 
-Open the Remote.It desktop application, finish signing in, and select **Detect and set up** again.
+Open the Remote.It desktop application, finish signing in, and select **Detect again**.
 
 ### Open Science asks you to add a Device
 
-In Remote.It, choose **+ → This system → Add Device** once. Do not use a claim code for the host computer. Return to Open Science and select **Detect and set up**; Open Science will create both managed services automatically.
+In Remote.It, choose **+ → This system → Add Device** once. Do not use a claim code for the host computer. Return to Open Science and select **Detect again**; Open Science will create both managed services automatically.
 
 ### Setup asks for administrator approval
 


### PR DESCRIPTION
## Summary
REMOTE_CONTROL.md drifted behind three UI/behavior changes; each is fixed against the current code:

1. **Setup button name** — the doc said `Detect and set up` (5 places), but the button is labeled `Detect again` (`src/renderer/src/pages/settings/RemoteControlPanel.tsx:416`). The doc's own troubleshooting section already used the new name, so it contradicted itself.
2. **Pairing approval labels** — the doc said `Allow once` / `Always trust this browser`; the actual choices are `Allow for up to 12 hours` / `Trust this browser for 180 days` (`RemoteControlPanel.tsx:836,844`; the remote-facing page copy in `src/main/remote-access/pairing-page.ts:75`). `pairing.test.ts:103-104` explicitly asserts the old labels are gone.
3. **Trusted browser duration** — the doc said `permanent access`; trust now expires after 180 days (`src/main/remote-access/repository.ts:8` `TRUSTED_BROWSER_TTL_MS`, UI shows `Expires {{time}}`).

Docs-only change, no code touched.