### PR TITLE
fix(cli): reject unused positional arguments

### DIFF
--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -140,6 +140,30 @@ const VALUE_OPTIONS = {
 
 const TASK_COMMANDS = new Set(['project', 'run', 'session', 'settings', 'plan', 'artifacts'])
 const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'settings', 'plan', 'artifacts'])
+// Project create, update, and session-defaults intentionally remain unbounded because their
+// positional Project names may contain multiple unquoted words.
+const POSITIONAL_LIMITS = new Map([
+  ['start', 0],
+  ['stop', 0],
+  ['status', 0],
+  ['url', 0],
+  ['update', 0],
+  ['rollback-to-0.7.3', 0],
+  ['codex login', 0],
+  ['project list', 0],
+  ['run', 0],
+  ['run status', 1],
+  ['run cancel', 1],
+  ['session status', 1],
+  ['session config', 2],
+  ['settings agent-routing', 1],
+  ['plan show', 1],
+  ['plan approve', 1],
+  ['plan reject', 1],
+  ['plan revise', 1],
+  ['artifacts list', 1],
+  ['artifacts download', 1]
+])
 
 export class CliUsageError extends Error {
   constructor(message) {
@@ -157,6 +181,16 @@ const parsePortOption = (value) => {
     throw new CliUsageError(`Invalid port: ${value}`)
   }
   return port
+}
+
+const assertPositionalLimit = (command, subcommand, positionals) => {
+  const commandPath = [command, subcommand].filter(Boolean).join(' ')
+  const limit = POSITIONAL_LIMITS.get(commandPath)
+  if (limit === undefined || positionals.length <= limit) return
+  if (limit === 0) throw new CliUsageError(`${commandPath} accepts no arguments.`)
+  throw new CliUsageError(
+    `${commandPath} accepts ${limit === 1 ? 'one argument' : 'two arguments'}.`
+  )
 }
 
 export const parseCliArgs = (argv) => {
@@ -335,9 +369,6 @@ export const parseCliArgs = (argv) => {
   if (options.force && (command !== 'codex' || subcommand !== 'login')) {
     throw new CliUsageError('--force requires codex login.')
   }
-  if (command === 'update' && positionals.length > 0) {
-    throw new CliUsageError('update accepts no arguments.')
-  }
   const isProjectCreate = command === 'project' && subcommand === 'create'
   const isProjectUpdate = command === 'project' && subcommand === 'update'
   const agentContextSources = [
@@ -375,7 +406,6 @@ export const parseCliArgs = (argv) => {
     if (options.json || options.jsonl) {
       throw new CliUsageError('codex login does not support machine-readable output.')
     }
-    if (positionals.length > 0) throw new CliUsageError('codex login accepts no arguments.')
   }
   const sessionConfigAction = command === 'session' && subcommand === 'config' && positionals[0]
   const projectDefaultsAction =
@@ -459,6 +489,7 @@ export const parseCliArgs = (argv) => {
   ) {
     throw new CliUsageError('Plan response options require a plan command.')
   }
+  assertPositionalLimit(command, subcommand, positionals)
   return {
     command,
     ...(subcommand ? { subcommand } : {}),

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -34,6 +34,92 @@ describe('task CLI', () => {
     expect(() => parseCliArgs(['start', '--port', '0'])).toThrow('Invalid port: 0')
   })
 
+  it.each([
+    { argv: ['start', 'unexpected'], message: 'start accepts no arguments.' },
+    { argv: ['stop', 'unexpected'], message: 'stop accepts no arguments.' },
+    { argv: ['status', 'unexpected'], message: 'status accepts no arguments.' },
+    { argv: ['url', 'unexpected'], message: 'url accepts no arguments.' },
+    { argv: ['update', 'unexpected'], message: 'update accepts no arguments.' },
+    {
+      argv: ['codex', 'login', 'unexpected'],
+      message: 'codex login accepts no arguments.'
+    },
+    {
+      argv: ['rollback-to-0.7.3', 'unexpected'],
+      message: 'rollback-to-0.7.3 accepts no arguments.'
+    },
+    { argv: ['project', 'list', 'unexpected'], message: 'project list accepts no arguments.' },
+    {
+      argv: ['run', 'unexpected', '--project', 'project-1', '--prompt', 'Research this.'],
+      message: 'run accepts no arguments.'
+    },
+    { argv: ['run', 'status', 'run-1', 'run-2'], message: 'run status accepts one argument.' },
+    { argv: ['run', 'cancel', 'run-1', 'run-2'], message: 'run cancel accepts one argument.' },
+    {
+      argv: ['session', 'status', 'session-1', 'session-2'],
+      message: 'session status accepts one argument.'
+    },
+    {
+      argv: ['session', 'config', 'show', 'session-1', 'session-2'],
+      message: 'session config accepts two arguments.'
+    },
+    {
+      argv: ['session', 'config', 'update', 'session-1', 'session-2'],
+      message: 'session config accepts two arguments.'
+    },
+    {
+      argv: ['settings', 'agent-routing', 'show', 'unexpected'],
+      message: 'settings agent-routing accepts one argument.'
+    },
+    {
+      argv: ['settings', 'agent-routing', 'update', 'unexpected'],
+      message: 'settings agent-routing accepts one argument.'
+    },
+    {
+      argv: ['plan', 'show', 'session-1', 'session-2'],
+      message: 'plan show accepts one argument.'
+    },
+    {
+      argv: ['plan', 'approve', 'session-1', 'session-2'],
+      message: 'plan approve accepts one argument.'
+    },
+    {
+      argv: ['plan', 'reject', 'session-1', 'session-2'],
+      message: 'plan reject accepts one argument.'
+    },
+    {
+      argv: ['plan', 'revise', 'session-1', 'session-2'],
+      message: 'plan revise accepts one argument.'
+    },
+    {
+      argv: ['artifacts', 'list', 'session-1', 'session-2'],
+      message: 'artifacts list accepts one argument.'
+    },
+    {
+      argv: ['artifacts', 'download', 'artifact-1', 'artifact-2'],
+      message: 'artifacts download accepts one argument.'
+    }
+  ])('rejects unused positional arguments before dispatch', ({ argv, message }) => {
+    expect(() => parseCliArgs(argv)).toThrow(message)
+  })
+
+  it.each([
+    ['create', ['project', 'create', 'Systematic', 'review'], ['Systematic', 'review']],
+    ['update', ['project', 'update', 'Systematic', 'review'], ['Systematic', 'review']],
+    [
+      'session-defaults show',
+      ['project', 'session-defaults', 'show', 'Systematic', 'review'],
+      ['show', 'Systematic', 'review']
+    ],
+    [
+      'session-defaults update',
+      ['project', 'session-defaults', 'update', 'Systematic', 'review'],
+      ['update', 'Systematic', 'review']
+    ]
+  ])('preserves a multi-word Project name for project %s', (_label, argv, positionals) => {
+    expect(parseCliArgs(argv).positionals).toEqual(positionals)
+  })
+
   it('parses the first milestone run interface', () => {
     expect(
       parseCliArgs(['project', 'create', 'Research', '--agent-context', 'Always cite sources.'])


### PR DESCRIPTION
## Problem

Fixed-arity CLI commands retained surplus positional arguments and then ignored them during dispatch. A typo such as `open-science run unexpected --project ...` could therefore start a run that the caller did not intend.

Closes #2264

## Proposed change

- Define positional-argument limits for every fixed-arity command path.
- Raise `CliUsageError` during argument parsing, before daemon connection or dispatch.
- Keep `project create`, `project update`, and `project session-defaults` unbounded so unquoted multi-word Project names continue to work.
- Add table-driven regression coverage for every fixed-arity path and the multi-word Project-name exceptions.

## Scope and non-goals

This only rejects surplus positional arguments. Validation for missing required positionals and unknown grouped subcommands is unchanged.

## Acceptance criteria and validation

All passing checks below ran after the final material edit on Windows:

- Fixed-arity commands reject extra positionals -> `npx vitest run cli packages/open-science` -> 20 files passed; 364 tests passed, 21 skipped.
- Multi-word Project names remain accepted -> same CLI Gate -> passed.
- Node and renderer types -> `npm run typecheck` -> passed.
- Lint -> `npm run lint` -> passed.
- Formatting -> `npx prettier --check packages/open-science/cli.mjs packages/open-science/cli.test.ts` -> passed.
- Patch whitespace -> `git diff --check` -> passed.

Full fallback attempt:

- `npm test` exited 1 locally after 1,235 test files and 20,593 tests passed; 242 files / 54 tests failed outside the changed CLI surface. Failures were associated with unavailable Windows symlink privileges, a missing `py` launcher, and resource exhaustion in the default high-concurrency run. No failing suite imports the modified CLI module, and the exact CLI Gate passes. Exact-head CI remains authoritative.

No E2E or platform-specific lane was added because validation happens in the pure argument parser before I/O.

## Review focus

- Completeness and accuracy of the positional-limit table versus the documented commands.
- Preservation of multi-word Project names on the intentionally unbounded Project command families.