### PR TITLE
fix(search): page all home artifacts and preserve command intent

### DIFF
--- a/src/main/project-files/host-artifact-catalog.test.ts
+++ b/src/main/project-files/host-artifact-catalog.test.ts
@@ -448,7 +448,7 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
     ])
 
     const search = await repository.searchArtifacts({
-      primaryProjectId: 'project-a',
+      primaryProjectIds: ['project-a'],
       otherProjectIds: [],
       filenameContains: 'catalog-',
       primaryLimit: 10,
@@ -506,7 +506,7 @@ describe('ManagedFileIndexRepository host Artifact catalog', () => {
       })
       expect(files.items.map((item) => item.sourceFileId).sort()).toEqual(expected)
       const search = await repository.searchArtifacts({
-        primaryProjectId: 'project-a',
+        primaryProjectIds: ['project-a'],
         otherProjectIds: [],
         filenameContains: 'artifact-a',
         primaryLimit: 10,

--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -90,7 +90,7 @@ describe('project files IPC handlers', () => {
       name: 'report.md'
     }
     const artifactSearchRequest = {
-      primaryProjectId: 'project-1',
+      primaryProjectIds: ['project-1'],
       otherProjectIds: ['project-2'],
       filenameContains: 'sin',
       primaryLimit: 8,
@@ -214,7 +214,7 @@ describe('project files IPC handlers', () => {
     })
     await handlers.listArtifactGroups({ projectId: 'project-1', limit: 10 })
     await handlers.searchArtifacts({
-      primaryProjectId: 'project-1',
+      primaryProjectIds: ['project-1', 'project-3'],
       otherProjectIds: ['project-2'],
       primaryLimit: 8,
       otherLimit: 0
@@ -239,7 +239,11 @@ describe('project files IPC handlers', () => {
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(2, ['project-1'])
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(3, ['project-1'])
     expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(4, ['project-1'])
-    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(5, ['project-1', 'project-2'])
+    expect(recovery.waitForProjectOperations).toHaveBeenNthCalledWith(5, [
+      'project-1',
+      'project-3',
+      'project-2'
+    ])
     expect(recovery.recoverPendingDeletions).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -64,7 +64,7 @@ const createProjectFilesHandlers = (
   },
   searchArtifacts: async (request) => {
     await recoveryBackend.waitForProjectOperations([
-      request.primaryProjectId,
+      ...request.primaryProjectIds,
       ...request.otherProjectIds
     ])
     return repository.searchArtifacts(request)

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -266,12 +266,20 @@ class ProjectFilesQueryOwner {
   }
 
   async searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult> {
-    requireIdentifier(request.primaryProjectId, 'primaryProjectId')
+    if (!Array.isArray(request.primaryProjectIds) || request.primaryProjectIds.length === 0) {
+      throw new Error('Project files primaryProjectIds must be a non-empty array.')
+    }
+    const primaryProjectIds = [...new Set(request.primaryProjectIds)]
+      .map((projectId) => {
+        requireIdentifier(projectId, 'primaryProjectId')
+        return projectId
+      })
+      .sort()
     if (!Array.isArray(request.otherProjectIds)) {
       throw new Error('Project files otherProjectIds must be an array.')
     }
     const otherProjectIds = [...new Set(request.otherProjectIds)]
-      .filter((projectId) => projectId !== request.primaryProjectId)
+      .filter((projectId) => !primaryProjectIds.includes(projectId))
       .map((projectId) => {
         requireIdentifier(projectId, 'otherProjectId')
         return projectId
@@ -288,12 +296,12 @@ class ProjectFilesQueryOwner {
         : { excludedSessionIds: request.excludedSessionIds })
     })
     const cursor = request.primaryCursor
-      ? decodeSearchArtifactCursor(request.primaryCursor, request.primaryProjectId, search)
+      ? decodeSearchArtifactCursor(request.primaryCursor, primaryProjectIds, search)
       : undefined
     const client = await this.getClient()
     const [primaryResult, otherRows] = await Promise.all([
       listAuthoritativeFiles(client, {
-        projectIds: [request.primaryProjectId],
+        projectIds: primaryProjectIds,
         source: 'artifact',
         search,
         cursor,
@@ -337,7 +345,7 @@ class ProjectFilesQueryOwner {
             ? encodeCursor({
                 version: 2,
                 kind: 'globalArtifacts',
-                primaryProjectId: request.primaryProjectId,
+                primaryProjectIds,
                 queryKey: search?.queryKey ?? '',
                 sortAtMs: lastPrimaryRow.sortAtMs.toString(),
                 seq: lastPrimaryRow.seq
@@ -345,7 +353,7 @@ class ProjectFilesQueryOwner {
             : undefined
       },
       other: otherRows.map(toItem),
-      isIndexComplete: [request.primaryProjectId, ...otherProjectIds].every((projectId) =>
+      isIndexComplete: [...primaryProjectIds, ...otherProjectIds].every((projectId) =>
         this.readIndexComplete(projectId)
       )
     }

--- a/src/main/project-files/query-support.ts
+++ b/src/main/project-files/query-support.ts
@@ -35,7 +35,7 @@ type GroupCursor = {
 type SearchArtifactCursor = {
   version: 2
   kind: 'globalArtifacts'
-  primaryProjectId: string
+  primaryProjectIds: string[]
   queryKey: string
   sortAtMs: string
   seq: number
@@ -534,7 +534,7 @@ const decodeGroupCursor = (cursor: string, request: ListArtifactGroupsRequest): 
 
 const decodeSearchArtifactCursor = (
   cursor: string,
-  primaryProjectId: string,
+  primaryProjectIds: string[],
   search: NormalizedSearch | undefined
 ): SearchArtifactCursor => {
   const value = parseCursor(cursor)
@@ -544,7 +544,7 @@ const decodeSearchArtifactCursor = (
     !isRecord(value) ||
     value.version !== 2 ||
     value.kind !== 'globalArtifacts' ||
-    value.primaryProjectId !== primaryProjectId ||
+    JSON.stringify(value.primaryProjectIds) !== JSON.stringify(primaryProjectIds) ||
     typeof value.queryKey !== 'string' ||
     typeof value.sortAtMs !== 'string' ||
     !/^-?\d+$/.test(value.sortAtMs) ||

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -623,7 +623,7 @@ describe('ManagedFileIndexRepository', () => {
     })
     await expect(
       repository.searchArtifacts({
-        primaryProjectId: PROJECT_ID,
+        primaryProjectIds: [PROJECT_ID],
         otherProjectIds: [],
         filenameContains: 'sin.png',
         primaryLimit: 8,
@@ -2710,6 +2710,116 @@ describe('ManagedFileIndexRepository', () => {
     ).rejects.toThrow(/cursor.*search/i)
   })
 
+  it('pages one authoritative artifact collection across Projects with scope-bound cursors', async () => {
+    const names = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta']
+    for (const name of names) {
+      const path = join(storageRoot, 'artifacts', 'project-b', 'session-b', `${name}.png`)
+      await writeManagedFile(path, name)
+    }
+    await repository.syncSession(
+      createSession({
+        id: 'session-b',
+        projectId: 'project-b',
+        artifacts: names.map((name, index) => ({
+          id: name,
+          kind: 'managed-file' as const,
+          name: `sin-${name}.png`,
+          path: join(storageRoot, 'artifacts', 'project-b', 'session-b', `${name}.png`),
+          mtimeMs: 100 + Math.floor(index / 2)
+        }))
+      })
+    )
+    const request = {
+      primaryProjectIds: [PROJECT_ID, 'project-b'],
+      otherProjectIds: [],
+      filenameContains: 'sin',
+      primaryLimit: 2,
+      otherLimit: 0 as const
+    }
+    const first = await repository.searchArtifacts(request)
+    expect(first.primary.totalCount).toBe(6)
+    expect(first.primary.items).toHaveLength(2)
+    expect(first.primary.nextCursor).toBeDefined()
+    const second = await repository.searchArtifacts({
+      ...request,
+      primaryProjectIds: ['project-b', PROJECT_ID, 'project-b'],
+      primaryCursor: first.primary.nextCursor
+    })
+    const third = await repository.searchArtifacts({
+      ...request,
+      primaryCursor: second.primary.nextCursor
+    })
+    expect(third.primary.nextCursor).toBeUndefined()
+    expect(
+      [...first.primary.items, ...second.primary.items, ...third.primary.items]
+        .map((item) => item.name)
+        .sort()
+    ).toEqual(names.map((name) => `sin-${name}.png`).sort())
+    await expect(
+      repository.searchArtifacts({
+        ...request,
+        primaryProjectIds: [PROJECT_ID],
+        primaryCursor: first.primary.nextCursor
+      })
+    ).rejects.toThrow(/cursor/i)
+    await expect(
+      repository.searchArtifacts({
+        ...request,
+        filenameContains: 'cos',
+        primaryCursor: first.primary.nextCursor
+      })
+    ).rejects.toThrow(/cursor/i)
+    await expect(
+      repository.searchArtifacts({
+        ...request,
+        excludedSessionIds: ['session-b'],
+        primaryCursor: first.primary.nextCursor
+      })
+    ).rejects.toThrow(/cursor/i)
+    await expect(
+      repository.searchArtifacts({ ...request, excludedSessionIds: ['session-b'] })
+    ).resolves.toMatchObject({ primary: { totalCount: 0, items: [] }, other: [] })
+    const localPath = join(storageRoot, 'artifacts', PROJECT_ID, SESSION_ID, 'local.png')
+    await writeManagedFile(localPath, 'local')
+    await repository.syncSession(
+      createSession({
+        artifacts: [
+          {
+            id: 'local',
+            name: 'sin-local.png',
+            kind: 'managed-file',
+            path: localPath,
+            mtimeMs: 101
+          }
+        ]
+      })
+    )
+    const mergedNames: string[] = []
+    let cursor: string | undefined
+    for (let page = 0; page < 4; page++) {
+      const result = await repository.searchArtifacts({ ...request, primaryCursor: cursor })
+      expect(result.primary.totalCount).toBe(7)
+      mergedNames.push(...result.primary.items.map((item) => item.name))
+      cursor = result.primary.nextCursor
+    }
+    expect(cursor).toBeUndefined()
+    const unpaged = await repository.searchArtifacts({ ...request, primaryLimit: 100 })
+    expect(mergedNames).toEqual(unpaged.primary.items.map((item) => item.name))
+    expect(mergedNames.slice(0, 2).sort()).toEqual(['sin-epsilon.png', 'sin-zeta.png'])
+    expect(mergedNames.slice(2, 5).sort()).toEqual([
+      'sin-delta.png',
+      'sin-gamma.png',
+      'sin-local.png'
+    ])
+    expect(mergedNames.slice(5).sort()).toEqual(['sin-alpha.png', 'sin-beta.png'])
+    await expect(repository.searchArtifacts({ ...request, primaryProjectIds: [] })).rejects.toThrow(
+      /non-empty array/
+    )
+    await expect(
+      repository.searchArtifacts({ ...request, primaryProjectIds: [''] })
+    ).rejects.toThrow(/primaryProjectId/)
+  })
+
   it('searches generated artifacts with a primary cursor and bounded other-project results', async () => {
     const primaryFiles = [
       ['sin-old', 'sin-old.png', 100],
@@ -2802,7 +2912,7 @@ describe('ManagedFileIndexRepository', () => {
     )
 
     const first = await repository.searchArtifacts({
-      primaryProjectId: PROJECT_ID,
+      primaryProjectIds: [PROJECT_ID],
       otherProjectIds: ['project-b'],
       filenameContains: 'SIN',
       primaryLimit: 2,
@@ -2824,7 +2934,7 @@ describe('ManagedFileIndexRepository', () => {
 
     await expect(
       repository.searchArtifacts({
-        primaryProjectId: 'project-b',
+        primaryProjectIds: ['project-b'],
         otherProjectIds: [],
         filenameContains: 'SIN',
         primaryLimit: 2,
@@ -2835,7 +2945,7 @@ describe('ManagedFileIndexRepository', () => {
 
     await expect(
       repository.searchArtifacts({
-        primaryProjectId: PROJECT_ID,
+        primaryProjectIds: [PROJECT_ID],
         otherProjectIds: ['project-b'],
         primaryLimit: 2,
         otherLimit: 6
@@ -2844,7 +2954,7 @@ describe('ManagedFileIndexRepository', () => {
 
     await expect(
       repository.searchArtifacts({
-        primaryProjectId: PROJECT_ID,
+        primaryProjectIds: [PROJECT_ID],
         otherProjectIds: ['project-b'],
         filenameContains: 'sin',
         primaryLimit: 2,
@@ -2862,7 +2972,7 @@ describe('ManagedFileIndexRepository', () => {
 
     await expect(
       repository.searchArtifacts({
-        primaryProjectId: PROJECT_ID,
+        primaryProjectIds: [PROJECT_ID],
         otherProjectIds: ['project-b'],
         filenameContains: 'sin',
         excludedSessionIds: [SESSION_ID],
@@ -3114,7 +3224,7 @@ describe('ManagedFileIndexRepository', () => {
     })
     await expect(
       repository.searchArtifacts({
-        primaryProjectId: PROJECT_ID,
+        primaryProjectIds: [PROJECT_ID],
         otherProjectIds: [],
         filenameContains: 'result',
         primaryLimit: 10,

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
-import { waitFor } from '@testing-library/react'
+import { fireEvent, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { i18next } from '@/i18n'
@@ -226,6 +226,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   Reflect.deleteProperty(window.HTMLElement.prototype, 'scrollIntoView')
+  vi.useRealTimers()
   vi.restoreAllMocks()
   void i18next.changeLanguage('en')
   vi.unstubAllGlobals()
@@ -561,7 +562,7 @@ describe('GlobalSearchDialog', () => {
     expect(document.body.querySelector('[role="group"][aria-label="Sessions"]')).toBeNull()
     expect(
       document.body.querySelector('[role="option"][aria-selected="true"]')?.textContent
-    ).toContain('New session')
+    ).toBeUndefined()
 
     await act(async () => {
       await new Promise((resolve) => window.setTimeout(resolve, 170))
@@ -571,7 +572,7 @@ describe('GlobalSearchDialog', () => {
     expect(document.body.querySelector('[role="group"][aria-label="Sessions"]')).toBeNull()
     expect(
       document.body.querySelector('[role="option"][aria-selected="true"]')?.textContent
-    ).toContain('New session')
+    ).toBeUndefined()
 
     await act(async () => {
       resolveSearch(delayedResult)
@@ -1160,7 +1161,7 @@ describe('GlobalSearchDialog', () => {
     expect(footer?.textContent).not.toContain('mention')
     expect(footer?.querySelectorAll('kbd')).toHaveLength(3)
     expect(window.api.projectFiles.searchArtifacts).toHaveBeenCalledWith(
-      expect.objectContaining({ primaryProjectId: 'project-b', otherLimit: 5 })
+      expect.objectContaining({ primaryProjectIds: ['project-b'], otherLimit: 5 })
     )
 
     const valueSetter = Object.getOwnPropertyDescriptor(
@@ -1236,5 +1237,308 @@ describe('GlobalSearchDialog', () => {
     expect(window.api.projectFiles.searchArtifacts).toHaveBeenCalledWith(
       expect.objectContaining({ excludedSessionIds: ['session-a'] })
     )
+  })
+})
+
+describe('Global Search result accessibility', () => {
+  const emptyResult = {
+    primary: { items: [], totalCount: 0 },
+    other: [],
+    isIndexComplete: true
+  }
+  const options = (): HTMLElement[] => [
+    ...document.body.querySelectorAll<HTMLElement>('[role="option"]')
+  ]
+  const optionWithText = (text: string): HTMLElement => {
+    const row = options().find((option) => option.textContent?.includes(text))
+    expect(row, `Expected a selectable row containing "${text}"`).toBeDefined()
+    return row!
+  }
+  const mount = async (onOpenChange = vi.fn()): Promise<HTMLInputElement> => {
+    await act(async () => {
+      root.render(<GlobalSearchDialog open onOpenChange={onOpenChange} isSessionPersistenceReady />)
+    })
+    // Control only the debounce; Radix and React retain their normal microtask behavior.
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    const input = document.body.querySelector<HTMLInputElement>('input[role="combobox"]')!
+    act(() => input.focus())
+    return input
+  }
+  const search = async (input: HTMLInputElement): Promise<void> => {
+    act(() => fireEvent.change(input, { target: { value: 'sin' } }))
+    await act(async () => vi.advanceTimersByTimeAsync(150))
+  }
+  const enter = (input: HTMLInputElement): void => {
+    act(() => fireEvent.keyDown(input, { key: 'Enter' }))
+  }
+
+  it('makes every matching artifact in another Project reachable from Home', async () => {
+    useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+    window.localStorage.setItem('open-science:last-opened-project', 'project-a')
+    const files = ['alpha', 'beta', 'gamma', 'delta', 'epsilon', 'zeta'].map((name) => ({
+      ...artifact,
+      id: name,
+      sourceFileId: name,
+      sourceVersionId: `version-${name}`,
+      name: `sin-${name}.png`,
+      projectId: 'project-b',
+      sessionId: 'session-b'
+    }))
+    // Honor the paged collection and bounded recommendation contract.
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockImplementation(async (request) => {
+      const primaryIds = request.primaryProjectIds
+      const matching = primaryIds.includes('project-b') ? files : []
+      return {
+        ...emptyResult,
+        primary: { items: matching.slice(0, request.primaryLimit), totalCount: matching.length },
+        other: request.otherProjectIds.includes('project-b')
+          ? files.slice(0, request.otherLimit)
+          : []
+      }
+    })
+    const input = await mount()
+    await search(input)
+    const more = options().find((row) => row.textContent?.includes('show more'))
+    if (more) await act(async () => more.click())
+    expect.soft(options().filter((row) => row.textContent?.includes('sin-'))).toHaveLength(6)
+    expect.soft(document.body.textContent).toContain('sin-zeta.png')
+    expect(document.body.textContent).not.toContain('Some artifact results may be missing')
+  })
+
+  it.each(['workspace', 'home'] as const)(
+    'does not enter creation from %s when Enter arrives during the debounce',
+    async (view) => {
+      useNavigationStore.setState({
+        view,
+        activeProjectId: view === 'workspace' ? 'project-a' : undefined
+      })
+      const onOpenChange = vi.fn()
+      const input = await mount(onOpenChange)
+      act(() => fireEvent.change(input, { target: { value: 'sin' } }))
+      enter(input)
+      expect.soft(useSessionStore.getState().selectedSessionId).toBe('session-a')
+      expect.soft(useNavigationStore.getState().pendingProjectCreation).toBe(false)
+      expect.soft(onOpenChange).not.toHaveBeenCalledWith(false)
+      expect.soft(input.getAttribute('aria-activedescendant')).toBeNull()
+      expect.soft(options().some((row) => row.getAttribute('aria-selected') === 'true')).toBe(false)
+    }
+  )
+
+  it('does not enter creation while the artifact request is unresolved', async () => {
+    const onOpenChange = vi.fn()
+    const input = await mount(onOpenChange)
+    let resolveSearch!: (value: typeof emptyResult) => void
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSearch = resolve
+      })
+    )
+    await search(input)
+    enter(input)
+    expect.soft(useSessionStore.getState().selectedSessionId).toBe('session-a')
+    expect.soft(onOpenChange).not.toHaveBeenCalledWith(false)
+    await act(async () => resolveSearch(emptyResult))
+    enter(input)
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-a')
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it.each(['ArrowDown', 'ArrowUp', 'Home', 'End', 'hover', 'click'])(
+    'allows explicit command selection with %s while search is pending',
+    async (method) => {
+      const onOpenChange = vi.fn()
+      const input = await mount(onOpenChange)
+      act(() => fireEvent.change(input, { target: { value: 'sin' } }))
+      const command = optionWithText('New session')
+      if (method === 'click') act(() => command.click())
+      else {
+        act(() =>
+          method === 'hover'
+            ? fireEvent.mouseOver(command)
+            : fireEvent.keyDown(input, { key: method })
+        )
+        expect(command.getAttribute('aria-selected')).toBe('true')
+        expect(input.getAttribute('aria-activedescendant')).toBe(command.id)
+        enter(input)
+      }
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+      expect(useSessionStore.getState().selectedSessionId).toBeUndefined()
+    }
+  )
+
+  it('keeps Enter inert when only Literature is still loading', async () => {
+    const onOpenChange = vi.fn()
+    const input = await mount(onOpenChange)
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue(emptyResult)
+    let resolveLiterature!: (value: { entries: [] }) => void
+    vi.mocked(window.api.literature.search).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLiterature = resolve
+      })
+    )
+    await search(input)
+    enter(input)
+    expect(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect(input.getAttribute('aria-activedescendant')).toBeNull()
+    await act(async () => resolveLiterature({ entries: [] }))
+    enter(input)
+    expect(onOpenChange).toHaveBeenCalledWith(false)
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-a')
+  })
+
+  it('retries the hovered artifact failure while Literature is still pending', async () => {
+    const onOpenChange = vi.fn()
+    const input = await mount(onOpenChange)
+    let resolveLiterature!: (value: { entries: [] }) => void
+    vi.mocked(window.api.literature.search).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveLiterature = resolve
+      })
+    )
+    vi.mocked(window.api.projectFiles.searchArtifacts)
+      .mockRejectedValueOnce(new Error('Unavailable'))
+      .mockResolvedValue(emptyResult)
+    await search(input)
+    const retry = optionWithText('Could not load artifacts — retry')
+    act(() => fireEvent.mouseOver(retry))
+    await act(async () => fireEvent.keyDown(input, { key: 'Enter' }))
+    expect.soft(onOpenChange).not.toHaveBeenCalledWith(false)
+    expect.soft(window.api.projectFiles.searchArtifacts).toHaveBeenCalledTimes(3)
+    await act(async () => resolveLiterature({ entries: [] }))
+  })
+
+  it('pages all Home artifact matches and announces their total', async () => {
+    useNavigationStore.setState({ view: 'home', activeProjectId: undefined })
+    const files = [
+      'alpha',
+      'beta',
+      'gamma',
+      'delta',
+      'epsilon',
+      'zeta',
+      'eta',
+      'theta',
+      'iota'
+    ].map((name) => ({
+      ...artifact,
+      id: name,
+      name: `sin-${name}.png`,
+      projectId: 'project-b',
+      sessionId: 'session-b'
+    }))
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockImplementation(async (request) => {
+      const matching = request.primaryProjectIds.includes('project-b') ? files : []
+      const offset = request.primaryCursor ? Number(request.primaryCursor) : 0
+      const end = offset + request.primaryLimit
+      return {
+        ...emptyResult,
+        primary: {
+          items: matching.slice(offset, end),
+          totalCount: matching.length,
+          nextCursor: end < matching.length ? String(end) : undefined
+        }
+      }
+    })
+    const input = await mount()
+    await search(input)
+    expect(document.body.querySelector('[aria-live="polite"]')?.textContent).toBe('11 results')
+    expect(options().filter((row) => row.textContent?.includes('sin-'))).toHaveLength(8)
+    act(() => fireEvent.mouseOver(optionWithText('show more')))
+    await act(async () => fireEvent.keyDown(input, { key: 'Enter' }))
+    expect(options().filter((row) => row.textContent?.includes('sin-'))).toHaveLength(9)
+    expect(document.body.textContent).toContain('sin-iota.png')
+    expect(options().some((row) => row.textContent?.includes('show more'))).toBe(false)
+    expect(window.api.projectFiles.searchArtifacts).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        primaryProjectIds: ['project-a', 'project-b'],
+        otherProjectIds: [],
+        otherLimit: 0,
+        primaryCursor: '8'
+      })
+    )
+  })
+
+  it.each(['sessions', 'artifacts', 'retry'] as const)(
+    'activates the hovered %s control with Enter',
+    async (kind) => {
+      const onOpenChange = vi.fn()
+      const input = await mount(onOpenChange)
+      if (kind === 'sessions') {
+        useSessionStore.setState((state) => ({
+          sessions: Array.from({ length: 9 }, (_, index) => ({
+            ...state.sessions[0],
+            id: `matching-session-${index}`,
+            title: `sin match ${index}`
+          }))
+        }))
+        vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue(emptyResult)
+      } else if (kind === 'artifacts') {
+        vi.mocked(window.api.projectFiles.searchArtifacts)
+          .mockResolvedValueOnce({
+            ...emptyResult,
+            primary: { items: [artifact], totalCount: 2, nextCursor: 'next-artifact-page' }
+          })
+          .mockResolvedValue({
+            ...emptyResult,
+            primary: { items: [{ ...artifact, id: 'last', name: 'sin-last.png' }], totalCount: 2 }
+          })
+      } else {
+        vi.mocked(window.api.projectFiles.searchArtifacts)
+          .mockRejectedValueOnce(new Error('Artifact query unavailable'))
+          .mockResolvedValue(emptyResult)
+      }
+      await search(input)
+      const row = optionWithText(
+        kind === 'retry' ? 'Could not load artifacts — retry' : 'show more'
+      )
+      const callsBefore = vi.mocked(window.api.projectFiles.searchArtifacts).mock.calls.length
+      act(() => fireEvent.mouseOver(row))
+      expect.soft(row.getAttribute('aria-selected')).toBe('true')
+      expect.soft(input.getAttribute('aria-activedescendant')).toBe(row.id)
+      await act(async () => fireEvent.keyDown(input, { key: 'Enter' }))
+      expect.soft(onOpenChange).not.toHaveBeenCalledWith(false)
+      expect.soft(useSessionStore.getState().selectedSessionId).toBe('session-a')
+      if (kind === 'sessions') {
+        expect
+          .soft(document.body.querySelectorAll('[data-testid="global-search-session-icon"]'))
+          .toHaveLength(9)
+      } else {
+        expect.soft(window.api.projectFiles.searchArtifacts).toHaveBeenCalledTimes(callsBefore + 1)
+        if (kind === 'artifacts') expect.soft(document.body.textContent).toContain('sin-last.png')
+        else
+          expect.soft(document.body.textContent).not.toContain('Could not load artifacts — retry')
+      }
+    }
+  )
+
+  it('keeps recent Sessions available and offers retry after recent artifacts fail', async () => {
+    vi.mocked(window.api.projectFiles.searchArtifacts)
+      .mockRejectedValueOnce(new Error('Artifact query unavailable'))
+      .mockResolvedValue({ ...emptyResult, primary: { items: [artifact], totalCount: 1 } })
+    await mount()
+    expect(document.body.textContent).toContain('Recent sessions')
+    expect(document.body.textContent).toContain('Python 绘制 sin 函数图')
+    const retry = optionWithText('Could not load artifacts — retry')
+    await act(async () => retry.click())
+    expect(document.body.textContent).toContain('sin.png')
+    expect(document.body.textContent).not.toContain('Could not load artifacts — retry')
+  })
+
+  it('expands matching Sessions when show more is clicked directly', async () => {
+    vi.mocked(window.api.projectFiles.searchArtifacts).mockResolvedValue(emptyResult)
+    useSessionStore.setState((state) => ({
+      sessions: Array.from({ length: 9 }, (_, index) => ({
+        ...state.sessions[0],
+        id: `matching-session-${index}`,
+        title: `sin match ${index}`
+      }))
+    }))
+    const input = await mount()
+    await search(input)
+    act(() => optionWithText('show more').click())
+    expect(
+      document.body.querySelectorAll('[data-testid="global-search-session-icon"]')
+    ).toHaveLength(9)
+    expect(useSessionStore.getState().selectedSessionId).toBe('session-a')
   })
 })

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -1366,6 +1366,30 @@ describe('Global Search result accessibility', () => {
     }
   )
 
+  it.each(['workspace', 'home'] as const)(
+    'preserves an explicitly selected command in %s after search results arrive',
+    async (view) => {
+      useNavigationStore.setState({
+        view,
+        activeProjectId: view === 'workspace' ? 'project-a' : undefined
+      })
+      const onOpenChange = vi.fn()
+      const input = await mount(onOpenChange)
+      act(() => fireEvent.change(input, { target: { value: 'sin' } }))
+      const command = optionWithText(view === 'workspace' ? 'New session' : 'New project')
+      act(() => fireEvent.mouseOver(command))
+      await act(async () => vi.advanceTimersByTimeAsync(150))
+      expect.soft(command.getAttribute('aria-selected')).toBe('true')
+      expect.soft(input.getAttribute('aria-activedescendant')).toBe(command.id)
+      enter(input)
+      expect.soft(usePreviewWorkbenchStore.getState().fileDialogItem).toBeUndefined()
+      if (view === 'workspace')
+        expect.soft(useSessionStore.getState().selectedSessionId).toBeUndefined()
+      else expect.soft(useNavigationStore.getState().pendingProjectCreation).toBe(true)
+      expect(onOpenChange).toHaveBeenCalledWith(false)
+    }
+  )
+
   it('keeps Enter inert when only Literature is still loading', async () => {
     const onOpenChange = vi.fn()
     const input = await mount(onOpenChange)

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -194,7 +194,8 @@ export const GlobalSearchDialog = ({
   const [failedArtifactCursor, setFailedArtifactCursor] = useState<string | undefined>()
   const [literature, setLiterature] = useState<LiteratureState>(emptyLiteratureState)
   const [actionError, setActionError] = useState<string | undefined>()
-  const [activeIndex, setActiveIndex] = useState(0)
+  // A command selection must survive asynchronous result insertion before the command row.
+  const [activeIndex, setActiveIndex] = useState<number | 'command'>(0)
 
   useLayoutEffect(() => {
     if (!open) mentionVersionRef.current += 1
@@ -538,9 +539,13 @@ export const GlobalSearchDialog = ({
   ])
 
   const activeRowIndex =
-    selectableRows.length === 0 || (isSearchPending && activeIndex < 0)
+    selectableRows.length === 0
       ? -1
-      : Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
+      : activeIndex === 'command'
+        ? selectableRows.length - 1
+        : isSearchPending && activeIndex < 0
+          ? -1
+          : Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
   const activeRowId = `global-search-option-${activeRowIndex}`
 
   useEffect(() => {
@@ -743,7 +748,7 @@ export const GlobalSearchDialog = ({
               ? selectableRows.length - 1
               : (normalized - 1 + selectableRows.length) % selectableRows.length
         keyboardNavigationRef.current = nextIndex !== current
-        return nextIndex
+        return nextIndex === selectableRows.length - 1 ? 'command' : nextIndex
       })
       return
     }
@@ -751,7 +756,7 @@ export const GlobalSearchDialog = ({
       event.preventDefault()
       setActiveIndex((current) => {
         keyboardNavigationRef.current = current !== 0
-        return 0
+        return selectableRows.length === 1 ? 'command' : 0
       })
       return
     }
@@ -760,7 +765,7 @@ export const GlobalSearchDialog = ({
       setActiveIndex((current) => {
         const nextIndex = Math.max(0, selectableRows.length - 1)
         keyboardNavigationRef.current = nextIndex !== current
-        return nextIndex
+        return nextIndex === selectableRows.length - 1 ? 'command' : nextIndex
       })
       return
     }
@@ -1204,7 +1209,7 @@ export const GlobalSearchDialog = ({
                       activeRowIndex === rowIndex - 1 && 'bg-bg-200 before:opacity-100',
                       isProjectScope && !isSessionPersistenceReady && 'opacity-50'
                     )}
-                    onMouseEnter={() => setActiveIndex(selectableRows.length - 1)}
+                    onMouseEnter={() => setActiveIndex('command')}
                     onClick={() =>
                       activate({ kind: isProjectScope ? 'new-session' : 'new-project' })
                     }

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -342,13 +342,19 @@ export const GlobalSearchDialog = ({
       setFailedArtifactCursor(undefined)
       try {
         const result = await window.api.projectFiles.searchArtifacts({
-          primaryProjectId: primaryProject.id,
-          otherProjectIds,
+          primaryProjectIds:
+            !isProjectScope && isSearchMode
+              ? [primaryProject.id, ...otherProjectIds]
+              : [primaryProject.id],
+          otherProjectIds: !isProjectScope && isSearchMode ? [] : otherProjectIds,
           ...(trimmedQuery ? { filenameContains: trimmedQuery } : {}),
           ...(archivedSessionIds.length > 0 ? { excludedSessionIds: archivedSessionIds } : {}),
           primaryLimit: GLOBAL_SEARCH_PAGE_SIZE,
           ...(cursor ? { primaryCursor: cursor } : {}),
-          otherLimit: !cursor && (!isProjectScope || isSearchMode) ? OTHER_PROJECT_RESULT_LIMIT : 0
+          otherLimit:
+            !cursor && (isProjectScope ? isSearchMode : !isSearchMode)
+              ? OTHER_PROJECT_RESULT_LIMIT
+              : 0
         })
         if (version !== requestVersionRef.current) return
         setArtifacts((current) =>
@@ -443,7 +449,7 @@ export const GlobalSearchDialog = ({
     setFailedArtifactCursor(undefined)
     setLiterature({ items: [], status: nextQuery.trim() ? 'loading' : 'idle' })
     setActionError(undefined)
-    setActiveIndex(0)
+    setActiveIndex(nextQuery.trim() ? -1 : 0)
     keyboardNavigationRef.current = false
   }
 
@@ -474,6 +480,7 @@ export const GlobalSearchDialog = ({
     isSearchMode && artifactStatus === 'loading' && displayedArtifacts.length === 0
   const isSearchPending =
     isSearchMode &&
+    artifactError === undefined &&
     displayedArtifacts.length === 0 &&
     literature.items.length === 0 &&
     (artifactSearchPending || literature.status === 'loading')
@@ -500,6 +507,7 @@ export const GlobalSearchDialog = ({
     if (!isSearchMode) {
       return [
         ...displayedArtifacts.map((artifact) => ({ kind: 'artifact' as const, artifact })),
+        ...(artifactError ? [{ kind: 'retry-artifacts' as const }] : []),
         ...recentSessions.map((session) => ({ kind: 'session' as const, session })),
         command
       ]
@@ -530,7 +538,9 @@ export const GlobalSearchDialog = ({
   ])
 
   const activeRowIndex =
-    selectableRows.length === 0 ? -1 : Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
+    selectableRows.length === 0 || (isSearchPending && activeIndex < 0)
+      ? -1
+      : Math.max(0, Math.min(activeIndex, selectableRows.length - 1))
   const activeRowId = `global-search-option-${activeRowIndex}`
 
   useEffect(() => {
@@ -679,6 +689,7 @@ export const GlobalSearchDialog = ({
         return
       }
       if (row.kind === 'more-artifacts' && artifacts.nextCursor) {
+        if (artifactStatus === 'loading') return
         void reloadArtifacts(artifacts.nextCursor)
         return
       }
@@ -700,6 +711,7 @@ export const GlobalSearchDialog = ({
     },
     [
       artifacts.nextCursor,
+      artifactStatus,
       canMentionArtifact,
       close,
       failedArtifactCursor,
@@ -723,11 +735,13 @@ export const GlobalSearchDialog = ({
       event.preventDefault()
       if (selectableRows.length === 0) return
       setActiveIndex((current) => {
-        const normalized = Math.max(0, Math.min(current, selectableRows.length - 1))
+        const normalized = activeRowIndex
         const nextIndex =
           event.key === 'ArrowDown'
             ? (normalized + 1) % selectableRows.length
-            : (normalized - 1 + selectableRows.length) % selectableRows.length
+            : normalized < 0
+              ? selectableRows.length - 1
+              : (normalized - 1 + selectableRows.length) % selectableRows.length
         keyboardNavigationRef.current = nextIndex !== current
         return nextIndex
       })
@@ -766,7 +780,8 @@ export const GlobalSearchDialog = ({
     : isSearchMode
       ? (sessionGroups?.primaryTotalCount ?? 0) +
         literature.items.length +
-        (isProjectScope ? artifacts.totalCount + otherRows.length : displayedArtifacts.length)
+        artifacts.totalCount +
+        otherRows.length
       : displayedArtifacts.length + recentSessions.length
   const renderSessionRow = (session: SessionSearchResult, rowIndex: number): React.JSX.Element => {
     const active = rowIndex === activeRowIndex
@@ -970,6 +985,53 @@ export const GlobalSearchDialog = ({
     )
   }
 
+  const renderArtifactRetry = (index: number): React.JSX.Element => (
+    <Button
+      id={`global-search-option-${index}`}
+      type="button"
+      role="option"
+      aria-selected={activeRowIndex === index}
+      variant="ghost"
+      className={cn(
+        'h-11 w-full cursor-pointer justify-start px-4 text-sm font-medium text-primary',
+        activeRowIndex === index && 'bg-bg-200'
+      )}
+      onMouseEnter={() => setActiveIndex(index)}
+      onClick={() => activate({ kind: 'retry-artifacts' })}
+    >
+      {failedArtifactCursor
+        ? t('Could not load more — retry')
+        : t('Could not load artifacts — retry')}
+    </Button>
+  )
+  const renderMoreRow = (
+    kind: 'more-artifacts' | 'more-sessions',
+    index: number
+  ): React.JSX.Element => (
+    <Button
+      id={`global-search-option-${index}`}
+      type="button"
+      role="option"
+      aria-selected={activeRowIndex === index}
+      variant="ghost"
+      disabled={kind === 'more-artifacts' && artifactStatus === 'loading'}
+      className={cn(
+        'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none disabled:cursor-not-allowed disabled:opacity-50',
+        activeRowIndex === index && 'bg-bg-200'
+      )}
+      onMouseEnter={() => setActiveIndex(index)}
+      onClick={
+        kind === 'more-artifacts'
+          ? () => activate({ kind: 'more-artifacts' })
+          : () => activate({ kind: 'more-sessions' })
+      }
+    >
+      {t('+{{count}} more matches — show more', {
+        count: kind === 'more-artifacts' ? artifactMoreCount : sessionMoreCount
+      })}
+    </Button>
+  )
+
   let rowIndex = 0
   const nextIndex = (): number => rowIndex++
 
@@ -995,7 +1057,7 @@ export const GlobalSearchDialog = ({
               role="combobox"
               aria-autocomplete="list"
               aria-controls={listboxId}
-              aria-activedescendant={selectableRows.length > 0 ? activeRowId : undefined}
+              aria-activedescendant={activeRowIndex >= 0 ? activeRowId : undefined}
               placeholder={
                 isProjectScope ? t('Search this project…') : t('Search sessions and artifacts…')
               }
@@ -1027,12 +1089,13 @@ export const GlobalSearchDialog = ({
                 </p>
               ) : !isSearchMode ? (
                 <>
-                  {displayedArtifacts.length > 0 ? (
+                  {displayedArtifacts.length > 0 || artifactError ? (
                     <section role="group" aria-label={t('Recent artifacts')}>
                       <h2 className={sectionTitleClassName}>{t('Recent artifacts')}</h2>
                       {displayedArtifacts.map((artifact) =>
                         renderArtifactRow(artifact, nextIndex())
                       )}
+                      {artifactError ? renderArtifactRetry(nextIndex()) : null}
                     </section>
                   ) : null}
                   {recentSessions.length > 0 ? (
@@ -1062,40 +1125,8 @@ export const GlobalSearchDialog = ({
                           {t('Searching…')}
                         </p>
                       ) : null}
-                      {artifactError ? (
-                        <Button
-                          id={`global-search-option-${nextIndex()}`}
-                          type="button"
-                          role="option"
-                          aria-selected={activeRowIndex === rowIndex - 1}
-                          variant="ghost"
-                          className="h-11 cursor-pointer justify-start px-4 text-sm font-medium text-primary"
-                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
-                          onClick={() => void reloadArtifacts(failedArtifactCursor)}
-                        >
-                          {failedArtifactCursor
-                            ? t('Could not load more — retry')
-                            : t('Could not load artifacts — retry')}
-                        </Button>
-                      ) : null}
-                      {canLoadMoreArtifacts ? (
-                        <Button
-                          id={`global-search-option-${nextIndex()}`}
-                          type="button"
-                          role="option"
-                          aria-selected={activeRowIndex === rowIndex - 1}
-                          variant="ghost"
-                          disabled={artifactStatus === 'loading'}
-                          className={cn(
-                            'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none disabled:cursor-not-allowed disabled:opacity-50',
-                            activeRowIndex === rowIndex - 1 && 'bg-bg-200'
-                          )}
-                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
-                          onClick={() => activate({ kind: 'more-artifacts' })}
-                        >
-                          {t('+{{count}} more matches — show more', { count: artifactMoreCount })}
-                        </Button>
-                      ) : null}
+                      {artifactError ? renderArtifactRetry(nextIndex()) : null}
+                      {canLoadMoreArtifacts ? renderMoreRow('more-artifacts', nextIndex()) : null}
                     </section>
                   ) : null}
                   {literature.items.length > 0 ||
@@ -1129,23 +1160,7 @@ export const GlobalSearchDialog = ({
                       {sessionGroups.primary.map((session) =>
                         renderSessionRow(session, nextIndex())
                       )}
-                      {sessionMoreCount > 0 ? (
-                        <Button
-                          id={`global-search-option-${nextIndex()}`}
-                          type="button"
-                          role="option"
-                          aria-selected={activeRowIndex === rowIndex - 1}
-                          variant="ghost"
-                          className={cn(
-                            'flex h-11 w-full cursor-pointer select-none items-center justify-start px-4 text-left text-sm font-medium text-primary outline-none',
-                            activeRowIndex === rowIndex - 1 && 'bg-bg-200'
-                          )}
-                          onMouseEnter={() => setActiveIndex(rowIndex - 1)}
-                          onClick={() => activate({ kind: 'more-sessions' })}
-                        >
-                          {t('+{{count}} more matches — show more', { count: sessionMoreCount })}
-                        </Button>
-                      ) : null}
+                      {sessionMoreCount > 0 ? renderMoreRow('more-sessions', nextIndex()) : null}
                     </section>
                   ) : null}
                   {!isSearchPending && otherRows.length > 0 ? (
@@ -1189,7 +1204,7 @@ export const GlobalSearchDialog = ({
                       activeRowIndex === rowIndex - 1 && 'bg-bg-200 before:opacity-100',
                       isProjectScope && !isSessionPersistenceReady && 'opacity-50'
                     )}
-                    onMouseEnter={() => setActiveIndex(rowIndex - 1)}
+                    onMouseEnter={() => setActiveIndex(selectableRows.length - 1)}
                     onClick={() =>
                       activate({ kind: isProjectScope ? 'new-session' : 'new-project' })
                     }

--- a/src/renderer/web/renderer-argument-shape-characterization.test.ts
+++ b/src/renderer/web/renderer-argument-shape-characterization.test.ts
@@ -389,9 +389,11 @@ describe('renderer argument-shape characterization', () => {
 
   it('keeps projectFiles.searchArtifacts request forwarding equivalent', async () => {
     const request = {
-      projectId: 'project-1',
-      query: 'analysis',
-      limit: 24
+      primaryProjectIds: ['project-1', 'project-2'],
+      otherProjectIds: [],
+      filenameContains: 'analysis',
+      primaryLimit: 8,
+      otherLimit: 0
     }
     const electron = await invokeElectron(electronApi, 'projectFiles.searchArtifacts', [request])
     const web = await invokeWeb(webApi, 'projectFiles.searchArtifacts', [request])

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -68,10 +68,10 @@ export type ResolveProjectFileRequest = {
   name: string
 }
 
-// Bounded global-search projection. The primary Project is independently paged; Other Projects
-// deliberately return only a small combined sample so the command palette remains responsive.
+// The primary Project set is one paged collection. Home searches all active Projects; Workspace
+// pages its current Project and requests a bounded sample from Other Projects.
 export type SearchArtifactsRequest = {
-  primaryProjectId: string
+  primaryProjectIds: string[]
   otherProjectIds: string[]
   filenameContains?: string
   excludedSessionIds?: string[]


### PR DESCRIPTION
## Problem

Home keyword search silently loses matching artifacts outside an implicit primary Project after five results. During initial search loading, Enter activates creation; hovering pagination or retry can also activate creation because handlers capture a mutable row counter. Failed recent-artifact loading has no recovery entry.

## Proposed change

- Page Home keyword artifacts as one collection across all active Projects, using the existing authoritative SQLite query, total, ordering, and continuation. Bind cursors to the normalized full Project set and query.
- Start pending searches without an active command. Enter waits unless the user explicitly selects a command by keyboard or pointer. Preserve that explicit command selection when asynchronous results arrive.
- Capture fixed indices for pagination/retry, and expose the same artifact retry row for empty-query recents. Keep retry selectable when artifact failure arrives before Literature completes.
- Forward the Project set consistently through Electron/Web and wait for deletion recovery for every queried Project.

## Scope and non-goals

Workspace primary paging and its five-item Other Projects recommendation remain intact. Home empty-query recents retain their existing bounds. No new search service, dependency, persistent state, database schema/index, migration, or business-state enum. The existing UI selection state gains one transient `command` tag so explicit command intent survives inserted results; it is not persisted. The request changes `primaryProjectId` to `primaryProjectIds`; the existing response page is reused. Cursors are transient; no historical-data or historical-cursor compatibility layer is needed. This updates same-release clients and servers, not mixed-version remote compatibility.

## Acceptance criteria and validation

Before production edits, the real component suite ran twice with **8 new behavior failures and 29 passes**, including the working direct-click control. The SQLite regression then failed with zero paged matches despite six matching artifacts in another Project. A contract-aware UI mock retained the five-result failure. No production test seam was introduced. Independent review then identified explicit command selection being displaced by arriving results; two additional Home/Workspace regressions failed before the follow-up fix and now pass. Real Chromium verification also selected the command with End during loading and confirmed it remained selected after results arrived, then Enter executed it. All case names describe behavior without report identifiers.

After the last material edit, **15 focused files / 1349 tests passed**, along with `npm run typecheck` and `npm run lint` (clean). The final focused command selected the following checks together:

| Behavior / boundary | Project-owned checks, run with `npx vitest run <paths>` | Result |
| --- | --- | --- |
| Home completeness, counts, paging; pending Enter; hover ARIA/action; recents retry | `src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx`, `src/renderer/src/components/global-search/global-search-catalog.test.ts` | Pass |
| Authoritative multi-Project paging, equal-time ordering, scoped/query cursors, archived Session exclusions, validation, recovery admission and downstream persistence | `src/main/project-files/repository.test.ts`, `src/main/project-files/repository.architecture.test.ts`, `src/main/project-files/ipc.test.ts`, `src/main/session-persistence/coordinator.test.ts`, `src/main/session-persistence/deletion-integration.test.ts`, `src/main/session-persistence/artifact-finalization-recovery.integration.test.ts` (the `project_files_repository` module set) | Pass |
| Existing Host catalog consumer | `src/main/project-files/host-artifact-catalog.test.ts` | Pass |
| Electron and local/remote Web request forwarding | `src/preload/index.test.ts`, `src/renderer/web/renderer-argument-shape-characterization.test.ts`, `src/shared/renderer-surface-matrix.test.ts`, `src/main/data-content-application-commands.test.ts` | Pass |
| Translated existing error/copy surfaces | `src/renderer/src/components/global-search/GlobalSearchDialog.i18n.render.test.tsx`, `src/renderer/src/i18n/resources.test.ts` | Pass |
| Runtime types and lint | `npm run typecheck`; `npm run lint` | Pass |

Real Chromium interaction verification used the actual component, stores, and CSS with isolated fixture API data: Home displays all nine artifacts after hover + Enter on Show more; pending Enter leaves creation inactive; recent-artifact failure retains Sessions and supports hover + Enter retry. Screenshots were delivered to the requester; local fixture/evidence files are not part of this PR. This is component/browser verification, not packaged Electron E2E.

`npm run test:affected:explain -- --base 5e6978b4 --head 2c2bc60` falls back to full because `host-artifact-catalog.test.ts` has no manifest module owner. The manual impact mapping above covers that consumer explicitly; the requester asked for focused local checks and full PR CI. The ownership manifest was not broadened just to suppress fallback. Required CI is the authority for complete portable and platform coverage. No platform-specific path logic changes; fixtures use Node path helpers. Cross-platform execution remains a CI check.

## Review focus

Review full-set cursor binding, recovery admission across all primary Projects, preservation of the Workspace recommendation limit, and agreement between visible rows, ARIA selection, and Enter behavior during asynchronous artifact/Literature results. Confirm the final evidence map against the diff before marking independently verified.
