### PR TITLE
fix(renderer-stores): preserve newer state across stale responses

### DIFF
--- a/src/renderer/src/stores/granted-folders-store.test.ts
+++ b/src/renderer/src/stores/granted-folders-store.test.ts
@@ -101,4 +101,41 @@ describe('granted-folders-store', () => {
 
     expect(useGrantedFoldersStore.getState().roots).toEqual(granted)
   })
+
+  it('does not restore a revoked root when an older refresh finishes last', async () => {
+    const older = Promise.withResolvers<GrantedLocalRoot[]>()
+    const newer = Promise.withResolvers<GrantedLocalRoot[]>()
+    setLocalFsApi({
+      listGrantedRoots: vi
+        .fn()
+        .mockReturnValueOnce(older.promise)
+        .mockReturnValueOnce(newer.promise)
+    })
+
+    const firstRefresh = useGrantedFoldersStore.getState().refresh()
+    const secondRefresh = useGrantedFoldersStore.getState().refresh()
+    newer.resolve([])
+    await secondRefresh
+    older.resolve([createRoot()])
+    const returned = await firstRefresh
+
+    expect(useGrantedFoldersStore.getState().roots).toEqual([])
+    expect(returned).toEqual([])
+  })
+  it('preserves the accepted cache when the newest refresh fails and an older read succeeds', async () => {
+    const older = Promise.withResolvers<GrantedLocalRoot[]>()
+    const accepted = [createRoot({ id: 'accepted' })]
+    useGrantedFoldersStore.setState({ roots: accepted, loaded: true })
+    setLocalFsApi({
+      listGrantedRoots: vi
+        .fn()
+        .mockReturnValueOnce(older.promise)
+        .mockRejectedValueOnce(new Error('offline'))
+    })
+    const first = useGrantedFoldersStore.getState().refresh()
+    await expect(useGrantedFoldersStore.getState().refresh()).rejects.toThrow('offline')
+    older.resolve([createRoot()])
+    expect(await first).toBe(accepted)
+    expect(useGrantedFoldersStore.getState().roots).toBe(accepted)
+  })
 })

--- a/src/renderer/src/stores/granted-folders-store.test.ts
+++ b/src/renderer/src/stores/granted-folders-store.test.ts
@@ -122,20 +122,24 @@ describe('granted-folders-store', () => {
     expect(useGrantedFoldersStore.getState().roots).toEqual([])
     expect(returned).toEqual([])
   })
-  it('preserves the accepted cache when the newest refresh fails and an older read succeeds', async () => {
-    const older = Promise.withResolvers<GrantedLocalRoot[]>()
-    const accepted = [createRoot({ id: 'accepted' })]
-    useGrantedFoldersStore.setState({ roots: accepted, loaded: true })
-    setLocalFsApi({
-      listGrantedRoots: vi
-        .fn()
-        .mockReturnValueOnce(older.promise)
-        .mockRejectedValueOnce(new Error('offline'))
-    })
-    const first = useGrantedFoldersStore.getState().refresh()
-    await expect(useGrantedFoldersStore.getState().refresh()).rejects.toThrow('offline')
-    older.resolve([createRoot()])
-    expect(await first).toBe(accepted)
-    expect(useGrantedFoldersStore.getState().roots).toBe(accepted)
-  })
+  it.each([false, true])(
+    'preserves the accepted cache when the newest refresh fails and an older read succeeds (loaded=%s)',
+    async (loaded) => {
+      const older = Promise.withResolvers<GrantedLocalRoot[]>()
+      const accepted = loaded ? [createRoot({ id: 'accepted' })] : []
+      useGrantedFoldersStore.setState({ roots: accepted, loaded })
+      setLocalFsApi({
+        listGrantedRoots: vi
+          .fn()
+          .mockReturnValueOnce(older.promise)
+          .mockRejectedValueOnce(new Error('offline'))
+      })
+      const first = useGrantedFoldersStore.getState().refresh()
+      await expect(useGrantedFoldersStore.getState().refresh()).rejects.toThrow('offline')
+      older.resolve([createRoot()])
+      expect(await first).toBe(accepted)
+      expect(useGrantedFoldersStore.getState().roots).toBe(accepted)
+      expect(useGrantedFoldersStore.getState().loaded).toBe(loaded)
+    }
+  )
 })

--- a/src/renderer/src/stores/granted-folders-store.ts
+++ b/src/renderer/src/stores/granted-folders-store.ts
@@ -27,6 +27,7 @@ export const createInitialGrantedFoldersState = (): GrantedFoldersStoreData => (
 
 export const useGrantedFoldersStore = create<GrantedFoldersStore>((set, get) => {
   let mutationRevision = 0
+  let refreshSequence = 0
 
   const apply = (roots: GrantedLocalRoot[]): GrantedLocalRoot[] => {
     set({ roots, loaded: true })
@@ -42,9 +43,12 @@ export const useGrantedFoldersStore = create<GrantedFoldersStore>((set, get) => 
     ...createInitialGrantedFoldersState(),
 
     refresh: async () => {
+      const sequence = ++refreshSequence
       const startedAtRevision = mutationRevision
       const roots = await window.api.localFs.listGrantedRoots()
-      return startedAtRevision === mutationRevision ? apply(roots) : get().roots
+      return sequence === refreshSequence && startedAtRevision === mutationRevision
+        ? apply(roots)
+        : get().roots
     },
 
     // Rejections carry a user-presentable message from main; callers surface them and the store

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -229,6 +229,50 @@ describe('tag store', () => {
     expect(useTagStore.getState()).toMatchObject({ revision: 2, assignments: [] })
   })
 
+  it('keeps a newer committed assignment when an older mutation and recovery load fail', async () => {
+    const older = Promise.withResolvers<TagSnapshot>()
+    const committed: TagSnapshot = {
+      ...favoriteSnapshot(2),
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill',
+          resourceId: 'newer-skill',
+          createdAt: 2
+        }
+      ]
+    }
+    const snapshot = vi.fn().mockRejectedValue(new Error('offline'))
+    setTagsApi({
+      snapshot,
+      setAssignment: vi.fn().mockReturnValueOnce(older.promise).mockResolvedValueOnce(committed)
+    })
+    useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+
+    const first = useTagStore.getState().setAssignment({
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill',
+      resourceId: 'older-skill',
+      assigned: true
+    })
+    const rejected = expect(first).rejects.toThrow('older mutation failed')
+    await useTagStore.getState().setAssignment({
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill',
+      resourceId: 'newer-skill',
+      assigned: true
+    })
+    expect(useTagStore.getState().assignments).toEqual(committed.assignments)
+    older.reject(new Error('older mutation failed'))
+    await rejected
+
+    expect(snapshot).toHaveBeenCalledOnce()
+    expect(useTagStore.getState()).toMatchObject({
+      revision: 2,
+      assignments: committed.assignments
+    })
+  })
+
   it('optimistically reorders custom Tags while keeping the system Tag first', async () => {
     const tags: TagSnapshot['tags'] = [
       ...favoriteSnapshot().tags,
@@ -269,6 +313,40 @@ describe('tag store', () => {
     expect(useTagStore.getState().revision).toBe(2)
   })
 
+  it('does not restore a deleted Tag when an older reorder and recovery load fail', async () => {
+    const older = Promise.withResolvers<TagSnapshot>()
+    const initial: TagSnapshot = {
+      ...favoriteSnapshot(1),
+      tags: [
+        ...favoriteSnapshot().tags,
+        {
+          id: 'tag-methods',
+          name: 'Methods',
+          iconKey: 'flask-conical',
+          colorKey: 'green',
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+    }
+    const committed = favoriteSnapshot(2)
+    setTagsApi({
+      snapshot: vi.fn().mockRejectedValue(new Error('offline')),
+      reorder: vi.fn().mockReturnValue(older.promise),
+      delete: vi.fn().mockResolvedValue(committed)
+    })
+    useTagStore.setState({ ...initial, status: 'ready' })
+
+    const first = useTagStore.getState().reorder({ tagIds: ['tag-methods'] })
+    const rejected = expect(first).rejects.toThrow('older reorder failed')
+    await useTagStore.getState().delete('tag-methods')
+    expect(useTagStore.getState().tags).toEqual(committed.tags)
+    older.reject(new Error('older reorder failed'))
+    await rejected
+
+    expect(useTagStore.getState()).toMatchObject({ revision: 2, tags: committed.tags })
+  })
+
   it('reloads the authoritative Tag order after a failed optimistic reorder', async () => {
     const authoritative = favoriteSnapshot(2)
     const snapshot = vi.fn().mockResolvedValue(authoritative)
@@ -296,4 +374,132 @@ describe('tag store', () => {
     expect(snapshot).toHaveBeenCalledOnce()
     expect(useTagStore.getState()).toMatchObject(authoritative)
   })
+  it.each(['older-first', 'newer-first'])(
+    'removes failed optimistic assignments when both writes and recovery fail (%s)',
+    async (order) => {
+      const older = Promise.withResolvers<TagSnapshot>()
+      const newer = Promise.withResolvers<TagSnapshot>()
+      setTagsApi({
+        snapshot: vi.fn().mockRejectedValue(new Error('offline')),
+        setAssignment: vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
+      })
+      useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+      const first = useTagStore.getState().setAssignment({
+        tagId: 'tag-favorite',
+        resourceType: 'catalog.skill',
+        resourceId: 'older',
+        assigned: true
+      })
+      const firstRejected = expect(first).rejects.toThrow('failed')
+      const second = useTagStore.getState().setAssignment({
+        tagId: 'tag-favorite',
+        resourceType: 'catalog.skill',
+        resourceId: 'newer',
+        assigned: true
+      })
+      const secondRejected = expect(second).rejects.toThrow('failed')
+      if (order === 'older-first') {
+        older.reject(new Error('failed'))
+        await firstRejected
+        const pendingIds = useTagStore.getState().assignments.map((a) => a.resourceId)
+        newer.reject(new Error('failed'))
+        await secondRejected
+        expect(pendingIds).toContain('newer')
+      } else {
+        newer.reject(new Error('failed'))
+        await secondRejected
+        expect(useTagStore.getState().assignments.map((a) => a.resourceId)).toEqual(['older'])
+        older.reject(new Error('failed'))
+        await firstRejected
+      }
+      expect(useTagStore.getState()).toMatchObject({
+        revision: 1,
+        assignments: [],
+        status: 'error'
+      })
+    }
+  )
+
+  it('keeps a snapshot delivered by a changed event when an older assignment fails', async () => {
+    const older = Promise.withResolvers<TagSnapshot>()
+    let listener: ((event: { revision: number }) => void) | undefined
+    const committed = {
+      ...favoriteSnapshot(2),
+      assignments: [
+        {
+          tagId: 'tag-favorite',
+          resourceType: 'catalog.skill' as const,
+          resourceId: 'remote',
+          createdAt: 2
+        }
+      ]
+    }
+    setTagsApi({
+      snapshot: vi
+        .fn()
+        .mockResolvedValueOnce(committed)
+        .mockRejectedValueOnce(new Error('offline')),
+      setAssignment: vi.fn().mockReturnValue(older.promise),
+      onChanged: vi.fn((next) => {
+        listener = next
+        return () => undefined
+      })
+    })
+    useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+    const stop = useTagStore.getState().listen()
+    const pending = useTagStore.getState().setAssignment({
+      tagId: 'tag-favorite',
+      resourceType: 'catalog.skill',
+      resourceId: 'older',
+      assigned: true
+    })
+    const rejected = expect(pending).rejects.toThrow('failed')
+    listener?.({ revision: 2 })
+    await vi.waitFor(() => expect(useTagStore.getState().revision).toBe(2))
+    older.reject(new Error('failed'))
+    await rejected
+    expect(useTagStore.getState().assignments).toEqual(committed.assignments)
+    stop()
+  })
+  it.each(['older-first', 'newer-first'])(
+    'restores the accepted order after overlapping reorders both fail (%s)',
+    async (order) => {
+      const older = Promise.withResolvers<TagSnapshot>()
+      const newer = Promise.withResolvers<TagSnapshot>()
+      const tags: TagSnapshot['tags'] = [
+        ...favoriteSnapshot().tags,
+        ...['a', 'b', 'c'].map((id) => ({
+          id,
+          name: id,
+          iconKey: 'tag' as const,
+          colorKey: 'blue' as const,
+          createdAt: 1,
+          updatedAt: 1
+        }))
+      ]
+      setTagsApi({
+        snapshot: vi.fn().mockRejectedValue(new Error('offline')),
+        reorder: vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(newer.promise)
+      })
+      useTagStore.setState({ ...favoriteSnapshot(1), tags, status: 'ready' })
+      const first = useTagStore.getState().reorder({ tagIds: ['b', 'a', 'c'] })
+      const firstRejected = expect(first).rejects.toThrow('failed')
+      const second = useTagStore.getState().reorder({ tagIds: ['c', 'b', 'a'] })
+      const secondRejected = expect(second).rejects.toThrow('failed')
+      if (order === 'older-first') {
+        older.reject(new Error('failed'))
+        await firstRejected
+        const pendingIds = useTagStore.getState().tags.map((tag) => tag.id)
+        newer.reject(new Error('failed'))
+        await secondRejected
+        expect(pendingIds).toEqual(['tag-favorite', 'c', 'b', 'a'])
+      } else {
+        newer.reject(new Error('failed'))
+        await secondRejected
+        older.reject(new Error('failed'))
+        await firstRejected
+      }
+      expect(useTagStore.getState().tags).toEqual(tags)
+    }
+  )
 })

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -48,6 +48,21 @@ export const createInitialTagState = (): TagSnapshot & {
 })
 let loadSequence = 0
 
+// A later optimistic backup may contain an earlier failed write. Follow those backups only
+// when the failing write still owns the projection; authority snapshots always take precedence.
+const failedTagProjections = new WeakMap<TagSnapshot['tags'], TagSnapshot['tags']>()
+const failedAssignmentProjections = new WeakMap<
+  TagSnapshot['assignments'],
+  TagSnapshot['assignments']
+>()
+
+const rollbackProjection = <T>(failed: WeakMap<T[], T[]>, optimistic: T[], before: T[]): T[] => {
+  failed.set(optimistic, before)
+  let restored = before
+  while (failed.has(restored)) restored = failed.get(restored)!
+  return restored
+}
+
 const stateFromSnapshot = (
   snapshot: TagSnapshot
 ): Pick<TagStore, keyof TagSnapshot | 'status'> => ({
@@ -120,6 +135,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
     set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
   },
   reorder: async (request) => {
+    const revision = get().revision
     const before = get().tags
     const byId = new Map(before.map((tag) => [tag.id, tag]))
     set({
@@ -131,17 +147,20 @@ export const useTagStore = create<TagStore>((set, get) => ({
         })
       ]
     })
+    const optimistic = get().tags
     try {
       const snapshot = await window.api.tags.reorder(request)
       loadSequence += 1
       set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
     } catch (error) {
-      set({ tags: before })
+      const restored = rollbackProjection(failedTagProjections, optimistic, before)
+      if (get().revision === revision && get().tags === optimistic) set({ tags: restored })
       await get().load()
       throw error
     }
   },
   setAssignment: async (request) => {
+    const revision = get().revision
     const before = get().assignments
     const matches = (assignment: TagSnapshot['assignments'][number]): boolean =>
       assignment.tagId === request.tagId &&
@@ -150,7 +169,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
     set({
       assignments: request.assigned
         ? before.some(matches)
-          ? before
+          ? [...before]
           : [
               ...before,
               {
@@ -162,12 +181,15 @@ export const useTagStore = create<TagStore>((set, get) => ({
             ]
         : before.filter((assignment) => !matches(assignment))
     })
+    const optimistic = get().assignments
     try {
       const snapshot = await window.api.tags.setAssignment(request)
       loadSequence += 1
       set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
     } catch (error) {
-      set({ assignments: before })
+      const restored = rollbackProjection(failedAssignmentProjections, optimistic, before)
+      if (get().revision === revision && get().assignments === optimistic)
+        set({ assignments: restored })
       await get().load()
       throw error
     }


### PR DESCRIPTION
## Problem

Out-of-order granted-folder refreshes could restore a revoked folder in the renderer cache. Failed optimistic Tag operations could replace newer confirmed data with an old array backup when recovery also failed.

## Proposed change

Fence granted-folder refresh publication by the latest-started read and the existing mutation revision. Stale callers receive the current cache. Gate Tag rollback by revision and projection ownership; skip already-failed optimistic backups when overlapping writes both fail. Keep authority reloads and error propagation.

## Scope and non-goals

First batch of the concurrency audit: two renderer stores only. No database/schema/legacy migration, persisted-format change, new enum, public API, ACP protocol, or global mutation serialization. New transient bookkeeping consists of a refresh sequence and weakly referenced failed optimistic backups. The remaining whole-repository audit and independent-client/process schedules are not certified by this PR.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Cache publication and rollback ordering -> `npx vitest run src/renderer/src/stores/granted-folders-store.test.ts src/renderer/src/stores/tag-store.test.ts` -> 26 passed. Covers latest refresh failure, newer authority responses, changed events, newer pending operations, and both overlapping-failure orders.
- Boundary and consumer coverage -> same Vitest run additionally selected `src/main/local-fs`, `src/main/tags`, `src/shared/local-fs.test.ts`, `src/shared/tags.test.ts`, GrantFolderAccessDialog layers/interaction tests, ProjectFilesView, TagsPanel, SkillsPanel, ConnectorsPanel, and SpecialistsPanel render tests -> 17 files / 402 tests passed; the initial 401-test selection was independently rerun in review.
- Renderer typing -> `npm run typecheck:web` -> passed.
- Source standards -> `npm run lint` and `git diff --check` -> passed.
- Browser distribution -> `npm run build:web` -> passed.
- Independent Standards and Spec reviews -> no actionable findings; coverage mapping confirmed.

No complete local suite was run, per maintainer instruction. No platform-specific, main/preload, protocol, or persistent-format logic changed; local platform/migration/ACP lanes were excluded for that reason. Exact-head PR CI supplies the complete/platform checks. UI verification uses a localhost Web service with disposable storage; no live provider calls are needed.

Browser checks completed on the built Web app with isolated storage:

- Reordered two test Tags with the keyboard. Held an older reorder, deleted Methods through the real API, observed the changed-event snapshot, then rejected the held reorder and the recovery snapshot. Methods remained absent; existing error messages remained visible.
- Held the Files-panel granted-root read, delivered a newer empty read through the folder dialog, then delivered the old revoked-root list. The revoked folder remained absent from the filter menu.
- These are real renderer consumers with controlled API response ordering. Folder navigation used an empty-directory fixture to avoid unrelated drive enumeration, and same-origin Bearer authentication worked around test-browser cookie interference. They are not independent-process transport stress tests.

## Refresh failure policy (maintainer-approved)

The newest-started refresh wins admission, including initial loading. If that request fails,
keep the last accepted cache and reject normally; do not fall back to an obsolete in-flight
response. Before the first accepted read, this intentionally retains `loaded: false` and an
empty cache. A later fresh refresh can initialize it. This avoids reinstating a root revoked
between overlapping reads. The owner test covers both initially unloaded and loaded caches.

The automatic review suggestion to accept an older initial read after a later failure would
change this explicitly approved policy, so it is not applied in this PR.

## Review focus

Authority snapshots must dominate old failures. Obsolete refresh return values must be fenced as well as stored values. Repeated failures must not resurrect a failed optimistic backup. These regression tests establish renderer projection behavior, not database corruption or permission restoration.
