### PR TITLE
fix(cli): restore service discovery and launcher reliability

### DIFF
--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -97,9 +97,15 @@ jobs:
         # unrelated shards or native sandbox. These are the suites from the recent failed batches.
         run: >-
           npm test --
-          cli/lifecycle.test.ts
-          src/main/cli-install/launcher.test.ts
-          src/main/cli-install/ipc.test.ts
+          vitest.config.test.ts
+          scripts/ci/release-workflows.test.ts
+          scripts/windows-release-workflows.test.ts
+          src/main/database/database-null-and-version-bounds.test.ts
+          src/main/database/migration-service.test.ts
+          src/main/notebook/runtime-service.test.ts
+          src/main/artifacts/provenance-repository.test.ts
+          src/main/artifacts/provenance-write-contract.test.ts
+          src/main/delegation/production-composition.test.ts
           --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
 
   notebook_sandbox:

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -97,15 +97,9 @@ jobs:
         # unrelated shards or native sandbox. These are the suites from the recent failed batches.
         run: >-
           npm test --
-          vitest.config.test.ts
-          scripts/ci/release-workflows.test.ts
-          scripts/windows-release-workflows.test.ts
-          src/main/database/database-null-and-version-bounds.test.ts
-          src/main/database/migration-service.test.ts
-          src/main/notebook/runtime-service.test.ts
-          src/main/artifacts/provenance-repository.test.ts
-          src/main/artifacts/provenance-write-contract.test.ts
-          src/main/delegation/production-composition.test.ts
+          cli/lifecycle.test.ts
+          src/main/cli-install/launcher.test.ts
+          src/main/cli-install/ipc.test.ts
           --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
 
   notebook_sandbox:

--- a/cli/index.test.ts
+++ b/cli/index.test.ts
@@ -3,6 +3,13 @@ import { describe, expect, it } from 'vitest'
 import { isProcessAlive, parseCliArgs } from './index.mjs'
 
 describe('CLI argument parsing', () => {
+  it.each(['start', 'url'])(
+    'rejects unsupported --json for %s instead of ignoring it',
+    (command) => {
+      expect(() => parseCliArgs([command, '--json'])).toThrow('--json is not supported')
+    }
+  )
+
   it('parses start options', () => {
     expect(
       parseCliArgs([

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -17,6 +17,8 @@ import {
   isProcessAlive,
   openLaunchLog,
   parseCliArgs,
+  runCli,
+  reportCliError,
   statusCommand,
   stopCommand,
   terminateDaemon,
@@ -31,6 +33,7 @@ import {
   STATE_FILE,
   TOKEN_FILE
 } from './config-root.mjs'
+import { connectToOpenScience } from '../packages/open-science/index.mjs'
 
 // A running daemon's on-disk state, as findServiceState would return it.
 const RUNNING_STATE = { pid: 4242, port: 44100, configRoot: '/tmp/os-config' }
@@ -75,6 +78,8 @@ const makeDeps = (overrides: Partial<CommandDeps> = {}): CommandDeps => {
 afterEach(() => {
   process.exitCode = undefined
   vi.unstubAllEnvs()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
   vi.mocked(homedir).mockReset()
 })
 
@@ -114,6 +119,7 @@ describe('C01 automatic service discovery', () => {
           return {
             ok: healthy,
             status: healthy ? 200 : 503,
+            json: async () => ({ data: { appName: 'Open Science' } }),
             arrayBuffer: async () => new ArrayBuffer(0)
           }
         })
@@ -123,6 +129,26 @@ describe('C01 automatic service discovery', () => {
       await rm(home, { recursive: true, force: true })
     }
   }
+
+  it.each(['dead', 'unhealthy'] as const)(
+    'connects the SDK past a %s candidate',
+    async (preferred) => {
+      await withCandidates(preferred, async ({ deps }) => {
+        const client = await connectToOpenScience({ fetch: deps.fetch })
+        expect(client.baseUrl).toBe('http://127.0.0.1:44102')
+      })
+    }
+  )
+
+  it('reuses the healthy production service on start past an unhealthy candidate', async () => {
+    await withCandidates('unhealthy', async ({ deps }) => {
+      vi.stubGlobal('fetch', deps.fetch)
+      vi.spyOn(process, 'kill').mockImplementation(() => true)
+      const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+      await runCli(['start', '--no-open', '--app-path', join(tmpdir(), 'missing-open-science-app')])
+      expect(log).toHaveBeenCalledWith('Open Science is already running (PID 4242).')
+    })
+  })
 
   it.each(['dead', 'unhealthy'] as const)(
     'finds the healthy production service on both queries with a %s preferred PID',
@@ -203,6 +229,46 @@ describe('C01 automatic service discovery', () => {
       expect(deps.fetch.mock.calls.some(([url]) => url.includes(':44102/'))).toBe(false)
     })
   })
+
+  it.each(['OPEN_SCIENCE_CONFIG_ROOT', 'OPEN_SCIENCE_STORAGE_ROOT'])(
+    'keeps discovery bounded by %s',
+    async (name) => {
+      await withCandidates('unhealthy', async ({ deps, devRoot }) => {
+        vi.stubEnv(name, devRoot)
+        await statusCommand({ json: true }, deps)
+        expect(JSON.parse(deps.log.mock.calls[0][0])).toEqual({ running: false })
+        expect(deps.fetch.mock.calls.some(([url]) => url.includes(':44102/'))).toBe(false)
+        await expect(connectToOpenScience({ fetch: deps.fetch })).rejects.toThrow()
+        expect(deps.fetch.mock.calls.some(([url]) => url.includes(':44102/'))).toBe(false)
+      })
+    }
+  )
+
+  it('fails a bounded stop without deleting or signalling a live unhealthy candidate', async () => {
+    await withCandidates('unhealthy', async ({ deps, devRoot }) => {
+      await expect(stopCommand({ configRoot: devRoot }, deps)).rejects.toThrow(
+        'authenticated shutdown request was not accepted'
+      )
+      expect(deps.removeState).not.toHaveBeenCalled()
+      expect(deps.forceKill).not.toHaveBeenCalled()
+      expect(deps.fetch.mock.calls.some(([url]) => url.includes(':44102/'))).toBe(false)
+    })
+  })
+
+  it('does not continue SDK discovery after cancellation', async () => {
+    await withCandidates('unhealthy', async ({ deps }) => {
+      const controller = new AbortController()
+      const reason = new Error('cancel connection')
+      deps.fetch.mockImplementationOnce(async () => {
+        controller.abort(reason)
+        throw reason
+      })
+      await expect(
+        connectToOpenScience({ fetch: deps.fetch, signal: controller.signal })
+      ).rejects.toBe(reason)
+      expect(deps.fetch).toHaveBeenCalledTimes(1)
+    })
+  })
 })
 
 describe('C05 stop --json output', () => {
@@ -230,10 +296,34 @@ describe('C05 stop --json output', () => {
       await stopCommand(parseCliArgs(['stop', '--json']).options, deps)
       expect(deps.log).toHaveBeenCalledTimes(1)
       const stdout = deps.log.mock.calls.map((args) => args.join(' ')).join('\n')
-      expect(JSON.parse(stdout)).toBeTypeOf('object')
+      expect(JSON.parse(stdout)).toEqual({
+        result:
+          kind === 'already stopped'
+            ? 'already-stopped'
+            : kind === 'daemon'
+              ? 'daemon-stopped'
+              : 'web-service-stopped'
+      })
       expect(process.exitCode).toBeUndefined()
     }
   )
+
+  it('keeps rejected shutdown machine-readable and unsuccessful', async () => {
+    const deps = makeDeps({ fetch: vi.fn().mockResolvedValue({ ok: false, status: 401 }) })
+    const errorOutput = vi.fn()
+    const setExitCode = vi.fn()
+    await stopCommand({ json: true }, deps).catch((error) => {
+      reportCliError(error, ['stop', '--json'], { error: errorOutput, setExitCode })
+    })
+    expect(deps.log).not.toHaveBeenCalled()
+    expect(JSON.parse(errorOutput.mock.calls[0][0])).toMatchObject({
+      error: { code: 'command_failed' },
+      exitCode: 1
+    })
+    expect(setExitCode).toHaveBeenCalledWith(1)
+    expect(deps.removeState).not.toHaveBeenCalled()
+    expect(deps.forceKill).not.toHaveBeenCalled()
+  })
 })
 
 describe('terminateDaemon', () => {

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -1,23 +1,36 @@
 import { EventEmitter } from 'node:events'
 import { closeSync } from 'node:fs'
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>()
+  return { ...actual, homedir: vi.fn(actual.homedir) }
+})
 
 import {
   buildAppLaunchArgs,
   formatStartupFailure,
   isProcessAlive,
   openLaunchLog,
+  parseCliArgs,
   statusCommand,
   stopCommand,
   terminateDaemon,
   urlCommand,
   waitForStartup
 } from './index.mjs'
-import { findServiceState, STATE_FILE } from './config-root.mjs'
+import {
+  DEV_CONFIG_DIR,
+  PROD_CONFIG_DIR,
+  findServiceState,
+  readWebToken,
+  STATE_FILE,
+  TOKEN_FILE
+} from './config-root.mjs'
 
 // A running daemon's on-disk state, as findServiceState would return it.
 const RUNNING_STATE = { pid: 4242, port: 44100, configRoot: '/tmp/os-config' }
@@ -61,6 +74,166 @@ const makeDeps = (overrides: Partial<CommandDeps> = {}): CommandDeps => {
 
 afterEach(() => {
   process.exitCode = undefined
+  vi.unstubAllEnvs()
+  vi.mocked(homedir).mockReset()
+})
+
+describe('C01 automatic service discovery', () => {
+  const withCandidates = async (
+    preferred: 'dead' | 'unhealthy' | 'healthy',
+    check: (fixture: { deps: CommandDeps; devRoot: string; prodRoot: string }) => Promise<void>
+  ): Promise<void> => {
+    const home = await mkdtemp(join(tmpdir(), 'open-science-candidates-'))
+    const devRoot = join(home, DEV_CONFIG_DIR)
+    const prodRoot = join(home, PROD_CONFIG_DIR)
+    vi.mocked(homedir).mockReturnValue(home)
+    vi.stubEnv('OPEN_SCIENCE_CONFIG_ROOT', undefined)
+    vi.stubEnv('OPEN_SCIENCE_STORAGE_ROOT', undefined)
+    let stopped = false
+    try {
+      for (const [configRoot, pid, port] of [
+        [devRoot, 4241, 44101],
+        [prodRoot, 4242, 44102]
+      ] as const) {
+        await mkdir(configRoot)
+        await writeFile(
+          join(configRoot, STATE_FILE),
+          JSON.stringify({ configRoot, pid, port, startedAt: '2026-09-01T00:00:00Z' })
+        )
+        await writeFile(join(configRoot, TOKEN_FILE), `token-${port}`)
+      }
+      const deps = makeDeps({
+        findServiceState: vi.fn((options) => findServiceState(options)),
+        readWebToken: vi.fn(readWebToken),
+        removeState: vi.fn((root) => rm(join(root, STATE_FILE), { force: true })),
+        isAlive: vi.fn((pid) => (pid === 4241 ? preferred !== 'dead' : !stopped)),
+        fetch: vi.fn(async (input: string) => {
+          const url = new URL(input)
+          const healthy = url.port === '44102' ? !stopped : preferred === 'healthy'
+          if (url.pathname === '/api/shutdown' && healthy) stopped = true
+          return {
+            ok: healthy,
+            status: healthy ? 200 : 503,
+            arrayBuffer: async () => new ArrayBuffer(0)
+          }
+        })
+      })
+      await check({ deps, devRoot, prodRoot })
+    } finally {
+      await rm(home, { recursive: true, force: true })
+    }
+  }
+
+  it.each(['dead', 'unhealthy'] as const)(
+    'finds the healthy production service on both queries with a %s preferred PID',
+    async (preferred) => {
+      await withCandidates(preferred, async ({ deps, devRoot, prodRoot }) => {
+        for (let attempt = 0; attempt < 2; attempt += 1) {
+          deps.log.mockClear()
+          deps.fetch.mockClear()
+          await statusCommand({ json: true }, deps)
+          expect.soft(JSON.parse(deps.log.mock.calls[0][0])).toMatchObject({
+            running: true,
+            configRoot: prodRoot
+          })
+          expect
+            .soft(deps.fetch)
+            .toHaveBeenCalledWith(
+              'http://127.0.0.1:44102/api/bootstrap',
+              expect.objectContaining({ headers: { authorization: 'Bearer token-44102' } })
+            )
+        }
+        if (preferred === 'unhealthy') {
+          expect(deps.removeState).not.toHaveBeenCalledWith(devRoot)
+          await expect(readFile(join(devRoot, STATE_FILE), 'utf8')).resolves.toContain('4241')
+        }
+      })
+    }
+  )
+
+  it.each(['dead', 'unhealthy'] as const)(
+    'gets the healthy URL past a %s candidate',
+    async (preferred) => {
+      await withCandidates(preferred, async ({ deps }) => {
+        await urlCommand({}, deps)
+        expect(deps.log).toHaveBeenCalledWith('http://127.0.0.1:44102/?token=token-44102')
+      })
+    }
+  )
+
+  it.each(['dead', 'unhealthy'] as const)(
+    'stops only the selected authenticated target past a %s candidate',
+    async (preferred) => {
+      await withCandidates(preferred, async ({ deps, devRoot, prodRoot }) => {
+        await stopCommand({}, deps)
+        expect(deps.fetch.mock.calls.filter(([url]) => url.endsWith('/api/shutdown'))).toEqual([
+          [
+            'http://127.0.0.1:44102/api/shutdown',
+            expect.objectContaining({
+              method: 'POST',
+              headers: { authorization: 'Bearer token-44102' }
+            })
+          ]
+        ])
+        expect(deps.removeState).toHaveBeenCalledWith(prodRoot)
+        if (preferred === 'unhealthy') expect(deps.removeState).not.toHaveBeenCalledWith(devRoot)
+        expect(deps.forceKill).not.toHaveBeenCalled()
+      })
+    }
+  )
+
+  it.each(['dead', 'unhealthy'] as const)(
+    'keeps explicit discovery bounded with a %s candidate',
+    async (preferred) => {
+      await withCandidates(preferred, async ({ deps, devRoot }) => {
+        await statusCommand({ json: true, configRoot: devRoot }, deps)
+        expect(JSON.parse(deps.log.mock.calls[0][0])).toEqual({ running: false })
+        expect(deps.fetch.mock.calls.some(([url]) => url.includes(':44102/'))).toBe(false)
+      })
+    }
+  )
+
+  it('preserves development-first selection when both instances are healthy', async () => {
+    await withCandidates('healthy', async ({ deps, devRoot }) => {
+      await statusCommand({ json: true }, deps)
+      expect(JSON.parse(deps.log.mock.calls[0][0])).toMatchObject({
+        running: true,
+        configRoot: devRoot
+      })
+      expect(deps.fetch.mock.calls.some(([url]) => url.includes(':44102/'))).toBe(false)
+    })
+  })
+})
+
+describe('C05 stop --json output', () => {
+  it.each(['already stopped', 'daemon', 'attached web service'] as const)(
+    'emits one parseable JSON object when stopping %s',
+    async (kind) => {
+      let stopped = false
+      const deps = makeDeps({
+        findServiceState: vi
+          .fn()
+          .mockResolvedValue(
+            kind === 'already stopped'
+              ? undefined
+              : { ...RUNNING_STATE, attached: kind === 'attached web service' }
+          ),
+        isAlive: vi.fn(() => kind === 'attached web service' || !stopped),
+        fetch: vi.fn(async (url: string) => {
+          if (url.endsWith('/api/shutdown')) {
+            stopped = true
+            return { ok: true, arrayBuffer: async () => new ArrayBuffer(0) }
+          }
+          return { ok: !stopped }
+        })
+      })
+      await stopCommand(parseCliArgs(['stop', '--json']).options, deps)
+      expect(deps.log).toHaveBeenCalledTimes(1)
+      const stdout = deps.log.mock.calls.map((args) => args.join(' ')).join('\n')
+      expect(JSON.parse(stdout)).toBeTypeOf('object')
+      expect(process.exitCode).toBeUndefined()
+    }
+  )
 })
 
 describe('terminateDaemon', () => {

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -244,6 +244,31 @@ describe('C01 automatic service discovery', () => {
     }
   )
 
+  it('cleans the enumerated dead root even when its record names another root', async () => {
+    await withCandidates('dead', async ({ deps, devRoot, prodRoot }) => {
+      const path = join(devRoot, STATE_FILE)
+      const state = JSON.parse(await readFile(path, 'utf8'))
+      await writeFile(path, JSON.stringify({ ...state, configRoot: prodRoot }))
+      await statusCommand({ json: true }, deps)
+      expect
+        .soft(JSON.parse(deps.log.mock.calls[0][0]))
+        .toMatchObject({ running: true, configRoot: prodRoot })
+      await expect.soft(readFile(join(prodRoot, STATE_FILE), 'utf8')).resolves.toContain('4242')
+      expect(deps.removeState).toHaveBeenCalledWith(devRoot)
+    })
+  })
+
+  it('reads tokens only from the explicit root even when its record names another root', async () => {
+    await withCandidates('unhealthy', async ({ deps, devRoot, prodRoot }) => {
+      const path = join(devRoot, STATE_FILE)
+      const state = JSON.parse(await readFile(path, 'utf8'))
+      await writeFile(path, JSON.stringify({ ...state, configRoot: prodRoot }))
+      await statusCommand({ configRoot: devRoot, json: true }, deps)
+      expect(deps.readWebToken.mock.calls.every(([root]) => root === devRoot)).toBe(true)
+      expect(deps.removeState).not.toHaveBeenCalled()
+    })
+  })
+
   it('fails a bounded stop without deleting or signalling a live unhealthy candidate', async () => {
     await withCandidates('unhealthy', async ({ deps, devRoot }) => {
       await expect(stopCommand({ configRoot: devRoot }, deps)).rejects.toThrow(
@@ -309,14 +334,17 @@ describe('C05 stop --json output', () => {
   )
 
   it('keeps rejected shutdown machine-readable and unsuccessful', async () => {
-    const deps = makeDeps({ fetch: vi.fn().mockResolvedValue({ ok: false, status: 401 }) })
     const errorOutput = vi.fn()
+    const deps = makeDeps({
+      fetch: vi.fn().mockResolvedValue({ ok: false, status: 401 }),
+      warn: errorOutput
+    })
     const setExitCode = vi.fn()
     await stopCommand({ json: true }, deps).catch((error) => {
       reportCliError(error, ['stop', '--json'], { error: errorOutput, setExitCode })
     })
     expect(deps.log).not.toHaveBeenCalled()
-    expect(JSON.parse(errorOutput.mock.calls[0][0])).toMatchObject({
+    expect(JSON.parse(errorOutput.mock.calls.map(([line]) => line).join('\n'))).toMatchObject({
       error: { code: 'command_failed' },
       exitCode: 1
     })

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -61,6 +61,23 @@ command fails without signalling the PID recorded in `web-service.json`; a stale
 reused by an unrelated process. The state file is retained for diagnosis and can be replaced by a
 later `open-science start`.
 
+Automatic discovery tries the development config directory before the production directory, skipping
+dead or unhealthy candidates until it finds a healthy service. An explicit `--config-root`,
+`OPEN_SCIENCE_CONFIG_ROOT`, or `OPEN_SCIENCE_STORAGE_ROOT` limits discovery to that directory. Live
+unhealthy records are retained; failed authentication never authorizes signalling a recorded PID.
+
+`open-science stop --json` prints exactly one result object on success:
+
+| `result`              | Meaning                                                            |
+| --------------------- | ------------------------------------------------------------------ |
+| `already-stopped`     | No live service record was found.                                  |
+| `daemon-stopped`      | The authenticated standalone daemon exited.                        |
+| `web-service-stopped` | The attached web service stopped; the desktop app remains running. |
+
+Among lifecycle commands, `status`, `stop`, and `update` support `--json`. `start` and `url` reject
+it; run `start --no-open` followed by `status --json` for machine-readable startup status. Errors
+with `--json` are reported on stderr as a JSON error object with a nonzero exit code.
+
 ## Application updates
 
 Check, download, and apply an Open Science application update without opening the browser or desktop

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -753,7 +753,7 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
     shutdownAccepted = true
     await response.arrayBuffer()
   } catch (error) {
-    deps.warn(`Graceful shutdown failed: ${error.message}`)
+    if (!options.json) deps.warn(`Graceful shutdown failed: ${error.message}`)
   }
 
   if (!shutdownAccepted) {

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -302,6 +302,9 @@ export const parseCliArgs = (argv) => {
   if (options.json && options.jsonl) {
     throw new CliUsageError('Use only one of --json or --jsonl.')
   }
+  if (options.json && (command === 'start' || command === 'url')) {
+    throw new CliUsageError(`--json is not supported for ${command}.`)
+  }
   if (options.cwd !== undefined && !options.cwd.trim()) {
     throw new CliUsageError('--cwd requires a non-empty path.')
   }
@@ -649,7 +652,7 @@ export const formatStartupFailure = (outcome, logTail, options) => {
 }
 
 const startCommand = async (options, deps = DEFAULT_DEPS) => {
-  const existing = await deps.findServiceState({ override: options.configRoot })
+  const existing = await findCurrentState(options, deps)
   if (await healthCheck(existing, deps)) {
     const url = await authenticatedUrl(existing, deps)
     deps.log(`Open Science is already running (PID ${existing.pid}).`)
@@ -713,19 +716,29 @@ const startCommand = async (options, deps = DEFAULT_DEPS) => {
 }
 
 const findCurrentState = async (options, deps = DEFAULT_DEPS) => {
-  const state = await deps.findServiceState({ override: options.configRoot })
-  if (!state) return undefined
-  if (!deps.isAlive(state.pid)) {
-    await deps.removeState(state.configRoot)
-    return undefined
-  }
-  return state
+  let firstLiveState
+  const state = await deps.findServiceState({
+    override: options.configRoot,
+    accept: async (candidate) => {
+      if (!deps.isAlive(candidate.pid)) {
+        await deps.removeState(candidate.configRoot)
+        return false
+      }
+      firstLiveState ??= candidate
+      return healthCheck(candidate, deps)
+    }
+  })
+  // Keep a live but unhealthy candidate when none passed: stop must still authenticate its shutdown
+  // or fail, rather than claim that an unreachable process has already stopped.
+  return state ?? firstLiveState
 }
 
 export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
   const state = await findCurrentState(options, deps)
   if (!state) {
-    deps.log('Open Science is not running.')
+    deps.log(
+      options.json ? JSON.stringify({ result: 'already-stopped' }) : 'Open Science is not running.'
+    )
     return
   }
   const token = await deps.readWebToken(state.configRoot)
@@ -759,7 +772,11 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
       )
     }
     await deps.removeState(state.configRoot)
-    deps.log('Open Science web service stopped; the app is still running.')
+    deps.log(
+      options.json
+        ? JSON.stringify({ result: 'web-service-stopped' })
+        : 'Open Science web service stopped; the app is still running.'
+    )
     return
   }
 
@@ -777,7 +794,7 @@ export const stopCommand = async (options, deps = DEFAULT_DEPS) => {
     )
   }
   await deps.removeState(state.configRoot)
-  deps.log('Open Science stopped.')
+  deps.log(options.json ? JSON.stringify({ result: 'daemon-stopped' }) : 'Open Science stopped.')
 }
 
 export const statusCommand = async (options, deps = DEFAULT_DEPS) => {

--- a/packages/open-science/config-root.mjs
+++ b/packages/open-science/config-root.mjs
@@ -54,7 +54,7 @@ export const findServiceState = async (options = {}) => {
   for (const configRoot of candidateConfigRoots(options)) {
     if (!(await exists(join(configRoot, STATE_FILE)))) continue
     const state = await readStateFromRoot(configRoot)
-    if (state) return state
+    if (state && (!options.accept || (await options.accept(state)))) return state
   }
   return undefined
 }

--- a/packages/open-science/config-root.mjs
+++ b/packages/open-science/config-root.mjs
@@ -44,7 +44,9 @@ export const readStateFromRoot = async (configRoot) => {
     ) {
       return undefined
     }
-    return { ...state, configRoot: state.configRoot || configRoot }
+    // The containing directory owns both the state and token. A stale or edited payload must not
+    // redirect credential reads or cleanup outside the enumerated candidate.
+    return { ...state, configRoot }
   } catch {
     return undefined
   }

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -634,8 +634,32 @@ export const connectToOpenScience = async ({
   requestTimeoutMs,
   signal
 } = {}) => {
-  const state = await findServiceState({ override: configRoot, env })
-  if (!state) {
+  let client
+  let lastError
+  await findServiceState({
+    override: configRoot,
+    env,
+    accept: async (state) => {
+      signal?.throwIfAborted()
+      try {
+        const candidate = new OpenScienceClient({
+          baseUrl: `http://127.0.0.1:${state.port}`,
+          token: await readWebToken(state.configRoot),
+          fetch,
+          requestTimeoutMs
+        })
+        await candidate.health({ signal })
+        client = candidate
+        return true
+      } catch (error) {
+        signal?.throwIfAborted()
+        lastError = error
+        return false
+      }
+    }
+  })
+  if (!client) {
+    if (lastError) throw lastError
     throw new OpenScienceApiError(
       'Open Science is not running. Start it with "open-science start".',
       {
@@ -643,13 +667,5 @@ export const connectToOpenScience = async ({
       }
     )
   }
-  const token = await readWebToken(state.configRoot)
-  const client = new OpenScienceClient({
-    baseUrl: `http://127.0.0.1:${state.port}`,
-    token,
-    fetch,
-    requestTimeoutMs
-  })
-  await client.health({ signal })
   return client
 }

--- a/src/main/cli-install/ipc.test.ts
+++ b/src/main/cli-install/ipc.test.ts
@@ -85,10 +85,21 @@ describe('registerCliInstallIpcHandlers', () => {
     expect(launcher.uninstallCliLauncher).toHaveBeenCalledTimes(1)
   })
 
-  it('get-status returns a safe default instead of rejecting when the launcher throws', async () => {
-    launcher.getCliLauncherStatus.mockRejectedValue(new Error('fs blew up'))
-    const result = await handlers.get('cli:get-status')!()
-    expect(result).toEqual({ installed: false, target: '', onPath: false })
+  it('C03 rejects an unavailable status and returns the real status after retry', async () => {
+    const error = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    launcher.getCliLauncherStatus.mockRejectedValueOnce(error).mockResolvedValueOnce(INSTALLED)
+
+    await expect.soft(handlers.get('cli:get-status')!()).rejects.toBe(error)
+    await expect(handlers.get('cli:get-status')!()).resolves.toEqual(INSTALLED)
+    expect(launcher.getCliLauncherStatus).toHaveBeenCalledTimes(2)
+  })
+
+  it.each(['install', 'uninstall'] as const)('preserves %s failure propagation', async (action) => {
+    const error = Object.assign(new Error('permission denied'), { code: 'EACCES' })
+    launcher[
+      action === 'install' ? 'installCliLauncher' : 'uninstallCliLauncher'
+    ].mockRejectedValueOnce(error)
+    await expect(handlers.get(`cli:${action}`)!()).rejects.toBe(error)
   })
 
   it('reconciles an AppImage launcher through the owner and logs failures', async () => {

--- a/src/main/cli-install/ipc.ts
+++ b/src/main/cli-install/ipc.ts
@@ -57,7 +57,7 @@ const createCliCommandOwner = (): CliCommandOwnerWithLifecycle => ({
       return await getCliLauncherStatus(resolveCliLauncherEnv())
     } catch (error) {
       logger.error('cli get-status failed', error)
-      return { installed: false, target: '', onPath: false }
+      throw error
     }
   },
   install: async (): Promise<CliLauncherStatus> => {

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -172,7 +172,7 @@ describe('planCliLauncher', () => {
   })
 })
 
-pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
+describe('initial CLI installation failure recovery', () => {
   it.each(['first write', 'partial write', 'chmod'] as const)(
     'C02 recovers a failed initial %s so installation can be retried',
     async (failure) => {
@@ -190,7 +190,7 @@ pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
         if (failure === 'partial write') {
           write.mockImplementationOnce(async function (this: FileHandle) {
             const prefix = Buffer.from(plan.shim).subarray(0, 8)
-            return originalWrite.call(this, prefix, 0, prefix.length, 0)
+            return Reflect.apply(originalWrite, this, [prefix, 0, prefix.length, 0])
           })
         }
         write.mockRejectedValueOnce(error)
@@ -208,26 +208,31 @@ pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
     }
   )
 
-  it('C02 preserves a concurrent user replacement when initial writing fails', async () => {
-    const env = posixEnv()
-    const plan = planCliLauncher(env)
-    const probe = await open(join(home, 'file-handle-probe'), 'w')
-    const prototype = Object.getPrototypeOf(probe) as FileHandle
-    await probe.close()
-    const error = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
-    const userContent = '#!/bin/sh\necho user-owned\n'
-    vi.spyOn(prototype, 'write').mockImplementationOnce(async () => {
-      const replacement = join(home, 'user-replacement')
-      await writeFile(replacement, userContent)
-      await rename(replacement, plan.target)
-      throw error
-    })
+  it.skipIf(process.platform === 'win32')(
+    'C02 preserves a concurrent user replacement when initial writing fails',
+    async () => {
+      const env = posixEnv()
+      const plan = planCliLauncher(env)
+      const probe = await open(join(home, 'file-handle-probe'), 'w')
+      const prototype = Object.getPrototypeOf(probe) as FileHandle
+      await probe.close()
+      const error = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+      const userContent = '#!/bin/sh\necho user-owned\n'
+      vi.spyOn(prototype, 'write').mockImplementationOnce(async () => {
+        const replacement = join(home, 'user-replacement')
+        await writeFile(replacement, userContent)
+        await rename(replacement, plan.target)
+        throw error
+      })
 
-    await expect(installCliLauncher(env)).rejects.toBe(error)
-    await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
-    await expect(installCliLauncher(env)).rejects.toThrow(/not managed by Open Science/)
-  })
+      await expect(installCliLauncher(env)).rejects.toBe(error)
+      await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
+      await expect(installCliLauncher(env)).rejects.toThrow(/not managed by Open Science/)
+    }
+  )
+})
 
+pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
   it('writes an executable shim and reports a PATH hint when not on PATH', async () => {
     const status = await installCliLauncher(posixEnv())
     expect(status.installed).toBe(true)

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -7,6 +7,7 @@ import {
   open,
   readFile,
   readdir,
+  rename,
   rm,
   stat,
   symlink,
@@ -172,6 +173,61 @@ describe('planCliLauncher', () => {
 })
 
 pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
+  it.each(['first write', 'partial write', 'chmod'] as const)(
+    'C02 recovers a failed initial %s so installation can be retried',
+    async (failure) => {
+      const env = posixEnv()
+      const plan = planCliLauncher(env)
+      const probe = await open(join(home, 'file-handle-probe'), 'w')
+      const prototype = Object.getPrototypeOf(probe) as FileHandle
+      await probe.close()
+      const error = Object.assign(new Error('injected install failure'), { code: 'ENOSPC' })
+      if (failure === 'chmod') {
+        vi.spyOn(prototype, 'chmod').mockRejectedValueOnce(error)
+      } else {
+        const originalWrite = prototype.write
+        const write = vi.spyOn(prototype, 'write')
+        if (failure === 'partial write') {
+          write.mockImplementationOnce(async function (this: FileHandle) {
+            const prefix = Buffer.from(plan.shim).subarray(0, 8)
+            return originalWrite.call(this, prefix, 0, prefix.length, 0)
+          })
+        }
+        write.mockRejectedValueOnce(error)
+      }
+
+      await expect(installCliLauncher(env)).rejects.toBe(error)
+      if (failure !== 'chmod') {
+        expect.soft((await getCliLauncherStatus(env)).installed).toBe(false)
+        await expect.soft(lstat(plan.target)).rejects.toMatchObject({ code: 'ENOENT' })
+      }
+      vi.restoreAllMocks()
+
+      await expect(installCliLauncher(env)).resolves.toMatchObject({ installed: true })
+      await expect(readFile(plan.target, 'utf8')).resolves.toBe(plan.shim)
+    }
+  )
+
+  it('C02 preserves a concurrent user replacement when initial writing fails', async () => {
+    const env = posixEnv()
+    const plan = planCliLauncher(env)
+    const probe = await open(join(home, 'file-handle-probe'), 'w')
+    const prototype = Object.getPrototypeOf(probe) as FileHandle
+    await probe.close()
+    const error = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    const userContent = '#!/bin/sh\necho user-owned\n'
+    vi.spyOn(prototype, 'write').mockImplementationOnce(async () => {
+      const replacement = join(home, 'user-replacement')
+      await writeFile(replacement, userContent)
+      await rename(replacement, plan.target)
+      throw error
+    })
+
+    await expect(installCliLauncher(env)).rejects.toBe(error)
+    await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
+    await expect(installCliLauncher(env)).rejects.toThrow(/not managed by Open Science/)
+  })
+
   it('writes an executable shim and reports a PATH hint when not on PATH', async () => {
     const status = await installCliLauncher(posixEnv())
     expect(status.installed).toBe(true)
@@ -263,6 +319,71 @@ pdescribe('installCliLauncher / status / uninstall (POSIX)', () => {
     expect(events.slice(flushedAt + 1)).toContainEqual({ operation: 'stat', fd: validatedFd })
     await expect(readFile(originalPlan.target, 'utf8')).resolves.toBe(planCliLauncher(nextEnv).shim)
   })
+})
+
+describe.skipIf(process.platform !== 'win32')('C04 native cmd caller environment', () => {
+  it.each([
+    [true, undefined, 0],
+    [true, undefined, 7],
+    [true, 'caller-original', 0],
+    [true, 'caller-original', 7],
+    [false, undefined, 0],
+    [false, undefined, 7],
+    [false, 'caller-original', 0],
+    [false, 'caller-original', 7]
+  ] as const)(
+    'restores variables for packaged=%s, original=%s, exit=%s',
+    async (packaged, original, exitCode) => {
+      const entry = join(home, 'cli-fixture.cjs')
+      const probe = join(home, 'environment-probe.cjs')
+      const snapshot =
+        'console.log(JSON.stringify({ electron: process.env.ELECTRON_RUN_AS_NODE ?? null, app: process.env.OPEN_SCIENCE_APP_PATH ?? null }))'
+      await writeFile(entry, `${snapshot}; process.exit(Number(process.argv[2]));`)
+      await writeFile(probe, snapshot)
+      const plan = planCliLauncher(
+        winEnv({ appExecPath: process.execPath, cliEntryPath: entry, packaged })
+      )
+      await mkdir(plan.binDir, { recursive: true })
+      await writeFile(plan.target, plan.shim)
+      const caller = join(home, 'caller.cmd')
+      await writeFile(
+        caller,
+        [
+          '@echo off',
+          `call "${plan.target}" ${exitCode}`,
+          'set "CLI_TEST_EXIT=%errorlevel%"',
+          `"${process.execPath}" "${probe}"`,
+          'exit /b %CLI_TEST_EXIT%',
+          ''
+        ].join('\r\n')
+      )
+      const env = { ...process.env }
+      delete env.ELECTRON_RUN_AS_NODE
+      delete env.OPEN_SCIENCE_APP_PATH
+      if (original !== undefined) {
+        env.ELECTRON_RUN_AS_NODE = original
+        env.OPEN_SCIENCE_APP_PATH = original
+      }
+      const result = spawnSync('cmd.exe', ['/d', '/c', 'caller.cmd'], {
+        cwd: home,
+        env,
+        encoding: 'utf8',
+        timeout: 10_000
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.stderr).toBe('')
+      expect(result.status).toBe(exitCode)
+      const [child, parent] = result.stdout
+        .trim()
+        .split(/\r?\n/)
+        .map((line) => JSON.parse(line))
+      expect(child).toEqual({
+        electron: '1',
+        app: packaged ? process.execPath : (original ?? null)
+      })
+      expect(parent).toEqual({ electron: original ?? null, app: original ?? null })
+    }
+  )
 })
 
 describe.each([

--- a/src/main/cli-install/launcher.test.ts
+++ b/src/main/cli-install/launcher.test.ts
@@ -19,6 +19,11 @@ import { join } from 'node:path'
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, rm: vi.fn(actual.rm) }
+})
+
 const pdescribe = describe.skipIf(process.platform === 'win32')
 const symlinkDescribe = describe.skipIf(process.platform === 'win32')
 
@@ -86,6 +91,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   vi.restoreAllMocks()
+  vi.mocked(rm).mockReset()
   await rm(home, { recursive: true, force: true })
 })
 
@@ -173,6 +179,29 @@ describe('planCliLauncher', () => {
 })
 
 describe('initial CLI installation failure recovery', () => {
+  it('preserves a user replacement made immediately before failure cleanup unlinks a path', async () => {
+    const env = posixEnv()
+    const plan = planCliLauncher(env)
+    const replacement = join(home, 'late-user-replacement')
+    const userContent = '#!/bin/sh\necho user-owned\n'
+    await writeFile(replacement, userContent)
+    const probe = await open(join(home, 'file-handle-probe'), 'w')
+    const prototype = Object.getPrototypeOf(probe) as FileHandle
+    await probe.close()
+    const error = Object.assign(new Error('disk full'), { code: 'ENOSPC' })
+    vi.spyOn(prototype, 'write').mockRejectedValueOnce(error)
+    const originalRm = vi.mocked(rm).getMockImplementation()!
+    vi.mocked(rm).mockImplementationOnce(async (...args) => {
+      // Replace after any ownership check, immediately before the actual unlink. Cleanup must only
+      // unlink staging, never the final pathname which another process can now own.
+      await rename(replacement, plan.target)
+      return originalRm(...args)
+    })
+
+    await expect(installCliLauncher(env)).rejects.toBe(error)
+    await expect(readFile(plan.target, 'utf8')).resolves.toBe(userContent)
+  })
+
   it.each(['first write', 'partial write', 'chmod'] as const)(
     'C02 recovers a failed initial %s so installation can be retried',
     async (failure) => {

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -153,8 +153,10 @@ const windowsShim = (env: CliLauncherEnv): string => {
     '@echo off',
     `rem ${MANAGED_LAUNCHER_HEADER_V1}`,
     'rem Edits are overwritten on reinstall.',
+    'setlocal EnableExtensions DisableDelayedExpansion',
     'set ELECTRON_RUN_AS_NODE=1',
     `${appPathLine}"${env.appExecPath}" "${env.cliEntryPath}" %*`,
+    'endlocal & exit /b %errorlevel%',
     ''
   ].join('\r\n')
 }
@@ -562,6 +564,8 @@ const replaceCliLauncher = async (
 
 const tryCreateCliLauncher = async (plan: CliLauncherPlan): Promise<boolean> => {
   let handle: FileHandle
+  let created: Stats | undefined
+  let closed = false
   try {
     handle = await open(
       plan.target,
@@ -574,14 +578,29 @@ const tryCreateCliLauncher = async (plan: CliLauncherPlan): Promise<boolean> => 
   }
 
   try {
+    created = await handle.stat()
     await writeCliLauncher(handle, plan)
-    const created = await handle.stat()
     if (!(await isOpenCliLauncherCurrent(plan.target, created))) {
       refuseUnmanagedCliLauncher(plan.target)
     }
     return true
+  } catch (error) {
+    // O_EXCL proves this attempt created the file; the identity check prevents cleanup from adopting
+    // a same-name user replacement. Retain the original error if inspection or cleanup also fails.
+    if (created) {
+      try {
+        if (process.platform === 'win32') {
+          await handle.close()
+          closed = true
+        }
+        if (await isOpenCliLauncherCurrent(plan.target, created)) await rm(plan.target)
+      } catch {
+        // Fail closed when ownership cannot be checked, without masking the installation failure.
+      }
+    }
+    throw error
   } finally {
-    await handle.close()
+    if (!closed) await handle.close()
   }
 }
 

--- a/src/main/cli-install/launcher.ts
+++ b/src/main/cli-install/launcher.ts
@@ -1,7 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { randomUUID } from 'node:crypto'
 import { constants, type Stats } from 'node:fs'
-import { lstat, mkdir, open, rename, rm, type FileHandle } from 'node:fs/promises'
+import { link, lstat, mkdir, open, rename, rm, type FileHandle } from 'node:fs/promises'
 import { basename, join, posix } from 'node:path'
 
 import type { CliLauncherStatus } from '../../shared/cli'
@@ -563,45 +563,43 @@ const replaceCliLauncher = async (
 }
 
 const tryCreateCliLauncher = async (plan: CliLauncherPlan): Promise<boolean> => {
-  let handle: FileHandle
-  let created: Stats | undefined
-  let closed = false
+  if ((await statCliLauncher(plan.target)) !== undefined) return false
+  const temporaryPath = join(
+    plan.binDir,
+    `.${basename(plan.target)}.${process.pid}-${randomUUID()}.tmp`
+  )
+  let handle: FileHandle | undefined
+  let temporaryCreated = false
+  let created: Stats
   try {
     handle = await open(
-      plan.target,
+      temporaryPath,
       constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | (constants.O_NOFOLLOW ?? 0),
       plan.mode ?? 0o666
     )
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false
-    throw error
-  }
-
-  try {
-    created = await handle.stat()
+    temporaryCreated = true
     await writeCliLauncher(handle, plan)
-    if (!(await isOpenCliLauncherCurrent(plan.target, created))) {
-      refuseUnmanagedCliLauncher(plan.target)
+    await handle.sync()
+    created = await handle.stat()
+    await handle.close()
+    handle = undefined
+    // link publishes complete bytes only if target is absent; unlike rename, it cannot overwrite a
+    // concurrent user's file. Failure cleanup never unlinks the final pathname.
+    try {
+      await link(temporaryPath, plan.target)
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false
+      throw error
     }
-    return true
-  } catch (error) {
-    // O_EXCL proves this attempt created the file; the identity check prevents cleanup from adopting
-    // a same-name user replacement. Retain the original error if inspection or cleanup also fails.
-    if (created) {
-      try {
-        if (process.platform === 'win32') {
-          await handle.close()
-          closed = true
-        }
-        if (await isOpenCliLauncherCurrent(plan.target, created)) await rm(plan.target)
-      } catch {
-        // Fail closed when ownership cannot be checked, without masking the installation failure.
-      }
-    }
-    throw error
   } finally {
-    if (!closed) await handle.close()
+    await handle?.close().catch(() => undefined)
+    if (temporaryCreated) await rm(temporaryPath, { force: true }).catch(() => undefined)
   }
+  if (!(await isOpenCliLauncherCurrent(plan.target, created))) {
+    refuseUnmanagedCliLauncher(plan.target)
+  }
+  await defaultFileDurability.syncDirectory(plan.binDir)
+  return true
 }
 
 // Writes the launcher shim and, on Windows, ensures its dir is on the user PATH. Returns the resulting


### PR DESCRIPTION
## Problem

A stale development service record masks a healthy production service; interrupted first-time launcher writes block retry; status-check errors are reported as “not installed”; Windows shims leak their temporary environment into the calling cmd.exe; and successful `stop --json` commands print plain text.

## Proposed change

- Validate each discovery candidate before selecting it, including SDK connection and `start`. Keep development-first precedence and explicit CLI/environment root bounds; derive credential and cleanup roots from the containing directory, never an embedded payload path. Retain live unhealthy records and require authenticated shutdown; never signal a persisted PID.
- Write initial launchers to an exclusive same-directory temporary file, flush and close it, then publish with `link`, which fails if the target already exists. Failure cleanup only removes staging; it never unlinks a concurrently replaced final target. Preserve existing managed-file protections.
- Propagate status-check errors through the existing IPC rejection path, enabling General's existing error and Check again controls.
- Scope generated Windows shim variables with `setlocal/endlocal` and preserve the CLI exit code.
- Emit one stop JSON result (`already-stopped`, `daemon-stopped`, or `web-service-stopped`), and one JSON stderr error without a preceding plaintext warning on shutdown failure. Reject the previously ignored `--json` flag on `start`/`url` and document the lifecycle support matrix.

## Scope and non-goals

No database, persisted schema, launcher ownership-marker, or service-state format changes. The three `result` values are stdout output only. Historical unmarked/empty launcher files are not automatically adopted or deleted. Existing Windows shims receive the change on reinstall; no automatic migration is added.

Launcher ownership remains in `src/main/cli-install`: exact target plus managed header for existing files, and an exclusive random staging path for new attempts. Existing removal, Windows PATH receipts, and explicit uninstall remain unchanged. Cleanup does not scan directories. First publication requires filesystem hard-link support; normal APFS/ext4/NTFS paths are covered locally/CI. A process crash between publication and temporary unlink, or a cleanup I/O failure, may leave two links and fail the existing ownership guard closed, requiring manual recovery. No registry or new journal is introduced. Historical service payloads retain their format; a copied or edited embedded `configRoot` is ignored in favor of the actual containing directory.

## Acceptance criteria and validation

Regression tests were written and run against unchanged production code before fixes. Two initial local runs reproduced identical C01/C02/C03/C05 failures; the existing 90-test baseline passed. Supplementary SDK/start and unsupported-flag tests also failed before their fixes. C02 chmod retry already worked and remains a passing control.

C04 was reproduced on native Windows **before editing the shim**: [red run](https://github.com/aipoch/open-science/actions/runs/34033995601). All eight cases failed on caller environment preservation, with the expected CLI exit codes intact. The same native cases pass after the fix: [green run](https://github.com/aipoch/open-science/actions/runs/34034433590). After the review fixes, the identical final source/tests passed the [latest native Windows run](https://github.com/aipoch/open-science/actions/runs/34036185345): 97 passed, 17 platform-specific skips, including the late user-replacement race and all eight cmd.exe cases. The temporary targeting of the existing Windows dry-run was restored; this PR has no workflow diff.

Independent review found embedded-root redirection, a cleanup unlink race, and plaintext preceding JSON stderr. Four assertions reproduced these failures twice before their fixes, then passed.

Checks after the last production/test edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Discovery, precedence, root bounds, authenticated stop, JSON, SDK cancellation | `npx --no-install vitest run cli/lifecycle.test.ts cli/index.test.ts cli/config-root.test.ts cli/locate-app.test.ts packages/open-science/cli.test.ts packages/open-science/client.test.ts packages/open-science/codex-login.test.ts packages/open-science/rollback-to-0.7.3.test.ts` | Pass |
| Install failure/retry, ownership preservation, status errors | `npx --no-install vitest run src/main/cli-install/launcher.test.ts src/main/cli-install/ipc.test.ts` | Pass; Windows-specific cases also pass in the native run |
| IPC/Host/preload/Web consumers and existing Settings retry UI | `npx --no-install vitest run src/main/host-application-commands.test.ts src/main/application-command-composition.test.ts src/preload/index.test.ts src/renderer/web/api-installer.test.ts src/renderer/src/pages/settings/GeneralPanel.render.test.tsx` | Pass |
| Main/preload and renderer types | `npm run typecheck:node`; `npm run typecheck:web` | Pass |
| Style | `npm run lint`; `git diff --check` | Pass |

The combined local test run passed **347**, with **8** native Windows cases skipped locally and verified on Windows. GeneralPanel was also rendered in ego-browser with an isolated EACCES fixture: Install disabled + error + Check again; retry removes the error and displays the installed path. No real user installation was changed.

The shared dependency install's Prisma Client does not match this clean worktree, so these non-database tests used the installed Vitest directly rather than the npm pretest hook. The complete local suite was not run, per maintainer instruction. Impact explain selects full CI because `packages/open-science/CLI.md` matches both CLI SDK and documentation ownership; PR Gate remains authoritative for that full plan. Relevant consumer adapters were checked locally; unrelated database/ACP framework suites are left to CI.

## Review focus

Candidate selection must not relax explicit bounds or shutdown authentication. Failure cleanup must preserve unowned or replaced files. Confirm output-only result values and the documented compatibility limits. Native Windows tests cover set/unset environment values, packaged/development shims, and exit codes 0/7; they use a Node executable fixture rather than launching an unrelated Electron application.
