### PR TITLE
fix(remote-access): recover from persistence and probe failures

### DIFF
--- a/src/main/remote-access/pairing-page.test.ts
+++ b/src/main/remote-access/pairing-page.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+import { runInNewContext } from 'node:vm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderPairingPage } from './pairing-page'
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  vi.setSystemTime(new Date('2026-09-06T00:00:00Z'))
+})
+
+afterEach(() => {
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  document.body.innerHTML = ''
+})
+
+const executePage = (
+  fetch: ReturnType<typeof vi.fn>,
+  expiresIn = 600_000
+): { events: EventTarget; replace: ReturnType<typeof vi.fn>; reload: ReturnType<typeof vi.fn> } => {
+  const { html } = renderPairingPage({
+    code: '123456',
+    browser: 'Safari',
+    platform: 'iOS/iPadOS',
+    expiresAt: Date.now() + expiresIn
+  })
+  document.documentElement.innerHTML = html
+  const script = document.querySelector('script')!.textContent!
+  const location = { replace: vi.fn(), reload: vi.fn() }
+  const events = new EventTarget()
+  const timers = { setTimeout, clearTimeout, setInterval, clearInterval }
+  runInNewContext(script, {
+    document,
+    fetch,
+    Date,
+    AbortController,
+    ...timers,
+    window: { ...timers, location, addEventListener: events.addEventListener.bind(events) }
+  })
+  return { events, replace: location.replace, reload: location.reload }
+}
+
+const hangingFetch = (stage: 'fetch' | 'json', honorAbort = true): ReturnType<typeof vi.fn> =>
+  vi.fn((_url, options) => {
+    const hanging = new Promise((_resolve, reject) => {
+      if (honorAbort) {
+        options.signal?.addEventListener('abort', () => reject(new Error('aborted')), {
+          once: true
+        })
+      }
+    })
+    return stage === 'fetch' ? hanging : Promise.resolve({ json: () => hanging })
+  })
+
+describe('Pairing page recovery', () => {
+  it.each(['fetch', 'json'] as const)(
+    'expires the page even when %s never completes',
+    async (stage) => {
+      const fetch = hangingFetch(stage, false)
+      executePage(fetch)
+      await vi.advanceTimersByTimeAsync(600_001)
+      expect(document.querySelector('#status')!.textContent).toContain('expired')
+    }
+  )
+
+  it.each(['fetch', 'json'] as const)(
+    'aborts a stalled %s and retries before pairing expires',
+    async (stage) => {
+      const fetch = hangingFetch(stage)
+      executePage(fetch)
+      await vi.advanceTimersByTimeAsync(30_000)
+      expect.soft(fetch.mock.calls[0][1].signal?.aborted).toBe(true)
+      expect(fetch.mock.calls.length).toBeGreaterThan(1)
+    }
+  )
+
+  it('expires normally while pending responses continue arriving', async () => {
+    executePage(vi.fn().mockResolvedValue({ json: async () => ({ status: 'pending' }) }))
+    await vi.advanceTimersByTimeAsync(600_001)
+    expect(document.querySelector('#status')!.textContent).toContain('expired')
+  })
+
+  it.each(['expired', 'rejected'])(
+    'offers a restart after the server reports %s',
+    async (status) => {
+      executePage(vi.fn().mockResolvedValue({ json: async () => ({ status }) }))
+      await vi.advanceTimersByTimeAsync(0)
+      expect(document.querySelector('#status')!.textContent).toContain(status)
+      const restart = [
+        ...document.querySelectorAll<HTMLButtonElement | HTMLAnchorElement>('button, a')
+      ].find((element) => /try again|start again|restart/i.test(element.textContent ?? ''))
+      expect(restart, 'Terminal pairing states need an actionable restart').toBeDefined()
+      expect(restart!.hidden).toBe(false)
+      expect(restart!.getAttribute('href')).toBe('/')
+      await vi.advanceTimersByTimeAsync(600_001)
+      expect(document.querySelector('#status')!.textContent).toContain(status)
+      expect(vi.getTimerCount()).toBe(0)
+    }
+  )
+
+  it('does not let a late approval replace the expired page', async () => {
+    let approve!: (result: unknown) => void
+    const fetch = vi.fn().mockResolvedValue({
+      json: () =>
+        new Promise((resolve) => {
+          approve = resolve
+        })
+    })
+    const { replace } = executePage(fetch, 1000)
+    await vi.advanceTimersByTimeAsync(1001)
+    approve({ status: 'approved' })
+    await vi.advanceTimersByTimeAsync(2000)
+    expect(document.querySelector('#status')!.textContent).toContain('expired')
+    expect(replace).not.toHaveBeenCalled()
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('opens the workspace after approval without a later expiry update', async () => {
+    const fetch = vi.fn().mockResolvedValue({ json: async () => ({ status: 'approved' }) })
+    const { replace } = executePage(fetch)
+    await vi.advanceTimersByTimeAsync(600_001)
+    expect(replace).toHaveBeenCalledExactlyOnceWith('/')
+    expect(document.querySelector('#status')!.textContent).toContain('Approved')
+    expect(document.querySelector<HTMLAnchorElement>('#restart')!.hidden).toBe(true)
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('cancels the request and all timers when leaving the page', async () => {
+    const fetch = hangingFetch('fetch')
+    const { events } = executePage(fetch)
+    events.dispatchEvent(new Event('pagehide'))
+    await vi.advanceTimersByTimeAsync(600_001)
+    expect(fetch.mock.calls[0][1].signal.aborted).toBe(true)
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('refreshes a pairing page restored from the back-forward cache', () => {
+    const { events, reload } = executePage(hangingFetch('fetch', false))
+    events.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: false }))
+    expect(reload).not.toHaveBeenCalled()
+    events.dispatchEvent(new Event('pagehide'))
+    events.dispatchEvent(new PageTransitionEvent('pageshow', { persisted: true }))
+    expect(reload).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/remote-access/pairing-page.ts
+++ b/src/main/remote-access/pairing-page.ts
@@ -53,6 +53,8 @@ export const renderPairingPage = (params: {
       .dot { width: 8px; height: 8px; border-radius: 50%; background: #d69e2e; box-shadow: 0 0 0 5px rgba(214, 158, 46, .13); }
       .status.approved .dot { background: #0d9a75; box-shadow: 0 0 0 5px rgba(13, 154, 117, .13); }
       .status.rejected .dot { background: #d14545; box-shadow: 0 0 0 5px rgba(209, 69, 69, .13); }
+      .restart { display: inline-block; margin-top: 20px; padding: 10px 16px; border: 1px solid currentColor; border-radius: 8px; color: inherit; font-size: 14px; text-decoration: none; }
+      .restart[hidden] { display: none; }
       @media (prefers-color-scheme: dark) {
         body { background: #101412; color: #edf2ef; }
         .card { background: #171c19; border-color: #303834; box-shadow: 0 24px 70px rgba(0, 0, 0, .35); }
@@ -74,44 +76,73 @@ export const renderPairingPage = (params: {
       <div class="code" aria-label="Pairing code">${code}</div>
       <p>Choose “Allow for up to 12 hours” or “Trust this browser for 180 days”. Do not share this pairing code with anyone.</p>
       <div class="device">${browser} · ${platform}</div>
-      <div id="status" class="status"><span class="dot"></span><span>Waiting for approval…</span></div>
+      <div id="status" class="status" role="status" aria-live="polite"><span class="dot"></span><span>Waiting for approval…</span></div>
+      <a id="restart" class="restart" href="/" hidden>Start again</a>
     </main>
     <script nonce="${nonce}">
       const statusNode = document.getElementById('status');
       const expiry = ${params.expiresAt};
       let stopped = false;
+      let expiryTimer;
+      let pollTimer;
+      let requestTimer;
+      let controller;
       const setStatus = (kind, message) => {
         statusNode.className = 'status ' + kind;
         statusNode.querySelector('span:last-child').textContent = message;
       };
+      const stop = () => {
+        stopped = true;
+        window.clearTimeout(expiryTimer);
+        window.clearTimeout(pollTimer);
+        window.clearTimeout(requestTimer);
+        controller?.abort();
+      };
+      const finish = (kind, message) => {
+        stop();
+        setStatus(kind, message);
+        document.getElementById('restart').hidden = kind === 'approved';
+      };
+      const expire = () => finish('rejected', 'This pairing code has expired. Refresh the page to try again.');
       const poll = async () => {
         if (stopped) return;
         if (Date.now() >= expiry) {
-          setStatus('rejected', 'This pairing code has expired. Refresh the page to try again.');
+          expire();
           return;
         }
+        controller = new AbortController();
+        const signal = controller.signal;
+        requestTimer = window.setTimeout(() => controller.abort(), 10000);
         try {
-          const response = await fetch('${REMOTE_PAIR_STATUS_PATH}', { cache: 'no-store', credentials: 'same-origin' });
+          const response = await fetch('${REMOTE_PAIR_STATUS_PATH}', { cache: 'no-store', credentials: 'same-origin', signal });
           const result = await response.json();
+          if (stopped) return;
+          if (Date.now() >= expiry) { expire(); return; }
+          if (signal.aborted) return;
           if (result.status === 'approved') {
-            stopped = true;
-            setStatus('approved', 'Approved. Opening Open Science…');
-            window.setTimeout(() => window.location.replace('/'), 300);
+            finish('approved', 'Approved. Opening Open Science…');
+            pollTimer = window.setTimeout(() => window.location.replace('/'), 300);
             return;
           }
           if (result.status === 'rejected') {
-            stopped = true;
-            setStatus('rejected', 'This request was rejected.');
+            finish('rejected', 'This request was rejected.');
             return;
           }
           if (result.status === 'expired') {
-            stopped = true;
-            setStatus('rejected', 'This pairing code has expired. Refresh the page to try again.');
+            expire();
             return;
           }
         } catch { /* retry while the home computer reconnects */ }
-        window.setTimeout(poll, 2000);
+        finally {
+          window.clearTimeout(requestTimer);
+          if (!stopped) pollTimer = window.setTimeout(poll, 2000);
+        }
       };
+      expiryTimer = window.setTimeout(expire, Math.max(0, expiry - Date.now()));
+      window.addEventListener('pagehide', stop, { once: true });
+      window.addEventListener('pageshow', (event) => {
+        if (event.persisted) window.location.reload();
+      });
       poll();
     </script>
   </body>

--- a/src/main/remote-access/pairing.test.ts
+++ b/src/main/remote-access/pairing.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtemp, rm } from 'node:fs/promises'
 import type { IncomingMessage, ServerResponse } from 'node:http'
 import { tmpdir } from 'node:os'
@@ -71,6 +72,120 @@ const response = (): CapturedResponse => {
 const cookiePair = (header: string): string => header.split(';', 1)[0]
 
 describe('RemoteSessionPairingManager', () => {
+  it.each(['http', 'websocket'] as const)(
+    'keeps valid trusted %s access available when only the activity timestamp cannot be saved',
+    async (transport) => {
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const repository = new RemoteAccessRepository(root)
+      let now = Date.now()
+      const lastSeenAt = now
+      const browser = {
+        id: 'trusted-browser',
+        browser: 'Safari',
+        platform: 'iOS/iPadOS',
+        tokenHash: createHash('sha256').update('trusted-secret').digest('hex'),
+        createdAt: now,
+        lastSeenAt,
+        expiresAt: now + TRUSTED_BROWSER_TTL_MS
+      }
+      await repository.save({ version: 5, mode: 'remoteit-public', trustedBrowsers: [browser] })
+      const manager = await RemoteSessionPairingManager.create({
+        repository,
+        now: () => now,
+        isEnabled: () => true,
+        isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+        onChanged: vi.fn()
+      })
+      const authorize = (): Promise<unknown> => {
+        const path = transport === 'http' ? '/api/bootstrap' : '/api/v1/events'
+        const req = request(path, {
+          cookie: 'open_science_remote_session=trusted-browser.trusted-secret',
+          origin: 'https://home.example.ts.net'
+        })
+        const url = new URL(path, 'https://home.example.ts.net')
+        return transport === 'http'
+          ? manager.webAccess.authorizeHttp(req, response().response, url)
+          : manager.webAccess.authorizeWebSocket(req, url)
+      }
+      try {
+        await expect(authorize()).resolves.toMatchObject({ principalId: browser.id })
+        now += 61_000
+        const save = vi.spyOn(repository, 'save').mockRejectedValueOnce(new Error('disk full'))
+        // Soft assertions also collect the unchanged disk state and successful retry on the baseline.
+        await expect.soft(authorize()).resolves.toMatchObject({ principalId: browser.id })
+        expect(save).toHaveBeenCalledOnce()
+        expect((await repository.load()).trustedBrowsers).toEqual([browser])
+        expect(manager.trustedViews()).toHaveLength(1)
+        await expect(authorize()).resolves.toMatchObject({ principalId: browser.id })
+        expect((await repository.load()).trustedBrowsers[0].lastSeenAt).toBe(now)
+      } finally {
+        manager.dispose()
+      }
+    }
+  )
+
+  it.each(['revocation', 'disable', 'expiry'] as const)(
+    'does not authorize after %s while a failed activity save is pending',
+    async (invalidation) => {
+      const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
+      roots.push(root)
+      const repository = new RemoteAccessRepository(root)
+      let now = Date.now()
+      let enabled = true
+      const expiresAt = now + TRUSTED_BROWSER_TTL_MS
+      await repository.save({
+        version: 5,
+        mode: 'remoteit-public',
+        trustedBrowsers: [
+          {
+            id: 'trusted-browser',
+            browser: 'Safari',
+            platform: 'iOS/iPadOS',
+            tokenHash: createHash('sha256').update('trusted-secret').digest('hex'),
+            createdAt: now,
+            lastSeenAt: now,
+            expiresAt
+          }
+        ]
+      })
+      const manager = await RemoteSessionPairingManager.create({
+        repository,
+        now: () => now,
+        isEnabled: () => enabled,
+        isAllowedRemoteHost: (hostname) => hostname === 'home.example.ts.net',
+        onChanged: vi.fn()
+      })
+      let rejectSave!: (error: Error) => void
+      const save = vi.spyOn(repository, 'save').mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectSave = reject
+          })
+      )
+      now += 61_000
+      const authorization = manager.webAccess.authorizeHttp(
+        request('/api/bootstrap', {
+          cookie: 'open_science_remote_session=trusted-browser.trusted-secret'
+        }),
+        response().response,
+        new URL('https://home.example.ts.net/api/bootstrap')
+      )
+      try {
+        await vi.waitFor(() => expect(save).toHaveBeenCalledOnce())
+        const revocation =
+          invalidation === 'revocation' ? manager.revoke('trusted-browser') : undefined
+        if (invalidation === 'disable') enabled = false
+        if (invalidation === 'expiry') now = expiresAt
+        rejectSave(new Error('disk full'))
+        await expect(authorization).resolves.toBe('denied')
+        await revocation
+      } finally {
+        manager.dispose()
+      }
+    }
+  )
+
   it('grants temporary access without allowing the browser to manage pairing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-pairing-'))
     roots.push(root)

--- a/src/main/remote-access/pairing.ts
+++ b/src/main/remote-access/pairing.ts
@@ -702,6 +702,9 @@ export class RemoteSessionPairingManager {
       let changed = await this.commitStoredMutation((stored) => {
         const current = stored.trustedBrowsers.find((browser) => browser.id === id)
         if (!current || !safeHashEqual(current.tokenHash, tokenHash)) return undefined
+        if (this.pendingRevocations.has(id) || this.unclaimedTrustedBrowserCleanup.has(id)) {
+          return undefined
+        }
         const lastSeenAt = this.now()
         if (current.expiresAt <= lastSeenAt) {
           expired = true
@@ -719,6 +722,11 @@ export class RemoteSessionPairingManager {
             browser.id === id ? { ...browser, lastSeenAt } : browser
           )
         }
+      }).catch((error: unknown) => {
+        // Only the activity timestamp is best-effort. Expiry removal and every other
+        // authorization-changing write must retain their strict persistence semantics.
+        if (!authorized || expired) throw error
+        return false
       })
       if (authorizedExpiresAt !== undefined && authorizedExpiresAt <= this.now()) {
         authorized = false
@@ -729,7 +737,13 @@ export class RemoteSessionPairingManager {
       if (changed) this.options.onChanged()
       if (!authorized) return undefined
     }
-    return { kind: 'trusted', sessionId: id }
+    const access = { kind: 'trusted', sessionId: id } as const
+    const current = this.stored.trustedBrowsers.find((browser) => browser.id === id)
+    return current &&
+      safeHashEqual(current.tokenHash, tokenHash) &&
+      this.isSessionAccessCurrent(access)
+      ? access
+      : undefined
   }
 
   private commitStoredMutation(

--- a/src/main/remote-access/service.test.ts
+++ b/src/main/remote-access/service.test.ts
@@ -129,6 +129,77 @@ const createReadyDeps = (): {
 }
 
 describe('RemoteAccessService', () => {
+  it('keeps access locally off after a failed preference save and supports retry before restart', async () => {
+    const repository = await createRepository()
+    const deps = createReadyDeps()
+    const service = await RemoteAccessService.create({ repository, ...deps, broadcast: vi.fn() })
+    const controller = webController()
+    service.attachWebController(controller)
+    await service.setMode('remoteit-public')
+    vi.spyOn(repository, 'save').mockRejectedValueOnce(new Error('disk full'))
+
+    await expect(service.disable()).resolves.toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      error: 'disk full'
+    })
+    expect((await repository.load()).mode).toBe('remoteit-public')
+    expect(controller.closeExternalConnections).toHaveBeenCalledOnce()
+
+    const restarted = await RemoteAccessService.create({
+      repository,
+      ...createReadyDeps(),
+      broadcast: vi.fn()
+    })
+    restarted.attachWebController(webController())
+    await restarted.restore()
+    expect(restarted.snapshot(true)).toMatchObject({
+      mode: 'remoteit-public',
+      enabled: true,
+      lifecycle: 'running'
+    })
+    await restarted.shutdown()
+
+    await expect(service.disable()).resolves.toMatchObject({
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled',
+      error: undefined
+    })
+    expect((await repository.load()).mode).toBe('off')
+    expect(deps.enableRemoteIt).toHaveBeenCalledOnce()
+    await service.shutdown()
+  })
+
+  it('exposes a failed read-only probe without closing access and clears it on a successful probe', async () => {
+    const repository = await createRepository()
+    const deps = createReadyDeps()
+    const service = await RemoteAccessService.create({ repository, ...deps, broadcast: vi.fn() })
+    const controller = webController()
+    service.attachWebController(controller)
+    await service.setMode('remoteit-public')
+    const running = service.snapshot(true)
+    const save = vi.spyOn(repository, 'save')
+    deps.detectRemoteIt.mockRejectedValueOnce(new Error('provider status unavailable'))
+
+    await expect(service.probe()).resolves.toMatchObject({
+      mode: 'remoteit-public',
+      enabled: true,
+      lifecycle: 'running',
+      error: undefined,
+      accessUrl: running.accessUrl,
+      remoteIt: { error: 'provider status unavailable' }
+    })
+    const recovered = await service.probe()
+    expect(recovered).toMatchObject({ enabled: true, lifecycle: 'running' })
+    expect(recovered.remoteIt.error).toBeUndefined()
+    expect(save).not.toHaveBeenCalled()
+    expect(controller.closeExternalConnections).not.toHaveBeenCalled()
+    expect(deps.enableRemoteIt).toHaveBeenCalledOnce()
+    await service.shutdown()
+  })
+
   it('keeps the app available and blocks mutations when persisted configuration cannot load', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-remote-service-invalid-config-'))
     roots.push(root)

--- a/src/renderer/src/pages/settings/RemoteControlPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.render.test.tsx
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RemoteAccessSnapshot } from '../../../../shared/remote-access'
+import { RemoteControlPanel } from './RemoteControlPanel'
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  delete (window as unknown as { api?: unknown }).api
+  vi.unstubAllGlobals()
+})
+
+const runningSnapshot = (): RemoteAccessSnapshot => ({
+  canManage: true,
+  canManagePairing: true,
+  mode: 'remoteit-public',
+  enabled: true,
+  lifecycle: 'running',
+  accessUrl: 'https://open-science.connect.remote.it/',
+  remoteIt: { installed: true, registered: true, loggedIn: true },
+  pendingRequests: [],
+  trustedBrowsers: []
+})
+
+const mount = async (
+  initial: RemoteAccessSnapshot,
+  probed = initial
+): Promise<
+  Record<'getSnapshot' | 'probe' | 'detect' | 'setMode' | 'onChanged', ReturnType<typeof vi.fn>>
+> => {
+  const api = {
+    getSnapshot: vi.fn().mockResolvedValue(initial),
+    probe: vi.fn().mockResolvedValue(probed),
+    detect: vi.fn().mockResolvedValue(initial),
+    setMode: vi.fn().mockResolvedValue({
+      ...initial,
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'disabled',
+      error: undefined
+    }),
+    onChanged: vi.fn(() => vi.fn())
+  }
+  Object.defineProperty(window, 'api', { configurable: true, value: { remoteAccess: api } })
+  await act(async () => root.render(<RemoteControlPanel />))
+  expect(api.probe).toHaveBeenCalledOnce()
+  return api
+}
+
+describe('Remote access failure recovery', () => {
+  it('offers a retry while Off remains selected after saving the preference fails', async () => {
+    const api = await mount({
+      ...runningSnapshot(),
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      accessUrl: undefined,
+      error: 'disk full'
+    })
+    const off = container.querySelector<HTMLInputElement>('input[aria-label="Off"]')!
+    expect(off.checked).toBe(true)
+    expect(container.textContent).toContain('disk full')
+    await act(async () => off.click())
+    expect(api.setMode).not.toHaveBeenCalled()
+
+    const retry = [...container.querySelectorAll('button')].find((button) =>
+      /retry|try again/i.test(button.textContent ?? '')
+    )
+    expect(retry, 'Off must offer recovery without first enabling access').toBeDefined()
+    await act(async () => retry!.click())
+    expect(api.setMode).toHaveBeenCalledExactlyOnceWith({ mode: 'off' })
+    expect(off.checked).toBe(true)
+    expect(container.textContent).not.toContain('disk full')
+    expect(document.activeElement).toBe(off)
+  })
+
+  it('warns about restart when locally disabling access could not be saved', async () => {
+    await mount({
+      ...runningSnapshot(),
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      accessUrl: undefined,
+      error: 'disk full'
+    })
+    expect(container.textContent).toMatch(/restart/i)
+  })
+
+  it('shows a failed external check and retries it without repairing the active route', async () => {
+    const running = runningSnapshot()
+    const api = await mount(running, {
+      ...running,
+      remoteIt: { ...running.remoteIt, error: 'provider status unavailable' }
+    })
+    expect.soft(container.textContent).toContain('provider status unavailable')
+    expect.soft(container.textContent).not.toContain('Connected')
+    expect.soft(container.textContent).not.toContain('Browser link is ready')
+    expect(container.querySelector(`a[href="${running.accessUrl}"]`)).not.toBeNull()
+    const retry = [...container.querySelectorAll('button')].find((button) =>
+      /check again|detect again|retry/i.test(button.textContent ?? '')
+    )
+    expect(retry).toBeDefined()
+    api.probe.mockResolvedValue(running)
+    await act(async () => retry!.click())
+    expect.soft(api.probe).toHaveBeenCalledTimes(2)
+    expect.soft(api.detect).not.toHaveBeenCalled()
+    expect(api.setMode).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('Connected')
+    expect(container.textContent).not.toContain('provider status unavailable')
+  })
+
+  it('keeps shutdown recovery visible when the retry fails again and prevents duplicate submissions', async () => {
+    const snapshot: RemoteAccessSnapshot = {
+      ...runningSnapshot(),
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      error: 'disk full'
+    }
+    const api = await mount(snapshot)
+    let finish!: (snapshot: RemoteAccessSnapshot) => void
+    api.setMode.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve
+        })
+    )
+    const retry = [...container.querySelectorAll('button')].find((button) =>
+      /retry/i.test(button.textContent ?? '')
+    )!
+    await act(async () => retry.click())
+    expect(retry.disabled).toBe(true)
+    await act(async () => retry.click())
+    expect(api.setMode).toHaveBeenCalledOnce()
+    await act(async () => finish(snapshot))
+    expect(retry.disabled).toBe(false)
+    expect(container.textContent).toContain('disk full')
+    expect(container.querySelector<HTMLInputElement>('input[aria-label="Off"]')!.checked).toBe(true)
+  })
+
+  it('shows both lifecycle and provider errors without asserting the saved preference is wrong', async () => {
+    await mount({
+      ...runningSnapshot(),
+      mode: 'off',
+      enabled: false,
+      lifecycle: 'error',
+      error: 'cleanup persistence failed',
+      remoteIt: {
+        ...runningSnapshot().remoteIt,
+        error: 'provider status unavailable'
+      }
+    })
+    expect(container.textContent).toContain('cleanup persistence failed')
+    expect(container.textContent).toContain('provider status unavailable')
+    expect(container.textContent).toContain('may not have been saved')
+  })
+})

--- a/src/renderer/src/pages/settings/RemoteControlPanel.tsx
+++ b/src/renderer/src/pages/settings/RemoteControlPanel.tsx
@@ -144,6 +144,7 @@ const getAccessModes = (
 ]
 
 const providerStatus = (snapshot: RemoteAccessSnapshot, t: TFunction): string => {
+  if (snapshot.remoteIt.error) return t('External status unconfirmed')
   if (!snapshot.remoteIt.installed) return t('Not installed')
   if (!snapshot.remoteIt.registered) return t('Device setup required')
   if (!snapshot.remoteIt.loggedIn) return t('Sign-in required')
@@ -216,6 +217,7 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
   const [copyStatus, setCopyStatus] = useState<CopyStatus>('idle')
 
   const operationTriggerRef = useRef<HTMLElement | null>(null)
+  const offModeRef = useRef<HTMLInputElement | null>(null)
   const initialLoadRetryRef = useRef(false)
   const mountedRef = useRef(false)
   const copyResetTimerRef = useRef<number | undefined>(undefined)
@@ -381,6 +383,9 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
   }
 
   const modeError = actionError ?? snapshot.error
+  const providerError = snapshot.remoteIt.error
+  const incompleteShutdown =
+    snapshot.mode === 'off' && !snapshot.enabled && snapshot.lifecycle === 'error'
   const changingMode = busy?.startsWith('mode:') === true
   const detectingAndRepairing = busy === 'detect'
   const blockingRemoteOperation = changingMode || detectingAndRepairing
@@ -392,7 +397,7 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
     snapshot.canManagePairing && (accessUsesPairing || snapshot.trustedBrowsers.length > 0)
   const statusLabel = providerStatus(snapshot, t)
   const statusClassName =
-    snapshot.enabled && snapshot.lifecycle === 'running'
+    !providerError && snapshot.enabled && snapshot.lifecycle === 'running'
       ? 'border-0 bg-primary/10 text-primary'
       : undefined
 
@@ -403,17 +408,22 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
       size="sm"
       disabled={busy !== null}
       onClick={(event) => {
-        operationTriggerRef.current = event.currentTarget
-        setBusy('detect')
-        void refresh(true)
+        operationTriggerRef.current =
+          snapshot.mode === 'off' ? offModeRef.current : event.currentTarget
+        if (providerError) {
+          void run('probe', () => window.api.remoteAccess.probe())
+        } else {
+          setBusy('detect')
+          void refresh(true)
+        }
       }}
       className="shrink-0"
     >
       <RefreshCw
-        className={`size-3.5 ${busy === 'detect' ? 'animate-spin' : ''}`}
+        className={`size-3.5 ${busy === 'detect' || busy === 'probe' ? 'animate-spin' : ''}`}
         aria-hidden="true"
       />
-      {t('Detect again')}
+      {providerError ? t('Check again') : t('Detect again')}
     </Button>
   ) : null
 
@@ -516,6 +526,7 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
               >
                 <input
                   type="radio"
+                  ref={option.mode === 'off' ? offModeRef : undefined}
                   name="remote-access-mode"
                   aria-label={option.title}
                   checked={selected}
@@ -550,6 +561,52 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
         {modeError ? (
           <div className="rounded-lg border border-destructive/35 bg-destructive/5 px-3 py-2 text-sm text-destructive">
             {t(modeError)}
+          </div>
+        ) : null}
+
+        {incompleteShutdown ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-status-warning-foreground/30 bg-status-warning-surface dark:bg-status-warning-dark-surface px-3 py-2 text-sm"
+          >
+            <p>
+              {t(
+                'Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.'
+              )}
+            </p>
+            {snapshot.canManage ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                disabled={busy !== null}
+                onClick={() => {
+                  operationTriggerRef.current = offModeRef.current
+                  void run('mode:off', () => window.api.remoteAccess.setMode({ mode: 'off' }))
+                }}
+              >
+                <RefreshCw className="size-3.5" aria-hidden="true" />
+                {t('Retry turning off')}
+              </Button>
+            ) : null}
+          </div>
+        ) : null}
+
+        {providerError ? (
+          <div
+            role="alert"
+            className="rounded-lg border border-status-warning-foreground/30 bg-status-warning-surface dark:bg-status-warning-dark-surface px-3 py-2 text-sm"
+          >
+            <p>
+              {snapshot.enabled
+                ? t(
+                    'Local remote access remains enabled, but the latest external status check failed.'
+                  )
+                : t('The latest external status check failed.')}
+            </p>
+            <p className="mt-1 break-words text-xs text-muted-foreground">{t(providerError)}</p>
+            {snapshot.mode === 'off' ? <div className="mt-3">{detectButton}</div> : null}
           </div>
         ) : null}
 
@@ -647,14 +704,21 @@ export const RemoteControlPanel: RemoteControlPanelComponent = () => {
               <div className="grid gap-4 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-start">
                 <div className="min-w-0 flex-1">
                   <div className="flex items-start gap-3">
-                    <CheckCircle2
-                      className="mt-0.5 size-5 shrink-0 text-blue-600"
-                      aria-hidden="true"
-                    />
+                    {providerError ? (
+                      <AlertTriangle
+                        className="mt-0.5 size-5 shrink-0 text-status-warning-foreground dark:text-status-warning-dark-foreground"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <CheckCircle2
+                        className="mt-0.5 size-5 shrink-0 text-blue-600"
+                        aria-hidden="true"
+                      />
+                    )}
                     <div className="min-w-0 flex-1">
                       <div className="flex flex-wrap items-center justify-between gap-2">
                         <div className="text-sm font-medium text-foreground">
-                          {t('Browser link is ready')}
+                          {providerError ? t('Saved browser link') : t('Browser link is ready')}
                         </div>
                         <div className="flex shrink-0 items-center gap-2">
                           <Button

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4694,6 +4694,12 @@
     "Could not load app icons.": "Die App-Symbole konnten nicht geladen werden.",
     "No app icons are available.": "Es sind keine App-Symbole verfügbar.",
     "Current icon: {{icon}}. Its preview is unavailable.": "Aktuelles Symbol: {{icon}}. Die Vorschau ist nicht verfügbar.",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Dieser Anbieter ist nicht mit {{framework}} kompatibel. Wählen Sie einen Anbieter mit einem von {{framework}} unterstützten API-Format oder wechseln Sie das Agenten-Framework."
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Dieser Anbieter ist nicht mit {{framework}} kompatibel. Wählen Sie einen Anbieter mit einem von {{framework}} unterstützten API-Format oder wechseln Sie das Agenten-Framework.",
+    "External status unconfirmed": "Externer Status unbestätigt",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "Der Fernzugriff auf diesem Computer ist ausgeschaltet, aber das Ausschalten wurde nicht abgeschlossen. Die Einstellung wurde möglicherweise nicht gespeichert und der Zugriff kann nach einem Neustart wieder aktiviert werden.",
+    "Retry turning off": "Ausschalten erneut versuchen",
+    "Local remote access remains enabled, but the latest external status check failed.": "Der lokale Fernzugriff bleibt aktiviert, aber die letzte Prüfung des externen Status ist fehlgeschlagen.",
+    "The latest external status check failed.": "Die letzte Prüfung des externen Status ist fehlgeschlagen.",
+    "Saved browser link": "Gespeicherter Browser-Link"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4856,6 +4856,12 @@
     "Could not load app icons.": "No se pudieron cargar los iconos de la aplicación.",
     "No app icons are available.": "No hay iconos de la aplicación disponibles.",
     "Current icon: {{icon}}. Its preview is unavailable.": "Icono actual: {{icon}}. Su vista previa no está disponible.",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Este proveedor no es compatible con {{framework}}. Seleccione un proveedor cuyo formato de API sea compatible con {{framework}} o cambie el framework del agente."
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Este proveedor no es compatible con {{framework}}. Seleccione un proveedor cuyo formato de API sea compatible con {{framework}} o cambie el framework del agente.",
+    "External status unconfirmed": "Estado externo sin confirmar",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "El acceso remoto está desactivado en este equipo, pero la desactivación no se completó. Es posible que el ajuste no se haya guardado y que el acceso vuelva a activarse tras reiniciar.",
+    "Retry turning off": "Reintentar la desactivación",
+    "Local remote access remains enabled, but the latest external status check failed.": "El acceso remoto local sigue activado, pero la última comprobación del estado externo falló.",
+    "The latest external status check failed.": "La última comprobación del estado externo falló.",
+    "Saved browser link": "Enlace del navegador guardado"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4856,6 +4856,12 @@
     "Could not load app icons.": "Impossible de charger les icônes de l’application.",
     "No app icons are available.": "Aucune icône d’application n’est disponible.",
     "Current icon: {{icon}}. Its preview is unavailable.": "Icône actuelle : {{icon}}. Son aperçu n’est pas disponible.",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Ce fournisseur n'est pas compatible avec {{framework}}. Choisissez un fournisseur dont le format d'API est pris en charge par {{framework}}, ou changez de framework d'agents."
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Ce fournisseur n'est pas compatible avec {{framework}}. Choisissez un fournisseur dont le format d'API est pris en charge par {{framework}}, ou changez de framework d'agents.",
+    "External status unconfirmed": "État externe non confirmé",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "L’accès à distance est désactivé sur cet ordinateur, mais la désactivation n’est pas terminée. Ce réglage n’a peut-être pas été enregistré et l’accès pourrait être réactivé après un redémarrage.",
+    "Retry turning off": "Réessayer de désactiver",
+    "Local remote access remains enabled, but the latest external status check failed.": "L’accès à distance local reste activé, mais la dernière vérification de l’état externe a échoué.",
+    "The latest external status check failed.": "La dernière vérification de l’état externe a échoué.",
+    "Saved browser link": "Lien de navigateur enregistré"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4540,6 +4540,12 @@
     "Could not load app icons.": "アプリアイコンを読み込めませんでした。",
     "No app icons are available.": "利用可能なアプリアイコンはありません。",
     "Current icon: {{icon}}. Its preview is unavailable.": "現在のアイコン：{{icon}}。プレビューは利用できません。",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "このプロバイダーは {{framework}} と互換性がありません。{{framework}} が対応する API 形式のプロバイダーを選択するか、エージェントフレームワークを変更してください。"
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "このプロバイダーは {{framework}} と互換性がありません。{{framework}} が対応する API 形式のプロバイダーを選択するか、エージェントフレームワークを変更してください。",
+    "External status unconfirmed": "外部の状態を確認できません",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "このコンピューターのリモートアクセスはオフですが、オフにする操作が完了していません。オフの設定が保存されておらず、再起動後にアクセスが再びオンになる可能性があります。",
+    "Retry turning off": "オフにする操作を再試行",
+    "Local remote access remains enabled, but the latest external status check failed.": "ローカルのリモートアクセスは有効のままですが、直近の外部状態の確認に失敗しました。",
+    "The latest external status check failed.": "直近の外部状態の確認に失敗しました。",
+    "Saved browser link": "保存済みのブラウザーリンク"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4538,6 +4538,12 @@
     "Could not load app icons.": "앱 아이콘을 불러오지 못했습니다.",
     "No app icons are available.": "사용 가능한 앱 아이콘이 없습니다.",
     "Current icon: {{icon}}. Its preview is unavailable.": "현재 아이콘: {{icon}}. 미리보기를 사용할 수 없습니다.",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "이 모델 제공업체는 {{framework}}에서 사용할 수 없습니다. {{framework}}에서 지원하는 API 형식의 모델 제공업체를 선택하거나 에이전트 프레임워크를 변경하세요."
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "이 모델 제공업체는 {{framework}}에서 사용할 수 없습니다. {{framework}}에서 지원하는 API 형식의 모델 제공업체를 선택하거나 에이전트 프레임워크를 변경하세요.",
+    "External status unconfirmed": "외부 상태 확인 안 됨",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "이 컴퓨터의 원격 액세스는 꺼졌지만 끄기 작업이 완료되지 않았습니다. 끄기 설정이 저장되지 않았을 수 있으며 다시 시작하면 액세스가 다시 켜질 수 있습니다.",
+    "Retry turning off": "끄기 다시 시도",
+    "Local remote access remains enabled, but the latest external status check failed.": "로컬 원격 액세스는 계속 활성화되어 있지만 최근 외부 상태 확인에 실패했습니다.",
+    "The latest external status check failed.": "최근 외부 상태 확인에 실패했습니다.",
+    "Saved browser link": "저장된 브라우저 링크"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4989,6 +4989,12 @@
     "Could not load app icons.": "Не удалось загрузить значки приложения.",
     "No app icons are available.": "Нет доступных значков приложения.",
     "Current icon: {{icon}}. Its preview is unavailable.": "Текущий значок: {{icon}}. Предпросмотр недоступен.",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Этот поставщик несовместим с {{framework}}. Выберите поставщика с форматом API, который поддерживает {{framework}}, или смените фреймворк агента."
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "Этот поставщик несовместим с {{framework}}. Выберите поставщика с форматом API, который поддерживает {{framework}}, или смените фреймворк агента.",
+    "External status unconfirmed": "Внешнее состояние не подтверждено",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "Удалённый доступ на этом компьютере выключен, но операция выключения не завершена. Настройка могла не сохраниться, и после перезапуска доступ может включиться снова.",
+    "Retry turning off": "Повторить выключение",
+    "Local remote access remains enabled, but the latest external status check failed.": "Локальный удалённый доступ остаётся включённым, но последняя проверка внешнего состояния завершилась ошибкой.",
+    "The latest external status check failed.": "Последняя проверка внешнего состояния завершилась ошибкой.",
+    "Saved browser link": "Сохранённая ссылка для браузера"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4540,6 +4540,12 @@
     "Could not load app icons.": "无法加载应用图标。",
     "No app icons are available.": "没有可用的应用图标。",
     "Current icon: {{icon}}. Its preview is unavailable.": "当前图标：{{icon}}。其预览不可用。",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "此提供商与 {{framework}} 不兼容。请选择 API 格式受 {{framework}} 支持的提供商，或更换智能体框架。"
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "此提供商与 {{framework}} 不兼容。请选择 API 格式受 {{framework}} 支持的提供商，或更换智能体框架。",
+    "External status unconfirmed": "外部状态未确认",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "此计算机上的远程访问已关闭，但关闭操作尚未完成。关闭设置可能未保存，重启后访问可能重新开启。",
+    "Retry turning off": "重试关闭",
+    "Local remote access remains enabled, but the latest external status check failed.": "本地远程访问仍已启用，但最近一次外部状态检测失败。",
+    "The latest external status check failed.": "最近一次外部状态检测失败。",
+    "Saved browser link": "已保存的浏览器链接"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4540,6 +4540,12 @@
     "Could not load app icons.": "無法載入應用程式圖示。",
     "No app icons are available.": "沒有可用的應用程式圖示。",
     "Current icon: {{icon}}. Its preview is unavailable.": "目前圖示：{{icon}}。其預覽無法使用。",
-    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "此提供商與 {{framework}} 不相容。請選擇 API 格式受 {{framework}} 支援的提供商，或更換智能體框架。"
+    "This provider isn't compatible with {{framework}}. Pick a provider whose API format {{framework}} supports, or change the agent framework.": "此提供商與 {{framework}} 不相容。請選擇 API 格式受 {{framework}} 支援的提供商，或更換智能體框架。",
+    "External status unconfirmed": "外部狀態未確認",
+    "Remote access is off on this computer, but turning it off did not finish. The Off setting may not have been saved, and access may turn on again after restarting.": "此電腦上的遠端存取已關閉，但關閉操作尚未完成。關閉設定可能未儲存，重新啟動後存取可能再次開啟。",
+    "Retry turning off": "重試關閉",
+    "Local remote access remains enabled, but the latest external status check failed.": "本機遠端存取仍已啟用，但最近一次外部狀態檢查失敗。",
+    "The latest external status check failed.": "最近一次外部狀態檢查失敗。",
+    "Saved browser link": "已儲存的瀏覽器連結"
   }
 }


### PR DESCRIPTION
## Problem

Remote access has several failure paths with no usable recovery or misleading status: saving Off can fail after local access stops; read-only provider errors are hidden behind success labels; a hung pairing request prevents expiry feedback; and a failed activity timestamp write rejects otherwise-valid trusted-browser access.

## Proposed change

- Keep Off selected, explain that an incomplete shutdown may not have saved the preference, and retry the existing Off command without enabling access. Wording also covers cleanup failures without falsely claiming the preference definitely failed to save.
- Show provider errors separately, distinguish enabled local access from unconfirmed external status, retain the link and authorizations, and retry through read-only `probe()` rather than route repair.
- Bound fetch and JSON reading with a ten-second abort timeout, advance pairing expiry independently, reject late results, and expose a same-origin restart link after expiry/rejection. Clean up on navigation and reload when restored from the back-forward cache.
- Treat only an activity-only `lastSeenAt` save failure as recoverable, retry it on a later request, and recheck current authorization. Persistent approvals, revocations, expiry removal, and cleanup retain strict semantics.

## Scope and non-goals

No new persisted or snapshot fields, state enum values, dependencies, lifecycle subsystem, or data migration. `remote-access.json` remains version 5, and existing historical parsing is unchanged. No provider resources are created or deleted by this change. New renderer copy is translated in all eight locales; the standalone pairing page retains its existing English presentation.

## Acceptance criteria and validation

Reproduced before changing production code: the original 50 Service/pairing tests passed; two repeated red runs then produced 53 passes and 11 expected failures with identical failing cases/reasons. Tests use public Service, PairingManager, renderer bridge, and generated-page behavior; no production test seam was added. Temporary repositories are real; provider, Web controller, and network failures are test doubles.

The following final checks ran after the last material edit:

| Behavior / consumers | Check | Result |
| --- | --- | --- |
| Off persistence/restart/retry; read-only probe; trusted HTTP/WebSocket authorization and invalidation; pairing timeout, expiry, restart, navigation; eight-locale copy; command and Settings consumers | `npm test -- src/main/remote-access src/shared/remote-access.test.ts src/main/host-application-commands.test.ts src/renderer/src/pages/settings/RemoteControlPanel.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx src/renderer/src/i18n/resources.test.ts` | 1,046 passed |
| HTTP/WebSocket server consumption of authorization | `npm test -- src/main/web-service/http-server.test.ts` | 58 passed |
| Main, sandbox, and renderer types | `npm run typecheck:node` and `npm run typecheck:web` | Passed |
| Source lint and formatting | `npm run lint`; Prettier check of changed files; `git diff --check` | Passed |
| Visual and interactive recovery | ego-browser with real renderer/CSS and generated pairing HTML, controlled local failure fixtures | Off remains selected after retry, focus restored; recheck calls only probe; expired/rejected restart visible; desktop and narrow dark layouts checked |

Dependency scope was checked with CodeGraph and explicit dynamic command/event consumers. Remote access has no dedicated entry in the module-impact manifest, so focused paths are explicit; global test routing was not changed. The maintainer requested no full local test run. Exact-head PR CI remains authoritative for full/platform checks. Real Remote.It infrastructure, physical mobile network failures, and packaged cross-platform Electron behavior were not reproduced locally.

## Review focus

Ensure last-seen error handling cannot swallow authorization-changing failures, pending revocation/expiry/disable still deny access, a failed Off save remains retryable without enabling access, provider checks stay read-only, and late pairing responses cannot overwrite expiry.
