### PR TITLE
fix(sessions): avoid full transcript scans before prompt dispatch

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -260,6 +260,7 @@ import {
   type ComputeJobDeletionParticipant,
   type SessionDeletion
 } from './session-persistence/coordinator'
+import { createSessionRuntimeLookup } from './session-persistence/runtime-lookup'
 import { withSessionCacheDeletion } from './compute/session-cache-owner'
 import { createMainPromptSideChatRelay } from './side-chat/main-prompt-relay'
 import { registerSideChatIpcHandlers } from './side-chat/ipc'
@@ -1728,12 +1729,14 @@ const createApplicationModules = async (
   // (validate + record) and the runtime switch so a hot-switch lands on the same source of truth.
   const sessionBindingService = new SessionBindingService(specialistService)
   const specialistPersistLog = createLogger('specialist:persist')
+  const findRuntimeSessions = createSessionRuntimeLookup({
+    repository: sessionRepository,
+    coordinator: sessionPersistenceCoordinator
+  })
   const loadSessionSpecialistBinding = async (
     sessionId: string
   ): Promise<PersistedSessionSpecialistBinding | undefined> => {
-    const session = (await sessionRepository.loadAll()).sessions.find(
-      (candidate) => candidate.id === sessionId
-    )
+    const session = (await findRuntimeSessions(sessionId))[0]
     return session
       ? {
           specialistId: session.specialistId,
@@ -1746,8 +1749,7 @@ const createApplicationModules = async (
     specialistId: string | undefined,
     pending: boolean
   ): Promise<void> => {
-    const allSessions = await sessionRepository.loadAll()
-    const session = allSessions.sessions.find((candidate) => candidate.id === sessionId)
+    const session = (await findRuntimeSessions(sessionId))[0]
     if (!session) {
       // Fresh unsent drafts are not durable yet. Carry both the desired ID and pending marker into
       // their first save; the marker can also be cleared here when runtime applies before that save.
@@ -2218,8 +2220,7 @@ const createApplicationModules = async (
       commands: sessionPersistenceCoordinator,
       readSession: ({ projectId, sessionId }) =>
         sessionRepository.loadSession(projectId, sessionId),
-      findSessions: async (sessionId) =>
-        (await sessionRepository.loadAll()).sessions.filter((session) => session.id === sessionId)
+      findSessions: findRuntimeSessions
     },
     async resolveInput(identity, session) {
       const artifact = parseArtifactVersionLocator(identity)

--- a/src/main/session-persistence/runtime-lookup.test.ts
+++ b/src/main/session-persistence/runtime-lookup.test.ts
@@ -1,0 +1,215 @@
+import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ app: { getPath: () => '/home/user', isPackaged: true } }))
+
+import type { AgentFrameworkId } from '../../shared/settings'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { createProductionDelegatedWorkComposition } from '../delegation/production-composition'
+import {
+  SessionSpecialistReconfiguration,
+  SPECIALIST_RECONFIGURATION_PENDING_ERROR
+} from '../specialist/session-reconfiguration'
+import { SessionPersistenceCoordinator, type SessionFileIndex } from './coordinator'
+import { SessionRepository } from './repository'
+import { createSessionRuntimeLookup } from './runtime-lookup'
+
+const fileIndex: SessionFileIndex = {
+  syncSession: async () => [],
+  softDeleteSession: async () => 'deleted',
+  restoreSession: async () => undefined,
+  softDeleteProject: async () => 'deleted',
+  reconcileActiveSessions: async () => undefined,
+  reconcileProjectSessions: async () => undefined,
+  markReconciliationIncomplete: () => undefined
+}
+
+const session = (
+  id: string,
+  frameworkId: AgentFrameworkId = 'claude-code'
+): PersistedChatSession => ({
+  id,
+  projectId: 'project-1',
+  title: id,
+  cwd: '/workspace',
+  status: 'idle',
+  agentFrameworkId: frameworkId,
+  messages: [],
+  createdAt: 1,
+  updatedAt: 1
+})
+
+const roots: string[] = []
+const createLookup = async (
+  hydrate = true,
+  dependencies: ConstructorParameters<typeof SessionRepository>[1] = {}
+): Promise<{
+  root: string
+  repository: SessionRepository
+  findSessions: ReturnType<typeof createSessionRuntimeLookup>
+}> => {
+  const root = await mkdtemp(join(tmpdir(), 'session-runtime-lookup-'))
+  roots.push(root)
+  const repository = new SessionRepository(root, dependencies)
+  await repository.saveSession(session('current'))
+  const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+  if (hydrate) await coordinator.loadAllReadOnly()
+  return { root, repository, findSessions: createSessionRuntimeLookup({ repository, coordinator }) }
+}
+
+const createSpecialist = (
+  findSessions: ReturnType<typeof createSessionRuntimeLookup>
+): SessionSpecialistReconfiguration =>
+  new SessionSpecialistReconfiguration({
+    sessionBinding: {
+      resolve: async () => ({ kind: 'main' }),
+      setBinding: () => undefined,
+      clearSession: () => undefined
+    },
+    loadBinding: async (id) => (await findSessions(id))[0],
+    persistBinding: async () => undefined
+  })
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('runtime Session lookup', () => {
+  // Codex Responses and Codex Bridge share this durable framework identity and lookup.
+  it.each(
+    (['claude-code', 'opencode', 'codex'] as const).flatMap((frameworkId) =>
+      (['Specialist admission', 'delegation settlement', 'delegation deletion'] as const).map(
+        (boundary) => [frameworkId, boundary] as const
+      )
+    )
+  )(
+    '%s %s becomes ready without waiting for unrelated Session contents',
+    async (frameworkId, boundary) => {
+      const root = await mkdtemp(join(tmpdir(), 'session-runtime-lookup-'))
+      roots.push(root)
+      let holdUnrelatedReads = false
+      let release!: () => void
+      const held = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      let unrelatedReadStarted!: () => void
+      const unrelatedRead = new Promise<'blocked on unrelated Session'>((resolve) => {
+        unrelatedReadStarted = () => resolve('blocked on unrelated Session')
+      })
+      const repository = new SessionRepository(root, {
+        readSessionFile: async (path) => {
+          if (holdUnrelatedReads && basename(path) === 'unrelated.json') {
+            unrelatedReadStarted()
+            await held
+          }
+          return readFile(path, 'utf8')
+        }
+      })
+      await repository.saveSession(session('current', frameworkId))
+      await repository.saveSession(session('unrelated'))
+      const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+      await coordinator.loadAllReadOnly()
+      const findSessions = createSessionRuntimeLookup({ repository, coordinator })
+      const specialist = createSpecialist(findSessions)
+      const delegation = createProductionDelegatedWorkComposition({
+        dataRoot: root,
+        sessions: {
+          commands: coordinator,
+          readSession: ({ projectId, sessionId }) => repository.loadSession(projectId, sessionId),
+          findSessions
+        },
+        frameworks: {
+          forSession: async () => {
+            throw new Error('No child execution expected')
+          }
+        },
+        resolveInput: async () => {
+          throw new Error('No input resolution expected')
+        },
+        resolveExecutionModel: async () => {
+          throw new Error('No model resolution expected')
+        },
+        settlementContinuations: {
+          dispatch: () => {
+            throw new Error('No continuation expected')
+          }
+        }
+      })
+      holdUnrelatedReads = true
+      const admission =
+        boundary === 'Specialist admission'
+          ? specialist.assertUserPromptReady('current')
+          : boundary === 'delegation settlement'
+            ? delegation.root.rootTurnStarted!({
+                sessionId: 'current',
+                originatingPromptId: 'prompt-1'
+              })
+            : delegation.root.deleteSession('current')
+      try {
+        // Both outcomes are controlled by the filesystem gate, not wall-clock/model latency.
+        await expect(Promise.race([admission.then(() => 'ready'), unrelatedRead])).resolves.toBe(
+          'ready'
+        )
+      } finally {
+        release()
+        await admission
+        await delegation.root.shutdown()
+      }
+    }
+  )
+
+  it('checks the latest durable pending binding instead of the hydration snapshot', async () => {
+    const { repository, findSessions } = await createLookup()
+    await repository.saveSession({
+      ...session('current'),
+      specialistId: 'specialist-1',
+      specialistBindingPending: true
+    })
+    await expect(createSpecialist(findSessions).assertUserPromptReady('current')).rejects.toThrow(
+      SPECIALIST_RECONFIGURATION_PENDING_ERROR
+    )
+  })
+
+  it.each(['missing', 'unreadable'] as const)(
+    'does not return stale contents for a %s Session',
+    async (state) => {
+      const { root, findSessions } = await createLookup()
+      const file = join(root, 'sessions', 'project-1', 'current.json')
+      if (state === 'missing') await rm(file)
+      else await writeFile(file, 'invalid JSON')
+      await expect(findSessions('current')).resolves.toEqual([])
+    }
+  )
+
+  it('rejects a conflicting global identity introduced after hydration', async () => {
+    const { root, findSessions } = await createLookup()
+    await mkdir(join(root, 'sessions', 'project-2'))
+    await writeFile(
+      join(root, 'sessions', 'project-2', 'current.json'),
+      await readFile(join(root, 'sessions', 'project-1', 'current.json'))
+    )
+    await expect(findSessions('current')).rejects.toThrow('already owned by another Project')
+  })
+
+  it('retains catalog discovery before hydration and returns no Session for an unsaved draft', async () => {
+    const { findSessions } = await createLookup(false)
+    await expect(findSessions('current')).resolves.toMatchObject([
+      { id: 'current', projectId: 'project-1' }
+    ])
+    await expect(findSessions('unsaved')).resolves.toEqual([])
+  })
+  it('fails closed when a directory cannot prove the current Session has a unique owner', async () => {
+    const { root, findSessions } = await createLookup(true, {
+      readDirectoryEntries: async (path) => {
+        if (basename(path) === 'project-2') {
+          throw Object.assign(new Error('Directory access denied'), { code: 'EACCES' })
+        }
+        return readdir(path, { withFileTypes: true })
+      }
+    })
+    await mkdir(join(root, 'sessions', 'project-2'))
+    await expect(findSessions('current')).rejects.toThrow('global identity ownership is unreadable')
+  })
+})

--- a/src/main/session-persistence/runtime-lookup.ts
+++ b/src/main/session-persistence/runtime-lookup.ts
@@ -1,5 +1,5 @@
 import type { PersistedChatSession } from '../../shared/session-persistence'
-import type { SessionPersistenceCoordinator } from './coordinator'
+import type { SessionCatalog } from './coordinator'
 import type { SessionRepository } from './repository'
 
 // Shared by Specialist binding and delegated-work admission in the application composition.
@@ -12,7 +12,7 @@ export const createSessionRuntimeLookup =
       SessionRepository,
       'loadAll' | 'loadSession' | 'assertSessionIdentityOwnership'
     >
-    coordinator: Pick<SessionPersistenceCoordinator, 'sessionProjectId'>
+    coordinator: Pick<SessionCatalog, 'sessionProjectId'>
   }): ((sessionId: string) => Promise<PersistedChatSession[]>) =>
   async (sessionId) => {
     const projectId = await coordinator.sessionProjectId(sessionId)

--- a/src/main/session-persistence/runtime-lookup.ts
+++ b/src/main/session-persistence/runtime-lookup.ts
@@ -1,0 +1,28 @@
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { SessionPersistenceCoordinator } from './coordinator'
+import type { SessionRepository } from './repository'
+
+// Shared by Specialist binding and delegated-work admission in the application composition.
+export const createSessionRuntimeLookup =
+  ({
+    repository,
+    coordinator
+  }: {
+    repository: Pick<
+      SessionRepository,
+      'loadAll' | 'loadSession' | 'assertSessionIdentityOwnership'
+    >
+    coordinator: Pick<SessionPersistenceCoordinator, 'sessionProjectId'>
+  }): ((sessionId: string) => Promise<PersistedChatSession[]>) =>
+  async (sessionId) => {
+    const projectId = await coordinator.sessionProjectId(sessionId)
+    if (projectId === undefined) {
+      // Before hydration or the first save, keep the existing catalog lookup semantics.
+      return (await repository.loadAll()).sessions.filter((session) => session.id === sessionId)
+    }
+    // Metadata locates the file; filename authority still rejects ambiguous global identities.
+    // Neither step needs to decode unrelated transcripts on the prompt's critical path.
+    await repository.assertSessionIdentityOwnership(sessionId, projectId)
+    const session = await repository.loadSession(projectId, sessionId)
+    return session ? [session] : []
+  }


### PR DESCRIPTION
## Problem

A new Claude + MiniMax-M3 Session can display generated Session details minutes before its primary response. Specialist admission and delegated-work initialization each load every saved transcript before dispatching the primary prompt. Details inference already runs independently.

## Proposed change

Share a small production-used lookup between Specialist binding reads/writes and delegated-work lookup. Resolve known Session owners using existing coordinator metadata, verify filename ownership, and decode only the current Session. Retain catalog discovery when ownership metadata is unavailable.

## Scope and non-goals

- Covers Specialist admission, delegation settlement, wake/resume and deletion cleanup.
- No new fields, enums, cache, durable format, historical-data migration, provider protocol or UI changes. Existing decoding and archive/deletion barriers remain in place.
- Identity verification now fails closed when a Project directory cannot be inspected; an incomplete scan could previously return a partial healthy match.
- Cold backend startup and the separately observed native startup exception are outside this fix.

## Acceptance criteria and validation

Independent review confirmed the runtime fix and the subsequent type-only CI correction. Validation timing is distinguished below.

- **Red/green:** a filesystem gate holds an unrelated Session read while exercising real Specialist admission and production delegation settlement/deletion. The original full-scan implementation fails all 9 framework/boundary cases with `blocked on unrelated Session`; the fixed implementation passes all 15 lookup cases. No model calls or elapsed-time thresholds drive these assertions.
- **Real App replay:** macOS, Node 22, `npm run dev`, same local data and a new Claude + MiniMax-M3 Session with a trivial no-tool prompt. Send-to-primary-dispatch decreased from **250.4 s to 5.1 s**; displayed completion elapsed decreased from **4m 18s to 10s**. After the fix, primary dispatch and completion precede details completion. These are measured runs, not a provider latency guarantee.
- **Runtime-fix validation:** 15 selected test files / **504 tests passed**; `npm run typecheck:node` and `npm run lint` passed. Full local `npm test` was intentionally not run.

| Affected behavior | Framework/path and coverage | Result |
| --- | --- | --- |
| Admission, settlement, deletion lookup | Parameterized `claude-code`, `opencode`, `codex` durable identities in `runtime-lookup.test.ts` | Passed |
| Current bindings, invalid/duplicate authority and historical decode | Lookup, repository, coordinator contract, Specialist and archive suites | Passed |
| Wake/resume, active branches, cancellation and dormant cleanup | Production delegation, settlement wake, runtime coordinator and deletion suites | Passed |
| Launcher compatibility | `provider-session-creator.test.ts` includes Claude, OpenCode, Codex Responses and Codex Bridge; the two Codex launchers share the unchanged `codex` lookup path | Passed |
| Independent details lifecycle | Details owner and restricted inference suites | Passed |

Exact selected-suite command:

```sh
npx vitest run \
  src/main/session-persistence/runtime-lookup.test.ts \
  src/main/session-persistence/repository.test.ts \
  src/main/session-persistence/coordinator-contract.test.ts \
  src/main/session-persistence/deletion-integration.test.ts \
  src/main/specialist/session-reconfiguration.test.ts \
  src/main/specialist/ipc.test.ts \
  src/main/archive/coordinator.test.ts \
  src/main/acp/runtime-coordinator.test.ts \
  src/main/acp/provider-session-creator.test.ts \
  src/main/delegation/production-composition.test.ts \
  src/main/delegation/production-frameworks.test.ts \
  src/main/delegation/delegation-settlement-wake-owner.test.ts \
  src/main/session-deletion/owner.test.ts \
  src/main/session-details/owner.test.ts \
  src/main/acp/restricted-inference-runner.test.ts \
  --maxWorkers=1
```

Initial sandbox runs failed to bind loopback test servers; subsequent high-load runs hit existing timeouts. The final suite passed with loopback access and unchanged assertions/timeouts. No live OpenCode/Codex model replay or Windows/Linux App replay is claimed. Filesystem tests use portable paths; cross-platform CI remains authoritative. Protocol payloads, permission/subscription behavior and renderer contracts are unchanged, so their exhaustive matrices are excluded.

## CI correction

The first complete portable CI run reported one failing test among 25,439 tests: the existing coordinator architecture guard rejected the new helper's concrete `SessionPersistenceCoordinator` type import. The helper now uses the existing `SessionCatalog` capability view, retaining the same `sessionProjectId` type. Emitted runtime JavaScript is byte-for-byte unchanged. No architecture assertion was weakened; `coordinator.architecture.test.ts` is now explicitly included in the final impact set. After this final type-only edit, all **43 tests across the three files below passed**, along with `npm run typecheck:node` and `npm run lint`:

```sh
npx vitest run src/main/session-persistence/coordinator.architecture.test.ts \
  src/main/session-persistence/runtime-lookup.test.ts \
  src/main/session-persistence/coordinator-contract.test.ts --maxWorkers=1
```

An earlier concurrent rerun hit existing 15-second timeouts during extreme local host load; the final isolated run passed in 6.87 seconds with unchanged assertions and timeouts.

The separate macOS failure is in the unchanged Notebook sandbox live-policy test (loopback gateway connection failed instead of producing the expected domain-block annotation). Local targeted replay passed with original assertions. It will be rechecked on the updated CI head; no Notebook or CI workflow changes are included.

## Review focus

Check that known-identity reads retain fresh durable state and fail closed on ambiguous ownership, and that the shared lookup remains appropriate for delegation recovery and deletion as well as initial prompt dispatch.
