### PR TITLE
fix(update): honor cancellation and preserve update offers

### DIFF
--- a/src/main/update/downloader.test.ts
+++ b/src/main/update/downloader.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 
 import type { DownloadProgress } from '../../shared/download-progress'
 import { downloadInstaller } from './downloader'
+import { parseManifest } from './manifest'
 
 const sha256 = (buf: Buffer): string => createHash('sha256').update(buf).digest('hex')
 
@@ -23,6 +24,42 @@ afterEach(async () => {
 })
 
 describe('downloadInstaller', () => {
+  it.each(['lowercase', 'uppercase', 'mixed', 'incorrect'])(
+    'U03: verifies a manifest checksum with %s hex through the real downloader',
+    async (casing) => {
+      dir = await mkdtemp(join(tmpdir(), 'upd-checksum-'))
+      const target = join(dir, 'installer.dmg')
+      const body = Buffer.from('installer-bytes')
+      const digest = sha256(body)
+      const checksum =
+        casing === 'uppercase'
+          ? digest.toUpperCase()
+          : casing === 'mixed'
+            ? [...digest].map((char, index) => (index % 2 ? char.toUpperCase() : char)).join('')
+            : casing === 'incorrect'
+              ? '0'.repeat(64)
+              : digest
+      const manifest = parseManifest({
+        version: '1.1.0',
+        downloads: {
+          'mac-arm64': { url: 'https://cdn/installer.dmg', size: body.byteLength, sha256: checksum }
+        }
+      })
+      const downloading = downloadInstaller(manifest.downloads['mac-arm64'], target, {
+        fetchImpl: async () => responseAt('https://cdn/installer.dmg', body)
+      })
+
+      if (casing === 'incorrect') {
+        await expect(downloading).rejects.toThrow('Checksum mismatch')
+        expect(existsSync(target)).toBe(false)
+        expect(existsSync(`${target}.part`)).toBe(false)
+      } else {
+        await expect(downloading).resolves.toBe(target)
+        expect(await readFile(target)).toEqual(body)
+      }
+    }
+  )
+
   it('writes to the target path, verifies sha256, and reports superset progress', async () => {
     dir = await mkdtemp(join(tmpdir(), 'upd-'))
     const target = join(dir, 'open-science-0.3.0-mac-arm64.dmg')

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -98,6 +98,97 @@ const diagnosticRecords = (log: Logger): Record<string, unknown>[] =>
   )
 
 describe('ElectronUpdaterStrategy', () => {
+  it.each(['up-to-date', 'error'])(
+    'releases a waiting download after a provider check returns %s',
+    async (outcome) => {
+      const updater = new FakeUpdater()
+      let releaseCheck!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseCheck = resolve
+      })
+      updater.checkForUpdates.mockImplementationOnce(async () => {
+        updater.emit('checking-for-update')
+        await gate
+        if (outcome === 'error') throw new Error('offline')
+        updater.emit('update-not-available', { version: '0.2.0' })
+      })
+      const strategy = new ElectronUpdaterStrategy({
+        updater,
+        currentVersion: '0.2.0',
+        broadcast: vi.fn(),
+        fetchImpl: offlineFetch()
+      })
+      const checking = strategy.check()
+      const downloading = strategy.download()
+      releaseCheck()
+      await checking
+      expect((await downloading).state).toBe(outcome)
+      expect(updater.downloadUpdate).not.toHaveBeenCalled()
+
+      await strategy.check()
+      expect((await strategy.download()).state).toBe('ready')
+      expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('lets only a fresh retry transfer after cancelling a waiting download', async () => {
+    const updater = new FakeUpdater()
+    let releaseCheck!: () => void
+    const gate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    updater.checkForUpdates.mockImplementationOnce(async () => {
+      updater.emit('checking-for-update')
+      await gate
+      updater.emit('update-available', { version: '0.3.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+    const checking = strategy.check()
+    const first = strategy.download()
+    await strategy.cancel()
+    const retry = strategy.download()
+    const duplicate = strategy.download()
+    releaseCheck()
+    await Promise.all([checking, first, retry, duplicate])
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+    expect(strategy.getStatus().state).toBe('ready')
+  })
+
+  it('U01: cancel prevents an in-place download waiting for check', async () => {
+    const updater = new FakeUpdater()
+    let releaseCheck!: () => void
+    const checkGate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    updater.checkForUpdates = vi.fn(async () => {
+      updater.emit('checking-for-update')
+      await checkGate
+      updater.emit('update-available', { version: '0.3.0' })
+    })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      fetchImpl: offlineFetch()
+    })
+
+    const checking = strategy.check()
+    expect(strategy.getStatus().state).toBe('checking')
+    const downloading = strategy.download()
+    await strategy.cancel()
+    releaseCheck()
+    await checking
+    const result = await downloading
+
+    expect.soft(updater.downloadUpdate).not.toHaveBeenCalled()
+    expect.soft(result.state).toBe('available')
+  })
+
   it('disables auto download/install on construction', () => {
     const updater = new FakeUpdater()
     new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast: vi.fn() })

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -441,7 +441,17 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     // The startup scheduler and notes hydration keep check() in flight after `update-available` has
     // already marked the status `available`. Returning that snapshot dropped RPC/UI download requests,
     // including the Windows upgrade-smoke harness talking to 0.18.0+. Wait for the check, then start.
-    if (this.checkLifecycle) await this.checkLifecycle
+    if (this.checkLifecycle) {
+      // A waiting download is cancellable before the provider check releases its status.
+      const waitingToken = this.createCancellationToken()
+      this.downloadToken = waitingToken
+      try {
+        await this.checkLifecycle
+        if (waitingToken.cancelled) return this.status
+      } finally {
+        if (this.downloadToken === waitingToken) this.downloadToken = undefined
+      }
+    }
     if (this.applying || this.downloadToken) return this.status
     if (!canStartUpdateDownload(this.status)) return this.status
 

--- a/src/main/update/manifest.ts
+++ b/src/main/update/manifest.ts
@@ -73,7 +73,7 @@ export const parseManifest = (data: unknown): UpdateManifest => {
     if (!DOWNLOAD_KEYS.has(key) || !isDownload(value)) {
       throw new Error(`Invalid download entry: ${key}`)
     }
-    downloads[key] = value
+    downloads[key] = { ...value, sha256: value.sha256.toLowerCase() }
   }
   return {
     version: data.version,

--- a/src/main/update/service.test.ts
+++ b/src/main/update/service.test.ts
@@ -49,6 +49,108 @@ const diagnosticRecords = (log: Logger): Record<string, unknown>[] =>
   )
 
 describe('UpdateService.check', () => {
+  it.each(['up-to-date', 'error'])(
+    'releases a waiting download after a check returns %s so a later offer can download',
+    async (outcome) => {
+      let releaseCheck!: () => void
+      const gate = new Promise<void>((resolve) => {
+        releaseCheck = resolve
+      })
+      const fetchImpl = vi.fn(async () => jsonResponse(manifest))
+      fetchImpl.mockImplementationOnce(async () => {
+        await gate
+        if (outcome === 'error') throw new Error('offline')
+        return jsonResponse({ ...manifest, version: '0.2.0' })
+      })
+      const promptSavePath = vi.fn(async () => null)
+      const service = new UpdateService({
+        fetchImpl,
+        platform: 'darwin',
+        arch: 'arm64',
+        currentVersion: '0.2.0',
+        manifestUrl: 'https://cdn/version.json',
+        broadcast: vi.fn(),
+        promptSavePath
+      })
+      const checking = service.check()
+      const downloading = service.download()
+      releaseCheck()
+      await checking
+      expect((await downloading).state).toBe(outcome)
+
+      await service.check()
+      await service.download()
+      expect(promptSavePath).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('lets only a fresh retry select a target after cancelling a waiting download', async () => {
+    let releaseCheck!: () => void
+    const gate = new Promise<void>((resolve) => {
+      releaseCheck = resolve
+    })
+    const promptSavePath = vi.fn(async () => null)
+    const service = new UpdateService({
+      fetchImpl: async () => {
+        await gate
+        return jsonResponse(manifest)
+      },
+      platform: 'darwin',
+      arch: 'arm64',
+      currentVersion: '0.2.0',
+      manifestUrl: 'https://cdn/version.json',
+      broadcast: vi.fn(),
+      promptSavePath
+    })
+    const checking = service.check()
+    const first = service.download()
+    await service.cancel()
+    const retry = service.download()
+    const duplicate = service.download()
+    expect(promptSavePath).not.toHaveBeenCalled()
+    releaseCheck()
+    await Promise.all([checking, first, retry, duplicate])
+    expect(promptSavePath).toHaveBeenCalledTimes(1)
+  })
+
+  it.each(['1.1.0-nightly.abc1234', '1.1.0-nightly.123abcd'])(
+    'U05: offers the stable release to %s',
+    async (currentVersion) => {
+      const service = new UpdateService({
+        fetchImpl: async () => jsonResponse({ ...manifest, version: '1.1.0' }),
+        platform: 'darwin',
+        arch: 'arm64',
+        currentVersion,
+        broadcast: vi.fn()
+      })
+
+      expect(await service.check()).toMatchObject({ state: 'available', latest: '1.1.0' })
+    }
+  )
+
+  it('U04: exposes a missing platform artifact without starting any download side effects', async () => {
+    const fetchImpl = vi.fn(async () => jsonResponse(manifest))
+    const promptSavePath = vi.fn(async () => null)
+    const openExternal = vi.fn(async () => undefined)
+    const service = new UpdateService({
+      fetchImpl,
+      platform: 'darwin',
+      arch: 'x64',
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      promptSavePath,
+      openExternal
+    })
+
+    const status = await service.check()
+    expect(status).toMatchObject({ state: 'available', applyKind: 'installer', latest: '0.3.0' })
+    expect(status.download).toBeUndefined()
+    expect(await service.download()).toBe(status)
+    expect(fetchImpl).toHaveBeenCalledTimes(1)
+    expect(promptSavePath).not.toHaveBeenCalled()
+    expect(openExternal).not.toHaveBeenCalled()
+  })
+
   it('records a completed manifest check without manifest payloads', async () => {
     const log = createLogSpy()
     const service = new UpdateService({
@@ -222,6 +324,56 @@ describe('UpdateService.download', () => {
       'mac-arm64': { url: 'https://statics.aipoch.com/releases/0.3.0/installer.dmg', size, sha256 }
     }
   })
+
+  it.each([false, true])(
+    'U01: cancel prevents a download waiting for check (nonInteractive=%s)',
+    async (nonInteractive) => {
+      dir = await mkdtemp(join(tmpdir(), 'svc-wait-cancel-'))
+      const target = join(dir, 'installer.dmg')
+      const body = Buffer.from('installer-bytes')
+      const pendingManifest = downloadManifest(
+        body.byteLength,
+        createHash('sha256').update(body).digest('hex')
+      )
+      let releaseCheck!: () => void
+      const checkGate = new Promise<void>((resolve) => {
+        releaseCheck = resolve
+      })
+      const installerFetch = vi.fn(async () => installerResponse(body))
+      const promptSavePath = vi.fn(async () => target)
+      const defaultDownloadPath = vi.fn(() => target)
+      const service = new UpdateService({
+        fetchImpl: async (input) => {
+          if (String(input).endsWith('version.json')) {
+            await checkGate
+            return jsonResponse(pendingManifest)
+          }
+          return installerFetch()
+        },
+        platform: 'darwin',
+        arch: 'arm64',
+        currentVersion: '0.2.0',
+        manifestUrl: 'https://statics.aipoch.com/version.json',
+        broadcast: vi.fn(),
+        promptSavePath,
+        defaultDownloadPath
+      })
+
+      const checking = service.check()
+      expect(service.getStatus().state).toBe('checking')
+      const downloading = service.download({ nonInteractive })
+      await service.cancel()
+      releaseCheck()
+      await checking
+      const result = await downloading
+
+      expect.soft(installerFetch).not.toHaveBeenCalled()
+      expect.soft(promptSavePath).not.toHaveBeenCalled()
+      expect.soft(defaultDownloadPath).not.toHaveBeenCalled()
+      expect.soft(existsSync(target)).toBe(false)
+      expect.soft(result.state).toBe('available')
+    }
+  )
 
   it('downloads to the path from promptSavePath, verifies, and reports ready', async () => {
     dir = await mkdtemp(join(tmpdir(), 'svc-'))

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -239,7 +239,17 @@ export class UpdateService implements UpdateStrategy {
     if (this.downloadAbort) return this.status
     // The startup scheduler owns check() at launch. Returning the in-flight snapshot dropped download
     // requests that arrived after the UI/RPC already observed `available`. Wait, then start.
-    if (this.checkLifecycle) await this.checkLifecycle
+    if (this.checkLifecycle) {
+      // Own the waiting intent too: cancel must prevent even target selection after the check.
+      const waitingAbort = new AbortController()
+      this.downloadAbort = waitingAbort
+      try {
+        await this.checkLifecycle
+        if (waitingAbort.signal.aborted) return this.status
+      } finally {
+        if (this.downloadAbort === waitingAbort) this.downloadAbort = undefined
+      }
+    }
     if (this.downloadAbort) return this.status
     if (!canStartUpdateDownload(this.status)) return this.status
 

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -30,6 +30,48 @@ afterEach(() => {
 })
 
 describe('UpdateDialog', () => {
+  it('U04: offers manual download instead of an inert button when the installer artifact is missing', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'available',
+        current: '0.2.0',
+        latest: '0.3.0',
+        applyKind: 'installer'
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+
+    const downloadButton = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Download update')
+    )
+    expect.soft(downloadButton).toBeUndefined()
+    const manualLink = Array.from(document.body.querySelectorAll('a')).find((link) =>
+      link.textContent?.includes('Download manually')
+    )
+    expect.soft(manualLink?.getAttribute('href')).toBe(APP.update.downloadPage)
+    expect(document.body.textContent).toContain('An installer is not available for this platform.')
+  })
+
+  it('U04: keeps in-place downloads actionable without a manifest download field', () => {
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: {
+        state: 'available',
+        current: '0.2.0',
+        latest: '0.3.0',
+        applyKind: 'restart'
+      }
+    })
+    act(() => root.render(<UpdateDialog />))
+
+    const downloadButton = Array.from(document.body.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Download update')
+    )
+    expect(downloadButton).toBeDefined()
+    expect(downloadButton?.disabled).toBe(false)
+  })
+
   it('preserves a covered update request while suppressing its presentation', () => {
     useUpdateStore.setState({
       isDialogOpen: true,

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -48,6 +48,10 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
   const isDownloading = dialogStatus?.state === 'downloading'
   const isReady = dialogStatus?.state === 'ready'
   const isApplying = dialogStatus?.state === 'applying'
+  const isInstallerUnavailable =
+    dialogStatus?.state === 'available' &&
+    dialogStatus.applyKind === 'installer' &&
+    !dialogStatus.download
   const isBackgroundProcessError =
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_ERROR ||
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
@@ -185,6 +189,13 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
                   </ExternalTextLink>
                 </div>
               ) : null}
+              {isInstallerUnavailable ? (
+                <p className="mt-3 text-xs text-muted-foreground">
+                  {t(
+                    'An installer is not available for this platform. Download manually to check other installation options.'
+                  )}
+                </p>
+              ) : null}
             </div>
 
             <div className={dialogFooterClassName}>
@@ -226,6 +237,10 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
                     </>
                   )}
                 </button>
+              ) : isInstallerUnavailable ? (
+                <ExternalTextLink href={APP.update.downloadPage}>
+                  {t('Download manually')}
+                </ExternalTextLink>
               ) : (
                 <button
                   type="button"

--- a/src/renderer/src/stores/update-store.test.ts
+++ b/src/renderer/src/stores/update-store.test.ts
@@ -2,6 +2,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { useUpdateStore } from './update-store'
+import type { UpdateStatus } from '../../../shared/update'
 
 const resetStore = (): void =>
   useUpdateStore.setState({
@@ -11,6 +12,104 @@ const resetStore = (): void =>
   })
 
 describe('useUpdateStore', () => {
+  it.each(['check', 'download', 'cancel', 'apply'] as const)(
+    'accepts a %s response when no newer status was observed',
+    async (command) => {
+      const status: UpdateStatus = { state: 'ready', current: '0.2.0', latest: '0.3.0' }
+      ;(window as unknown as { api: unknown }).api = {
+        update: { [command]: async () => status }
+      }
+      await useUpdateStore.getState()[command]()
+      expect(useUpdateStore.getState().status).toBe(status)
+    }
+  )
+
+  it.each(['getStatus', 'check', 'download', 'cancel', 'apply'] as const)(
+    'preserves progress received while %s is waiting',
+    async (command) => {
+      let progressListener!: (progress: unknown) => void
+      let releaseResponse!: (status: UpdateStatus) => void
+      const response = new Promise<UpdateStatus>((resolve) => {
+        releaseResponse = resolve
+      })
+      ;(window as unknown as { api: unknown }).api = {
+        update: {
+          getAppInfo: async () => ({ name: 'Open Science', version: '0.2.0', copyright: '' }),
+          getStatus: async () => ({ state: 'downloading', current: '0.2.0', progress: 10 }),
+          onStatus: vi.fn(),
+          onProgress: (listener: (progress: unknown) => void) => {
+            progressListener = listener
+          },
+          [command]: () => response
+        }
+      }
+      const cleanup = useUpdateStore.getState().init()
+      await Promise.resolve()
+      const pending =
+        command === 'getStatus' ? Promise.resolve() : useUpdateStore.getState()[command]()
+      progressListener({
+        phase: 'downloading',
+        percent: 70,
+        transferred: 700,
+        total: 1000,
+        bytesPerSecond: 100,
+        attempt: 0
+      })
+      releaseResponse({ state: 'downloading', current: '0.2.0', progress: 10 })
+      await pending
+      await Promise.resolve()
+      expect(useUpdateStore.getState().status.progress).toBe(70)
+      expect(useUpdateStore.getState().status.downloadProgress?.bytesPerSecond).toBe(100)
+      cleanup()
+    }
+  )
+
+  it.each(['check', 'download', 'cancel', 'apply'] as const)(
+    'U02: a delayed %s response cannot overwrite newer live status',
+    async (command) => {
+      let statusListener!: (status: UpdateStatus) => void
+      let releaseResponse!: (status: UpdateStatus) => void
+      const response = new Promise<UpdateStatus>((resolve) => {
+        releaseResponse = resolve
+      })
+      ;(window as unknown as { api: unknown }).api = {
+        update: {
+          getAppInfo: async () => ({ name: 'Open Science', version: '0.2.0', copyright: '' }),
+          getStatus: async () => ({ state: 'available', current: '0.2.0', latest: '0.3.0' }),
+          onStatus: (listener: (status: UpdateStatus) => void) => {
+            statusListener = listener
+            return () => undefined
+          },
+          onProgress: vi.fn(),
+          [command]: () => response
+        }
+      }
+      const cleanup = useUpdateStore.getState().init()
+      await Promise.resolve()
+      try {
+        const pending = useUpdateStore.getState()[command]()
+        statusListener({ state: 'available', current: '0.2.0', latest: '0.3.0' })
+        statusListener({ state: 'downloading', current: '0.2.0', latest: '0.3.0' })
+        statusListener({
+          state: 'ready',
+          current: '0.2.0',
+          latest: '0.3.0',
+          localPath: '/installer'
+        })
+        expect(useUpdateStore.getState().status.state).toBe('ready')
+        releaseResponse({ state: 'available', current: '0.2.0', latest: '0.3.0' })
+        await pending
+
+        expect(useUpdateStore.getState().status).toMatchObject({
+          state: 'ready',
+          localPath: '/installer'
+        })
+      } finally {
+        cleanup()
+      }
+    }
+  )
+
   beforeEach(() => {
     resetStore()
     vi.restoreAllMocks()

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -17,6 +17,17 @@ type UpdateStore = {
 }
 
 let cleanupUpdateSubscriptions: (() => void) | undefined
+let statusRevision = 0
+
+// ponytail: local observation order protects replies from newer live state. Arbitrarily reordered
+// broadcasts would require a main-process revision shared by every response and event.
+const acceptUpdateResponse = async (request: () => Promise<UpdateStatus | void>): Promise<void> => {
+  const revision = statusRevision
+  const status = await request()
+  if (!status || revision !== statusRevision) return
+  statusRevision += 1
+  useUpdateStore.setState({ status })
+}
 
 // Single source of truth for update state in the renderer. The main process broadcasts every
 // transition; this store mirrors it so the settings section and the external capsule agree.
@@ -42,15 +53,17 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
     // immediately a status (electron-updater does on every tick) would otherwise wipe the speed the
     // progress event just set. Preserve downloadProgress across a status update while downloading so
     // DownloadProgressLine keeps rendering speed/ETA on Win/Linux.
-    const removeStatusListener = api.onStatus((status) =>
+    const removeStatusListener = api.onStatus((status) => {
+      statusRevision += 1
       set((s) => ({
         status: {
           ...status,
           downloadProgress: status.state === 'downloading' ? s.status.downloadProgress : undefined
         }
       }))
-    )
-    const removeProgressListener = api.onProgress((progress) =>
+    })
+    const removeProgressListener = api.onProgress((progress) => {
+      statusRevision += 1
       set((s) => ({
         status: {
           ...s.status,
@@ -63,16 +76,14 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
           downloadProgress: progress
         }
       }))
-    )
-    void api.getStatus().then((status) => {
-      // Only apply the startup snapshot if no live broadcast has updated us yet.
-      if (get().status.state === 'idle') set({ status })
     })
+    void acceptUpdateResponse(() => api.getStatus())
 
     let active = true
     const cleanup = (): void => {
       if (!active) return
       active = false
+      statusRevision += 1
       removeStatusListener?.()
       removeProgressListener?.()
       if (cleanupUpdateSubscriptions === cleanup) cleanupUpdateSubscriptions = undefined
@@ -84,7 +95,7 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
   check: async () => {
     const api = window.api?.update
     if (!api) return
-    set({ status: await api.check() })
+    await acceptUpdateResponse(() => api.check())
   },
 
   openDialog: () => set({ isDialogOpen: true }),
@@ -101,19 +112,18 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
   download: async () => {
     const api = window.api?.update
     if (!api) return
-    set({ status: await api.download() })
+    await acceptUpdateResponse(() => api.download())
   },
 
   cancel: async () => {
     const cancel = window.api?.update?.cancel
     if (!cancel) return
-    set({ status: await cancel() })
+    await acceptUpdateResponse(() => cancel())
   },
 
   apply: async () => {
     const api = window.api?.update
     if (!api) return
-    const status = await api.apply()
-    if (status) set({ status })
+    await acceptUpdateResponse(() => api.apply())
   }
 }))

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -100,6 +100,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "Für diese Plattform ist kein Installationsprogramm verfügbar. Laden Sie es manuell herunter, um andere Installationsmöglichkeiten zu prüfen.",
     "Latest saved version": "Zuletzt gespeicherte Version",
     "Unable to discard the Plan.": "Der Plan kann nicht verworfen werden.",
     "Discard unavailable Plan": "Nicht verfügbaren Plan verwerfen",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "No hay un instalador disponible para esta plataforma. Descargue manualmente para consultar otras opciones de instalación.",
     "Latest saved version": "Última versión guardada",
     "Unable to discard the Plan.": "No se puede descartar el plan.",
     "Discard unavailable Plan": "Descartar el plan no disponible",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "Aucun programme d’installation n’est disponible pour cette plateforme. Consultez le téléchargement manuel pour découvrir d’autres options d’installation.",
     "Latest saved version": "Dernière version enregistrée",
     "Unable to discard the Plan.": "Impossible d’abandonner le plan.",
     "Discard unavailable Plan": "Abandonner le plan indisponible",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "このプラットフォーム用のインストーラーはありません。手動ダウンロードのページで他のインストール方法を確認してください。",
     "Latest saved version": "最後に保存されたバージョン",
     "Unable to discard the Plan.": "プランを破棄できません。",
     "Discard unavailable Plan": "利用できないプランを破棄",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "이 플랫폼에서 사용할 수 있는 설치 프로그램이 없습니다. 수동 다운로드 페이지에서 다른 설치 방법을 확인하세요.",
     "Latest saved version": "최근 저장된 버전",
     "Unable to discard the Plan.": "계획을 삭제할 수 없습니다.",
     "Discard unavailable Plan": "사용할 수 없는 계획 삭제",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "Установщик для этой платформы недоступен. Перейдите к ручной загрузке, чтобы узнать о других вариантах установки.",
     "Latest saved version": "Последняя сохранённая версия",
     "Unable to discard the Plan.": "Не удалось удалить план.",
     "Discard unavailable Plan": "Удалить недоступный план",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "此平台暂无可用的安装包。请前往手动下载页面查看其他安装选项。",
     "Latest saved version": "最新保存的版本",
     "Unable to discard the Plan.": "无法丢弃计划。",
     "Discard unavailable Plan": "丢弃不可用计划",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "An installer is not available for this platform. Download manually to check other installation options.": "此平台暫無可用的安裝套件。請前往手動下載頁面查看其他安裝選項。",
     "Latest saved version": "最新儲存的版本",
     "Unable to discard the Plan.": "無法捨棄計畫。",
     "Discard unavailable Plan": "捨棄無法使用的計畫",

--- a/src/shared/update.test.ts
+++ b/src/shared/update.test.ts
@@ -31,6 +31,21 @@ describe('compareVersions', () => {
 })
 
 describe('isNewer', () => {
+  it.each([
+    ['1.1.0', '1.1.0-nightly.abc1234', true],
+    ['1.1.0', '1.1.0-nightly.123abcd', true],
+    ['1.1.0', '1.1.0-nightly.0001234', true],
+    ['1.1.0+release', '1.1.0-nightly.123abcd+build', true],
+    ['1.0.9', '1.1.0-nightly.abc1234', false],
+    ['1.1.1', '1.1.0-nightly.abc1234', true],
+    ['1.1.0', '1.1.0+build', false],
+    ['1.1.0-nightly.abc1234', '1.1.0', false],
+    ['1.1.0-nightly.999abcd', '1.1.0-nightly.123abcd', false],
+    ['1.1.0-nightly.abc1234', '1.1.0-nightly.def5678', false]
+  ])('compares release eligibility for %s against %s', (latest, current, expected) => {
+    expect(isNewer(latest, current)).toBe(expected)
+  })
+
   it('is true only when latest exceeds current', () => {
     expect(isNewer('0.3.0', '0.2.0')).toBe(true)
     expect(isNewer('0.2.0', '0.2.0')).toBe(false)

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -69,8 +69,15 @@ export const compareVersions = (a: string, b: string): -1 | 0 | 1 => {
   return 0
 }
 
-export const isNewer = (latest: string, current: string): boolean =>
-  compareVersions(latest, current) > 0
+// Release eligibility is distinct from the numeric comparison used for runtime compatibility.
+// A stable release supersedes its matching Nightly base; SHA identifiers cannot order Nightlies.
+export const isNewer = (latest: string, current: string): boolean => {
+  const latestVersion = latest.split('+', 1)[0]
+  const currentVersion = current.split('+', 1)[0]
+  const compared = compareVersions(latestVersion.split('-', 1)[0], currentVersion.split('-', 1)[0])
+  if (compared !== 0) return compared > 0
+  return !latestVersion.includes('-') && currentVersion.includes('-')
+}
 
 // Maps the host to its manifest download key. Linux prefers the deb; selectDownload falls back to
 // the AppImage when the deb is absent.


### PR DESCRIPTION
## Problem

Downloads waiting for an update check ignored cancellation in both strategies, and delayed renderer command replies could replace newer live state. Valid mixed-case manifest checksums failed integrity verification. Missing platform artifacts left an inert download button, and installed Nightlies missed a stable release with the same numeric version.

## Proposed change

- Register cancellation while waiting for checks, then retain the existing transfer cleanup/drain protection.
- Apply one renderer response guard to hydration and all update commands; status/progress observed during a request takes precedence.
- Normalize validated manifest SHA-256 values to lowercase.
- Show a platform-unavailable explanation and manual-download link for installer offers without an artifact; keep restart-strategy downloads available.
- Recognize stable releases above matching Nightly bases without assigning chronological meaning to SHA identifiers or changing Codex runtime compatibility checks.

## Scope and non-goals

No new UpdateStatus fields, enum values, persistence formats, database migrations, dependencies, or update services. Existing mixed-case manifests and installed Nightly version strings remain accepted. Already-installed old binaries may still require one manual upgrade. Renderer ordering protection is intentionally local: arbitrary broadcast reordering would require a main-process revision contract. This does not introduce a Nightly channel or installer execution changes.

## Acceptance criteria and validation

All local checks below ran after the last material source/test edit on `35f1add`.

Before any production fix, the same 12 regression cases failed in three consecutive runs, with failures matching U01–U05. Four controls passed. The third baseline run also passed all 120 existing tests in the five affected files. The original cases now pass.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Waiting cancellation, immediate retry, early-return cleanup, existing transfer drain, strategy routing and save dialogs | `src/main/update` | Pass |
| Digest integrity through real temporary files | `update/downloader.test.ts`, `update/manifest.test.ts`, `net/resilient-download.test.ts` | Pass; incorrect digest still rejected |
| Stable/Nightly eligibility | `shared/update.test.ts`, real strategy/service tests | Pass |
| Desktop/local command contract forwarding | `main/host-application-commands.test.ts`, `shared/application-command-contract.test.ts`, `update/ipc.test.ts` | Pass |
| Late replies, progress preservation, missing-artifact and restart controls | `update-store.test.ts`, `UpdateDialog.render.test.tsx`, `UpdateDialog.lifecycle.test.tsx` | Pass |
| Eight translated locales | `renderer/src/i18n/resources.test.ts` | Pass |
| Main/renderer types and style | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint`, changed-file Prettier, `git diff --check` | Pass |

Combined focused Vitest invocation: **17 files, 1,069 tests passed, zero failures**. Full local `npm test` was intentionally omitted at the maintainer's request. The affected-test explain planner selects full CI because the curated registry does not own the update module; the registry is unchanged. Exact-head PR CI remains the full-suite/platform authority.

Visual verification is pending: the real UpdateDialog/i18n/styles fixture is ready, but ego-browser requires the maintainer to finish first-run onboarding. Keep this PR draft until screenshots are attached/reviewed. No actual installer was run. Real multi-window network races, signing and platform package installation are not claimed by the local deterministic tests.

## Review focus

Cancellation ownership across check completion and cancel/retry; preservation of transfer drain; the explicitly bounded renderer response policy; restart downloads without a manifest field; stable-only release policy without changing runtime version support. Independent review and CI are pending.
