### PR TITLE
fix(archive)!: preserve admission and recovery safety

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -396,6 +396,14 @@ colors communicate a successful or failed probe/migration result.
   recovery, legacy data move, update, compute approval, Connector approval, Skill import approval,
   global search, Settings, preview, then base content. A covered presentation stays requested and
   resumes when higher-priority work clears.
+- Archived Session rows and permanent-delete confirmations show the owning Project name so
+  identically named Sessions remain distinguishable. If the delete RPC rejects, the current modal
+  announces that the result could not be confirmed and offers Retry; it does not claim the Session
+  was kept or deleted until an authoritative result arrives.
+- Archive and restore compare a persisted generation, independently of the displayed archive date.
+  Project archive revisions advance on both transitions; Session commands use the existing Session
+  revision. A stale command refreshes the authoritative projection for an explicit retry and does
+  not replay itself. Archive operations preserve the research activity timestamp.
 - A successful Project or Session archive adds an eight-second app-root Undo receipt. The latest
   unexpired archive owns the visible shortcut hint and responds to `Cmd+Z` on macOS or `Ctrl+Z` on
   Windows/Linux; older receipts remain clickable. Text inputs, textareas, selects, ARIA textboxes,

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -713,6 +713,17 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await expect(archive).toBeEnabled()
   await archive.click()
 
+  const undo = page.getByTestId('archive-undo-snackbar')
+  const conflict = page.getByText(/Session revision conflict:/)
+  await expect(undo.or(conflict)).toBeVisible()
+  if (await conflict.isVisible()) {
+    // Terminal persistence can advance the whole-Session revision after the click. The stale
+    // command must remain rejected; only a new user action may use the refreshed authority.
+    await expect(undo).toBeHidden()
+    await page.getByRole('button', { name: 'Open navigation' }).click()
+    await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
+    await page.getByRole('menuitem', { name: 'Archive' }).click()
+  }
   await expect(page.getByTestId('archive-undo-snackbar')).toContainText('Archived session')
   await expect(page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` })).toBeHidden()
 })

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -727,3 +727,26 @@ test('archives a completed session from its mobile sidebar actions', async ({ ap
   await expect(page.getByTestId('archive-undo-snackbar')).toContainText('Archived session')
   await expect(page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` })).toBeHidden()
 })
+
+test('identifies the Project before deleting a workspace Session', async ({ app }, testInfo) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await createProject(page)
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill(USER_MESSAGE)
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await expect(page.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+
+  await page.setViewportSize({ width: 375, height: 900 })
+  await page.getByRole('button', { name: 'Open navigation' }).click()
+  await page.getByRole('button', { name: `Open actions for ${USER_MESSAGE}` }).click()
+  await page.getByRole('menuitem', { name: 'Delete', exact: true }).click()
+  const confirmation = page.getByRole('alertdialog', { name: 'Delete Session?' })
+  await expect(confirmation).toContainText(`Project: ${PROJECT_NAME}`)
+  await expect(confirmation).toContainText(USER_MESSAGE)
+  await page.screenshot({
+    path: testInfo.outputPath('workspace-delete-project.png'),
+    animations: 'disabled'
+  })
+  await confirmation.getByRole('button', { name: 'Cancel', exact: true }).click()
+  await expect(confirmation).toBeHidden()
+})

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -28,6 +28,7 @@ model Project {
   isExample        Boolean              @default(false)
   pinned           Boolean              @default(false)
   archivedAt       DateTime?
+  archiveRevision  Int                  @default(0)
   deletedAt        DateTime?
   createdAt        DateTime             @default(now())
   updatedAt        DateTime             @updatedAt

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -124,6 +124,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0030_literature_foundation',
     checksum: '0f432ea09aec2d7edbd9834a4f2c38dd6bc4870cd4ff01d4ea4899b3e66dc5e2'
+  },
+  {
+    id: '0031_project_archive_revision',
+    checksum: '77d0476e02c6993e54772e2a17908b62a6998c540c56d826a691fe358ac1093a'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -73,7 +73,8 @@ const rebuildComputeJobWithoutAnalysisConstraints = async (
   await client.$executeRawUnsafe('CREATE INDEX "ComputeJob_status_idx" ON "ComputeJob"("status")')
 }
 
-const removeLiteratureFoundationSchema = async (client: PrismaClient): Promise<void> => {
+const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<void> => {
+  await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
   for (const table of [
     'ArtifactLiteratureManifest',
     'ProjectLiterature',
@@ -100,7 +101,7 @@ const removeLiteratureFoundationSchema = async (client: PrismaClient): Promise<v
 
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.slice(-8).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+    expect(MIGRATION_MANIFEST.slice(-9).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
@@ -132,6 +133,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0030_literature_foundation',
         checksum: '0f432ea09aec2d7edbd9834a4f2c38dd6bc4870cd4ff01d4ea4899b3e66dc5e2'
+      },
+      {
+        id: '0031_project_archive_revision',
+        checksum: '77d0476e02c6993e54772e2a17908b62a6998c540c56d826a691fe358ac1093a'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -168,9 +173,9 @@ describe('packaged database migration ledger smoke', () => {
         })
       }
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
-      await removeLiteratureFoundationSchema(client)
+      await removeArchiveAndLiteratureSchema(client)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
       )
 
       await migrateApplicationDatabase(client)
@@ -206,7 +211,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -240,7 +245,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -338,10 +343,10 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
-      await removeLiteratureFoundationSchema(client)
+      await removeArchiveAndLiteratureSchema(client)
 
       await migrateApplicationDatabase(client)
 
@@ -419,11 +424,11 @@ describe('packaged database migration ledger smoke', () => {
            '0027_project_session_defaults',
            '0028_database_numeric_and_null_constraints',
            '0029_compute_host_execution_mode',
-           '0030_literature_foundation'
+           '0030_literature_foundation', '0031_project_archive_revision'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
-      await removeLiteratureFoundationSchema(client)
+      await removeArchiveAndLiteratureSchema(client)
       await client.$executeRawUnsafe(
         'ALTER TABLE "ComputeJob" DROP COLUMN "sensitiveDataEncrypted"'
       )

--- a/src/main/archive/coordinator.test.ts
+++ b/src/main/archive/coordinator.test.ts
@@ -43,12 +43,16 @@ describe('ArchiveCoordinator', () => {
     coordinator.setMarkReadSessions(markRead)
 
     await expect(
-      coordinator.updateProjectArchive({ id: project.id, archived: true, expectedArchivedAt: null })
+      coordinator.updateProjectArchive({
+        id: project.id,
+        archived: true,
+        expectedArchiveRevision: 0
+      })
     ).resolves.toMatchObject({ archivedAt: 50 })
 
     expect(sessions.assertProjectArchivable).toHaveBeenCalledWith(project.id, expect.any(Function))
     expect(projects.updateArchive).toHaveBeenCalledWith(
-      { id: project.id, archived: true, expectedArchivedAt: null },
+      { id: project.id, archived: true, expectedArchiveRevision: 0 },
       expect.any(Number)
     )
     expect(markRead).toHaveBeenCalledWith([session.id])
@@ -56,7 +60,7 @@ describe('ArchiveCoordinator', () => {
 
   it('rejects an archive request whose compare-and-set value is stale', async () => {
     const projects = {
-      get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40 }),
+      get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40, archiveRevision: 1 }),
       updateArchive: vi.fn()
     }
     const sessions = {
@@ -72,7 +76,11 @@ describe('ArchiveCoordinator', () => {
     })
 
     await expect(
-      coordinator.updateProjectArchive({ id: project.id, archived: false, expectedArchivedAt: 39 })
+      coordinator.updateProjectArchive({
+        id: project.id,
+        archived: false,
+        expectedArchiveRevision: 0
+      })
     ).rejects.toThrow('Project archive state changed elsewhere.')
 
     expect(projects.updateArchive).not.toHaveBeenCalled()
@@ -80,7 +88,7 @@ describe('ArchiveCoordinator', () => {
 
   it('does not restore a session while its project remains archived', async () => {
     const projects = {
-      get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40 }),
+      get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40, archiveRevision: 1 }),
       updateArchive: vi.fn()
     }
     const sessions = {
@@ -100,7 +108,7 @@ describe('ArchiveCoordinator', () => {
         projectId: project.id,
         sessionId: session.id,
         archived: false,
-        expectedArchivedAt: 40
+        expectedRevision: 0
       })
     ).rejects.toThrow('Restore this archived Project before continuing.')
 
@@ -167,7 +175,7 @@ describe('ArchiveCoordinator', () => {
       projectId: project.id,
       sessionId: session.id,
       archived: true,
-      expectedArchivedAt: null
+      expectedRevision: 0
     })
     await Promise.resolve()
     expect(sessions.updateArchive).not.toHaveBeenCalled()
@@ -205,7 +213,7 @@ describe('ArchiveCoordinator', () => {
         projectId: project.id,
         sessionId: session.id,
         archived: true,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
     ).rejects.toThrow('Finish or stop this session before archiving.')
 
@@ -230,7 +238,11 @@ describe('ArchiveCoordinator', () => {
     })
 
     await expect(
-      coordinator.updateProjectArchive({ id: project.id, archived: true, expectedArchivedAt: null })
+      coordinator.updateProjectArchive({
+        id: project.id,
+        archived: true,
+        expectedArchiveRevision: 0
+      })
     ).rejects.toThrow('Finish or stop active sessions before archiving this project.')
 
     expect(sessions.assertProjectArchivable).not.toHaveBeenCalled()
@@ -255,7 +267,11 @@ describe('ArchiveCoordinator', () => {
     })
 
     await expect(
-      coordinator.updateProjectArchive({ id: project.id, archived: true, expectedArchivedAt: null })
+      coordinator.updateProjectArchive({
+        id: project.id,
+        archived: true,
+        expectedArchiveRevision: 0
+      })
     ).resolves.toMatchObject({ archivedAt: 40 })
 
     expect(projects.updateArchive).toHaveBeenCalledOnce()
@@ -263,7 +279,7 @@ describe('ArchiveCoordinator', () => {
 
   it('resolves a fresh live session owner before archive admission', async () => {
     const projects = {
-      get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40 }),
+      get: vi.fn().mockResolvedValue({ ...project, archivedAt: 40, archiveRevision: 1 }),
       updateArchive: vi.fn()
     }
     const sessions = {

--- a/src/main/archive/coordinator.ts
+++ b/src/main/archive/coordinator.ts
@@ -13,18 +13,18 @@ type ProjectArchiveRepository = {
 type SessionArchivePersistence = {
   assertProjectArchivable(
     projectId: string,
-    isRuntimeBusy: (sessionId: string) => boolean
+    isRuntimeBusy: (sessionId: string) => boolean | Promise<boolean>
   ): Promise<string[]>
   assertSessionAvailable(projectId: string, sessionId: string): Promise<void>
   sessionProjectId(sessionId: string): Promise<string | undefined>
   updateArchive(
     request: UpdateSessionArchiveRequest,
-    isRuntimeBusy: () => boolean
+    isRuntimeBusy: () => boolean | Promise<boolean>
   ): Promise<PersistedChatSession>
 }
 
 type SessionRuntimeActivity = {
-  isSessionBusy(projectId: string, sessionId: string): boolean
+  isSessionBusy(projectId: string, sessionId: string): boolean | Promise<boolean>
   isProjectBusy(projectId: string): boolean | Promise<boolean>
   liveSessionProjectId(sessionId: string): string | undefined
 }
@@ -76,7 +76,7 @@ class ArchiveCoordinator {
       const project = await this.projects.get(request.id)
       if (!project) throw new Error('Project not found.')
       const currentArchivedAt = project.archivedAt ?? null
-      if (currentArchivedAt !== request.expectedArchivedAt) {
+      if ((project.archiveRevision ?? 0) !== request.expectedArchiveRevision) {
         throw new Error('Project archive state changed elsewhere.')
       }
       if (request.archived === (currentArchivedAt !== null)) return project

--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -511,7 +511,7 @@ describe('Data and content application commands', () => {
       },
       {
         key: 'projectUpdateArchive',
-        args: [{ id: 'project-1', archived: true, expectedArchivedAt: null }],
+        args: [{ id: 'project-1', archived: true, expectedArchiveRevision: 0 }],
         owner: deps.projects.updateArchive
       },
       {
@@ -521,7 +521,7 @@ describe('Data and content application commands', () => {
             projectId: 'project-1',
             sessionId: 'session-1',
             archived: true,
-            expectedArchivedAt: null
+            expectedRevision: 0
           }
         ],
         owner: deps.sessions.updateArchive
@@ -882,7 +882,7 @@ describe('Data and content application commands', () => {
       },
       {
         command: 'projectUpdateArchive' as const,
-        args: [{ id: 'project-1', archived: true, expectedArchivedAt: null }]
+        args: [{ id: 'project-1', archived: true, expectedArchiveRevision: 0 }]
       },
       {
         command: 'projectUpdate' as const,
@@ -1040,7 +1040,7 @@ describe('Data and content application commands', () => {
             projectId: 'project-1',
             sessionId: 'session-1',
             archived: true,
-            expectedArchivedAt: null
+            expectedRevision: 0
           }
         ]
       },
@@ -1393,7 +1393,7 @@ describe('Data and content application commands', () => {
             projectId: 'project-1',
             sessionId: 'session-1',
             archived: true,
-            expectedArchivedAt: null
+            expectedRevision: 0
           }
         ] as const)
       )
@@ -1466,7 +1466,7 @@ describe('Data and content application commands', () => {
           projectId: 'project-1',
           sessionId: 'session-1',
           archived: true,
-          expectedArchivedAt: null
+          expectedRevision: 0
         }
       ] as const)
     )
@@ -1541,7 +1541,7 @@ describe('Data and content application commands', () => {
           projectId: 'project-1',
           sessionId: 'session-1',
           archived: true,
-          expectedArchivedAt: null
+          expectedRevision: 0
         }
       ] as const)
     )
@@ -1699,7 +1699,7 @@ describe('Data and content application commands', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         archived: true,
-        expectedArchivedAt: null,
+        expectedRevision: 0,
         force: true
       },
       owner: 'updateArchive' as const
@@ -1711,7 +1711,7 @@ describe('Data and content application commands', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         archived: false,
-        expectedArchivedAt: Number.NaN
+        expectedRevision: Number.NaN
       },
       owner: 'updateArchive' as const
     },

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0030_literature_foundation'
+const CURRENT_MIGRATION_ID = '0031_project_archive_revision'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -309,7 +309,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -323,6 +323,7 @@ describe('agent memory project scope migration', () => {
       '0027_project_session_defaults',
       '0028_database_numeric_and_null_constraints',
       '0029_compute_host_execution_mode',
+      '0030_literature_foundation',
       CURRENT_MIGRATION_ID
     )
 
@@ -341,6 +342,7 @@ describe('agent memory project scope migration', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
+        '0030_literature_foundation',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -214,7 +214,8 @@ describe('application database (integration)', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
 
@@ -1057,14 +1058,14 @@ describe('application database (integration)', () => {
 
     const archivedAt = renamed.updatedAt + 1000
     const archived = await repository.updateArchive(
-      { id: created.id, archived: true, expectedArchivedAt: null },
+      { id: created.id, archived: true, expectedArchiveRevision: 0 },
       archivedAt
     )
     expect(archived.archivedAt).toBe(archivedAt)
     expect(archived.updatedAt).toBe(renamed.updatedAt)
 
     const restored = await repository.updateArchive(
-      { id: created.id, archived: false, expectedArchivedAt: archivedAt },
+      { id: created.id, archived: false, expectedArchiveRevision: archived.archiveRevision! },
       archivedAt + 1
     )
     expect(restored.archivedAt).toBeUndefined()
@@ -1150,7 +1151,7 @@ describe('application database (integration)', () => {
 
     await expect(
       repository.updateArchive(
-        { id: created.id, archived: true, expectedArchivedAt: null },
+        { id: created.id, archived: true, expectedArchiveRevision: 0 },
         archivedAt
       )
     ).resolves.toMatchObject({
@@ -1273,7 +1274,8 @@ describe('application database (integration)', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -26,7 +26,7 @@ describe('Compute Job operation migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -45,7 +45,7 @@ describe('Compute Job operation migration', () => {
       client.$queryRawUnsafe<Array<{ id: string }>>(
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1`
       )
-    ).resolves.toEqual([{ id: '0030_literature_foundation' }])
+    ).resolves.toEqual([{ id: '0031_project_archive_revision' }])
   })
 
   it('adds a constrained operation sidecar without rebuilding historical ComputeJob rows', async () => {

--- a/src/main/database/compute-job-remote-cleanup-migration.test.ts
+++ b/src/main/database/compute-job-remote-cleanup-migration.test.ts
@@ -72,10 +72,11 @@ describe('Compute Job remote cleanup migration', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0025_managed_file_version_foundation',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -77,10 +77,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0015_session_model_call_usage',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/content-blob-migration.test.ts
+++ b/src/main/database/content-blob-migration.test.ts
@@ -34,7 +34,7 @@ const createDatabaseBeforeLiteratureFoundation = async (client: PrismaClient): P
   await client.$executeRawUnsafe('DROP TABLE "ContentBlob"')
   await client.$executeRawUnsafe(
     `DELETE FROM "_open_science_migrations"
-     WHERE "id" IN ('0030_literature_foundation')`
+     WHERE "id" >= '0030_literature_foundation'`
   )
 }
 
@@ -69,7 +69,7 @@ describe('Content blob migration', () => {
     )
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      applied: ['0030_literature_foundation']
+      applied: ['0030_literature_foundation', '0031_project_archive_revision']
     })
     await expect(
       client.literatureIdentifier.findMany({ orderBy: { id: 'asc' }, select: { itemId: true } })
@@ -90,7 +90,7 @@ describe('Content blob migration', () => {
         await client.$executeRawUnsafe(
           schema === 'pre-ledger'
             ? 'DELETE FROM "_open_science_migrations"'
-            : `DELETE FROM "_open_science_migrations" WHERE "id" = '0030_literature_foundation'`
+            : `DELETE FROM "_open_science_migrations" WHERE "id" >= '0030_literature_foundation'`
         )
       }
 
@@ -141,9 +141,9 @@ describe('Content blob migration', () => {
         applied:
           schema === 'pre-ledger'
             ? MIGRATION_MANIFEST.map(({ id }) => id)
-            : ['0030_literature_foundation'],
+            : ['0030_literature_foundation', '0031_project_archive_revision'],
         from: schema === 'pre-ledger' ? null : '0029_compute_host_execution_mode',
-        to: '0030_literature_foundation'
+        to: '0031_project_archive_revision'
       })
 
       await expect(
@@ -216,7 +216,7 @@ describe('Content blob migration', () => {
       // The fixture rewinds the ledger after changing data; discard its earlier recovery snapshot.
       await rm(`${databasePath}.before-0030_literature_foundation.backup`, { force: true })
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" = '0030_literature_foundation'`
+        `DELETE FROM "_open_science_migrations" WHERE "id" >= '0030_literature_foundation'`
       )
       await migrateApplicationDatabase(client)
       expect(await readContent()).toEqual(before)

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -169,10 +169,11 @@ describe('database JSON constraints migration', () => {
           '0027_project_session_defaults',
           '0028_database_numeric_and_null_constraints',
           '0029_compute_host_execution_mode',
-          '0030_literature_foundation'
+          '0030_literature_foundation',
+          '0031_project_archive_revision'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0030_literature_foundation'
+        to: '0031_project_archive_revision'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -366,8 +366,13 @@ describe('D02/D04 persisted database boundaries', () => {
       const before = await Promise.all(tables.map(readRows))
       const ledger = await readRows('_open_science_migrations')
       await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-        applied: [migrationId, '0029_compute_host_execution_mode', '0030_literature_foundation'],
-        to: '0030_literature_foundation'
+        applied: [
+          migrationId,
+          '0029_compute_host_execution_mode',
+          '0030_literature_foundation',
+          '0031_project_archive_revision'
+        ],
+        to: '0031_project_archive_revision'
       })
       // Literature adds contentBlobId to version rows while preserving their original fields.
       expect(await Promise.all(tables.map(readRows))).toMatchObject(before)

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -122,7 +122,8 @@ describe('database startup logging', () => {
               '0027_project_session_defaults',
               '0028_database_numeric_and_null_constraints',
               '0029_compute_host_execution_mode',
-              '0030_literature_foundation'
+              '0030_literature_foundation',
+              '0031_project_archive_revision'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -10,6 +10,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "isExample" BOOLEAN NOT NULL DEFAULT false,
     "pinned" BOOLEAN NOT NULL DEFAULT false,
     "archivedAt" DATETIME,
+    "archiveRevision" INTEGER NOT NULL DEFAULT 0,
     "deletedAt" DATETIME,
     "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
     "updatedAt" DATETIME NOT NULL

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -474,10 +474,11 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: null,
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -490,8 +491,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0030_literature_foundation',
-      to: '0030_literature_foundation'
+      from: '0031_project_archive_revision',
+      to: '0031_project_archive_revision'
     })
   })
 
@@ -591,7 +592,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(
@@ -675,7 +677,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -720,7 +723,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -773,10 +776,11 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -857,10 +861,11 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$queryRaw<
@@ -983,7 +988,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0030_literature_foundation'
+      migrationId: '0031_project_archive_revision'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -1000,7 +1005,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual({
       adoptedLegacy: false,
       applied: ['9997_test_suffix'],
-      from: '0030_literature_foundation',
+      from: '0031_project_archive_revision',
       to: '9997_test_suffix'
     })
     await expect(
@@ -1038,6 +1043,7 @@ describe('application database migrations', () => {
       { id: '0028_database_numeric_and_null_constraints' },
       { id: '0029_compute_host_execution_mode' },
       { id: '0030_literature_foundation' },
+      { id: '0031_project_archive_revision' },
       { id: '9997_test_suffix' }
     ])
   })
@@ -1120,10 +1126,11 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     expect(backupEvents).toEqual([
       {
@@ -1207,7 +1214,8 @@ describe('application database migrations', () => {
       { id: '0027_project_session_defaults' },
       { id: '0028_database_numeric_and_null_constraints' },
       { id: '0029_compute_host_execution_mode' },
-      { id: '0030_literature_foundation' }
+      { id: '0030_literature_foundation' },
+      { id: '0031_project_archive_revision' }
     ])
   })
 
@@ -1331,6 +1339,7 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
+        '0031_project_archive_revision',
         '9997_test_suffix'
       ],
       to: '9997_test_suffix'
@@ -1468,7 +1477,7 @@ describe('application database migrations', () => {
       adoptedLegacy: false,
       applied: MIGRATION_MANIFEST.slice(computePasswordAuthIndex).map(({ id }) => id),
       from: '0009_vision_evidence',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$queryRaw<Array<{ projectId: string }>>`
@@ -1586,7 +1595,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(
@@ -1713,7 +1723,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1792,7 +1803,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(
@@ -1874,7 +1886,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -1990,7 +2003,8 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ]
     })
     await expect(
@@ -2513,8 +2527,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0029_compute_host_execution_mode.backup',
       'open-science.db.before-0030_literature_foundation.backup',
+      'open-science.db.before-0031_project_archive_revision.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -2813,10 +2827,11 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ currentVersionId: string | null }>>(
@@ -2875,7 +2890,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -2937,10 +2952,11 @@ describe('application database migrations', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -1,3 +1,4 @@
+import { projectArchiveRevisionMigration } from './migrations/0031-project-archive-revision'
 import { createHash } from 'node:crypto'
 import { access, rename, rm } from 'node:fs/promises'
 
@@ -674,6 +675,17 @@ const MIGRATION_MANIFEST = [
   {
     ...literatureFoundationMigration,
     checksum: LITERATURE_FOUNDATION_CHECKSUM,
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...projectArchiveRevisionMigration,
+    checksum: checksumMigrationPayload(
+      projectArchiveRevisionMigration.id,
+      projectArchiveRevisionMigration.statements,
+      projectArchiveRevisionMigration.verifiers,
+      projectArchiveRevisionMigration.operations
+    ),
     backupOnApply: 'required',
     backupRetention: 'retain'
   }

--- a/src/main/database/migrations/0031-project-archive-revision.ts
+++ b/src/main/database/migrations/0031-project-archive-revision.ts
@@ -1,0 +1,14 @@
+/* Immutable 0031 migration snapshot. Do not regenerate after release. */
+
+const projectArchiveRevisionMigration = {
+  id: '0031_project_archive_revision',
+  statements: [
+    `ALTER TABLE "Project" ADD COLUMN "archiveRevision" INTEGER NOT NULL DEFAULT 0`
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'column-exists', version: 1, table: 'Project', column: 'archiveRevision' }
+  ] as const
+}
+
+export { projectArchiveRevisionMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -89,10 +89,11 @@ describe('notification attention metadata migration', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0006_database_domain_constraints',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/project-archive-revision.test.ts
+++ b/src/main/database/project-archive-revision.test.ts
@@ -1,0 +1,90 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createProjectDbClient } from '../projects/prisma-client'
+import { ProjectRepository } from '../projects/repository'
+import { migrateApplicationDatabase } from './migration-service'
+
+describe('Project archive revision', () => {
+  let root: string | undefined
+  let client: ReturnType<typeof createProjectDbClient> | undefined
+
+  afterEach(async () => {
+    await client?.$disconnect()
+    if (root) await rm(root, { recursive: true, force: true })
+  })
+
+  it('upgrades active and archived Projects without changing timestamps or relationships', async () => {
+    root = await mkdtemp(join(tmpdir(), 'archive-migration-'))
+    client = createProjectDbClient(root)
+    await migrateApplicationDatabase(client)
+    const repository = new ProjectRepository(async () => client!)
+    const active = await repository.create({ name: 'Active' })
+    const archived = await repository.create({ name: 'Archived' })
+    await repository.updateArchive(
+      { id: archived.id, archived: true, expectedArchiveRevision: 0 },
+      1000
+    )
+    const before = await client.$queryRawUnsafe(
+      'SELECT "id", "archivedAt", "updatedAt" FROM "Project" ORDER BY "id"'
+    )
+    // Reconstruct the immediately preceding released schema and ledger, including real row data.
+    await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
+    await client.$executeRawUnsafe(
+      'DELETE FROM "_open_science_migrations" WHERE id = \'0031_project_archive_revision\''
+    )
+    await expect(
+      migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
+    ).resolves.toMatchObject({ applied: ['0031_project_archive_revision'] })
+    expect(
+      await client.$queryRawUnsafe(
+        'SELECT "id", "archivedAt", "updatedAt" FROM "Project" ORDER BY "id"'
+      )
+    ).toEqual(before)
+    expect(await repository.get(active.id)).toMatchObject({ archiveRevision: 0 })
+    expect(await repository.get(archived.id)).toMatchObject({
+      archiveRevision: 0,
+      archivedAt: 1000
+    })
+    expect(await client.$queryRawUnsafe('PRAGMA foreign_key_check')).toEqual([])
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+  })
+
+  it('rejects delayed archives and old Undo after restart even with identical timestamps', async () => {
+    root = await mkdtemp(join(tmpdir(), 'archive-cas-'))
+    client = createProjectDbClient(root)
+    await migrateApplicationDatabase(client)
+    let repository = new ProjectRepository(async () => client!)
+    const initial = await repository.create({ name: 'Research' })
+    const oldArchive = {
+      id: initial.id,
+      archived: true,
+      expectedArchiveRevision: initial.archiveRevision!
+    }
+    const first = await repository.updateArchive(oldArchive, 1000)
+    const oldUndo = {
+      id: initial.id,
+      archived: false,
+      expectedArchiveRevision: first.archiveRevision!
+    }
+    const restored = await repository.updateArchive(oldUndo, 1000)
+    await client.$disconnect()
+    client = createProjectDbClient(root)
+    repository = new ProjectRepository(async () => client!)
+    await expect(repository.updateArchive(oldArchive, 1000)).rejects.toThrow('changed elsewhere')
+    const second = await repository.updateArchive(
+      { ...oldArchive, expectedArchiveRevision: restored.archiveRevision! },
+      1000
+    )
+    expect(second.archivedAt).toBe(first.archivedAt)
+    expect(second.archiveRevision).toBe(3)
+    await expect(repository.updateArchive(oldUndo, 1000)).rejects.toThrow('changed elsewhere')
+    expect(await repository.get(initial.id)).toMatchObject({
+      archivedAt: 1000,
+      archiveRevision: 3,
+      updatedAt: initial.updatedAt
+    })
+  })
+})

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -67,10 +67,11 @@ describe('Project Session defaults migration', () => {
         '0027_project_session_defaults',
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
-        '0030_literature_foundation'
+        '0030_literature_foundation',
+        '0031_project_archive_revision'
       ],
       from: '0026_compute_job_remote_cleanup',
-      to: '0030_literature_foundation'
+      to: '0031_project_archive_revision'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1247,11 +1247,19 @@ const createApplicationModules = async (
     projectRepository,
     sessionPersistenceCoordinator,
     {
-      isSessionBusy: (projectId, sessionId) =>
-        sideChatOwnerRef.current?.hasForParent(sessionId) === true ||
-        detectArchiveBlockingSessions().some(
-          (session) => session.projectId === projectId && session.sessionId === sessionId
-        ),
+      isSessionBusy: async (projectId, sessionId) => {
+        const computeJobs = computeJobActivityRef.current
+        if (!computeJobs) throw new Error('Compute Job activity is not initialized.')
+        const jobs = await computeJobs.countNonTerminalBySession(sessionId)
+        // Read synchronous activity after the database await so a newly active runtime is visible.
+        return (
+          jobs > 0 ||
+          sideChatOwnerRef.current?.hasForParent(sessionId) === true ||
+          detectArchiveBlockingSessions().some(
+            (session) => session.projectId === projectId && session.sessionId === sessionId
+          )
+        )
+      },
       isProjectBusy: async (projectId) => {
         if (
           reviewerProjectRuntime.isProjectBusy(projectId) ||

--- a/src/main/projects/ipc.test.ts
+++ b/src/main/projects/ipc.test.ts
@@ -183,7 +183,7 @@ describe('createProjectHandlers', () => {
       handlers.updateArchive({
         id: unrelatedProject.id,
         archived: true,
-        expectedArchivedAt: null
+        expectedArchiveRevision: 0
       })
     ]
     await flushMicrotasks()

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -366,7 +366,7 @@ describe('project repository', () => {
 
     await expect(
       repository.updateArchive(
-        { id: 'project-1', archived: true, expectedArchivedAt: null },
+        { id: 'project-1', archived: true, expectedArchiveRevision: 0 },
         1710000000200
       )
     ).resolves.toMatchObject({ archivedAt: 1710000000200, updatedAt: 1710000000100 })

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -73,6 +73,7 @@ const toProject = (row: PrismaProject): Project => ({
   isExample: row.isExample,
   ...(row.pinned ? { pinned: true } : {}),
   ...(row.archivedAt ? { archivedAt: row.archivedAt.getTime() } : {}),
+  archiveRevision: row.archiveRevision,
   createdAt: row.createdAt.getTime(),
   updatedAt: row.updatedAt.getTime()
 })
@@ -230,7 +231,10 @@ class ProjectRepository {
   // forge or clear visibility state. The compare-and-set condition also makes Undo safe across
   // windows without changing the research activity timestamp.
   async updateArchive(request: UpdateProjectArchiveRequest, archivedAt: number): Promise<Project> {
-    if (!Number.isSafeInteger(request.expectedArchivedAt) && request.expectedArchivedAt !== null) {
+    if (
+      !Number.isSafeInteger(request.expectedArchiveRevision) ||
+      request.expectedArchiveRevision < 0
+    ) {
       throw new Error('Project archive state is invalid.')
     }
     if (!Number.isSafeInteger(archivedAt) || archivedAt <= 0) {
@@ -238,15 +242,15 @@ class ProjectRepository {
     }
 
     const client = await this.getClient()
-    const expectedArchivedAt = request.expectedArchivedAt
     // Prisma's @updatedAt automation also runs for administrative changes. Updating only the archive
-    // column in SQL preserves the activity timestamp without reading and later restoring a stale value.
+    // columns in SQL preserves the activity timestamp without reading and later restoring a stale value.
     const updated = await client.$executeRaw`
       UPDATE "Project"
-      SET "archivedAt" = ${request.archived ? new Date(archivedAt) : null}
+      SET "archivedAt" = ${request.archived ? new Date(archivedAt) : null},
+          "archiveRevision" = "archiveRevision" + 1
       WHERE "id" = ${request.id}
         AND "deletedAt" IS NULL
-        AND "archivedAt" IS ${expectedArchivedAt === null ? null : new Date(expectedArchivedAt)}
+        AND "archiveRevision" = ${request.expectedArchiveRevision}
     `
     if (updated !== 1) {
       const current = await client.project.findUnique({ where: { id: request.id } })

--- a/src/main/session-persistence/coordinator-contract.test.ts
+++ b/src/main/session-persistence/coordinator-contract.test.ts
@@ -1,3 +1,7 @@
+import { readFileSync } from 'node:fs'
+import ts from 'typescript'
+import { ArchiveCoordinator, type SessionRuntimeActivity } from '../archive/coordinator'
+import type { Project, UpdateProjectArchiveRequest } from '../../shared/projects'
 import { setImmediate } from 'node:timers/promises'
 import { describe, expect, it, vi } from 'vitest'
 
@@ -6,6 +10,7 @@ import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
 import type {
   PersistedChatSession,
+  UpdateSessionArchiveRequest,
   SessionPlanRuntimeContext
 } from '../../shared/session-persistence'
 import {
@@ -541,13 +546,18 @@ describe('SessionPersistenceCoordinator contracts', () => {
 
   it('applies optimistic archive checks before changing durable Session visibility', async () => {
     const { repository, sessions } = createRepository()
+    repository.saveSession = vi.fn(async (session) => {
+      const next = { ...session, revision: (sessions.get(session.id)?.revision ?? 0) + 1 }
+      sessions.set(session.id, next)
+      return next
+    })
     const coordinator = new SessionPersistenceCoordinator(repository, createFileIndex())
 
     const archived = await coordinator.updateArchive({
       projectId: 'project-1',
       sessionId: 'session-1',
       archived: true,
-      expectedArchivedAt: null
+      expectedRevision: 0
     })
     expect(archived.archivedAt).toEqual(expect.any(Number))
 
@@ -556,9 +566,9 @@ describe('SessionPersistenceCoordinator contracts', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         archived: false,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
-    ).rejects.toThrow('Session archive state changed elsewhere.')
+    ).rejects.toThrow('Session revision conflict')
 
     const running = createSession({ id: 'session-2', status: 'running' })
     sessions.set(running.id, running)
@@ -567,7 +577,7 @@ describe('SessionPersistenceCoordinator contracts', () => {
         projectId: 'project-1',
         sessionId: 'session-2',
         archived: true,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
     ).rejects.toThrow('Finish or stop this session before archiving.')
   })
@@ -762,4 +772,258 @@ describe('SessionPersistenceCoordinator contracts', () => {
     expect(reconcileSessionCleanup).toHaveBeenCalledWith([session])
     expect(reconcileMessageSnapshots).not.toHaveBeenCalled()
   })
+})
+
+// Execute the composition root's real activity adapter. Importing ipc.ts would boot Electron and
+// unrelated application modules; this test-only extraction keeps its wiring observable without a
+// production seam or a duplicate implementation of the archive policy.
+const archiveRuntime = (
+  jobs: {
+    countNonTerminalBySession: (sessionId: string) => Promise<number>
+    findNonTerminal: () => Promise<{ project_id: string }[]>
+  },
+  detect: () => { projectId: string; sessionId: string }[] = () => []
+): SessionRuntimeActivity => {
+  const source = ts.createSourceFile(
+    'ipc.ts',
+    readFileSync(new URL('../ipc.ts', import.meta.url), 'utf8'),
+    ts.ScriptTarget.Latest,
+    true
+  )
+  let runtime: ts.Expression | undefined
+  const visit = (node: ts.Node): void => {
+    if (ts.isNewExpression(node) && node.expression.getText(source) === 'ArchiveCoordinator') {
+      runtime = node.arguments?.[2]
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(source)
+  if (!runtime) throw new Error('ArchiveCoordinator runtime wiring was not found')
+  const script = ts.transpileModule(`return (${runtime.getText(source)})`, {
+    compilerOptions: { target: ts.ScriptTarget.ES2022, module: ts.ModuleKind.CommonJS }
+  }).outputText
+  return new Function(
+    'sideChatOwnerRef',
+    'detectArchiveBlockingSessions',
+    'reviewerProjectRuntime',
+    'computeJobActivityRef',
+    'runtimeRef',
+    script
+  )({}, detect, { isProjectBusy: () => false }, { current: jobs }, {})
+}
+
+const createArchiveHarness = (
+  runtime?: SessionRuntimeActivity
+): {
+  coordinator: ArchiveCoordinator
+  sessions: Map<string, PersistedChatSession>
+  projects: { get(): Promise<Project> }
+  repository: SessionMutationRepository
+} => {
+  const { repository, sessions } = createRepository([createSession({ revision: 1 })])
+  // Model the repository's existing durable revision advancement, including archive writes.
+  repository.saveSession = vi.fn(async (next) => {
+    const persisted = { ...next, revision: (sessions.get(next.id)?.revision ?? 0) + 1 }
+    sessions.set(next.id, structuredClone(persisted))
+    return persisted
+  })
+  const persistence = new SessionPersistenceCoordinator(repository, createFileIndex())
+  let project: Project = {
+    id: 'project-1',
+    name: 'Project',
+    description: '',
+    isExample: false,
+    createdAt: 1,
+    updatedAt: 2
+  }
+  const projects = {
+    get: vi.fn(async () => ({ ...project })),
+    updateArchive: vi.fn(async (request: UpdateProjectArchiveRequest, archivedAt: number) => {
+      if ((project.archiveRevision ?? 0) !== request.expectedArchiveRevision) {
+        throw new Error('Project archive state changed elsewhere.')
+      }
+      project = {
+        ...project,
+        archivedAt: request.archived ? archivedAt : undefined,
+        archiveRevision: (project.archiveRevision ?? 0) + 1
+      }
+      return { ...project }
+    })
+  }
+  const coordinator = new ArchiveCoordinator(
+    projects,
+    persistence,
+    runtime ?? {
+      isSessionBusy: () => false,
+      isProjectBusy: () => false,
+      liveSessionProjectId: () => 'project-1'
+    }
+  )
+  return { coordinator, sessions, projects, repository }
+}
+
+const sessionArchiveRequest = (
+  archived: boolean,
+  expectedRevision: number
+): UpdateSessionArchiveRequest => ({
+  projectId: 'project-1',
+  sessionId: 'session-1',
+  archived,
+  expectedRevision
+})
+
+describe('archive admission regressions', () => {
+  it.each(['queued', 'submitted', 'running'])(
+    'rejects an idle Session with a %s Compute Job through the real IPC activity adapter',
+    async (status) => {
+      const job = { session_id: 'session-1', project_id: 'project-1', status }
+      const jobs = {
+        countNonTerminalBySession: vi.fn(async (id: string) => (id === job.session_id ? 1 : 0)),
+        findNonTerminal: vi.fn(async () => [job])
+      }
+      const { coordinator, repository } = createArchiveHarness(archiveRuntime(jobs))
+      await expect(
+        coordinator.updateProjectArchive({
+          id: 'project-1',
+          archived: true,
+          expectedArchiveRevision: 0
+        })
+      ).rejects.toThrow('Finish or stop active sessions')
+      await expect(
+        coordinator.updateSessionArchive(sessionArchiveRequest(true, 1))
+      ).rejects.toThrow('Finish or stop')
+      expect(repository.saveSession).not.toHaveBeenCalled()
+      expect(jobs.countNonTerminalBySession).toHaveBeenCalledWith('session-1')
+    }
+  )
+
+  it('fails closed when the Session Compute Job query rejects', async () => {
+    const jobs = {
+      countNonTerminalBySession: vi.fn().mockRejectedValue(new Error('Job database unavailable')),
+      findNonTerminal: vi.fn().mockResolvedValue([])
+    }
+    const { coordinator, repository } = createArchiveHarness(archiveRuntime(jobs))
+    await expect(coordinator.updateSessionArchive(sessionArchiveRequest(true, 1))).rejects.toThrow(
+      'Job database unavailable'
+    )
+    expect(repository.saveSession).not.toHaveBeenCalled()
+  })
+
+  it('waits for the Session Compute Job query before persisting archive state', async () => {
+    const gate = createDeferred<number>()
+    const jobs = {
+      countNonTerminalBySession: vi.fn(() => gate.promise),
+      findNonTerminal: vi.fn().mockResolvedValue([])
+    }
+    const { coordinator, repository } = createArchiveHarness(archiveRuntime(jobs))
+    const outcome = coordinator.updateSessionArchive(sessionArchiveRequest(true, 1)).then(
+      () => 'archived',
+      () => 'rejected'
+    )
+    // Drain local I/O/microtasks without depending on a wall-clock timeout or a sleep duration.
+    await setImmediate()
+    const writesBeforeQueryCompleted = vi.mocked(repository.saveSession).mock.calls.length
+    gate.resolve(1)
+    const result = await outcome
+    expect(writesBeforeQueryCompleted).toBe(0)
+    expect(result).toBe('rejected')
+    expect(jobs.countNonTerminalBySession).toHaveBeenCalledWith('session-1')
+  })
+
+  it('rechecks runtime activity after the asynchronous Compute Job query', async () => {
+    const gate = createDeferred<number>()
+    let running = false
+    const jobs = {
+      countNonTerminalBySession: vi.fn(() => gate.promise),
+      findNonTerminal: vi.fn().mockResolvedValue([])
+    }
+    const { coordinator, repository } = createArchiveHarness(
+      archiveRuntime(jobs, () =>
+        running ? [{ projectId: 'project-1', sessionId: 'session-1' }] : []
+      )
+    )
+    const result = coordinator.updateSessionArchive(sessionArchiveRequest(true, 1))
+    const rejected = expect(result).rejects.toThrow('Finish or stop')
+    await setImmediate()
+    running = true
+    gate.resolve(0)
+    await rejected
+    expect(repository.saveSession).not.toHaveBeenCalled()
+  })
+
+  it.each(['success', 'failed', 'timeout', 'error', 'another Session'])(
+    'allows Session archive when the only Compute Job is %s',
+    async (status) => {
+      const jobs = {
+        countNonTerminalBySession: vi.fn(async (id: string) =>
+          status === 'another Session' && id === 'session-2' ? 1 : 0
+        ),
+        findNonTerminal: vi.fn(async () =>
+          status === 'another Session' ? [{ project_id: 'project-1' }] : []
+        )
+      }
+      const { coordinator } = createArchiveHarness(archiveRuntime(jobs))
+      await expect(
+        coordinator.updateSessionArchive(sessionArchiveRequest(true, 1))
+      ).resolves.toMatchObject({ archivedAt: expect.any(Number), updatedAt: 2 })
+    }
+  )
+
+  it.each(['Project', 'Session'] as const)(
+    'rejects a delayed %s archive created before another window archives and restores',
+    async (target) => {
+      const { coordinator, sessions, projects } = createArchiveHarness()
+      const update = (
+        archived: boolean,
+        expectedRevision: number
+      ): Promise<Project | PersistedChatSession> =>
+        target === 'Project'
+          ? coordinator.updateProjectArchive({
+              id: 'project-1',
+              archived,
+              expectedArchiveRevision: expectedRevision
+            })
+          : coordinator.updateSessionArchive(sessionArchiveRequest(archived, expectedRevision))
+      // Window A captures its command now but sends it only after Window B's round trip.
+      const initialRevision = target === 'Project' ? 0 : 1
+      const delayed = (): Promise<Project | PersistedChatSession> => update(true, initialRevision)
+      await update(true, initialRevision)
+      await update(false, initialRevision + 1)
+      expect((await projects.get()).updatedAt).toBe(2)
+      expect(sessions.get('session-1')?.updatedAt).toBe(2)
+      if (target === 'Session') expect(sessions.get('session-1')?.revision).toBe(3)
+      await expect(delayed()).rejects.toThrow(/changed elsewhere|revision/i)
+    }
+  )
+
+  it.each(['Project', 'Session'] as const)(
+    'rejects an old %s Undo when two archives use the same millisecond',
+    async (target) => {
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(1000)
+      try {
+        const { coordinator } = createArchiveHarness()
+        const update = (
+          archived: boolean,
+          expectedRevision: number
+        ): Promise<Project | PersistedChatSession> =>
+          target === 'Project'
+            ? coordinator.updateProjectArchive({
+                id: 'project-1',
+                archived,
+                expectedArchiveRevision: expectedRevision
+              })
+            : coordinator.updateSessionArchive(sessionArchiveRequest(archived, expectedRevision))
+        const initialRevision = target === 'Project' ? 0 : 1
+        const first = await update(true, initialRevision)
+        await update(false, initialRevision + 1)
+        const second = await update(true, initialRevision + 2)
+        expect(second.archivedAt).toBe(first.archivedAt)
+        await expect(update(false, initialRevision + 1)).rejects.toThrow(
+          /changed elsewhere|revision/i
+        )
+      } finally {
+        clock.mockRestore()
+      }
+    }
+  )
 })

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -2840,7 +2840,7 @@ describe('SessionPersistenceCoordinator', () => {
         projectId: 'project-1',
         sessionId: 'session-1',
         archived: true,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
     ).rejects.toThrow('Finish or stop this session before archiving.')
   })
@@ -2883,7 +2883,7 @@ describe('SessionPersistenceCoordinator', () => {
         projectId: delegated.projectId,
         sessionId: delegated.id,
         archived: true,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
     ).rejects.toThrow('Finish or stop this session before archiving.')
 
@@ -2899,7 +2899,7 @@ describe('SessionPersistenceCoordinator', () => {
         projectId: inactiveRoute.projectId,
         sessionId: inactiveRoute.id,
         archived: true,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
     ).rejects.toThrow('Finish or stop this session before archiving.')
 
@@ -2915,7 +2915,7 @@ describe('SessionPersistenceCoordinator', () => {
         projectId: terminal.projectId,
         sessionId: terminal.id,
         archived: true,
-        expectedArchivedAt: null
+        expectedRevision: 0
       })
     ).resolves.toMatchObject({ archivedAt: expect.any(Number) })
   })
@@ -2938,7 +2938,7 @@ describe('SessionPersistenceCoordinator', () => {
           projectId: delegated.projectId,
           sessionId: delegated.id,
           archived: true,
-          expectedArchivedAt: null
+          expectedRevision: persisted?.revision ?? 0
         })
       ])
 

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -718,7 +718,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
   // cannot prove that an omitted Session is idle, so it is unsafe to hide the whole Project.
   assertProjectArchivable(
     projectId: string,
-    isRuntimeBusy: (sessionId: string) => boolean = () => false
+    isRuntimeBusy: (sessionId: string) => boolean | Promise<boolean> = () => false
   ): Promise<string[]> {
     return this.operationScheduler.runProject(projectId, () =>
       this.deletionOwner.assertProjectArchivable(projectId, isRuntimeBusy)
@@ -745,7 +745,7 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
   // never allows a stale renderer projection to alter archive state.
   updateArchive(
     request: UpdateSessionArchiveRequest,
-    isRuntimeBusy: () => boolean = () => false
+    isRuntimeBusy: () => boolean | Promise<boolean> = () => false
   ): Promise<PersistedChatSession> {
     return this.operationScheduler.runSession(request.projectId, request.sessionId, () =>
       this.deletionOwner.updateArchive(request, isRuntimeBusy)

--- a/src/main/session-persistence/deletion-owner.ts
+++ b/src/main/session-persistence/deletion-owner.ts
@@ -6,6 +6,8 @@ import {
 } from '../../shared/delegated-work-projection'
 import {
   SessionDeletionCommittedError,
+  sessionRevision,
+  SessionRevisionConflictError,
   type LoadAllSessionsResult,
   type PersistedChatSession,
   type PersistedChatMessage,
@@ -82,7 +84,10 @@ type SessionDeletionRepository = {
     | { status: 'missing' }
     | { status: 'unreadable' }
   >
-  saveSession(session: PersistedChatSession): Promise<PersistedChatSession | void>
+  saveSession(
+    session: PersistedChatSession,
+    expectedRevision?: number
+  ): Promise<PersistedChatSession | void>
   saveCommittedProjectSession(session: PersistedChatSession): Promise<void>
   deleteSession(projectId: string, sessionId: string): Promise<void>
   deleteProjectSessions(projectId: string): Promise<void>
@@ -160,12 +165,6 @@ const ARCHIVE_BLOCKING_SESSION_STATUSES = new Set<PersistedSessionStatus>([
   'waiting-plan-approval'
 ])
 
-const assertArchiveExpectedAt = (value: number | null, target: 'Project' | 'Session'): void => {
-  if (value !== null && (!Number.isSafeInteger(value) || value <= 0)) {
-    throw new Error(`${target} archive state is invalid.`)
-  }
-}
-
 const isSessionArchiveBlocked = (session: PersistedChatSession): boolean =>
   ARCHIVE_BLOCKING_SESSION_STATUSES.has(session.status)
 
@@ -203,18 +202,16 @@ class SessionPersistenceDeletionOwner {
 
   async assertProjectArchivable(
     projectId: string,
-    isRuntimeBusy: (sessionId: string) => boolean = () => false
+    isRuntimeBusy: (sessionId: string) => boolean | Promise<boolean> = () => false
   ): Promise<string[]> {
     const loaded = await this.repository.loadProjectWithDiagnostics(projectId)
     if (!loaded.isComplete) {
       throw new Error('Cannot archive a Project while its Session catalog is incomplete.')
     }
-    if (
-      loaded.sessions.some(
-        (session) => isSessionArchiveBlockedByPersistedWork(session) || isRuntimeBusy(session.id)
-      )
-    ) {
-      throw new Error('Finish or stop active sessions before archiving this project.')
+    for (const session of loaded.sessions) {
+      if (isSessionArchiveBlockedByPersistedWork(session) || (await isRuntimeBusy(session.id))) {
+        throw new Error('Finish or stop active sessions before archiving this project.')
+      }
     }
     return loaded.sessions.map((session) => session.id)
   }
@@ -232,9 +229,11 @@ class SessionPersistenceDeletionOwner {
 
   async updateArchive(
     request: UpdateSessionArchiveRequest,
-    isRuntimeBusy: () => boolean = () => false
+    isRuntimeBusy: () => boolean | Promise<boolean> = () => false
   ): Promise<PersistedChatSession> {
-    assertArchiveExpectedAt(request.expectedArchivedAt, 'Session')
+    if (!Number.isSafeInteger(request.expectedRevision) || request.expectedRevision < 0) {
+      throw new Error('Session archive state is invalid.')
+    }
     this.assertArchiveMutable(request.projectId, request.sessionId)
 
     const loaded = await this.repository.loadSessionWithDiagnostics(
@@ -247,21 +246,25 @@ class SessionPersistenceDeletionOwner {
     }
 
     const currentArchivedAt = loaded.session.archivedAt ?? null
-    if (currentArchivedAt !== request.expectedArchivedAt) {
-      throw new Error('Session archive state changed elsewhere.')
+    if (sessionRevision(loaded.session) !== request.expectedRevision) {
+      throw new SessionRevisionConflictError(
+        request.expectedRevision,
+        sessionRevision(loaded.session)
+      )
     }
     if (
       request.archived &&
-      (isSessionArchiveBlockedByPersistedWork(loaded.session) || isRuntimeBusy())
+      (isSessionArchiveBlockedByPersistedWork(loaded.session) || (await isRuntimeBusy()))
     ) {
       throw new Error('Finish or stop this session before archiving.')
     }
+    this.assertArchiveMutable(request.projectId, request.sessionId)
     if (request.archived === (currentArchivedAt !== null)) return loaded.session
 
     const next: PersistedChatSession = { ...loaded.session }
     if (request.archived) next.archivedAt = Date.now()
     else delete next.archivedAt
-    const persisted = await saveSessionWithRevision(this.repository, next)
+    const persisted = await saveSessionWithRevision(this.repository, next, request.expectedRevision)
     this.stateOwner.recordSession(persisted)
     return persisted
   }

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -252,7 +252,7 @@ describe('session persistence IPC handlers', () => {
       projectId: session.projectId,
       sessionId: session.id,
       archived: true,
-      expectedArchivedAt: null
+      expectedRevision: 0
     })
     await repository.deleteSession(session.projectId, session.id)
     await repository.saveManifest({ lastSessionId: session.id })

--- a/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
+++ b/src/renderer/src/components/PermissionUndoSnackbar.test.tsx
@@ -29,6 +29,7 @@ const archivedProjectNotice = (
   kind: 'project',
   projectId: id,
   archivedAt,
+  revision: 0,
   expiresAt: Date.now() + 8_000,
   messageKey: 'Archived project “{{name}}”.',
   messageParams: { name }
@@ -176,7 +177,7 @@ describe('PermissionUndoSnackbar', () => {
     expect(updateProjectArchive).toHaveBeenCalledWith({
       id: 'project-1',
       archived: false,
-      expectedArchivedAt: 10
+      expectedArchiveRevision: 0
     })
     expectSnackbarExiting(container, '[data-testid="archive-undo-snackbar"]')
   })
@@ -222,7 +223,7 @@ describe('PermissionUndoSnackbar', () => {
     expect(updateProjectArchive).toHaveBeenCalledWith({
       id: 'project-2',
       archived: false,
-      expectedArchivedAt: 20
+      expectedArchiveRevision: 0
     })
     expect(restore).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/hooks/useLifecycleSync.test.tsx
+++ b/src/renderer/src/hooks/useLifecycleSync.test.tsx
@@ -196,7 +196,7 @@ describe('useLifecycleSync', () => {
       projectId: project.id,
       sessionId: session.id,
       archived: true,
-      expectedArchivedAt: null
+      expectedRevision: 0
     })
     await act(async () => {
       listeners.sessionUpdated?.({

--- a/src/renderer/src/pages/home/HomePage.persistence.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.persistence.test.tsx
@@ -247,7 +247,7 @@ describe('HomePage persistence recovery', () => {
     expect(updateProjectArchive).toHaveBeenCalledWith({
       id: project.id,
       archived: true,
-      expectedArchivedAt: null
+      expectedArchiveRevision: 0
     })
     expect(container.querySelector('[role="alert"]')?.textContent).toBe(
       'Repair the project index before archiving.'

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -514,7 +514,11 @@ const HomePage = ({
 
     setArchivingProjectIds((current) => new Set(current).add(project.id))
     setProjectActionError(undefined)
-    void updateProjectArchive({ id: project.id, archived: true, expectedArchivedAt: null })
+    void updateProjectArchive({
+      id: project.id,
+      archived: true,
+      expectedArchiveRevision: project.archiveRevision ?? 0
+    })
       .then((archived) => enqueueProjectArchive(archived))
       .catch((error: unknown) =>
         setProjectActionError(

--- a/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
@@ -80,7 +80,7 @@ describe('ArchivedPanel', () => {
       projectId: project.id,
       sessionId: session.id,
       archived: false,
-      expectedArchivedAt: 2
+      expectedRevision: 0
     })
     expect(useSessionStore.getState().sessions[0]?.archivedAt).toBeUndefined()
   })
@@ -262,6 +262,112 @@ describe('ArchivedPanel', () => {
     })
     expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
   })
+
+  it.each(['before commit', 'after commit with a lost response'])(
+    'shows an uncertain deletion inside the modal and retries after RPC rejection %s',
+    async (failurePoint) => {
+      let committed = false
+      deleteSession
+        .mockImplementationOnce(async () => {
+          committed = failurePoint !== 'before commit'
+          throw new Error('Connection lost')
+        })
+        .mockImplementationOnce(async () => {
+          // The authoritative delete command accepts a retry even if the first call committed.
+          committed = true
+          return { status: 'deleted', runtimeDetached: true }
+        })
+      await act(async () =>
+        root.render(<ArchivedPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+      )
+      const openDelete = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent === 'Delete'
+      )!
+      expect(openDelete).toBeDefined()
+      await act(async () => openDelete.click())
+      let dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')!
+      const confirm = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent === 'Delete'
+      )!
+      await act(async () => confirm.click())
+
+      expect(deleteSession).toHaveBeenCalledOnce()
+      expect(committed).toBe(failurePoint !== 'before commit')
+      dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')!
+      expect(dialog).not.toBeNull()
+      const alert = dialog.querySelector<HTMLElement>('[role="alert"]')
+      expect(alert).not.toBeNull()
+      expect(alert?.closest('[aria-hidden="true"]')).toBeNull()
+      expect(alert?.textContent).toMatch(/confirm.*delet/i)
+      expect(alert?.textContent).not.toMatch(/was not deleted|were kept|was deleted/i)
+      const retry = Array.from(dialog.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => button.textContent === 'Retry'
+      )!
+      expect(retry).toBeDefined()
+      await act(async () => retry.click())
+      expect(deleteSession).toHaveBeenNthCalledWith(2, {
+        projectId: project.id,
+        sessionId: session.id
+      })
+      expect(committed).toBe(true)
+      expect(document.body.querySelector('[role="alertdialog"]')).toBeNull()
+    }
+  )
+
+  it('identifies the Project on each individually archived Session row', async () => {
+    const projects = [
+      { ...project, name: 'Alpha biology' },
+      { ...project, id: 'project-2', name: 'Beta physics' }
+    ]
+    useProjectStore.setState({ projects })
+    useSessionStore.setState({
+      sessions: projects.map((owner, index) => ({
+        ...session,
+        id: `session-${index + 1}`,
+        projectId: owner.id
+      }))
+    })
+    await act(async () =>
+      root.render(<ArchivedPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    )
+    const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).filter(
+      (button) => button.textContent === 'Delete'
+    )
+    expect(buttons).toHaveLength(2)
+    buttons.forEach((button, index) => {
+      expect(button.parentElement?.textContent).toContain(projects[index].name)
+    })
+  })
+
+  it.each([0, 1])(
+    'identifies the selected Project inside deletion confirmation for row %s',
+    async (index) => {
+      const projects = [
+        { ...project, name: 'Alpha biology' },
+        { ...project, id: 'project-2', name: 'Beta physics' }
+      ]
+      useProjectStore.setState({ projects })
+      useSessionStore.setState({
+        sessions: projects.map((owner, index) => ({
+          ...session,
+          id: `session-${index + 1}`,
+          projectId: owner.id
+        }))
+      })
+      await act(async () =>
+        root.render(<ArchivedPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+      )
+      const buttons = Array.from(container.querySelectorAll<HTMLButtonElement>('button')).filter(
+        (button) => button.textContent === 'Delete'
+      )
+      expect(buttons).toHaveLength(2)
+      await act(async () => buttons[index].click())
+      const dialog = document.body.querySelector<HTMLElement>('[role="alertdialog"]')!
+      expect(dialog).not.toBeNull()
+      expect(dialog.textContent).toContain(projects[index].name)
+      expect(dialog.textContent).not.toContain(projects[1 - index].name)
+    }
+  )
 
   it('clears a failed Project deletion error before opening the next confirmation', async () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)

--- a/src/renderer/src/pages/settings/ArchivedPanel.tsx
+++ b/src/renderer/src/pages/settings/ArchivedPanel.tsx
@@ -14,6 +14,7 @@ import { useProjectStore } from '@/stores/project-store'
 import type { ChatSession } from '@/stores/session-store'
 import { useSessionStore } from '@/stores/session-store'
 import type { Project } from '../../../../shared/projects'
+import { sessionRevision } from '../../../../shared/session-persistence'
 
 export type ArchivedView = { kind: 'list' } | { kind: 'project'; projectId: string }
 
@@ -51,7 +52,7 @@ const ArchivedPanel = ({
   const [panelError, setPanelError] = useState<string | undefined>()
   const [projectDeleteError, setProjectDeleteError] = useState<string | undefined>()
   const [sessionDeleteError, setSessionDeleteError] = useState<
-    'runtime' | 'persistence' | undefined
+    'runtime' | 'persistence' | 'unknown' | undefined
   >()
 
   const archivedProjects = useMemo(
@@ -95,7 +96,7 @@ const ArchivedPanel = ({
     void updateProjectArchive({
       id: project.id,
       archived: false,
-      expectedArchivedAt: project.archivedAt
+      expectedArchiveRevision: project.archiveRevision ?? 0
     })
       .then(() => onNavigate({ kind: 'list' }))
       .catch((restoreError: unknown) =>
@@ -114,7 +115,7 @@ const ArchivedPanel = ({
       projectId: session.projectId,
       sessionId: session.id,
       archived: false,
-      expectedArchivedAt: session.archivedAt
+      expectedRevision: sessionRevision(session)
     })
       .catch((restoreError: unknown) =>
         setPanelError(describeError(restoreError, t('Could not restore session.')))
@@ -145,9 +146,7 @@ const ArchivedPanel = ({
         useArchiveUndoStore.getState().dismissSession(session.id)
         setSessionToDelete(undefined)
       })
-      .catch((deleteError: unknown) =>
-        setPanelError(describeError(deleteError, t('Could not delete session.')))
-      )
+      .catch(() => setSessionDeleteError('unknown'))
       .finally(() => finishOperation(key))
   }
 
@@ -190,6 +189,11 @@ const ArchivedPanel = ({
     <div key={session.id} className="flex items-center gap-3 rounded-lg border border-border p-3">
       <div className="min-w-0 flex-1">
         <p className="truncate text-sm font-medium text-foreground">{session.title}</p>
+        <p className="mt-0.5 break-words text-xs text-muted-foreground">
+          {t('Project: {{name}}', {
+            name: projects.find((project) => project.id === session.projectId)?.name ?? ''
+          })}
+        </p>
         <p className="mt-0.5 text-xs text-muted-foreground">
           {session.archivedAt === undefined
             ? t('Hidden because its project is archived.')
@@ -362,6 +366,7 @@ const ArchivedPanel = ({
       />
       <DeleteSessionDialog
         session={sessionToDelete}
+        projectName={projects.find((project) => project.id === sessionToDelete?.projectId)?.name}
         canDelete={canDeleteProjects}
         isDeleting={busyKeys.has(`session:${sessionToDelete?.id}`)}
         error={sessionDeleteError}

--- a/src/renderer/src/pages/workspace/DeleteSessionDialog.tsx
+++ b/src/renderer/src/pages/workspace/DeleteSessionDialog.tsx
@@ -19,9 +19,10 @@ import type { ChatSession } from '@/stores/session-store'
 
 type DeleteSessionDialogProps = {
   session: ChatSession | undefined
+  projectName?: string
   canDelete: boolean
   isDeleting?: boolean
-  error?: 'runtime' | 'persistence'
+  error?: 'runtime' | 'persistence' | 'unknown'
   onCancel: () => void
   onConfirmDelete: () => void
 }
@@ -32,6 +33,7 @@ const deleteDialogConfirmButtonClassName =
 // Destructive deletion requires confirmation before the session is removed from memory.
 const DeleteSessionDialog = ({
   session,
+  projectName,
   canDelete,
   isDeleting = false,
   error,
@@ -40,6 +42,7 @@ const DeleteSessionDialog = ({
 }: DeleteSessionDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
   const dialogSession = useRetainedDialogValue(session)
+  const dialogProjectName = useRetainedDialogValue(session ? (projectName ?? '') : undefined)
 
   return (
     <AlertDialog.Root
@@ -73,11 +76,18 @@ const DeleteSessionDialog = ({
             </Button>
           </div>
           <div className={dialogBodyClassName}>
-            <AlertDialog.Description className={dialogDescriptionClassName}>
-              {t(
-                'This will permanently delete "{{title}}". Artifacts created in this session will remain in the project. Messages and execution evidence attached to those Artifacts will remain available in Provenance. Files in its working folder are not deleted. This action cannot be undone.',
-                { title: dialogSession?.title ?? '' }
-              )}
+            <AlertDialog.Description asChild>
+              <div className={dialogDescriptionClassName}>
+                {dialogProjectName ? (
+                  <p className="mb-2 break-words font-medium">
+                    {t('Project: {{name}}', { name: dialogProjectName })}
+                  </p>
+                ) : null}
+                {t(
+                  'This will permanently delete "{{title}}". Artifacts created in this session will remain in the project. Messages and execution evidence attached to those Artifacts will remain available in Provenance. Files in its working folder are not deleted. This action cannot be undone.',
+                  { title: dialogSession?.title ?? '' }
+                )}
+              </div>
             </AlertDialog.Description>
             {isDeleting ? (
               <p className="mt-3 text-sm text-muted-foreground" role="status" aria-live="polite">
@@ -86,13 +96,15 @@ const DeleteSessionDialog = ({
             ) : null}
             {error ? (
               <p className="mt-3 text-sm text-destructive" role="alert">
-                {error === 'persistence'
-                  ? t(
-                      "The agent was stopped, but Open Science couldn't delete the saved Session. The Session, draft, and attachments were kept. Please try again."
-                    )
-                  : t(
-                      "Open Science couldn't stop the agent for this Session. The Session was not deleted. Please try again."
-                    )}
+                {error === 'unknown'
+                  ? t('Could not confirm the deletion result. Please try again.')
+                  : error === 'persistence'
+                    ? t(
+                        "The agent was stopped, but Open Science couldn't delete the saved Session. The Session, draft, and attachments were kept. Please try again."
+                      )
+                    : t(
+                        "Open Science couldn't stop the agent for this Session. The Session was not deleted. Please try again."
+                      )}
               </p>
             ) : null}
           </div>

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -39,13 +39,9 @@ let downloadArtifactsDialogProps: {
   session: ChatSession | undefined
   onClose: () => void
 }
-let deleteDialogProps: {
-  session: ChatSession | undefined
-  canDelete: boolean
-  isDeleting?: boolean
-  error?: 'runtime' | 'persistence'
-  onConfirmDelete: () => void
-}
+let deleteDialogProps: Parameters<
+  (typeof import('./DeleteSessionDialog'))['DeleteSessionDialog']
+>[0]
 
 // The runtime bridge is stubbed; sendMessage resolves truthy so the success path clears the composer.
 const runtime = vi.hoisted(() => ({
@@ -99,12 +95,16 @@ vi.mock('./EditSessionDialog', () => ({
   EditSessionDialog: (): React.JSX.Element => <div />
 }))
 
-vi.mock('./DeleteSessionDialog', () => ({
-  DeleteSessionDialog: (props: typeof deleteDialogProps): React.JSX.Element => {
-    deleteDialogProps = props
-    return <div />
+vi.mock('./DeleteSessionDialog', async () => {
+  const actual =
+    await vi.importActual<typeof import('./DeleteSessionDialog')>('./DeleteSessionDialog')
+  return {
+    DeleteSessionDialog: (props: typeof deleteDialogProps): React.JSX.Element => {
+      deleteDialogProps = props
+      return <actual.DeleteSessionDialog {...props} />
+    }
   }
-}))
+})
 
 vi.mock('./DownloadSessionArtifactsDialog', () => ({
   DownloadSessionArtifactsDialog: (
@@ -962,6 +962,28 @@ describe('WorkspacePage draft preservation', () => {
     expect(deleteUpload).toHaveBeenCalledWith({ path: firstAttachment.path })
     expect(deleteUpload).not.toHaveBeenCalledWith({ path: newerAttachment.path })
   })
+
+  it.each(['proj-1', 'proj-2'])(
+    'identifies the owning Project in the delete modal for %s',
+    async (projectId) => {
+      const first = { ...useProjectStore.getState().projects[0], name: 'Alpha biology' }
+      const second = { ...first, id: 'proj-2', name: 'Beta physics' }
+      useProjectStore.setState({ projects: [first, second] })
+      const target = { ...createSession('same-title-target', projectId), title: 'Experiment notes' }
+      useSessionStore.setState((state) => ({ sessions: [...state.sessions, target] }))
+      await renderPage()
+      await act(async () => sidebarProps.onDeleteSession(target))
+      const dialog = document.querySelector('[role="alertdialog"]')
+      const projectName = projectId === 'proj-1' ? first.name : second.name
+      expect(dialog?.textContent).toContain('Experiment notes')
+      expect(dialog?.textContent).toContain(`Project: ${projectName}`)
+
+      await act(async () => useNavigationStore.setState({ activeProjectId: 'proj-2' }))
+      expect(document.querySelector('[role="alertdialog"]')?.textContent).toContain(
+        `Project: ${projectName}`
+      )
+    }
+  )
 
   it('drops a stored draft and deletes its staged files when the session is deleted', async () => {
     await renderPage()

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -385,6 +385,12 @@ const WorkspacePage = ({
     deleteSession,
     onSessionSizeLimit
   })
+  const deleteSessionProjectName = useProjectStore(
+    (state) =>
+      state.projects.find(
+        (project) => project.id === sessionController.view.dialogs.delete?.session.projectId
+      )?.name
+  )
   const exportConversationSessionId = sessionController.view.dialogs.exportConversation?.id
   const currentExportConversationSession = useSessionStore((state) =>
     state.sessions.find((session) => session.id === exportConversationSessionId)
@@ -1426,6 +1432,7 @@ const WorkspacePage = ({
       />
       <DeleteSessionDialog
         session={sessionController.view.dialogs.delete?.session}
+        projectName={deleteSessionProjectName}
         canDelete={canDeleteConversations}
         isDeleting={sessionController.view.dialogs.delete?.isDeleting}
         error={sessionController.view.dialogs.delete?.error ?? undefined}

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -200,6 +200,7 @@ const renderController = (overrides: Partial<Options> = {}): ControllerHook => {
 
 const mounted: Array<ReturnType<typeof renderController>> = []
 const originalApi = window.api
+const originalSessionArchive = useSessionStore.getState().updateSessionArchive
 
 beforeEach(() => {
   window.api = {} as Window['api']
@@ -729,6 +730,58 @@ describe('workspace session controller', () => {
 
     expect(hook.result.current.lifecycle.canStartSend()).toBe(false)
     expect(hook.result.current.lifecycle.canStartSend(inactive.id)).toBe(false)
+  })
+
+  it('keeps a stale archive rejected until a new user action uses refreshed authority', async () => {
+    const active = session({ revision: 3 })
+    const refreshed = { ...active, revision: 4 }
+    const archived = { ...refreshed, revision: 5, archivedAt: 2 }
+    const updateArchive = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Session revision conflict: expected 3, actual 4.'))
+      .mockResolvedValueOnce(archived)
+    window.api = {
+      sessions: { updateArchive, loadOne: vi.fn().mockResolvedValue(refreshed) }
+    } as unknown as Window['api']
+    const enqueueSession = vi.fn()
+    const clearSelection = vi.fn()
+    useArchiveUndoStore.setState({ enqueueSession })
+    useSessionStore.setState({
+      sessions: [active],
+      selectedSessionId: active.id,
+      updateSessionArchive: originalSessionArchive,
+      clearSelection
+    })
+    const hook = renderController({ activeSession: active })
+    mounted.push(hook)
+    await act(async () => hook.result.current.actions.archive(active))
+    expect(updateArchive).toHaveBeenCalledOnce()
+    expect(updateArchive).toHaveBeenLastCalledWith({
+      projectId: active.projectId,
+      sessionId: active.id,
+      archived: true,
+      expectedRevision: 3
+    })
+    expect(hook.result.current.view.exportError).toContain('Session revision conflict:')
+    expect(enqueueSession).not.toHaveBeenCalled()
+    expect(clearSelection).not.toHaveBeenCalled()
+    const current = useSessionStore.getState().sessions[0]
+    expect(current.revision).toBe(4)
+    expect(current.archivedAt).toBeUndefined()
+    hook.rerender(current)
+    await act(async () => hook.result.current.actions.archive(current))
+    expect(updateArchive).toHaveBeenCalledTimes(2)
+    expect(updateArchive).toHaveBeenLastCalledWith({
+      projectId: active.projectId,
+      sessionId: active.id,
+      archived: true,
+      expectedRevision: 4
+    })
+    expect(enqueueSession).toHaveBeenCalledWith(
+      expect.objectContaining({ revision: 5, archivedAt: 2 })
+    )
+    expect(clearSelection).toHaveBeenCalledOnce()
+    expect(hook.result.current.view.exportError).toBeNull()
   })
 
   it('archives durably before enqueueing undo and clearing the active selection', async () => {

--- a/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.test.ts
@@ -1337,6 +1337,45 @@ describe('workspace session controller', () => {
     )
   })
 
+  it.each(['before commit', 'after commit'])(
+    'keeps a rejected deletion result uncertain %s and retries the same Session',
+    async (failurePoint) => {
+      const active = session()
+      let serverHasSession = true
+      const deleteSession = vi
+        .fn()
+        .mockImplementationOnce(async () => {
+          if (failurePoint === 'after commit') serverHasSession = false
+          throw new Error('Connection lost')
+        })
+        .mockImplementationOnce(async () => {
+          serverHasSession = false
+          return { status: 'deleted', runtimeDetached: true }
+        })
+      const settleSessionDeletion = vi.fn()
+      const hook = renderController({ activeSession: active, deleteSession, settleSessionDeletion })
+      mounted.push(hook)
+      act(() => hook.result.current.actions.openDelete(active))
+      await act(async () => hook.result.current.actions.confirmDelete())
+
+      expect(serverHasSession).toBe(failurePoint === 'before commit')
+      expect(hook.result.current.view.dialogs.delete).toMatchObject({
+        session: { id: active.id },
+        isDeleting: false,
+        error: 'unknown'
+      })
+      expect(hook.result.current.view.deletingIds.has(active.id)).toBe(false)
+      await act(async () => hook.result.current.actions.confirmDelete())
+      expect(deleteSession).toHaveBeenNthCalledWith(2, {
+        projectId: active.projectId,
+        sessionId: active.id
+      })
+      expect(serverHasSession).toBe(false)
+      expect(settleSessionDeletion).toHaveBeenLastCalledWith(active.id, true)
+      expect(hook.result.current.view.dialogs.delete).toBeNull()
+    }
+  )
+
   it('keeps a background Session dialog open with a retryable persistence error', async () => {
     const active = session({ id: 'session-active' })
     const background = session({ id: 'session-background' })

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -64,7 +64,7 @@ type SessionDeletionFailureReason = Extract<SessionDeletionResult, { status: 'fa
 type SessionDeleteDialogState = {
   session: ChatSession
   isDeleting: boolean
-  error: SessionDeletionFailureReason | null
+  error: SessionDeletionFailureReason | 'unknown' | null
 }
 type SpecialistSendIntent = {
   draftSpecialistId: string | null | undefined
@@ -325,7 +325,7 @@ const useWorkspaceSessionController = ({
         settleSessionDeletion(sessionId, false)
         setDeleteDialog((current) =>
           current?.session.id === sessionId
-            ? { ...current, isDeleting: false, error: 'runtime' }
+            ? { ...current, isDeleting: false, error: 'unknown' }
             : current
         )
       })

--- a/src/renderer/src/pages/workspace/workspace-session-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-controller.ts
@@ -12,7 +12,7 @@ import type {
   DeleteSessionRequest,
   SessionDeletionResult
 } from '../../../../shared/session-persistence'
-import { isSessionSizeLimitError } from '../../../../shared/session-persistence'
+import { isSessionSizeLimitError, sessionRevision } from '../../../../shared/session-persistence'
 import type {
   CompletionHandoffLifecycleEvent,
   SpecialistListItem
@@ -260,7 +260,7 @@ const useWorkspaceSessionController = ({
       projectId: session.projectId,
       sessionId: session.id,
       archived: true,
-      expectedArchivedAt: null
+      expectedRevision: sessionRevision(session)
     })
       .then((archived) => {
         if (clearIdleRetry(session.id)) clearPending(session.id)

--- a/src/renderer/src/stores/archive-undo-store.test.ts
+++ b/src/renderer/src/stores/archive-undo-store.test.ts
@@ -1,6 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { useProjectStore } from './project-store'
+import { useSessionStore } from './session-store'
 import { useArchiveUndoStore } from './archive-undo-store'
+
+const updateProjectArchive = useProjectStore.getState().updateProjectArchive
+const updateSessionArchive = useSessionStore.getState().updateSessionArchive
 
 const project = {
   id: 'project-1',
@@ -26,8 +31,58 @@ const session = {
 
 describe('archive undo store deletion reconciliation', () => {
   beforeEach(() => {
+    useProjectStore.setState({ updateProjectArchive })
+    useSessionStore.setState({ updateSessionArchive })
     useArchiveUndoStore.setState({ notices: [], restoringKey: undefined })
   })
+
+  afterEach(() => vi.restoreAllMocks())
+
+  it.each(['project', 'session'] as const)(
+    'keeps the %s Undo generation captured at archive time',
+    async (kind) => {
+      const command =
+        kind === 'project'
+          ? vi.spyOn(useProjectStore.getState(), 'updateProjectArchive').mockResolvedValue(project)
+          : vi.spyOn(useSessionStore.getState(), 'updateSessionArchive').mockResolvedValue(session)
+      const store = useArchiveUndoStore.getState()
+      if (kind === 'project') store.enqueueProject({ ...project, archiveRevision: 1 })
+      else store.enqueueSession({ ...session, revision: 1 })
+      const oldKey = useArchiveUndoStore.getState().notices[0].key
+      // A newer store snapshot must not silently replace the command's compared generation.
+      if (kind === 'project')
+        useProjectStore.setState({ projects: [{ ...project, archiveRevision: 3 }] })
+      else useSessionStore.setState({ sessions: [{ ...session, revision: 3 }] })
+      await store.undo(oldKey)
+      expect(command).toHaveBeenCalledWith(
+        kind === 'project'
+          ? { id: project.id, archived: false, expectedArchiveRevision: 1 }
+          : { projectId: project.id, sessionId: session.id, archived: false, expectedRevision: 1 }
+      )
+    }
+  )
+
+  it.each(['project', 'session'] as const)(
+    'does not resolve an old %s Undo key to a same-millisecond archive',
+    async (kind) => {
+      const command =
+        kind === 'project'
+          ? vi.spyOn(useProjectStore.getState(), 'updateProjectArchive').mockResolvedValue(project)
+          : vi.spyOn(useSessionStore.getState(), 'updateSessionArchive').mockResolvedValue(session)
+      const store = useArchiveUndoStore.getState()
+      if (kind === 'project') store.enqueueProject({ ...project, archiveRevision: 1 })
+      else store.enqueueSession({ ...session, revision: 1 })
+      const oldKey = useArchiveUndoStore.getState().notices[0].key
+      if (kind === 'project') store.enqueueProject({ ...project, archiveRevision: 3 })
+      else store.enqueueSession({ ...session, revision: 3 })
+      expect(useArchiveUndoStore.getState().notices[0].key).not.toBe(oldKey)
+      await store.undo(oldKey)
+      expect(command).not.toHaveBeenCalled()
+      if (kind === 'project') store.reconcileProject({ ...project, archiveRevision: 5 })
+      else store.reconcileSession({ ...session, revision: 5 })
+      expect(useArchiveUndoStore.getState().notices).toEqual([])
+    }
+  )
 
   it('dismisses the matching session notice', () => {
     useArchiveUndoStore.getState().enqueueSession(session)

--- a/src/renderer/src/stores/archive-undo-store.ts
+++ b/src/renderer/src/stores/archive-undo-store.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 
 import type { Project } from '../../../shared/projects'
-import type { PersistedChatSession } from '../../../shared/session-persistence'
+import { sessionRevision, type PersistedChatSession } from '../../../shared/session-persistence'
 import { useProjectStore } from './project-store'
 import { useSessionStore } from './session-store'
 
@@ -21,6 +21,7 @@ type ArchiveUndo = ArchiveUndoText &
         key: string
         kind: 'project'
         projectId: string
+        revision: number
         archivedAt: number
         expiresAt: number
         retry?: boolean
@@ -30,6 +31,7 @@ type ArchiveUndo = ArchiveUndoText &
         kind: 'session'
         projectId: string
         sessionId: string
+        revision: number
         archivedAt: number
         expiresAt: number
         retry?: boolean
@@ -49,8 +51,8 @@ type ArchiveUndoStore = {
   undo: (key: string) => Promise<void>
 }
 
-const archiveKey = (kind: ArchiveUndo['kind'], id: string, archivedAt: number): string =>
-  `${kind}:${id}:${archivedAt}`
+const archiveKey = (kind: ArchiveUndo['kind'], id: string, revision: number): string =>
+  `${kind}:${id}:${revision}`
 
 const prune = (notices: ArchiveUndo[]): ArchiveUndo[] =>
   notices.filter((notice) => notice.expiresAt > Date.now())
@@ -64,12 +66,13 @@ export const useArchiveUndoStore = create<ArchiveUndoStore>((set, get) => ({
 
   enqueueProject: (project) => {
     if (project.archivedAt === undefined) return
-    const key = archiveKey('project', project.id, project.archivedAt)
+    const key = archiveKey('project', project.id, project.archiveRevision ?? 0)
     const notice: ArchiveUndo = {
       key,
       kind: 'project',
       projectId: project.id,
       archivedAt: project.archivedAt,
+      revision: project.archiveRevision ?? 0,
       messageKey: 'Archived project “{{name}}”.',
       messageParams: { name: project.name },
       expiresAt: Date.now() + ARCHIVE_UNDO_DURATION_MS
@@ -81,13 +84,14 @@ export const useArchiveUndoStore = create<ArchiveUndoStore>((set, get) => ({
 
   enqueueSession: (session) => {
     if (session.archivedAt === undefined) return
-    const key = archiveKey('session', session.id, session.archivedAt)
+    const key = archiveKey('session', session.id, sessionRevision(session))
     const notice: ArchiveUndo = {
       key,
       kind: 'session',
       projectId: session.projectId,
       sessionId: session.id,
       archivedAt: session.archivedAt,
+      revision: sessionRevision(session),
       messageKey: 'Archived session “{{title}}”.',
       messageParams: { title: session.title },
       expiresAt: Date.now() + ARCHIVE_UNDO_DURATION_MS
@@ -137,7 +141,9 @@ export const useArchiveUndoStore = create<ArchiveUndoStore>((set, get) => ({
         // previously archived child session remains independently restorable.
         return project.archivedAt === undefined
           ? notice.kind === 'session'
-          : notice.kind === 'project' && project.archivedAt === notice.archivedAt
+          : notice.kind === 'project' &&
+              project.archivedAt === notice.archivedAt &&
+              (project.archiveRevision ?? 0) === notice.revision
       })
     })),
 
@@ -147,7 +153,7 @@ export const useArchiveUndoStore = create<ArchiveUndoStore>((set, get) => ({
         (notice) =>
           notice.kind !== 'session' ||
           notice.sessionId !== session.id ||
-          session.archivedAt === notice.archivedAt
+          (session.archivedAt === notice.archivedAt && sessionRevision(session) === notice.revision)
       )
     })),
 
@@ -160,14 +166,14 @@ export const useArchiveUndoStore = create<ArchiveUndoStore>((set, get) => ({
         await useProjectStore.getState().updateProjectArchive({
           id: notice.projectId,
           archived: false,
-          expectedArchivedAt: notice.archivedAt
+          expectedArchiveRevision: notice.revision
         })
       } else {
         await useSessionStore.getState().updateSessionArchive({
           projectId: notice.projectId,
           sessionId: notice.sessionId,
           archived: false,
-          expectedArchivedAt: notice.archivedAt
+          expectedRevision: notice.revision
         })
       }
       set((state) => ({

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -24,6 +24,26 @@ beforeEach(() => {
 })
 
 describe('project store', () => {
+  it('refreshes authoritative archive state after a rejected command without replaying it', async () => {
+    const current = createProject({ archiveRevision: 2 })
+    const updateArchive = vi
+      .fn()
+      .mockRejectedValue(new Error('Project archive state changed elsewhere.'))
+    const get = vi.fn().mockResolvedValue(current)
+    setProjectsApi({ updateArchive, get })
+    useProjectStore.setState({ projects: [createProject({ archiveRevision: 0 })] })
+    await expect(
+      useProjectStore.getState().updateProjectArchive({
+        id: current.id,
+        archived: true,
+        expectedArchiveRevision: 0
+      })
+    ).rejects.toThrow('changed elsewhere')
+    expect(get).toHaveBeenCalledWith(current.id)
+    expect(updateArchive).toHaveBeenCalledOnce()
+    expect(useProjectStore.getState().projects).toEqual([current])
+  })
+
   it('loads projects sorted most-recently-updated first', async () => {
     setProjectsApi({
       list: vi

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -190,7 +190,22 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   updateProjectArchive: async (request) => {
     const generation = beginProjectProjection()
-    const project = await window.api.projects.updateArchive(request)
+    let project: Project
+    try {
+      project = await window.api.projects.updateArchive(request)
+    } catch (error) {
+      // Refresh authority for the next explicit user action; never replay the rejected intent.
+      try {
+        const current = await window.api.projects.get(request.id)
+        if (current && commitProjectProjection(current.id, generation)) {
+          projectMutationSequence += 1
+          set((state) => ({ projects: upsertProjectList(state.projects, current) }))
+        }
+      } catch {
+        /* Keep the original command failure when recovery is also unavailable. */
+      }
+      throw error
+    }
 
     projectMutationSequence += 1
     if (commitProjectProjection(project.id, generation)) {

--- a/src/renderer/src/stores/session-store.archive-order.test.ts
+++ b/src/renderer/src/stores/session-store.archive-order.test.ts
@@ -131,6 +131,32 @@ describe('session archive authority ordering', () => {
     expect(store.getState().sessions[0].contentLoaded).not.toBe(false)
   })
 
+  it('refreshes archive authority after conflict while preserving local content and the original failure', async () => {
+    const store = createSessionStore()
+    store.getState().hydrateSessions([{ ...session, revision: 1 }])
+    const updateArchive = vi.fn().mockRejectedValue(new Error('Session revision conflict'))
+    const loadOne = vi
+      .fn()
+      .mockResolvedValue({ ...session, revision: 3, archivedAt: undefined, messages: [] })
+    vi.stubGlobal('window', { api: { sessions: { updateArchive, loadOne } } })
+    await expect(
+      store.getState().updateSessionArchive({
+        projectId: session.projectId,
+        sessionId: session.id,
+        archived: true,
+        expectedRevision: 1
+      })
+    ).rejects.toThrow('revision conflict')
+    expect(updateArchive).toHaveBeenCalledOnce()
+    expect(loadOne).toHaveBeenCalledWith({ projectId: session.projectId, sessionId: session.id })
+    expect(store.getState().sessions[0]).toMatchObject({
+      revision: 3,
+      updatedAt: session.updatedAt
+    })
+    expect(store.getState().sessions[0].archivedAt).toBeUndefined()
+    expect(store.getState().sessions[0].messages[0]?.content).toBe('Keep local content')
+  })
+
   it('advances archive RPC revision without replacing local content or activity time', async () => {
     const store = createSessionStore()
     store.getState().hydrateSessions([session])
@@ -153,7 +179,7 @@ describe('session archive authority ordering', () => {
       projectId: session.projectId,
       sessionId: session.id,
       archived: false,
-      expectedArchivedAt: 20
+      expectedRevision: 0
     })
     expect(store.getState().sessions[0]).toMatchObject({
       revision: 4,

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -4,7 +4,10 @@ import { createStore, type StoreApi } from 'zustand/vanilla'
 import type { AcpContextUsage } from '../../../shared/acp'
 import type { PermissionProfileId } from '../../../shared/permission-profiles'
 import type { SessionAgentConfiguration } from '../../../shared/settings'
-import type { UpdateSessionArchiveRequest } from '../../../shared/session-persistence'
+import type {
+  PersistedChatSession,
+  UpdateSessionArchiveRequest
+} from '../../../shared/session-persistence'
 import { createSessionMessageGraphOwner } from './session-store-message-graph-owner'
 import type { SessionMessageGraphActions } from './session-store-message-graph-helpers'
 import {
@@ -292,7 +295,28 @@ const createSessionStoreInitializer = (): StateCreator<SessionStore> => (set, ge
 
   updateSessionArchive: async (request) => {
     const source = get().sessions.find((session) => session.id === request.sessionId)
-    const persisted = await window.api.sessions.updateArchive(request)
+    let persisted: PersistedChatSession
+    try {
+      persisted = await window.api.sessions.updateArchive(request)
+    } catch (error) {
+      // A conflict or lost response requires a fresh projection, not a new version on the old intent.
+      try {
+        const current = await window.api.sessions.loadOne({
+          projectId: request.projectId,
+          sessionId: request.sessionId
+        })
+        if (source && current) {
+          get().applyDurableSessionProjection({
+            source,
+            session: current,
+            mode: 'archive-authority'
+          })
+        }
+      } catch {
+        /* Keep the original failure if the authority cannot be reached. */
+      }
+      throw error
+    }
     if (source)
       get().applyDurableSessionProjection({ source, session: persisted, mode: 'archive-authority' })
     return (

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -100,6 +100,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Project: {{name}}": "Projekt: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Für diese Plattform ist kein Installationsprogramm verfügbar. Laden Sie es manuell herunter, um andere Installationsmöglichkeiten zu prüfen.",
     "Latest saved version": "Zuletzt gespeicherte Version",
     "Unable to discard the Plan.": "Der Plan kann nicht verworfen werden.",
@@ -924,7 +925,7 @@
     "Could not check whether package registries are reachable.": "Es konnte nicht überprüft werden, ob Paketregistrierungen erreichbar sind.",
     "Could not choose the data location. Try again.": "Der Datenspeicherort konnte nicht ausgewählt werden. Versuchen Sie es erneut.",
     "Could not delete project.": "Projekt konnte nicht gelöscht werden.",
-    "Could not delete session.": "Sitzung konnte nicht gelöscht werden.",
+    "Could not confirm the deletion result. Please try again.": "Das Ergebnis des Löschvorgangs konnte nicht bestätigt werden. Bitte versuchen Sie es erneut.",
     "Could not delete the project. Please try again.": "Das Projekt konnte nicht gelöscht werden. Bitte versuchen Sie es erneut.",
     "Could not disconnect Claude from Open Science.": "Claude konnte nicht von Open Science getrennt werden.",
     "Could not export this Skill.": "Diese Fähigkeit konnte nicht exportiert werden.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Project: {{name}}": "Proyecto: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "No hay un instalador disponible para esta plataforma. Descargue manualmente para consultar otras opciones de instalación.",
     "Latest saved version": "Última versión guardada",
     "Unable to discard the Plan.": "No se puede descartar el plan.",
@@ -989,7 +990,7 @@
     "Could not check whether package registries are reachable.": "No se pudo comprobar si se puede acceder a los registros de paquetes.",
     "Could not choose the data location. Try again.": "No se pudo elegir la ubicación de los datos. Inténtelo de nuevo.",
     "Could not delete project.": "No se pudo eliminar el proyecto.",
-    "Could not delete session.": "No se pudo eliminar la sesión.",
+    "Could not confirm the deletion result. Please try again.": "No se pudo confirmar el resultado de la eliminación. Vuelva a intentarlo.",
     "Could not delete the project. Please try again.": "No se pudo eliminar el proyecto. Inténtelo de nuevo.",
     "Project cleanup": "Limpieza de proyectos",
     "Deleted project": "Proyecto eliminado",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Project: {{name}}": "Projet : {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Aucun programme d’installation n’est disponible pour cette plateforme. Consultez le téléchargement manuel pour découvrir d’autres options d’installation.",
     "Latest saved version": "Dernière version enregistrée",
     "Unable to discard the Plan.": "Impossible d’abandonner le plan.",
@@ -989,7 +990,7 @@
     "Could not check whether package registries are reachable.": "Impossible de vérifier si les registres de paquets sont accessibles.",
     "Could not choose the data location. Try again.": "Impossible de choisir l'emplacement des données. Essayer à nouveau.",
     "Could not delete project.": "Impossible de supprimer le projet.",
-    "Could not delete session.": "Impossible de supprimer la session.",
+    "Could not confirm the deletion result. Please try again.": "Impossible de confirmer le résultat de la suppression. Veuillez réessayer.",
     "Could not delete the project. Please try again.": "Impossible de supprimer le projet. Veuillez réessayer.",
     "Project cleanup": "Nettoyage des projets",
     "Deleted project": "Projet supprimé",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Project: {{name}}": "プロジェクト：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "このプラットフォーム用のインストーラーはありません。手動ダウンロードのページで他のインストール方法を確認してください。",
     "Latest saved version": "最後に保存されたバージョン",
     "Unable to discard the Plan.": "プランを破棄できません。",
@@ -940,7 +941,7 @@
     "Could not check whether package registries are reachable.": "パッケージレジストリに接続できるかどうかを確認できませんでした。",
     "Could not choose the data location. Try again.": "データの場所を選択できませんでした。もう一度やり直してください。",
     "Could not delete project.": "プロジェクトを削除できませんでした。",
-    "Could not delete session.": "セッションを削除できませんでした。",
+    "Could not confirm the deletion result. Please try again.": "削除結果を確認できませんでした。もう一度お試しください。",
     "Could not delete the project. Please try again.": "プロジェクトを削除できませんでした。もう一度試してください。",
     "Project cleanup": "プロジェクトのクリーンアップ",
     "Deleted project": "削除済みのプロジェクト",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Project: {{name}}": "프로젝트: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "이 플랫폼에서 사용할 수 있는 설치 프로그램이 없습니다. 수동 다운로드 페이지에서 다른 설치 방법을 확인하세요.",
     "Latest saved version": "최근 저장된 버전",
     "Unable to discard the Plan.": "계획을 삭제할 수 없습니다.",
@@ -959,7 +960,7 @@
     "Could not check whether package registries are reachable.": "패키지 레지스트리에 연결할 수 있는지 확인할 수 없습니다.",
     "Could not choose the data location. Try again.": "데이터 위치를 선택할 수 없습니다. 다시 시도해 보세요.",
     "Could not delete project.": "프로젝트를 삭제할 수 없습니다.",
-    "Could not delete session.": "세션을 삭제할 수 없습니다.",
+    "Could not confirm the deletion result. Please try again.": "삭제 결과를 확인할 수 없습니다. 다시 시도해 주세요.",
     "Could not delete the project. Please try again.": "프로젝트를 삭제할 수 없습니다. 다시 시도해 주세요.",
     "Project cleanup": "프로젝트 정리",
     "Deleted project": "삭제된 프로젝트",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Project: {{name}}": "Проект: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Установщик для этой платформы недоступен. Перейдите к ручной загрузке, чтобы узнать о других вариантах установки.",
     "Latest saved version": "Последняя сохранённая версия",
     "Unable to discard the Plan.": "Не удалось удалить план.",
@@ -985,7 +986,7 @@
     "Could not check whether package registries are reachable.": "Не удалось проверить, доступны ли реестры пакетов.",
     "Could not choose the data location. Try again.": "Не удалось выбрать папку с данными. Попробуйте снова.",
     "Could not delete project.": "Не удалось удалить проект.",
-    "Could not delete session.": "Не удалось удалить сессию.",
+    "Could not confirm the deletion result. Please try again.": "Не удалось подтвердить результат удаления. Попробуйте ещё раз.",
     "Could not delete the project. Please try again.": "Не удалось удалить проект. Попробуйте снова.",
     "Project cleanup": "Очистка проектов",
     "Deleted project": "Удалённый проект",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Project: {{name}}": "项目：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "此平台暂无可用的安装包。请前往手动下载页面查看其他安装选项。",
     "Latest saved version": "最新保存的版本",
     "Unable to discard the Plan.": "无法丢弃计划。",
@@ -1026,7 +1027,7 @@
     "Could not check whether package registries are reachable.": "无法检查软件源是否可达。",
     "Could not choose the data location. Try again.": "无法选择数据位置。请重试。",
     "Could not delete project.": "无法删除项目。",
-    "Could not delete session.": "无法删除会话。",
+    "Could not confirm the deletion result. Please try again.": "未能确认删除结果，请重试。",
     "Could not delete the project. Please try again.": "无法删除项目。请重试。",
     "Project cleanup": "项目清理",
     "Deleted project": "已删除的项目",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Project: {{name}}": "專案：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "此平台暫無可用的安裝套件。請前往手動下載頁面查看其他安裝選項。",
     "Latest saved version": "最新儲存的版本",
     "Unable to discard the Plan.": "無法捨棄計畫。",
@@ -1025,7 +1026,7 @@
     "Could not check whether package registries are reachable.": "無法檢查軟體源是否可連線。",
     "Could not choose the data location. Try again.": "無法選擇資料位置。請重試。",
     "Could not delete project.": "無法刪除專案。",
-    "Could not delete session.": "無法刪除會話。",
+    "Could not confirm the deletion result. Please try again.": "未能確認刪除結果，請重試。",
     "Could not delete the project. Please try again.": "無法刪除專案。請重試。",
     "Project cleanup": "專案清理",
     "Deleted project": "已刪除的專案",

--- a/src/shared/projects.test.ts
+++ b/src/shared/projects.test.ts
@@ -50,9 +50,9 @@ describe('project application command contracts', () => {
     ).toEqual({ ...project, agentContext: 'Always cite DOIs.' })
     expect(
       projectApplicationCommandContracts.updateArchive.args.parse([
-        { id: 'project-1', archived: true, expectedArchivedAt: null }
+        { id: 'project-1', archived: true, expectedArchiveRevision: 0 }
       ])
-    ).toEqual([{ id: 'project-1', archived: true, expectedArchivedAt: null }])
+    ).toEqual([{ id: 'project-1', archived: true, expectedArchiveRevision: 0 }])
     expect(projectApplicationCommandContracts.delete.args.parse([{ id: 'project-1' }])).toEqual([
       { id: 'project-1' }
     ])

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -27,6 +27,8 @@ export const projectSchema = z
     // An absent timestamp keeps the Project on active surfaces. Archive is reversible and does not
     // affect the Project's research activity ordering.
     archivedAt: z.number().finite().optional(),
+    // Missing only in older snapshots; current database reads always include this generation.
+    archiveRevision: z.number().int().nonnegative().optional(),
     createdAt: z.number().finite(),
     updatedAt: z.number().finite()
   })
@@ -75,7 +77,7 @@ export const updateProjectArchiveRequestSchema = z
     archived: z.boolean(),
     // The last authoritative archive value prevents a stale renderer from restoring or archiving a
     // Project after another window has already changed it.
-    expectedArchivedAt: z.number().finite().nullable()
+    expectedArchiveRevision: z.number().int().nonnegative()
   })
   .strict()
 

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -4936,7 +4936,7 @@ export const updateSessionArchiveRequestSchema = z
     projectId: z.string().min(1),
     sessionId: z.string().min(1),
     archived: z.boolean(),
-    expectedArchivedAt: z.number().int().positive().nullable()
+    expectedRevision: z.number().int().nonnegative()
   })
   .strict()
 


### PR DESCRIPTION
## Problem

An idle Session could be archived while its Compute Job was still queued, submitted, or running, even though Project archive rejected that work. Timestamp-only archive preconditions also accepted delayed commands after archive/restore returned to the same value. In Settings, rejected delete RPCs placed errors behind the modal, and same-title archived Sessions lacked their Project identity. The Workspace deletion caller also classified rejected RPCs as known runtime failures, which could claim a committed deletion had not happened.

## Proposed change

- Await the existing per-Session nonterminal job query in main-process archive admission. Query failures fail closed; synchronous runtime activity is read after the await, and persistence retains its existing scheduling and mutability checks.
- Compare durable versions for both archive and restore, including stale no-ops. Project writes atomically increment `archiveRevision`; package certification pins the new migration identity/checksum alongside the existing ledger; Session writes compare the existing `revision`. Carry the original version through callers and Undo receipts, and refresh authority after errors without replaying a stale intent. Research activity timestamps and ordering stay intact.
- Display uncertain deletion results in the current modal with an accessible alert and Retry from both Settings and Workspace. Known business failures keep their existing messages. Show the loaded Project name in each archived Session row and both Settings/Workspace delete confirmations, translated in all eight locales. Resolve the Project from the Session being deleted so navigation cannot relabel an open confirmation.

## Scope and non-goals

**Persistence and historical data:** new immutable migration `0031_project_archive_revision` adds the Prisma-owned Project column with default `0`. Existing active and archived rows retain archive/activity timestamps and relationships. Sessions reuse their existing revision normalization; no new Session JSON field or bulk rewrite. Session content updates can conservatively invalidate an old archive/Undo command.

**Protocol compatibility:** `expectedArchiveRevision` (Project) and `expectedRevision` (Session) replace `expectedArchivedAt`. Obsolete unversioned commands are rejected and require a client refresh; there is no timestamp fallback. Pre-upgrade operation history cannot be reconstructed and is not invented.

**New state:** `unknown` is only a local dialog error variant. No new persisted lifecycle status, shared deletion result, service, entity relationship, or cancellation policy.

## Acceptance criteria and validation

Before production edits, two repeated runs of the existing coordinator-contract and ArchivedPanel render suites produced the same 14 relevant failures and 36 passes. Failures covered job admission/query boundaries, stale archive/Undo for both object types, pre-commit and lost-response deletion rejection, and Project identification. Tests use real coordinators and React/Radix components with injected external dependencies. The runtime wiring test extracts the real IPC activity object because directly importing the composition root boots unrelated Electron services. No production test seam was added. Request fixtures were updated to the new versioned wire contract after baseline reproduction.

The following evidence covers the final implementation. Main/persistence and archive UI checks ran after their last material edits; the final Workspace caller change additionally passed its module, shared-dialog consumers, web typecheck and lint after that edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Session archive, queued/submitted/running jobs, query rejection/pending await, runtime activation during await, stale commands, persistence consumers | `npm run test:module -- session_persistence` | 10 files / 629 tests passed |
| Project lifecycle, archive repository/coordinator, IPC/preload/Web consumers, Home and project store | `npm run test:module -- project_lifecycle` | 29 files / 725 tests passed |
| Historical database upgrades, durable CAS across restart, identical timestamps, order preservation, real job repository | `node node_modules/vitest/vitest.mjs run src/main/database src/main/compute/job-repository.test.ts --maxWorkers=3` | 21 files / 320 tests passed |
| Modal uncertainty/identity, Undo snapshot isolation, authority refresh, lifecycle sync, i18n and runtime wiring | Focused Vitest run of the nine files below | 9 files / 963 tests passed |
| Workspace module and representative consumers | `npm run test:module -- workspace_page` | 30 files / 816 tests passed, including real controller/store conflict-refresh-explicit-retry and Workspace modal Project identity across navigation |
| Workspace deletion rejection before/after commit, retry and draft preservation | `npm test -- src/renderer/src/pages/workspace/workspace-session-controller.test.ts src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/session-dialogs.render.test.tsx src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx` | 4 files / 101 tests passed; the two new rejection cases first failed with `runtime` instead of `unknown` |
| Packaged migration ledger, historical fixtures, Linux/macOS/Windows smoke consumers | `npm test -- scripts/database-migration-ledger-smoke.test.ts scripts/linux-package-smoke.test.ts scripts/macos-package-smoke.test.ts scripts/windows-installer-smoke.test.ts` | 4 files / 60 tests passed; seven ledger cases first reproduced the CI failures locally |
| Mobile archive success with one explicit retry only for a revision conflict | `npm run build:e2e`; `npm run test:e2e -- e2e/workspace-conversation.spec.ts -g 'archives a completed session'` | Local Electron build and single E2E passed; final archive snackbar and removal remain required |
| Workspace owning-Project label through the real shared modal | `npm test -- src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx src/renderer/src/pages/workspace/session-dialogs.render.test.tsx src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx` | 3 files / 61 tests passed; both new Project cases first failed because the modal lacked its label |
| Workspace delete confirmation in Electron | `npm run test:e2e -- e2e/workspace-conversation.spec.ts -g 'identifies the Project'` | Passed with a screenshot of the actual Project label; cancels without deletion |
| Main, sandbox and renderer types | `npm run typecheck` | Passed |
| Prisma/runtime schema consistency | `npm run db:schema:check` | Passed |
| Source lint and whitespace | `npm run lint`; `git diff --check` | Passed |

Focused files: `ArchivedPanel.render.test.tsx`, `session-dialogs.render.test.tsx`, `PermissionUndoSnackbar.test.tsx`, `archive-undo-store.test.ts`, `session-store.archive-order.test.ts`, `project-store.test.ts`, `useLifecycleSync.test.tsx`, `resources.test.ts`, and `coordinator-contract.test.ts`.

Browser verification used actual components, styles and stores in an isolated fixture with same-title/same-time Sessions under two Projects. Screenshots confirmed visible Project labels in rows and confirmation, an alert inside the modal without an `aria-hidden` ancestor, and Retry; successful retry closed the modal.

The committed-diff impact explanation selects the full plan because `prisma/schema.prisma` has unknown ownership. Per maintainer instruction, the complete local suite was not run: exact-head PR Gate remains authoritative for complete and platform coverage. Local coverage includes changed shared-contract consumers and SQLite persistence; it does not induce real network loss, contact a remote Compute Host, or exercise packaged Electron on all operating systems. The mobile E2E now reflects the approved whole-Session revision contract: terminal persistence may reject a stale click; it may attempt one new user action only after an explicit revision conflict, never ignore arbitrary errors or retry automatically in product code. A deterministic controller/store test verifies rejection, authority refresh, no automatic replay, and the fresh version on the second action. No execution-framework protocol or platform path logic changes.

## Review focus

Confirm version snapshots survive all callers and Undo reconciliation; activity is awaited before persistence; the migration and backup ledger remain valid; and the final behavior-to-check mapping covers the changed interfaces and their consumers. Independently review this mapping before treating CI success as sufficient for merge.


