### PR TITLE
perf(sessions): bound handoff, preview, and ACP window reads

### DIFF
--- a/src/main/acp/filesystem.test.ts
+++ b/src/main/acp/filesystem.test.ts
@@ -1,7 +1,40 @@
 import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { tmpdir } from 'node:os'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const fileReadProbe = vi.hoisted(() => ({ path: '', bytes: 0, closed: Promise.resolve() }))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...original,
+    readFile: async (...args: Parameters<typeof original.readFile>) => {
+      const contents = await original.readFile(...args)
+      if (args[0] === fileReadProbe.path) fileReadProbe.bytes += Buffer.byteLength(contents)
+      return contents
+    }
+  }
+})
+
+vi.mock('node:fs', async (importOriginal) => {
+  const original = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...original,
+    createReadStream: (...args: Parameters<typeof original.createReadStream>) => {
+      const stream = original.createReadStream(...args)
+      if (args[0] === fileReadProbe.path) {
+        fileReadProbe.closed = new Promise<void>((resolve) => {
+          stream.once('close', resolve)
+        })
+        stream.on('data', (chunk) => {
+          fileReadProbe.bytes += Buffer.byteLength(chunk)
+        })
+      }
+      return stream
+    }
+  }
+})
 
 import { readWorkspaceTextFile, writeWorkspaceTextFile } from './filesystem'
 
@@ -29,6 +62,84 @@ describe('ACP workspace filesystem adapter', () => {
         limit: 1
       })
     ).resolves.toEqual({ content: 'two' })
+  })
+
+  it('returns a short line window without reading the distant file tail', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-'))
+    const filePath = join(workspaceRoot, 'large-log.txt')
+    await writeFile(filePath, 'one\ntwo\n' + 'unrelated history\n'.repeat(32768), 'utf8')
+    fileReadProbe.path = filePath
+    fileReadProbe.bytes = 0
+    try {
+      await expect(
+        readWorkspaceTextFile(workspaceRoot, {
+          sessionId: 'session-1',
+          path: filePath,
+          line: 2,
+          limit: 1
+        })
+      ).resolves.toEqual({ content: 'two' })
+      await fileReadProbe.closed
+      expect(
+        fileReadProbe.bytes,
+        'a two-line request consumes the complete log'
+      ).toBeLessThanOrEqual(64 * 1024)
+    } finally {
+      fileReadProbe.path = ''
+    }
+  })
+
+  it.each([
+    ['CRLF', 'one\r\ntwo\r\nthree', 2, 1, 'two'],
+    ['bare CR', 'one\rtwo\nthree', 1, 1, 'one\rtwo'],
+    ['trailing LF', 'one\ntwo\n', 2, 3, 'two\n'],
+    ['trailing CR', 'one\ntwo\r', 2, 1, 'two\r'],
+    ['empty file', '', 1, 2, ''],
+    ['past EOF', 'one\ntwo', 9, 2, ''],
+    ['unlimited suffix', 'one\ntwo\nthree', 2, 0, 'two\nthree'],
+    ['default start', 'one\ntwo', undefined, 1, 'one'],
+    ['full read', 'one\r\ntwo\n', undefined, undefined, 'one\r\ntwo\n']
+  ] as const)('preserves %s text semantics', async (_label, content, line, limit, expected) => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-'))
+    const path = join(workspaceRoot, 'text.txt')
+    await writeFile(path, content, 'utf8')
+    await expect(
+      readWorkspaceTextFile(workspaceRoot, { sessionId: 'session-1', path, line, limit })
+    ).resolves.toEqual({ content: expected })
+  })
+
+  it('preserves Unicode and CRLF across read chunks', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-'))
+    const path = join(workspaceRoot, 'unicode.txt')
+    const first = 'x'.repeat(16 * 1024 - 1) + '中文😀'
+    await writeFile(path, first + '\r\nsecond\n', 'utf8')
+    await expect(
+      readWorkspaceTextFile(workspaceRoot, { sessionId: 'session-1', path, limit: 2 })
+    ).resolves.toEqual({ content: first + '\nsecond' })
+  })
+
+  it('preserves CRLF split between chunks', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-'))
+    const path = join(workspaceRoot, 'crlf.txt')
+    const first = 'x'.repeat(16 * 1024 - 1)
+    await writeFile(path, first + '\r\nsecond\n', 'utf8')
+    await expect(
+      readWorkspaceTextFile(workspaceRoot, { sessionId: 'session-1', path, limit: 2 })
+    ).resolves.toEqual({ content: first + '\nsecond' })
+  })
+
+  it('closes a failed window read and preserves the filesystem error', async () => {
+    workspaceRoot = await mkdtemp(join(tmpdir(), 'open-science-acp-'))
+    const path = join(workspaceRoot, 'missing.txt')
+    fileReadProbe.path = path
+    try {
+      await expect(
+        readWorkspaceTextFile(workspaceRoot, { sessionId: 'session-1', path, limit: 1 })
+      ).rejects.toMatchObject({ code: 'ENOENT' })
+      await fileReadProbe.closed
+    } finally {
+      fileReadProbe.path = ''
+    }
   })
 
   it('writes only inside the workspace', async () => {

--- a/src/main/acp/filesystem.ts
+++ b/src/main/acp/filesystem.ts
@@ -4,22 +4,44 @@ import type {
   WriteTextFileRequest,
   WriteTextFileResponse
 } from '@agentclientprotocol/sdk'
+import { createReadStream } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 
 import { assertWorkspacePath, isPathInsideWorkspace } from './workspace-path'
 
-// Returns the requested line window while preserving full content by default.
-const sliceLines = (content: string, line?: number | null, limit?: number | null): string => {
-  if (!line && !limit) {
-    return content
-  }
-
-  const lines = content.split(/\r?\n/)
+// Scan only through the requested window. String decoding handles UTF-8 split across chunks;
+// split on LF explicitly so a bare CR retains the existing text-file semantics.
+const readLineWindow = async (
+  filePath: string,
+  line?: number | null,
+  limit?: number | null
+): Promise<string> => {
   const startIndex = Math.max((line ?? 1) - 1, 0)
-  const endIndex = limit ? startIndex + Math.max(limit, 0) : undefined
-
-  return lines.slice(startIndex, endIndex).join('\n')
+  const endIndex = limit ? startIndex + Math.max(limit, 0) : Infinity
+  const selected: string[] = []
+  let index = 0
+  let pending = ''
+  let scanned = 0
+  const stream = createReadStream(filePath, { encoding: 'utf8', highWaterMark: 16 * 1024 })
+  for await (const chunk of stream) {
+    pending += chunk
+    let newline: number
+    while ((newline = pending.indexOf('\n', scanned)) !== -1) {
+      if (index >= startIndex && index < endIndex) {
+        const text = pending.slice(0, newline)
+        selected.push(text.endsWith('\r') ? text.slice(0, -1) : text)
+      }
+      index += 1
+      if (index >= endIndex) return selected.join('\n')
+      pending = pending.slice(newline + 1)
+      scanned = 0
+    }
+    scanned = pending.length
+  }
+  // split(/\r?\n/) includes the final empty line when the file ends with LF.
+  if (index >= startIndex && index < endIndex) selected.push(pending)
+  return selected.join('\n')
 }
 
 // Rejects reads that resolve inside an app-owned protected directory — e.g. the CLAUDE_CONFIG_DIR
@@ -44,10 +66,11 @@ const readWorkspaceTextFile = async (
   // ACP paths are absolute, but resolve again here so path traversal is checked in one place.
   const filePath = assertWorkspacePath(workspaceRoot, params.path)
   assertNotProtected(filePath, protectedRoots)
-  const content = await readFile(filePath, 'utf8')
-
   return {
-    content: sliceLines(content, params.line, params.limit)
+    content:
+      !params.line && !params.limit
+        ? await readFile(filePath, 'utf8')
+        : await readLineWindow(filePath, params.line, params.limit)
   }
 }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -334,10 +334,8 @@ import {
   FileCompletionHandoffRepository
 } from './agents/completion-handoff-lifecycle'
 import { registerCompletionHandoffIpcHandlers } from './agents/completion-handoff-ipc'
-import {
-  registerClaudeCodeCompletionGateRuntime,
-  selectPersistedUserTaskContext
-} from './agents/claude-code-handoff'
+import { createPersistedClaudeReplayPreparer } from './session-persistence/claude-replay'
+import { registerClaudeCodeCompletionGateRuntime } from './agents/claude-code-handoff'
 import { installCompletionGateDiagnostics } from './agents/completion-gate-diagnostics'
 import { PendingSessionSpecialistBindings } from './agents/pending-session-specialist-bindings'
 import { createCodexCompletionGateRuntime } from './acp/codex-completion-handoff'
@@ -3202,15 +3200,11 @@ const createApplicationModules = async (
         }
       }
     },
-    prepareReplayContext: async (input) => {
-      const persisted = (await sessionRepository.loadAll()).sessions.find(
-        (session) => session.id === input.sessionId
-      )
-      runtime.prepareClaudeCodeHandoffReplay({
-        ...input,
-        supportedTaskContext: selectPersistedUserTaskContext(persisted?.messages ?? [])
-      })
-    },
+    prepareReplayContext: createPersistedClaudeReplayPreparer({
+      repository: sessionRepository,
+      coordinator: sessionPersistenceCoordinator,
+      prepareReplay: (input) => runtime.prepareClaudeCodeHandoffReplay(input)
+    }),
     discardReplayContext: async (sessionId) => runtime.discardClaudeCodeHandoffReplay(sessionId),
     switchSpecialist: (sessionId, specialistId) =>
       sessionSpecialistReconfiguration.applyPersisted(sessionId, specialistId),

--- a/src/main/session-persistence/claude-replay.test.ts
+++ b/src/main/session-persistence/claude-replay.test.ts
@@ -1,0 +1,179 @@
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({ app: { getPath: () => '/home/user', isPackaged: true } }))
+
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import {
+  createClaudeCodeCompletionGateRuntime,
+  type ClaudeCodeReplayInput
+} from '../agents/claude-code-handoff'
+import { SessionPersistenceCoordinator, type SessionFileIndex } from './coordinator'
+import { SessionRepository } from './repository'
+import { createPersistedClaudeReplayPreparer } from './claude-replay'
+
+const fileIndex: SessionFileIndex = {
+  syncSession: async () => [],
+  softDeleteSession: async () => 'deleted',
+  restoreSession: async () => undefined,
+  softDeleteProject: async () => 'deleted',
+  reconcileActiveSessions: async () => undefined,
+  reconcileProjectSessions: async () => undefined,
+  markReconciliationIncomplete: () => undefined
+}
+const session = (id: string): PersistedChatSession => ({
+  id,
+  projectId: 'project-1',
+  title: id,
+  cwd: '/workspace',
+  status: 'idle',
+  agentFrameworkId: 'claude-code',
+  createdAt: 1,
+  updatedAt: 1,
+  messages: [
+    {
+      id: `${id}-user`,
+      role: 'user',
+      content: id,
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+  ]
+})
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+describe('persisted Claude handoff replay', () => {
+  it.each([false, true])('resolves current context with hydrated ownership %s', async (hydrate) => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-replay-owner-'))
+    roots.push(root)
+    const repository = new SessionRepository(root)
+    await repository.saveSession(session('current'))
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    if (hydrate) await coordinator.loadAllReadOnly()
+    const prepareReplay = vi.fn()
+    const prepare = createPersistedClaudeReplayPreparer({ repository, coordinator, prepareReplay })
+    await prepare({
+      sessionId: 'current',
+      capturedCompletion: { kind: 'returned', value: 'done' },
+      switchReadBack: {
+        status: 'approved',
+        operation: 'switch',
+        binding: { sessionId: 'current', specialistId: undefined, targetName: null }
+      }
+    })
+    expect(prepareReplay).toHaveBeenCalledWith(
+      expect.objectContaining({
+        supportedTaskContext: [{ messageId: 'current-user', text: 'current' }]
+      })
+    )
+  })
+
+  it('refuses replay after another Project claims the same Session identity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-replay-duplicate-'))
+    roots.push(root)
+    const repository = new SessionRepository(root)
+    await repository.saveSession(session('current'))
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    await coordinator.loadAllReadOnly()
+    await repository.saveSession({ ...session('current'), projectId: 'project-2' })
+    const prepareReplay = vi.fn()
+    const prepare = createPersistedClaudeReplayPreparer({ repository, coordinator, prepareReplay })
+    await expect(
+      prepare({
+        sessionId: 'current',
+        capturedCompletion: { kind: 'returned', value: 'done' },
+        switchReadBack: {
+          status: 'approved',
+          operation: 'switch',
+          binding: { sessionId: 'current', specialistId: undefined, targetName: null }
+        }
+      })
+    ).rejects.toThrow()
+    expect(prepareReplay).not.toHaveBeenCalled()
+  })
+
+  it('reconfigures with fresh task context while unrelated Session reads are blocked', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'claude-replay-'))
+    roots.push(root)
+    let hold = false
+    let release!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let observed!: (value: string) => void
+    const unrelated = new Promise<string>((resolve) => {
+      observed = resolve
+    })
+    const repository = new SessionRepository(root, {
+      readSessionFile: async (path) => {
+        if (hold && basename(path) === 'unrelated.json') {
+          observed('blocked on unrelated Session')
+          await gate
+        }
+        return readFile(path, 'utf8')
+      }
+    })
+    await repository.saveSession(session('current'))
+    await repository.saveSession(session('unrelated'))
+    const coordinator = new SessionPersistenceCoordinator(repository, fileIndex)
+    await coordinator.loadAllReadOnly()
+    const fresh = session('current')
+    fresh.messages[0].content = 'Continue the latest saved task'
+    await repository.saveSession(fresh)
+    let replay: ClaudeCodeReplayInput | undefined
+    const readBack = {
+      status: 'approved' as const,
+      operation: 'switch' as const,
+      binding: { sessionId: 'current', specialistId: 'approved', targetName: 'Specialist' }
+    }
+    const runtime = createClaudeCodeCompletionGateRuntime({
+      sessionFramework: () => 'claude-code',
+      cancelPrompt: async () => undefined,
+      waitForPromptOwnershipRelease: async () => undefined,
+      resolveSpecialistId: () => 'approved',
+      resolveSwitchReadBack: async () => readBack,
+      prepareReplayContext: createPersistedClaudeReplayPreparer({
+        repository,
+        coordinator,
+        prepareReplay: (input) => {
+          replay = input
+        }
+      }),
+      discardReplayContext: async () => undefined,
+      switchSpecialist: async () => ({ contextReset: true }),
+      createContinuationRequest: vi.fn(),
+      sendAppContinuation: vi.fn()
+    })
+    hold = true
+    const work = runtime.reconfigure(
+      {
+        kind: 'capture-for-handoff',
+        targetName: 'Specialist',
+        generation: 1,
+        envelope: { kind: 'returned', value: 'finished tool' }
+      },
+      {
+        sessionId: 'current',
+        turnId: 'turn',
+        controlInvocationGeneration: 1,
+        toolInvocationId: 'tool'
+      }
+    )
+    try {
+      expect(await Promise.race([work.then(() => 'reconfigured'), unrelated])).toBe('reconfigured')
+      expect(replay?.supportedTaskContext).toEqual([
+        { messageId: 'current-user', text: 'Continue the latest saved task' }
+      ])
+    } finally {
+      release()
+      await work
+    }
+  })
+})

--- a/src/main/session-persistence/claude-replay.ts
+++ b/src/main/session-persistence/claude-replay.ts
@@ -1,0 +1,26 @@
+import { createSessionRuntimeLookup } from './runtime-lookup'
+import {
+  selectPersistedUserTaskContext,
+  type ClaudeCodeReplayInput
+} from '../agents/claude-code-handoff'
+import type { SessionRepository } from './repository'
+import type { SessionCatalog } from './coordinator'
+
+// Production handoff callback, kept separate from application bootstrap so filesystem stalls can
+// be exercised through the same replay preparation used by Claude continuation.
+export const createPersistedClaudeReplayPreparer =
+  (options: {
+    repository: Pick<
+      SessionRepository,
+      'loadAll' | 'loadSession' | 'assertSessionIdentityOwnership'
+    >
+    coordinator: Pick<SessionCatalog, 'sessionProjectId'>
+    prepareReplay(input: ClaudeCodeReplayInput): void
+  }): ((input: ClaudeCodeReplayInput) => Promise<void>) =>
+  async (input) => {
+    const persisted = (await createSessionRuntimeLookup(options)(input.sessionId))[0]
+    options.prepareReplay({
+      ...input,
+      supportedTaskContext: selectPersistedUserTaskContext(persisted?.messages ?? [])
+    })
+  }

--- a/src/main/session-persistence/runtime-lookup.ts
+++ b/src/main/session-persistence/runtime-lookup.ts
@@ -1,0 +1,28 @@
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { SessionCatalog } from './coordinator'
+import type { SessionRepository } from './repository'
+
+// Shared by Specialist binding and delegated-work admission in the application composition.
+export const createSessionRuntimeLookup =
+  ({
+    repository,
+    coordinator
+  }: {
+    repository: Pick<
+      SessionRepository,
+      'loadAll' | 'loadSession' | 'assertSessionIdentityOwnership'
+    >
+    coordinator: Pick<SessionCatalog, 'sessionProjectId'>
+  }): ((sessionId: string) => Promise<PersistedChatSession[]>) =>
+  async (sessionId) => {
+    const projectId = await coordinator.sessionProjectId(sessionId)
+    if (projectId === undefined) {
+      // Before hydration or the first save, keep the existing catalog lookup semantics.
+      return (await repository.loadAll()).sessions.filter((session) => session.id === sessionId)
+    }
+    // Metadata locates the file; filename authority still rejects ambiguous global identities.
+    // Neither step needs to decode unrelated transcripts on the prompt's critical path.
+    await repository.assertSessionIdentityOwnership(sessionId, projectId)
+    const session = await repository.loadSession(projectId, sessionId)
+    return session ? [session] : []
+  }

--- a/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx
+++ b/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx
@@ -780,6 +780,82 @@ describe('release-gate Subagent surfaces', () => {
     expect(screen.queryByText('Thinking')).toBeNull()
   })
 
+  it('recovers the selected Frame without waiting for unrelated Session history', async () => {
+    const durable = createSession()
+    const incomplete = createSession()
+    incomplete.conversationGraph!.frames = incomplete.conversationGraph!.frames.filter(
+      (frame) => frame.id !== 'child-a'
+    )
+    useSessionStore.setState({ sessions: [incomplete] })
+    let releaseCatalog!: () => void
+    const catalogGate = new Promise<void>((resolve) => {
+      releaseCatalog = resolve
+    })
+    vi.stubGlobal('api', {
+      ...window.api,
+      sessions: {
+        ...window.api.sessions,
+        loadAll: async () => {
+          await catalogGate
+          return { sessions: [durable] }
+        },
+        loadOne: async (request: { projectId: string; sessionId: string }) =>
+          request.projectId === durable.projectId && request.sessionId === durable.id
+            ? durable
+            : undefined
+      }
+    })
+    renderSurface(
+      <SubagentPreview
+        item={{
+          id: 'tool:session-1:subagents',
+          type: 'tool',
+          toolKind: 'subagents',
+          title: 'Subagents',
+          sessionId: durable.id,
+          selectedAgentFrameId: 'child-a'
+        }}
+      />
+    )
+    try {
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: 'Retry Subagent preview' }))
+      })
+      expect(
+        screen.queryByRole('alert') === null,
+        'selected Frame remains blocked by unrelated history'
+      ).toBe(true)
+    } finally {
+      await act(async () => {
+        releaseCatalog()
+      })
+    }
+  })
+
+  it('recovers a restored legacy tab before its Session owner is known', async () => {
+    useSessionStore.setState({ sessions: [] })
+    vi.stubGlobal('api', {
+      ...window.api,
+      sessions: { ...window.api.sessions, loadAll: async () => ({ sessions: [createSession()] }) }
+    })
+    renderSurface(
+      <SubagentPreview
+        item={{
+          id: 'tool:session-1:subagents',
+          type: 'tool',
+          toolKind: 'subagents',
+          title: 'Subagents',
+          sessionId: 'session-1',
+          selectedAgentFrameId: 'child-a'
+        }}
+      />
+    )
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Retry Subagent preview' }))
+    })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
   it('offers Retry when the selected durable Frame cannot be read', () => {
     renderSurface(
       <SubagentPreview

--- a/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.tsx
+++ b/src/renderer/src/pages/workspace/SubagentReleaseSurfaces.tsx
@@ -360,8 +360,14 @@ const SubagentPreview = ({
     if (isRetrying) return
     setIsRetrying(true)
     try {
-      const result = await window.api.sessions.loadAll()
-      const durable = result.sessions.find((candidate) => candidate.id === item.sessionId)
+      const projectId = session?.projectId ?? item.projectId
+      if (!item.sessionId) return
+      // Restored legacy tabs may not carry a Project until their Session is hydrated.
+      const durable = projectId
+        ? await window.api.sessions.loadOne({ projectId, sessionId: item.sessionId })
+        : (await window.api.sessions.loadAll()).sessions.find(
+            (candidate) => candidate.id === item.sessionId
+          )
       if (durable) useSessionStore.getState().upsertPersistedSession(durable)
     } catch {
       // The alert remains visible and the action remains retryable.


### PR DESCRIPTION
## Problem

Claude Specialist handoff loads every saved Session before preparing the current Session's replay. Subagent preview Retry similarly loads and transports the full catalog. ACP requests for a few text lines read and split the entire file before returning a window.

Related: #2256. This PR extends the same bounded lookup approach to Claude handoff; it does not include that PR's Specialist/delegation admission call-site changes.

## Proposed change

- Locate known Session owners through existing metadata and verify filename ownership before reading the current transcript. Extract the existing replay callback from bootstrap so its production behavior is regression-testable.
- Use existing `sessions.loadOne` for Subagent Retry when ownership is known; retain discovery for restored legacy tabs without an owner.
- Stream ACP line windows and stop after the requested range. Preserve full-read defaults, text semantics, path checks and error behavior.

The shared `runtime-lookup.ts` is reused from open #2256, with a type-only adjustment to the existing `SessionCatalog` capability required by the architecture guard. No competing lookup algorithm is introduced.

## Scope and non-goals

No new persisted fields, status/enum values, schema, storage format, migration, retention rule, API, or page layout. Historical Session decoding and unknown-owner catalog discovery remain. No transcript cache or line-offset index. Notebook segmented history, incremental Claude usage recovery and startup snapshot sharing remain deferred pending measurement/design decisions.

Claude handoff behavior is Claude-only. The filesystem callback is shared by Claude Code, OpenCode, Codex Responses and Codex Bridge. Model selection does not branch this callback. Subscriptions, permission routing, cancellation and provider wire shapes are unchanged. Text-window output remains proportional to requested lines, and reading a late window must still scan its prefix.

## Acceptance criteria and validation

Red/green evidence was obtained before each fix, without model calls or wall-clock thresholds:

- Real Claude runtime reconfiguration plus production persistence callback: twice failed with `blocked on unrelated Session` while another transcript's read was held. Same regression passes and returns freshly saved user context. The callback was first moved unchanged out of bootstrap because existing tests mocked it; no behavior was fixed before obtaining red.
- Rendered Subagent Retry: twice left the Frame error visible while unrelated catalog loading was held. Same click/result assertion now passes. Restored ownerless tabs retain tested recovery.
- Public ACP file read: twice consumed all 589,832 bytes for line 2/limit 1. Same regression now satisfies a 64 KiB read budget; real file reads are measured at the filesystem boundary, without a production test seam.

Final checks ran after the last material edit; independent review confirmed the code and framework/surface coverage mapping.

| Behavior / path | Command or selected files | Result |
| --- | --- | --- |
| Replay freshness, owner fallback, duplicate identity; Claude handoff | `claude-replay.test.ts`, `agents/claude-code-handoff.test.ts` | Passed |
| Session read/recovery/identity contracts | `repository.test.ts`, `coordinator.architecture.test.ts`, `coordinator-contract.test.ts`, `deletion-integration.test.ts`, `ipc.test.ts` under session-persistence | Passed |
| Shared ACP text and wire callback | `acp/filesystem.test.ts`, `acp/agent-connection-adapter.test.ts` | Passed |
| Claude/OpenCode/Codex Responses/Codex Bridge launcher selection | `acp/provider-session-creator.test.ts`; `acp/runtime.test.ts -t 'ACP runtime provider prompt acceptance'` | Passed; four launcher smoke cases |
| Other framework handoff compatibility | `acp/codex-completion-handoff.integration.test.ts`, `acp/opencode-immediate-handoff.integration.test.ts` | Passed |
| Retry + Electron/local Web/remote Web loadOne contracts | `SubagentReleaseSurfaces.render.test.tsx`, `renderer-contract-catalog.test.ts`, `renderer-argument-shape-characterization.test.ts` | Passed |
| Recovery module follow-up | `session-persistence/artifact-finalization-recovery.integration.test.ts` | 31 passed |
| Static checks / Web build | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint`, `npm run build:web` | Passed |

The final 15-file affected set contains 275 tests: 274 passed together; the only timeout (OpenCode) passed unchanged when rerun alone. Four additional launcher smoke cases and 31 recovery cases passed. Initial sandbox loopback EPERM and high-load test/Prisma transaction timeouts are environmental failures, not passing runs; no assertion or timeout was relaxed. No complete local `npm test` was run, per maintainer direction. Exact-head CI is authoritative for the full portable and platform matrix.

Representative command: `node node_modules/vitest/vitest.mjs run <listed-test-files> --maxWorkers=1` under Node 22. Live provider/model replay and native Windows/Linux App replay were not run; the change uses portable Node streams and path helpers. No API-map regeneration is required because contracts are unchanged.

## Review focus

Confirm that known-owner fast paths retain durable freshness and identity checks; that ownerless restored tabs still recover; and that finite ACP reads preserve EOF, LF/CRLF, bare CR, Unicode chunk boundaries and stream closure. Remaining full reads are deliberate fallback/full-file behavior, not a claim that all catalog scans have been eliminated.
