### PR TITLE
fix(tags): preserve drafts and confirmed resource state

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -994,13 +994,18 @@ Preference-save and app-icon-preview failures use one line of small red text wit
 action for dismiss or retry. Do not add a border, background, brand mark, or status icon. Keep the
 language rollback explanation available to screen readers.
 
-Use the shared `ErrorNotice` for error summaries. Center the decorative flask mark (`size-18`) above
+Use the shared `ErrorNotice` for error summaries. In its default page-level layout, center the decorative flask mark (`size-18`) above
 the summary with a 32px gap to distinguish it from the smaller status icon. Use one bounded column
 (`max-w-md`, `min-w-0`), and left-align headings, descriptions, codes, and help.
 Pair the status icon with the first text line. Long error text and identifiers must wrap inside the
 column. Group primary and secondary actions at the trailing edge with `flex-wrap` and a consistent
 small gap; wrap whole controls instead of splitting their labels. Preserve semantic status tones,
 disabled/loading behavior, and immediately visible keyboard focus.
+
+Inside an existing form or resource list, use `compact` ErrorNotice: omit the decorative flask,
+use a small status icon and semantic tinted surface, and align smaller actions beneath the text.
+Keep the notice at the content width with 16px padding and 14px text; retain the same action,
+loading, and focus behavior. Tag draft conflicts and catalog retries use this inline presentation.
 
 Provenance diagnostics share the summary's width below a divider. A disclosure button exposes its
 expanded state and controls the diagnostic region; the copy action belongs in that region's header

--- a/docs/design.md
+++ b/docs/design.md
@@ -913,10 +913,22 @@ colors communicate a successful or failed probe/migration result.
   also removes its assignments before the deleted ID can be reused. Skill, Connector, and Specialist
   file formats are unchanged, and no pin, bookmark, Group, import/export, or cloud-sync data is
   migrated.
+- Temporary catalog unavailability, including a Skill identity conflict, preserves existing Tag
+  assignments. Reconciliation uses all existing resource IDs; adding assignments still requires an
+  available resource. No catalog or assignment storage format changes are needed.
+- A Tag editor keeps its draft and submission version when a newer snapshot arrives. A conflict
+  blocks saving until the user reloads the latest values or explicitly keeps the draft for another
+  save. That save still checks the acknowledged version. Reordering retains its existing timestamp
+  semantics and can therefore require confirmation without discarding the draft.
+- Resource catalog loading is tracked independently by type. Failed catalogs show a retry action,
+  available resource rows remain visible, and Tag totals and type totals count known assignments
+  even when metadata is missing. An incomplete catalog is not presented as an empty Tag.
 - Resource rows and detail/editor surfaces share the same searchable assignment menu. Creating a Tag
   from that menu assigns it immediately with the default visual; the Tags manager can then change its
   icon or color. Assignment changes update optimistically and reload the authoritative snapshot after
-  a failure. The Tags browser keeps its selected Tag, resource filter, query, and scroll position when
+  a failure. Rollback preserves newer authoritative revisions and other pending assignments; order
+  rollback only runs while the failed operation still owns the current Tag array. The Tags browser
+  keeps its selected Tag, resource filter, query, and scroll position when
   Settings history opens a resource and returns.
 
 #### Specialist-scoped resources and Marketplace

--- a/docs/design.md
+++ b/docs/design.md
@@ -995,11 +995,21 @@ action for dismiss or retry. Do not add a border, background, brand mark, or sta
 language rollback explanation available to screen readers.
 
 Use the shared `ErrorNotice` for error summaries. The default is a compact inline surface across
-Settings, workspace previews, conversations, and Literature: a small status icon, semantic tinted
-surface, 16px padding, 14px text, and smaller actions aligned beneath the copy. Omit the decorative
-flask, use the available content width, and avoid adding a second border or background in wrappers.
-Long error text and identifiers wrap; actions wrap as whole controls. Callers own alert semantics
-and translated copy. Preserve semantic tones, loading/disabled behavior, and visible keyboard focus.
+Settings, workspace previews, conversations, and Literature: a neutral `bg-card` surface with a
+`border-border` outline, a small semantically colored status icon, 16px padding, and 14px copy.
+Place a single recovery action at the trailing edge, wrapping below the copy in narrow containers.
+Keep inline actions low emphasis so they do not compete with the page's primary task. Omit the
+flask and avoid a second border or background in wrappers. All copy and identifiers wrap.
+
+Conflicts can include owner-provided content and two described choices below the summary. Tag
+editors show the latest saved name, icon, and color without replacing the draft. Continue editing
+only acknowledges that version; a separate Save submits the draft. Loading the latest version
+replaces the draft. Each action's consequence is connected with `aria-describedby`.
+
+Callers translate all copy. Inline technical codes use a native, initially closed diagnostic
+disclosure with a caller-provided label; recovery actions remain available outside it. When using
+`role`, ErrorNotice announces only its summary, leaving diagnostics outside the live region.
+Preserve semantic tones, loading/disabled behavior, and visible keyboard focus.
 
 Only app startup blockers (database startup and initial settings loading) opt into `fullPage`:
 center the decorative flask (`size-18`) above a bounded `max-w-md` column, with larger status icons,

--- a/docs/design.md
+++ b/docs/design.md
@@ -994,18 +994,17 @@ Preference-save and app-icon-preview failures use one line of small red text wit
 action for dismiss or retry. Do not add a border, background, brand mark, or status icon. Keep the
 language rollback explanation available to screen readers.
 
-Use the shared `ErrorNotice` for error summaries. In its default page-level layout, center the decorative flask mark (`size-18`) above
-the summary with a 32px gap to distinguish it from the smaller status icon. Use one bounded column
-(`max-w-md`, `min-w-0`), and left-align headings, descriptions, codes, and help.
-Pair the status icon with the first text line. Long error text and identifiers must wrap inside the
-column. Group primary and secondary actions at the trailing edge with `flex-wrap` and a consistent
-small gap; wrap whole controls instead of splitting their labels. Preserve semantic status tones,
-disabled/loading behavior, and immediately visible keyboard focus.
+Use the shared `ErrorNotice` for error summaries. The default is a compact inline surface across
+Settings, workspace previews, conversations, and Literature: a small status icon, semantic tinted
+surface, 16px padding, 14px text, and smaller actions aligned beneath the copy. Omit the decorative
+flask, use the available content width, and avoid adding a second border or background in wrappers.
+Long error text and identifiers wrap; actions wrap as whole controls. Callers own alert semantics
+and translated copy. Preserve semantic tones, loading/disabled behavior, and visible keyboard focus.
 
-Inside an existing form or resource list, use `compact` ErrorNotice: omit the decorative flask,
-use a small status icon and semantic tinted surface, and align smaller actions beneath the text.
-Keep the notice at the content width with 16px padding and 14px text; retain the same action,
-loading, and focus behavior. Tag draft conflicts and catalog retries use this inline presentation.
+Only app startup blockers (database startup and initial settings loading) opt into `fullPage`:
+center the decorative flask (`size-18`) above a bounded `max-w-md` column, with larger status icons,
+16px headings, and trailing actions. This single presentation option replaces independent brand
+visibility and compactness switches; it does not introduce application state or persisted data.
 
 Provenance diagnostics share the summary's width below a divider. A disclosure button exposes its
 expanded state and controls the diagnostic region; the copy action belongs in that region's header

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -687,6 +687,33 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await page.getByRole('button', { name: 'Send message' }).click()
   await expect(page.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
 
+  const advanceRevision = async (): Promise<void> => {
+    const session = await page.evaluate(async (title) => {
+      const session = (await window.api.sessions.loadAll()).sessions.find(
+        (candidate) => candidate.title === title
+      )
+      if (!session) throw new Error('Archive fixture Session was not persisted.')
+      return session
+    }, USER_MESSAGE)
+    await page.getByRole('menuitem', { name: 'Archive' }).evaluate((element, session) => {
+      // Queue another client's write immediately before the menu submits its captured version.
+      element.addEventListener(
+        'click',
+        () => {
+          void window.api.sessions.editDetails({
+            projectId: session.projectId!,
+            sessionId: session.id,
+            title: session.title,
+            description: `${session.description ?? ''} concurrent edit`,
+            expectedTitle: session.title,
+            expectedDescription: session.description ?? ''
+          })
+        },
+        { capture: true, once: true }
+      )
+    }, session)
+  }
+
   await page.setViewportSize({ width: 375, height: 900 })
   await page.getByRole('button', { name: 'Open navigation' }).click()
   await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
@@ -707,24 +734,24 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await exportDialog.getByRole('button', { name: 'Close' }).click()
   await expect(exportDialog).toBeHidden()
 
-  await page.getByRole('button', { name: 'Open navigation' }).click()
-  await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
-  const archive = page.getByRole('menuitem', { name: 'Archive' })
-  await expect(archive).toBeEnabled()
-  await archive.click()
-
   const undo = page.getByTestId('archive-undo-snackbar')
   const conflict = page.getByText(/Session revision conflict:/)
-  await expect(undo.or(conflict)).toBeVisible()
-  if (await conflict.isVisible()) {
-    // Terminal persistence can advance the whole-Session revision after the click. The stale
-    // command must remain rejected; only a new user action may use the refreshed authority.
-    await expect(undo).toBeHidden()
+  // Exercise two consecutive authority changes, not just one lucky retry. Each conflict
+  // must finish refreshing the projection before a fresh user action opens the menu again.
+  for (let attempt = 0; attempt < 3; attempt += 1) {
     await page.getByRole('button', { name: 'Open navigation' }).click()
     await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
-    await page.getByRole('menuitem', { name: 'Archive' }).click()
+    const archive = page.getByRole('menuitem', { name: 'Archive' })
+    await expect(archive).toBeEnabled()
+    if (attempt < 2) await advanceRevision()
+    await archive.click()
+    if (attempt < 2) {
+      await expect(conflict).toBeVisible()
+      await expect(undo).toBeHidden()
+    } else {
+      await expect(undo).toContainText('Archived session')
+    }
   }
-  await expect(page.getByTestId('archive-undo-snackbar')).toContainText('Archived session')
   await expect(page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` })).toBeHidden()
 })
 

--- a/src/main/tags/repository.test.ts
+++ b/src/main/tags/repository.test.ts
@@ -7,6 +7,8 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { TagRepository, cleanTagName, tagNameKey } from './repository'
+import { TagResourceCatalog } from './resource-catalog'
+import { TagService } from './service'
 
 describe('TagRepository', () => {
   let root: string
@@ -198,6 +200,38 @@ describe('TagRepository', () => {
       })
     ).resolves.toBe(1)
     expect((await repository.snapshot(1)).assignments).toEqual([])
+  })
+
+  it('preserves assignments through temporary identity conflicts and prunes actual deletion', async () => {
+    let skills = [{ id: 'analysis', available: true }]
+    const catalog = new TagResourceCatalog({
+      listSkills: async () => skills,
+      listConnectors: async () => ({ connectors: [], customServers: [] }),
+      listSpecialists: async () => [],
+      listLiteratureItems: async () => []
+    })
+    const service = new TagService(repository, catalog, { publish: () => undefined })
+    const assignment = {
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill' as const,
+      resourceId: 'analysis',
+      assigned: true
+    }
+    await service.setAssignment(assignment)
+    skills = [
+      { id: 'analysis', available: false },
+      { id: 'analysis', available: false }
+    ]
+    await service.snapshot()
+    expect(await client.tagAssignment.count()).toBe(1)
+    await expect(service.setAssignment(assignment)).rejects.toThrow(
+      'Tag resource no longer exists.'
+    )
+    skills = [{ id: 'analysis', available: true }]
+    expect((await service.snapshot()).assignments).toHaveLength(1)
+    skills = []
+    expect((await service.snapshot()).assignments).toEqual([])
+    expect(await client.tagAssignment.count()).toBe(0)
   })
 
   it('removes assignments at the resource deletion boundary', async () => {

--- a/src/main/tags/repository.test.ts
+++ b/src/main/tags/repository.test.ts
@@ -202,6 +202,38 @@ describe('TagRepository', () => {
     expect((await repository.snapshot(1)).assignments).toEqual([])
   })
 
+  it('returns persisted assignments when an unrelated catalog fails and reconciles after recovery', async () => {
+    let catalogFails = false
+    let skills = [{ id: 'analysis' }]
+    const catalog = new TagResourceCatalog({
+      listSkills: async () => skills,
+      listConnectors: async () => ({ connectors: [], customServers: [] }),
+      listSpecialists: async () => {
+        if (catalogFails) throw new Error('Specialist catalog offline')
+        return []
+      },
+      listLiteratureItems: async () => []
+    })
+    const service = new TagService(repository, catalog, { publish: () => undefined })
+    const assignment = {
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill' as const,
+      resourceId: 'analysis',
+      assigned: true
+    }
+    const saved = await service.setAssignment(assignment)
+    catalogFails = true
+    skills = []
+
+    await expect(service.snapshot()).resolves.toEqual(saved)
+    expect(await client.tagAssignment.count()).toBe(1)
+    await expect(service.setAssignment(assignment)).rejects.toThrow('Specialist catalog offline')
+
+    catalogFails = false
+    expect((await service.snapshot()).assignments).toEqual([])
+    expect(await client.tagAssignment.count()).toBe(0)
+  })
+
   it('preserves assignments through temporary identity conflicts and prunes actual deletion', async () => {
     let skills = [{ id: 'analysis', available: true }]
     const catalog = new TagResourceCatalog({

--- a/src/main/tags/resource-catalog.ts
+++ b/src/main/tags/resource-catalog.ts
@@ -18,7 +18,7 @@ type TagResourceCatalogSnapshot = Readonly<Record<TagResourceType, ReadonlySet<s
 class TagResourceCatalog {
   constructor(private readonly dependencies: TagResourceCatalogDependencies) {}
 
-  async snapshot(): Promise<TagResourceCatalogSnapshot> {
+  async snapshot({ includeUnavailable = false } = {}): Promise<TagResourceCatalogSnapshot> {
     const [skills, connectors, specialists, literatureItems] = await Promise.all([
       this.dependencies.listSkills(),
       this.dependencies.listConnectors(),
@@ -27,7 +27,9 @@ class TagResourceCatalog {
     ])
     return Object.freeze({
       'catalog.skill': new Set(
-        skills.filter(({ available }) => available !== false).map(({ id }) => id)
+        skills
+          .filter(({ available }) => includeUnavailable || available !== false)
+          .map(({ id }) => id)
       ),
       'catalog.connector': new Set([
         ...connectors.connectors.map(({ id }) => id),

--- a/src/main/tags/service.ts
+++ b/src/main/tags/service.ts
@@ -48,7 +48,8 @@ class TagService {
           this.events.publish('tags:changed', { revision: this.revision })
         }
       }
-      const resources = await this.resources.snapshot()
+      // Unavailable identities still exist; only assignment creation requires availability.
+      const resources = await this.resources.snapshot({ includeUnavailable: true })
       const pruned = await this.repository.pruneStaleAssignments(resources)
       if (pruned > 0) {
         this.revision += 1

--- a/src/main/tags/service.ts
+++ b/src/main/tags/service.ts
@@ -49,8 +49,12 @@ class TagService {
         }
       }
       // Unavailable identities still exist; only assignment creation requires availability.
-      const resources = await this.resources.snapshot({ includeUnavailable: true })
-      const pruned = await this.repository.pruneStaleAssignments(resources)
+      const resources = await this.resources
+        .snapshot({ includeUnavailable: true })
+        .catch(() => undefined)
+      // Catalog outages do not invalidate saved relationships. Retry reconciliation on the
+      // next snapshot; renderer catalog loaders already own per-type errors and retry actions.
+      const pruned = resources ? await this.repository.pruneStaleAssignments(resources) : 0
       if (pruned > 0) {
         this.revision += 1
         this.events.publish('tags:changed', { revision: this.revision })

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -64,6 +64,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           className="flex min-h-svh items-center justify-center bg-background p-6 text-foreground"
         >
           <ErrorNotice
+            fullPage
             title={t('Settings could not be loaded')}
             description={startup.settings.loadError}
             primaryButton={{

--- a/src/renderer/src/components/JobDetailModal.tsx
+++ b/src/renderer/src/components/JobDetailModal.tsx
@@ -277,13 +277,14 @@ function JobDetailView({ job, onBack, onOpenFileBrowser }: JobDetailViewProps): 
 
       {latestJob.needs_attention ? (
         <div
-          role="alert"
           data-testid="job-integrity-diagnostic"
           className="flex justify-center border-b border-border p-5"
         >
           <ErrorNotice
             icon={ShieldAlert}
             tone="red"
+            role="alert"
+            diagnosticsLabel={t('Diagnostics')}
             title={t('Saved remote job data needs attention')}
             description={t(
               'This job remains visible, but automatic result analysis is paused because its saved state is incompatible.'

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -180,6 +180,7 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
       aria-live="polite"
     >
       <ErrorNotice
+        fullPage
         icon={guidance?.icon}
         tone={guidance?.tone}
         title={t("Open Science couldn't start")}

--- a/src/renderer/src/components/error-notice.test.tsx
+++ b/src/renderer/src/components/error-notice.test.tsx
@@ -6,13 +6,15 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ErrorNotice } from './error-notice'
 
-describe.each([false, true])('ErrorNotice (compact: %s)', (compact) => {
+describe.each([false, true])('ErrorNotice (fullPage: %s)', (fullPage) => {
   afterEach(cleanup)
 
   it('renders only the sections whose props are provided', () => {
-    render(<ErrorNotice compact={compact} title="Something broke" />)
+    render(<ErrorNotice fullPage={fullPage} title="Something broke" />)
 
-    expect(screen.getByText('Something broke')).toBeTruthy()
+    expect(
+      screen.getByRole('heading', { name: 'Something broke', level: fullPage ? 1 : 2 })
+    ).toBeTruthy()
     expect(screen.queryByRole('button')).toBeNull()
   })
 
@@ -23,7 +25,7 @@ describe.each([false, true])('ErrorNotice (compact: %s)', (compact) => {
 
     render(
       <ErrorNotice
-        compact={compact}
+        fullPage={fullPage}
         icon={ShieldX}
         tone="red"
         title="Broken"
@@ -64,7 +66,7 @@ describe.each([false, true])('ErrorNotice (compact: %s)', (compact) => {
   it('renders either button on its own', () => {
     render(
       <ErrorNotice
-        compact={compact}
+        fullPage={fullPage}
         title="t"
         primaryButton={{ label: 'Retry', onClick: () => undefined }}
       />
@@ -78,7 +80,7 @@ describe.each([false, true])('ErrorNotice (compact: %s)', (compact) => {
     const onRetry = vi.fn()
     const { container } = render(
       <ErrorNotice
-        compact={compact}
+        fullPage={fullPage}
         title="t"
         primaryButton={{ label: 'Retrying…', onClick: onRetry, loading: true }}
       />

--- a/src/renderer/src/components/error-notice.test.tsx
+++ b/src/renderer/src/components/error-notice.test.tsx
@@ -6,11 +6,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { ErrorNotice } from './error-notice'
 
-describe('ErrorNotice', () => {
+describe.each([false, true])('ErrorNotice (compact: %s)', (compact) => {
   afterEach(cleanup)
 
   it('renders only the sections whose props are provided', () => {
-    render(<ErrorNotice title="Something broke" />)
+    render(<ErrorNotice compact={compact} title="Something broke" />)
 
     expect(screen.getByText('Something broke')).toBeTruthy()
     expect(screen.queryByRole('button')).toBeNull()
@@ -23,6 +23,7 @@ describe('ErrorNotice', () => {
 
     render(
       <ErrorNotice
+        compact={compact}
         icon={ShieldX}
         tone="red"
         title="Broken"
@@ -61,7 +62,13 @@ describe('ErrorNotice', () => {
   })
 
   it('renders either button on its own', () => {
-    render(<ErrorNotice title="t" primaryButton={{ label: 'Retry', onClick: () => undefined }} />)
+    render(
+      <ErrorNotice
+        compact={compact}
+        title="t"
+        primaryButton={{ label: 'Retry', onClick: () => undefined }}
+      />
+    )
 
     expect(screen.getByRole('button', { name: 'Retry' })).toBeTruthy()
     expect(screen.queryByRole('button', { name: 'Quit' })).toBeNull()
@@ -71,6 +78,7 @@ describe('ErrorNotice', () => {
     const onRetry = vi.fn()
     const { container } = render(
       <ErrorNotice
+        compact={compact}
         title="t"
         primaryButton={{ label: 'Retrying…', onClick: onRetry, loading: true }}
       />

--- a/src/renderer/src/components/error-notice.test.tsx
+++ b/src/renderer/src/components/error-notice.test.tsx
@@ -94,3 +94,55 @@ describe.each([false, true])('ErrorNotice (fullPage: %s)', (fullPage) => {
     expect(onRetry).not.toHaveBeenCalled()
   })
 })
+
+describe('contextual notice content', () => {
+  afterEach(cleanup)
+
+  it('keeps diagnostics collapsed and outside the alert while recovery stays available', () => {
+    render(
+      <ErrorNotice
+        role="alert"
+        title="Version check failed"
+        errorCode="version_mismatch"
+        diagnosticsLabel="Diagnostics"
+        primaryButton={{ label: 'Retry', onClick: vi.fn() }}
+      />
+    )
+    const diagnostics = screen.getByText('Diagnostics').closest('details')!
+    expect(diagnostics).not.toBeNull()
+    expect(diagnostics.open).toBe(false)
+    expect(screen.getByText('version_mismatch').closest('[role="alert"]')).toBeNull()
+    expect(screen.getByRole('alert').textContent).toContain('Version check failed')
+    expect(screen.getByRole('button', { name: 'Retry' }).closest('details')).toBeNull()
+  })
+
+  it('associates each recovery choice with its consequence and renders owner content', () => {
+    render(
+      <ErrorNotice
+        title="Tag version updated"
+        primaryButton={{
+          label: 'Continue editing draft',
+          description: 'Save later to replace the latest version.',
+          onClick: vi.fn()
+        }}
+        secondaryButton={{
+          label: 'Load latest version',
+          description: 'Replace the current draft.',
+          onClick: vi.fn()
+        }}
+      >
+        <p>Latest saved version: Research</p>
+      </ErrorNotice>
+    )
+    expect(screen.getByText('Latest saved version: Research')).toBeTruthy()
+    for (const [name, description] of [
+      ['Continue editing draft', 'Save later to replace the latest version.'],
+      ['Load latest version', 'Replace the current draft.']
+    ]) {
+      const button = screen.getByRole('button', { name })
+      expect(document.getElementById(button.getAttribute('aria-describedby')!)?.textContent).toBe(
+        description
+      )
+    }
+  })
+})

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -1,4 +1,11 @@
-import { CircleAlert, CircleQuestionMark, LoaderCircle, type LucideIcon } from 'lucide-react'
+import { useId, type ReactNode } from 'react'
+import {
+  ChevronRight,
+  CircleAlert,
+  CircleQuestionMark,
+  LoaderCircle,
+  type LucideIcon
+} from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
@@ -13,6 +20,7 @@ type ErrorNoticeTone = 'teal' | 'amber' | 'red'
 
 type ErrorNoticeButton = {
   label: string
+  description?: string
   onClick: () => void
   disabled?: boolean
   // Shows a spinner beside the label and disables the button while an action is in flight.
@@ -21,11 +29,15 @@ type ErrorNoticeButton = {
 
 type ErrorNoticeProps = {
   fullPage?: boolean
+  // Announce the summary without reading technical diagnostics or recovery controls.
+  role?: 'alert' | 'status'
+  children?: ReactNode
   icon?: LucideIcon
   tone?: ErrorNoticeTone
   title?: string
   description?: string
   errorCode?: string
+  diagnosticsLabel?: string
   help?: { whyLabel: string; why: string; howLabel: string; how: string }
   issueLink?: { label: string; tooltip: string; onClick: () => void }
   secondaryButton?: ErrorNoticeButton
@@ -41,38 +53,64 @@ const TONE_CLASSES: Record<ErrorNoticeTone, string> = {
   red: 'bg-status-failure-surface text-status-failure-foreground dark:bg-status-failure-dark-surface dark:text-status-failure-dark-foreground'
 }
 
+const ICON_TONE_CLASSES: Record<ErrorNoticeTone, string> = {
+  teal: 'text-status-info-foreground dark:text-status-info-dark-foreground',
+  amber: 'text-status-warning-foreground dark:text-status-warning-dark-foreground',
+  red: 'text-status-failure-foreground dark:text-status-failure-dark-foreground'
+}
+
 const NoticeButton = ({
   button,
-  variant,
+  secondary = false,
   compact
 }: {
   button: ErrorNoticeButton
-  variant?: 'secondary'
-  compact?: boolean
-}): React.JSX.Element => (
-  <Button
-    type="button"
-    className="focus-visible:transition-none"
-    variant={compact && variant === 'secondary' ? 'outline' : variant}
-    size={compact ? 'sm' : 'default'}
-    onClick={button.onClick}
-    disabled={button.disabled || button.loading}
-    aria-busy={button.loading || undefined}
-  >
-    {button.loading ? (
-      <LoaderCircle className="size-4 animate-spin motion-reduce:animate-none" aria-hidden="true" />
-    ) : null}
-    {button.label}
-  </Button>
-)
+  secondary?: boolean
+  compact: boolean
+}): React.JSX.Element => {
+  const descriptionId = useId()
+  return (
+    <div className="min-w-0">
+      <Button
+        type="button"
+        className={cn(
+          'focus-visible:transition-none',
+          compact && 'h-auto min-h-8 max-w-full whitespace-normal text-left'
+        )}
+        variant={compact ? (secondary ? 'ghost' : 'outline') : secondary ? 'secondary' : 'default'}
+        size={compact ? 'sm' : 'default'}
+        onClick={button.onClick}
+        disabled={button.disabled || button.loading}
+        aria-busy={button.loading || undefined}
+        aria-describedby={button.description ? descriptionId : undefined}
+      >
+        {button.loading ? (
+          <LoaderCircle
+            className="size-4 animate-spin motion-reduce:animate-none"
+            aria-hidden="true"
+          />
+        ) : null}
+        {button.label}
+      </Button>
+      {button.description ? (
+        <p id={descriptionId} className="mt-1.5 text-xs leading-5 text-muted-foreground">
+          {button.description}
+        </p>
+      ) : null}
+    </div>
+  )
+}
 
 const ErrorNotice = ({
   fullPage = false,
+  role,
+  children,
   icon: Icon = fullPage ? undefined : CircleAlert,
   tone,
   title,
   description,
   errorCode,
+  diagnosticsLabel,
   help,
   issueLink,
   secondaryButton,
@@ -80,30 +118,44 @@ const ErrorNotice = ({
 }: ErrorNoticeProps): React.JSX.Element => {
   const compact = !fullPage
   const Heading = compact ? 'h2' : 'h1'
+  const trailingAction =
+    compact &&
+    (title !== undefined || description !== undefined) &&
+    primaryButton &&
+    !secondaryButton &&
+    !primaryButton.description &&
+    !children &&
+    !help
+  const describedActions = compact && (primaryButton?.description || secondaryButton?.description)
+  const diagnosticContent = (
+    <pre className="w-full whitespace-pre-wrap rounded-lg bg-muted px-3 py-2.5 font-mono text-xs leading-5 text-muted-foreground [overflow-wrap:anywhere]">
+      {errorCode}
+    </pre>
+  )
   return (
     <section
       className={cn(
         'flex w-full min-w-0 flex-col text-left',
-        compact
-          ? ['gap-3 rounded-lg border border-current/15 p-4', TONE_CLASSES[tone ?? 'amber']]
-          : 'max-w-md gap-4'
+        compact ? 'gap-3 rounded-lg border border-border bg-card p-4' : 'max-w-md gap-4'
       )}
     >
       {fullPage ? <FlaskLogo className="mb-4 size-18 self-center text-text-300" /> : null}
 
       {title !== undefined || description !== undefined ? (
-        <div className="flex min-w-0 items-start gap-3">
+        <div className="flex min-w-0 flex-wrap items-start gap-3">
           {Icon ? (
             <div
               className={cn(
                 'flex shrink-0 items-center justify-center',
-                compact ? 'h-5 w-4' : ['size-9 rounded-full', TONE_CLASSES[tone ?? 'amber']]
+                compact
+                  ? ['mt-0.5 h-5 w-4', ICON_TONE_CLASSES[tone ?? 'amber']]
+                  : ['size-9 rounded-full', TONE_CLASSES[tone ?? 'amber']]
               )}
             >
               <Icon className="size-4" strokeWidth={1.8} aria-hidden="true" />
             </div>
           ) : null}
-          <div className="flex min-w-0 flex-1 flex-col gap-1">
+          <div role={role} className="flex min-w-0 flex-1 basis-40 flex-col gap-1">
             {title !== undefined ? (
               <Heading
                 className={cn(
@@ -115,24 +167,22 @@ const ErrorNotice = ({
               </Heading>
             ) : null}
             {description !== undefined ? (
-              <p
-                className={cn(
-                  'text-sm text-muted-foreground [overflow-wrap:anywhere]',
-                  compact ? 'leading-5' : 'leading-6'
-                )}
-              >
+              <p className="text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
                 {description}
               </p>
             ) : null}
           </div>
+          {trailingAction ? (
+            <div className="ml-7 shrink-0 sm:ml-0">
+              <NoticeButton button={primaryButton} compact />
+            </div>
+          ) : null}
         </div>
       ) : null}
 
-      {errorCode !== undefined ? (
-        <p className="w-full rounded-lg bg-muted px-3 py-2.5 font-mono text-xs text-muted-foreground [overflow-wrap:anywhere]">
-          {errorCode}
-        </p>
-      ) : null}
+      {children ? <div className={cn('min-w-0', compact && Icon && 'pl-7')}>{children}</div> : null}
+
+      {fullPage && errorCode !== undefined ? diagnosticContent : null}
 
       {help ? (
         <div className="flex w-full min-w-0 flex-col gap-4 rounded-lg bg-muted p-4 [overflow-wrap:anywhere]">
@@ -147,18 +197,37 @@ const ErrorNotice = ({
         </div>
       ) : null}
 
-      {secondaryButton !== undefined || primaryButton !== undefined ? (
+      {!trailingAction && (secondaryButton || primaryButton) ? (
         <div
           className={cn(
-            'flex w-full flex-wrap items-center gap-2',
-            compact ? Icon && 'pl-7' : 'justify-end'
+            describedActions
+              ? 'grid gap-3 border-t border-border pt-3 sm:grid-cols-2'
+              : 'flex flex-wrap items-center gap-2',
+            compact ? Icon && 'ml-7' : 'justify-end'
           )}
         >
+          {compact && primaryButton ? <NoticeButton button={primaryButton} compact /> : null}
           {secondaryButton ? (
-            <NoticeButton button={secondaryButton} variant="secondary" compact={compact} />
+            <NoticeButton button={secondaryButton} secondary compact={compact} />
           ) : null}
-          {primaryButton ? <NoticeButton button={primaryButton} compact={compact} /> : null}
+          {!compact && primaryButton ? (
+            <NoticeButton button={primaryButton} compact={false} />
+          ) : null}
         </div>
+      ) : null}
+
+      {compact && errorCode !== undefined ? (
+        diagnosticsLabel ? (
+          <details className={cn('group border-t border-border pt-2.5', Icon && 'ml-7')}>
+            <summary className="flex w-fit cursor-pointer list-none items-center gap-1 rounded-sm text-xs leading-5 text-muted-foreground hover:text-foreground focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring [&::-webkit-details-marker]:hidden">
+              <ChevronRight className="size-3 shrink-0 group-open:rotate-90" aria-hidden="true" />
+              {diagnosticsLabel}
+            </summary>
+            <div className="mt-2">{diagnosticContent}</div>
+          </details>
+        ) : (
+          diagnosticContent
+        )
       ) : null}
 
       {issueLink ? (

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -1,12 +1,13 @@
 import { CircleQuestionMark, LoaderCircle, type LucideIcon } from 'lucide-react'
 
+import { cn } from '@/lib/utils'
+
 import { FlaskLogo } from '@/components/flask-logo'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
-// Generic error notice column: the brand mark is optional, everything else is data-driven. Each
-// section renders only when its prop is present, so callers compose anything from a bare title to
-// a full troubleshooting card. All copy arrives as final display strings — callers translate.
+// Error summaries use a branded column by default; compact notices fit within an existing form
+// or resource list. All copy arrives as final display strings — callers translate.
 
 type ErrorNoticeTone = 'teal' | 'amber' | 'red'
 
@@ -19,6 +20,7 @@ type ErrorNoticeButton = {
 }
 
 type ErrorNoticeProps = {
+  compact?: boolean
   showBrand?: boolean
   icon?: LucideIcon
   tone?: ErrorNoticeTone
@@ -42,15 +44,18 @@ const TONE_CLASSES: Record<ErrorNoticeTone, string> = {
 
 const NoticeButton = ({
   button,
-  variant
+  variant,
+  compact
 }: {
   button: ErrorNoticeButton
   variant?: 'secondary'
+  compact?: boolean
 }): React.JSX.Element => (
   <Button
     type="button"
     className="focus-visible:transition-none"
-    variant={variant}
+    variant={compact && variant === 'secondary' ? 'outline' : variant}
+    size={compact ? 'sm' : 'default'}
     onClick={button.onClick}
     disabled={button.disabled || button.loading}
     aria-busy={button.loading || undefined}
@@ -63,6 +68,7 @@ const NoticeButton = ({
 )
 
 const ErrorNotice = ({
+  compact = false,
   showBrand = true,
   icon: Icon,
   tone,
@@ -74,27 +80,50 @@ const ErrorNotice = ({
   secondaryButton,
   primaryButton
 }: ErrorNoticeProps): React.JSX.Element => {
+  const Heading = compact ? 'h2' : 'h1'
   return (
-    <section className="flex w-full min-w-0 max-w-md flex-col gap-4 text-left">
-      {showBrand ? <FlaskLogo className="mb-4 size-18 self-center text-text-300" /> : null}
+    <section
+      className={cn(
+        'flex w-full min-w-0 flex-col text-left',
+        compact
+          ? ['gap-3 rounded-lg border border-current/15 p-4', TONE_CLASSES[tone ?? 'amber']]
+          : 'max-w-md gap-4'
+      )}
+    >
+      {!compact && showBrand ? (
+        <FlaskLogo className="mb-4 size-18 self-center text-text-300" />
+      ) : null}
 
       {title !== undefined || description !== undefined ? (
         <div className="flex min-w-0 items-start gap-3">
           {Icon ? (
             <div
-              className={`flex size-9 shrink-0 items-center justify-center rounded-full ${TONE_CLASSES[tone ?? 'amber']}`}
+              className={cn(
+                'flex shrink-0 items-center justify-center',
+                compact ? 'h-5 w-4' : ['size-9 rounded-full', TONE_CLASSES[tone ?? 'amber']]
+              )}
             >
               <Icon className="size-4" strokeWidth={1.8} aria-hidden="true" />
             </div>
           ) : null}
           <div className="flex min-w-0 flex-1 flex-col gap-1">
             {title !== undefined ? (
-              <h1 className="text-base leading-6 font-semibold text-foreground [overflow-wrap:anywhere]">
+              <Heading
+                className={cn(
+                  'font-semibold text-foreground [overflow-wrap:anywhere]',
+                  compact ? 'text-sm leading-5' : 'text-base leading-6'
+                )}
+              >
                 {title}
-              </h1>
+              </Heading>
             ) : null}
             {description !== undefined ? (
-              <p className="text-sm leading-6 text-muted-foreground [overflow-wrap:anywhere]">
+              <p
+                className={cn(
+                  'text-sm text-muted-foreground [overflow-wrap:anywhere]',
+                  compact ? 'leading-5' : 'leading-6'
+                )}
+              >
                 {description}
               </p>
             ) : null}
@@ -122,9 +151,16 @@ const ErrorNotice = ({
       ) : null}
 
       {secondaryButton !== undefined || primaryButton !== undefined ? (
-        <div className="flex w-full flex-wrap items-center justify-end gap-2">
-          {secondaryButton ? <NoticeButton button={secondaryButton} variant="secondary" /> : null}
-          {primaryButton ? <NoticeButton button={primaryButton} /> : null}
+        <div
+          className={cn(
+            'flex w-full flex-wrap items-center gap-2',
+            compact ? Icon && 'pl-7' : 'justify-end'
+          )}
+        >
+          {secondaryButton ? (
+            <NoticeButton button={secondaryButton} variant="secondary" compact={compact} />
+          ) : null}
+          {primaryButton ? <NoticeButton button={primaryButton} compact={compact} /> : null}
         </div>
       ) : null}
 

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -1,4 +1,4 @@
-import { CircleQuestionMark, LoaderCircle, type LucideIcon } from 'lucide-react'
+import { CircleAlert, CircleQuestionMark, LoaderCircle, type LucideIcon } from 'lucide-react'
 
 import { cn } from '@/lib/utils'
 
@@ -6,8 +6,8 @@ import { FlaskLogo } from '@/components/flask-logo'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
-// Error summaries use a branded column by default; compact notices fit within an existing form
-// or resource list. All copy arrives as final display strings — callers translate.
+// Inline notices share one compact presentation. Only startup-blocking surfaces opt into
+// the full-page branded layout. All copy arrives as final display strings — callers translate.
 
 type ErrorNoticeTone = 'teal' | 'amber' | 'red'
 
@@ -20,8 +20,7 @@ type ErrorNoticeButton = {
 }
 
 type ErrorNoticeProps = {
-  compact?: boolean
-  showBrand?: boolean
+  fullPage?: boolean
   icon?: LucideIcon
   tone?: ErrorNoticeTone
   title?: string
@@ -68,9 +67,8 @@ const NoticeButton = ({
 )
 
 const ErrorNotice = ({
-  compact = false,
-  showBrand = true,
-  icon: Icon,
+  fullPage = false,
+  icon: Icon = fullPage ? undefined : CircleAlert,
   tone,
   title,
   description,
@@ -80,6 +78,7 @@ const ErrorNotice = ({
   secondaryButton,
   primaryButton
 }: ErrorNoticeProps): React.JSX.Element => {
+  const compact = !fullPage
   const Heading = compact ? 'h2' : 'h1'
   return (
     <section
@@ -90,9 +89,7 @@ const ErrorNotice = ({
           : 'max-w-md gap-4'
       )}
     >
-      {!compact && showBrand ? (
-        <FlaskLogo className="mb-4 size-18 self-center text-text-300" />
-      ) : null}
+      {fullPage ? <FlaskLogo className="mb-4 size-18 self-center text-text-300" /> : null}
 
       {title !== undefined || description !== undefined ? (
         <div className="flex min-w-0 items-start gap-3">

--- a/src/renderer/src/pages/literature/LiteratureErrorNotice.tsx
+++ b/src/renderer/src/pages/literature/LiteratureErrorNotice.tsx
@@ -1,13 +1,12 @@
-import { AlertCircle } from 'lucide-react'
 import { ErrorNotice, type ErrorNoticeProps } from '@/components/error-notice'
 
 /** Recoverable library errors share a compact surface; field validation stays by its input. */
 export function LiteratureErrorNotice(
-  props: Omit<ErrorNoticeProps, 'showBrand'>
+  props: Omit<ErrorNoticeProps, 'fullPage'>
 ): React.JSX.Element {
   return (
-    <div role="alert" className="rounded-lg border border-border bg-bg-000 p-3">
-      <ErrorNotice icon={AlertCircle} tone="amber" {...props} showBrand={false} />
+    <div role="alert">
+      <ErrorNotice {...props} />
     </div>
   )
 }

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
@@ -51,6 +51,15 @@ describe('LiteratureFullTextLookup', () => {
     })
   })
   afterEach(cleanup)
+  it('uses a single error surface when full-text search fails', async () => {
+    fullText.mockRejectedValue(new Error('offline'))
+    render(<LiteratureFullTextLookup {...props} />)
+    const alert = await screen.findByRole('alert')
+    const surface = within(alert).getByRole('heading').closest('section')!
+    expect(surface.classList.contains('border')).toBe(true)
+    expect(alert.classList.contains('border')).toBe(false)
+  })
+
   it('configures Unpaywall inline using shared contact email while preserving the NCBI key', async () => {
     fullText.mockResolvedValue({
       mode: 'search',

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.tsx
@@ -325,7 +325,6 @@ export const LiteratureFullTextLookup = ({
           ) : failed ? (
             <div role="alert" className="mb-3 rounded-lg border border-border bg-bg-000 p-4">
               <ErrorNotice
-                showBrand={false}
                 icon={AlertCircle}
                 tone={error === 'runtime' ? 'teal' : 'amber'}
                 title={

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.tsx
@@ -323,7 +323,7 @@ export const LiteratureFullTextLookup = ({
               <p>{t('Searching for a matching full-text PDF…')}</p>
             </div>
           ) : failed ? (
-            <div role="alert" className="mb-3 rounded-lg border border-border bg-bg-000 p-4">
+            <div role="alert" className="mb-3">
               <ErrorNotice
                 icon={AlertCircle}
                 tone={error === 'runtime' ? 'teal' : 'amber'}

--- a/src/renderer/src/pages/settings/DeviceCredentialLoadNotice.tsx
+++ b/src/renderer/src/pages/settings/DeviceCredentialLoadNotice.tsx
@@ -18,7 +18,6 @@ export function DeviceCredentialLoadNotice({
     return (
       <div role="alert" className="mb-4">
         <ErrorNotice
-          showBrand={false}
           icon={AlertTriangle}
           tone="amber"
           title={

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -142,7 +142,7 @@ describe('TagsPanel', () => {
     }
   )
 
-  it.each(['catalog.skill', 'catalog.connector', 'catalog.specialist'] as const)(
+  it.each(['catalog.skill', 'catalog.connector', 'catalog.specialist', 'literature.item'] as const)(
     'shows pending and failed %s independently of loaded resources',
     async (type) => {
       let reject!: (error: Error) => void
@@ -157,6 +157,11 @@ describe('TagsPanel', () => {
       if (type === 'catalog.connector')
         useSettingsStore.setState({ connectorsLoaded: false, loadConnectors: load })
       if (type === 'catalog.specialist') useSpecialistStore.setState({ isLoaded: false, load })
+      if (type === 'literature.item')
+        Object.defineProperty(window, 'api', {
+          configurable: true,
+          value: { literature: { get: load } }
+        })
       useTagStore.setState((state) => ({
         assignments: [
           ...state.assignments,
@@ -185,6 +190,15 @@ describe('TagsPanel', () => {
         'Analysis'
       )
       expect(container.textContent).not.toContain('No resources match this Tag.')
+      if (type === 'literature.item') {
+        load.mockResolvedValueOnce(undefined)
+        const retry = Array.from(container.querySelectorAll('button')).find(
+          (b) => b.textContent === 'Retry'
+        )!
+        await act(async () => retry.click())
+        expect(load).toHaveBeenCalledTimes(2)
+        expect(container.querySelector('[role="alert"]')).toBeNull()
+      }
     }
   )
 

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -157,6 +157,70 @@ describe('TagsPanel', () => {
     }
   )
 
+  it('explains an unavailable assignment without reporting an empty Tag, and recovers with the catalog', async () => {
+    useSpecialistStore.setState({ isLoaded: true, loadError: undefined })
+    useSettingsStore.setState((state) => ({
+      skills: state.skills.map((skill) => ({ ...skill, available: false }))
+    }))
+    await act(async () =>
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
+    )
+    expect(useTagStore.getState().assignments).toHaveLength(1)
+    expect(container.querySelector('[data-slot="tag-list-count"]')?.textContent).toBe('1')
+    expect(container.querySelector('[data-slot="tag-resource-row"]')).toBeNull()
+    expect(container.textContent).not.toContain('No resources match this Tag.')
+    const notice = container.querySelector('[role="status"]')!
+    expect(notice.textContent).toContain('1 tagged resource is currently unavailable.')
+    expect(notice.textContent).toContain('Tag assignments are preserved.')
+    expect(notice.closest('section')!.querySelector('button')).toBeNull()
+
+    act(() => useTagStore.getState().setBrowserTypeFilter('catalog.connector'))
+    expect(container.querySelector('[role="status"]')).toBeNull()
+    expect(container.textContent).toContain('No resources match this Tag.')
+
+    act(() => useTagStore.getState().setBrowserTypeFilter('all'))
+    act(() =>
+      useSettingsStore.setState((state) => ({
+        skills: state.skills.map((skill) => ({ ...skill, available: true }))
+      }))
+    )
+    expect(container.querySelector('[role="status"]')).toBeNull()
+    expect(container.querySelector('[data-slot="tag-resource-row"]')?.textContent).toContain(
+      'Analysis'
+    )
+    expect(useTagStore.getState().assignments).toHaveLength(1)
+  })
+
+  it('keeps available resources visible alongside unresolved assignments', async () => {
+    useSpecialistStore.setState({ isLoaded: true, loadError: undefined })
+    useTagStore.setState((state) => ({
+      assignments: [
+        ...state.assignments,
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'unavailable',
+          createdAt: 2
+        }
+      ]
+    }))
+    await act(async () =>
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
+    )
+    expect(container.querySelector('[data-slot="tag-list-count"]')?.textContent).toBe('2')
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      '1 tagged resource is currently unavailable.'
+    )
+    expect(container.querySelector('[data-slot="tag-resource-row"]')?.textContent).toContain(
+      'Analysis'
+    )
+    expect(container.textContent).not.toContain('No resources match this Tag.')
+  })
+
   it.each(['catalog.skill', 'catalog.connector', 'catalog.specialist', 'literature.item'] as const)(
     'shows pending and failed %s independently of loaded resources',
     async (type) => {

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -114,12 +114,12 @@ describe('TagsPanel', () => {
       expect(container.querySelector('[role="alert"]')?.textContent).toContain(
         'Tag version updated'
       )
-      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
-        'Latest saved version'
-      )
-      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
-        contentChanged ? 'Remote' : 'Research'
-      )
+      const alert = container.querySelector('[role="alert"]')!
+      expect(alert.querySelector('button')).toBeNull()
+      expect(alert.textContent).not.toContain('Latest saved version')
+      const notice = alert.closest('section')!
+      expect(notice.textContent).toContain('Latest saved version')
+      expect(notice.textContent).toContain(contentChanged ? 'Remote' : 'Research')
       await act(async () => container.querySelector<HTMLFormElement>('form')!.requestSubmit())
       expect(update).not.toHaveBeenCalled()
       const keep = Array.from(container.querySelectorAll('button')).find(
@@ -141,7 +141,7 @@ describe('TagsPanel', () => {
           tags: [{ ...tag, name: 'Latest', iconKey: 'star', colorKey: 'red', updatedAt: 4 }]
         })
       )
-      const latestSummary = container.querySelector('[role="alert"]')!
+      const latestSummary = container.querySelector('[role="alert"]')!.closest('section')!
       expect(latestSummary.textContent).toContain('Latest')
       expect(latestSummary.textContent).toContain('Icon: Star')
       expect(latestSummary.textContent).toContain('Color: Red')

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -111,13 +111,23 @@ describe('TagsPanel', () => {
       )
       expect(container.querySelector('#tag-form-name')).toBe(name)
       expect(name.value).toBe('Unsaved important draft')
-      expect(container.querySelector('[role="alert"]')?.textContent).toContain('This Tag changed')
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'Tag version updated'
+      )
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        'Latest saved version'
+      )
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+        contentChanged ? 'Remote' : 'Research'
+      )
       await act(async () => container.querySelector<HTMLFormElement>('form')!.requestSubmit())
       expect(update).not.toHaveBeenCalled()
       const keep = Array.from(container.querySelectorAll('button')).find(
-        (button) => button.textContent === 'Keep draft'
+        (button) => button.textContent === 'Continue editing draft'
       )!
       act(() => keep.click())
+      expect(update).not.toHaveBeenCalled()
+      expect(name.value).toBe('Unsaved important draft')
       await act(async () => container.querySelector<HTMLFormElement>('form')!.requestSubmit())
       expect(update).toHaveBeenCalledWith({
         id: tag.id,
@@ -131,8 +141,13 @@ describe('TagsPanel', () => {
           tags: [{ ...tag, name: 'Latest', iconKey: 'star', colorKey: 'red', updatedAt: 4 }]
         })
       )
+      const latestSummary = container.querySelector('[role="alert"]')!
+      expect(latestSummary.textContent).toContain('Latest')
+      expect(latestSummary.textContent).toContain('Icon: Star')
+      expect(latestSummary.textContent).toContain('Color: Red')
+      expect(name.value).toBe('Unsaved important draft')
       const reload = Array.from(container.querySelectorAll('button')).find(
-        (button) => button.textContent === 'Reload'
+        (button) => button.textContent === 'Load latest version'
       )!
       act(() => reload.click())
       expect(name.value).toBe('Latest')

--- a/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.render.test.tsx
@@ -32,6 +32,8 @@ beforeEach(() => {
   root = createRoot(container)
   useSettingsStore.setState({
     ...createInitialSettingsState(),
+    skillsLoaded: true,
+    connectorsLoaded: true,
     skills: [
       {
         id: 'analysis',
@@ -71,6 +73,161 @@ afterEach(() => {
 })
 
 describe('TagsPanel', () => {
+  it.each([false, true])(
+    'preserves an editing draft on external updates (content change: %s)',
+    async (contentChanged) => {
+      const tag = {
+        id: 'tag-research',
+        name: 'Research',
+        iconKey: 'book-open' as const,
+        colorKey: 'purple' as const,
+        createdAt: 2,
+        updatedAt: 2
+      }
+      const update = vi.fn().mockResolvedValue(undefined)
+      useTagStore.setState({ tags: [tag], update })
+      await act(async () => {
+        root.render(
+          <TagsPanel
+            view={{ kind: 'edit', tagId: tag.id }}
+            onNavigate={vi.fn()}
+            onOpenResource={vi.fn()}
+          />
+        )
+      })
+      const name = container.querySelector<HTMLInputElement>('#tag-form-name')!
+      act(() => {
+        Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(
+          name,
+          'Unsaved important draft'
+        )
+        name.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+      act(() =>
+        useTagStore.setState({
+          revision: 2,
+          tags: [{ ...tag, updatedAt: 3, ...(contentChanged ? { name: 'Remote' } : {}) }]
+        })
+      )
+      expect(container.querySelector('#tag-form-name')).toBe(name)
+      expect(name.value).toBe('Unsaved important draft')
+      expect(container.querySelector('[role="alert"]')?.textContent).toContain('This Tag changed')
+      await act(async () => container.querySelector<HTMLFormElement>('form')!.requestSubmit())
+      expect(update).not.toHaveBeenCalled()
+      const keep = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Keep draft'
+      )!
+      act(() => keep.click())
+      await act(async () => container.querySelector<HTMLFormElement>('form')!.requestSubmit())
+      expect(update).toHaveBeenCalledWith({
+        id: tag.id,
+        iconKey: tag.iconKey,
+        colorKey: tag.colorKey,
+        expectedUpdatedAt: 3,
+        name: 'Unsaved important draft'
+      })
+      act(() =>
+        useTagStore.setState({
+          tags: [{ ...tag, name: 'Latest', iconKey: 'star', colorKey: 'red', updatedAt: 4 }]
+        })
+      )
+      const reload = Array.from(container.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Reload'
+      )!
+      act(() => reload.click())
+      expect(name.value).toBe('Latest')
+      expect(container.querySelector('[aria-label="Star"][aria-pressed="true"]')).not.toBeNull()
+      expect(container.querySelector('[aria-label="Red"][aria-pressed="true"]')).not.toBeNull()
+      expect(container.querySelector('[role="alert"]')).toBeNull()
+    }
+  )
+
+  it.each(['catalog.skill', 'catalog.connector', 'catalog.specialist'] as const)(
+    'shows pending and failed %s independently of loaded resources',
+    async (type) => {
+      let reject!: (error: Error) => void
+      const load = vi.fn(
+        () =>
+          new Promise<void>((_, fail) => {
+            reject = fail
+          })
+      )
+      if (type === 'catalog.skill')
+        useSettingsStore.setState({ skillsLoaded: false, loadSkills: load })
+      if (type === 'catalog.connector')
+        useSettingsStore.setState({ connectorsLoaded: false, loadConnectors: load })
+      if (type === 'catalog.specialist') useSpecialistStore.setState({ isLoaded: false, load })
+      useTagStore.setState((state) => ({
+        assignments: [
+          ...state.assignments,
+          {
+            tagId: 'tag-favorite',
+            resourceType: type,
+            resourceId: 'pending-resource',
+            createdAt: 2
+          }
+        ]
+      }))
+      await act(async () =>
+        root.render(
+          <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+        )
+      )
+      expect(container.querySelector('[role="status"]')).not.toBeNull()
+      expect(container.querySelector('[role="status"]')?.textContent).toContain('Loading')
+      expect(container.querySelector('[data-slot="tag-list-count"]')?.textContent).toBe('2')
+      expect(container.querySelector('[data-slot="tag-resource-row"]')?.textContent).toContain(
+        'Analysis'
+      )
+      await act(async () => reject(new Error('catalog failed')))
+      expect(container.querySelector('[role="alert"]')).not.toBeNull()
+      expect(container.querySelector('[data-slot="tag-resource-row"]')?.textContent).toContain(
+        'Analysis'
+      )
+      expect(container.textContent).not.toContain('No resources match this Tag.')
+    }
+  )
+
+  it('shows a catalog failure and preserves assignment counts until a successful retry', async () => {
+    const load = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('catalog unavailable'))
+      .mockImplementationOnce(async () => {
+        useSpecialistStore.setState({ isLoaded: true, loadError: undefined })
+      })
+    useSettingsStore.setState({ skillsLoaded: true, connectorsLoaded: true })
+    useSpecialistStore.setState({
+      items: [],
+      isLoaded: false,
+      loadError: 'catalog unavailable',
+      load
+    })
+    useTagStore.setState({
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.specialist',
+          resourceId: 'expert',
+          createdAt: 1
+        }
+      ]
+    })
+    await act(async () => {
+      root.render(
+        <TagsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} onOpenResource={vi.fn()} />
+      )
+    })
+    expect(container.querySelector('[data-slot="tag-list-count"]')?.textContent).toBe('1')
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('Specialists')
+    expect(container.textContent).not.toContain('No resources match this Tag.')
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Retry'
+    )!
+    expect(retry).toBeDefined()
+    await act(async () => retry.click())
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+  })
   it('includes tagged Literature references in Settings Tags', async () => {
     useTagStore.setState({
       assignments: [

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -158,6 +158,7 @@ const TagForm = ({
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string>()
   const conflicted = tag !== undefined && tag.updatedAt !== baseVersion
+  const LatestIcon = tag ? TAG_ICONS[tag.iconKey] : undefined
   const canSubmit = Boolean(draft.name.trim()) && !saving && !conflicted
 
   const save = async (): Promise<void> => {
@@ -194,12 +195,13 @@ const TagForm = ({
       {conflicted ? (
         <div role="alert">
           <ErrorNotice
-            title={t('This Tag changed while you were editing.')}
+            title={t('Tag version updated')}
             description={t(
-              'Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.'
+              'Your draft is still below. Choose how to handle the latest version before saving.'
             )}
             secondaryButton={{
-              label: t('Reload'),
+              label: t('Load latest version'),
+              description: t('Replace your draft with the latest values.'),
               onClick: () => {
                 setDraft({ name: tag.name, iconKey: tag.iconKey, colorKey: tag.colorKey })
                 setBaseVersion(tag.updatedAt)
@@ -208,14 +210,32 @@ const TagForm = ({
               disabled: saving
             }}
             primaryButton={{
-              label: t('Keep draft'),
+              label: t('Continue editing draft'),
+              description: t('Not saved yet. Saving later will replace the latest version.'),
               onClick: () => {
                 setBaseVersion(tag.updatedAt)
                 setFormError(undefined)
               },
               disabled: saving
             }}
-          />
+          >
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-2 border-t border-border pt-3 text-sm">
+              <span className="text-muted-foreground">{t('Latest saved version')}</span>
+              <span className="inline-flex min-w-0 items-center gap-1.5 font-medium text-foreground [overflow-wrap:anywhere]">
+                {LatestIcon ? (
+                  <LatestIcon
+                    className={cn('size-4 shrink-0 rounded-sm', TAG_COLORS[tag.colorKey])}
+                    aria-hidden="true"
+                  />
+                ) : null}
+                {tag.name}
+              </span>
+              <span className="text-xs text-muted-foreground">
+                {t('Icon')}: {iconLabel(t, tag.iconKey)} · {t('Color')}:{' '}
+                {colorLabel(t, tag.colorKey)}
+              </span>
+            </div>
+          </ErrorNotice>
         </div>
       ) : null}
       <label className="space-y-1.5 text-sm font-medium" htmlFor="tag-form-name">
@@ -918,6 +938,9 @@ const TagsList = ({
                   <div key={type} role="alert" className="mb-4">
                     <ErrorNotice
                       title={t('Could not load {{type}}.', { type: resourceTypeLabel(t, type) })}
+                      description={t(
+                        'Tag assignments are loaded, but these resource details are unavailable.'
+                      )}
                       primaryButton={{ label: t('Retry'), onClick: catalog.retry }}
                     />
                   </div>

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -580,6 +580,12 @@ const TagsList = ({
     (type) => typeFilter === 'all' || typeFilter === type
   )
   const catalogsReady = visibleCatalogTypes.every((type) => catalogLoads[type].status === 'ready')
+  const unavailableAssignmentCount = selectedAssignments.filter(
+    (assignment) =>
+      visibleCatalogTypes.includes(assignment.resourceType) &&
+      catalogLoads[assignment.resourceType].status === 'ready' &&
+      !resourcesByKey.has(`${assignment.resourceType}:${assignment.resourceId}`)
+  ).length
 
   const confirmDelete = async (): Promise<void> => {
     if (!deleting || deleteBusy) return
@@ -951,6 +957,18 @@ const TagsList = ({
                   </p>
                 )
               })}
+              {unavailableAssignmentCount > 0 ? (
+                <div className="mb-4">
+                  <ErrorNotice
+                    role="status"
+                    title={t('{{count}} tagged resources are currently unavailable.', {
+                      count: unavailableAssignmentCount,
+                      defaultValue_one: '{{count}} tagged resource is currently unavailable.'
+                    })}
+                    description={t('Tag assignments are preserved.')}
+                  />
+                </div>
+              ) : null}
               {filteredResources.length > 0 ? (
                 <div data-slot="tag-resource-groups" className="divide-y divide-border">
                   {resourceGroups.map(({ resourceType, resources: groupedResources }) => {
@@ -1043,7 +1061,7 @@ const TagsList = ({
                     )
                   })}
                 </div>
-              ) : catalogsReady ? (
+              ) : catalogsReady && unavailableAssignmentCount === 0 ? (
                 <p className="py-12 text-center text-sm text-muted-foreground">
                   {t('No resources match this Tag.')}
                 </p>

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -20,6 +20,7 @@ import {
 } from 'lucide-react'
 import {
   useEffect,
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -40,6 +41,7 @@ import {
 import type { LiteratureItemView } from '../../../../shared/literature'
 import type { ArtifactLiteratureReference } from '../../../../shared/artifact-literature'
 import { Button } from '@/components/ui/button'
+import { ErrorNotice } from '@/components/error-notice'
 import {
   dialogBodyClassName,
   dialogCancelButtonClassName,
@@ -148,12 +150,15 @@ const TagForm = ({
   const { t } = useTranslation()
   const createTag = useTagStore((state) => state.create)
   const updateTag = useTagStore((state) => state.update)
+  const loadTags = useTagStore((state) => state.load)
+  const [baseVersion, setBaseVersion] = useState(tag?.updatedAt)
   const [draft, setDraft] = useState<TagDraft>(
     tag ? { name: tag.name, iconKey: tag.iconKey, colorKey: tag.colorKey } : EMPTY_DRAFT
   )
   const [saving, setSaving] = useState(false)
   const [formError, setFormError] = useState<string>()
-  const canSubmit = Boolean(draft.name.trim()) && !saving
+  const conflicted = tag !== undefined && tag.updatedAt !== baseVersion
+  const canSubmit = Boolean(draft.name.trim()) && !saving && !conflicted
 
   const save = async (): Promise<void> => {
     if (!canSubmit) return
@@ -161,13 +166,14 @@ const TagForm = ({
     setFormError(undefined)
     try {
       if (tag) {
-        await updateTag({ id: tag.id, expectedUpdatedAt: tag.updatedAt, ...draft })
+        await updateTag({ id: tag.id, expectedUpdatedAt: baseVersion!, ...draft })
         onSaved(tag.id)
       } else {
         onSaved(await createTag(draft))
       }
     } catch {
       setFormError(t('Could not save Tag.'))
+      if (tag) await loadTags()
     } finally {
       setSaving(false)
     }
@@ -185,6 +191,33 @@ const TagForm = ({
       <p className="text-sm text-muted-foreground">
         {t('Choose a name, icon, and color. Names are unique regardless of case.')}
       </p>
+      {conflicted ? (
+        <div role="alert">
+          <ErrorNotice
+            title={t('This Tag changed while you were editing.')}
+            description={t(
+              'Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.'
+            )}
+            secondaryButton={{
+              label: t('Reload'),
+              onClick: () => {
+                setDraft({ name: tag.name, iconKey: tag.iconKey, colorKey: tag.colorKey })
+                setBaseVersion(tag.updatedAt)
+                setFormError(undefined)
+              },
+              disabled: saving
+            }}
+            primaryButton={{
+              label: t('Keep draft'),
+              onClick: () => {
+                setBaseVersion(tag.updatedAt)
+                setFormError(undefined)
+              },
+              disabled: saving
+            }}
+          />
+        </div>
+      ) : null}
       <label className="space-y-1.5 text-sm font-medium" htmlFor="tag-form-name">
         <span>
           {t('Name')}
@@ -263,6 +296,36 @@ const TagForm = ({
   )
 }
 
+const useResourceCatalogLoad = (
+  load: (retry: boolean) => Promise<void>,
+  loaded: boolean,
+  loadError?: string
+): { status: 'loading' | 'error' | 'ready'; retry(): void } => {
+  const [attempt, setAttempt] = useState(0)
+  const [failed, setFailed] = useState(false)
+  useEffect(() => {
+    let active = true
+    void load(attempt > 0).then(
+      () => {
+        if (active) setFailed(false)
+      },
+      () => {
+        if (active) setFailed(true)
+      }
+    )
+    return () => {
+      active = false
+    }
+  }, [load, attempt])
+  return {
+    status: loadError || (failed && !loaded) ? 'error' : loaded ? 'ready' : 'loading',
+    retry: () => {
+      setFailed(false)
+      setAttempt((value) => value + 1)
+    }
+  }
+}
+
 const TagsList = ({
   onOpenResource,
   onSelectedTagChange,
@@ -290,6 +353,23 @@ const TagsList = ({
   const loadConnectors = useSettingsStore((state) => state.loadConnectors)
   const specialistItems = useSpecialistStore((state) => state.items)
   const loadSpecialists = useSpecialistStore((state) => state.load)
+  const skillsLoaded = useSettingsStore((state) => state.skillsLoaded)
+  const connectorsLoaded = useSettingsStore((state) => state.connectorsLoaded)
+  const specialistsLoaded = useSpecialistStore((state) => state.isLoaded)
+  const specialistLoadError = useSpecialistStore((state) => state.loadError)
+  const refreshSpecialists = useCallback(
+    (force: boolean) => loadSpecialists({ force }),
+    [loadSpecialists]
+  )
+  const catalogLoads = {
+    'catalog.skill': useResourceCatalogLoad(loadSkills, skillsLoaded),
+    'catalog.connector': useResourceCatalogLoad(loadConnectors, connectorsLoaded),
+    'catalog.specialist': useResourceCatalogLoad(
+      refreshSpecialists,
+      specialistsLoaded,
+      specialistLoadError
+    )
+  }
   const selectedId = useTagStore((state) => state.browserSelectedId)
   const setSelectedId = useTagStore((state) => state.setBrowserSelectedId)
   const typeFilter = useTagStore((state) => state.browserTypeFilter)
@@ -336,8 +416,7 @@ const TagsList = ({
 
   useEffect(() => {
     if (status === 'idle') void loadTags()
-    void Promise.all([loadSkills(), loadConnectors(), loadSpecialists()])
-  }, [loadConnectors, loadSkills, loadSpecialists, loadTags, status])
+  }, [loadTags, status])
 
   useEffect(() => {
     let active = true
@@ -425,9 +504,7 @@ const TagsList = ({
 
   const counts = new Map(tags.map((tag) => [tag.id, 0]))
   for (const assignment of assignments) {
-    if (resourcesByKey.has(`${assignment.resourceType}:${assignment.resourceId}`)) {
-      counts.set(assignment.tagId, (counts.get(assignment.tagId) ?? 0) + 1)
-    }
+    counts.set(assignment.tagId, (counts.get(assignment.tagId) ?? 0) + 1)
   }
   const filteredResources = selectedAssignments
     .map((assignment) => resourcesByKey.get(`${assignment.resourceType}:${assignment.resourceId}`))
@@ -452,6 +529,10 @@ const TagsList = ({
       resources: filteredResources.filter((resource) => resource.resourceType === resourceType)
     }))
     .filter(({ resources }) => resources.length > 0)
+  const visibleCatalogTypes = resourceTypes.filter(
+    (type) => typeFilter === 'all' || typeFilter === type
+  )
+  const catalogsReady = visibleCatalogTypes.every((type) => catalogLoads[type].status === 'ready')
 
   const confirmDelete = async (): Promise<void> => {
     if (!deleting || deleteBusy) return
@@ -574,406 +655,418 @@ const TagsList = ({
 
   return (
     <TooltipProvider delayDuration={200}>
-      <div data-slot="tags-panel" className="flex h-full min-h-0 flex-col px-3 py-3 md:px-4">
-        {error ? (
-          <p role="alert" className="mb-3 text-xs text-destructive">
-            {t('Tags could not be loaded.')}
-          </p>
-        ) : null}
-        <div
-          data-slot="tag-master-detail"
-          className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[220px_minmax(0,1fr)]"
+    <div data-slot="tags-panel" className="flex h-full min-h-0 flex-col px-3 py-3 md:px-4">
+      {error ? (
+        <p role="alert" className="mb-3 text-xs text-destructive">
+          {t('Tags could not be loaded.')}
+        </p>
+      ) : null}
+      <div
+        data-slot="tag-master-detail"
+        className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[220px_minmax(0,1fr)]"
+      >
+        <aside
+          className="min-h-0 overflow-y-auto border-b border-border bg-muted/20 p-2 md:border-r md:border-b-0"
+          aria-busy={reorderBusy || undefined}
         >
-          <aside
-            className="min-h-0 overflow-y-auto border-b border-border bg-muted/20 p-2 md:border-r md:border-b-0"
-            aria-busy={reorderBusy || undefined}
-          >
-            {reorderError ? (
-              <p role="alert" className="mb-2 px-2 text-xs text-destructive">
-                {reorderError}
-              </p>
-            ) : null}
-            <p className="sr-only" aria-live="polite" aria-atomic="true">
-              {reorderAnnouncement}
+          {reorderError ? (
+            <p role="alert" className="mb-2 px-2 text-xs text-destructive">
+              {reorderError}
             </p>
-            <ol className="space-y-1">
-              {tags.map((tag) => {
-                const customIndex = customTags.findIndex((candidate) => candidate.id === tag.id)
-                const dropBefore =
-                  tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'before'
-                const dropAfter = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'after'
-                return (
-                  <li
-                    key={tag.id}
-                    data-reorderable-tag-id={'systemKey' in tag ? undefined : tag.id}
-                    className={cn(
-                      'relative flex min-w-0 items-center',
-                      draggedTagId === tag.id &&
-                        'rounded-md bg-muted/60 ring-1 ring-primary/30 ring-inset'
-                    )}
-                  >
-                    {dropBefore || dropAfter ? (
-                      <span
-                        aria-hidden="true"
-                        className={cn(
-                          'pointer-events-none absolute right-1 left-1 z-10 h-0.5 rounded-full bg-primary',
-                          dropBefore ? '-top-px' : '-bottom-px'
-                        )}
-                      />
-                    ) : null}
-                    {'systemKey' in tag ? (
-                      <span
-                        className="flex size-9 shrink-0 items-center justify-center text-muted-foreground/60 [@media(pointer:coarse)]:size-11"
-                        role="img"
-                        aria-label={t('System Tags stay first')}
-                        title={t('System Tags stay first')}
-                      >
-                        <LockKeyhole className="size-3.5" aria-hidden="true" />
-                      </span>
-                    ) : (
-                      <button
-                        type="button"
-                        disabled={reorderBusy}
-                        className="flex size-9 shrink-0 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground select-none hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:size-11"
-                        aria-label={t('Reorder {{tag}}', { tag: tag.name })}
-                        title={t('Drag or use arrow keys to reorder')}
-                        onPointerCancel={finishTagDrag}
-                        onPointerDown={(event) => {
-                          if (event.isPrimary === false || event.button !== 0 || reorderBusy) return
-                          event.currentTarget.setPointerCapture?.(event.pointerId)
-                          tagPointerDragRef.current = {
-                            pointerId: event.pointerId,
-                            tagId: tag.id,
-                            startY: event.clientY,
-                            active: false,
-                            dropZones: Array.from(
-                              event.currentTarget
-                                .closest('ol')
-                                ?.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]') ?? []
-                            )
-                              .filter((row) => row.dataset.reorderableTagId !== tag.id)
-                              .flatMap((row) => {
-                                const tagId = row.dataset.reorderableTagId
-                                if (!tagId) return []
-                                const bounds = row.getBoundingClientRect()
-                                return [{ tagId, top: bounds.top, bottom: bounds.bottom }]
-                              })
-                          }
-                        }}
-                        onPointerMove={moveTagPointer}
-                        onPointerUp={endTagPointer}
-                        onKeyDown={(event) => {
-                          if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
-                          event.preventDefault()
-                          const target =
-                            customTags[customIndex + (event.key === 'ArrowUp' ? -1 : 1)]
-                          if (target) {
-                            void moveTag(
-                              tag.id,
-                              target.id,
-                              event.key === 'ArrowUp' ? 'before' : 'after'
-                            )
-                          }
-                        }}
-                      >
-                        <GripVertical className="size-4" aria-hidden="true" />
-                      </button>
-                    )}
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="lg"
-                      data-slot="tag-list-row"
-                      aria-current={tag.id === currentSelectedId ? 'page' : undefined}
-                      onClick={() => {
-                        setSelectedId(tag.id)
-                        onSelectedTagChange?.(tag.id)
-                      }}
-                      className={cn(
-                        'min-w-0 flex-1 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
-                        tag.id === currentSelectedId && 'bg-muted font-medium'
-                      )}
-                    >
-                      <TagBadge tag={tag} className="min-w-0" />
-                      <span
-                        data-slot="tag-list-count"
-                        className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
-                      >
-                        {counts.get(tag.id) ?? 0}
-                      </span>
-                    </Button>
-                  </li>
-                )
-              })}
-              <li>
-                <button
-                  type="button"
-                  onClick={onCreate}
-                  className="flex h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground active:bg-muted/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [@media(pointer:coarse)]:min-h-11"
-                >
-                  <Plus className="size-4 shrink-0" aria-hidden="true" />
-                  <span className="truncate">{t('New Tag')}</span>
-                </button>
-              </li>
-            </ol>
-          </aside>
-
-          <section
-            ref={resourceListRef}
-            className="min-h-0 min-w-0 overflow-y-auto bg-card p-4"
-            onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
-          >
-            {selectedTag ? (
-              <>
-                <div
-                  data-slot="tag-detail-header"
-                  className="mb-4 flex min-h-7 flex-wrap items-center justify-between gap-3"
-                >
-                  <div className="flex min-w-0 items-center gap-2">
-                    <TagBadge tag={selectedTag} />
-                    <span className="shrink-0 text-xs text-muted-foreground">
-                      {t('{{count}} resources', {
-                        count: filteredResources.length,
-                        defaultValue_one: '{{count}} resource'
-                      })}
-                    </span>
-                  </div>
-                  {'systemKey' in selectedTag ? null : (
-                    <div
-                      data-slot="tag-detail-actions"
-                      className="flex shrink-0 items-center gap-1"
-                    >
-                      <SettingsIconAction
-                        label={t('Edit Tag')}
-                        icon={Pencil}
-                        onClick={() => onEdit(selectedTag)}
-                      />
-                      <SettingsIconAction
-                        label={t('Delete Tag')}
-                        icon={Trash2}
-                        danger
-                        onClick={() => {
-                          setDeleteError(undefined)
-                          setDeleting(selectedTag)
-                        }}
-                      />
-                    </div>
+          ) : null}
+          <p className="sr-only" aria-live="polite" aria-atomic="true">
+            {reorderAnnouncement}
+          </p>
+          <ol className="space-y-1">
+            {tags.map((tag) => {
+              const customIndex = customTags.findIndex((candidate) => candidate.id === tag.id)
+              const dropBefore = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'before'
+              const dropAfter = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'after'
+              return (
+                <li
+                  key={tag.id}
+                  data-reorderable-tag-id={'systemKey' in tag ? undefined : tag.id}
+                  className={cn(
+                    'relative flex min-w-0 items-center',
+                    draggedTagId === tag.id &&
+                      'rounded-md bg-muted/60 ring-1 ring-primary/30 ring-inset'
                   )}
-                </div>
-                <div className="mb-3 flex items-center gap-2">
-                  <Select
-                    value={typeFilter}
-                    onValueChange={(value) => setTypeFilter(value as typeof typeFilter)}
-                  >
-                    <SelectTrigger aria-label={t('Filter resources by type')} className="w-40">
-                      <span>{resourceTypeLabel(t, typeFilter)}</span>
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectItem value="all">{t('All resources')}</SelectItem>
-                      <SelectItem value="catalog.skill">
-                        {t('Skills')} ({typeCounts.get('catalog.skill') ?? 0})
-                      </SelectItem>
-                      <SelectItem value="catalog.connector">
-                        {t('Connectors')} ({typeCounts.get('catalog.connector') ?? 0})
-                      </SelectItem>
-                      <SelectItem value="catalog.specialist">
-                        {t('Specialists')} ({typeCounts.get('catalog.specialist') ?? 0})
-                      </SelectItem>
-                      <SelectItem value="literature.item">
-                        {t('References')} ({typeCounts.get('literature.item') ?? 0})
-                      </SelectItem>
-                    </SelectContent>
-                  </Select>
-                  <div className="relative min-w-40 flex-1">
-                    <Search
-                      className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+                >
+                  {dropBefore || dropAfter ? (
+                    <span
                       aria-hidden="true"
+                      className={cn(
+                        'pointer-events-none absolute right-1 left-1 z-10 h-0.5 rounded-full bg-primary',
+                        dropBefore ? '-top-px' : '-bottom-px'
+                      )}
                     />
-                    <Input
-                      type="search"
-                      aria-label={t('Search tagged resources')}
-                      placeholder={t('Search resources…')}
-                      className="pl-8"
-                      value={query}
-                      onChange={(event) => setQuery(event.target.value)}
-                    />
-                  </div>
-                </div>
-                {assignmentError ? (
-                  <p role="alert" className="mb-3 text-xs text-destructive">
-                    {assignmentError}
-                  </p>
-                ) : null}
-                {filteredResources.length > 0 ? (
-                  <div data-slot="tag-resource-groups" className="divide-y divide-border">
-                    {resourceGroups.map(({ resourceType, resources: groupedResources }) => {
-                      const expanded = !collapsed[resourceType]
-                      const Icon =
-                        resourceType === 'catalog.skill'
-                          ? ScrollText
-                          : resourceType === 'catalog.connector'
-                            ? ConnectorsNavIcon
-                            : resourceType === 'literature.item'
-                              ? BookOpenText
-                              : Users
-                      return (
-                        <section key={resourceType} className="py-3 first:pt-0 last:pb-0">
-                          <button
-                            type="button"
-                            data-slot="tag-resource-group"
-                            aria-expanded={expanded}
-                            onClick={() =>
-                              setCollapsed((value) => ({
-                                ...value,
-                                [resourceType]: !value[resourceType]
-                              }))
-                            }
-                            className="flex w-full cursor-pointer items-center gap-1 text-left text-sm font-semibold text-foreground"
-                          >
-                            <Icon className="size-4 shrink-0 text-muted-foreground" />
-                            <span>
-                              {resourceTypeLabel(t, resourceType)} ({groupedResources.length})
-                            </span>
-                            <ChevronDown
-                              className={cn(
-                                'size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none',
-                                !expanded && '-rotate-90'
-                              )}
-                              aria-hidden="true"
-                            />
-                          </button>
-                          {expanded ? (
-                            <ul className="mt-1">
-                              {groupedResources.map((resource) => {
-                                const key = `${resource.resourceType}:${resource.resourceId}`
-                                return (
-                                  <li
-                                    key={key}
-                                    className="group -mx-2 flex items-center gap-1 rounded-lg px-2 hover:bg-muted/50 focus-within:bg-muted/50"
-                                  >
-                                    <button
-                                      type="button"
-                                      data-slot="tag-resource-row"
-                                      className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 py-3 text-left hover:text-primary"
-                                      onClick={() => {
-                                        if (resource.literatureReference) {
-                                          setSelectedLiteratureReference(
-                                            resource.literatureReference
-                                          )
-                                        } else {
-                                          onOpenResource(resource)
-                                        }
-                                      }}
-                                    >
-                                      <span className="min-w-0 flex-1">
-                                        <span className="block truncate text-sm">
-                                          {resource.title}
-                                        </span>
-                                        {resource.subtitle ? (
-                                          <span
-                                            data-slot="tag-resource-subtitle"
-                                            className="block truncate text-xs text-muted-foreground"
-                                          >
-                                            {resource.subtitle}
-                                          </span>
-                                        ) : null}
-                                      </span>
-                                    </button>
-                                    <SettingsIconAction
-                                      label={t('Remove {{resource}} from {{tag}}', {
-                                        resource: resource.accessibleTitle ?? resource.title,
-                                        tag: tagPresentation(selectedTag, t).name
-                                      })}
-                                      icon={X}
-                                      disabled={removingResourceKey === key}
-                                      className="pointer-events-auto shrink-0 opacity-100 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100"
-                                      onClick={() => void removeResource(resource)}
-                                    />
-                                  </li>
-                                )
-                              })}
-                            </ul>
-                          ) : null}
-                        </section>
-                      )
-                    })}
-                  </div>
-                ) : (
-                  <p className="py-12 text-center text-sm text-muted-foreground">
-                    {t('No resources match this Tag.')}
-                  </p>
-                )}
-              </>
-            ) : (
-              <p className="py-12 text-center text-sm text-muted-foreground">
-                {status === 'loading'
-                  ? t('Loading Tags…')
-                  : t('Create a Tag to organize resources.')}
-              </p>
-            )}
-          </section>
-        </div>
-
-        <AlertDialog.Root
-          open={deleting !== undefined}
-          onOpenChange={(open) => !open && !deleteBusy && setDeleting(undefined)}
-        >
-          <AlertDialog.Portal>
-            <AlertDialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
-            <AlertDialog.Content
-              className={dialogPanelClassName('z-[60] w-[min(440px,calc(100vw-2rem))] p-0')}
-            >
-              <div className={dialogBodyClassName}>
-                <AlertDialog.Title className={dialogTitleClassName}>
-                  {t('Delete Tag?')}
-                </AlertDialog.Title>
-                <AlertDialog.Description className={cn(dialogDescriptionClassName, 'mt-2')}>
-                  {t(
-                    'The Tag will be removed from every resource. The resources themselves will not be deleted.'
+                  ) : null}
+                  {'systemKey' in tag ? (
+                    <span
+                      className="flex size-9 shrink-0 items-center justify-center text-muted-foreground/60 [@media(pointer:coarse)]:size-11"
+                      role="img"
+                      aria-label={t('System Tags stay first')}
+                      title={t('System Tags stay first')}
+                    >
+                      <LockKeyhole className="size-3.5" aria-hidden="true" />
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      disabled={reorderBusy}
+                      className="flex size-9 shrink-0 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground select-none hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:size-11"
+                      aria-label={t('Reorder {{tag}}', { tag: tag.name })}
+                      title={t('Drag or use arrow keys to reorder')}
+                      onPointerCancel={finishTagDrag}
+                      onPointerDown={(event) => {
+                        if (event.isPrimary === false || event.button !== 0 || reorderBusy) return
+                        event.currentTarget.setPointerCapture?.(event.pointerId)
+                        tagPointerDragRef.current = {
+                          pointerId: event.pointerId,
+                          tagId: tag.id,
+                          startY: event.clientY,
+                          active: false,
+                          dropZones: Array.from(
+                            event.currentTarget
+                              .closest('ol')
+                              ?.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]') ?? []
+                          )
+                            .filter((row) => row.dataset.reorderableTagId !== tag.id)
+                            .flatMap((row) => {
+                              const tagId = row.dataset.reorderableTagId
+                              if (!tagId) return []
+                              const bounds = row.getBoundingClientRect()
+                              return [{ tagId, top: bounds.top, bottom: bounds.bottom }]
+                            })
+                        }
+                      }}
+                      onPointerMove={moveTagPointer}
+                      onPointerUp={endTagPointer}
+                      onKeyDown={(event) => {
+                        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
+                        event.preventDefault()
+                        const target = customTags[customIndex + (event.key === 'ArrowUp' ? -1 : 1)]
+                        if (target) {
+                          void moveTag(
+                            tag.id,
+                            target.id,
+                            event.key === 'ArrowUp' ? 'before' : 'after'
+                          )
+                        }
+                      }}
+                    >
+                      <GripVertical className="size-4" aria-hidden="true" />
+                    </button>
                   )}
-                </AlertDialog.Description>
-                <p className="mt-2 text-xs text-muted-foreground">
-                  {t('Assignments to remove: {{count}}.', {
-                    count: deleting ? (counts.get(deleting.id) ?? 0) : 0,
-                    defaultValue_one: 'Assignment to remove: {{count}}.'
-                  })}
-                </p>
-                {deleteError ? (
-                  <p role="alert" className="mt-3 text-xs text-destructive">
-                    {deleteError}
-                  </p>
-                ) : null}
-              </div>
-              <div className={dialogFooterClassName}>
-                <AlertDialog.Cancel asChild>
                   <Button
                     type="button"
                     variant="ghost"
-                    className={dialogCancelButtonClassName}
-                    disabled={deleteBusy}
+                    size="lg"
+                    data-slot="tag-list-row"
+                    aria-current={tag.id === currentSelectedId ? 'page' : undefined}
+                    onClick={() => {
+                      setSelectedId(tag.id)
+                      onSelectedTagChange?.(tag.id)
+                    }}
+                    className={cn(
+                      'min-w-0 flex-1 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
+                      tag.id === currentSelectedId && 'bg-muted font-medium'
+                    )}
                   >
-                    {t('Cancel')}
+                    <TagBadge tag={tag} className="min-w-0" />
+                    <span
+                      data-slot="tag-list-count"
+                      className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
+                    >
+                      {counts.get(tag.id) ?? 0}
+                    </span>
                   </Button>
-                </AlertDialog.Cancel>
+                </li>
+              )
+            })}
+            <li>
+              <button
+                type="button"
+                onClick={onCreate}
+                className="flex h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground active:bg-muted/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [@media(pointer:coarse)]:min-h-11"
+              >
+                <Plus className="size-4 shrink-0" aria-hidden="true" />
+                <span className="truncate">{t('New Tag')}</span>
+              </button>
+            </li>
+          </ol>
+        </aside>
+
+        <section
+          ref={resourceListRef}
+          className="min-h-0 min-w-0 overflow-y-auto bg-card p-4"
+          onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+        >
+          {selectedTag ? (
+            <>
+              <div
+                data-slot="tag-detail-header"
+                className="mb-4 flex min-h-7 flex-wrap items-center justify-between gap-3"
+              >
+                <div className="flex min-w-0 items-center gap-2">
+                  <TagBadge tag={selectedTag} />
+                  <span className="shrink-0 text-xs text-muted-foreground">
+                    {t('{{count}} resources', {
+                      count: query.trim()
+                        ? filteredResources.length
+                        : selectedAssignments.filter(
+                            (assignment) =>
+                              typeFilter === 'all' || assignment.resourceType === typeFilter
+                          ).length,
+                      defaultValue_one: '{{count}} resource'
+                    })}
+                  </span>
+                </div>
+                {'systemKey' in selectedTag ? null : (
+                  <div data-slot="tag-detail-actions" className="flex shrink-0 items-center gap-1">
+                    <SettingsIconAction
+                      label={t('Edit Tag')}
+                      icon={Pencil}
+                      onClick={() => onEdit(selectedTag)}
+                    />
+                    <SettingsIconAction
+                      label={t('Delete Tag')}
+                      icon={Trash2}
+                      danger
+                      onClick={() => {
+                        setDeleteError(undefined)
+                        setDeleting(selectedTag)
+                      }}
+                    />
+                  </div>
+                )}
+              </div>
+              <div className="mb-3 flex items-center gap-2">
+                <Select
+                  value={typeFilter}
+                  onValueChange={(value) => setTypeFilter(value as typeof typeFilter)}
+                >
+                  <SelectTrigger aria-label={t('Filter resources by type')} className="w-40">
+                    <span>{resourceTypeLabel(t, typeFilter)}</span>
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">{t('All resources')}</SelectItem>
+                    <SelectItem value="catalog.skill">
+                      {t('Skills')} ({typeCounts.get('catalog.skill') ?? 0})
+                    </SelectItem>
+                    <SelectItem value="catalog.connector">
+                      {t('Connectors')} ({typeCounts.get('catalog.connector') ?? 0})
+                    </SelectItem>
+                    <SelectItem value="catalog.specialist">
+                      {t('Specialists')} ({typeCounts.get('catalog.specialist') ?? 0})
+                    </SelectItem>
+                    <SelectItem value="literature.item">
+                      {t('References')} ({typeCounts.get('literature.item') ?? 0})
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
+                <div className="relative min-w-40 flex-1">
+                  <Search
+                    className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+                    aria-hidden="true"
+                  />
+                  <Input
+                    type="search"
+                    aria-label={t('Search tagged resources')}
+                    placeholder={t('Search resources…')}
+                    className="pl-8"
+                    value={query}
+                    onChange={(event) => setQuery(event.target.value)}
+                  />
+                </div>
+              </div>
+              {assignmentError ? (
+                <p role="alert" className="mb-3 text-xs text-destructive">
+                  {assignmentError}
+                </p>
+              ) : null}
+              {visibleCatalogTypes.map((type) => {
+                const catalog = catalogLoads[type]
+                if (catalog.status === 'ready') return null
+                return catalog.status === 'error' ? (
+                  <div key={type} role="alert" className="mb-4">
+                    <ErrorNotice
+                      title={t('Could not load {{type}}.', { type: resourceTypeLabel(t, type) })}
+                      primaryButton={{ label: t('Retry'), onClick: catalog.retry }}
+                    />
+                  </div>
+                ) : (
+                  <p key={type} role="status" className="py-3 text-sm text-muted-foreground">
+                    {t('Loading {{type}}…', { type: resourceTypeLabel(t, type) })}
+                  </p>
+                )
+              })}
+              {filteredResources.length > 0 ? (
+                <div data-slot="tag-resource-groups" className="divide-y divide-border">
+                  {resourceGroups.map(({ resourceType, resources: groupedResources }) => {
+                    const expanded = !collapsed[resourceType]
+                    const Icon =
+                      resourceType === 'catalog.skill'
+                        ? ScrollText
+                        : resourceType === 'catalog.connector'
+                          ? ConnectorsNavIcon
+                          : resourceType === 'literature.item'
+                            ? BookOpenText
+                            : Users
+                    return (
+                      <section key={resourceType} className="py-3 first:pt-0 last:pb-0">
+                        <button
+                          type="button"
+                          data-slot="tag-resource-group"
+                          aria-expanded={expanded}
+                          onClick={() =>
+                            setCollapsed((value) => ({
+                              ...value,
+                              [resourceType]: !value[resourceType]
+                            }))
+                          }
+                          className="flex w-full cursor-pointer items-center gap-1 text-left text-sm font-semibold text-foreground"
+                        >
+                          <Icon className="size-4 shrink-0 text-muted-foreground" />
+                          <span>
+                            {resourceTypeLabel(t, resourceType)} ({groupedResources.length})
+                          </span>
+                          <ChevronDown
+                            className={cn(
+                              'size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none',
+                              !expanded && '-rotate-90'
+                            )}
+                            aria-hidden="true"
+                          />
+                        </button>
+                        {expanded ? (
+                          <ul className="mt-1">
+                            {groupedResources.map((resource) => {
+                              const key = `${resource.resourceType}:${resource.resourceId}`
+                              return (
+                                <li
+                                  key={key}
+                                  className="group -mx-2 flex items-center gap-1 rounded-lg px-2 hover:bg-muted/50 focus-within:bg-muted/50"
+                                >
+                                  <button
+                                    type="button"
+                                    data-slot="tag-resource-row"
+                                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 py-3 text-left hover:text-primary"
+                                    onClick={() => {
+                                      if (resource.literatureReference) {
+                                        setSelectedLiteratureReference(resource.literatureReference)
+                                      } else {
+                                        onOpenResource(resource)
+                                      }
+                                    }}
+                                  >
+                                    <span className="min-w-0 flex-1">
+                                      <span className="block truncate text-sm">
+                                        {resource.title}
+                                      </span>
+                                      {resource.subtitle ? (
+                                        <span
+                                          data-slot="tag-resource-subtitle"
+                                          className="block truncate text-xs text-muted-foreground"
+                                        >
+                                          {resource.subtitle}
+                                        </span>
+                                      ) : null}
+                                    </span>
+                                  </button>
+                                  <SettingsIconAction
+                                    label={t('Remove {{resource}} from {{tag}}', {
+                                      resource: resource.accessibleTitle ?? resource.title,
+                                      tag: tagPresentation(selectedTag, t).name
+                                    })}
+                                    icon={X}
+                                    disabled={removingResourceKey === key}
+                                    className="pointer-events-auto shrink-0 opacity-100 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100"
+                                    onClick={() => void removeResource(resource)}
+                                  />
+                                </li>
+                              )
+                            })}
+                          </ul>
+                        ) : null}
+                      </section>
+                    )
+                  })}
+                </div>
+              ) : catalogsReady ? (
+                <p className="py-12 text-center text-sm text-muted-foreground">
+                  {t('No resources match this Tag.')}
+                </p>
+              ) : null}
+            </>
+          ) : (
+            <p className="py-12 text-center text-sm text-muted-foreground">
+              {status === 'loading' ? t('Loading Tags…') : t('Create a Tag to organize resources.')}
+            </p>
+          )}
+        </section>
+      </div>
+
+      <AlertDialog.Root
+        open={deleting !== undefined}
+        onOpenChange={(open) => !open && !deleteBusy && setDeleting(undefined)}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
+          <AlertDialog.Content
+            className={dialogPanelClassName('z-[60] w-[min(440px,calc(100vw-2rem))] p-0')}
+          >
+            <div className={dialogBodyClassName}>
+              <AlertDialog.Title className={dialogTitleClassName}>
+                {t('Delete Tag?')}
+              </AlertDialog.Title>
+              <AlertDialog.Description className={cn(dialogDescriptionClassName, 'mt-2')}>
+                {t(
+                  'The Tag will be removed from every resource. The resources themselves will not be deleted.'
+                )}
+              </AlertDialog.Description>
+              <p className="mt-2 text-xs text-muted-foreground">
+                {t('Assignments to remove: {{count}}.', {
+                  count: deleting ? (counts.get(deleting.id) ?? 0) : 0,
+                  defaultValue_one: 'Assignment to remove: {{count}}.'
+                })}
+              </p>
+              {deleteError ? (
+                <p role="alert" className="mt-3 text-xs text-destructive">
+                  {deleteError}
+                </p>
+              ) : null}
+            </div>
+            <div className={dialogFooterClassName}>
+              <AlertDialog.Cancel asChild>
                 <Button
                   type="button"
-                  variant="destructive"
+                  variant="ghost"
+                  className={dialogCancelButtonClassName}
                   disabled={deleteBusy}
-                  onClick={() => void confirmDelete()}
                 >
-                  {deleteBusy ? t('Deleting…') : t('Delete Tag')}
+                  {t('Cancel')}
                 </Button>
-              </div>
-            </AlertDialog.Content>
-          </AlertDialog.Portal>
-        </AlertDialog.Root>
-        <ArtifactLiteratureDetailDialog
-          reference={selectedLiteratureReference}
-          onOpenChange={(open) => {
-            if (!open) setSelectedLiteratureReference(undefined)
-          }}
-        />
-      </div>
+              </AlertDialog.Cancel>
+              <Button
+                type="button"
+                variant="destructive"
+                disabled={deleteBusy}
+                onClick={() => void confirmDelete()}
+              >
+                {deleteBusy ? t('Deleting…') : t('Delete Tag')}
+              </Button>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+      <ArtifactLiteratureDetailDialog
+        reference={selectedLiteratureReference}
+        onOpenChange={(open) => {
+          if (!open) setSelectedLiteratureReference(undefined)
+        }}
+      />
+    </div>
     </TooltipProvider>
   )
 }
@@ -1014,7 +1107,7 @@ const TagsPanel = ({
   if (view.kind === 'edit' && editTag) {
     return (
       <TagForm
-        key={`${editTag.id}:${editTag.updatedAt}`}
+        key={editTag.id}
         tag={editTag}
         onCancel={() => onNavigate({ kind: 'list', tagId: editTag.id })}
         onSaved={(tagId) => onNavigate({ kind: 'list', tagId })}

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -708,433 +708,442 @@ const TagsList = ({
 
   return (
     <TooltipProvider delayDuration={200}>
-    <div data-slot="tags-panel" className="flex h-full min-h-0 flex-col px-3 py-3 md:px-4">
-      {error ? (
-        <p role="alert" className="mb-3 text-xs text-destructive">
-          {t('Tags could not be loaded.')}
-        </p>
-      ) : null}
-      <div
-        data-slot="tag-master-detail"
-        className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[220px_minmax(0,1fr)]"
-      >
-        <aside
-          className="min-h-0 overflow-y-auto border-b border-border bg-muted/20 p-2 md:border-r md:border-b-0"
-          aria-busy={reorderBusy || undefined}
-        >
-          {reorderError ? (
-            <p role="alert" className="mb-2 px-2 text-xs text-destructive">
-              {reorderError}
-            </p>
-          ) : null}
-          <p className="sr-only" aria-live="polite" aria-atomic="true">
-            {reorderAnnouncement}
+      <div data-slot="tags-panel" className="flex h-full min-h-0 flex-col px-3 py-3 md:px-4">
+        {error ? (
+          <p role="alert" className="mb-3 text-xs text-destructive">
+            {t('Tags could not be loaded.')}
           </p>
-          <ol className="space-y-1">
-            {tags.map((tag) => {
-              const customIndex = customTags.findIndex((candidate) => candidate.id === tag.id)
-              const dropBefore = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'before'
-              const dropAfter = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'after'
-              return (
-                <li
-                  key={tag.id}
-                  data-reorderable-tag-id={'systemKey' in tag ? undefined : tag.id}
-                  className={cn(
-                    'relative flex min-w-0 items-center',
-                    draggedTagId === tag.id &&
-                      'rounded-md bg-muted/60 ring-1 ring-primary/30 ring-inset'
-                  )}
-                >
-                  {dropBefore || dropAfter ? (
-                    <span
-                      aria-hidden="true"
-                      className={cn(
-                        'pointer-events-none absolute right-1 left-1 z-10 h-0.5 rounded-full bg-primary',
-                        dropBefore ? '-top-px' : '-bottom-px'
-                      )}
-                    />
-                  ) : null}
-                  {'systemKey' in tag ? (
-                    <span
-                      className="flex size-9 shrink-0 items-center justify-center text-muted-foreground/60 [@media(pointer:coarse)]:size-11"
-                      role="img"
-                      aria-label={t('System Tags stay first')}
-                      title={t('System Tags stay first')}
-                    >
-                      <LockKeyhole className="size-3.5" aria-hidden="true" />
-                    </span>
-                  ) : (
-                    <button
+        ) : null}
+        <div
+          data-slot="tag-master-detail"
+          className="grid min-h-0 flex-1 grid-cols-1 overflow-hidden rounded-lg border border-border md:grid-cols-[220px_minmax(0,1fr)]"
+        >
+          <aside
+            className="min-h-0 overflow-y-auto border-b border-border bg-muted/20 p-2 md:border-r md:border-b-0"
+            aria-busy={reorderBusy || undefined}
+          >
+            {reorderError ? (
+              <p role="alert" className="mb-2 px-2 text-xs text-destructive">
+                {reorderError}
+              </p>
+            ) : null}
+            <p className="sr-only" aria-live="polite" aria-atomic="true">
+              {reorderAnnouncement}
+            </p>
+            <ol className="space-y-1">
+              {tags.map((tag) => {
+                const customIndex = customTags.findIndex((candidate) => candidate.id === tag.id)
+                const dropBefore =
+                  tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'before'
+                const dropAfter = tagDropTarget?.tagId === tag.id && tagDropTarget.edge === 'after'
+                return (
+                  <li
+                    key={tag.id}
+                    data-reorderable-tag-id={'systemKey' in tag ? undefined : tag.id}
+                    className={cn(
+                      'relative flex min-w-0 items-center',
+                      draggedTagId === tag.id &&
+                        'rounded-md bg-muted/60 ring-1 ring-primary/30 ring-inset'
+                    )}
+                  >
+                    {dropBefore || dropAfter ? (
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          'pointer-events-none absolute right-1 left-1 z-10 h-0.5 rounded-full bg-primary',
+                          dropBefore ? '-top-px' : '-bottom-px'
+                        )}
+                      />
+                    ) : null}
+                    {'systemKey' in tag ? (
+                      <span
+                        className="flex size-9 shrink-0 items-center justify-center text-muted-foreground/60 [@media(pointer:coarse)]:size-11"
+                        role="img"
+                        aria-label={t('System Tags stay first')}
+                        title={t('System Tags stay first')}
+                      >
+                        <LockKeyhole className="size-3.5" aria-hidden="true" />
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        disabled={reorderBusy}
+                        className="flex size-9 shrink-0 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground select-none hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:size-11"
+                        aria-label={t('Reorder {{tag}}', { tag: tag.name })}
+                        title={t('Drag or use arrow keys to reorder')}
+                        onPointerCancel={finishTagDrag}
+                        onPointerDown={(event) => {
+                          if (event.isPrimary === false || event.button !== 0 || reorderBusy) return
+                          event.currentTarget.setPointerCapture?.(event.pointerId)
+                          tagPointerDragRef.current = {
+                            pointerId: event.pointerId,
+                            tagId: tag.id,
+                            startY: event.clientY,
+                            active: false,
+                            dropZones: Array.from(
+                              event.currentTarget
+                                .closest('ol')
+                                ?.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]') ?? []
+                            )
+                              .filter((row) => row.dataset.reorderableTagId !== tag.id)
+                              .flatMap((row) => {
+                                const tagId = row.dataset.reorderableTagId
+                                if (!tagId) return []
+                                const bounds = row.getBoundingClientRect()
+                                return [{ tagId, top: bounds.top, bottom: bounds.bottom }]
+                              })
+                          }
+                        }}
+                        onPointerMove={moveTagPointer}
+                        onPointerUp={endTagPointer}
+                        onKeyDown={(event) => {
+                          if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
+                          event.preventDefault()
+                          const target =
+                            customTags[customIndex + (event.key === 'ArrowUp' ? -1 : 1)]
+                          if (target) {
+                            void moveTag(
+                              tag.id,
+                              target.id,
+                              event.key === 'ArrowUp' ? 'before' : 'after'
+                            )
+                          }
+                        }}
+                      >
+                        <GripVertical className="size-4" aria-hidden="true" />
+                      </button>
+                    )}
+                    <Button
                       type="button"
-                      disabled={reorderBusy}
-                      className="flex size-9 shrink-0 touch-none cursor-grab items-center justify-center rounded-md text-muted-foreground select-none hover:bg-muted hover:text-foreground active:cursor-grabbing focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 [@media(pointer:coarse)]:size-11"
-                      aria-label={t('Reorder {{tag}}', { tag: tag.name })}
-                      title={t('Drag or use arrow keys to reorder')}
-                      onPointerCancel={finishTagDrag}
-                      onPointerDown={(event) => {
-                        if (event.isPrimary === false || event.button !== 0 || reorderBusy) return
-                        event.currentTarget.setPointerCapture?.(event.pointerId)
-                        tagPointerDragRef.current = {
-                          pointerId: event.pointerId,
-                          tagId: tag.id,
-                          startY: event.clientY,
-                          active: false,
-                          dropZones: Array.from(
-                            event.currentTarget
-                              .closest('ol')
-                              ?.querySelectorAll<HTMLElement>('[data-reorderable-tag-id]') ?? []
-                          )
-                            .filter((row) => row.dataset.reorderableTagId !== tag.id)
-                            .flatMap((row) => {
-                              const tagId = row.dataset.reorderableTagId
-                              if (!tagId) return []
-                              const bounds = row.getBoundingClientRect()
-                              return [{ tagId, top: bounds.top, bottom: bounds.bottom }]
-                            })
-                        }
+                      variant="ghost"
+                      size="lg"
+                      data-slot="tag-list-row"
+                      aria-current={tag.id === currentSelectedId ? 'page' : undefined}
+                      onClick={() => {
+                        setSelectedId(tag.id)
+                        onSelectedTagChange?.(tag.id)
                       }}
-                      onPointerMove={moveTagPointer}
-                      onPointerUp={endTagPointer}
-                      onKeyDown={(event) => {
-                        if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
-                        event.preventDefault()
-                        const target = customTags[customIndex + (event.key === 'ArrowUp' ? -1 : 1)]
-                        if (target) {
-                          void moveTag(
-                            tag.id,
-                            target.id,
-                            event.key === 'ArrowUp' ? 'before' : 'after'
-                          )
-                        }
-                      }}
+                      className={cn(
+                        'min-w-0 flex-1 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
+                        tag.id === currentSelectedId && 'bg-muted font-medium'
+                      )}
                     >
-                      <GripVertical className="size-4" aria-hidden="true" />
-                    </button>
+                      <TagBadge tag={tag} className="min-w-0" />
+                      <span
+                        data-slot="tag-list-count"
+                        className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
+                      >
+                        {counts.get(tag.id) ?? 0}
+                      </span>
+                    </Button>
+                  </li>
+                )
+              })}
+              <li>
+                <button
+                  type="button"
+                  onClick={onCreate}
+                  className="flex h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground active:bg-muted/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [@media(pointer:coarse)]:min-h-11"
+                >
+                  <Plus className="size-4 shrink-0" aria-hidden="true" />
+                  <span className="truncate">{t('New Tag')}</span>
+                </button>
+              </li>
+            </ol>
+          </aside>
+
+          <section
+            ref={resourceListRef}
+            className="min-h-0 min-w-0 overflow-y-auto bg-card p-4"
+            onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
+          >
+            {selectedTag ? (
+              <>
+                <div
+                  data-slot="tag-detail-header"
+                  className="mb-4 flex min-h-7 flex-wrap items-center justify-between gap-3"
+                >
+                  <div className="flex min-w-0 items-center gap-2">
+                    <TagBadge tag={selectedTag} />
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {t('{{count}} resources', {
+                        count: query.trim()
+                          ? filteredResources.length
+                          : selectedAssignments.filter(
+                              (assignment) =>
+                                typeFilter === 'all' || assignment.resourceType === typeFilter
+                            ).length,
+                        defaultValue_one: '{{count}} resource'
+                      })}
+                    </span>
+                  </div>
+                  {'systemKey' in selectedTag ? null : (
+                    <div
+                      data-slot="tag-detail-actions"
+                      className="flex shrink-0 items-center gap-1"
+                    >
+                      <SettingsIconAction
+                        label={t('Edit Tag')}
+                        icon={Pencil}
+                        onClick={() => onEdit(selectedTag)}
+                      />
+                      <SettingsIconAction
+                        label={t('Delete Tag')}
+                        icon={Trash2}
+                        danger
+                        onClick={() => {
+                          setDeleteError(undefined)
+                          setDeleting(selectedTag)
+                        }}
+                      />
+                    </div>
                   )}
+                </div>
+                <div className="mb-3 flex items-center gap-2">
+                  <Select
+                    value={typeFilter}
+                    onValueChange={(value) => setTypeFilter(value as typeof typeFilter)}
+                  >
+                    <SelectTrigger aria-label={t('Filter resources by type')} className="w-40">
+                      <span>{resourceTypeLabel(t, typeFilter)}</span>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">{t('All resources')}</SelectItem>
+                      <SelectItem value="catalog.skill">
+                        {t('Skills')} ({typeCounts.get('catalog.skill') ?? 0})
+                      </SelectItem>
+                      <SelectItem value="catalog.connector">
+                        {t('Connectors')} ({typeCounts.get('catalog.connector') ?? 0})
+                      </SelectItem>
+                      <SelectItem value="catalog.specialist">
+                        {t('Specialists')} ({typeCounts.get('catalog.specialist') ?? 0})
+                      </SelectItem>
+                      <SelectItem value="literature.item">
+                        {t('References')} ({typeCounts.get('literature.item') ?? 0})
+                      </SelectItem>
+                    </SelectContent>
+                  </Select>
+                  <div className="relative min-w-40 flex-1">
+                    <Search
+                      className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
+                      aria-hidden="true"
+                    />
+                    <Input
+                      type="search"
+                      aria-label={t('Search tagged resources')}
+                      placeholder={t('Search resources…')}
+                      className="pl-8"
+                      value={query}
+                      onChange={(event) => setQuery(event.target.value)}
+                    />
+                  </div>
+                </div>
+                {assignmentError ? (
+                  <p role="alert" className="mb-3 text-xs text-destructive">
+                    {assignmentError}
+                  </p>
+                ) : null}
+                {visibleCatalogTypes.map((type) => {
+                  const catalog = catalogLoads[type]
+                  if (catalog.status === 'ready') return null
+                  return catalog.status === 'error' ? (
+                    <div key={type} role="alert" className="mb-4">
+                      <ErrorNotice
+                        title={t('Could not load {{type}}.', { type: resourceTypeLabel(t, type) })}
+                        description={t(
+                          'Tag assignments are loaded, but these resource details are unavailable.'
+                        )}
+                        primaryButton={{ label: t('Retry'), onClick: catalog.retry }}
+                      />
+                    </div>
+                  ) : (
+                    <p key={type} role="status" className="py-3 text-sm text-muted-foreground">
+                      {t('Loading {{type}}…', { type: resourceTypeLabel(t, type) })}
+                    </p>
+                  )
+                })}
+                {unavailableAssignmentCount > 0 ? (
+                  <div className="mb-4">
+                    <ErrorNotice
+                      role="status"
+                      title={t('{{count}} tagged resources are currently unavailable.', {
+                        count: unavailableAssignmentCount,
+                        defaultValue_one: '{{count}} tagged resource is currently unavailable.'
+                      })}
+                      description={t('Tag assignments are preserved.')}
+                    />
+                  </div>
+                ) : null}
+                {filteredResources.length > 0 ? (
+                  <div data-slot="tag-resource-groups" className="divide-y divide-border">
+                    {resourceGroups.map(({ resourceType, resources: groupedResources }) => {
+                      const expanded = !collapsed[resourceType]
+                      const Icon =
+                        resourceType === 'catalog.skill'
+                          ? ScrollText
+                          : resourceType === 'catalog.connector'
+                            ? ConnectorsNavIcon
+                            : resourceType === 'literature.item'
+                              ? BookOpenText
+                              : Users
+                      return (
+                        <section key={resourceType} className="py-3 first:pt-0 last:pb-0">
+                          <button
+                            type="button"
+                            data-slot="tag-resource-group"
+                            aria-expanded={expanded}
+                            onClick={() =>
+                              setCollapsed((value) => ({
+                                ...value,
+                                [resourceType]: !value[resourceType]
+                              }))
+                            }
+                            className="flex w-full cursor-pointer items-center gap-1 text-left text-sm font-semibold text-foreground"
+                          >
+                            <Icon className="size-4 shrink-0 text-muted-foreground" />
+                            <span>
+                              {resourceTypeLabel(t, resourceType)} ({groupedResources.length})
+                            </span>
+                            <ChevronDown
+                              className={cn(
+                                'size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none',
+                                !expanded && '-rotate-90'
+                              )}
+                              aria-hidden="true"
+                            />
+                          </button>
+                          {expanded ? (
+                            <ul className="mt-1">
+                              {groupedResources.map((resource) => {
+                                const key = `${resource.resourceType}:${resource.resourceId}`
+                                return (
+                                  <li
+                                    key={key}
+                                    className="group -mx-2 flex items-center gap-1 rounded-lg px-2 hover:bg-muted/50 focus-within:bg-muted/50"
+                                  >
+                                    <button
+                                      type="button"
+                                      data-slot="tag-resource-row"
+                                      className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 py-3 text-left hover:text-primary"
+                                      onClick={() => {
+                                        if (resource.literatureReference) {
+                                          setSelectedLiteratureReference(
+                                            resource.literatureReference
+                                          )
+                                        } else {
+                                          onOpenResource(resource)
+                                        }
+                                      }}
+                                    >
+                                      <span className="min-w-0 flex-1">
+                                        <span className="block truncate text-sm">
+                                          {resource.title}
+                                        </span>
+                                        {resource.subtitle ? (
+                                          <span
+                                            data-slot="tag-resource-subtitle"
+                                            className="block truncate text-xs text-muted-foreground"
+                                          >
+                                            {resource.subtitle}
+                                          </span>
+                                        ) : null}
+                                      </span>
+                                    </button>
+                                    <SettingsIconAction
+                                      label={t('Remove {{resource}} from {{tag}}', {
+                                        resource: resource.accessibleTitle ?? resource.title,
+                                        tag: tagPresentation(selectedTag, t).name
+                                      })}
+                                      icon={X}
+                                      disabled={removingResourceKey === key}
+                                      className="pointer-events-auto shrink-0 opacity-100 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100"
+                                      onClick={() => void removeResource(resource)}
+                                    />
+                                  </li>
+                                )
+                              })}
+                            </ul>
+                          ) : null}
+                        </section>
+                      )
+                    })}
+                  </div>
+                ) : catalogsReady && unavailableAssignmentCount === 0 ? (
+                  <p className="py-12 text-center text-sm text-muted-foreground">
+                    {t('No resources match this Tag.')}
+                  </p>
+                ) : null}
+              </>
+            ) : (
+              <p className="py-12 text-center text-sm text-muted-foreground">
+                {status === 'loading'
+                  ? t('Loading Tags…')
+                  : t('Create a Tag to organize resources.')}
+              </p>
+            )}
+          </section>
+        </div>
+
+        <AlertDialog.Root
+          open={deleting !== undefined}
+          onOpenChange={(open) => !open && !deleteBusy && setDeleting(undefined)}
+        >
+          <AlertDialog.Portal>
+            <AlertDialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
+            <AlertDialog.Content
+              className={dialogPanelClassName('z-[60] w-[min(440px,calc(100vw-2rem))] p-0')}
+            >
+              <div className={dialogBodyClassName}>
+                <AlertDialog.Title className={dialogTitleClassName}>
+                  {t('Delete Tag?')}
+                </AlertDialog.Title>
+                <AlertDialog.Description className={cn(dialogDescriptionClassName, 'mt-2')}>
+                  {t(
+                    'The Tag will be removed from every resource. The resources themselves will not be deleted.'
+                  )}
+                </AlertDialog.Description>
+                <p className="mt-2 text-xs text-muted-foreground">
+                  {t('Assignments to remove: {{count}}.', {
+                    count: deleting ? (counts.get(deleting.id) ?? 0) : 0,
+                    defaultValue_one: 'Assignment to remove: {{count}}.'
+                  })}
+                </p>
+                {deleteError ? (
+                  <p role="alert" className="mt-3 text-xs text-destructive">
+                    {deleteError}
+                  </p>
+                ) : null}
+              </div>
+              <div className={dialogFooterClassName}>
+                <AlertDialog.Cancel asChild>
                   <Button
                     type="button"
                     variant="ghost"
-                    size="lg"
-                    data-slot="tag-list-row"
-                    aria-current={tag.id === currentSelectedId ? 'page' : undefined}
-                    onClick={() => {
-                      setSelectedId(tag.id)
-                      onSelectedTagChange?.(tag.id)
-                    }}
-                    className={cn(
-                      'min-w-0 flex-1 cursor-pointer justify-start gap-2 px-2 text-left font-normal hover:bg-muted',
-                      tag.id === currentSelectedId && 'bg-muted font-medium'
-                    )}
+                    className={dialogCancelButtonClassName}
+                    disabled={deleteBusy}
                   >
-                    <TagBadge tag={tag} className="min-w-0" />
-                    <span
-                      data-slot="tag-list-count"
-                      className="ml-auto min-w-5 shrink-0 text-right text-xs tabular-nums text-muted-foreground"
-                    >
-                      {counts.get(tag.id) ?? 0}
-                    </span>
+                    {t('Cancel')}
                   </Button>
-                </li>
-              )
-            })}
-            <li>
-              <button
-                type="button"
-                onClick={onCreate}
-                className="flex h-9 w-full cursor-pointer items-center gap-2 rounded-lg px-2 text-left text-sm text-muted-foreground hover:bg-muted hover:text-foreground active:bg-muted/80 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 [@media(pointer:coarse)]:min-h-11"
-              >
-                <Plus className="size-4 shrink-0" aria-hidden="true" />
-                <span className="truncate">{t('New Tag')}</span>
-              </button>
-            </li>
-          </ol>
-        </aside>
-
-        <section
-          ref={resourceListRef}
-          className="min-h-0 min-w-0 overflow-y-auto bg-card p-4"
-          onScroll={(event) => setScrollTop(event.currentTarget.scrollTop)}
-        >
-          {selectedTag ? (
-            <>
-              <div
-                data-slot="tag-detail-header"
-                className="mb-4 flex min-h-7 flex-wrap items-center justify-between gap-3"
-              >
-                <div className="flex min-w-0 items-center gap-2">
-                  <TagBadge tag={selectedTag} />
-                  <span className="shrink-0 text-xs text-muted-foreground">
-                    {t('{{count}} resources', {
-                      count: query.trim()
-                        ? filteredResources.length
-                        : selectedAssignments.filter(
-                            (assignment) =>
-                              typeFilter === 'all' || assignment.resourceType === typeFilter
-                          ).length,
-                      defaultValue_one: '{{count}} resource'
-                    })}
-                  </span>
-                </div>
-                {'systemKey' in selectedTag ? null : (
-                  <div data-slot="tag-detail-actions" className="flex shrink-0 items-center gap-1">
-                    <SettingsIconAction
-                      label={t('Edit Tag')}
-                      icon={Pencil}
-                      onClick={() => onEdit(selectedTag)}
-                    />
-                    <SettingsIconAction
-                      label={t('Delete Tag')}
-                      icon={Trash2}
-                      danger
-                      onClick={() => {
-                        setDeleteError(undefined)
-                        setDeleting(selectedTag)
-                      }}
-                    />
-                  </div>
-                )}
-              </div>
-              <div className="mb-3 flex items-center gap-2">
-                <Select
-                  value={typeFilter}
-                  onValueChange={(value) => setTypeFilter(value as typeof typeFilter)}
-                >
-                  <SelectTrigger aria-label={t('Filter resources by type')} className="w-40">
-                    <span>{resourceTypeLabel(t, typeFilter)}</span>
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="all">{t('All resources')}</SelectItem>
-                    <SelectItem value="catalog.skill">
-                      {t('Skills')} ({typeCounts.get('catalog.skill') ?? 0})
-                    </SelectItem>
-                    <SelectItem value="catalog.connector">
-                      {t('Connectors')} ({typeCounts.get('catalog.connector') ?? 0})
-                    </SelectItem>
-                    <SelectItem value="catalog.specialist">
-                      {t('Specialists')} ({typeCounts.get('catalog.specialist') ?? 0})
-                    </SelectItem>
-                    <SelectItem value="literature.item">
-                      {t('References')} ({typeCounts.get('literature.item') ?? 0})
-                    </SelectItem>
-                  </SelectContent>
-                </Select>
-                <div className="relative min-w-40 flex-1">
-                  <Search
-                    className="pointer-events-none absolute top-1/2 left-2.5 size-4 -translate-y-1/2 text-muted-foreground"
-                    aria-hidden="true"
-                  />
-                  <Input
-                    type="search"
-                    aria-label={t('Search tagged resources')}
-                    placeholder={t('Search resources…')}
-                    className="pl-8"
-                    value={query}
-                    onChange={(event) => setQuery(event.target.value)}
-                  />
-                </div>
-              </div>
-              {assignmentError ? (
-                <p role="alert" className="mb-3 text-xs text-destructive">
-                  {assignmentError}
-                </p>
-              ) : null}
-              {visibleCatalogTypes.map((type) => {
-                const catalog = catalogLoads[type]
-                if (catalog.status === 'ready') return null
-                return catalog.status === 'error' ? (
-                  <div key={type} role="alert" className="mb-4">
-                    <ErrorNotice
-                      title={t('Could not load {{type}}.', { type: resourceTypeLabel(t, type) })}
-                      description={t(
-                        'Tag assignments are loaded, but these resource details are unavailable.'
-                      )}
-                      primaryButton={{ label: t('Retry'), onClick: catalog.retry }}
-                    />
-                  </div>
-                ) : (
-                  <p key={type} role="status" className="py-3 text-sm text-muted-foreground">
-                    {t('Loading {{type}}…', { type: resourceTypeLabel(t, type) })}
-                  </p>
-                )
-              })}
-              {unavailableAssignmentCount > 0 ? (
-                <div className="mb-4">
-                  <ErrorNotice
-                    role="status"
-                    title={t('{{count}} tagged resources are currently unavailable.', {
-                      count: unavailableAssignmentCount,
-                      defaultValue_one: '{{count}} tagged resource is currently unavailable.'
-                    })}
-                    description={t('Tag assignments are preserved.')}
-                  />
-                </div>
-              ) : null}
-              {filteredResources.length > 0 ? (
-                <div data-slot="tag-resource-groups" className="divide-y divide-border">
-                  {resourceGroups.map(({ resourceType, resources: groupedResources }) => {
-                    const expanded = !collapsed[resourceType]
-                    const Icon =
-                      resourceType === 'catalog.skill'
-                        ? ScrollText
-                        : resourceType === 'catalog.connector'
-                          ? ConnectorsNavIcon
-                          : resourceType === 'literature.item'
-                            ? BookOpenText
-                            : Users
-                    return (
-                      <section key={resourceType} className="py-3 first:pt-0 last:pb-0">
-                        <button
-                          type="button"
-                          data-slot="tag-resource-group"
-                          aria-expanded={expanded}
-                          onClick={() =>
-                            setCollapsed((value) => ({
-                              ...value,
-                              [resourceType]: !value[resourceType]
-                            }))
-                          }
-                          className="flex w-full cursor-pointer items-center gap-1 text-left text-sm font-semibold text-foreground"
-                        >
-                          <Icon className="size-4 shrink-0 text-muted-foreground" />
-                          <span>
-                            {resourceTypeLabel(t, resourceType)} ({groupedResources.length})
-                          </span>
-                          <ChevronDown
-                            className={cn(
-                              'size-4 shrink-0 text-muted-foreground transition-transform motion-reduce:transition-none',
-                              !expanded && '-rotate-90'
-                            )}
-                            aria-hidden="true"
-                          />
-                        </button>
-                        {expanded ? (
-                          <ul className="mt-1">
-                            {groupedResources.map((resource) => {
-                              const key = `${resource.resourceType}:${resource.resourceId}`
-                              return (
-                                <li
-                                  key={key}
-                                  className="group -mx-2 flex items-center gap-1 rounded-lg px-2 hover:bg-muted/50 focus-within:bg-muted/50"
-                                >
-                                  <button
-                                    type="button"
-                                    data-slot="tag-resource-row"
-                                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-3 py-3 text-left hover:text-primary"
-                                    onClick={() => {
-                                      if (resource.literatureReference) {
-                                        setSelectedLiteratureReference(resource.literatureReference)
-                                      } else {
-                                        onOpenResource(resource)
-                                      }
-                                    }}
-                                  >
-                                    <span className="min-w-0 flex-1">
-                                      <span className="block truncate text-sm">
-                                        {resource.title}
-                                      </span>
-                                      {resource.subtitle ? (
-                                        <span
-                                          data-slot="tag-resource-subtitle"
-                                          className="block truncate text-xs text-muted-foreground"
-                                        >
-                                          {resource.subtitle}
-                                        </span>
-                                      ) : null}
-                                    </span>
-                                  </button>
-                                  <SettingsIconAction
-                                    label={t('Remove {{resource}} from {{tag}}', {
-                                      resource: resource.accessibleTitle ?? resource.title,
-                                      tag: tagPresentation(selectedTag, t).name
-                                    })}
-                                    icon={X}
-                                    disabled={removingResourceKey === key}
-                                    className="pointer-events-auto shrink-0 opacity-100 transition-opacity focus-visible:pointer-events-auto focus-visible:opacity-100 sm:pointer-events-none sm:opacity-0 sm:group-hover:pointer-events-auto sm:group-hover:opacity-100 sm:group-focus-within:pointer-events-auto sm:group-focus-within:opacity-100"
-                                    onClick={() => void removeResource(resource)}
-                                  />
-                                </li>
-                              )
-                            })}
-                          </ul>
-                        ) : null}
-                      </section>
-                    )
-                  })}
-                </div>
-              ) : catalogsReady && unavailableAssignmentCount === 0 ? (
-                <p className="py-12 text-center text-sm text-muted-foreground">
-                  {t('No resources match this Tag.')}
-                </p>
-              ) : null}
-            </>
-          ) : (
-            <p className="py-12 text-center text-sm text-muted-foreground">
-              {status === 'loading' ? t('Loading Tags…') : t('Create a Tag to organize resources.')}
-            </p>
-          )}
-        </section>
-      </div>
-
-      <AlertDialog.Root
-        open={deleting !== undefined}
-        onOpenChange={(open) => !open && !deleteBusy && setDeleting(undefined)}
-      >
-        <AlertDialog.Portal>
-          <AlertDialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
-          <AlertDialog.Content
-            className={dialogPanelClassName('z-[60] w-[min(440px,calc(100vw-2rem))] p-0')}
-          >
-            <div className={dialogBodyClassName}>
-              <AlertDialog.Title className={dialogTitleClassName}>
-                {t('Delete Tag?')}
-              </AlertDialog.Title>
-              <AlertDialog.Description className={cn(dialogDescriptionClassName, 'mt-2')}>
-                {t(
-                  'The Tag will be removed from every resource. The resources themselves will not be deleted.'
-                )}
-              </AlertDialog.Description>
-              <p className="mt-2 text-xs text-muted-foreground">
-                {t('Assignments to remove: {{count}}.', {
-                  count: deleting ? (counts.get(deleting.id) ?? 0) : 0,
-                  defaultValue_one: 'Assignment to remove: {{count}}.'
-                })}
-              </p>
-              {deleteError ? (
-                <p role="alert" className="mt-3 text-xs text-destructive">
-                  {deleteError}
-                </p>
-              ) : null}
-            </div>
-            <div className={dialogFooterClassName}>
-              <AlertDialog.Cancel asChild>
+                </AlertDialog.Cancel>
                 <Button
                   type="button"
-                  variant="ghost"
-                  className={dialogCancelButtonClassName}
+                  variant="destructive"
                   disabled={deleteBusy}
+                  onClick={() => void confirmDelete()}
                 >
-                  {t('Cancel')}
+                  {deleteBusy ? t('Deleting…') : t('Delete Tag')}
                 </Button>
-              </AlertDialog.Cancel>
-              <Button
-                type="button"
-                variant="destructive"
-                disabled={deleteBusy}
-                onClick={() => void confirmDelete()}
-              >
-                {deleteBusy ? t('Deleting…') : t('Delete Tag')}
-              </Button>
-            </div>
-          </AlertDialog.Content>
-        </AlertDialog.Portal>
-      </AlertDialog.Root>
-      <ArtifactLiteratureDetailDialog
-        reference={selectedLiteratureReference}
-        onOpenChange={(open) => {
-          if (!open) setSelectedLiteratureReference(undefined)
-        }}
-      />
-    </div>
+              </div>
+            </AlertDialog.Content>
+          </AlertDialog.Portal>
+        </AlertDialog.Root>
+        <ArtifactLiteratureDetailDialog
+          reference={selectedLiteratureReference}
+          onOpenChange={(open) => {
+            if (!open) setSelectedLiteratureReference(undefined)
+          }}
+        />
+      </div>
     </TooltipProvider>
   )
 }

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -193,8 +193,9 @@ const TagForm = ({
         {t('Choose a name, icon, and color. Names are unique regardless of case.')}
       </p>
       {conflicted ? (
-        <div role="alert">
+        <div>
           <ErrorNotice
+            role="alert"
             title={t('Tag version updated')}
             description={t(
               'Your draft is still below. Choose how to handle the latest version before saving.'

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -6,7 +6,6 @@ import { TooltipProvider } from '@/components/ui/tooltip'
  */
 import { AlertDialog } from 'radix-ui'
 import {
-  CircleAlert,
   ChevronDown,
   BookOpenText,
   GripVertical,
@@ -195,8 +194,6 @@ const TagForm = ({
       {conflicted ? (
         <div role="alert">
           <ErrorNotice
-            compact
-            icon={CircleAlert}
             title={t('This Tag changed while you were editing.')}
             description={t(
               'Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.'
@@ -364,15 +361,6 @@ const TagsList = ({
     (force: boolean) => loadSpecialists({ force }),
     [loadSpecialists]
   )
-  const catalogLoads = {
-    'catalog.skill': useResourceCatalogLoad(loadSkills, skillsLoaded),
-    'catalog.connector': useResourceCatalogLoad(loadConnectors, connectorsLoaded),
-    'catalog.specialist': useResourceCatalogLoad(
-      refreshSpecialists,
-      specialistsLoaded,
-      specialistLoadError
-    )
-  }
   const selectedId = useTagStore((state) => state.browserSelectedId)
   const setSelectedId = useTagStore((state) => state.setBrowserSelectedId)
   const typeFilter = useTagStore((state) => state.browserTypeFilter)
@@ -395,9 +383,12 @@ const TagsList = ({
   const [tagDropTarget, setTagDropTarget] = useState<TagDropTarget>()
   const [selectedLiteratureReference, setSelectedLiteratureReference] =
     useState<ArtifactLiteratureReference>()
+  const [literatureLoadAttempt, setLiteratureLoadAttempt] = useState(0)
   const [literatureResourceCache, setLiteratureResourceCache] = useState<{
     key: string
     rows: TagResourceRow[]
+    failed?: boolean
+    attempt?: number
   }>({ key: '', rows: [] })
   const tagPointerDragRef = useRef<TagPointerDrag | undefined>(undefined)
   const currentSelectedId = tags.some((tag) => tag.id === selectedId) ? selectedId : tags[0]?.id
@@ -417,40 +408,72 @@ const TagsList = ({
     [literatureResourceCache, literatureResourceIdsKey]
   )
 
+  const catalogLoads = {
+    'catalog.skill': useResourceCatalogLoad(loadSkills, skillsLoaded),
+    'catalog.connector': useResourceCatalogLoad(loadConnectors, connectorsLoaded),
+    'catalog.specialist': useResourceCatalogLoad(
+      refreshSpecialists,
+      specialistsLoaded,
+      specialistLoadError
+    ),
+    'literature.item': {
+      status: !literatureResourceIdsKey
+        ? 'ready'
+        : literatureResourceCache.key !== literatureResourceIdsKey ||
+            literatureResourceCache.attempt !== literatureLoadAttempt
+          ? 'loading'
+          : literatureResourceCache.failed
+            ? 'error'
+            : 'ready',
+      retry: () => setLiteratureLoadAttempt((attempt) => attempt + 1)
+    }
+  }
+
   useEffect(() => {
     if (status === 'idle') void loadTags()
   }, [loadTags, status])
 
   useEffect(() => {
     let active = true
-    if (!literatureResourceIdsKey || !window.api?.literature) {
+    if (!literatureResourceIdsKey) {
       return () => {
         active = false
       }
     }
-    void Promise.all(
-      literatureResourceIdsKey
-        .split('\n')
-        .map((resourceId) => window.api.literature.get(resourceId))
-    ).then(
-      (items) => {
-        if (!active) return
-        setLiteratureResourceCache({
-          key: literatureResourceIdsKey,
-          rows: items.flatMap((item): TagResourceRow[] => {
-            if (!item) return []
-            return [literatureResourceRow(item)]
+    void Promise.resolve()
+      .then(() =>
+        Promise.all(
+          literatureResourceIdsKey
+            .split('\n')
+            .map((resourceId) => window.api.literature.get(resourceId))
+        )
+      )
+      .then(
+        (items) => {
+          if (!active) return
+          setLiteratureResourceCache({
+            key: literatureResourceIdsKey,
+            attempt: literatureLoadAttempt,
+            rows: items.flatMap((item): TagResourceRow[] => {
+              if (!item) return []
+              return [literatureResourceRow(item)]
+            })
           })
-        })
-      },
-      () => {
-        if (active) setLiteratureResourceCache({ key: literatureResourceIdsKey, rows: [] })
-      }
-    )
+        },
+        () => {
+          if (active)
+            setLiteratureResourceCache({
+              key: literatureResourceIdsKey,
+              attempt: literatureLoadAttempt,
+              rows: [],
+              failed: true
+            })
+        }
+      )
     return () => {
       active = false
     }
-  }, [literatureResourceIdsKey])
+  }, [literatureResourceIdsKey, literatureLoadAttempt])
 
   useLayoutEffect(() => {
     if (resourceListRef.current) resourceListRef.current.scrollTop = scrollTop
@@ -894,8 +917,6 @@ const TagsList = ({
                 return catalog.status === 'error' ? (
                   <div key={type} role="alert" className="mb-4">
                     <ErrorNotice
-                      compact
-                      icon={CircleAlert}
                       title={t('Could not load {{type}}.', { type: resourceTypeLabel(t, type) })}
                       primaryButton={{ label: t('Retry'), onClick: catalog.retry }}
                     />

--- a/src/renderer/src/pages/settings/TagsPanel.tsx
+++ b/src/renderer/src/pages/settings/TagsPanel.tsx
@@ -6,6 +6,7 @@ import { TooltipProvider } from '@/components/ui/tooltip'
  */
 import { AlertDialog } from 'radix-ui'
 import {
+  CircleAlert,
   ChevronDown,
   BookOpenText,
   GripVertical,
@@ -194,6 +195,8 @@ const TagForm = ({
       {conflicted ? (
         <div role="alert">
           <ErrorNotice
+            compact
+            icon={CircleAlert}
             title={t('This Tag changed while you were editing.')}
             description={t(
               'Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.'
@@ -891,6 +894,8 @@ const TagsList = ({
                 return catalog.status === 'error' ? (
                   <div key={type} role="alert" className="mb-4">
                     <ErrorNotice
+                      compact
+                      icon={CircleAlert}
                       title={t('Could not load {{type}}.', { type: resourceTypeLabel(t, type) })}
                       primaryButton={{ label: t('Retry'), onClick: catalog.retry }}
                     />

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -769,7 +769,7 @@ describe('ConversationPanel composer errors', () => {
     const alert = container.querySelector('[role="alert"]')
     expect(alert?.textContent).toContain('Annotation payload is too large.')
     expect(alert?.querySelector('section')).not.toBeNull()
-    expect(alert?.querySelector('.bg-status-failure-surface')).not.toBeNull()
+    expect(alert?.querySelector('.text-status-failure-foreground')).not.toBeNull()
     expect(alert?.className).not.toContain('bg-red-50')
   })
 

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -32,10 +32,6 @@ vi.mock('@/components/ui/resizable', () => ({
   ResizablePanel: ({ children }: PropsWithChildren): React.JSX.Element => <div>{children}</div>
 }))
 
-vi.mock('@/lib/utils', () => ({
-  cn: (...values: Array<string | false | undefined>) => values.filter(Boolean).join(' ')
-}))
-
 // Radix DropdownMenu calls pointer-capture APIs that jsdom does not implement.
 // Replace with a flat render so items are always visible in the DOM.
 vi.mock('@/components/ui/dropdown-menu', () => ({

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1114,10 +1114,7 @@ const ConversationPanel = ({
                   />
                 ) : null}
                 {composerError ? (
-                  <div
-                    role="alert"
-                    className="mb-2 [&>section]:max-w-none [&>section]:items-start [&>section]:gap-2 [&>section>svg]:hidden [&_h1]:text-xs"
-                  >
+                  <div role="alert" className="mb-2">
                     <ErrorNotice icon={AlertTriangle} tone="red" title={composerError} />
                   </div>
                 ) : null}

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -375,7 +375,15 @@ describe('PreviewFileSurface managed text versions', () => {
     expect(alert?.textContent).toContain(
       failure === 'result' ? error.message : 'Version transport disconnected.'
     )
-    if (failure === 'result') expect(alert?.textContent).toContain(error.code)
+    const notice = alert!.closest('section')!
+    const diagnostics = notice.querySelector('details')
+    if (failure === 'result') {
+      expect(diagnostics!.open).toBe(false)
+      expect(diagnostics!.closest('[role="alert"]')).toBeNull()
+      expect(diagnostics!.textContent).toContain(error.code)
+    } else {
+      expect(diagnostics).toBeNull()
+    }
     expect(container.querySelector('[aria-label="Edit README.md"]')).toBeNull()
     const failedRequest = inspect.mock.calls.at(-1)![0]
     let finish!: (result: Result) => void
@@ -385,7 +393,7 @@ describe('PreviewFileSurface managed text versions', () => {
           finish = resolve
         })
     )
-    await click(alert!.querySelector('button'))
+    await click(notice.querySelector('button'))
     expect(inspect).toHaveBeenLastCalledWith(failedRequest)
     expect(
       [...container.querySelectorAll('[role="status"]')].some((status) =>

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1537,11 +1537,10 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                   {t('Checking version…')}
                 </div>
               ) : !provenanceFocused && managedWorkflow.inspectError ? (
-                <div
-                  role="alert"
-                  className="max-h-64 shrink-0 overflow-y-auto border-b border-border-300/50 p-3"
-                >
+                <div className="max-h-64 shrink-0 overflow-y-auto border-b border-border-300/50 p-3">
                   <ErrorNotice
+                    role="alert"
+                    diagnosticsLabel={t('Diagnostics')}
                     title={t('Version check failed.')}
                     description={managedWorkflow.inspectError.message}
                     errorCode={managedWorkflow.inspectError.code}

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -473,7 +473,10 @@ describe('PreviewPanel', () => {
     const alert = container.querySelector<HTMLElement>('[data-source-preview-error]')
     expect(alert?.textContent).toContain('Could not load this source')
     expect(alert?.textContent).toContain('This source does not allow embedded previews.')
-    expect(alert?.textContent).toContain('ERR_BLOCKED_BY_RESPONSE (-27)')
+    const diagnostics = alert!.querySelector('details')!
+    expect(diagnostics.open).toBe(false)
+    expect(diagnostics.textContent).toContain('ERR_BLOCKED_BY_RESPONSE (-27)')
+    expect(diagnostics.closest('[role="alert"]')).toBeNull()
     expect(container.querySelector('[data-source-preview-progress]')).toBeNull()
 
     const retryButton = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1758,10 +1758,7 @@ const WorkspaceMessageItemImpl = ({
                     focusRequest={editFocusRequest}
                   />
                   {editError ? (
-                    <div
-                      role="alert"
-                      className="[&>section]:max-w-none [&>section]:gap-2 [&_h1]:text-xs"
-                    >
+                    <div role="alert">
                       <ErrorNotice tone="red" title={editError} />
                     </div>
                   ) : null}

--- a/src/renderer/src/pages/workspace/previews/SourceWebPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/SourceWebPreview.tsx
@@ -303,6 +303,8 @@ const SourceWebPreviewContent = ({
               <ErrorNotice
                 icon={Globe2}
                 tone="amber"
+                role="alert"
+                diagnosticsLabel={t('Diagnostics')}
                 title={t('Could not load this source')}
                 description={failureDescription}
                 errorCode={getFailureCode(loadState)}

--- a/src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.tsx
+++ b/src/renderer/src/pages/workspace/session-plan/UnavailablePlanNotice.tsx
@@ -39,10 +39,7 @@ const UnavailablePlanNotice = ({ session }: { session: ChatSession }): React.JSX
     }
   }
   return (
-    <div
-      role="alert"
-      className="mb-2 [&>section]:max-w-none [&>section]:items-start [&>section]:gap-2 [&>section>svg]:hidden [&_h1]:text-xs"
-    >
+    <div role="alert" className="mb-2">
       <ErrorNotice
         icon={AlertTriangle}
         tone="amber"

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -467,10 +467,12 @@ describe('tag store', () => {
       resourceId: 'newer-skill',
       assigned: true
     })
-    expect(useTagStore.getState().assignments).toEqual(committed.assignments)
+    const pendingResourceIds = useTagStore.getState().assignments.map((item) => item.resourceId)
     older.reject(new Error('older mutation failed'))
     await rejected
 
+    // An unrelated success must keep the older request visible until it settles.
+    expect(pendingResourceIds).toEqual(['newer-skill', 'older-skill'])
     expect(snapshot).toHaveBeenCalledOnce()
     expect(useTagStore.getState()).toMatchObject({
       revision: 2,

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -20,6 +20,115 @@ beforeEach(() => {
 })
 
 describe('tag store', () => {
+  it.each([false, true])(
+    'rolls back only the failed relationship (same resource: %s)',
+    async (sameResource) => {
+      const reject: Array<(error: Error) => void> = []
+      setTagsApi({
+        snapshot: vi.fn().mockRejectedValue(new Error('read failed')),
+        setAssignment: vi.fn(
+          () =>
+            new Promise<TagSnapshot>((_, fail) => {
+              reject.push(fail)
+            })
+        )
+      })
+      useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+      const reference = {
+        tagId: 'tag-favorite',
+        resourceType: 'catalog.skill' as const,
+        resourceId: 'analysis'
+      }
+      const first = useTagStore.getState().setAssignment({ ...reference, assigned: true })
+      const firstFailed = expect(first).rejects.toThrow('first failed')
+      const second = useTagStore.getState().setAssignment({
+        ...reference,
+        resourceId: sameResource ? 'analysis' : 'other',
+        assigned: true
+      })
+      const secondFailed = expect(second).rejects.toThrow('second failed')
+      reject[0]!(new Error('first failed'))
+      await firstFailed
+      expect(useTagStore.getState().assignments.map((item) => item.resourceId)).toEqual([
+        sameResource ? 'analysis' : 'other'
+      ])
+      reject[1]!(new Error('second failed'))
+      await secondFailed
+      expect(useTagStore.getState().assignments).toEqual([])
+    }
+  )
+  it('keeps a newer confirmed assignment when an older write and recovery read fail', async () => {
+    let rejectOlder!: (error: Error) => void
+    const pending = new Promise<TagSnapshot>((_, reject) => {
+      rejectOlder = reject
+    })
+    const confirmed = {
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill' as const,
+      resourceId: 'confirmed',
+      createdAt: 2
+    }
+    setTagsApi({
+      snapshot: vi.fn().mockRejectedValue(new Error('read failed')),
+      setAssignment: vi
+        .fn()
+        .mockReturnValueOnce(pending)
+        .mockResolvedValueOnce({
+          ...favoriteSnapshot(2),
+          assignments: [confirmed]
+        })
+    })
+    useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+    const older = useTagStore
+      .getState()
+      .setAssignment({ ...confirmed, resourceId: 'older', assigned: true })
+    const failed = expect(older).rejects.toThrow('write failed')
+    await useTagStore.getState().setAssignment({ ...confirmed, assigned: true })
+    rejectOlder(new Error('write failed'))
+    await failed
+    expect(useTagStore.getState()).toMatchObject({
+      revision: 2,
+      assignments: [confirmed],
+      status: 'error'
+    })
+  })
+
+  it('keeps a confirmed rename when an older reorder and recovery read fail', async () => {
+    let rejectReorder!: (error: Error) => void
+    const pending = new Promise<TagSnapshot>((_, reject) => {
+      rejectReorder = reject
+    })
+    const tag = {
+      id: 'research',
+      name: 'Research',
+      iconKey: 'tag' as const,
+      colorKey: 'blue' as const,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const confirmed = {
+      ...favoriteSnapshot(2),
+      tags: [...favoriteSnapshot().tags, { ...tag, name: 'Confirmed', updatedAt: 2 }]
+    }
+    setTagsApi({
+      snapshot: vi
+        .fn()
+        .mockResolvedValueOnce(confirmed)
+        .mockRejectedValueOnce(new Error('read failed')),
+      reorder: vi.fn().mockReturnValue(pending)
+    })
+    useTagStore.setState({
+      ...favoriteSnapshot(1),
+      tags: [...favoriteSnapshot().tags, tag],
+      status: 'ready'
+    })
+    const reorder = useTagStore.getState().reorder({ tagIds: [tag.id] })
+    const failed = expect(reorder).rejects.toThrow('write failed')
+    await useTagStore.getState().load()
+    rejectReorder(new Error('write failed'))
+    await failed
+    expect(useTagStore.getState()).toMatchObject({ ...confirmed, status: 'error' })
+  })
   it('preserves browser scroll when restoring the currently selected Tag', () => {
     useTagStore.setState({ browserSelectedId: 'tag-favorite', browserScrollTop: 240 })
 

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -20,6 +20,102 @@ beforeEach(() => {
 })
 
 describe('tag store', () => {
+  it('removes failed pending intent without losing a newer loaded assignment', async () => {
+    let reject!: (error: Error) => void
+    const confirmed = {
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill' as const,
+      resourceId: 'confirmed',
+      createdAt: 2
+    }
+    setTagsApi({
+      setAssignment: vi.fn(
+        () =>
+          new Promise<TagSnapshot>((_, fail) => {
+            reject = fail
+          })
+      ),
+      snapshot: vi
+        .fn()
+        .mockResolvedValueOnce({ ...favoriteSnapshot(2), assignments: [confirmed] })
+        .mockRejectedValueOnce(new Error('offline'))
+    })
+    useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+    const pending = useTagStore
+      .getState()
+      .setAssignment({ ...confirmed, resourceId: 'pending', assigned: true })
+    const failed = expect(pending).rejects.toThrow('write failed')
+    await useTagStore.getState().load()
+    expect(useTagStore.getState().assignments.map((item) => item.resourceId)).toEqual([
+      'confirmed',
+      'pending'
+    ])
+    reject(new Error('write failed'))
+    await failed
+    expect(useTagStore.getState()).toMatchObject({ revision: 2, assignments: [confirmed] })
+  })
+
+  it.each(['success', 'failure'] as const)(
+    'does not revive older same-resource intent after a newer success (%s)',
+    async (outcome) => {
+      let finish!: (snapshot: TagSnapshot) => void
+      let reject!: (error: Error) => void
+      setTagsApi({
+        setAssignment: vi
+          .fn()
+          .mockImplementationOnce(
+            () =>
+              new Promise<TagSnapshot>((resolve, fail) => {
+                finish = resolve
+                reject = fail
+              })
+          )
+          .mockResolvedValueOnce(favoriteSnapshot(3)),
+        snapshot: vi.fn().mockRejectedValue(new Error('offline'))
+      })
+      useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+      const reference = {
+        tagId: 'tag-favorite',
+        resourceType: 'catalog.skill' as const,
+        resourceId: 'analysis'
+      }
+      const older = useTagStore.getState().setAssignment({ ...reference, assigned: true })
+      const finished = outcome === 'failure' ? expect(older).rejects.toThrow('write failed') : older
+      await useTagStore.getState().setAssignment({ ...reference, assigned: false })
+      expect(useTagStore.getState().assignments).toEqual([])
+      if (outcome === 'failure') reject(new Error('write failed'))
+      else finish({ ...favoriteSnapshot(2), assignments: [{ ...reference, createdAt: 2 }] })
+      await finished
+      expect(useTagStore.getState()).toMatchObject({ revision: 3, assignments: [] })
+    }
+  )
+
+  it.each([false, true])(
+    'preserves newer pending assignment intent after older success (same resource: %s)',
+    async (sameResource) => {
+      const finish: Array<(snapshot: TagSnapshot) => void> = []
+      setTagsApi({
+        setAssignment: vi.fn(() => new Promise<TagSnapshot>((resolve) => finish.push(resolve)))
+      })
+      useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+      const first = {
+        tagId: 'tag-favorite',
+        resourceType: 'catalog.skill' as const,
+        resourceId: 'analysis',
+        createdAt: 2
+      }
+      const second = { ...first, resourceId: sameResource ? 'analysis' : 'other' }
+      const a = useTagStore.getState().setAssignment({ ...first, assigned: true })
+      const b = useTagStore.getState().setAssignment({ ...second, assigned: !sameResource })
+      finish[0]({ ...favoriteSnapshot(2), assignments: [first] })
+      await a
+      const visible = useTagStore.getState().assignments.map((item) => item.resourceId)
+      finish[1]({ ...favoriteSnapshot(3), assignments: sameResource ? [] : [first, second] })
+      await b
+      expect(visible).toEqual(sameResource ? [] : ['analysis', 'other'])
+    }
+  )
+
   it.each([false, true])(
     'rolls back only the failed relationship (same resource: %s)',
     async (sameResource) => {

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { createOptimisticBooleanCoordinator } from './settings-optimistic-boolean'
 
 import type {
   CreateTagRequest,
@@ -47,15 +48,12 @@ export const createInitialTagState = (): TagSnapshot & {
   browserScrollTop: 0
 })
 let loadSequence = 0
+let assignmentRevision = -1
+let assignmentWrites = createOptimisticBooleanCoordinator()
 
 // A later optimistic backup may contain an earlier failed write. Follow those backups only
 // when the failing write still owns the projection; authority snapshots always take precedence.
 const failedTagProjections = new WeakMap<TagSnapshot['tags'], TagSnapshot['tags']>()
-const failedAssignmentProjections = new WeakMap<
-  TagSnapshot['assignments'],
-  TagSnapshot['assignments']
->()
-
 const rollbackProjection = <T>(failed: WeakMap<T[], T[]>, optimistic: T[], before: T[]): T[] => {
   failed.set(optimistic, before)
   let restored = before
@@ -161,15 +159,25 @@ export const useTagStore = create<TagStore>((set, get) => ({
   },
   setAssignment: async (request) => {
     const revision = get().revision
+    if (assignmentRevision !== revision) {
+      assignmentRevision = revision
+      assignmentWrites = createOptimisticBooleanCoordinator()
+    }
+    const writes = assignmentWrites
     const before = get().assignments
     const matches = (assignment: TagSnapshot['assignments'][number]): boolean =>
       assignment.tagId === request.tagId &&
       assignment.resourceType === request.resourceType &&
       assignment.resourceId === request.resourceId
+    const token = writes.begin(
+      JSON.stringify([request.tagId, request.resourceType, request.resourceId]),
+      before.some(matches),
+      request.assigned
+    )
     set({
       assignments: request.assigned
         ? before.some(matches)
-          ? [...before]
+          ? before
           : [
               ...before,
               {
@@ -181,15 +189,30 @@ export const useTagStore = create<TagStore>((set, get) => ({
             ]
         : before.filter((assignment) => !matches(assignment))
     })
-    const optimistic = get().assignments
     try {
       const snapshot = await window.api.tags.setAssignment(request)
+      writes.succeed(token, snapshot.assignments.some(matches))
       loadSequence += 1
       set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
     } catch (error) {
-      const restored = rollbackProjection(failedAssignmentProjections, optimistic, before)
-      if (get().revision === revision && get().assignments === optimistic)
-        set({ assignments: restored })
+      const assigned = writes.fail(token)
+      if (get().revision === revision) {
+        set((state) => ({
+          assignments: assigned
+            ? state.assignments.some(matches)
+              ? state.assignments
+              : [
+                  ...state.assignments,
+                  before.find(matches) ?? {
+                    tagId: request.tagId,
+                    resourceType: request.resourceType,
+                    resourceId: request.resourceId,
+                    createdAt: Date.now()
+                  }
+                ]
+            : state.assignments.filter((assignment) => !matches(assignment))
+        }))
+      }
       await get().load()
       throw error
     }

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -1,5 +1,4 @@
 import { create } from 'zustand'
-import { createOptimisticBooleanCoordinator } from './settings-optimistic-boolean'
 
 import type {
   CreateTagRequest,
@@ -48,8 +47,38 @@ export const createInitialTagState = (): TagSnapshot & {
   browserScrollTop: 0
 })
 let loadSequence = 0
-let assignmentRevision = -1
-let assignmentWrites = createOptimisticBooleanCoordinator()
+// Keep the last authoritative assignments separate from in-flight local intent.
+// Every accepted snapshot is projected through the pending writes in request order.
+let confirmedAssignments: TagSnapshot['assignments'] = []
+let nextAssignmentWrite = 0
+const pendingAssignments = new Map<
+  number,
+  { request: SetTagAssignmentRequest; createdAt: number }
+>()
+const settledAssignments = new Map<string, number>()
+const assignmentKey = (
+  value: Pick<SetTagAssignmentRequest, 'tagId' | 'resourceType' | 'resourceId'>
+): string => JSON.stringify([value.tagId, value.resourceType, value.resourceId])
+
+const projectAssignments = (tags: TagSnapshot['tags']): TagSnapshot['assignments'] => {
+  const assignments = new Map(
+    confirmedAssignments.map((assignment) => [assignmentKey(assignment), assignment])
+  )
+  const tagIds = new Set(tags.map((tag) => tag.id))
+  for (const [sequence, { request, createdAt }] of pendingAssignments) {
+    const key = assignmentKey(request)
+    if (sequence <= (settledAssignments.get(key) ?? 0) || !tagIds.has(request.tagId)) continue
+    if (!request.assigned) assignments.delete(key)
+    else if (!assignments.has(key))
+      assignments.set(key, {
+        tagId: request.tagId,
+        resourceType: request.resourceType,
+        resourceId: request.resourceId,
+        createdAt
+      })
+  }
+  return [...assignments.values()]
+}
 
 // A later optimistic backup may contain an earlier failed write. Follow those backups only
 // when the failing write still owns the projection; authority snapshots always take precedence.
@@ -61,12 +90,10 @@ const rollbackProjection = <T>(failed: WeakMap<T[], T[]>, optimistic: T[], befor
   return restored
 }
 
-const stateFromSnapshot = (
-  snapshot: TagSnapshot
-): Pick<TagStore, keyof TagSnapshot | 'status'> => ({
-  ...snapshot,
-  status: 'ready'
-})
+const stateFromSnapshot = (snapshot: TagSnapshot): Pick<TagStore, keyof TagSnapshot | 'status'> => {
+  confirmedAssignments = snapshot.assignments
+  return { ...snapshot, assignments: projectAssignments(snapshot.tags), status: 'ready' }
+}
 
 const stateFromMutationSnapshot = (
   snapshot: TagSnapshot,
@@ -158,63 +185,31 @@ export const useTagStore = create<TagStore>((set, get) => ({
     }
   },
   setAssignment: async (request) => {
-    const revision = get().revision
-    if (assignmentRevision !== revision) {
-      assignmentRevision = revision
-      assignmentWrites = createOptimisticBooleanCoordinator()
+    if (pendingAssignments.size === 0) {
+      confirmedAssignments = get().assignments
+      settledAssignments.clear()
     }
-    const writes = assignmentWrites
-    const before = get().assignments
-    const matches = (assignment: TagSnapshot['assignments'][number]): boolean =>
-      assignment.tagId === request.tagId &&
-      assignment.resourceType === request.resourceType &&
-      assignment.resourceId === request.resourceId
-    const token = writes.begin(
-      JSON.stringify([request.tagId, request.resourceType, request.resourceId]),
-      before.some(matches),
-      request.assigned
-    )
-    set({
-      assignments: request.assigned
-        ? before.some(matches)
-          ? before
-          : [
-              ...before,
-              {
-                tagId: request.tagId,
-                resourceType: request.resourceType,
-                resourceId: request.resourceId,
-                createdAt: Date.now()
-              }
-            ]
-        : before.filter((assignment) => !matches(assignment))
-    })
+    const sequence = ++nextAssignmentWrite
+    const key = assignmentKey(request)
+    pendingAssignments.set(sequence, { request, createdAt: Date.now() })
+    set({ assignments: projectAssignments(get().tags) })
     try {
       const snapshot = await window.api.tags.setAssignment(request)
-      writes.succeed(token, snapshot.assignments.some(matches))
+      pendingAssignments.delete(sequence)
+      settledAssignments.set(key, Math.max(sequence, settledAssignments.get(key) ?? 0))
       loadSequence += 1
-      set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
+      set((state) => ({
+        assignments: projectAssignments(state.tags),
+        ...stateFromMutationSnapshot(snapshot, state.revision),
+        error: undefined
+      }))
     } catch (error) {
-      const assigned = writes.fail(token)
-      if (get().revision === revision) {
-        set((state) => ({
-          assignments: assigned
-            ? state.assignments.some(matches)
-              ? state.assignments
-              : [
-                  ...state.assignments,
-                  before.find(matches) ?? {
-                    tagId: request.tagId,
-                    resourceType: request.resourceType,
-                    resourceId: request.resourceId,
-                    createdAt: Date.now()
-                  }
-                ]
-            : state.assignments.filter((assignment) => !matches(assignment))
-        }))
-      }
+      pendingAssignments.delete(sequence)
+      set({ assignments: projectAssignments(get().tags) })
       await get().load()
       throw error
+    } finally {
+      if (pendingAssignments.size === 0) settledAssignments.clear()
     }
   },
   listen: () => {

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4720,6 +4720,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Geben Sie eine vollständige Proxy-URL ein, zum Beispiel http://127.0.0.1:1086.",
     "Automatic mirror selection": "Automatische Spiegelauswahl",
     "Automatic mirror selection · Custom CA bundle configured": "Automatische Spiegelauswahl · Benutzerdefiniertes CA-Bündel konfiguriert",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Das Deaktivieren einer integrierten Domain hebt den automatischen Zugriff auf. Exakte Hostnamen unter Erlaubte Domains bleiben erlaubt."
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Das Deaktivieren einer integrierten Domain hebt den automatischen Zugriff auf. Exakte Hostnamen unter Erlaubte Domains bleiben erlaubt.",
+    "Could not load {{type}}.": "{{type}} konnten nicht geladen werden.",
+    "Keep draft": "Entwurf behalten",
+    "This Tag changed while you were editing.": "Dieses Tag wurde während der Bearbeitung geändert.",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Ihr Entwurf bleibt erhalten. Laden Sie die aktuellen Werte neu oder behalten Sie Ihren Entwurf und speichern Sie erneut, um die aktuellen Werte zu ersetzen.",
+    "Loading {{type}}…": "{{type}} werden geladen…"
   }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4722,9 +4722,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "Automatische Spiegelauswahl · Benutzerdefiniertes CA-Bündel konfiguriert",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Das Deaktivieren einer integrierten Domain hebt den automatischen Zugriff auf. Exakte Hostnamen unter Erlaubte Domains bleiben erlaubt.",
     "Could not load {{type}}.": "{{type}} konnten nicht geladen werden.",
-    "Keep draft": "Entwurf behalten",
-    "This Tag changed while you were editing.": "Dieses Tag wurde während der Bearbeitung geändert.",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Ihr Entwurf bleibt erhalten. Laden Sie die aktuellen Werte neu oder behalten Sie Ihren Entwurf und speichern Sie erneut, um die aktuellen Werte zu ersetzen.",
-    "Loading {{type}}…": "{{type}} werden geladen…"
+    "Loading {{type}}…": "{{type}} werden geladen…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "Die Tag-Zuordnungen wurden geladen, aber die Details dieser Ressourcen sind nicht verfügbar.",
+    "Replace your draft with the latest values.": "Ihren Entwurf durch die neuesten Werte ersetzen.",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "Ihr Entwurf bleibt unten erhalten. Wählen Sie vor dem Speichern, wie Sie mit der neuesten Version umgehen möchten.",
+    "Continue editing draft": "Entwurf weiter bearbeiten",
+    "Tag version updated": "Tag-Version aktualisiert",
+    "Not saved yet. Saving later will replace the latest version.": "Noch nicht gespeichert. Späteres Speichern ersetzt die neueste Version."
   }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4728,6 +4728,9 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "Ihr Entwurf bleibt unten erhalten. Wählen Sie vor dem Speichern, wie Sie mit der neuesten Version umgehen möchten.",
     "Continue editing draft": "Entwurf weiter bearbeiten",
     "Tag version updated": "Tag-Version aktualisiert",
-    "Not saved yet. Saving later will replace the latest version.": "Noch nicht gespeichert. Späteres Speichern ersetzt die neueste Version."
+    "Not saved yet. Saving later will replace the latest version.": "Noch nicht gespeichert. Späteres Speichern ersetzt die neueste Version.",
+    "Tag assignments are preserved.": "Die Tag-Zuordnungen bleiben erhalten.",
+    "{{count}} tagged resources are currently unavailable._other": "{{count}} getaggte Ressourcen sind derzeit nicht verfügbar.",
+    "{{count}} tagged resources are currently unavailable._one": "{{count}} getaggte Ressource ist derzeit nicht verfügbar."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4883,9 +4883,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "Selección automática de mirror · Paquete de CA personalizado configurado",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Desactivar un dominio integrado elimina el acceso automático. Los nombres de host exactos de Dominios permitidos siguen estando permitidos.",
     "Could not load {{type}}.": "No se pudo cargar: {{type}}.",
-    "Keep draft": "Conservar borrador",
-    "This Tag changed while you were editing.": "Esta etiqueta cambió durante la edición.",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Su borrador se conserva. Vuelva a cargar los valores más recientes o conserve su borrador y guarde de nuevo para reemplazarlos.",
-    "Loading {{type}}…": "Cargando {{type}}…"
+    "Loading {{type}}…": "Cargando {{type}}…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "Las asociaciones de etiquetas se han cargado, pero los detalles de estos recursos no están disponibles.",
+    "Replace your draft with the latest values.": "Reemplazar su borrador por los valores más recientes.",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "Su borrador se conserva a continuación. Antes de guardar, elija cómo gestionar la última versión.",
+    "Continue editing draft": "Seguir editando el borrador",
+    "Tag version updated": "Versión de etiqueta actualizada",
+    "Not saved yet. Saving later will replace the latest version.": "Aún no se ha guardado. Al guardar más adelante se reemplazará la última versión."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4881,6 +4881,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Introduzca una URL de proxy completa, p. ej., http://127.0.0.1:1086.",
     "Automatic mirror selection": "Selección automática de mirror",
     "Automatic mirror selection · Custom CA bundle configured": "Selección automática de mirror · Paquete de CA personalizado configurado",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Desactivar un dominio integrado elimina el acceso automático. Los nombres de host exactos de Dominios permitidos siguen estando permitidos."
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Desactivar un dominio integrado elimina el acceso automático. Los nombres de host exactos de Dominios permitidos siguen estando permitidos.",
+    "Could not load {{type}}.": "No se pudo cargar: {{type}}.",
+    "Keep draft": "Conservar borrador",
+    "This Tag changed while you were editing.": "Esta etiqueta cambió durante la edición.",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Su borrador se conserva. Vuelva a cargar los valores más recientes o conserve su borrador y guarde de nuevo para reemplazarlos.",
+    "Loading {{type}}…": "Cargando {{type}}…"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4889,6 +4889,10 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "Su borrador se conserva a continuación. Antes de guardar, elija cómo gestionar la última versión.",
     "Continue editing draft": "Seguir editando el borrador",
     "Tag version updated": "Versión de etiqueta actualizada",
-    "Not saved yet. Saving later will replace the latest version.": "Aún no se ha guardado. Al guardar más adelante se reemplazará la última versión."
+    "Not saved yet. Saving later will replace the latest version.": "Aún no se ha guardado. Al guardar más adelante se reemplazará la última versión.",
+    "Tag assignments are preserved.": "Las asociaciones de etiquetas se conservan.",
+    "{{count}} tagged resources are currently unavailable._many": "{{count}} recursos etiquetados no están disponibles actualmente.",
+    "{{count}} tagged resources are currently unavailable._other": "{{count}} recursos etiquetados no están disponibles actualmente.",
+    "{{count}} tagged resources are currently unavailable._one": "{{count}} recurso etiquetado no está disponible actualmente."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4889,6 +4889,10 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "Votre brouillon est conservé ci-dessous. Avant de l’enregistrer, choisissez comment traiter la dernière version.",
     "Continue editing draft": "Continuer à modifier le brouillon",
     "Tag version updated": "Version du tag mise à jour",
-    "Not saved yet. Saving later will replace the latest version.": "Pas encore enregistré. Un enregistrement ultérieur remplacera la dernière version."
+    "Not saved yet. Saving later will replace the latest version.": "Pas encore enregistré. Un enregistrement ultérieur remplacera la dernière version.",
+    "Tag assignments are preserved.": "Les associations de tags sont conservées.",
+    "{{count}} tagged resources are currently unavailable._many": "{{count}} ressources associées à ce tag sont actuellement indisponibles.",
+    "{{count}} tagged resources are currently unavailable._other": "{{count}} ressources associées à ce tag sont actuellement indisponibles.",
+    "{{count}} tagged resources are currently unavailable._one": "{{count}} ressource associée à ce tag est actuellement indisponible."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4883,9 +4883,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "Sélection automatique du miroir · Ensemble de certificats CA personnalisé configuré",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Désactiver un domaine intégré supprime l’accès automatique. Les noms d’hôte exacts dans Domaines autorisés restent autorisés.",
     "Could not load {{type}}.": "Impossible de charger : {{type}}.",
-    "Keep draft": "Conserver le brouillon",
-    "This Tag changed while you were editing.": "Ce tag a été modifié pendant votre saisie.",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Votre brouillon est conservé. Rechargez les valeurs actuelles, ou conservez votre brouillon et enregistrez à nouveau pour les remplacer.",
-    "Loading {{type}}…": "Chargement : {{type}}…"
+    "Loading {{type}}…": "Chargement : {{type}}…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "Les associations de tags sont chargées, mais les détails de ces ressources sont indisponibles.",
+    "Replace your draft with the latest values.": "Remplacer votre brouillon par les dernières valeurs.",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "Votre brouillon est conservé ci-dessous. Avant de l’enregistrer, choisissez comment traiter la dernière version.",
+    "Continue editing draft": "Continuer à modifier le brouillon",
+    "Tag version updated": "Version du tag mise à jour",
+    "Not saved yet. Saving later will replace the latest version.": "Pas encore enregistré. Un enregistrement ultérieur remplacera la dernière version."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4881,6 +4881,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Saisissez une URL de proxy complète, par exemple http://127.0.0.1:1086.",
     "Automatic mirror selection": "Sélection automatique du miroir",
     "Automatic mirror selection · Custom CA bundle configured": "Sélection automatique du miroir · Ensemble de certificats CA personnalisé configuré",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Désactiver un domaine intégré supprime l’accès automatique. Les noms d’hôte exacts dans Domaines autorisés restent autorisés."
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Désactiver un domaine intégré supprime l’accès automatique. Les noms d’hôte exacts dans Domaines autorisés restent autorisés.",
+    "Could not load {{type}}.": "Impossible de charger : {{type}}.",
+    "Keep draft": "Conserver le brouillon",
+    "This Tag changed while you were editing.": "Ce tag a été modifié pendant votre saisie.",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Votre brouillon est conservé. Rechargez les valeurs actuelles, ou conservez votre brouillon et enregistrez à nouveau pour les remplacer.",
+    "Loading {{type}}…": "Chargement : {{type}}…"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4569,9 +4569,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "ミラーを自動選択 · カスタム CA バンドル設定済み",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "組み込みドメインを無効にすると、自動アクセスが解除されます。「許可されたドメイン」に登録した完全一致のホスト名は引き続き許可されます。",
     "Could not load {{type}}.": "{{type}}を読み込めませんでした。",
-    "Keep draft": "下書きを保持",
-    "This Tag changed while you were editing.": "編集中にこのタグが変更されました。",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "下書きは保持されています。最新の値を再読み込みするか、下書きを保持して再度保存し、最新の値を置き換えてください。",
-    "Loading {{type}}…": "{{type}}を読み込み中…"
+    "Loading {{type}}…": "{{type}}を読み込み中…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "タグの関連付けは読み込まれましたが、これらのリソースの詳細は表示できません。",
+    "Replace your draft with the latest values.": "下書きを最新の内容に置き換えます。",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "下の下書きは保持されています。保存する前に、最新バージョンをどう扱うか選んでください。",
+    "Continue editing draft": "下書きの編集を続ける",
+    "Tag version updated": "タグのバージョンが更新されました",
+    "Not saved yet. Saving later will replace the latest version.": "まだ保存されていません。後で保存すると最新バージョンを上書きします。"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4575,6 +4575,8 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "下の下書きは保持されています。保存する前に、最新バージョンをどう扱うか選んでください。",
     "Continue editing draft": "下書きの編集を続ける",
     "Tag version updated": "タグのバージョンが更新されました",
-    "Not saved yet. Saving later will replace the latest version.": "まだ保存されていません。後で保存すると最新バージョンを上書きします。"
+    "Not saved yet. Saving later will replace the latest version.": "まだ保存されていません。後で保存すると最新バージョンを上書きします。",
+    "Tag assignments are preserved.": "タグの関連付けは保持されています。",
+    "{{count}} tagged resources are currently unavailable._other": "タグ付けされたリソース {{count}} 件は現在利用できません。"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4567,6 +4567,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "完全なプロキシ URL を入力してください（例：http://127.0.0.1:1086）。",
     "Automatic mirror selection": "ミラーを自動選択",
     "Automatic mirror selection · Custom CA bundle configured": "ミラーを自動選択 · カスタム CA バンドル設定済み",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "組み込みドメインを無効にすると、自動アクセスが解除されます。「許可されたドメイン」に登録した完全一致のホスト名は引き続き許可されます。"
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "組み込みドメインを無効にすると、自動アクセスが解除されます。「許可されたドメイン」に登録した完全一致のホスト名は引き続き許可されます。",
+    "Could not load {{type}}.": "{{type}}を読み込めませんでした。",
+    "Keep draft": "下書きを保持",
+    "This Tag changed while you were editing.": "編集中にこのタグが変更されました。",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "下書きは保持されています。最新の値を再読み込みするか、下書きを保持して再度保存し、最新の値を置き換えてください。",
+    "Loading {{type}}…": "{{type}}を読み込み中…"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4567,9 +4567,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "미러 자동 선택 · 사용자 지정 CA 번들 설정됨",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "기본 제공 도메인을 끄면 자동 액세스가 해제됩니다. 허용된 도메인에 등록한 정확한 호스트 이름은 계속 허용됩니다.",
     "Could not load {{type}}.": "{{type}}을(를) 불러오지 못했습니다.",
-    "Keep draft": "초안 유지",
-    "This Tag changed while you were editing.": "편집 중에 이 태그가 변경되었습니다.",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "초안이 유지되었습니다. 최신 값을 다시 불러오거나 초안을 유지하고 다시 저장하여 최신 값을 덮어쓰세요.",
-    "Loading {{type}}…": "{{type}} 불러오는 중…"
+    "Loading {{type}}…": "{{type}} 불러오는 중…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "태그 연결은 불러왔지만 이 리소스의 세부 정보를 표시할 수 없습니다.",
+    "Replace your draft with the latest values.": "초안을 최신 내용으로 바꿉니다.",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "아래 초안은 유지됩니다. 저장하기 전에 최신 버전을 어떻게 처리할지 선택하세요.",
+    "Continue editing draft": "초안 편집 계속",
+    "Tag version updated": "태그 버전이 업데이트되었습니다",
+    "Not saved yet. Saving later will replace the latest version.": "아직 저장되지 않았습니다. 나중에 저장하면 최신 버전을 덮어씁니다."
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4573,6 +4573,8 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "아래 초안은 유지됩니다. 저장하기 전에 최신 버전을 어떻게 처리할지 선택하세요.",
     "Continue editing draft": "초안 편집 계속",
     "Tag version updated": "태그 버전이 업데이트되었습니다",
-    "Not saved yet. Saving later will replace the latest version.": "아직 저장되지 않았습니다. 나중에 저장하면 최신 버전을 덮어씁니다."
+    "Not saved yet. Saving later will replace the latest version.": "아직 저장되지 않았습니다. 나중에 저장하면 최신 버전을 덮어씁니다.",
+    "Tag assignments are preserved.": "태그 연결은 유지됩니다.",
+    "{{count}} tagged resources are currently unavailable._other": "태그가 지정된 리소스 {{count}}개를 현재 사용할 수 없습니다."
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4565,6 +4565,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "완전한 프록시 URL을 입력하세요. 예: http://127.0.0.1:1086.",
     "Automatic mirror selection": "미러 자동 선택",
     "Automatic mirror selection · Custom CA bundle configured": "미러 자동 선택 · 사용자 지정 CA 번들 설정됨",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "기본 제공 도메인을 끄면 자동 액세스가 해제됩니다. 허용된 도메인에 등록한 정확한 호스트 이름은 계속 허용됩니다."
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "기본 제공 도메인을 끄면 자동 액세스가 해제됩니다. 허용된 도메인에 등록한 정확한 호스트 이름은 계속 허용됩니다.",
+    "Could not load {{type}}.": "{{type}}을(를) 불러오지 못했습니다.",
+    "Keep draft": "초안 유지",
+    "This Tag changed while you were editing.": "편집 중에 이 태그가 변경되었습니다.",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "초안이 유지되었습니다. 최신 값을 다시 불러오거나 초안을 유지하고 다시 저장하여 최신 값을 덮어쓰세요.",
+    "Loading {{type}}…": "{{type}} 불러오는 중…"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5015,9 +5015,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "Автоматический выбор зеркала · Настроен пользовательский пакет CA",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Отключение встроенного домена отменяет автоматический доступ. Точные имена хостов в списке разрешённых доменов остаются разрешёнными.",
     "Could not load {{type}}.": "Не удалось загрузить: {{type}}.",
-    "Keep draft": "Оставить черновик",
-    "This Tag changed while you were editing.": "Этот тег изменился во время редактирования.",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Черновик сохранён. Загрузите актуальные значения или оставьте черновик и сохраните его ещё раз, чтобы заменить их.",
-    "Loading {{type}}…": "Загрузка: {{type}}…"
+    "Loading {{type}}…": "Загрузка: {{type}}…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "Связи тегов загружены, но сведения об этих ресурсах недоступны.",
+    "Replace your draft with the latest values.": "Заменить черновик актуальными значениями.",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "Ваш черновик сохранён ниже. Перед сохранением выберите, как поступить с последней версией.",
+    "Continue editing draft": "Продолжить редактирование",
+    "Tag version updated": "Версия тега обновлена",
+    "Not saved yet. Saving later will replace the latest version.": "Ещё не сохранено. При сохранении последняя версия будет заменена."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5021,6 +5021,11 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "Ваш черновик сохранён ниже. Перед сохранением выберите, как поступить с последней версией.",
     "Continue editing draft": "Продолжить редактирование",
     "Tag version updated": "Версия тега обновлена",
-    "Not saved yet. Saving later will replace the latest version.": "Ещё не сохранено. При сохранении последняя версия будет заменена."
+    "Not saved yet. Saving later will replace the latest version.": "Ещё не сохранено. При сохранении последняя версия будет заменена.",
+    "Tag assignments are preserved.": "Связи тегов сохранены.",
+    "{{count}} tagged resources are currently unavailable._many": "{{count}} ресурсов с тегом сейчас недоступны.",
+    "{{count}} tagged resources are currently unavailable._few": "{{count}} ресурса с тегом сейчас недоступны.",
+    "{{count}} tagged resources are currently unavailable._other": "{{count}} ресурса с тегом сейчас недоступны.",
+    "{{count}} tagged resources are currently unavailable._one": "{{count}} ресурс с тегом сейчас недоступен."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5013,6 +5013,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Введите полный URL прокси, например http://127.0.0.1:1086.",
     "Automatic mirror selection": "Автоматический выбор зеркала",
     "Automatic mirror selection · Custom CA bundle configured": "Автоматический выбор зеркала · Настроен пользовательский пакет CA",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Отключение встроенного домена отменяет автоматический доступ. Точные имена хостов в списке разрешённых доменов остаются разрешёнными."
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Отключение встроенного домена отменяет автоматический доступ. Точные имена хостов в списке разрешённых доменов остаются разрешёнными.",
+    "Could not load {{type}}.": "Не удалось загрузить: {{type}}.",
+    "Keep draft": "Оставить черновик",
+    "This Tag changed while you were editing.": "Этот тег изменился во время редактирования.",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "Черновик сохранён. Загрузите актуальные значения или оставьте черновик и сохраните его ещё раз, чтобы заменить их.",
+    "Loading {{type}}…": "Загрузка: {{type}}…"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4569,9 +4569,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "自动选择镜像 · 已配置自定义 CA 证书包",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "关闭内置域名会取消自动访问权限。“允许的域名”中的精确主机名仍可访问。",
     "Could not load {{type}}.": "无法加载{{type}}。",
-    "Keep draft": "保留草稿",
-    "This Tag changed while you were editing.": "此标签在您编辑期间发生了更改。",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "您的草稿已保留。请重新加载最新内容，或保留草稿并再次保存以替换最新内容。",
-    "Loading {{type}}…": "正在加载{{type}}…"
+    "Loading {{type}}…": "正在加载{{type}}…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "标签关联已加载，但暂时无法显示这些资源的详细信息。",
+    "Replace your draft with the latest values.": "用最新内容替换当前草稿。",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "你的草稿仍保留在下方。保存前，请确认如何处理最新版本。",
+    "Continue editing draft": "继续编辑草稿",
+    "Tag version updated": "标签版本已更新",
+    "Not saved yet. Saving later will replace the latest version.": "尚未保存。之后保存会覆盖最新版本。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4575,6 +4575,8 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "你的草稿仍保留在下方。保存前，请确认如何处理最新版本。",
     "Continue editing draft": "继续编辑草稿",
     "Tag version updated": "标签版本已更新",
-    "Not saved yet. Saving later will replace the latest version.": "尚未保存。之后保存会覆盖最新版本。"
+    "Not saved yet. Saving later will replace the latest version.": "尚未保存。之后保存会覆盖最新版本。",
+    "Tag assignments are preserved.": "标签关联已保留。",
+    "{{count}} tagged resources are currently unavailable._other": "{{count}} 个已关联资源暂不可用。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4567,6 +4567,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "请输入完整的代理 URL，例如 http://127.0.0.1:1086。",
     "Automatic mirror selection": "自动选择镜像",
     "Automatic mirror selection · Custom CA bundle configured": "自动选择镜像 · 已配置自定义 CA 证书包",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "关闭内置域名会取消自动访问权限。“允许的域名”中的精确主机名仍可访问。"
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "关闭内置域名会取消自动访问权限。“允许的域名”中的精确主机名仍可访问。",
+    "Could not load {{type}}.": "无法加载{{type}}。",
+    "Keep draft": "保留草稿",
+    "This Tag changed while you were editing.": "此标签在您编辑期间发生了更改。",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "您的草稿已保留。请重新加载最新内容，或保留草稿并再次保存以替换最新内容。",
+    "Loading {{type}}…": "正在加载{{type}}…"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4569,9 +4569,12 @@
     "Automatic mirror selection · Custom CA bundle configured": "自動選擇鏡像 · 已設定自訂 CA 憑證組合",
     "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "關閉內建網域會取消自動存取權限。「允許的網域」中的精確主機名稱仍可存取。",
     "Could not load {{type}}.": "無法載入{{type}}。",
-    "Keep draft": "保留草稿",
-    "This Tag changed while you were editing.": "此標籤在您編輯期間發生了變更。",
-    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "您的草稿已保留。請重新載入最新內容，或保留草稿並再次儲存以取代最新內容。",
-    "Loading {{type}}…": "正在載入{{type}}…"
+    "Loading {{type}}…": "正在載入{{type}}…",
+    "Tag assignments are loaded, but these resource details are unavailable.": "標籤關聯已載入，但暫時無法顯示這些資源的詳細資訊。",
+    "Replace your draft with the latest values.": "以最新內容取代目前的草稿。",
+    "Your draft is still below. Choose how to handle the latest version before saving.": "你的草稿仍保留在下方。儲存前，請確認如何處理最新版本。",
+    "Continue editing draft": "繼續編輯草稿",
+    "Tag version updated": "標籤版本已更新",
+    "Not saved yet. Saving later will replace the latest version.": "尚未儲存。之後儲存會覆寫最新版本。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4567,6 +4567,11 @@
     "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "請輸入完整的代理 URL，例如 http://127.0.0.1:1086。",
     "Automatic mirror selection": "自動選擇鏡像",
     "Automatic mirror selection · Custom CA bundle configured": "自動選擇鏡像 · 已設定自訂 CA 憑證組合",
-    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "關閉內建網域會取消自動存取權限。「允許的網域」中的精確主機名稱仍可存取。"
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "關閉內建網域會取消自動存取權限。「允許的網域」中的精確主機名稱仍可存取。",
+    "Could not load {{type}}.": "無法載入{{type}}。",
+    "Keep draft": "保留草稿",
+    "This Tag changed while you were editing.": "此標籤在您編輯期間發生了變更。",
+    "Your draft is preserved. Reload the latest values, or keep your draft and save again to replace them.": "您的草稿已保留。請重新載入最新內容，或保留草稿並再次儲存以取代最新內容。",
+    "Loading {{type}}…": "正在載入{{type}}…"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4575,6 +4575,8 @@
     "Your draft is still below. Choose how to handle the latest version before saving.": "你的草稿仍保留在下方。儲存前，請確認如何處理最新版本。",
     "Continue editing draft": "繼續編輯草稿",
     "Tag version updated": "標籤版本已更新",
-    "Not saved yet. Saving later will replace the latest version.": "尚未儲存。之後儲存會覆寫最新版本。"
+    "Not saved yet. Saving later will replace the latest version.": "尚未儲存。之後儲存會覆寫最新版本。",
+    "Tag assignments are preserved.": "標籤關聯已保留。",
+    "{{count}} tagged resources are currently unavailable._other": "{{count}} 個已關聯資源暫時無法使用。"
   }
 }


### PR DESCRIPTION
## Problem

Tag snapshots could discard an open editing draft, permanently prune assignments for temporarily unavailable skill identities, or let a late optimistic failure overwrite newer confirmed client state. Failed resource metadata loads appeared as empty tag results. Error notices also used inconsistent page-sized layouts inside forms, conversations, and Literature.

## Proposed change

- Preserve the editor instance and its captured version. External updates retain the draft and show the latest saved name, icon, and color. Continue editing draft acknowledges that version without saving; Load latest version replaces the draft. Both choices explain their consequences.
- Reconcile persisted assignments against the complete existence catalog while retaining availability checks for new assignments.
- Keep authoritative assignments separate from pending local writes. Project pending intent over accepted snapshots and remove only settled intent; late failures and older successful responses cannot erase newer confirmed results or newer pending choices.
- Display per-type resource loading/failure/retry states while retaining assignment counts and other loaded resources. Integrate the newly added Literature resource type, including its reading dialog and retry handling.
- Unify ErrorNotice around a neutral inline card with a small semantic status icon. Single recovery actions sit at the trailing edge and wrap on narrow surfaces; described conflict choices appear below owner-provided context. Inline technical diagnostics are collapsed with native disclosure controls, outside the summary live region. Only database/initial-settings startup blockers opt into `fullPage`. Remove `showBrand`/public `compact` switches, Literature's duplicate box, and conversation/plan/message-specific descendant styling, and the redundant full-text lookup border.

Rebased onto `origin/main` at `9b98202c` (head `f159413a`). Conflicts were limited to eight locale catalogs; resolutions preserve the incoming network-settings translations and all existing tag safety changes. PR-only and incoming-only source/tests are byte-identical to their respective pre-rebase versions.

## Scope and non-goals

No new database fields, schema changes, migrations, or historical-data conversion. Existing assignments are retained during identity conflicts; already-deleted relationships cannot be reconstructed. Cleanup eligibility is the only persistent behavior change. Sorting still updates `updatedAt`.

Editing versions, pending/settled assignment request maps, the last authoritative assignment list, and catalog retries use transient renderer bookkeeping. Native diagnostic disclosure adds only local presentation state. `fullPage` is a rendering prop, not a business-state enum. No new persisted/IPC enum or compatibility layer. No automatic draft merge or persistent draft storage.

## Acceptance criteria and validation

The original 11 regression cases were demonstrated failing on the unfixed baseline and passing after repair through real React/store and SQLite/service boundaries. Two independently reviewed issues were also reproduced before repair: an older success hiding a newer pending assignment (two cases), and the double border in failed full-text lookup (one case). Additional tests cover loaded snapshots during pending writes and reversed settlement order. New disclosure/choice tests demonstrated the missing content on the previous UI before implementation. After the first rebase, existing tag render tests exposed the missing Literature loading-state integration; that integration is fixed and the pending/failure/retry case also covers Literature.

At `a752696f`, the explicit Test Impact Set passed: **29 files / 1,784 tests**. The subsequent conflict-alert fix (`326f1788`) changes only TagsPanel and its render tests; its final affected checks pass: TagsPanel, ErrorNotice, and SettingsPage (142 tests), plus the translation guard (805 tests), renderer type checking, lint, and formatting. The approved unavailable-resource follow-up (`3f0fe312`) changes TagsPanel, its render tests, and eight locale catalogs; the final affected set passes (949 tests), together with renderer type checking, lint, and formatting. No local full test suite was run, as requested by the maintainer.

| Behavior / interface | Project-owned checks | Final result |
| --- | --- | --- |
| Tag persistence, identity conflicts, cleanup and shared contracts | `src/main/tags`, `src/shared/tags.test.ts` | Passed |
| Optimistic state, editing conflicts, four resource types and navigation | `tag-store.test.ts`, `TagsPanel.render.test.tsx`, SettingsPage/SkillsPanel/ConnectorsPanel/SpecialistsPanel/SpecialistEditor render tests | Passed |
| Shared notice layouts, callbacks, pending actions and startup consumer | `error-notice.test.tsx`, `database-startup-gate.test.tsx`, `JobDetailModal.render.test.tsx` | Passed |
| Workspace consumers | ReadingContextPicker, UnavailablePlanNotice, NotebookPreview.gate, PreviewFileSurface + freshness, PreviewPanel (source failure diagnostics), ConversationPanel.interaction, WorkspaceMessageItem.actions | Passed |
| Literature wrapper and consumers | LiteratureLibraryPage, LiteratureBatchLookupDialog, LiteratureFullTextLookup, LiteratureDuplicatesView, LiteratureDuplicateBatch, LiteratureBackgroundTasks | Passed |
| Translation catalogs | `src/renderer/src/i18n/resources.test.ts` | Passed |
| Renderer types / lint / formatting | `npm run typecheck:web`, `npm run lint`, changed-file Prettier, `git diff --check` | Passed |
| Main-process typecheck | `npm run typecheck` | See the latest rebase validation below; the earlier local dependency limitation is resolved. |

Consumer selection follows the shared ErrorNotice call paths and tag store/catalog ownership; it includes Literature and startup consumers because the public presentation default changed. These changes add no platform-specific code; full exact-head and platform suites remain delegated to PR CI. Tags have no curated module owner in the impact manifest, so CI may select the full fallback. Independent AI review must assess the final mapping before declaring verification complete.

Browser verification used actual production components with temporary controlled fixtures: the real TagForm retains an entered draft on an external timestamp update, acknowledgment performs no write, and separate Save submits the acknowledged version. Light/dark screenshots and 390px wrapping were checked without horizontal overflow. Native diagnostics start closed and open with Enter; recovery remains outside the disclosure and technical codes stay outside live alerts. Screenshots were delivered to the maintainer. Temporary harness/browser space were removed. This is component UI verification, not Electron/network fault injection.

Design references: [Carbon notification guidance](https://carbondesignsystem.com/components/notification/usage/), [Primer banners](https://primer.style/product/components/banner/), and [PatternFly alert guidance](https://www.patternfly.org/components/alert/design-guidelines/). The maintainer approved the contextual prototype before implementation; neutral surfaces adapt these information/action patterns to the existing project tokens.

## Review focus

Preserve optimistic concurrency when acknowledging a draft; distinguish existence from assignability; keep newer confirmed snapshots on failures; retain Literature resource behavior after rebase; ensure all inline consumers use one notice presentation while startup blockers retain their full-page layout. Confirm final exact-head CI and consumer coverage.

## Unavailable-resource presentation

The maintainer approved a non-interactive notice for preserved assignments whose ready catalog has no displayable resource. It reports the unavailable count and retained associations, suppresses the misleading empty message, respects the resource-type filter, and preserves available rows. Catalog recovery restores the row without modifying assignments. This is a derived rendering branch, not a new stored state or enum; it adds no persistence or removal workflow. The public React regression failed before repair and now passes. The conflict-summary live-region correction is included in `326f1788`.

## Prior integration validation

Prior integration: base `c878904a`, head `26b7b5ba`. Conflicts were limited to the eight translation catalogs. Merged by namespace and translation key, preserving both branches' additions, changes and intentional removals. Verified exact three-way results for the Literature full-text source/tests and all locale values; other PR source/tests are unchanged, and non-overlapping incoming files match main exactly.

The previously approved pending-assignment behavior, failed-reorder recovery, credential notice adaptation and shared tooltip providers remain intact. Main's arXiv discovery/source-applicability behavior is retained alongside this PR's shared notice presentation. This rebase adds no new state enum, persistence, schema, migration, historical-compatibility decision or interaction design.

After the final conflict resolution, the selected checks cover:

| Behavior | Project-owned checks |
| --- | --- |
| Tag drafts, loading and unavailable-resource UI | `src/renderer/src/pages/settings/TagsPanel.render.test.tsx` |
| Assignment/reorder concurrency | `src/renderer/src/stores/tag-store.test.ts` |
| Persisted relationships and catalog/service contracts | `src/main/tags/{repository,service,resource-catalog}.test.ts` |
| Shared notices and merged translation entries | `src/renderer/src/components/error-notice.test.tsx`, `src/renderer/src/i18n/resources.test.ts` |
| Merged Literature lookup, arXiv applicability and user-selected attachment | `src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx` |
| Lookup provider and PDF acquisition/batch contracts | `src/main/literature/{full-text-finder,agent-pdf-acquisition,batch-jobs}.test.ts` |

`npm test -- <the 11 explicit test paths above> --maxWorkers=2`: **11 files / 946 tests passed**. Main, notebook sandbox and renderer type checking (`npm run typecheck`), lint, changed-file formatting and `git diff --check` also passed after conflict resolution.

During verification main advanced with a release-version bump and CLI positional-argument validation. Rebased again without conflicts onto `c878904a`. Verified every `src/` file is byte-identical to the already-tested integration; package manifests differ only in release version, and all other incoming files match main. The additional CLI check (`npm test -- packages/open-science/cli.test.ts --maxWorkers=2`) passed **71 tests**; lint and whitespace validation passed on the final head. Total targeted coverage: **12 files / 1,017 tests**. No full local test suite was run.

The targeted selection covers the conflicting locale surface, the merged Literature component and its provider contracts, plus the original tag safety invariants. The incoming granted-folders store and other non-overlapping source match main exactly. Full portable/platform and UI end-to-end verification remains with new-head PR CI; earlier review verdicts do not establish this head's result.


## Catalog outage follow-up

Originally validated at `cee8c9b0`. A resource-catalog read failure no longer prevents the tag repository snapshot from being returned. Automatic reconciliation is deferred until a complete catalog snapshot succeeds; renderer catalog loaders retain their existing per-type error/retry UI. The fallback is limited to catalog reads: repository failures and explicit deletion-cleanup failures still propagate, and new assignment validation is unchanged.

The real SQLite + TagResourceCatalog + TagService regression failed twice on the previous implementation with `Specialist catalog offline` rejecting the entire snapshot. After repair it verifies the saved snapshot and relationship survive an unrelated catalog outage, assignment validation still rejects, and recovery resumes removal of a genuinely missing resource.

After the final edit, `npm test -- src/main/tags/repository.test.ts src/main/tags/service.test.ts src/main/tags/resource-catalog.test.ts src/renderer/src/stores/tag-store.test.ts src/renderer/src/pages/settings/TagsPanel.render.test.tsx --maxWorkers=2` passed **5 files / 73 tests**. Main and sandbox type checking, lint, formatting and `git diff --check` passed. These cover the changed service, persisted relationship and catalog contracts, and renderer hydration consumers; no IPC/type contract, renderer source, schema or dependency changed.

This introduces no stored fields, state enums or data-model changes. The intentional tradeoff is delaying all automatic stale-assignment cleanup during a catalog outage until the next complete catalog read, rather than adding a partial-catalog protocol. Existing explicit deletion receipts remain effective. New-head CI remains authoritative for complete portable and platform validation.

The previous Windows E2E shard 2 failure is separate: the mobile archive test encountered another Session revision conflict after its one retry, then passed on the test-level retry. The lane rejects flaky tests. It has not been fixed or waived by this catalog change.


## Windows archive E2E follow-up

Originally validated at `029bc5d5`. The maintainer approved extending this PR to `e2e/workspace-conversation.spec.ts`. The previous test assumed that one manual retry was sufficient after an archive revision conflict; the Windows failure artifact showed a second conflict (expected 37, actual 38) instead of the expected Undo notice.

The test now queues real `sessions.editDetails` writes immediately before the first two Archive clicks, using the existing public API and isolated fixture data. It explicitly verifies each conflict and absence of an Undo receipt before a fresh user action, then verifies successful archive on the third click. It does not retry a failed assertion or relax timeouts, whole-test retry settings, or `--fail-on-flaky-tests`. No production code, API, test-only application hook, persisted format or user interaction changed.

Reproduction: the unmodified scenario passed 3/3 locally, confirming that timing alone was not reliable. Adding the two controlled writes to the old one-retry flow produced 2/2 failures at the same missing-Undo assertion as CI, with a second real revision conflict in the captured UI. After correcting the sequence, the same controlled scenario passed 5/5 on local macOS Electron with `--retries=0 --repeat-each=5 --workers=1 --fail-on-flaky-tests`.

Final checks: `npm run build:e2e` passed; `npm run test:e2e -- e2e/workspace-conversation.spec.ts -g 'archives a completed session from its mobile sidebar actions' --retries=0 --repeat-each=5 --workers=1 --fail-on-flaky-tests` passed; main/E2E and sandbox type checking (`npm run typecheck:node`), lint, formatting and whitespace checks passed after the final test edit. The already-built production source is unchanged. Windows validation remains pending new-head CI; local macOS success does not establish a Windows pass.


## Current rebase validation

Head `f159413a` is rebased onto main `9b98202c`. Only the eight translation catalogs conflicted. Namespace/key-level three-way checks confirm both sides' additions, changes, and intentional removals are retained. All PR-only source/tests match the previously validated head byte for byte; all incoming-only source/tests match main. The catalog-outage fallback and archive E2E correction are unchanged. No new interaction, architecture, data model, state enum, persistence, or compatibility decision was introduced by this rebase.

Checks run after the final conflict resolution:

| Behavior / boundary | Check | Result |
| --- | --- | --- |
| Tag drafts, snapshot concurrency, persisted assignments and catalog outage/recovery | `npx vitest run` with `src/main/tags/{repository,service,resource-catalog}.test.ts`, `tag-store.test.ts`, `TagsPanel.render.test.tsx` | Passed |
| Merged locale coverage and incoming network-settings consumers | Same explicit run with `resources.test.ts`, `NetworkPanel.render.test.tsx`, `NetworkProxyForm.test.tsx`, `NotebookNetworkDomainsForm.render.test.tsx`, `network-panel-i18n.render.test.tsx`, `SettingsPage.render.test.tsx`, `network-store.test.ts`, `settings-snapshot-commit-owner.test.ts` | Passed |
| Main, notebook sandbox and renderer contracts | `npm run typecheck` | Passed |
| Lint, locale formatting and whitespace | `npm run lint`, locale `prettier --check`, `git diff --check` | Passed |

The targeted Vitest run passed **13 files / 1,044 tests**. No full local test suite was run. The existing real Electron archive evidence above remains historical evidence for unchanged test source; Electron E2E was not rerun for this locale-only conflict resolution. New-head PR CI remains authoritative for Windows E2E shard 2, PR Gate, and complete platform coverage; earlier review or CI results are not attributed to this new head.
