### PR TITLE
feat(literature): add arXiv PDF discovery and parallel source lookup

### DIFF
--- a/src/main/literature/agent-pdf-acquisition.test.ts
+++ b/src/main/literature/agent-pdf-acquisition.test.ts
@@ -101,3 +101,39 @@ it('rejects local links and reports unavailable sources without staging metadata
   })
   expect(stageAcquiredPdf).not.toHaveBeenCalled()
 })
+
+it('preserves the arXiv download and article provenance in Inbox', async () => {
+  const { service, discover, stageAcquiredPdf } = setup()
+  discover.mockResolvedValueOnce({
+    mode: 'search',
+    candidates: [
+      {
+        id: 'arxiv-pdf',
+        provider: 'arxiv',
+        source: 'arXiv',
+        url: 'https://arxiv.org/pdf/2401.12345',
+        sourceUrl: 'https://arxiv.org/abs/2401.12345'
+      }
+    ],
+    notices: []
+  })
+  await expect(service.acquire({ candidate, origin: candidate.origin })).resolves.toMatchObject({
+    status: 'pending-review',
+    sourceUrl: 'https://arxiv.org/abs/2401.12345'
+  })
+  expect(stageAcquiredPdf).toHaveBeenCalledWith(
+    expect.objectContaining({
+      source: expect.objectContaining({
+        rawMetadata: {
+          metadata: {},
+          fullText: {
+            provider: 'arxiv',
+            sourceUrl: 'https://arxiv.org/abs/2401.12345',
+            downloadUrl: 'https://arxiv.org/pdf/2401.12345'
+          }
+        }
+      })
+    }),
+    expect.objectContaining({ sourceUrl: 'https://arxiv.org/abs/2401.12345' })
+  )
+})

--- a/src/main/literature/batch-jobs.test.ts
+++ b/src/main/literature/batch-jobs.test.ts
@@ -365,3 +365,46 @@ it('preserves completed apply counts when resuming older checkpoints without pha
     phaseTotal: 2
   })
 })
+
+it.each(['pmc', 'arxiv'] as const)(
+  'restores reviewed %s candidates and revalidates them before attachment',
+  async (provider) => {
+    const { jobs, options, fullText } = await setup()
+    const candidate = {
+      ...source,
+      provider,
+      ...(provider === 'arxiv'
+        ? {
+            source: 'arXiv',
+            url: 'https://arxiv.org/pdf/2401.12345',
+            sourceUrl: 'https://arxiv.org/abs/2401.12345'
+          }
+        : {})
+    }
+    fullText.mockResolvedValue({ mode: 'search', candidates: [candidate], notices: [] })
+    const jobId = randomUUID()
+    await jobs.run({ action: 'create', mode: 'full-text', itemIds: ['a'], requestId: jobId })
+    await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+    await jobs.close()
+    const reopened = new LiteratureBatchJobs(options)
+    cleanup.push(() => reopened.close())
+    expect((await state(reopened, jobId)).rows[0].candidates).toEqual([candidate])
+    fullText.mockImplementation(async (request) =>
+      request.mode === 'search'
+        ? { mode: 'search', candidates: [{ ...candidate, id: 'fresh-token' }], notices: [] }
+        : { mode: 'attach', item: item('a') }
+    )
+    await reopened.run({
+      action: 'apply',
+      jobId,
+      selections: [{ itemId: 'a', candidateId: candidate.id }]
+    })
+    await vi.waitFor(async () => expect((await state(reopened, jobId)).state).toBe('completed'))
+    expect(fullText).toHaveBeenLastCalledWith({
+      mode: 'attach',
+      itemId: 'a',
+      candidateId: 'fresh-token'
+    })
+    expect((await state(reopened, jobId)).rows[0].status).toBe('done')
+  }
+)

--- a/src/main/literature/full-text-finder.test.ts
+++ b/src/main/literature/full-text-finder.test.ts
@@ -445,3 +445,144 @@ describe('Literature full-text discovery and attachment', () => {
     expect(await finder.run({ mode: 'search', itemId: item.id })).toMatchObject({ candidates: [] })
   })
 })
+
+it.each([
+  ['2401.12345', '2401.12345'],
+  ['arXiv:0706.0001v2', '0706.0001'],
+  ['https://arxiv.org/pdf/hep-th/9901001v3.pdf', 'hep-th/9901001'],
+  ['math.GT/0309136', 'math.GT/0309136']
+])(
+  'discovers and attaches the latest arXiv PDF for %s without provider credentials',
+  async (value, id) => {
+    const { finder, options, item } = setup()
+    item.item.identifiers = [{ scheme: 'arxiv', value, isPrimary: true }]
+    const result = await finder.run({ mode: 'search', itemId: item.id })
+    if (result.mode !== 'search') throw new Error('Expected search')
+    expect(result.notices).toEqual([])
+    expect(result.candidates).toEqual([
+      {
+        id: expect.any(String),
+        provider: 'arxiv',
+        source: 'arXiv',
+        url: `https://arxiv.org/pdf/${id}`,
+        sourceUrl: `https://arxiv.org/abs/${id}`
+      }
+    ])
+    expect(options.fetch).not.toHaveBeenCalled()
+    expect(options.openAlexKey).not.toHaveBeenCalled()
+    expect(options.download).not.toHaveBeenCalled()
+    await finder.run({ mode: 'attach', itemId: item.id, candidateId: result.candidates[0].id })
+    expect(options.download).toHaveBeenCalledWith(
+      `https://arxiv.org/pdf/${id}`,
+      expect.any(Number),
+      expect.any(Function)
+    )
+    expect(options.catalog.attachContent).toHaveBeenCalledTimes(1)
+  }
+)
+
+it.each([
+  '',
+  'not-an-id',
+  '../../private',
+  'https://evil.example/abs/2401.12345',
+  '2401.12345/extra'
+])('rejects invalid arXiv identifier %s without requests', async (value) => {
+  const { finder, options, item } = setup()
+  item.item.identifiers = [{ scheme: 'arxiv', value, isPrimary: true }]
+  await expect(finder.discover(item.item)).resolves.toEqual({
+    mode: 'search',
+    candidates: [],
+    notices: ['missing-identifiers']
+  })
+  expect(options.fetch).not.toHaveBeenCalled()
+})
+
+it('starts every metadata source before any responds and preserves precedence despite completion order', async () => {
+  const { finder, options, item } = setup()
+  item.item.identifiers.push({ scheme: 'arxiv', value: '2401.12345', isPrimary: false })
+  options.openAlexKey = async () => 'test-key'
+  options.contactEmail = async () => 'research@lab.org'
+  const pending = new Map<string, (response: Response) => void>()
+  options.fetch = vi.fn(
+    async (input) =>
+      new Promise<Response>((resolve) => pending.set(new URL(String(input)).hostname, resolve))
+  )
+  const searching = finder.run({ mode: 'search', itemId: item.id })
+  await vi.waitFor(() =>
+    expect([...pending.keys()].sort()).toEqual([
+      'api.openalex.org',
+      'api.unpaywall.org',
+      'pmc.ncbi.nlm.nih.gov',
+      'www.ebi.ac.uk'
+    ])
+  )
+  pending.get('api.unpaywall.org')!(
+    Response.json({
+      doi: '10.1000/example',
+      oa_locations: [
+        { url_for_pdf: 'https://journal.example/shared.pdf' },
+        { url_for_pdf: 'https://journal.example/unpaywall.pdf' }
+      ]
+    })
+  )
+  pending.get('api.openalex.org')!(
+    Response.json({
+      results: [
+        {
+          doi: '10.1000/example',
+          locations: [
+            { is_oa: true, pdf_url: 'https://journal.example/shared.pdf' },
+            { is_oa: true, pdf_url: 'https://journal.example/openalex.pdf' }
+          ]
+        }
+      ]
+    })
+  )
+  pending.get('pmc.ncbi.nlm.nih.gov')!(Response.json({ records: [] }))
+  pending.get('www.ebi.ac.uk')!(
+    Response.json({
+      resultList: {
+        result: [
+          {
+            doi: '10.1000/example',
+            fullTextUrlList: {
+              fullTextUrl: [
+                {
+                  availabilityCode: 'OA',
+                  documentStyle: 'pdf',
+                  url: 'https://journal.example/shared.pdf'
+                }
+              ]
+            }
+          }
+        ]
+      }
+    })
+  )
+  const result = await searching
+  if (result.mode !== 'search') throw new Error('Expected search')
+  expect(result.candidates.map(({ provider }) => provider)).toEqual([
+    'europe-pmc',
+    'openalex',
+    'unpaywall',
+    'arxiv'
+  ])
+  expect(result.candidates.map(({ url }) => url)).toEqual([
+    'https://journal.example/shared.pdf',
+    'https://journal.example/openalex.pdf',
+    'https://journal.example/unpaywall.pdf',
+    'https://arxiv.org/pdf/2401.12345'
+  ])
+})
+
+it('retains arXiv and other results when OpenAlex credential lookup fails', async () => {
+  const { finder, options, item } = setup()
+  item.item.identifiers.push({ scheme: 'arxiv', value: '2401.12345', isPrimary: false })
+  options.openAlexKey = async () => {
+    throw new Error('Credential store unavailable')
+  }
+  const result = await finder.discover(item.item)
+  expect(result.notices).toContain('openalex-unavailable')
+  expect(result.candidates.map(({ provider }) => provider)).toEqual(['europe-pmc', 'arxiv'])
+})

--- a/src/main/literature/full-text-finder.test.ts
+++ b/src/main/literature/full-text-finder.test.ts
@@ -586,3 +586,61 @@ it('retains arXiv and other results when OpenAlex credential lookup fails', asyn
   expect(result.notices).toContain('openalex-unavailable')
   expect(result.candidates.map(({ provider }) => provider)).toEqual(['europe-pmc', 'arxiv'])
 })
+
+it.each([
+  { count: 9, arxivIndex: -1, hasIdentifier: true },
+  { count: 10, arxivIndex: -1, hasIdentifier: true },
+  { count: 12, arxivIndex: -1, hasIdentifier: true },
+  { count: 12, arxivIndex: 0, hasIdentifier: true },
+  { count: 12, arxivIndex: 9, hasIdentifier: true },
+  { count: 12, arxivIndex: 11, hasIdentifier: true },
+  { count: 12, arxivIndex: -1, hasIdentifier: false }
+])(
+  'reserves one bounded result for arXiv without duplicating provider URLs: %j',
+  async ({ count, arxivIndex, hasIdentifier }) => {
+    const { finder, options, item } = setup()
+    const arxivUrl = 'https://arxiv.org/pdf/2401.12345'
+    if (hasIdentifier)
+      item.item.identifiers.push({ scheme: 'arxiv', value: '2401.12345', isPrimary: false })
+    const urls = Array.from({ length: count }, (_, index) =>
+      index === arxivIndex ? arxivUrl : `https://journal.example/paper-${index}.pdf`
+    )
+    options.openAlexKey = async () => 'test-key'
+    options.fetch = vi.fn(async (input) => {
+      const host = new URL(String(input)).hostname
+      if (host === 'api.openalex.org')
+        return Response.json({
+          results: [
+            {
+              doi: '10.1000/example',
+              locations: urls.map((url) => ({ is_oa: true, pdf_url: url }))
+            }
+          ]
+        })
+      if (host === 'pmc.ncbi.nlm.nih.gov') return Response.json({ records: [] })
+      return Response.json({ resultList: { result: [] } })
+    })
+    const result = await finder.run({ mode: 'search', itemId: item.id })
+    if (result.mode !== 'search') throw new Error('Expected search')
+    const selectedUrls = result.candidates.map(({ url }) => url)
+    expect(selectedUrls).toHaveLength(10)
+    expect(new Set(selectedUrls).size).toBe(10)
+    if (!hasIdentifier || (arxivIndex >= 0 && arxivIndex < 10)) {
+      expect(selectedUrls).toEqual(urls.slice(0, 10))
+    } else {
+      expect(selectedUrls).toEqual([...urls.slice(0, 9), arxivUrl])
+    }
+    expect(options.download).not.toHaveBeenCalled()
+    if (hasIdentifier) {
+      const selected = result.candidates.find(({ url }) => url === arxivUrl)!
+      // Retain the first provider's attribution when it already discovered the same PDF.
+      expect(selected.provider).toBe(arxivIndex >= 0 ? 'openalex' : 'arxiv')
+      await finder.run({ mode: 'attach', itemId: item.id, candidateId: selected.id })
+      expect(options.download).toHaveBeenCalledWith(
+        arxivUrl,
+        expect.any(Number),
+        expect.any(Function)
+      )
+    }
+  }
+)

--- a/src/main/literature/full-text-finder.ts
+++ b/src/main/literature/full-text-finder.ts
@@ -10,7 +10,10 @@ import type {
   LiteratureFullTextResult,
   LiteratureItemView
 } from '../../shared/literature'
-import { normalizeLiteratureIdentifierValue } from '../../shared/literature'
+import {
+  createLiteratureIdentifierUrl,
+  normalizeLiteratureIdentifierValue
+} from '../../shared/literature'
 import type { LiteratureCatalog } from './catalog'
 import type { ContentRepository } from '../storage/content-repository'
 import { findPmcPdfs, findUnpaywallPdfs, readFullTextProvider } from './full-text-sources'
@@ -116,7 +119,8 @@ class LiteratureFullTextFinder {
     const doi = identifiers.get('doi')?.toLowerCase()
     const pmid = identifiers.get('pmid')
     const pmcid = identifiers.get('pmcid')
-    if (!doi && !pmid && !pmcid)
+    const arxivPage = createLiteratureIdentifierUrl('arxiv', identifiers.get('arxiv') ?? '')
+    if (!doi && !pmid && !pmcid && !arxivPage)
       return { mode: 'search', candidates: [], notices: ['missing-identifiers'] }
     const found: Candidate[] = []
     const notices: SearchResult['notices'] = []
@@ -137,7 +141,7 @@ class LiteratureFullTextFinder {
     })()
     const pmc = findPmcPdfs({ doi, pmid, pmcid }, this.options.fetch)
       .then((result) => {
-        if (result.noRecord) notices.push('pmc-no-record')
+        if (result.noRecord && (doi || pmid || pmcid)) notices.push('pmc-no-record')
         return result.candidates
       })
       .catch(() => {
@@ -166,7 +170,9 @@ class LiteratureFullTextFinder {
           : doi
             ? `DOI:"${doi.replace(/["\\]/gu, '')}"`
             : undefined
-    if (query) {
+    const europe = (async (): Promise<Candidate[]> => {
+      const candidates: Candidate[] = []
+      if (!query) return candidates
       try {
         const url = new URL('https://www.ebi.ac.uk/europepmc/webservices/rest/search')
         url.search = new URLSearchParams({
@@ -210,7 +216,7 @@ class LiteratureFullTextFinder {
                 /^https:\/\/(?:www\.)?europepmc\.org\/articles\/(PMC\d+)(?:[/?#]|$)/iu.exec(
                   link.url
                 )
-              add({
+              candidates.push({
                 provider: 'europe-pmc',
                 url: link.url,
                 sourceUrl:
@@ -226,54 +232,65 @@ class LiteratureFullTextFinder {
       } catch {
         notices.push('europe-pmc-unavailable')
       }
-    }
-    if (doi) {
-      const key = await this.options.openAlexKey()
-      if (!key) notices.push('openalex-not-configured')
-      else {
-        try {
-          const url = new URL('https://api.openalex.org/works')
-          url.search = new URLSearchParams({
-            filter: `doi:https://doi.org/${doi}`,
-            per_page: '5',
-            select: 'doi,best_oa_location,locations',
-            api_key: key
-          }).toString()
-          const result = z
-            .object({ results: z.array(openAlexWork) })
-            .parse(await this.json(url.href))
-          for (const work of result.results) {
-            if (
-              !work.doi ||
-              normalizeLiteratureIdentifierValue('doi', work.doi).toLowerCase() !== doi
-            )
-              continue
-            for (const entry of [work.best_oa_location, ...(work.locations ?? [])]) {
-              if (!entry?.is_oa || !entry.pdf_url) continue
-              const version =
-                entry.version === 'publishedVersion'
-                  ? 'published'
-                  : entry.version === 'acceptedVersion'
-                    ? 'accepted'
-                    : entry.version === 'submittedVersion'
-                      ? 'submitted'
-                      : undefined
-              add({
-                provider: 'openalex',
-                url: entry.pdf_url,
-                sourceUrl: entry.landing_page_url || `https://doi.org/${doi}`,
-                source: entry.source?.display_name || 'OpenAlex',
-                ...(version ? { version } : {}),
-                ...(entry.license ? { license: entry.license } : {})
-              })
-            }
-          }
-        } catch {
-          notices.push('openalex-unavailable')
+      return candidates
+    })()
+    const openAlex = (async (): Promise<Candidate[]> => {
+      const candidates: Candidate[] = []
+      if (!doi) return candidates
+      try {
+        const key = await this.options.openAlexKey()
+        if (!key) {
+          notices.push('openalex-not-configured')
+          return candidates
         }
+        const url = new URL('https://api.openalex.org/works')
+        url.search = new URLSearchParams({
+          filter: `doi:https://doi.org/${doi}`,
+          per_page: '5',
+          select: 'doi,best_oa_location,locations',
+          api_key: key
+        }).toString()
+        const result = z.object({ results: z.array(openAlexWork) }).parse(await this.json(url.href))
+        for (const work of result.results) {
+          if (
+            !work.doi ||
+            normalizeLiteratureIdentifierValue('doi', work.doi).toLowerCase() !== doi
+          )
+            continue
+          for (const entry of [work.best_oa_location, ...(work.locations ?? [])]) {
+            if (!entry?.is_oa || !entry.pdf_url) continue
+            const version =
+              entry.version === 'publishedVersion'
+                ? 'published'
+                : entry.version === 'acceptedVersion'
+                  ? 'accepted'
+                  : entry.version === 'submittedVersion'
+                    ? 'submitted'
+                    : undefined
+            candidates.push({
+              provider: 'openalex',
+              url: entry.pdf_url,
+              sourceUrl: entry.landing_page_url || `https://doi.org/${doi}`,
+              source: entry.source?.display_name || 'OpenAlex',
+              ...(version ? { version } : {}),
+              ...(entry.license ? { license: entry.license } : {})
+            })
+          }
+        }
+      } catch {
+        notices.push('openalex-unavailable')
       }
-    }
-    for (const candidates of await Promise.all([unpaywall, pmc])) candidates.forEach(add)
+      return candidates
+    })()
+    for (const candidates of await Promise.all([europe, openAlex, unpaywall, pmc]))
+      candidates.forEach(add)
+    if (arxivPage)
+      add({
+        provider: 'arxiv',
+        source: 'arXiv',
+        sourceUrl: arxivPage,
+        url: arxivPage.replace('/abs/', '/pdf/')
+      })
     const now = Date.now()
     for (const [id, value] of this.candidates) if (value.expires < now) this.candidates.delete(id)
     const candidates = found.slice(0, 10).map((candidate) => {

--- a/src/main/literature/full-text-finder.ts
+++ b/src/main/literature/full-text-finder.ts
@@ -291,9 +291,13 @@ class LiteratureFullTextFinder {
         sourceUrl: arxivPage,
         url: arxivPage.replace('/abs/', '/pdf/')
       })
+    const shortlist = found.slice(0, 10)
+    const arxivCandidate = found.find(({ url }) => url === arxivPage?.replace('/abs/', '/pdf/'))
+    // Keep the identified arXiv PDF selectable even when other sources fill the result limit.
+    if (arxivCandidate && !shortlist.includes(arxivCandidate)) shortlist[9] = arxivCandidate
     const now = Date.now()
     for (const [id, value] of this.candidates) if (value.expires < now) this.candidates.delete(id)
-    const candidates = found.slice(0, 10).map((candidate) => {
+    const candidates = shortlist.map((candidate) => {
       const id = randomUUID()
       this.candidates.set(id, {
         candidate,

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
@@ -239,4 +239,43 @@ describe('LiteratureFullTextLookup', () => {
     ).not.toBeNull()
     expect(fullText).toHaveBeenCalledTimes(2)
   })
+  it('offers an arXiv-only PDF with accurate source applicability and attaches only after selection', async () => {
+    const arxivItem = {
+      ...item,
+      item: {
+        ...item.item,
+        identifiers: [{ scheme: 'arxiv' as const, value: '2401.12345', isPrimary: true }]
+      }
+    }
+    fullText.mockImplementation(async (request) =>
+      request.mode === 'attach'
+        ? { mode: 'attach', item: arxivItem }
+        : {
+            mode: 'search',
+            notices: [],
+            candidates: [
+              {
+                id: 'arxiv-pdf',
+                provider: 'arxiv',
+                source: 'arXiv',
+                url: 'https://arxiv.org/pdf/2401.12345',
+                sourceUrl: 'https://arxiv.org/abs/2401.12345'
+              }
+            ]
+          }
+    )
+    const onAdded = vi.fn()
+    render(<LiteratureFullTextLookup {...props} item={arxivItem} onAdded={onAdded} />)
+    const add = await screen.findByRole('button', { name: 'Add attachment' })
+    expect(fullText.mock.calls.every(([request]) => request.mode === 'search')).toBe(true)
+    expect(screen.getByRole('link', { name: 'Open source' }).getAttribute('href')).toBe(
+      'https://arxiv.org/abs/2401.12345'
+    )
+    fireEvent.click(screen.getByText('Search sources'))
+    const sources = within(screen.getByRole('region', { name: 'Search sources' }))
+    expect(sources.getByText('Direct PDF link')).not.toBeNull()
+    expect(sources.queryByText('Search completed')).toBeNull()
+    fireEvent.click(add)
+    await vi.waitFor(() => expect(onAdded).toHaveBeenCalledWith(arxivItem))
+  })
 })

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.tsx
@@ -18,6 +18,7 @@ import type {
   LiteratureFullTextResult,
   LiteratureItemView
 } from '../../../../shared/literature'
+import { createLiteratureIdentifierUrl } from '../../../../shared/literature'
 import { formatBytes } from '../../../../shared/update'
 import { LiteratureOpenAlexCredential } from './LiteratureOpenAlexCredential'
 import { UnpaywallCredentialForm } from '../settings/UnpaywallCredentialForm'
@@ -139,11 +140,14 @@ export const LiteratureFullTextLookup = ({
     }
   }
 
+  const hasArxiv = item.item.identifiers.some(
+    ({ scheme, value }) => scheme === 'arxiv' && createLiteratureIdentifierUrl('arxiv', value)
+  )
+  const hasBiomedicalIdentifier = item.item.identifiers.some(
+    ({ scheme, value }) => ['doi', 'pmid', 'pmcid'].includes(scheme) && value.trim()
+  )
   const missingIdentifiers =
-    result?.notices.includes('missing-identifiers') ??
-    !item.item.identifiers.some(
-      ({ scheme, value }) => ['doi', 'pmid', 'pmcid'].includes(scheme) && value.trim()
-    )
+    result?.notices.includes('missing-identifiers') ?? !(hasArxiv || hasBiomedicalIdentifier)
   const hasDoi = item.item.identifiers.some(({ scheme, value }) => scheme === 'doi' && value.trim())
   const europeUnavailable = result?.notices.includes('europe-pmc-unavailable')
   const openAlexUnavailable = result?.notices.includes('openalex-unavailable')
@@ -155,7 +159,9 @@ export const LiteratureFullTextLookup = ({
     (europeUnavailable || openAlexUnavailable || unpaywallUnavailable || pmcUnavailable)
   const failed = error || incomplete
   const sourceStatus = (provider: LiteratureFullTextCandidate['provider']): string => {
-    if (missingIdentifiers) return t('Needs identifiers')
+    if (provider === 'arxiv')
+      return hasArxiv ? t('Direct PDF link') : t('arXiv identifier required')
+    if (missingIdentifiers || !hasBiomedicalIdentifier) return t('Needs identifiers')
     if ((provider === 'openalex' || provider === 'unpaywall') && !hasDoi) return t('DOI required')
     if (searching) return t('Searching…')
     if (!result) return t('Not checked')
@@ -171,7 +177,8 @@ export const LiteratureFullTextLookup = ({
     'europe-pmc': t('Europe PMC'),
     openalex: t('OpenAlex'),
     unpaywall: t('Unpaywall'),
-    pmc: t('PubMed Central')
+    pmc: t('PubMed Central'),
+    arxiv: t('arXiv')
   }
   const versions = {
     published: t('Published version'),
@@ -288,6 +295,17 @@ export const LiteratureFullTextLookup = ({
                   </p>
                 ) : null}
               </div>
+              <div className="py-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <h4 className="font-medium">{t('arXiv')}</h4>
+                  <span className="text-xs text-muted-foreground">{sourceStatus('arxiv')}</span>
+                </div>
+                <p className="mt-1 text-xs leading-5 text-muted-foreground">
+                  {t(
+                    'Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.'
+                  )}
+                </p>
+              </div>
             </div>
           </details>
         </section>
@@ -341,7 +359,9 @@ export const LiteratureFullTextLookup = ({
             </div>
           ) : missingIdentifiers ? (
             <div className="space-y-3 py-2">
-              <p>{t('Add a DOI, PMID or PMCID to find a matching full-text PDF.')}</p>
+              <p>
+                {t('Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.')}
+              </p>
               <Button variant="outline" onClick={onCompleteMetadata}>
                 {t('Complete metadata')}
               </Button>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -227,7 +227,6 @@
     "Find full-text PDF": "Volltext-PDF suchen",
     "Full-text search failed. Try again.": "Volltextsuche fehlgeschlagen. Bitte erneut versuchen.",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "Das PDF konnte nicht hinzugefügt werden. Der Link ist möglicherweise abgelaufen, erfordert eine Anmeldung oder die Datei überschreitet 50 MB. Suchen Sie erneut oder laden Sie ein PDF hoch.",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "Fügen Sie eine DOI, PMID oder PMCID hinzu, um ein passendes Volltext-PDF zu finden.",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC ist nicht verfügbar. Ergebnisse sind möglicherweise unvollständig.",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex ist nicht verfügbar. Ergebnisse sind möglicherweise unvollständig.",
     "Published version": "Veröffentlichte Version",
@@ -4699,6 +4698,11 @@
     "Retry turning off": "Ausschalten erneut versuchen",
     "Local remote access remains enabled, but the latest external status check failed.": "Der lokale Fernzugriff bleibt aktiviert, aber die letzte Prüfung des externen Status ist fehlgeschlagen.",
     "The latest external status check failed.": "Die letzte Prüfung des externen Status ist fehlgeschlagen.",
-    "Saved browser link": "Gespeicherter Browser-Link"
+    "Saved browser link": "Gespeicherter Browser-Link",
+    "arXiv": "arXiv",
+    "Direct PDF link": "Direkter PDF-Link",
+    "arXiv identifier required": "arXiv-Kennung erforderlich",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Neueste PDF über die arXiv-Kennung. Kein API-Schlüssel erforderlich. Die Datei wird beim Herunterladen geprüft.",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Fügen Sie eine DOI, PMID, PMCID oder arXiv-Kennung hinzu, um eine passende Volltext-PDF zu finden."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -230,7 +230,6 @@
     "Find full-text PDF": "Buscar PDF del texto completo",
     "Full-text search failed. Try again.": "La búsqueda del texto completo ha fallado. Inténtelo de nuevo.",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "No se pudo añadir el PDF. Es posible que el enlace haya caducado, requiera iniciar sesión o que el archivo supere los 50 MB. Busque de nuevo o cargue un PDF.",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "Añada un DOI, PMID o PMCID para encontrar el PDF del texto completo correspondiente.",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC no está disponible. Los resultados pueden estar incompletos.",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex no está disponible. Los resultados pueden estar incompletos.",
     "Published version": "Versión publicada",
@@ -4860,6 +4859,11 @@
     "Retry turning off": "Reintentar la desactivación",
     "Local remote access remains enabled, but the latest external status check failed.": "El acceso remoto local sigue activado, pero la última comprobación del estado externo falló.",
     "The latest external status check failed.": "La última comprobación del estado externo falló.",
-    "Saved browser link": "Enlace del navegador guardado"
+    "Saved browser link": "Enlace del navegador guardado",
+    "arXiv": "arXiv",
+    "Direct PDF link": "Enlace directo al PDF",
+    "arXiv identifier required": "Se requiere un identificador de arXiv",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "PDF más reciente mediante el identificador de arXiv. No requiere clave de API. El archivo se verifica al descargarlo.",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Añada un DOI, PMID, PMCID o identificador de arXiv para encontrar un PDF de texto completo correspondiente."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -230,7 +230,6 @@
     "Find full-text PDF": "Rechercher le PDF intégral",
     "Full-text search failed. Try again.": "La recherche du texte intégral a échoué. Réessayez.",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "Impossible d’ajouter le PDF. Le lien a peut-être expiré, nécessite une connexion ou le fichier dépasse 50 MB. Relancez la recherche ou téléversez un PDF.",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "Ajoutez un DOI, PMID ou PMCID pour trouver le PDF intégral correspondant.",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC est indisponible. Les résultats peuvent être incomplets.",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex est indisponible. Les résultats peuvent être incomplets.",
     "Published version": "Version publiée",
@@ -4860,6 +4859,11 @@
     "Retry turning off": "Réessayer de désactiver",
     "Local remote access remains enabled, but the latest external status check failed.": "L’accès à distance local reste activé, mais la dernière vérification de l’état externe a échoué.",
     "The latest external status check failed.": "La dernière vérification de l’état externe a échoué.",
-    "Saved browser link": "Lien de navigateur enregistré"
+    "Saved browser link": "Lien de navigateur enregistré",
+    "arXiv": "arXiv",
+    "Direct PDF link": "Lien direct vers le PDF",
+    "arXiv identifier required": "Identifiant arXiv requis",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Dernier PDF via l’identifiant arXiv. Aucune clé API requise. Le fichier est vérifié lors du téléchargement.",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Ajoutez un DOI, PMID, PMCID ou identifiant arXiv pour trouver un PDF du texte intégral correspondant."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -224,7 +224,6 @@
     "Find full-text PDF": "全文 PDF を検索",
     "Full-text search failed. Try again.": "全文検索に失敗しました。再試行してください。",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "PDF を追加できませんでした。リンクの期限切れ、ログインの必要性、または 50 MB の超過が考えられます。再検索するか PDF をアップロードしてください。",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "一致する全文 PDF を検索するには、DOI、PMID または PMCID を追加してください。",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC を利用できません。結果が不完全な場合があります。",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex を利用できません。結果が不完全な場合があります。",
     "Published version": "出版版",
@@ -4546,6 +4545,11 @@
     "Retry turning off": "オフにする操作を再試行",
     "Local remote access remains enabled, but the latest external status check failed.": "ローカルのリモートアクセスは有効のままですが、直近の外部状態の確認に失敗しました。",
     "The latest external status check failed.": "直近の外部状態の確認に失敗しました。",
-    "Saved browser link": "保存済みのブラウザーリンク"
+    "Saved browser link": "保存済みのブラウザーリンク",
+    "arXiv": "arXiv",
+    "Direct PDF link": "PDF への直接リンク",
+    "arXiv identifier required": "arXiv 識別子が必要です",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "arXiv 識別子から最新の PDF を取得します。API キーは不要です。ダウンロード時にファイルを検証します。",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI、PMID、PMCID または arXiv 識別子を追加して、一致する全文 PDF を検索します。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -224,7 +224,6 @@
     "Find full-text PDF": "전문 PDF 찾기",
     "Full-text search failed. Try again.": "전문 검색에 실패했습니다. 다시 시도하세요.",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "PDF를 추가할 수 없습니다. 링크가 만료되었거나 로그인이 필요하거나 파일이 50 MB를 초과할 수 있습니다. 다시 검색하거나 PDF를 업로드하세요.",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "일치하는 전문 PDF를 찾으려면 DOI, PMID 또는 PMCID를 추가하세요.",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC를 사용할 수 없습니다. 결과가 불완전할 수 있습니다.",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex를 사용할 수 없습니다. 결과가 불완전할 수 있습니다.",
     "Published version": "출판본",
@@ -4544,6 +4543,11 @@
     "Retry turning off": "끄기 다시 시도",
     "Local remote access remains enabled, but the latest external status check failed.": "로컬 원격 액세스는 계속 활성화되어 있지만 최근 외부 상태 확인에 실패했습니다.",
     "The latest external status check failed.": "최근 외부 상태 확인에 실패했습니다.",
-    "Saved browser link": "저장된 브라우저 링크"
+    "Saved browser link": "저장된 브라우저 링크",
+    "arXiv": "arXiv",
+    "Direct PDF link": "PDF 직접 링크",
+    "arXiv identifier required": "arXiv 식별자 필요",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "arXiv 식별자로 최신 PDF를 가져옵니다. API 키가 필요하지 않습니다. 다운로드할 때 파일을 검증합니다.",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI, PMID, PMCID 또는 arXiv 식별자를 추가하여 일치하는 전문 PDF를 찾으세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -233,7 +233,6 @@
     "Find full-text PDF": "Найти PDF полного текста",
     "Full-text search failed. Try again.": "Не удалось найти полный текст. Повторите попытку.",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "Не удалось добавить PDF. Возможно, ссылка устарела, требуется вход или файл превышает 50 MB. Повторите поиск или загрузите PDF.",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "Добавьте DOI, PMID или PMCID, чтобы найти соответствующий PDF полного текста.",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC недоступен. Результаты могут быть неполными.",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex недоступен. Результаты могут быть неполными.",
     "Published version": "Опубликованная версия",
@@ -4992,6 +4991,11 @@
     "Retry turning off": "Повторить выключение",
     "Local remote access remains enabled, but the latest external status check failed.": "Локальный удалённый доступ остаётся включённым, но последняя проверка внешнего состояния завершилась ошибкой.",
     "The latest external status check failed.": "Последняя проверка внешнего состояния завершилась ошибкой.",
-    "Saved browser link": "Сохранённая ссылка для браузера"
+    "Saved browser link": "Сохранённая ссылка для браузера",
+    "arXiv": "arXiv",
+    "Direct PDF link": "Прямая ссылка на PDF",
+    "arXiv identifier required": "Требуется идентификатор arXiv",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Последний PDF по идентификатору arXiv. API-ключ не требуется. Файл проверяется при скачивании.",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Добавьте DOI, PMID, PMCID или идентификатор arXiv, чтобы найти подходящий PDF полного текста."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -224,7 +224,6 @@
     "Find full-text PDF": "查找全文 PDF",
     "Full-text search failed. Try again.": "全文检索失败，请重试。",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "无法添加 PDF。链接可能已失效、需要登录，或文件超过 50 MB。请重新检索或上传 PDF。",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "请添加 DOI、PMID 或 PMCID，以查找匹配的全文 PDF。",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC 暂不可用，结果可能不完整。",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex 暂不可用，结果可能不完整。",
     "Published version": "正式发表版本",
@@ -4546,6 +4545,11 @@
     "Retry turning off": "重试关闭",
     "Local remote access remains enabled, but the latest external status check failed.": "本地远程访问仍已启用，但最近一次外部状态检测失败。",
     "The latest external status check failed.": "最近一次外部状态检测失败。",
-    "Saved browser link": "已保存的浏览器链接"
+    "Saved browser link": "已保存的浏览器链接",
+    "arXiv": "arXiv",
+    "Direct PDF link": "PDF 直链",
+    "arXiv identifier required": "需要 arXiv 标识符",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "通过 arXiv 标识符获取最新 PDF。无需 API 密钥，下载时会校验文件。",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "添加 DOI、PMID、PMCID 或 arXiv 标识符以查找匹配的全文 PDF。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -224,7 +224,6 @@
     "Find full-text PDF": "尋找全文 PDF",
     "Full-text search failed. Try again.": "全文檢索失敗，請重試。",
     "PDF could not be added. The link may have expired, require sign-in, or exceed 50 MB. Search again or upload a PDF.": "無法新增 PDF。連結可能已失效、需要登入，或檔案超過 50 MB。請重新檢索或上傳 PDF。",
-    "Add a DOI, PMID or PMCID to find a matching full-text PDF.": "請新增 DOI、PMID 或 PMCID，以尋找相符的全文 PDF。",
     "Europe PMC is unavailable. Results may be incomplete.": "Europe PMC 暫時無法使用，結果可能不完整。",
     "OpenAlex is unavailable. Results may be incomplete.": "OpenAlex 暫時無法使用，結果可能不完整。",
     "Published version": "正式發表版本",
@@ -4546,6 +4545,11 @@
     "Retry turning off": "重試關閉",
     "Local remote access remains enabled, but the latest external status check failed.": "本機遠端存取仍已啟用，但最近一次外部狀態檢查失敗。",
     "The latest external status check failed.": "最近一次外部狀態檢查失敗。",
-    "Saved browser link": "已儲存的瀏覽器連結"
+    "Saved browser link": "已儲存的瀏覽器連結",
+    "arXiv": "arXiv",
+    "Direct PDF link": "PDF 直接連結",
+    "arXiv identifier required": "需要 arXiv 識別碼",
+    "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "透過 arXiv 識別碼取得最新 PDF。無需 API 金鑰，下載時會驗證檔案。",
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "新增 DOI、PMID、PMCID 或 arXiv 識別碼以尋找相符的全文 PDF。"
   }
 }

--- a/src/shared/literature.ts
+++ b/src/shared/literature.ts
@@ -803,7 +803,7 @@ const literatureMetadataCompletionResultSchema = z
 const literatureFullTextCandidateSchema = z
   .object({
     id: nonEmptyTextSchema,
-    provider: z.enum(['europe-pmc', 'openalex', 'unpaywall', 'pmc']),
+    provider: z.enum(['europe-pmc', 'openalex', 'unpaywall', 'pmc', 'arxiv']),
     url: z.string().url(),
     sourceUrl: z.string().url().optional(),
     source: nonEmptyTextSchema,


### PR DESCRIPTION
## Problem

References containing only an arXiv identifier are currently treated as missing identifiers by full-text lookup. Europe PMC also blocks OpenAlex discovery even though the sources are independent.

## Proposed change

Recognize existing arXiv identifiers and offer the official latest-version PDF and article links. Start all applicable metadata sources concurrently, then merge candidates in the existing stable provider order. Reserve one of the ten results for the identified arXiv PDF if it would otherwise be truncated, preserving first-provider attribution for duplicate URLs. Keep URL deduplication, candidate limits, download validation, and explicit source confirmation. Extend source guidance in all eight translated locales.

## Scope and non-goals

- Add `arxiv` to the full-text candidate provider enum. No task status, download phase, RPC method, MCP schema, or database changes.
- Existing batch journals and Agent Inbox provenance can store the new provider using their existing formats. Existing journals remain readable without migration. Older applications cannot read tasks containing the new provider; downgrade migration is intentionally excluded.
- Preserve existing versionless arXiv normalization, which resolves the latest version. Do not infer licenses or manuscript versions.
- No additional dependencies, browser download integration, institutional sessions, article-page scraping, or automatic source switching.

## Acceptance criteria and validation

The focused test set, Node typecheck and repository lint were rerun after the final candidate-limit fix. Web typecheck, Web build and real Web download/screenshots passed before this main-process-only follow-up; no renderer or shared contract code changed in the follow-up.

| Behavior | Command | Result |
| --- | --- | --- |
| arXiv discovery, parallel starts, deterministic precedence, saturated result limits and duplicate arXiv URLs, partial failure, selected attachment, source and download boundaries, shared schema, batch journal reload/revalidation, Agent provenance, renderer consumers and translations | `npm test -- src/main/literature/full-text-finder.test.ts src/main/literature/full-text-sources.test.ts src/main/literature/full-text-download.test.ts src/main/literature/full-text-download-progress.test.ts src/main/literature/full-text-proxy.test.ts src/main/literature/batch-jobs.test.ts src/main/literature/agent-pdf-acquisition.test.ts src/main/literature/library-mcp-server.test.ts src/shared/literature.test.ts src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx src/renderer/src/i18n/resources.test.ts` | 13 files, 1,038 tests passed |
| Main/shared and renderer types | `npm run typecheck:node`; `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Web bundle and generated map check | `npm run build:web` | Passed; existing bundle warnings only |
| Real Web interaction | `npm run dev:headless`, isolated storage, arXiv-only reference, open full-text lookup and expand sources | Correct source eligibility, canonical article link and explicit Add attachment action; real arXiv PDF download succeeded (2.1 MB) and one attachment was persisted; source and attachment screenshots inspected |
| Independent standards/spec reviews | Review final diff and consumer/test mapping | No findings |

No local full suite was run. Literature has no declared `test:module` ID, so explicit owner, contract, and consumer paths were selected. Shared discovery is used by individual lookup, batch jobs, and Agent acquisition; all three are covered. No ACP wire behavior or Electron-only interaction changed, and no new platform-specific filesystem logic was introduced. PR CI is the final authority for portable and platform lanes. Live publisher availability remains outside deterministic test guarantees.

## Review focus

Provider precedence after parallel completion, arXiv-only source applicability, and the new provider value in persisted task snapshots. Confirm final-head CI before squash merge.
