### PR TITLE
fix(diagnostics): harden log output and refresh status

### DIFF
--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync } from 'node:fs'
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -49,6 +49,195 @@ const productionTypeScriptFiles = (directory: string): string[] =>
   })
 
 describe('logger: main-process boundary', () => {
+  it.each(['object', 'JSON', 'Error.message', 'escaped JSON key'] as const)(
+    'D01 redacts compound credentials in %s at both output boundaries',
+    async (representation) => {
+      logDir = await mkdtemp(join(tmpdir(), 'os-logger-d01-'))
+      initLogger({ logDir, mirrorToConsole: true })
+      const mirror = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const credentials = {
+        OPENAI_API_KEY: 'fictional-d01-environment-7319',
+        providerApiKey: 'fictional-d01-left-7319"\\\nfictional-d01-right-7319',
+        provider: 'example-provider',
+        inputTokens: 21,
+        outputTokens: 8
+      }
+      const json = JSON.stringify(credentials)
+      const data =
+        representation === 'object'
+          ? credentials
+          : representation === 'JSON'
+            ? json
+            : representation === 'Error.message'
+              ? new Error(json)
+              : new Error(json.replace('providerApiKey', 'providerApi\\u004bey'))
+      createLogger('diagnostics').error('provider failed', data)
+      await flushLogs()
+
+      const file = await readFile(join(logDir, 'main.log'), 'utf8')
+      const consoleOutput = JSON.stringify(mirror.mock.calls)
+      for (const output of [file, consoleOutput]) {
+        for (const secret of [
+          'fictional-d01-environment-7319',
+          'fictional-d01-left-7319',
+          'fictional-d01-right-7319'
+        ]) {
+          expect.soft(output.includes(secret), `${representation} leaks ${secret}`).toBe(false)
+        }
+        expect(output).toContain('example-provider')
+        expect(output).toContain('inputTokens')
+        expect(output).toContain('21')
+        expect(output).toContain('outputTokens')
+      }
+      expect(JSON.parse(file)).toMatchObject({ level: 'error', scope: 'diagnostics' })
+    }
+  )
+
+  it('D02 stops expanding a shared DAG while retaining correlation fields', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-d02-'))
+    initLogger({ logDir, runId: 'bounded-run', mirrorToConsole: false })
+    const read = vi.fn(() => 'kept')
+    const leaf = Object.defineProperty({}, 'detail', { enumerable: true, get: read })
+    const data = Array(30).fill(Array(30).fill(Array(30).fill(leaf)))
+    runWithDiagnosticCorrelation(() => createLogger('diagnostics').error('shared DAG', data))
+    await flushLogs()
+    expect.soft(read.mock.calls.length).toBeLessThanOrEqual(10000)
+    const file = await readFile(join(logDir, 'main.log'), 'utf8')
+    expect(JSON.parse(file)).toMatchObject({
+      scope: 'diagnostics',
+      msg: 'shared DAG',
+      runId: 'bounded-run',
+      correlationId: expect.any(String)
+    })
+    expect(file).toContain('truncated')
+  })
+
+  it('D02 budgets JSON escaping and UTF-8 bytes in the complete record', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-d02-'))
+    initLogger({ logDir, mirrorToConsole: false })
+    createLogger('diagnostics').error('escaped content', Array(100).fill('\u0000中'.repeat(4000)))
+    await flushLogs()
+    const file = await readFile(join(logDir, 'main.log'), 'utf8')
+    expect(Buffer.byteLength(file)).toBeLessThanOrEqual(2 * 1024 * 1024)
+    expect(JSON.parse(file)).toMatchObject({ msg: 'escaped content' })
+  })
+
+  it('D02 rejects a record exceeding a custom file cap and recovers on the next small record', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-d02-'))
+    initLogger({ logDir, maxBytes: 512, mirrorToConsole: false })
+    const log = createLogger('diagnostics')
+    log.error('too large', { detail: 'x'.repeat(1000) })
+    await flushLogs()
+    expect
+      .soft(await getLogFileStatus())
+      .toMatchObject({ lastWriteSucceeded: false, lastFailureCategory: 'append' })
+    log.error('recovered', { code: 'EIO' })
+    await flushLogs()
+    const file = await readFile(join(logDir, 'main.log'), 'utf8')
+    expect.soft(Buffer.byteLength(file)).toBeLessThanOrEqual(512)
+    expect(JSON.parse(file)).toMatchObject({ msg: 'recovered' })
+    await expect(getLogFileStatus()).resolves.toMatchObject({
+      lastWriteSucceeded: true,
+      lastFailureCategory: null
+    })
+  })
+
+  it.each(['array', 'object', 'shared references'] as const)(
+    'D02 bounds ordinary %s data before output and accepts the next error',
+    async (shape) => {
+      logDir = await mkdtemp(join(tmpdir(), 'os-logger-d02-'))
+      initLogger({ logDir, mirrorToConsole: true })
+      const mirror = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const value = 'x'.repeat(8000)
+      const shared = { detail: value }
+      const data =
+        shape === 'object'
+          ? Object.fromEntries(Array.from({ length: 800 }, (_, index) => [`field${index}`, value]))
+          : Array.from({ length: 800 }, () => (shape === 'array' ? value : shared))
+      const log = createLogger('diagnostics')
+      log.error('wide payload', data)
+      await flushLogs()
+      const file = await readFile(join(logDir, 'main.log'), 'utf8')
+      // A single normal record must fit the existing default file budget, including JSON framing.
+      expect.soft(Buffer.byteLength(file)).toBeLessThanOrEqual(5 * 1024 * 1024)
+      expect
+        .soft(Buffer.byteLength(JSON.stringify(mirror.mock.calls)))
+        .toBeLessThanOrEqual(5 * 1024 * 1024)
+      expect.soft(/truncat|omitted|more (?:items|keys)/i.test(file)).toBe(true)
+      expect(JSON.parse(file)).toMatchObject({
+        level: 'error',
+        scope: 'diagnostics',
+        msg: 'wide payload'
+      })
+
+      log.error('subsequent failure', { code: 'EIO' })
+      await flushLogs()
+      const current = await readFile(join(logDir, 'main.log'), 'utf8')
+      const records = current
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      expect(records.at(-1)).toMatchObject({ msg: 'subsequent failure', data: { code: 'EIO' } })
+      await expect(getLogFileStatus()).resolves.toMatchObject({
+        lastWriteSucceeded: true,
+        lastFailureCategory: null
+      })
+      for (const name of await readdir(logDir)) {
+        expect
+          .soft((await readFile(join(logDir, name))).byteLength)
+          .toBeLessThanOrEqual(5 * 1024 * 1024)
+      }
+    }
+  )
+
+  it.each([false, true])(
+    'D03 preserves retained backups and reports rotation failure (injected=%s)',
+    async (injectFailure) => {
+      logDir = await mkdtemp(join(tmpdir(), 'os-logger-d03-'))
+      const original = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      const active = `${JSON.stringify({ msg: 'active diagnostic', detail: 'a'.repeat(350) })}\n`
+      const retained = `${JSON.stringify({ msg: 'retained diagnostic' })}\n`
+      await writeFile(join(logDir, 'main.log'), active)
+      await writeFile(join(logDir, 'main.1.log'), retained)
+      await writeFile(
+        join(logDir, 'main.2.log'),
+        `${JSON.stringify({ msg: 'expired diagnostic' })}\n`
+      )
+      initLogger({ logDir, maxBytes: 512, maxFiles: 3, mirrorToConsole: false })
+      renameFile.mockImplementation(async (source, destination) => {
+        if (injectFailure && source === join(logDir!, 'main.1.log')) {
+          throw Object.assign(new Error('injected retained-backup move failure'), {
+            code: 'EACCES'
+          })
+        }
+        return original.rename(source, destination)
+      })
+      try {
+        createLogger('diagnostics').error('rotation trigger', { detail: 'x'.repeat(150) })
+        await flushLogs()
+        if (injectFailure) {
+          expect.soft(await readFile(join(logDir, 'main.1.log'), 'utf8')).toBe(retained)
+          expect.soft(await readFile(join(logDir, 'main.log'), 'utf8')).toBe(active)
+          expect
+            .soft(await getLogFileStatus())
+            .toMatchObject({ lastWriteSucceeded: false, lastFailureCategory: 'rotation' })
+          renameFile.mockImplementation(original.rename)
+          createLogger('diagnostics').error('rotation recovered', { detail: 'x'.repeat(150) })
+          await flushLogs()
+        }
+        expect
+          .soft(await readFile(join(logDir, 'main.2.log'), 'utf8').catch(() => null))
+          .toBe(retained)
+        await expect(getLogFileStatus()).resolves.toMatchObject({
+          lastWriteSucceeded: true,
+          lastFailureCategory: null
+        })
+      } finally {
+        renameFile.mockImplementation(original.rename)
+      }
+    }
+  )
+
   it('keeps the central logger as the only production console adapter', () => {
     const directConsoleCalls = productionTypeScriptFiles(__dirname).flatMap((path) => {
       const source = readFileSync(path, 'utf8')
@@ -96,7 +285,7 @@ describe('logger: formatLine', () => {
     const line = formatLine('warn', 'x', 'circular', circular)
 
     expect(() => JSON.parse(line)).not.toThrow()
-    expect((JSON.parse(line) as { data: unknown }).data).toBe('[unserializable]')
+    expect((JSON.parse(line) as { data: unknown }).data).toEqual({ self: '[circular]' })
   })
 
   it('recursively redacts sensitive field variants while retaining token metrics', () => {
@@ -1423,7 +1612,7 @@ describe('logger: rotation (auto-cleanup)', () => {
     logDir = await mkdtemp(join(tmpdir(), 'os-logger-'))
 
     // Tiny cap so a handful of lines forces several rotations; keep the live file + 2 backups.
-    initLogger({ logDir, fileName: 'main.log', maxBytes: 120, maxFiles: 3, mirrorToConsole: false })
+    initLogger({ logDir, fileName: 'main.log', maxBytes: 512, maxFiles: 3, mirrorToConsole: false })
     const log = createLogger('test')
 
     for (let i = 0; i < 50; i += 1) {
@@ -1441,7 +1630,7 @@ describe('logger: rotation (auto-cleanup)', () => {
   it('keeps the live file when maxFiles is 1 (drop-and-restart)', async () => {
     logDir = await mkdtemp(join(tmpdir(), 'os-logger-'))
 
-    initLogger({ logDir, fileName: 'main.log', maxBytes: 120, maxFiles: 1, mirrorToConsole: false })
+    initLogger({ logDir, fileName: 'main.log', maxBytes: 512, maxFiles: 1, mirrorToConsole: false })
     const log = createLogger('test')
 
     for (let i = 0; i < 30; i += 1) {
@@ -1458,7 +1647,7 @@ describe('logger: rotation (auto-cleanup)', () => {
     logDir = await mkdtemp(join(tmpdir(), 'os-logger-'))
     const runId = 'rotation-failure-run'
     const firstLineBytes =
-      Buffer.byteLength(formatLine('info', 'test', 'seed', undefined, runId)) + 1
+      Buffer.byteLength(formatLine('info', 'test', 'blocked-1', undefined, runId)) + 1
 
     initLogger({
       logDir,

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -19,7 +19,8 @@ import {
 //
 // Logs self-clean: each file is capped at `maxBytes`; on overflow the file rotates (main.log ->
 // main.1.log -> ...) and the oldest beyond `maxFiles` is deleted. Total on-disk size is therefore
-// bounded (~maxBytes * maxFiles) no matter how heavily the app is used — no manual cleanup needed.
+// bounded (~maxBytes * maxFiles) for queued writes. Fatal synchronous writes have a documented
+// one-record exception below; logging requires no manual cleanup during normal operation.
 
 export type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
@@ -60,16 +61,6 @@ const runWithDiagnosticCorrelation = <Result>(operation: () => Result): Result =
   return diagnosticCorrelation.run(correlationId, operation)
 }
 
-// Turns arbitrary log payloads into JSON-safe values, unwrapping Errors (whose fields are non-enumerable)
-// so a stack trace actually lands in the log instead of `{}`.
-const toSerializable = (value: unknown): unknown => {
-  if (value instanceof Error) {
-    return { name: value.name, message: value.message, stack: value.stack }
-  }
-
-  return value
-}
-
 // Own-property keys carried by common runtime errors that a bare message+stack capture would drop:
 // JSON-RPC RequestErrors attach code + data (the provider/agent's real reason lives in data), and Node
 // system errors attach errno/syscall/path/code. Enumerated explicitly because they are non-enumerable
@@ -101,6 +92,8 @@ const MAX_TOTAL_NODES = 10000
 // Global bound on total emitted characters per sanitize call. The node budget bounds node COUNT; this
 // bounds total SIZE, since node-count × per-string-cap alone would still allow a very large line.
 const MAX_TOTAL_CHARS = 256 * 1024
+// Includes JSON escaping, structure, and the terminating newline.
+const MAX_RECORD_BYTES = 2 * 1024 * 1024
 
 // One mandatory policy for every logger sink. Callers may still pre-sanitize, but cannot opt out here.
 const OVERSIZED_TEXT_MARKER = '[redacted: oversized text]'
@@ -117,7 +110,7 @@ const CONTENT_BEARING_KEYS = new Set([
 // Mutable budget shared across one errorLogFields call: `nodes` bounds how many values are emitted,
 // `chars` bounds their combined length — together they bound both the count and the size of the output
 // regardless of reference sharing.
-type Budget = { nodes: number; chars: number }
+type Budget = { nodes: number; chars: number; redact?: boolean }
 
 // Per-field code-unit cap only (no global budget); used by the outer fallback where no budget is live.
 const truncate = (value: string): string =>
@@ -133,22 +126,25 @@ const redactLogText = (value: string): string => {
   return redactSensitiveText(value)
 }
 
-const stringifyLogRecord = (record: Record<string, unknown>): string =>
-  // JSON's replacer recursively covers every serializable descendant and prunes sensitive subtrees
-  // before they can reach the file or the console mirror.
-  JSON.stringify(record, (key, value: unknown) => {
-    if (key && (isSensitiveDiagnosticKey(key) || isContentBearingLogKey(key))) {
-      return REDACTED_MARKER
-    }
-    const serializable = toSerializable(value)
-    return typeof serializable === 'string' ? redactLogText(serializable) : serializable
-  })
+const stringifyLogRecord = (record: Record<string, unknown>): string => {
+  // Bound traversal before JSON.stringify and never invoke a payload's custom toJSON.
+  // Metadata precedes data, so wide payloads cannot consume its budget.
+  const safe = toLogSafe(record, new Set(), 0, {
+    nodes: MAX_TOTAL_NODES,
+    chars: MAX_TOTAL_CHARS,
+    redact: true
+  }) as Record<string, unknown>
+  const line = JSON.stringify(safe)
+  if (Buffer.byteLength(line, 'utf8') + 1 <= MAX_RECORD_BYTES) return line
+  return JSON.stringify({ ...safe, data: '[truncated: record byte limit]' })
+}
 
 // Applies the per-field cap AND the shared character budget to a string about to be emitted, charging
 // the budget for what it keeps. Once the global budget is spent, further strings collapse to a short
 // marker so the total line size stays bounded.
 const chargeString = (value: string, budget: Budget): string => {
   if (budget.chars <= 0) return '…[truncated]'
+  if (budget.redact) value = redactLogText(value)
   const capped = truncate(value)
   if (capped.length <= budget.chars) {
     budget.chars -= capped.length
@@ -237,7 +233,8 @@ const safeToString = (value: unknown, budget: Budget): string => {
 const toLogSafe = (value: unknown, seen: Set<object>, depth: number, budget: Budget): unknown => {
   // Charge one node per value visited so total output is bounded across the whole traversal — this is
   // what stops a shared DAG from expanding combinatorially even though each single path is capped.
-  if (budget.nodes <= 0) return '[truncated: budget exceeded]'
+  if (budget.nodes <= 0 || (budget.redact && budget.chars <= 0))
+    return '[truncated: budget exceeded]'
   budget.nodes -= 1
 
   const type = typeof value
@@ -269,7 +266,15 @@ const toLogSafe = (value: unknown, seen: Set<object>, depth: number, budget: Bud
     if (depth >= MAX_SANITIZE_DEPTH) return '[max depth]'
     seen.add(value as object)
     try {
-      if (value instanceof Error) return formatError(value, seen, depth, budget)
+      if (value instanceof Error) {
+        if (!budget.redact) return formatError(value, seen, depth, budget)
+        // Preserve the ordinary logger's Error shape; errorLogFields owns richer expansion.
+        const fields = nullProtoRecord()
+        for (const key of ['name', 'message', 'stack']) {
+          fields[key] = sanitizeSlot(safeRead(value, key), seen, depth + 1, undefined, budget)
+        }
+        return fields
+      }
       if (Array.isArray(value)) {
         // Build a fresh plain array by index rather than value.map: map respects Symbol.species (a
         // hijacked constructor could produce an object with a throwing toJSON) and a throwing index
@@ -289,7 +294,7 @@ const toLogSafe = (value: unknown, seen: Set<object>, depth: number, budget: Bud
         let index = 0
         let budgetHit = false
         for (; index < cap; index += 1) {
-          if (budget.nodes <= 0) {
+          if (budget.nodes <= 0 || (budget.redact && budget.chars <= 0)) {
             budgetHit = true
             break
           }
@@ -324,7 +329,7 @@ const toLogSafe = (value: unknown, seen: Set<object>, depth: number, budget: Bud
       let processed = 0
       let objBudgetHit = false
       for (; processed < limit; processed += 1) {
-        if (budget.nodes <= 0) {
+        if (budget.nodes <= 0 || (budget.redact && budget.chars <= 0)) {
           objBudgetHit = true
           break
         }
@@ -337,7 +342,15 @@ const toLogSafe = (value: unknown, seen: Set<object>, depth: number, budget: Bud
         }
         // Charge per slot (see the array note): a key whose read throws must still cost budget.
         budget.nodes -= 1
-        const raw = safeRead(value as object, keys[processed])
+        const sourceKey = keys[processed]
+        if (
+          budget.redact &&
+          (isSensitiveDiagnosticKey(sourceKey) || isContentBearingLogKey(sourceKey))
+        ) {
+          out[key] = REDACTED_MARKER
+          continue
+        }
+        const raw = safeRead(value as object, sourceKey)
         out[key] = raw === UNREADABLE ? UNREADABLE_MARKER : toLogSafe(raw, seen, depth + 1, budget)
       }
       // One marker counting all unprocessed keys (budget-skipped within the cap + beyond the cap).
@@ -489,9 +502,8 @@ const diagnosticErrorFields = (error: unknown): { errorCategory: string } => {
 }
 
 // Expands an unknown thrown value into a log-safe record for nesting inside a larger context object.
-// toSerializable only unwraps a *top-level* Error; an Error nested inside `{ error, ...ctx }` serializes
-// to `{}` because its fields are non-enumerable — losing the message, stack, and (worse) the code/data
-// that name the real cause. Spread the result into the log context so all of it survives:
+// The ordinary sink keeps an Error’s name/message/stack. Use this helper when code/data/cause
+// are needed as well. Spread the result into the log context so all of it survives:
 //   log.error('connect failed', { ...errorLogFields(err), framework })
 // The result is guaranteed acyclic and JSON-serializable, and this function never throws: every branch
 // runs through toLogSafe (which unwraps nested Errors, breaks any cycle, bounds depth, and guards every
@@ -604,7 +616,7 @@ const formatLine = (
 
   if (runId !== undefined) record.runId = runId
   if (correlationId !== undefined) record.correlationId = correlationId
-  if (data !== undefined) record.data = toSerializable(data)
+  if (data !== undefined) record.data = data
 
   try {
     return stringifyLogRecord(record)
@@ -643,7 +655,7 @@ const fileSize = async (path: string): Promise<number> => {
 }
 
 // Shifts the live file into backups, dropping any beyond `maxFiles`. Best-effort: a missing file at
-// any step is ignored so logging never fails because of rotation.
+// any step is ignored; other I/O errors stop the chain before an unmoved backup is overwritten.
 const rotate = async (logDir: string, fileName: string, maxFiles: number): Promise<boolean> => {
   const path = (name: string): string => join(logDir, name)
   const backups = Math.max(0, maxFiles - 1)
@@ -657,11 +669,13 @@ const rotate = async (logDir: string, fileName: string, maxFiles: number): Promi
   }
 
   // Delete the oldest backup, then shift each backup up one slot, then the live file becomes .1.
-  await rm(path(rotatedName(fileName, backups)), { force: true }).catch(() => undefined)
+  await rm(path(rotatedName(fileName, backups)), { force: true })
 
   for (let index = backups - 1; index >= 1; index -= 1) {
     await rename(path(rotatedName(fileName, index)), path(rotatedName(fileName, index + 1))).catch(
-      () => undefined
+      (error: unknown) => {
+        if (!isMissingFileError(error)) throw error
+      }
     )
   }
 
@@ -690,6 +704,13 @@ const appendLine = (line: string): void => {
         }
 
         const lineBytes = Buffer.byteLength(line, 'utf8') + 1 // include the newline
+
+        // Even an empty file must not accept a record larger than its configured cap.
+        if (lineBytes > maxBytes) {
+          lastWriteSucceeded = false
+          lastFailureCategory = 'append'
+          return
+        }
 
         // Rotate before writing when the next line would exceed the cap (but never rotate an empty file).
         if (currentBytes > 0 && currentBytes + lineBytes > maxBytes) {

--- a/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.render.test.tsx
@@ -398,6 +398,119 @@ describe('GeneralPanel close behavior', () => {
 })
 
 describe('GeneralPanel diagnostics', () => {
+  it('D04 distinguishes a missing file with a known path from a failed status request', async () => {
+    vi.mocked(window.api.logs.getStatus).mockResolvedValueOnce({
+      configured: true,
+      path: '/logs/main.log',
+      existing: false,
+      lastWriteSucceeded: null,
+      lastFailureCategory: null
+    })
+    await act(async () => root.render(<GeneralPanel />))
+    await flush()
+    const diagnostics = container.querySelector('[aria-label="Diagnostics"]')!
+    expect(diagnostics.textContent).toContain('Not available yet.')
+    expect(diagnostics.querySelector('[role="alert"]')).toBeNull()
+    expect(findButton(/^open$/i)?.disabled).toBe(true)
+  })
+
+  it.each([new Error('log status unavailable'), undefined])(
+    'D04 offers an inline retry after the initial log status request fails (%s)',
+    async (error) => {
+      const getStatus = vi.mocked(window.api.logs.getStatus)
+      getStatus.mockRejectedValueOnce(error)
+      await act(async () => root.render(<GeneralPanel />))
+      await flush()
+
+      const diagnostics = container.querySelector('[aria-label="Diagnostics"]')!
+      expect.soft(diagnostics.querySelector('[role="alert"]')).not.toBeNull()
+      const retry = Array.from(diagnostics.querySelectorAll('button')).find((button) =>
+        /retry|try again|check again|refresh/i.test(button.textContent ?? '')
+      )
+      expect(retry).toBeDefined()
+      expect(retry?.disabled).toBe(false)
+      await act(async () => retry?.click())
+      await flush()
+      expect(getStatus).toHaveBeenCalledTimes(2)
+      expect(diagnostics.querySelector('[role="alert"]')).toBeNull()
+      expect(findButton(/^open$/i)?.disabled).toBe(false)
+      expect(findButton(/^reveal$/i)?.disabled).toBe(false)
+    }
+  )
+
+  it('D04 refreshes on focus and ignores stale status responses', async () => {
+    const getStatus = vi.mocked(window.api.logs.getStatus)
+    type Status = Awaited<ReturnType<typeof window.api.logs.getStatus>>
+    let resolveOld!: (status: Status) => void
+    getStatus.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveOld = resolve
+        })
+    )
+    await act(async () => root.render(<GeneralPanel />))
+    expect(container.querySelector('[aria-label="Log file path"]')?.textContent).toBe('Loading…')
+
+    const failure: Status = {
+      configured: true,
+      path: '/logs/main.log',
+      existing: true,
+      lastWriteSucceeded: false,
+      lastFailureCategory: 'rotation'
+    }
+    getStatus.mockResolvedValueOnce(failure)
+    await act(async () => window.dispatchEvent(new Event('focus')))
+    await flush()
+    expect(getStatus).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('The log backups could not be rotated.')
+    await act(async () =>
+      resolveOld({ ...failure, lastWriteSucceeded: true, lastFailureCategory: null })
+    )
+    await flush()
+    expect(container.textContent).toContain('The log backups could not be rotated.')
+  })
+
+  it.each(['open', 'reveal'] as const)(
+    'D04 refreshes write failure and recovery after %s',
+    async (action) => {
+      const getStatus = vi.mocked(window.api.logs.getStatus)
+      const status = {
+        configured: true,
+        path: '/logs/main.log',
+        existing: true,
+        lastWriteSucceeded: true,
+        lastFailureCategory: null
+      }
+      getStatus.mockResolvedValueOnce(status)
+      await act(async () => root.render(<GeneralPanel />))
+      await flush()
+      getStatus.mockResolvedValueOnce({
+        ...status,
+        lastWriteSucceeded: false,
+        lastFailureCategory: 'append'
+      })
+      const button = findButton(new RegExp(`^${action}$`, 'i'))!
+      await act(async () => button.click())
+      await flush()
+      expect.soft(getStatus).toHaveBeenCalledTimes(2)
+      expect
+        .soft(
+          container.textContent?.includes(
+            'The app could not write to the log file during its most recent attempt.'
+          )
+        )
+        .toBe(true)
+
+      getStatus.mockResolvedValueOnce(status)
+      await act(async () => button.click())
+      await flush()
+      expect(getStatus).toHaveBeenCalledTimes(3)
+      expect(container.textContent).not.toContain(
+        'The app could not write to the log file during its most recent attempt.'
+      )
+    }
+  )
+
   it('shows a recent write failure without hiding an existing log file', async () => {
     const getStatus = (
       window as unknown as { api: { logs: { getStatus: ReturnType<typeof vi.fn> } } }

--- a/src/renderer/src/pages/settings/GeneralPanel.tsx
+++ b/src/renderer/src/pages/settings/GeneralPanel.tsx
@@ -1,6 +1,6 @@
 import { ExternalLink, FolderOpen, Globe, Terminal } from 'lucide-react'
 import type { TFunction } from 'i18next'
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { Trans, useTranslation } from 'react-i18next'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
@@ -14,7 +14,7 @@ import { errorDetail } from '@/lib/error-detail'
 import { useSettingsStore } from '@/stores/settings-store'
 import type { CloseActionPreference } from '../../../../shared/window-controls'
 import type { CliLauncherStatus } from '../../../../shared/cli'
-import type { LogFileStatus } from '../../../../shared/logs'
+import type { LogFileStatus, LogWriteFailureCategory } from '../../../../shared/logs'
 import { APP } from '../../../../shared/app-config'
 import type {
   NotificationDesktopAvailability,
@@ -47,6 +47,21 @@ const generalActionErrorCopy = (error: GeneralActionError, t: TFunction): string
   }
 }
 
+const logFailureCopy = (category: LogWriteFailureCategory | null, t: TFunction): string => {
+  switch (category) {
+    case 'directory':
+      return t('The log folder could not be created.')
+    case 'inspect':
+      return t('The log file could not be checked.')
+    case 'rotation':
+      return t('The log backups could not be rotated.')
+    case 'append':
+      return t('The log record could not be appended.')
+    default:
+      return ''
+  }
+}
+
 // Discord and X are brand marks that lucide-react dropped in v1, so we inline the official SVGs.
 // currentColor lets them inherit the link's text color like the other icons.
 const DiscordMark = ({ className }: { className?: string }): React.JSX.Element => (
@@ -67,6 +82,43 @@ const GeneralPanel = (): React.JSX.Element => {
   const { t } = useTranslation()
   const isMac = window.api.platform === 'darwin'
   const [logStatus, setLogStatus] = useState<LogFileStatus | null>(null)
+  const [isCheckingLog, setIsCheckingLog] = useState(true)
+  const [logStatusError, setLogStatusError] = useState<string>()
+  const logStatusRequest = useRef(0)
+
+  const checkLogStatus = useCallback((): Promise<void> => {
+    const request = ++logStatusRequest.current
+    return Promise.resolve()
+      .then(() => window.api.logs.getStatus())
+      .then(
+        (status) => {
+          if (request !== logStatusRequest.current) return
+          setLogStatus(status)
+          setLogStatusError(undefined)
+        },
+        (error: unknown) => {
+          if (request !== logStatusRequest.current) return
+          setLogStatusError(errorDetail(error) ?? '')
+        }
+      )
+      .finally(() => {
+        if (request === logStatusRequest.current) setIsCheckingLog(false)
+      })
+  }, [])
+
+  const refreshLogStatus = useCallback((): Promise<void> => {
+    setIsCheckingLog(true)
+    return checkLogStatus()
+  }, [checkLogStatus])
+
+  useEffect(() => {
+    void checkLogStatus()
+    window.addEventListener('focus', refreshLogStatus)
+    return () => {
+      window.removeEventListener('focus', refreshLogStatus)
+      logStatusRequest.current += 1
+    }
+  }, [checkLogStatus, refreshLogStatus])
   const [message, setMessage] = useState<GeneralActionError | undefined>(undefined)
   const [isOpening, setIsOpening] = useState(false)
   const [cli, setCli] = useState<CliLauncherStatus | null>(null)
@@ -97,7 +149,6 @@ const GeneralPanel = (): React.JSX.Element => {
   }
 
   useEffect(() => {
-    void window.api.logs.getStatus().then(setLogStatus, () => setLogStatus(null))
     void window.api.cli.getStatus().then(setCli, (error) => {
       setCliError({ action: 'cli-status', detail: errorDetail(error) })
     })
@@ -157,6 +208,7 @@ const GeneralPanel = (): React.JSX.Element => {
     } catch (error) {
       setMessage({ action: 'open-log', detail: errorDetail(error) })
     } finally {
+      await refreshLogStatus()
       setIsOpening(false)
     }
   }
@@ -172,6 +224,8 @@ const GeneralPanel = (): React.JSX.Element => {
       }
     } catch (error) {
       setMessage({ action: 'reveal-log', detail: errorDetail(error) })
+    } finally {
+      await refreshLogStatus()
     }
   }
 
@@ -378,12 +432,48 @@ const GeneralPanel = (): React.JSX.Element => {
           className="overflow-x-auto rounded-lg border border-border bg-muted/60 px-3 py-2.5 font-mono text-xs text-foreground"
           aria-label={t('Log file path')}
         >
-          {logPath ?? t('Not available yet.')}
+          {logPath ??
+            (isCheckingLog
+              ? t('Loading…')
+              : logStatusError !== undefined
+                ? '—'
+                : t('Not available yet.'))}
         </pre>
 
-        {logStatus?.lastWriteSucceeded === false ? (
+        {logStatus &&
+        logPath &&
+        !logExists &&
+        !isCheckingLog &&
+        logStatusError === undefined &&
+        !logStatus.lastFailureCategory ? (
+          <p className="mt-2 text-xs text-muted-foreground" role="status">
+            {t('Not available yet.')}
+          </p>
+        ) : null}
+
+        {logStatusError !== undefined ? (
+          <div className="mt-2 space-y-2">
+            <p className="text-xs text-destructive" role="alert">
+              {t('Could not check the log file.')}
+            </p>
+            <DiagnosticDetails detail={logStatusError} />
+            <Button
+              type="button"
+              variant="outline"
+              disabled={isCheckingLog}
+              onClick={() => void refreshLogStatus()}
+            >
+              {isCheckingLog ? t('Loading…') : t('Check again')}
+            </Button>
+          </div>
+        ) : null}
+
+        {logStatus && (logStatus.lastWriteSucceeded === false || logStatus.lastFailureCategory) ? (
           <p className="mt-2 text-xs text-destructive" role="status">
-            {t('The app could not write to the log file during its most recent attempt.')}
+            {logStatus.lastWriteSucceeded === false
+              ? t('The app could not write to the log file during its most recent attempt.')
+              : null}{' '}
+            {logFailureCopy(logStatus.lastFailureCategory, t)}
           </p>
         ) : null}
 

--- a/src/shared/diagnostic-redaction.ts
+++ b/src/shared/diagnostic-redaction.ts
@@ -129,11 +129,46 @@ const redactEmbeddedUrlCredentials = (rawUrl: string): string => {
   return hasEscapedSeparators ? redacted.replace('://', ':\\/\\/') : redacted
 }
 
+// Inspect assignment prefixes independently: a non-sensitive prefix such as "Error:" must not
+// consume and hide a later sensitive assignment in its value.
+const redactSensitiveAssignments = (value: string): string => {
+  let output = ''
+  let cursor = 0
+  for (const match of value.matchAll(/\b([a-z][a-z0-9_-]*)(\s*["']?\s*[:=]\s*)/gi)) {
+    if (match.index < cursor || !isSensitiveDiagnosticKey(match[1])) continue
+    const start = match.index + match[0].length
+    const rest = value.slice(start)
+    const quoted = /^(["'])(?:\\.|(?!\1)[^\\\r\n])*\1/.exec(rest)
+    const unquoted = quoted
+      ? null
+      : /^(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^"'&;}\r\n]+/i.exec(rest)
+    const content = quoted ?? unquoted
+    if (!content) continue
+    const quote = quoted?.[1] ?? ''
+    output += `${value.slice(cursor, start)}${quote}${REDACTED_MARKER}${quote}`
+    cursor = start + content[0].length
+  }
+  return output + value.slice(cursor)
+}
+
 // Shared credential-text policy for diagnostic sinks and persisted tool payloads. Keep this
 // helper unbounded: each caller owns its own output budget, while the credential patterns stay
 // identical at every boundary.
 const redactSensitiveText = (value: string): string =>
-  value
+  redactSensitiveAssignments(value)
+    // Match complete quoted values before header rules can stop at an escaped quote.
+    .replace(
+      /("(?:\\.|[^"\\])*")(\s*:\s*)("(?:\\.|[^"\\])*")/g,
+      (match, key: string, separator: string) => {
+        try {
+          return isSensitiveDiagnosticKey(JSON.parse(key) as string)
+            ? `${key}${separator}"${REDACTED_MARKER}"`
+            : match
+        } catch {
+          return match
+        }
+      }
+    )
     .replace(/\b[a-z][a-z0-9+.-]*:(?:\\?\/){2}[^\s"'<>]+/gi, redactEmbeddedUrlCredentials)
     .replace(
       /\b(authorization|proxy-authorization|x-api-key|api-key|x-auth-token|x-amz-security-token|cookie|set-cookie)\b(\s*["']?\s*:\s*["']?)[^"'\r\n}]*/gi,
@@ -146,18 +181,6 @@ const redactSensitiveText = (value: string): string =>
     .replace(
       /\b(api[_-]?key|access[_-]?key|access[_-]?token|auth[_-]?token|authorization|bearer[_-]?token|client[_-]?secret|cookie|credential|password|passphrase|passwd|private[_-]?key|refresh[_-]?token|secret|secret[_-]?access[_-]?key|security[_-]?token|session[_-]?token|token)\b(\s*["']?\s*[:=]\s*["']?)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^"'&;}\r\n]+/gi,
       `$1$2${REDACTED_MARKER}`
-    )
-    .replace(
-      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(["'])(?:\\.|(?!\3)[^\\\r\n])*\3/gi,
-      (match, key: string, separator: string, quote: string) =>
-        isSensitiveDiagnosticKey(key)
-          ? `${key}${separator}${quote}${REDACTED_MARKER}${quote}`
-          : match
-    )
-    .replace(
-      /\b([a-z][a-z0-9_-]*)(\s*=\s*)(?:(?:Bearer|Basic|Digest|Negotiate)\s+)?[^"'&;}\r\n]+/gi,
-      (match, key: string, separator: string) =>
-        isSensitiveDiagnosticKey(key) ? `${key}${separator}${REDACTED_MARKER}` : match
     )
     .replace(
       /(--?(?:access[-_]?key|access[-_]?token|api[-_]?key|auth[-_]?token|authorization|bearer[-_]?token|client[-_]?secret|cookie|credentials?|passphrase|passwd|password|pat|private[-_]?key|secret|token))(\s+|=)(["'])(?:\\.|(?!\3)[^\\\r\n])*\3/gi,

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4680,6 +4680,11 @@
     "Processing failed. Refresh and try again.": "Verarbeitung fehlgeschlagen. Aktualisieren Sie die Ansicht und versuchen Sie es erneut.",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "Referenzen wurden nach der Prüfung geändert. Öffnen Sie den Zusammenführungsdialog erneut, um die aktuellen Metadaten zu vergleichen.",
     "A collection with this name already exists at this level. Choose another name.": "Auf dieser Ebene gibt es bereits eine Sammlung mit diesem Namen. Wählen Sie einen anderen Namen.",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Eine untergeordnete Sammlung hätte denselben Namen wie eine Sammlung auf oberster Ebene. Benennen Sie sie um, bevor Sie diese Sammlung löschen."
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Eine untergeordnete Sammlung hätte denselben Namen wie eine Sammlung auf oberster Ebene. Benennen Sie sie um, bevor Sie diese Sammlung löschen.",
+    "Could not check the log file.": "Die Protokolldatei konnte nicht überprüft werden.",
+    "The log folder could not be created.": "Der Protokollordner konnte nicht erstellt werden.",
+    "The log file could not be checked.": "Die Protokolldatei konnte nicht überprüft werden.",
+    "The log backups could not be rotated.": "Die Protokollsicherungen konnten nicht rotiert werden.",
+    "The log record could not be appended.": "Der Protokolleintrag konnte nicht angehängt werden."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4842,6 +4842,11 @@
     "Processing failed. Refresh and try again.": "El procesamiento falló. Actualice e inténtelo de nuevo.",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "Las referencias cambiaron después de la revisión. Vuelva a abrir el diálogo de fusión para comparar los metadatos más recientes.",
     "A collection with this name already exists at this level. Choose another name.": "Ya existe una colección con este nombre en este nivel. Elija otro nombre.",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Una colección secundaria tendría el mismo nombre que una de nivel superior. Cámbiele el nombre antes de eliminar esta colección."
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Una colección secundaria tendría el mismo nombre que una de nivel superior. Cámbiele el nombre antes de eliminar esta colección.",
+    "Could not check the log file.": "No se pudo comprobar el archivo de registro.",
+    "The log folder could not be created.": "No se pudo crear la carpeta de registros.",
+    "The log file could not be checked.": "No se pudo comprobar el archivo de registro.",
+    "The log backups could not be rotated.": "No se pudieron rotar las copias de seguridad del registro.",
+    "The log record could not be appended.": "No se pudo añadir la entrada al registro."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4842,6 +4842,11 @@
     "Processing failed. Refresh and try again.": "Échec du traitement. Actualisez et réessayez.",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "Les références ont changé depuis la vérification. Rouvrez la fenêtre de fusion pour comparer les dernières métadonnées.",
     "A collection with this name already exists at this level. Choose another name.": "Une collection portant ce nom existe déjà à ce niveau. Choisissez un autre nom.",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Une collection enfant porterait le même nom qu’une collection de premier niveau. Renommez-la avant de supprimer cette collection."
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Une collection enfant porterait le même nom qu’une collection de premier niveau. Renommez-la avant de supprimer cette collection.",
+    "Could not check the log file.": "Impossible de vérifier le fichier journal.",
+    "The log folder could not be created.": "Le dossier des journaux n’a pas pu être créé.",
+    "The log file could not be checked.": "Le fichier journal n’a pas pu être vérifié.",
+    "The log backups could not be rotated.": "La rotation des sauvegardes du journal a échoué.",
+    "The log record could not be appended.": "L’entrée n’a pas pu être ajoutée au journal."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4526,6 +4526,11 @@
     "Processing failed. Refresh and try again.": "処理に失敗しました。更新して再試行してください。",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "確認後に文献が変更されました。統合ダイアログを開き直して最新のメタデータを比較してください。",
     "A collection with this name already exists at this level. Choose another name.": "この階層には同じ名前のコレクションが既に存在します。別の名前を指定してください。",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "子コレクションの名前が最上位のコレクションと重複します。このコレクションを削除する前に、子コレクションの名前を変更してください。"
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "子コレクションの名前が最上位のコレクションと重複します。このコレクションを削除する前に、子コレクションの名前を変更してください。",
+    "Could not check the log file.": "ログファイルを確認できませんでした。",
+    "The log folder could not be created.": "ログフォルダーを作成できませんでした。",
+    "The log file could not be checked.": "ログファイルを確認できませんでした。",
+    "The log backups could not be rotated.": "ログのバックアップをローテーションできませんでした。",
+    "The log record could not be appended.": "ログレコードを追記できませんでした。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4524,6 +4524,11 @@
     "Processing failed. Refresh and try again.": "처리하지 못했습니다. 새로고침 후 다시 시도하세요.",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "검토 후 문헌이 변경되었습니다. 병합 대화상자를 다시 열어 최신 메타데이터를 비교하세요.",
     "A collection with this name already exists at this level. Choose another name.": "이 수준에 같은 이름의 컬렉션이 이미 있습니다. 다른 이름을 선택하세요.",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "하위 컬렉션의 이름이 최상위 컬렉션과 중복됩니다. 이 컬렉션을 삭제하기 전에 하위 컬렉션의 이름을 변경하세요."
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "하위 컬렉션의 이름이 최상위 컬렉션과 중복됩니다. 이 컬렉션을 삭제하기 전에 하위 컬렉션의 이름을 변경하세요.",
+    "Could not check the log file.": "로그 파일을 확인하지 못했습니다.",
+    "The log folder could not be created.": "로그 폴더를 만들지 못했습니다.",
+    "The log file could not be checked.": "로그 파일을 확인하지 못했습니다.",
+    "The log backups could not be rotated.": "로그 백업을 순환하지 못했습니다.",
+    "The log record could not be appended.": "로그 항목을 추가하지 못했습니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4975,6 +4975,11 @@
     "Processing failed. Refresh and try again.": "Ошибка обработки. Обновите список и повторите попытку.",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "Записи изменились после проверки. Откройте диалог объединения заново, чтобы сравнить актуальные метаданные.",
     "A collection with this name already exists at this level. Choose another name.": "На этом уровне уже есть коллекция с таким названием. Выберите другое название.",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Название дочерней коллекции совпадёт с названием коллекции верхнего уровня. Переименуйте её перед удалением этой коллекции."
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "Название дочерней коллекции совпадёт с названием коллекции верхнего уровня. Переименуйте её перед удалением этой коллекции.",
+    "Could not check the log file.": "Не удалось проверить файл журнала.",
+    "The log folder could not be created.": "Не удалось создать папку журнала.",
+    "The log file could not be checked.": "Не удалось проверить файл журнала.",
+    "The log backups could not be rotated.": "Не удалось выполнить ротацию резервных копий журнала.",
+    "The log record could not be appended.": "Не удалось добавить запись в журнал."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4526,6 +4526,11 @@
     "Processing failed. Refresh and try again.": "处理失败，请刷新后重试。",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "题录在审阅后发生变化，请重新打开合并弹窗以比较最新元数据。",
     "A collection with this name already exists at this level. Choose another name.": "此层级已存在同名合集，请使用其他名称。",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "子合集的名称与顶层合集重名。请先重命名子合集，再删除此合集。"
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "子合集的名称与顶层合集重名。请先重命名子合集，再删除此合集。",
+    "Could not check the log file.": "无法检查日志文件。",
+    "The log folder could not be created.": "无法创建日志文件夹。",
+    "The log file could not be checked.": "无法检查日志文件。",
+    "The log backups could not be rotated.": "无法轮转日志备份。",
+    "The log record could not be appended.": "无法追加日志记录。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4526,6 +4526,11 @@
     "Processing failed. Refresh and try again.": "處理失敗，請重新整理後再試。",
     "References changed after review. Reopen the merge dialog to compare the latest metadata.": "題錄在審閱後發生變更，請重新開啟合併對話框以比較最新中繼資料。",
     "A collection with this name already exists at this level. Choose another name.": "此層級已存在同名合集，請使用其他名稱。",
-    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "子合集的名稱與頂層合集重名。請先重新命名子合集，再刪除此合集。"
+    "A child collection would duplicate a top-level name. Rename it before deleting this collection.": "子合集的名稱與頂層合集重名。請先重新命名子合集，再刪除此合集。",
+    "Could not check the log file.": "無法檢查日誌檔案。",
+    "The log folder could not be created.": "無法建立日誌資料夾。",
+    "The log file could not be checked.": "無法檢查日誌檔案。",
+    "The log backups could not be rotated.": "無法輪替日誌備份。",
+    "The log record could not be appended.": "無法附加日誌記錄。"
   }
 }


### PR DESCRIPTION
## Problem

D01–D04 affect the final diagnostic boundary: compound credentials in JSON error text bypass field redaction, ordinary wide payloads exceed the file budget, ignored backup-move failures can overwrite retained history, and General settings displays a one-time log-status snapshot.

## Proposed change

- Reuse sensitive-key classification for quoted/colon assignments and escaped JSON keys before final file/console output.
- Reuse bounded traversal for ordinary records (10,000 nodes, 256 Ki UTF-16 character budget, 2 MiB final JSONL ceiling). Preserve metadata and complete JSON with omission markers; reject records exceeding a smaller configured file cap using the existing `append` failure category. Avoid payload `toJSON` execution and retain readable circular-object fields.
- Stop rotation on intermediate I/O failure; ignore only missing backups. Keep existing `rotation` status and successful-write recovery.
- Add local status-read failure/retry, loading feedback, and refresh after Open/Reveal and window focus. Ignore stale responses and translate failure explanations in all eight locales.

## Scope and non-goals

No new dependencies, shared enums, IPC fields, database schema, archive system, or polling service. Renderer request/error state is local only. Existing JSONL format and `main.N.log` layout remain; old logs are not rewritten or retroactively redacted. Future persisted tool-detail text also uses the strengthened shared helper. Synchronous fatal logging retains its documented one-bounded-record file-cap exception. Arbitrary user getters/proxies cannot be preempted by JavaScript; traversal does not amplify shared structures.

## Acceptance criteria and validation

Tests were added before production edits. On the unchanged base `109dca720da1f0aaab2782e5c328f70c9b35df72`, the final regression cases ran twice with identical outcomes: **16 failures matching the reports and 2 passing controls**. The repaired cases pass.

Checks below ran after the last material edit and the translation-only conflict resolution onto main (`fb0ccbe0`):

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| File + console privacy, wide arrays/objects/DAGs, escaped byte size, cap recovery, backup failure/recovery | `src/main/logger.test.ts` | Pass |
| Shared redaction consumers and persisted tool payloads | `src/shared/tool-detail-sanitizer.test.ts`, `src/shared/session-persistence.test.ts`, `src/main/database/startup-diagnostics.test.ts`, `src/main/connectors/mcp-client-manager.test.ts` | Pass |
| Diagnostic producers and failure lifecycle | `src/main/diagnostics/`, `crash-diagnostics.test.ts`, `renderer-diagnostics.test.ts`, `notebook/runtime-diagnostics.test.ts`, `agents/completion-gate-diagnostics.test.ts` | Pass |
| Electron/Web command and preload contracts | `logs-ipc.test.ts`, `host-application-commands.test.ts`, `application-command-wiring.test.ts`, `src/preload/index.test.ts` | Pass |
| Loading, retry, Open/Reveal refresh, focus, stale responses, translations | `GeneralPanel.render.test.tsx`, `src/renderer/src/i18n/resources.test.ts` | Pass |

These explicit Vitest targets total **1,345 tests across 22 files**. MCP tests ran outside the filesystem sandbox because their loopback OAuth callback servers require local port binding. `npm run lint`, changed-file Prettier checks, `git diff --check`, and `npm run typecheck:web` pass on the rebased head. The complete `npm run typecheck` passed before rebase. On the rebased head its Node stage is blocked only by the newly merged literature dependency `citeme-engine-wasm`, which is absent from the reused local dependency tree; CI Static checks validates the locked dependency environment. The worktree uses an isolated Prisma client generated from the current main schema; other worktrees’ generated clients were not changed.

The repository's affected-test classifier reports `logger.test.ts -> unknown module owner -> full`. Per maintainer instruction, no complete local `npm test` was run; PR CI supplies full and platform validation. CodeGraph established shared-helper/logger consumers; the worktree has no local index, so final interface preservation was checked against the diff and consumer/type checks, without treating the main-checkout index as current worktree evidence.

Browser verification used the actual GeneralPanel and styles with a local mocked log API: initial failure → retry → usable log actions → Open shows rotation failure → Reveal clears the recovered warning. Screenshots were delivered to the maintainer. This checks renderer behavior, not native OS application launching. Windows/macOS/Linux lock behavior remains covered by injected I/O tests locally and platform CI; no real Windows lock was induced.

## Review focus

Check privacy before budget truncation, early termination on shared structures, retained-backup preservation after an intermediate failure, and stale status-response rejection. Independent PR review and required CI remain the final verification authority.
