### PR TITLE
fix(onboarding): preserve runtime and provider setup progress

### DIFF
--- a/src/renderer/src/pages/onboarding/EnvironmentStep.tsx
+++ b/src/renderer/src/pages/onboarding/EnvironmentStep.tsx
@@ -16,23 +16,30 @@ import { EnvironmentSetupCard } from './EnvironmentSetupCard'
 
 type EnvironmentStepProps = {
   onContinue: () => void
+  isSelectingAgent?: boolean
 }
 
 // First step: confirm the host meets the core requirements (system, storage, secure storage,
 // network). The agent runtime is set up on the next step.
-const EnvironmentStep = ({ onContinue }: EnvironmentStepProps): React.JSX.Element => {
+const EnvironmentStep = ({
+  onContinue,
+  isSelectingAgent = false
+}: EnvironmentStepProps): React.JSX.Element => {
   const { t } = useTranslation()
   const environmentCheck = useSettingsStore((state) => state.environmentCheck)
   const environmentCheckError = useSettingsStore((state) => state.environmentCheckError)
   const isCheckingEnvironment = useSettingsStore((state) => state.isCheckingEnvironment)
   const checkEnvironment = useSettingsStore((state) => state.checkEnvironment)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
 
   // environmentCheck.ready covers the agent runtime too, so it can't gate this host-only step.
   // When the agent is the only gap the main process reports canAutoInstall — which by definition
   // means every host check passed.
   const hostReady =
     !isCheckingEnvironment &&
+    !isSelectingAgent &&
     environmentCheck !== undefined &&
+    environmentCheck.agentFrameworkId === agentFrameworkId &&
     (environmentCheck.ready === true || environmentCheck.canAutoInstall === true)
 
   return (
@@ -49,7 +56,7 @@ const EnvironmentStep = ({ onContinue }: EnvironmentStepProps): React.JSX.Elemen
             variant="outline"
             size="sm"
             onClick={() => void checkEnvironment()}
-            disabled={isCheckingEnvironment}
+            disabled={isCheckingEnvironment || isSelectingAgent}
           >
             <RefreshCw className={cn(isCheckingEnvironment && 'animate-spin')} aria-hidden="true" />
             {isCheckingEnvironment ? t('Checking…') : t('Check again')}

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.regressions.test.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.regressions.test.tsx
@@ -1,0 +1,403 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { fireEvent } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { runEnvironmentCheck } from '../../../../main/settings/environment-check'
+import type { AgentFrameworkId, EnvironmentCheckResult } from '../../../../shared/settings'
+import { i18next } from '@/i18n'
+import { useSettingsStore } from '@/stores/settings-store'
+import { OnboardingWizard } from './OnboardingWizard'
+import {
+  clickButton,
+  fillRequiredProviderFields,
+  findButton,
+  readyClaudeState,
+  resetOnboardingStores,
+  selectOption,
+  stubWindowApi
+} from './onboarding-test-utils'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  resetOnboardingStores()
+  stubWindowApi()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  act(() => root.unmount())
+  container.remove()
+  document.body.innerHTML = ''
+  delete (window as unknown as { api?: unknown }).api
+  await i18next.changeLanguage('en')
+})
+
+const renderWizard = async (): Promise<void> => {
+  await act(async () => root.render(<OnboardingWizard />))
+}
+
+const section = (label: string): Element | null =>
+  container.querySelector(`section[aria-label="${label}"]`)
+
+const goToProvider = async (): Promise<void> => {
+  readyClaudeState()
+  await renderWizard()
+  await clickButton(/^continue$/i)
+  await clickButton(/^continue$/i)
+  await clickButton(/^continue$/i)
+  expect(section('Configure model')).not.toBeNull()
+  await fillRequiredProviderFields(container)
+}
+
+const configureUnavailableRegistries = async (
+  failure?: 'storage' | 'system' | 'no-runtime',
+  alternative: AgentFrameworkId = 'opencode',
+  selected: AgentFrameworkId = 'claude-code'
+): Promise<void> => {
+  const frameworks = [
+    { id: selected, label: selected, runtime: { found: false } },
+    { id: alternative, label: alternative, runtime: { found: failure !== 'no-runtime' } }
+  ]
+  const probeRegistry = vi.fn().mockRejectedValue(new Error('Installation source unreachable'))
+  const inspect = (agentFrameworkId: AgentFrameworkId): Promise<EnvironmentCheckResult> =>
+    runEnvironmentCheck({
+      storageRoot: '/fixture/data',
+      agentFrameworkId,
+      frameworks,
+      encryptionAvailable: true,
+      deps: {
+        platform: 'darwin',
+        architecture: 'arm64',
+        verifyStorage: async () => {
+          if (failure === 'storage') throw new Error('Permission denied')
+        },
+        resolveManagedPlatform: () => {
+          if (failure === 'system') throw new Error('Unsupported system')
+          return { key: 'darwin-arm64' }
+        },
+        findPython: async () => undefined,
+        detectAvx2: () => true,
+        probeRegistry,
+        now: () => 1
+      }
+    })
+  const environmentCheck = await inspect(selected)
+  expect(probeRegistry).toHaveBeenCalledTimes(2)
+  expect(environmentCheck).toMatchObject({ ready: false, canAutoInstall: false })
+  expect(environmentCheck.checks.find((check) => check.id === 'install-network')?.status).toBe(
+    'failed'
+  )
+  if (failure !== 'no-runtime') {
+    expect(
+      environmentCheck.checks.find((check) => check.label === `${alternative} runtime`)?.status
+    ).toBe('passed')
+  }
+  useSettingsStore.setState({
+    agentFrameworkId: selected,
+    environmentCheck,
+    agentFrameworks: frameworks.map(({ id, label }) => ({
+      id,
+      displayName: label,
+      supportsSkills: true
+    })),
+    preflight: {
+      claudeReady: alternative === 'claude-code' && failure !== 'no-runtime',
+      opencodeReady: alternative === 'opencode' && failure !== 'no-runtime',
+      codexReady: alternative === 'codex' && failure !== 'no-runtime',
+      codebuddyReady: alternative === 'codebuddy' && failure !== 'no-runtime',
+      agentFrameworkId: selected,
+      agentReady: false,
+      activeProviderReady: false
+    },
+    setAgentFramework: vi.fn(async (agentFrameworkId: AgentFrameworkId) => {
+      useSettingsStore.setState({ agentFrameworkId })
+    }),
+    checkEnvironment: vi.fn(async () => {
+      const result = await inspect(useSettingsStore.getState().agentFrameworkId)
+      useSettingsStore.setState({ environmentCheck: result })
+      return result
+    })
+  })
+}
+
+describe('Onboarding navigation regressions', () => {
+  it.each(['claude-code', 'codex', 'codebuddy'] as const)(
+    'checks the installed %s alternative before continuing',
+    async (alternative) => {
+      await configureUnavailableRegistries(
+        undefined,
+        alternative,
+        alternative === 'claude-code' ? 'opencode' : 'claude-code'
+      )
+      await renderWizard()
+      expect(useSettingsStore.getState().setAgentFramework).toHaveBeenCalledWith(alternative)
+      expect(useSettingsStore.getState().environmentCheck).toMatchObject({
+        ready: true,
+        agentFrameworkId: alternative
+      })
+      expect(findButton(/^continue$/i)?.disabled).toBe(false)
+    }
+  )
+
+  it('does not select an unsupported Codex adapter as an installed alternative', async () => {
+    await configureUnavailableRegistries(undefined, 'codex')
+    useSettingsStore.setState({ codex: { version: '0.0.1' } })
+    await renderWizard()
+    expect(useSettingsStore.getState().setAgentFramework).not.toHaveBeenCalled()
+    expect(findButton(/^continue$/i)?.disabled).toBe(true)
+  })
+
+  it('waits for the selected alternative check and preserves the selection on Back', async () => {
+    await configureUnavailableRegistries()
+    const inspect = useSettingsStore.getState().checkEnvironment
+    const pending = Promise.withResolvers<void>()
+    useSettingsStore.setState({
+      checkEnvironment: vi.fn(async () => {
+        await pending.promise
+        return inspect()
+      })
+    })
+    await renderWizard()
+    expect(useSettingsStore.getState().agentFrameworkId).toBe('opencode')
+    expect(findButton(/^continue$/i)?.disabled).toBe(true)
+    await act(async () => pending.resolve())
+    expect(findButton(/^continue$/i)?.disabled).toBe(false)
+    await clickButton(/^continue$/i)
+    await clickButton(/^back$/i)
+    expect(useSettingsStore.getState().setAgentFramework).toHaveBeenCalledOnce()
+  })
+
+  it('allows setup with an installed alternative when installation sources are unreachable', async () => {
+    await configureUnavailableRegistries()
+    await renderWizard()
+
+    expect(section('Prepare environment')).not.toBeNull()
+    expect(findButton(/^continue$/i)?.disabled).toBe(false)
+    await clickButton(/^continue$/i)
+    expect(section('Choose data location')).not.toBeNull()
+    await clickButton(/^continue$/i)
+    expect(useSettingsStore.getState().setAgentFramework).toHaveBeenCalledWith('opencode')
+    expect(useSettingsStore.getState().installOpencode).not.toHaveBeenCalled()
+    expect(useSettingsStore.getState().installClaude).not.toHaveBeenCalled()
+  })
+
+  it.each(['storage', 'system', 'no-runtime'] as const)(
+    'keeps setup blocked when the remaining requirement is %s',
+    async (failure) => {
+      await configureUnavailableRegistries(failure)
+      await renderWizard()
+      expect(findButton(/^continue$/i)?.disabled).toBe(true)
+      await clickButton(/^continue$/i)
+      expect(section('Prepare environment')).not.toBeNull()
+    }
+  )
+
+  it('preserves the current location step when a provider test succeeds after Back', async () => {
+    const pending =
+      Promise.withResolvers<
+        Awaited<ReturnType<ReturnType<typeof useSettingsStore.getState>['saveAndActivateProvider']>>
+      >()
+    const save = vi.fn().mockReturnValue(pending.promise)
+    useSettingsStore.setState({ saveAndActivateProvider: save })
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    expect(save).toHaveBeenCalledOnce()
+    await clickButton(/^back$/i)
+    await clickButton(/^back$/i)
+    expect(section('Choose data location')).not.toBeNull()
+
+    await act(async () => {
+      pending.resolve({ providerId: 'saved-1', validation: { ok: true, category: 'ok' } })
+    })
+
+    expect.soft(section('Choose data location')).not.toBeNull()
+    expect.soft(section('Notebook runtime (optional)')).toBeNull()
+    expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
+  })
+
+  it('updates the saved provider identity after returning from Notebook', async () => {
+    const save = vi.fn().mockResolvedValue({
+      providerId: 'saved-1',
+      validation: { ok: true, category: 'ok' }
+    })
+    useSettingsStore.setState({ saveAndActivateProvider: save })
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    expect(section('Notebook runtime (optional)')).not.toBeNull()
+    expect(save.mock.calls[0][0].id).toBeUndefined()
+    await clickButton(/^back$/i)
+    await clickButton(/test & continue/i)
+
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save.mock.calls[1][0]).toMatchObject({ ...save.mock.calls[0][0], id: 'saved-1' })
+    expect(section('Notebook runtime (optional)')).not.toBeNull()
+  })
+
+  it('keeps a remounted provider page open when its previous test completes', async () => {
+    const pending = Promise.withResolvers<{
+      providerId: string
+      validation: { ok: true; category: 'ok' }
+    }>()
+    const save = vi
+      .fn()
+      .mockReturnValueOnce(pending.promise)
+      .mockResolvedValue({
+        providerId: 'saved-1',
+        validation: { ok: true, category: 'ok' }
+      })
+    useSettingsStore.setState({ saveAndActivateProvider: save })
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    await clickButton(/^back$/i)
+    await clickButton(/^continue$/i)
+    await act(async () => {
+      pending.resolve({ providerId: 'saved-1', validation: { ok: true, category: 'ok' } })
+    })
+    expect(section('Configure model')).not.toBeNull()
+    await clickButton(/test & continue/i)
+    expect(save.mock.calls[1][0]).toMatchObject({ id: 'saved-1', requireExisting: true })
+    expect(section('Notebook runtime (optional)')).not.toBeNull()
+  })
+
+  it('reuses the committed identity after failed validation and edited connection fields', async () => {
+    const save = vi.fn().mockResolvedValue({
+      providerId: 'saved-1',
+      validation: { ok: false, category: 'network' }
+    })
+    useSettingsStore.setState({ saveAndActivateProvider: save })
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    expect(section('Configure model')).not.toBeNull()
+    await act(async () => {
+      fireEvent.change(container.querySelector('#provider-base-url')!, {
+        target: { value: 'https://replacement.example' }
+      })
+    })
+    await clickButton(/test & continue/i)
+    expect(save.mock.calls[1][0]).toMatchObject({
+      id: 'saved-1',
+      requireExisting: true,
+      baseUrl: 'https://replacement.example'
+    })
+  })
+
+  it('starts a new identity after changing provider kind and returning to custom', async () => {
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    await clickButton(/^back$/i)
+    await selectOption('Provider type', 'Anthropic')
+    expect(container.querySelector('[aria-label="Provider type"]')?.textContent).toContain(
+      'Anthropic'
+    )
+    await selectOption('Provider type', 'Custom Gateway')
+    await fillRequiredProviderFields(container)
+    await clickButton(/test & continue/i)
+    const save = vi.mocked(useSettingsStore.getState().saveAndActivateProvider)
+    expect(save).toHaveBeenCalledTimes(2)
+    expect(save.mock.calls[1][0].id).toBeUndefined()
+  })
+
+  it('does not attach a late saved identity to a new provider draft', async () => {
+    const pending = Promise.withResolvers<{
+      providerId: string
+      validation: { ok: true; category: 'ok' }
+    }>()
+    const save = vi
+      .fn()
+      .mockReturnValueOnce(pending.promise)
+      .mockResolvedValue({
+        providerId: 'saved-2',
+        validation: { ok: true, category: 'ok' }
+      })
+    useSettingsStore.setState({ saveAndActivateProvider: save })
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    await clickButton(/^back$/i)
+    await clickButton(/^continue$/i)
+    await selectOption('Provider type', 'Anthropic')
+    expect(container.querySelector('[aria-label="Provider type"]')?.textContent).toContain(
+      'Anthropic'
+    )
+    await selectOption('Provider type', 'Custom Gateway')
+    await fillRequiredProviderFields(container)
+    await act(async () => {
+      pending.resolve({ providerId: 'saved-1', validation: { ok: true, category: 'ok' } })
+    })
+    expect(section('Configure model')).not.toBeNull()
+    await clickButton(/test & continue/i)
+    expect(save.mock.calls[1][0].id).toBeUndefined()
+  })
+
+  it('requires the saved entity to exist and starts a new one only on an explicit retry', async () => {
+    const save = vi
+      .fn()
+      .mockResolvedValueOnce({ providerId: 'saved-1', validation: { ok: true, category: 'ok' } })
+      .mockRejectedValueOnce(new Error('Provider no longer exists.'))
+      .mockResolvedValueOnce({ providerId: 'saved-2', validation: { ok: true, category: 'ok' } })
+    useSettingsStore.setState({ saveAndActivateProvider: save })
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    await clickButton(/^back$/i)
+    await clickButton(/test & continue/i)
+    expect(save.mock.calls[1][0]).toMatchObject({ id: 'saved-1', requireExisting: true })
+    expect(section('Configure model')).not.toBeNull()
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Provider no longer exists.'
+    )
+    await clickButton(/test & continue/i)
+    expect(save.mock.calls[2][0].id).toBeUndefined()
+  })
+
+  it('localizes an incompatible provider draft after switching to Codex', async () => {
+    await goToProvider()
+    await clickButton(/^back$/i)
+    await act(async () => {
+      const state = useSettingsStore.getState()
+      useSettingsStore.setState({
+        agentFrameworkId: 'codex',
+        agentFrameworks: [
+          {
+            id: 'codex',
+            displayName: 'Codex',
+            supportedApiTypes: ['responses'],
+            supportsSkills: true
+          }
+        ],
+        preflight: {
+          ...state.preflight,
+          agentFrameworkId: 'codex',
+          agentReady: true,
+          codexReady: true
+        },
+        environmentCheck: { ...state.environmentCheck!, agentFrameworkId: 'codex' }
+      })
+    })
+    await clickButton(/^continue$/i)
+    expect(section('Configure model')).not.toBeNull()
+    await act(async () => i18next.changeLanguage('zh-Hans'))
+    await clickButton(/测试并继续/)
+
+    expect(useSettingsStore.getState().saveAndActivateProvider).not.toHaveBeenCalled()
+    const alert = container.querySelector('[role="alert"]')
+    expect(alert?.textContent).toContain('Codex')
+    expect(alert?.textContent).toMatch(/不兼容/)
+    expect(alert?.textContent).not.toContain("This provider isn't compatible")
+  })
+
+  it('advances on a current successful test and finishes only on explicit Finish', async () => {
+    await goToProvider()
+    await clickButton(/test & continue/i)
+    expect(section('Notebook runtime (optional)')).not.toBeNull()
+    expect(useSettingsStore.getState().completeOnboarding).not.toHaveBeenCalled()
+    await clickButton(/^finish$/i)
+    expect(useSettingsStore.getState().completeOnboarding).toHaveBeenCalledOnce()
+  })
+})

--- a/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
+++ b/src/renderer/src/pages/onboarding/OnboardingWizard.tsx
@@ -5,6 +5,8 @@ import { useTranslation } from 'react-i18next'
 import { Card } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { APP } from '../../../../shared/app-config'
+import { isSupportedCodexAcpVersion } from '../../../../shared/codex-runtime'
+import type { AgentFrameworkId } from '../../../../shared/settings'
 import type { StorageInfo } from '../../../../shared/storage'
 import { useNotebookEnvStore } from '@/stores/notebook-env-store'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -176,6 +178,11 @@ const OnboardingWizard = ({
   const environmentCheckError = useSettingsStore((state) => state.environmentCheckError)
   const isCheckingEnvironment = useSettingsStore((state) => state.isCheckingEnvironment)
   const checkEnvironment = useSettingsStore((state) => state.checkEnvironment)
+  const agentFrameworkId = useSettingsStore((state) => state.agentFrameworkId)
+  const agentFrameworks = useSettingsStore((state) => state.agentFrameworks)
+  const preflight = useSettingsStore((state) => state.preflight)
+  const codexVersion = useSettingsStore((state) => state.codex.version)
+  const setAgentFramework = useSettingsStore((state) => state.setAgentFramework)
 
   // First-time setup always starts on the visible environment summary, even when every check has
   // already passed. The user explicitly continues to agent setup after reviewing it.
@@ -197,9 +204,29 @@ const OnboardingWizard = ({
     }
   }, [step])
   // The provider draft lives here (not in ProviderStep) so going Back and returning keeps it.
-  const [formValue, setFormValue] = useState<ProviderFormValue>(() =>
-    createEmptyProviderFormValue()
+  const [providerDraft, setProviderDraft] = useState<{
+    value: ProviderFormValue
+    providerId?: string
+    generation: number
+  }>(() => ({ value: createEmptyProviderFormValue(), generation: 0 }))
+  const setFormValue = useCallback<React.Dispatch<React.SetStateAction<ProviderFormValue>>>(
+    (update) => {
+      setProviderDraft((current) => {
+        const value = typeof update === 'function' ? update(current.value) : update
+        if (value === current.value) return current
+        const changedKind =
+          value.type !== current.value.type || value.vendorId !== current.value.vendorId
+        return changedKind ? { value, generation: current.generation + 1 } : { ...current, value }
+      })
+    },
+    []
   )
+  const recordSavedProvider = (providerId: string | undefined): void => {
+    // A response for an abandoned provider kind cannot attach its identity to the new draft.
+    setProviderDraft((current) =>
+      current.generation === providerDraft.generation ? { ...current, providerId } : current
+    )
+  }
   // Fetched once, up front, so Location has the default to show and a post-selection relaunch can
   // resume after the already-completed storage step.
   const [dataRootInfo, setDataRootInfo] = useState<StorageInfo | null>(null)
@@ -239,6 +266,73 @@ const OnboardingWizard = ({
 
   const didRequestCheck = useRef(false)
   const didKickEnv = useRef(false)
+  const didSelectInitialAgent = useRef(false)
+  const [isSelectingInitialAgent, setIsSelectingInitialAgent] = useState(false)
+
+  useEffect(() => {
+    if (step !== 'environment') {
+      didSelectInitialAgent.current = true
+      return
+    }
+    if (
+      didSelectInitialAgent.current ||
+      isCheckingEnvironment ||
+      !environmentCheck ||
+      environmentCheck.agentFrameworkId !== agentFrameworkId ||
+      environmentCheck.runtime.found ||
+      !['system', 'storage'].every((id) =>
+        environmentCheck.checks.some((check) => check.id === id && check.status === 'passed')
+      ) ||
+      environmentCheck.checks.some(
+        (check) =>
+          check.status === 'failed' && check.id !== 'agent' && check.id !== 'install-network'
+      )
+    ) {
+      return
+    }
+    // Match AgentPanel's installed-runtime ordering and Codex adapter compatibility guard.
+    const ready: Record<AgentFrameworkId, boolean> = {
+      'claude-code': preflight.claudeReady,
+      opencode: preflight.opencodeReady,
+      codex: preflight.codexReady && (!codexVersion || isSupportedCodexAcpVersion(codexVersion)),
+      codebuddy: preflight.codebuddyReady
+    }
+    if (ready[agentFrameworkId]) return
+    const installed = agentFrameworks.find((framework) => ready[framework.id])
+    if (!installed) return
+
+    didSelectInitialAgent.current = true
+    didRequestCheck.current = true
+    useSettingsStore.setState({ environmentCheck: undefined, environmentCheckError: undefined })
+    void Promise.resolve().then(async () => {
+      setIsSelectingInitialAgent(true)
+      try {
+        await setAgentFramework(installed.id)
+        await checkEnvironment({ force: true })
+      } catch (error) {
+        didSelectInitialAgent.current = false
+        useSettingsStore.setState({
+          environmentCheckError:
+            error instanceof Error
+              ? error.message
+              : t('Could not switch to {{name}}', { name: installed.displayName })
+        })
+      } finally {
+        setIsSelectingInitialAgent(false)
+      }
+    })
+  }, [
+    step,
+    isCheckingEnvironment,
+    environmentCheck,
+    agentFrameworkId,
+    agentFrameworks,
+    preflight,
+    codexVersion,
+    setAgentFramework,
+    checkEnvironment,
+    t
+  ])
 
   // Fetch the current data location once, up front, for Location display and relaunch resume.
   const handleDataRootInfoSuccess = useCallback((info: StorageInfo): void => {
@@ -373,7 +467,10 @@ const OnboardingWizard = ({
             {/* Each step owns its validation gate and advances only through its callback. The shell
                 owns cross-step drafts so Back/Continue never discards provider or location input. */}
             {step === 'environment' ? (
-              <EnvironmentStep onContinue={() => setStep('location')} />
+              <EnvironmentStep
+                isSelectingAgent={isSelectingInitialAgent}
+                onContinue={() => setStep('location')}
+              />
             ) : step === 'location' ? (
               <LocationStep
                 dataRootInfo={dataRootInfo}
@@ -396,10 +493,14 @@ const OnboardingWizard = ({
               />
             ) : step === 'provider' ? (
               <ProviderStep
-                formValue={formValue}
+                formValue={providerDraft.value}
                 setFormValue={setFormValue}
+                providerId={providerDraft.providerId}
+                onProviderSaved={recordSavedProvider}
                 onBack={() => setStep('agent')}
-                onAdvance={() => setStep('notebook')}
+                onAdvance={() =>
+                  setStep((current) => (current === 'provider' ? 'notebook' : current))
+                }
               />
             ) : step === 'notebook' ? (
               <NotebookStep onBack={() => setStep('provider')} />

--- a/src/renderer/src/pages/onboarding/ProviderStep.tsx
+++ b/src/renderer/src/pages/onboarding/ProviderStep.tsx
@@ -34,7 +34,8 @@ const isBrowserSignInProvider = (type: ProviderFormValue['type']): boolean =>
   type === 'xai-subscription'
 
 // Converts a form value into the upsert request the main process expects.
-const toUpsertRequest = (value: ProviderFormValue): UpsertProviderRequest => ({
+const toUpsertRequest = (value: ProviderFormValue, id?: string): UpsertProviderRequest => ({
+  ...(id ? { id, requireExisting: true } : {}),
   type: value.type,
   codexTransport: value.codexTransport,
   name: value.name,
@@ -56,6 +57,8 @@ type ProviderStepProps = {
   // validation, saving, and the isolated Codex sign-in flow.
   formValue: ProviderFormValue
   setFormValue: React.Dispatch<React.SetStateAction<ProviderFormValue>>
+  providerId?: string
+  onProviderSaved?: (id: string | undefined) => void
   onBack: () => void
   onAdvance: () => void
 }
@@ -65,6 +68,8 @@ type ProviderStepProps = {
 const ProviderStep = ({
   formValue,
   setFormValue,
+  providerId: savedProviderId,
+  onProviderSaved,
   onBack,
   onAdvance
 }: ProviderStepProps): React.JSX.Element => {
@@ -92,6 +97,16 @@ const ProviderStep = ({
   const cancelXaiOAuthLogin = useSettingsStore((state) => state.cancelXaiOAuthLogin)
 
   const [isSaving, setIsSaving] = useState(false)
+  const mounted = useRef(false)
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+  const advanceIfMounted = (): void => {
+    if (mounted.current) onAdvance()
+  }
   const [isClaudeSignInOpen, setIsClaudeSignInOpen] = useState(false)
   const [xaiSession, setXaiSession] = useState<XaiOAuthDeviceAuthorization>()
   const claudeProviderIdRef = useRef<string | undefined>(undefined)
@@ -146,7 +161,7 @@ const ProviderStep = ({
     })
   }, [agentFrameworkId, customApiEndpoint, setFormValue])
 
-  // Onboarding always creates a provider, so required fields must be filled before it can continue.
+  // Required fields must be filled before the draft can be tested.
   const formErrors = getProviderFormErrors(formValue)
 
   const handleClaudeTokenFallback = async (token: string): Promise<ValidateProviderResult> => {
@@ -172,7 +187,7 @@ const ProviderStep = ({
           await setActiveProvider(claudeProviderIdRef.current)
         }
         setIsClaudeSignInOpen(false)
-        onAdvance()
+        advanceIfMounted()
       }
 
       return result
@@ -213,10 +228,13 @@ const ProviderStep = ({
     ) {
       const label =
         agentFrameworks.find((framework) => framework.id === agentFrameworkId)?.displayName ??
-        'the selected agent'
+        t('The selected agent')
       setValidationOk(false)
       setValidationMessage(
-        `This provider isn't compatible with ${label}. Pick a provider whose API format ${label} supports, or change the agent framework.`
+        t(
+          "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.",
+          { framework: label }
+        )
       )
       return
     }
@@ -252,7 +270,7 @@ const ProviderStep = ({
 
         if (validation.ok) {
           if (providerId) await setActiveProvider(providerId)
-          onAdvance()
+          advanceIfMounted()
         }
         return
       }
@@ -291,7 +309,7 @@ const ProviderStep = ({
         if (validation.ok) {
           setIsClaudeSignInOpen(false)
           if (providerId) await setActiveProvider(providerId)
-          onAdvance()
+          advanceIfMounted()
         }
         return
       }
@@ -322,7 +340,7 @@ const ProviderStep = ({
 
         if (validation.ok) {
           if (providerId) await setActiveProvider(providerId)
-          onAdvance()
+          advanceIfMounted()
         }
         return
       }
@@ -351,12 +369,17 @@ const ProviderStep = ({
         setValidationMessage(describeValidation(validation, tSettings))
         if (validation.ok) {
           await setActiveProvider(providerId)
-          onAdvance()
+          advanceIfMounted()
         }
         return
       }
 
-      const { validation } = await saveAndActivateProvider(toUpsertRequest(providerValue))
+      const { providerId, validation } = await saveAndActivateProvider(
+        toUpsertRequest(providerValue, savedProviderId)
+      )
+      // Persistence survives Back even though this page's permission to navigate does not.
+      if (providerId) onProviderSaved?.(providerId)
+      if (!mounted.current) return
 
       // A validation superseded by a newer test (or a provider removed/edited mid-test) reports its
       // outcome but was not recorded; do not finish onboarding on a result the stored provider never
@@ -371,9 +394,13 @@ const ProviderStep = ({
       setValidationMessage(describeValidation(validation, tSettings))
 
       if (validation.ok) {
-        onAdvance()
+        advanceIfMounted()
       }
     } catch (error) {
+      if (error instanceof Error && error.message === 'Provider no longer exists.') {
+        onProviderSaved?.(undefined)
+      }
+      if (!mounted.current) return
       if (formValue.type === 'xai-subscription' && xaiLoginCancelledRef.current) return
       setValidationOk(false)
       setValidationMessage(
@@ -462,7 +489,14 @@ const ProviderStep = ({
             {t('Cancel sign-in')}
           </Button>
         ) : (
-          <Button type="button" variant="outline" onClick={onBack}>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              mounted.current = false
+              onBack()
+            }}
+          >
             {t('Back', { context: 'step' })}
           </Button>
         )}

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4693,6 +4693,7 @@
     "Loading app icons…": "App-Symbole werden geladen…",
     "Could not load app icons.": "Die App-Symbole konnten nicht geladen werden.",
     "No app icons are available.": "Es sind keine App-Symbole verfügbar.",
-    "Current icon: {{icon}}. Its preview is unavailable.": "Aktuelles Symbol: {{icon}}. Die Vorschau ist nicht verfügbar."
+    "Current icon: {{icon}}. Its preview is unavailable.": "Aktuelles Symbol: {{icon}}. Die Vorschau ist nicht verfügbar.",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Dieser Anbieter ist nicht mit {{framework}} kompatibel. Wählen Sie einen Anbieter mit einem von {{framework}} unterstützten API-Format oder wechseln Sie das Agenten-Framework."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4855,6 +4855,7 @@
     "Loading app icons…": "Cargando iconos de la aplicación…",
     "Could not load app icons.": "No se pudieron cargar los iconos de la aplicación.",
     "No app icons are available.": "No hay iconos de la aplicación disponibles.",
-    "Current icon: {{icon}}. Its preview is unavailable.": "Icono actual: {{icon}}. Su vista previa no está disponible."
+    "Current icon: {{icon}}. Its preview is unavailable.": "Icono actual: {{icon}}. Su vista previa no está disponible.",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Este proveedor no es compatible con {{framework}}. Seleccione un proveedor cuyo formato de API sea compatible con {{framework}} o cambie el framework del agente."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4855,6 +4855,7 @@
     "Loading app icons…": "Chargement des icônes de l’application…",
     "Could not load app icons.": "Impossible de charger les icônes de l’application.",
     "No app icons are available.": "Aucune icône d’application n’est disponible.",
-    "Current icon: {{icon}}. Its preview is unavailable.": "Icône actuelle : {{icon}}. Son aperçu n’est pas disponible."
+    "Current icon: {{icon}}. Its preview is unavailable.": "Icône actuelle : {{icon}}. Son aperçu n’est pas disponible.",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Ce fournisseur n'est pas compatible avec {{framework}}. Choisissez un fournisseur dont le format d'API est pris en charge par {{framework}}, ou changez de framework d'agents."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4539,6 +4539,7 @@
     "Loading app icons…": "アプリアイコンを読み込み中…",
     "Could not load app icons.": "アプリアイコンを読み込めませんでした。",
     "No app icons are available.": "利用可能なアプリアイコンはありません。",
-    "Current icon: {{icon}}. Its preview is unavailable.": "現在のアイコン：{{icon}}。プレビューは利用できません。"
+    "Current icon: {{icon}}. Its preview is unavailable.": "現在のアイコン：{{icon}}。プレビューは利用できません。",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "このプロバイダーは {{framework}} と互換性がありません。{{framework}} が対応する API 形式のプロバイダーを選択するか、エージェントフレームワークを変更してください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4537,6 +4537,7 @@
     "Loading app icons…": "앱 아이콘 불러오는 중…",
     "Could not load app icons.": "앱 아이콘을 불러오지 못했습니다.",
     "No app icons are available.": "사용 가능한 앱 아이콘이 없습니다.",
-    "Current icon: {{icon}}. Its preview is unavailable.": "현재 아이콘: {{icon}}. 미리보기를 사용할 수 없습니다."
+    "Current icon: {{icon}}. Its preview is unavailable.": "현재 아이콘: {{icon}}. 미리보기를 사용할 수 없습니다.",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "이 모델 제공업체는 {{framework}}에서 사용할 수 없습니다. {{framework}}에서 지원하는 API 형식의 모델 제공업체를 선택하거나 에이전트 프레임워크를 변경하세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4988,6 +4988,7 @@
     "Loading app icons…": "Загрузка значков приложения…",
     "Could not load app icons.": "Не удалось загрузить значки приложения.",
     "No app icons are available.": "Нет доступных значков приложения.",
-    "Current icon: {{icon}}. Its preview is unavailable.": "Текущий значок: {{icon}}. Предпросмотр недоступен."
+    "Current icon: {{icon}}. Its preview is unavailable.": "Текущий значок: {{icon}}. Предпросмотр недоступен.",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Этот поставщик несовместим с {{framework}}. Выберите поставщика с форматом API, который поддерживает {{framework}}, или смените фреймворк агента."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4539,6 +4539,7 @@
     "Loading app icons…": "正在加载应用图标…",
     "Could not load app icons.": "无法加载应用图标。",
     "No app icons are available.": "没有可用的应用图标。",
-    "Current icon: {{icon}}. Its preview is unavailable.": "当前图标：{{icon}}。其预览不可用。"
+    "Current icon: {{icon}}. Its preview is unavailable.": "当前图标：{{icon}}。其预览不可用。",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "此提供商与 {{framework}} 不兼容。请选择 API 格式受 {{framework}} 支持的提供商，或更换智能体框架。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4539,6 +4539,7 @@
     "Loading app icons…": "正在載入應用程式圖示…",
     "Could not load app icons.": "無法載入應用程式圖示。",
     "No app icons are available.": "沒有可用的應用程式圖示。",
-    "Current icon: {{icon}}. Its preview is unavailable.": "目前圖示：{{icon}}。其預覽無法使用。"
+    "Current icon: {{icon}}. Its preview is unavailable.": "目前圖示：{{icon}}。其預覽無法使用。",
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "此提供商與 {{framework}} 不相容。請選擇 API 格式受 {{framework}} 支援的提供商，或更換智能體框架。"
   }
 }


### PR DESCRIPTION
## Problem

First-time setup can block on unreachable installation sources even when another agent is already
installed. A provider test completing after Back can replace the user's current page with Notebook.
Returning to a successfully saved provider and continuing again sends another create request, and
incompatible-provider guidance stays in English in translated interfaces.

## Proposed change

- Select an installed alternative during the initial environment step, preserving system/storage
  requirements and Codex adapter checks. Recheck the selected framework before enabling Continue.
- Keep Back available, but expire the departing provider page's navigation permission. The shell
  also advances only from the provider step; committed saves remain intact.
- Retain the saved provider ID with the wizard draft. Subsequent submissions update that identity;
  kind/vendor changes detach it. Late results cannot attach an abandoned draft's identity to a new
  kind. Updates require an existing entity; a confirmed deletion permits creation only on a later,
  explicit retry.
- Translate compatibility guidance with framework interpolation in all eight locales and reuse the
  translated unknown-agent fallback.

## Scope and non-goals

Three onboarding components, one regression suite, and eight locale catalogs change. Added IDs,
draft generations, and lifecycle flags are renderer memory only. No new persisted fields, enums,
schema, migrations, IPC contracts, dependencies, or protocol adapters. Framework preference and
provider writes use existing interfaces. Previously created duplicate providers remain untouched;
no name/URL deduplication or historical cleanup is attempted.

## Acceptance criteria and validation

The complete real wizard reproduces the reports through DOM actions. Environment cases use the real
`runEnvironmentCheck` with injected host/network probes. Provider requests use controllable store
boundaries; no real network calls, installations, credential writes, or remote model validation ran.
On unchanged production code, the expanded suite failed identically twice: **12 assertion failures,
6 passing controls**. Fixed: **18/18 pass**.

All following local checks ran after the final material edit:

The branch was rebased to resolve independent locale-entry conflicts with main. All 1,147 module
tests, Node/sandbox/Web typechecks, lint and diff checks also pass on the rebased head `d1689e72`;
the onboarding source and regression suite are unchanged by the rebase.

| Behavior / boundary | Project-owned check | Result |
| --- | --- | --- |
| Wizard, host gates, framework choice, provider identity, Back, subscription cleanup | Onboarding suites | 146 pass |
| Shared provider form and conversion | ProviderForm and provider-form-value suites | 62 pass |
| Provider identity and persistence/store contracts | settings-provider-auth-slice and provider-accounts suites | 75 pass |
| Host checks and runtime owner | environment-check and agent-runtime-manager suites | 59 pass |
| Locale keys, interpolation, glossary and renderer coverage | i18n/resources suite | 805 pass |
| Node, sandbox and renderer types | `npm run typecheck` | Pass |
| Source quality | `npm run lint`; `git diff --check` | Pass |

The 15 test files ran together, **1,147/1,147 passing**:

```sh
npm test -- src/renderer/src/pages/onboarding src/renderer/src/pages/settings/ProviderForm.render.test.tsx src/renderer/src/pages/settings/provider-form-value.test.ts src/renderer/src/stores/settings-provider-auth-slice.test.ts src/main/settings/environment-check.test.ts src/main/settings/agent-runtime-manager.test.ts src/main/settings/provider-accounts.test.ts src/renderer/src/i18n/resources.test.ts --maxWorkers=3
```

Actual components/styles were also checked in an isolated browser with simulated APIs: the first
page reports that OpenCode needs no download; Chinese compatibility guidance renders; two Back
actions remain on Location after the old test succeeds. Screenshots are retained in the local task.

`npm run test:affected:explain -- --base origin/main --head HEAD` selects the full plan because
EnvironmentStep has no curated module owner. The explicit local set above follows the maintainer's
module-only instruction; the full plan is retained for PR CI, not claimed as locally executed.
The owner/consumer map includes all registered agent alternatives and the existing subscription
cases. Conversation branches, protocol translation and history replay are unchanged. No full local
suite was run at the maintainer's request; exact-head PR CI owns complete portable/platform checks,
and independent PR review is still required before declaring final verification.

## Review focus

Check that initial selection cannot bypass hard host failures, stale provider callbacks cannot
navigate a remounted page, and provider identity follows the draft rather than name/URL matching.
