### PR TITLE
fix(network): align access policies and settings feedback

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/gateway/address-policy.ts
+++ b/packages/notebook-network-sandbox/runtime/src/gateway/address-policy.ts
@@ -12,6 +12,7 @@ type Rule = Readonly<{
 
 type DestinationPolicyOptions = Readonly<{
   allowedDomains: readonly string[]
+  askDomains?: readonly string[]
   deniedDomains: readonly string[]
   deniedDomainReasons?: Readonly<Record<string, string>>
 }>
@@ -167,11 +168,13 @@ const isInternetAddress = (address: string): boolean => {
 
 class DestinationPolicy {
   readonly #allowed: readonly Rule[]
+  readonly #asked: readonly Rule[]
   readonly #denied: readonly Readonly<{ raw: string; rule: Rule }>[]
   readonly #reasons: Readonly<Record<string, string>>
 
   constructor(options: DestinationPolicyOptions) {
     this.#allowed = options.allowedDomains.map(parseRule)
+    this.#asked = (options.askDomains ?? []).map(parseRule)
     this.#denied = options.deniedDomains.map((raw) => ({ raw, rule: parseRule(raw) }))
     this.#reasons = options.deniedDomainReasons ?? {}
   }
@@ -204,7 +207,14 @@ class DestinationPolicy {
       }
     }
     const address = addresses[0]!
-    if (this.#allowed.some((rule) => ruleAccepts(rule, host, port))) {
+    const needsApproval = this.#asked.some((rule) => ruleAccepts(rule, host, port))
+    if (
+      this.#allowed.some(
+        (rule) =>
+          ruleAccepts(rule, host, port) &&
+          (!needsApproval || (!rule.subdomains && !rule.labels && !rule.all))
+      )
+    ) {
       return { kind: 'allow', address }
     }
     return { kind: 'ask', host, address }

--- a/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
+++ b/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
@@ -32,6 +32,7 @@ type SandboxDependencyCheck = Readonly<{ warnings: string[]; errors: string[] }>
 
 type NetworkRuntimeConfig = Readonly<{
   allowedDomains: readonly string[]
+  askDomains?: readonly string[]
   deniedDomains: readonly string[]
   deniedDomainReasons?: Readonly<Record<string, string>>
   parentProxy?: Readonly<{ http?: string; https?: string; noProxy?: string }>
@@ -87,6 +88,7 @@ const parentSettings = (config: NetworkRuntimeConfig): ParentProxySettings | und
 const buildPolicy = (config: NetworkRuntimeConfig): DestinationPolicy =>
   new DestinationPolicy({
     allowedDomains: config.allowedDomains,
+    askDomains: config.askDomains,
     deniedDomains: config.deniedDomains,
     ...(config.deniedDomainReasons ? { deniedDomainReasons: config.deniedDomainReasons } : {})
   })

--- a/packages/notebook-network-sandbox/src/config.ts
+++ b/packages/notebook-network-sandbox/src/config.ts
@@ -72,6 +72,7 @@ const validateDomainPattern = (pattern: string, allowFlexibleWildcard: boolean):
 
 const normalizePolicy = (policy: NotebookNetworkPolicy): NotebookNetworkPolicy => ({
   allowedDomains: normalizeDomains(policy.allowedDomains),
+  ...(policy.askDomains ? { askDomains: normalizeDomains(policy.askDomains) } : {}),
   deniedDomains: normalizeDomains(policy.deniedDomains),
   ...(policy.deniedDomainReasons
     ? {
@@ -91,6 +92,7 @@ const createRuntimeConfig = (
   const arch = architectureDirectory(architecture)
   const policy = normalizePolicy(options.policy)
   for (const domain of policy.allowedDomains) validateDomainPattern(domain, false)
+  for (const domain of policy.askDomains ?? []) validateDomainPattern(domain, false)
   for (const domain of policy.deniedDomains) validateDomainPattern(domain, true)
   const resourceRoot = options.resources.root
   const installationId = WINDOWS_INSTALLATION_ID
@@ -103,6 +105,7 @@ const createRuntimeConfig = (
   )
   return {
     allowedDomains: [...policy.allowedDomains],
+    ...(policy.askDomains ? { askDomains: [...policy.askDomains] } : {}),
     deniedDomains: [...policy.deniedDomains],
     ...(policy.deniedDomainReasons
       ? { deniedDomainReasons: { ...policy.deniedDomainReasons } }

--- a/packages/notebook-network-sandbox/src/runtime-config.test.ts
+++ b/packages/notebook-network-sandbox/src/runtime-config.test.ts
@@ -7,6 +7,10 @@ const gateway = vi.hoisted(() => ({
   close: vi.fn().mockResolvedValue(undefined)
 }))
 
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => [{ address: '8.8.8.8', family: 4 }])
+}))
+
 vi.mock('../runtime/src/gateway/command-gateway.js', () => ({
   CommandGateway: { open: vi.fn().mockResolvedValue(gateway) }
 }))
@@ -38,6 +42,11 @@ import {
   type NetworkRuntimeConfig
 } from '../runtime/src/notebook-runtime.js'
 import { CommandGateway } from '../runtime/src/gateway/command-gateway.js'
+import {
+  buildNotebookNetworkPolicy,
+  normalizeNotebookNetworkSettings
+} from '../../../src/shared/notebook-network.js'
+import { createRuntimeConfig } from './config.js'
 import { linuxLaunch } from '../runtime/src/platform/linux-isolation.js'
 import { readAppContainerStatus } from '../runtime/src/platform/windows-appcontainer.js'
 import {
@@ -78,6 +87,22 @@ afterEach(async () => {
 })
 
 describe('Notebook runtime configuration updates', () => {
+  it('routes disabled overlapping domains through approval after a live policy update', async () => {
+    const settings = normalizeNotebookNetworkSettings({
+      disabledOpenScienceDomains: ['rest.uniprot.org']
+    })
+    const next = (value: typeof settings): NetworkRuntimeConfig =>
+      createRuntimeConfig({
+        resources: { root: '/resources' },
+        policy: buildNotebookNetworkPolicy(value)
+      })
+    NotebookNetworkRuntime.updateConfig(next(settings))
+    const decide = vi.mocked(CommandGateway.open).mock.calls[0]![0].decide
+    await expect(decide('rest.uniprot.org', 443)).resolves.toMatchObject({ allowed: false })
+    await expect(decide('www.uniprot.org', 443)).resolves.toMatchObject({ allowed: true })
+    NotebookNetworkRuntime.updateConfig(next({ ...settings, allowedDomains: ['rest.uniprot.org'] }))
+    await expect(decide('rest.uniprot.org', 443)).resolves.toMatchObject({ allowed: true })
+  })
   it('disconnects existing tunnels before they can outlive a policy change', () => {
     NotebookNetworkRuntime.updateConfig(config([]))
 

--- a/packages/notebook-network-sandbox/src/types.ts
+++ b/packages/notebook-network-sandbox/src/types.ts
@@ -1,5 +1,7 @@
 export type NotebookNetworkPolicy = Readonly<{
   allowedDomains: readonly string[]
+  /** Overrides wildcard allows; an exact allow still represents explicit approval. */
+  askDomains?: readonly string[]
   deniedDomains: readonly string[]
   deniedDomainReasons?: Readonly<Record<string, string>>
 }>

--- a/src/main/notebook/mirror-probe.test.ts
+++ b/src/main/notebook/mirror-probe.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { netFetchStandard } from '../skills/net-fetch'
+import { mirrorStatusText } from '../../renderer/src/pages/settings/mirror-view'
+import { i18next } from '../../renderer/src/i18n'
 
 import {
   DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
@@ -206,6 +208,14 @@ describe('pickFastestMirror', () => {
 })
 
 describe('effectiveMirrorAsync', () => {
+  it('describes automatic selection when an unconfigured install selects a third-party mirror', async () => {
+    const effective = await effectiveMirrorAsync(undefined, 'en-US', {
+      candidates,
+      probe: probeFrom(reachableLatencies)
+    })
+    expect(effective.condaChannel).toBe('https://tuna/conda-forge/')
+    expect(mirrorStatusText(undefined, i18next.getFixedT('en'))).toBe('Automatic mirror selection')
+  })
   it('returns the user override without probing', async () => {
     const probe = vi.fn()
     const result = await effectiveMirrorAsync({ condaChannel: 'https://corp/conda' }, 'en-US', {

--- a/src/main/settings/network-proxy-settings.test.ts
+++ b/src/main/settings/network-proxy-settings.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { NetworkProxySettings } from '../../shared/network-proxy'
 import { createEmptySettings } from './types'
+import { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
 
 vi.mock('electron', () => ({
   app: { getPath: () => tmpdir(), getAppPath: () => tmpdir(), isPackaged: false },
@@ -25,6 +26,34 @@ describe('Network proxy settings persistence', () => {
 
   afterEach(async () => {
     await rm(dir, { recursive: true, force: true })
+  })
+
+  it('returns the applied proxy when the subsequent settings projection fails', async () => {
+    const repository = new SettingsRepository(dir)
+    let applied: NetworkProxySettings = { mode: 'system' }
+    const service = new SettingsService({
+      repository,
+      configRoot: dir,
+      applyNetworkProxy: async (value) => {
+        applied = value
+      }
+    })
+    const publish = vi.fn()
+    const commits = new SettingsSnapshotCommitOwner(
+      {
+        getSettingsView: vi.fn().mockRejectedValue(new Error('snapshot unavailable'))
+      },
+      { publish }
+    )
+    const outcome = await commits.projectAfter(service.setNetworkProxy({ mode: 'direct' })).then(
+      (value) => ({ value }),
+      (error) => ({ error })
+    )
+
+    expect((await repository.getSettings()).networkProxy).toEqual({ mode: 'direct' })
+    expect(applied).toEqual({ mode: 'direct' })
+    expect(outcome).toEqual({ value: { mode: 'direct' } })
+    expect(publish).not.toHaveBeenCalled()
   })
 
   it('round-trips a normalized manual proxy without credentials', async () => {

--- a/src/main/settings/settings-snapshot-commit-owner.test.ts
+++ b/src/main/settings/settings-snapshot-commit-owner.test.ts
@@ -23,6 +23,22 @@ const snapshot = (): SettingsSnapshot => ({
 })
 
 describe('SettingsSnapshotCommitOwner', () => {
+  it('preserves real operation errors and allows projection recovery after publication fails', async () => {
+    const current = snapshot()
+    const read = vi.fn().mockResolvedValue(current)
+    const failure = new Error('apply failed')
+    const publish = vi.fn().mockImplementationOnce(() => {
+      throw new Error('publication failed')
+    })
+    const owner = new SettingsSnapshotCommitOwner({ getSettingsView: read }, { publish })
+
+    await expect(owner.projectAfter(Promise.reject(failure))).rejects.toBe(failure)
+    expect(read).not.toHaveBeenCalled()
+    await expect(owner.projectAfter(Promise.resolve('saved'))).resolves.toBe('saved')
+    await expect(owner.readCurrentSnapshot()).resolves.toBe(current)
+    await expect(owner.projectAfter(Promise.resolve('saved again'))).resolves.toBe('saved again')
+    expect(publish).toHaveBeenCalledTimes(2)
+  })
   it('assigns monotonic revisions to distinct committed projections', async () => {
     const first = snapshot()
     const second = snapshot()

--- a/src/main/settings/settings-snapshot-commit-owner.ts
+++ b/src/main/settings/settings-snapshot-commit-owner.ts
@@ -21,7 +21,13 @@ class SettingsSnapshotCommitOwner {
 
   async projectAfter<Result>(pending: Promise<Result>): Promise<Result> {
     const result = await pending
-    await this.enqueueCurrentSnapshot(true)
+    try {
+      await this.enqueueCurrentSnapshot(true)
+    } catch (error) {
+      // The operation has already committed. A projection failure cannot undo it or turn
+      // its authoritative result into a failed save. Explicit snapshot reads remain retryable.
+      console.warn('Settings operation completed, but snapshot publication failed.', error)
+    }
     return result
   }
 

--- a/src/main/settings/settings-snapshot-commit-owner.ts
+++ b/src/main/settings/settings-snapshot-commit-owner.ts
@@ -1,5 +1,8 @@
 import type { SettingsSnapshot } from '../../shared/settings'
 import type { ApplicationEventPublisher } from '../application-events'
+import { createLogger, diagnosticErrorFields } from '../logger'
+
+const log = createLogger('settings')
 
 type SettingsSnapshotStore = {
   getSettingsView(): Promise<SettingsSnapshot>
@@ -26,7 +29,10 @@ class SettingsSnapshotCommitOwner {
     } catch (error) {
       // The operation has already committed. A projection failure cannot undo it or turn
       // its authoritative result into a failed save. Explicit snapshot reads remain retryable.
-      console.warn('Settings operation completed, but snapshot publication failed.', error)
+      log.warn(
+        'Settings operation completed, but snapshot publication failed.',
+        diagnosticErrorFields(error)
+      )
     }
     return result
   }

--- a/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.render.test.tsx
@@ -47,6 +47,23 @@ const changeInput = async (input: HTMLInputElement, value: string): Promise<void
 }
 
 describe('NetworkPanel offline retry', () => {
+  it('allows checking again after a successful reachability probe', async () => {
+    Object.defineProperty(window.navigator, 'onLine', { value: true, configurable: true })
+    useNetworkStore.setState({ isOnline: true, connectivity: 'reachable' })
+    const checkConnectivity = vi.fn().mockResolvedValue(false)
+    ;(window as unknown as { api: unknown }).api = { network: { checkConnectivity } }
+    await act(async () =>
+      root.render(<NetworkPanel view={{ kind: 'list' }} onNavigate={() => {}} />)
+    )
+    expect(buttonWithText('Check again')).not.toBeUndefined()
+    await act(async () => buttonWithText('Check again').click())
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500)
+    })
+    expect(container.textContent).toContain(
+      'The network link is up, but package registries are unreachable.'
+    )
+  })
   it('confirms a CA bundle change and shows progress while saving', async () => {
     let resolveSave!: () => void
     const setPackageMirror = vi.fn(

--- a/src/renderer/src/pages/settings/NetworkPanel.tsx
+++ b/src/renderer/src/pages/settings/NetworkPanel.tsx
@@ -247,26 +247,28 @@ const NetworkPanel = ({
               )}
             </ul>
 
-            {!isOnline || connectivity === 'unreachable' || connectivity === 'probe-failed' ? (
-              <div className="mb-4 rounded-lg bg-bg-10 px-4 py-4 ring-1 ring-border-200">
-                <ol className="list-decimal space-y-1 pl-5 text-xs leading-relaxed text-muted-foreground">
-                  {!isOnline ? <li>{t('Check your cable or Wi-Fi connection.')}</li> : null}
-                  <li>{t('Check proxy, VPN, or firewall settings.')}</li>
-                  <li>{t('Check the package mirror configuration below.')}</li>
-                </ol>
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="mt-3"
-                  onClick={handleRetry}
-                  disabled={isChecking}
-                >
-                  <RefreshCw className={cn(isChecking && 'animate-spin')} aria-hidden="true" />
-                  {isChecking ? t('Checking…') : t('Check again')}
-                </Button>
-              </div>
-            ) : null}
+            <div className="pb-4">
+              {!isOnline || connectivity === 'unreachable' || connectivity === 'probe-failed' ? (
+                <div className="mb-4 rounded-lg bg-bg-10 px-4 py-4 ring-1 ring-border-200">
+                  <ol className="list-decimal space-y-1 pl-5 text-xs leading-relaxed text-muted-foreground">
+                    {!isOnline ? <li>{t('Check your cable or Wi-Fi connection.')}</li> : null}
+                    <li>{t('Check proxy, VPN, or firewall settings.')}</li>
+                    <li>{t('Check the package mirror configuration below.')}</li>
+                  </ol>
+                </div>
+              ) : null}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="mt-3"
+                onClick={handleRetry}
+                disabled={isChecking}
+              >
+                <RefreshCw className={cn(isChecking && 'animate-spin')} aria-hidden="true" />
+                {isChecking ? t('Checking…') : t('Check again')}
+              </Button>
+            </div>
           </div>
         </section>
       ) : null}

--- a/src/renderer/src/pages/settings/NetworkProxyForm.test.tsx
+++ b/src/renderer/src/pages/settings/NetworkProxyForm.test.tsx
@@ -3,9 +3,14 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { DEFAULT_NETWORK_PROXY_SETTINGS } from '../../../../shared/network-proxy'
+import {
+  DEFAULT_NETWORK_PROXY_SETTINGS,
+  type NetworkProxySettings
+} from '../../../../shared/network-proxy'
 import { createInitialSettingsState, useSettingsStore } from '../../stores/settings-store'
 import { NetworkProxyForm } from './NetworkProxyForm'
+import { fireEvent } from '@testing-library/react'
+import { i18next } from '@/i18n'
 
 let container: HTMLDivElement
 let root: Root
@@ -33,6 +38,70 @@ describe('NetworkProxyForm', () => {
     act(() => root.unmount())
     container.remove()
     vi.restoreAllMocks()
+    void i18next.changeLanguage('en')
+  })
+
+  it('only confirms the visible proxy that was submitted before a delayed save', async () => {
+    const saved = { mode: 'manual' as const, server: 'http://proxy-a.example:8080' }
+    let finish!: () => void
+    const save = vi.fn<(settings: NetworkProxySettings) => Promise<void>>(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        })
+    )
+    useSettingsStore.setState({ networkProxy: saved, setNetworkProxy: save })
+    act(() => root.render(<NetworkProxyForm onDone={vi.fn()} />))
+    await act(async () =>
+      click([...container.querySelectorAll('button')].find((b) => b.textContent === 'Save')!)
+    )
+    const input = container.querySelector<HTMLInputElement>('#network-proxy-server')!
+    if (!input.disabled)
+      act(() => {
+        fireEvent.change(input, { target: { value: 'http://proxy-b.example:8080' } })
+      })
+    expect
+      .soft(container.querySelector<HTMLButtonElement>('[aria-label="Proxy mode"]')!.disabled)
+      .toBe(true)
+    expect
+      .soft(container.querySelector<HTMLInputElement>('#network-proxy-bypass')!.disabled)
+      .toBe(true)
+    await act(async () => finish())
+    expect(container.querySelector('[role="status"]')?.textContent).toContain(
+      'Proxy settings saved.'
+    )
+    expect(input.value).toBe(save.mock.calls[0]?.[0]?.server)
+  })
+
+  it('clears the saved confirmation when bypass rules are edited', async () => {
+    useSettingsStore.setState({
+      networkProxy: { mode: 'manual', server: 'http://proxy.example:8080' },
+      setNetworkProxy: vi.fn().mockResolvedValue(undefined)
+    })
+    act(() => root.render(<NetworkProxyForm onDone={vi.fn()} />))
+    await act(async () =>
+      click([...container.querySelectorAll('button')].find((b) => b.textContent === 'Save')!)
+    )
+    expect(container.querySelector('[role="status"]')).not.toBeNull()
+    act(() => {
+      fireEvent.change(container.querySelector('#network-proxy-bypass')!, {
+        target: { value: 'internal.example' }
+      })
+    })
+    expect(container.querySelector('[role="status"]')).toBeNull()
+  })
+
+  it.each([
+    ['zh-Hans', '请输入代理服务器 URL，例如 http://127.0.0.1:1086。'],
+    ['zh-Hant', '請輸入代理伺服器 URL，例如 http://127.0.0.1:1086。']
+  ])('translates a blurred empty proxy server in %s', async (language, expected) => {
+    await i18next.changeLanguage(language)
+    useSettingsStore.setState({ networkProxy: { mode: 'manual', server: '' } })
+    act(() => root.render(<NetworkProxyForm onDone={vi.fn()} />))
+    act(() => {
+      fireEvent.blur(container.querySelector('#network-proxy-server')!)
+    })
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe(expected)
   })
 
   it('renders System as the historical default and explains process lifecycle', () => {

--- a/src/renderer/src/pages/settings/NetworkProxyForm.tsx
+++ b/src/renderer/src/pages/settings/NetworkProxyForm.tsx
@@ -90,6 +90,7 @@ const NetworkProxyForm = ({ onDone }: NetworkProxyFormProps): React.JSX.Element 
           className="pt-0"
         >
           <Select
+            disabled={isSaving}
             value={draft.mode}
             onValueChange={(value) => handleModeChange(value as NetworkProxyMode)}
           >
@@ -123,6 +124,7 @@ const NetworkProxyForm = ({ onDone }: NetworkProxyFormProps): React.JSX.Element 
                   aria-invalid={showServerError ? true : undefined}
                   aria-describedby="network-proxy-server-help"
                   value={draft.server ?? ''}
+                  disabled={isSaving}
                   placeholder={t('http://127.0.0.1:1086')}
                   onBlur={() => setServerTouched(true)}
                   onChange={(event) => {
@@ -141,7 +143,7 @@ const NetworkProxyForm = ({ onDone }: NetworkProxyFormProps): React.JSX.Element 
                   }
                   role={showServerError ? 'alert' : undefined}
                 >
-                  {showServerError || t('Example: http://127.0.0.1:1086')}
+                  {showServerError ? t(showServerError) : t('Example: http://127.0.0.1:1086')}
                 </p>
               </div>
             </SettingsRow>
@@ -156,10 +158,13 @@ const NetworkProxyForm = ({ onDone }: NetworkProxyFormProps): React.JSX.Element 
                 id="network-proxy-bypass"
                 aria-label={t('Proxy bypass rules')}
                 value={draft.bypassRules ?? ''}
+                disabled={isSaving}
                 placeholder={t('*.internal.example, 10.0.0.0/8')}
-                onChange={(event) =>
+                onChange={(event) => {
                   setDraft((current) => ({ ...current, bypassRules: event.target.value }))
-                }
+                  setMessage(undefined)
+                  setIsSuccess(false)
+                }}
               />
             </SettingsRow>
           </>

--- a/src/renderer/src/pages/settings/NotebookNetworkDomainsForm.render.test.tsx
+++ b/src/renderer/src/pages/settings/NotebookNetworkDomainsForm.render.test.tsx
@@ -53,6 +53,58 @@ afterEach(() => {
 })
 
 describe('NotebookNetworkDomainsForm', () => {
+  it('does not discard domain edits when a pending save completes', async () => {
+    let finish!: (value: typeof DEFAULT_NOTEBOOK_NETWORK_SETTINGS) => void
+    const save = vi.fn(
+      () =>
+        new Promise<typeof DEFAULT_NOTEBOOK_NETWORK_SETTINGS>((resolve) => {
+          finish = resolve
+        })
+    )
+    useSettingsStore.setState({ setNotebookNetwork: save })
+    await act(async () => root.render(<NotebookNetworkDomainsForm />))
+    await act(async () => button('Save changes').click())
+    const input = container.querySelector<HTMLInputElement>('[aria-label="Domain hostname"]')!
+    if (!input.disabled) {
+      await typeInput(input, 'during-save.example.org')
+      await act(async () => button('Add').click())
+    }
+    const before = container.querySelector('[aria-label="Allowed domains"]')!.textContent
+    await act(async () => finish(DEFAULT_NOTEBOOK_NETWORK_SETTINGS))
+    expect(container.querySelector('[aria-label="Allowed domains"]')!.textContent).toBe(before)
+    expect(input.disabled).toBe(false)
+  })
+
+  it('disables every domain editor while saving and clears success after another edit', async () => {
+    let finish!: (value: typeof DEFAULT_NOTEBOOK_NETWORK_SETTINGS) => void
+    const saved = { ...DEFAULT_NOTEBOOK_NETWORK_SETTINGS, allowedDomains: ['existing.example.org'] }
+    useSettingsStore.setState({
+      notebookNetwork: saved,
+      setNotebookNetwork: vi.fn(
+        () =>
+          new Promise<typeof DEFAULT_NOTEBOOK_NETWORK_SETTINGS>((resolve) => {
+            finish = resolve
+          })
+      )
+    })
+    await act(async () => root.render(<NotebookNetworkDomainsForm />))
+    await typeInput(container.querySelector('input')!, 'next.example.org')
+    await act(async () => button('Save changes').click())
+    const controls = container.querySelectorAll<HTMLInputElement | HTMLButtonElement>(
+      '[aria-label="Open Science domains"] button, [aria-label="Allowed domains"] button, input'
+    )
+    expect
+      .soft(
+        [...controls]
+          .filter((control) => !control.disabled)
+          .map((control) => control.getAttribute('aria-label') ?? control.textContent)
+      )
+      .toEqual([])
+    await act(async () => finish(saved))
+    expect(container.querySelector('[role="status"]')).not.toBeNull()
+    await act(async () => button('Add').click())
+    expect(container.querySelector('[role="status"]')).toBeNull()
+  })
   it('locks package registries and validates, adds, removes, and saves custom domains', async () => {
     await act(async () => root.render(<NotebookNetworkDomainsForm />))
     await flush()

--- a/src/renderer/src/pages/settings/NotebookNetworkDomainsForm.tsx
+++ b/src/renderer/src/pages/settings/NotebookNetworkDomainsForm.tsx
@@ -102,6 +102,7 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
   }
 
   const toggleGroup = (id: OpenScienceDomainGroupId, enabled: boolean): void => {
+    setMessage(undefined)
     const disabled = new Set(draft.disabledOpenScienceDomainGroups)
     if (enabled) disabled.delete(id)
     else disabled.add(id)
@@ -109,6 +110,7 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
   }
 
   const toggleBuiltInDomain = (domain: string, enabled: boolean): void => {
+    setMessage(undefined)
     const disabled = new Set(draft.disabledOpenScienceDomains)
     if (enabled) disabled.delete(domain)
     else disabled.add(domain)
@@ -266,6 +268,11 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
         <h3 className="mb-1 text-sm font-semibold text-foreground">{t('Open Science domains')}</h3>
         <p className="mb-3 text-xs leading-relaxed text-muted-foreground">
           {t(
+            'Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.'
+          )}
+        </p>
+        <p className="mb-3 text-xs leading-relaxed text-muted-foreground">
+          {t(
             'Notebook Python, R, REPL, Bash, and package downloads use enabled scientific services and domains you add below. Protected execution blocks other outbound domains.'
           )}
         </p>
@@ -288,7 +295,7 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
                   </div>
                   <Switch
                     checked={groupEnabled}
-                    disabled={group.locked}
+                    disabled={isSaving || group.locked}
                     aria-label={t('Allow {{name}}', { name: t(GROUP_LABELS[group.id]) })}
                     onClick={(event) => event.stopPropagation()}
                     onCheckedChange={(checked) => toggleGroup(group.id, checked)}
@@ -300,7 +307,7 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
                       <code className="break-all text-foreground">{domain}</code>
                       <Switch
                         size="sm"
-                        disabled={!groupEnabled || group.locked}
+                        disabled={isSaving || !groupEnabled || group.locked}
                         checked={groupEnabled && !draft.disabledOpenScienceDomains.includes(domain)}
                         aria-label={t('Allow {{domain}}', { domain })}
                         onCheckedChange={(checked) => toggleBuiltInDomain(domain, checked)}
@@ -325,9 +332,13 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
           <div className="flex gap-2">
             <Input
               value={newDomain}
+              disabled={isSaving}
               aria-label={t('Domain hostname')}
               placeholder={DOMAIN_EXAMPLE}
-              onChange={(event) => setNewDomain(event.target.value)}
+              onChange={(event) => {
+                setNewDomain(event.target.value)
+                setMessage(undefined)
+              }}
               onKeyDown={(event) => {
                 if (event.key === 'Enter') {
                   event.preventDefault()
@@ -335,7 +346,12 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
                 }
               }}
             />
-            <Button type="button" variant="outline" onClick={addDomain} disabled={!newDomain}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={addDomain}
+              disabled={isSaving || !newDomain}
+            >
               <Plus aria-hidden="true" />
               {t('Add')}
             </Button>
@@ -349,13 +365,15 @@ const NotebookNetworkDomainsForm = (): React.JSX.Element => {
                     type="button"
                     variant="ghost"
                     size="icon-sm"
+                    disabled={isSaving}
                     aria-label={t('Remove {{domain}}', { domain })}
-                    onClick={() =>
+                    onClick={() => {
+                      setMessage(undefined)
                       setDraft({
                         ...draft,
                         allowedDomains: draft.allowedDomains.filter((item) => item !== domain)
                       })
-                    }
+                    }}
                   >
                     <Trash2 aria-hidden="true" />
                   </Button>

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -3391,7 +3391,7 @@ describe('SettingsPage layout', () => {
     })
 
     // Unconfigured by default (the mocked getSettings snapshot has no packageMirror).
-    expect(document.body.textContent).toContain('Not configured')
+    expect(document.body.textContent).toContain('Automatic mirror selection')
 
     const configureButton = Array.from(
       document.body.querySelectorAll<HTMLButtonElement>('button')

--- a/src/renderer/src/pages/settings/mirror-view.test.ts
+++ b/src/renderer/src/pages/settings/mirror-view.test.ts
@@ -17,10 +17,8 @@ describe('isMirrorConfigured', () => {
 })
 
 describe('mirrorStatusText', () => {
-  it('shows the default public-hosts message when unconfigured', () => {
-    expect(mirrorStatusText(undefined, t)).toBe(
-      'Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)'
-    )
+  it('describes automatic selection when unconfigured', () => {
+    expect(mirrorStatusText(undefined, t)).toBe('Automatic mirror selection')
   })
   it('summarizes the configured hosts when set', () => {
     expect(
@@ -29,12 +27,12 @@ describe('mirrorStatusText', () => {
   })
   it('reports a trust-only configuration without inventing a package host', () => {
     expect(mirrorStatusText({ caBundle: '/certs/complete.pem' }, t)).toBe(
-      'Custom CA bundle configured'
+      'Automatic mirror selection · Custom CA bundle configured'
     )
   })
   it('translates the sentence but keeps the host values verbatim', () => {
     const zh = i18next.getFixedT('zh-Hans')
-    expect(mirrorStatusText(undefined, zh)).toContain('未配置')
+    expect(mirrorStatusText(undefined, zh)).toContain('自动选择镜像')
     expect(mirrorStatusText({ condaChannel: 'https://c' }, zh)).toBe('正在从 https://c 获取软件包')
   })
 })

--- a/src/renderer/src/pages/settings/mirror-view.ts
+++ b/src/renderer/src/pages/settings/mirror-view.ts
@@ -10,14 +10,14 @@ export { MIRROR_HELP_URL } from '../../../../shared/mirror'
 export const isMirrorConfigured = (mirror: PackageMirror | undefined): boolean =>
   Boolean(mirror && (mirror.condaChannel || mirror.pypiIndex || mirror.caBundle))
 
-// Default state copy matches the mockup exactly; configured state summarizes the active hosts.
+// Summarize configured preferences without claiming which automatic candidate is active.
 // Host names and the user's own mirror URLs are config values, so only the sentence around them
 // is translated.
 export const mirrorStatusText = (mirror: PackageMirror | undefined, t: TFunction): string => {
   if (!isMirrorConfigured(mirror)) {
-    return t('Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)')
+    return t('Automatic mirror selection')
   }
   const parts = [mirror!.condaChannel, mirror!.pypiIndex].filter(Boolean)
-  if (parts.length === 0) return t('Custom CA bundle configured')
+  if (parts.length === 0) return t('Automatic mirror selection · Custom CA bundle configured')
   return t('Fetching packages from {{hosts}}', { hosts: parts.join(' , ') })
 }

--- a/src/renderer/src/pages/settings/network-panel-i18n.render.test.tsx
+++ b/src/renderer/src/pages/settings/network-panel-i18n.render.test.tsx
@@ -50,20 +50,20 @@ describe('NetworkPanel list view', () => {
   it('translates the heading and the unconfigured status, and re-renders on language change', () => {
     render(<NetworkPanel view={{ kind: 'list' }} onNavigate={noop} />)
     expect(container.textContent).toContain('Package mirror')
-    expect(container.textContent).toContain('Not configured')
+    expect(container.textContent).toContain('Automatic mirror selection')
     expect(container.textContent).toContain('Configure')
 
     switchTo('zh-Hans')
     expect(container.textContent).toContain('软件包镜像')
-    expect(container.textContent).toContain('未配置')
+    expect(container.textContent).toContain('自动选择镜像')
     expect(container.textContent).toContain('配置')
     expect(container.textContent).not.toContain('Package mirror')
-    expect(container.textContent).not.toContain('Not configured')
+    expect(container.textContent).not.toContain('Automatic mirror selection')
 
     // zh-Hant has its own catalog; a fallback to zh-Hans would leave Simplified glyphs on screen.
     switchTo('zh-Hant')
     expect(container.textContent).toContain('套件鏡像')
-    expect(container.textContent).toContain('未設定')
+    expect(container.textContent).toContain('自動選擇鏡像')
     expect(container.textContent).not.toContain('软件包镜像')
   })
 

--- a/src/renderer/src/stores/network-store.test.ts
+++ b/src/renderer/src/stores/network-store.test.ts
@@ -2,6 +2,7 @@
 import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { startNetworkMonitor, useNetworkStore } from './network-store'
+import { useSettingsStore } from './settings-store'
 
 type CheckConnectivity = () => Promise<boolean>
 
@@ -54,6 +55,53 @@ describe('useNetworkStore', () => {
 })
 
 describe('probeConnectivity', () => {
+  it.each(['unreachable', 'probe-failed'] as const)(
+    'rechecks a saved proxy and discards prior success on %s',
+    async (result) => {
+      const checkConnectivity = vi.fn().mockResolvedValueOnce(true)
+      if (result === 'unreachable') checkConnectivity.mockResolvedValue(false)
+      else checkConnectivity.mockRejectedValue(new Error('probe unavailable'))
+      ;(window as unknown as { api: unknown }).api = {
+        network: { checkConnectivity },
+        settings: {
+          setNetworkProxy: vi
+            .fn()
+            .mockResolvedValue({ mode: 'manual', server: `http://${result}.example:8080` })
+        }
+      }
+      await useNetworkStore.getState().probeConnectivity()
+      expect(useNetworkStore.getState().connectivity).toBe('reachable')
+      await useSettingsStore
+        .getState()
+        .setNetworkProxy({ mode: 'manual', server: `http://${result}.example:8080` })
+      window.dispatchEvent(new Event('focus'))
+      await vi.advanceTimersByTimeAsync(500)
+      expect.soft(checkConnectivity).toHaveBeenCalledTimes(2)
+      expect(useNetworkStore.getState().connectivity).toBe(result)
+    }
+  )
+
+  it('ignores a delayed probe from before a proxy change', async () => {
+    let finish!: (value: boolean) => void
+    const checkConnectivity = vi
+      .fn()
+      .mockReturnValueOnce(
+        new Promise<boolean>((resolve) => {
+          finish = resolve
+        })
+      )
+      .mockResolvedValue(false)
+    ;(window as unknown as { api: unknown }).api = {
+      network: { checkConnectivity },
+      settings: { setNetworkProxy: vi.fn().mockResolvedValue({ mode: 'direct' }) }
+    }
+    const previous = useNetworkStore.getState().probeConnectivity()
+    await useSettingsStore.getState().setNetworkProxy({ mode: 'direct' })
+    await vi.advanceTimersByTimeAsync(500)
+    finish(true)
+    await previous
+    expect(useNetworkStore.getState().connectivity).toBe('unreachable')
+  })
   beforeEach(() => {
     vi.useFakeTimers()
   })

--- a/src/renderer/src/stores/network-store.ts
+++ b/src/renderer/src/stores/network-store.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand'
+import { useSettingsStore } from './settings-store'
 
 // Real end-to-end reachability probed by the main process (the same HTTPS HEAD check the
 // onboarding environment step uses). 'unknown' means a probe is in flight and surfaces render it
@@ -20,7 +21,7 @@ type NetworkStore = {
   // holds the result for MIN_CHECKING_MS (user-visible re-checks); silent probes apply as soon
   // as the answer lands. With no link the probe short-circuits to 'unreachable' — no point
   // issuing HTTPS requests we know cannot get out.
-  probeConnectivity: (options?: { announce?: boolean }) => Promise<void>
+  probeConnectivity: (options?: { announce?: boolean; invalidate?: boolean }) => Promise<void>
 }
 
 // Minimum time an announced probe's Checking… presentation stays visible, so a clicked
@@ -31,11 +32,16 @@ export const useNetworkStore = create<NetworkStore>((set, get) => {
   let probeGeneration = 0
   let lastKnownConnectivity: Extract<NetworkConnectivity, 'reachable' | 'unreachable'> | undefined
 
-  const probeConnectivity = async ({ announce = false } = {}): Promise<void> => {
+  const probeConnectivity = async ({
+    announce = false,
+    invalidate = false
+  } = {}): Promise<void> => {
     const generation = ++probeGeneration
     const startedAt = Date.now()
     const currentConnectivity = get().connectivity
-    if (currentConnectivity === 'reachable' || currentConnectivity === 'unreachable') {
+    if (invalidate) {
+      lastKnownConnectivity = undefined
+    } else if (currentConnectivity === 'reachable' || currentConnectivity === 'unreachable') {
       lastKnownConnectivity = currentConnectivity
     }
 
@@ -105,6 +111,19 @@ let monitorStarted = false
 export const startNetworkMonitor = (): void => {
   if (monitorStarted || typeof window === 'undefined') return
   monitorStarted = true
+
+  useSettingsStore.subscribe((state, previous) => {
+    const next = state.networkProxy
+    const before = previous.networkProxy
+    if (
+      next.mode === before.mode &&
+      next.server === before.server &&
+      next.bypassRules === before.bypassRules
+    )
+      return
+    // A new proxy invalidates both the cached result and all older in-flight probes.
+    void useNetworkStore.getState().probeConnectivity({ announce: true, invalidate: true })
+  })
 
   window.addEventListener('online', () => {
     useNetworkStore.setState({ isOnline: true })

--- a/src/renderer/src/stores/settings-preferences-slice.test.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.test.ts
@@ -217,6 +217,45 @@ const createHarness = (): {
 }
 
 describe('settings preferences slice', () => {
+  it('keeps a newer committed proxy snapshot when an older save response arrives last', async () => {
+    const { commands, store } = createHarness()
+    const older = deferred<NetworkProxySettings>()
+    const latest: NetworkProxySettings = { mode: 'manual', server: 'http://latest.example:8080' }
+    commands.setNetworkProxy.mockReturnValueOnce(older.promise).mockResolvedValueOnce(latest)
+    commands.getSettings.mockResolvedValue(snapshot({ networkProxy: latest }))
+    const pending = store.getState().setNetworkProxy({ mode: 'direct' })
+    await store.getState().setNetworkProxy(latest)
+    older.resolve({ mode: 'direct' })
+    await pending
+    expect(store.getState().networkProxy).toEqual(latest)
+  })
+  it.each(['networkProxy', 'packageMirror', 'notebookNetwork'] as const)(
+    'keeps a successful %s save when a full settings refresh is unavailable',
+    async (field) => {
+      const { commands, store } = createHarness()
+      commands.getSettings.mockRejectedValue(new Error('refresh unavailable'))
+      const values = {
+        networkProxy: { mode: 'direct' as const },
+        packageMirror: { caBundle: '/certs/new.pem' },
+        notebookNetwork: {
+          ...DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+          allowedDomains: ['data.example.org']
+        }
+      }
+      const pending =
+        field === 'networkProxy'
+          ? store.getState().setNetworkProxy(values.networkProxy)
+          : field === 'packageMirror'
+            ? store.getState().setPackageMirror(values.packageMirror)
+            : store.getState().setNotebookNetwork(values.notebookNetwork)
+      const result = await pending.then(
+        () => 'saved',
+        (error) => error
+      )
+      expect.soft(result).toBe('saved')
+      expect(store.getState()[field]).toEqual(values[field])
+    }
+  )
   let commands: CommandMocks
   let reconcileSnapshot: Mock
   let store: StoreApi<TestStore>

--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -161,6 +161,20 @@ export const createSettingsPreferencesSlice = ({
   reconcileSnapshot,
   writeCoordinator
 }: SettingsPreferencesSliceOptions): SettingsPreferencesActions => {
+  const refreshAfterCommit = async (saved: Partial<SettingsPreferencesState>): Promise<void> => {
+    const refresh = getCommands().getSettings
+    if (refresh) {
+      try {
+        reconcileSnapshot(await refresh())
+        return
+      } catch (error) {
+        console.warn('Settings saved, but the settings refresh failed.', error)
+      }
+    }
+    // The command already persisted and applied this value. A failed read is not a failed save.
+    setState(saved)
+  }
+
   const runOptimisticWrite = async <Field extends OptimisticPreferenceField>(
     field: Field,
     key: OptimisticSettingsWriteKey,
@@ -363,18 +377,14 @@ export const createSettingsPreferencesSlice = ({
 
     setPackageMirror: async (mirror) => {
       const saved = await getCommands().setPackageMirror(mirror)
-      const refresh = getCommands().getSettings
-      if (refresh) reconcileSnapshot(await refresh())
-      else setState({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
+      await refreshAfterCommit({ packageMirror: isMirrorConfigured(saved) ? saved : undefined })
     },
 
     setNetworkProxy: async (networkProxy) => {
       const setNetworkProxy = getCommands().setNetworkProxy
       if (!setNetworkProxy) throw new Error('Network proxy settings are unavailable.')
       const saved = await setNetworkProxy(networkProxy)
-      const refresh = getCommands().getSettings
-      if (refresh) reconcileSnapshot(await refresh())
-      else setState({ networkProxy: saved })
+      await refreshAfterCommit({ networkProxy: saved })
     },
 
     setNotebookNetwork: async (notebookNetwork, baseAllowedDomains) => {
@@ -385,9 +395,7 @@ export const createSettingsPreferencesSlice = ({
         ...(baseAllowedDomains === undefined ? {} : { baseAllowedDomains })
       }
       const saved = await command(request)
-      const refresh = getCommands().getSettings
-      if (refresh) reconcileSnapshot(await refresh())
-      else setState({ notebookNetwork: saved })
+      await refreshAfterCommit({ notebookNetwork: saved })
       return saved
     }
   }

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -125,7 +125,7 @@ type SettingsStoreData = RuntimeSetupState &
     codebuddyManaged: boolean
     onboardingCompletedAt: number | undefined
     encryptionAvailable: boolean
-    // Configured package mirror (conda/pip); undefined means public hosts (unconfigured).
+    // Configured package mirror (conda/pip); undefined means automatic mirror selection.
     packageMirror?: PackageMirror
     networkProxy: NetworkProxySettings
     notebookNetwork: NotebookNetworkSettings

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -1660,7 +1660,6 @@
     "Not available yet.": "Noch nicht verfügbar.",
     "Not compatible with the active agent framework.": "Nicht mit dem aktiven Agenten-Framework kompatibel.",
     "Not configured": "Nicht konfiguriert",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "Nicht konfiguriert – Pakete stammen von den öffentlichen Hosts (conda.anaconda.org, pypi.org)",
     "Not importable": "Nicht importierbar",
     "Not installed": "Nicht installiert",
     "Not probed": "Nicht geprüft",
@@ -1785,7 +1784,6 @@
     "PDB couldn't be read for preview": "PDB konnte nicht zur Vorschau gelesen werden",
     "PDB viewer could not be initialized: {{error}}": "PDB-Viewer konnte nicht initialisiert werden: {{error}}",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "Lassen Sie das Feld leer, um öffentliche Zertifizierungsstellen zu verwenden. Wählen Sie andernfalls ein vollständiges PEM-Bundle mit öffentlichen und unternehmensinternen Stammzertifikaten; Notebook-Sitzungen und Paketdownloads vertrauen dann diesen Zertifikaten.",
-    "Custom CA bundle configured": "Benutzerdefiniertes CA-Bundle konfiguriert",
     "PHASE {{number}}": "PHASE {{number}}",
     "PINNED": "GEPINNT",
     "Package": "Paket",
@@ -4711,6 +4709,17 @@
     "Direct PDF link": "Direkter PDF-Link",
     "arXiv identifier required": "arXiv-Kennung erforderlich",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Neueste PDF über die arXiv-Kennung. Kein API-Schlüssel erforderlich. Die Datei wird beim Herunterladen geprüft.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Fügen Sie eine DOI, PMID, PMCID oder arXiv-Kennung hinzu, um eine passende Volltext-PDF zu finden."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Fügen Sie eine DOI, PMID, PMCID oder arXiv-Kennung hinzu, um eine passende Volltext-PDF zu finden.",
+    "Choose a proxy mode.": "Wählen Sie einen Proxy-Modus.",
+    "Choose System, Manual, or Direct.": "Wählen Sie System, Manuell oder Direkt.",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "Geben Sie eine Proxyserver-URL ein, zum Beispiel http://127.0.0.1:1086.",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "Verwenden Sie eine Proxy-URL mit http, https, socks, socks4 oder socks5.",
+    "Enter a proxy URL with a host name or IP address.": "Geben Sie eine Proxy-URL mit Hostnamen oder IP-Adresse ein.",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "Proxy-URLs mit eingebetteten Benutzernamen oder Passwörtern werden nicht unterstützt.",
+    "Enter only the proxy scheme, host, and optional port.": "Geben Sie nur Proxy-Protokoll, Host und optionalen Port ein.",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Geben Sie eine vollständige Proxy-URL ein, zum Beispiel http://127.0.0.1:1086.",
+    "Automatic mirror selection": "Automatische Spiegelauswahl",
+    "Automatic mirror selection · Custom CA bundle configured": "Automatische Spiegelauswahl · Benutzerdefiniertes CA-Bündel konfiguriert",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Das Deaktivieren einer integrierten Domain hebt den automatischen Zugriff auf. Exakte Hostnamen unter Erlaubte Domains bleiben erlaubt."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1843,7 +1843,6 @@
     "The app could not write to the log file during its most recent attempt.": "La aplicación no pudo escribir en el archivo de registro durante el intento más reciente.",
     "Not compatible with the active agent framework.": "No es compatible con el framework de agentes activo.",
     "Not configured": "No configurado",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "No configurado: los paquetes provienen de hosts públicos (conda.anaconda.org, pypi.org)",
     "Not importable": "No importable",
     "Not installed": "No instalado",
     "Not probed": "Sin comprobar",
@@ -1970,7 +1969,6 @@
     "In session context": "En el contexto de la sesión",
     "Open PDF context {{name}}": "Abrir el contexto PDF {{name}}",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "Déjelo en blanco para usar autoridades de certificación públicas. De lo contrario, seleccione un paquete PEM completo con raíces públicas y corporativas; las sesiones de Notebook y las descargas de paquetes confiarán en él.",
-    "Custom CA bundle configured": "Paquete de CA personalizado configurado",
     "PHASE {{number}}": "FASE {{number}}",
     "PINNED": "FIJADO",
     "Package": "Paquete",
@@ -4872,6 +4870,17 @@
     "Direct PDF link": "Enlace directo al PDF",
     "arXiv identifier required": "Se requiere un identificador de arXiv",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "PDF más reciente mediante el identificador de arXiv. No requiere clave de API. El archivo se verifica al descargarlo.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Añada un DOI, PMID, PMCID o identificador de arXiv para encontrar un PDF de texto completo correspondiente."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Añada un DOI, PMID, PMCID o identificador de arXiv para encontrar un PDF de texto completo correspondiente.",
+    "Choose a proxy mode.": "Seleccione un modo de proxy.",
+    "Choose System, Manual, or Direct.": "Seleccione Sistema, Manual o Directo.",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "Introduzca una URL de servidor proxy, p. ej., http://127.0.0.1:1086.",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "Utilice una URL de proxy con http, https, socks, socks4 o socks5.",
+    "Enter a proxy URL with a host name or IP address.": "Introduzca una URL de proxy con un nombre de host o una dirección IP.",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "No se admiten URL de proxy con nombres de usuario o contraseñas incorporados.",
+    "Enter only the proxy scheme, host, and optional port.": "Introduzca solo el esquema del proxy, el host y el puerto opcional.",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Introduzca una URL de proxy completa, p. ej., http://127.0.0.1:1086.",
+    "Automatic mirror selection": "Selección automática de mirror",
+    "Automatic mirror selection · Custom CA bundle configured": "Selección automática de mirror · Paquete de CA personalizado configurado",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Desactivar un dominio integrado elimina el acceso automático. Los nombres de host exactos de Dominios permitidos siguen estando permitidos."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1842,7 +1842,6 @@
     "The app could not write to the log file during its most recent attempt.": "L’application n’a pas pu écrire dans le fichier journal lors de sa dernière tentative.",
     "Not compatible with the active agent framework.": "Non compatible avec le framework d'agents actif.",
     "Not configured": "Non configuré",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "Non configuré — les paquets proviennent des hôtes publics (conda.anaconda.org, pypi.org)",
     "Not importable": "Non importable",
     "Not installed": "Non installé",
     "Not probed": "Non sondé",
@@ -1970,7 +1969,6 @@
     "In session context": "Dans le contexte de la session",
     "Open PDF context {{name}}": "Ouvrir le contexte PDF {{name}}",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "Laissez ce champ vide pour utiliser les autorités de certification publiques. Sinon, choisissez un bundle PEM complet contenant les racines publiques et celles de votre entreprise ; les sessions Notebook et les téléchargements de paquets lui feront confiance.",
-    "Custom CA bundle configured": "Bundle d’autorités de certification personnalisé configuré",
     "PHASE {{number}}": "PHASE {{number}}",
     "PINNED": "ÉPINGLEÉ",
     "Package": "Paquet",
@@ -4872,6 +4870,17 @@
     "Direct PDF link": "Lien direct vers le PDF",
     "arXiv identifier required": "Identifiant arXiv requis",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Dernier PDF via l’identifiant arXiv. Aucune clé API requise. Le fichier est vérifié lors du téléchargement.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Ajoutez un DOI, PMID, PMCID ou identifiant arXiv pour trouver un PDF du texte intégral correspondant."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Ajoutez un DOI, PMID, PMCID ou identifiant arXiv pour trouver un PDF du texte intégral correspondant.",
+    "Choose a proxy mode.": "Choisissez un mode de proxy.",
+    "Choose System, Manual, or Direct.": "Choisissez Système, Manuel ou Direct.",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "Saisissez une URL de serveur proxy, par exemple http://127.0.0.1:1086.",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "Utilisez une URL de proxy avec http, https, socks, socks4 ou socks5.",
+    "Enter a proxy URL with a host name or IP address.": "Saisissez une URL de proxy avec un nom d’hôte ou une adresse IP.",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "Les URL de proxy contenant un nom d’utilisateur ou un mot de passe ne sont pas prises en charge.",
+    "Enter only the proxy scheme, host, and optional port.": "Saisissez uniquement le protocole du proxy, l’hôte et le port facultatif.",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Saisissez une URL de proxy complète, par exemple http://127.0.0.1:1086.",
+    "Automatic mirror selection": "Sélection automatique du miroir",
+    "Automatic mirror selection · Custom CA bundle configured": "Sélection automatique du miroir · Ensemble de certificats CA personnalisé configuré",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Désactiver un domaine intégré supprime l’accès automatique. Les noms d’hôte exacts dans Domaines autorisés restent autorisés."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1769,7 +1769,6 @@
     "The app could not write to the log file during its most recent attempt.": "直近の試行で、アプリはログファイルに書き込めませんでした。",
     "Not compatible with the active agent framework.": "アクティブなエージェントフレームワークと互換性がありません。",
     "Not configured": "未設定",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "未設定 — パッケージはパブリックホスト (conda.anaconda.org、pypi.org) から取得されます。",
     "Not importable": "インポート不可",
     "Not installed": "インストールされていません",
     "Not probed": "未確認",
@@ -1901,7 +1900,6 @@
     "In session context": "セッションのコンテキストに追加済み",
     "Open PDF context {{name}}": "PDF コンテキスト {{name}} を開く",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "空欄の場合は公開認証局を使用します。それ以外の場合は、公開ルートと企業ルートを含む完全な PEM バンドルを選択してください。Notebook セッションとパッケージのダウンロードで信頼されます。",
-    "Custom CA bundle configured": "カスタム CA バンドルを設定済み",
     "PHASE {{number}}": "フェーズ {{number}}",
     "PINNED": "固定済み",
     "Package": "パッケージ",
@@ -4558,6 +4556,17 @@
     "Direct PDF link": "PDF への直接リンク",
     "arXiv identifier required": "arXiv 識別子が必要です",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "arXiv 識別子から最新の PDF を取得します。API キーは不要です。ダウンロード時にファイルを検証します。",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI、PMID、PMCID または arXiv 識別子を追加して、一致する全文 PDF を検索します。"
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI、PMID、PMCID または arXiv 識別子を追加して、一致する全文 PDF を検索します。",
+    "Choose a proxy mode.": "プロキシモードを選択してください。",
+    "Choose System, Manual, or Direct.": "システム、手動、または直接接続を選択してください。",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "プロキシサーバーの URL を入力してください（例：http://127.0.0.1:1086）。",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "http、https、socks、socks4、または socks5 のプロキシ URL を使用してください。",
+    "Enter a proxy URL with a host name or IP address.": "ホスト名または IP アドレスを含むプロキシ URL を入力してください。",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "ユーザー名やパスワードを含むプロキシ URL はサポートされていません。",
+    "Enter only the proxy scheme, host, and optional port.": "プロキシのスキーム、ホスト、任意のポートのみを入力してください。",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "完全なプロキシ URL を入力してください（例：http://127.0.0.1:1086）。",
+    "Automatic mirror selection": "ミラーを自動選択",
+    "Automatic mirror selection · Custom CA bundle configured": "ミラーを自動選択 · カスタム CA バンドル設定済み",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "組み込みドメインを無効にすると、自動アクセスが解除されます。「許可されたドメイン」に登録した完全一致のホスト名は引き続き許可されます。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1784,7 +1784,6 @@
     "The app could not write to the log file during its most recent attempt.": "최근 시도에서 앱이 로그 파일에 쓰지 못했습니다.",
     "Not compatible with the active agent framework.": "활성 에이전트 프레임워크와 호환되지 않습니다.",
     "Not configured": "구성되지 않음",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "구성되지 않음 - 패키지가 공개 호스트(conda.anaconda.org, pypi.org)에서 제공됩니다.",
     "Not importable": "가져올 수 없음",
     "Not installed": "설치되지 않음",
     "Not probed": "프로브되지 않음",
@@ -1912,7 +1911,6 @@
     "In session context": "세션 컨텍스트에 추가됨",
     "Open PDF context {{name}}": "PDF 컨텍스트 {{name}} 열기",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "비워 두면 공용 인증 기관을 사용합니다. 그렇지 않으면 공용 루트와 회사 루트가 포함된 전체 PEM 번들을 선택하세요. Notebook 세션과 패키지 다운로드에서 이 번들을 신뢰합니다.",
-    "Custom CA bundle configured": "사용자 지정 CA 번들 구성됨",
     "PHASE {{number}}": "단계 {{number}}",
     "PINNED": "고정됨",
     "Package": "패키지",
@@ -4556,6 +4554,17 @@
     "Direct PDF link": "PDF 직접 링크",
     "arXiv identifier required": "arXiv 식별자 필요",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "arXiv 식별자로 최신 PDF를 가져옵니다. API 키가 필요하지 않습니다. 다운로드할 때 파일을 검증합니다.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI, PMID, PMCID 또는 arXiv 식별자를 추가하여 일치하는 전문 PDF를 찾으세요."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI, PMID, PMCID 또는 arXiv 식별자를 추가하여 일치하는 전문 PDF를 찾으세요.",
+    "Choose a proxy mode.": "프록시 모드를 선택하세요.",
+    "Choose System, Manual, or Direct.": "시스템, 수동 또는 직접 연결을 선택하세요.",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "프록시 서버 URL을 입력하세요. 예: http://127.0.0.1:1086.",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "http, https, socks, socks4 또는 socks5 프록시 URL을 사용하세요.",
+    "Enter a proxy URL with a host name or IP address.": "호스트 이름 또는 IP 주소가 포함된 프록시 URL을 입력하세요.",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "사용자 이름이나 비밀번호가 포함된 프록시 URL은 지원되지 않습니다.",
+    "Enter only the proxy scheme, host, and optional port.": "프록시 스킴, 호스트 및 선택 사항인 포트만 입력하세요.",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "완전한 프록시 URL을 입력하세요. 예: http://127.0.0.1:1086.",
+    "Automatic mirror selection": "미러 자동 선택",
+    "Automatic mirror selection · Custom CA bundle configured": "미러 자동 선택 · 사용자 지정 CA 번들 설정됨",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "기본 제공 도메인을 끄면 자동 액세스가 해제됩니다. 허용된 도메인에 등록한 정확한 호스트 이름은 계속 허용됩니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1844,7 +1844,6 @@
     "The app could not write to the log file during its most recent attempt.": "При последней попытке приложению не удалось записать данные в файл журнала.",
     "Not compatible with the active agent framework.": "Несовместимо с активным фреймворком агента.",
     "Not configured": "Не настроен",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "Не настроен — пакеты поступают с публичных хостов (conda.anaconda.org, pypi.org)",
     "Not importable": "Невозможно импортировать",
     "Not installed": "Не установлен",
     "Not probed": "Не проверен",
@@ -1973,7 +1972,6 @@
     "In session context": "В контексте сеанса",
     "Open PDF context {{name}}": "Открыть контекст PDF {{name}}",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "Оставьте поле пустым, чтобы использовать общедоступные центры сертификации. В противном случае выберите полный PEM-пакет с общедоступными и корпоративными корневыми сертификатами; ему будут доверять сессии Notebook и загрузки пакетов.",
-    "Custom CA bundle configured": "Настроен пользовательский пакет сертификатов CA",
     "PHASE {{number}}": "ФАЗА {{number}}",
     "PINNED": "ЗАКРЕПЛЕННЫЙ",
     "Package": "Пакет",
@@ -5004,6 +5002,17 @@
     "Direct PDF link": "Прямая ссылка на PDF",
     "arXiv identifier required": "Требуется идентификатор arXiv",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Последний PDF по идентификатору arXiv. API-ключ не требуется. Файл проверяется при скачивании.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Добавьте DOI, PMID, PMCID или идентификатор arXiv, чтобы найти подходящий PDF полного текста."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Добавьте DOI, PMID, PMCID или идентификатор arXiv, чтобы найти подходящий PDF полного текста.",
+    "Choose a proxy mode.": "Выберите режим прокси.",
+    "Choose System, Manual, or Direct.": "Выберите системный, ручной или прямой режим.",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "Введите URL прокси-сервера, например http://127.0.0.1:1086.",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "Используйте URL прокси с протоколом http, https, socks, socks4 или socks5.",
+    "Enter a proxy URL with a host name or IP address.": "Введите URL прокси с именем хоста или IP-адресом.",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "URL прокси со встроенными именами пользователей или паролями не поддерживаются.",
+    "Enter only the proxy scheme, host, and optional port.": "Введите только протокол прокси, хост и необязательный порт.",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "Введите полный URL прокси, например http://127.0.0.1:1086.",
+    "Automatic mirror selection": "Автоматический выбор зеркала",
+    "Automatic mirror selection · Custom CA bundle configured": "Автоматический выбор зеркала · Настроен пользовательский пакет CA",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "Отключение встроенного домена отменяет автоматический доступ. Точные имена хостов в списке разрешённых доменов остаются разрешёнными."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1856,7 +1856,6 @@
     "The app could not write to the log file during its most recent attempt.": "应用在最近一次尝试中无法写入日志文件。",
     "Not compatible with the active agent framework.": "与当前智能体框架不兼容。",
     "Not configured": "未配置",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "未配置 —— 软件包来自公共源（conda.anaconda.org、pypi.org）",
     "Not importable": "无法导入",
     "Not installed": "未安装",
     "Not probed": "未探测",
@@ -1988,7 +1987,6 @@
     "In session context": "已加入当前会话上下文",
     "Open PDF context {{name}}": "打开 PDF 上下文 {{name}}",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "留空将使用公共证书颁发机构。否则，请选择包含公共根证书和企业根证书的完整 PEM 证书包；Notebook 会话和软件包下载都会信任它。",
-    "Custom CA bundle configured": "已配置自定义 CA 证书包",
     "PHASE {{number}}": "阶段 {{number}}",
     "PINNED": "已固定",
     "Package": "软件包",
@@ -4558,6 +4556,17 @@
     "Direct PDF link": "PDF 直链",
     "arXiv identifier required": "需要 arXiv 标识符",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "通过 arXiv 标识符获取最新 PDF。无需 API 密钥，下载时会校验文件。",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "添加 DOI、PMID、PMCID 或 arXiv 标识符以查找匹配的全文 PDF。"
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "添加 DOI、PMID、PMCID 或 arXiv 标识符以查找匹配的全文 PDF。",
+    "Choose a proxy mode.": "请选择代理模式。",
+    "Choose System, Manual, or Direct.": "请选择系统、手动或直连。",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "请输入代理服务器 URL，例如 http://127.0.0.1:1086。",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "请使用 http、https、socks、socks4 或 socks5 代理 URL。",
+    "Enter a proxy URL with a host name or IP address.": "请输入包含主机名或 IP 地址的代理 URL。",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "不支持包含用户名或密码的代理 URL。",
+    "Enter only the proxy scheme, host, and optional port.": "请仅输入代理协议、主机和可选端口。",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "请输入完整的代理 URL，例如 http://127.0.0.1:1086。",
+    "Automatic mirror selection": "自动选择镜像",
+    "Automatic mirror selection · Custom CA bundle configured": "自动选择镜像 · 已配置自定义 CA 证书包",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "关闭内置域名会取消自动访问权限。“允许的域名”中的精确主机名仍可访问。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1854,7 +1854,6 @@
     "The app could not write to the log file during its most recent attempt.": "應用程式在最近一次嘗試中無法寫入日誌檔案。",
     "Not compatible with the active agent framework.": "與目前的智能體框架不相容。",
     "Not configured": "未設定",
-    "Not configured — packages come from the public hosts (conda.anaconda.org, pypi.org)": "未設定 —— 套件來自公共來源（conda.anaconda.org、pypi.org）",
     "Not importable": "無法匯入",
     "Not installed": "未安裝",
     "Not probed": "未探測",
@@ -1986,7 +1985,6 @@
     "In session context": "已加入目前工作階段上下文",
     "Open PDF context {{name}}": "開啟 PDF 上下文 {{name}}",
     "Leave blank to use public certificate authorities. Otherwise, choose a complete PEM bundle with public and corporate roots; Notebook sessions and package downloads will trust it.": "留空將使用公開憑證授權單位。否則，請選擇包含公開根憑證與企業根憑證的完整 PEM 憑證包；Notebook 工作階段和套件下載都會信任它。",
-    "Custom CA bundle configured": "已設定自訂 CA 憑證包",
     "PHASE {{number}}": "階段 {{number}}",
     "PINNED": "已釘選",
     "Package": "套件",
@@ -4558,6 +4556,17 @@
     "Direct PDF link": "PDF 直接連結",
     "arXiv identifier required": "需要 arXiv 識別碼",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "透過 arXiv 識別碼取得最新 PDF。無需 API 金鑰，下載時會驗證檔案。",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "新增 DOI、PMID、PMCID 或 arXiv 識別碼以尋找相符的全文 PDF。"
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "新增 DOI、PMID、PMCID 或 arXiv 識別碼以尋找相符的全文 PDF。",
+    "Choose a proxy mode.": "請選擇代理模式。",
+    "Choose System, Manual, or Direct.": "請選擇系統、手動或直接連線。",
+    "Enter a proxy server URL, for example http://127.0.0.1:1086.": "請輸入代理伺服器 URL，例如 http://127.0.0.1:1086。",
+    "Use an http, https, socks, socks4, or socks5 proxy URL.": "請使用 http、https、socks、socks4 或 socks5 代理 URL。",
+    "Enter a proxy URL with a host name or IP address.": "請輸入包含主機名稱或 IP 位址的代理 URL。",
+    "Proxy URLs with embedded usernames or passwords are not supported.": "不支援包含使用者名稱或密碼的代理 URL。",
+    "Enter only the proxy scheme, host, and optional port.": "請僅輸入代理通訊協定、主機及選填的連接埠。",
+    "Enter a complete proxy URL, for example http://127.0.0.1:1086.": "請輸入完整的代理 URL，例如 http://127.0.0.1:1086。",
+    "Automatic mirror selection": "自動選擇鏡像",
+    "Automatic mirror selection · Custom CA bundle configured": "自動選擇鏡像 · 已設定自訂 CA 憑證組合",
+    "Turning off a built-in domain removes automatic access. Exact hostnames in Allowed domains remain allowed.": "關閉內建網域會取消自動存取權限。「允許的網域」中的精確主機名稱仍可存取。"
   }
 }

--- a/src/shared/notebook-network.test.ts
+++ b/src/shared/notebook-network.test.ts
@@ -1,11 +1,44 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+import { DestinationPolicy } from '../../packages/notebook-network-sandbox/runtime/src/gateway/address-policy'
+import { createRuntimeConfig } from '../../packages/notebook-network-sandbox/src/config'
 
 import {
   DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
   buildNotebookNetworkPolicy,
   normalizeNotebookNetworkSettings,
+  notebookNetworkSettingsAllowDomain,
   validateCustomAllowedDomain
 } from './notebook-network'
+
+vi.mock('node:dns/promises', () => ({
+  lookup: vi.fn(async () => [{ address: '8.8.8.8', family: 4 }])
+}))
+
+describe('disabled automatic domain access', () => {
+  it.each([
+    ['rest.uniprot.org', 'rest.uniprot.org', 'www.uniprot.org'],
+    ['*.ncbi.nlm.nih.gov', 'eutils.ncbi.nlm.nih.gov', 'www.nih.gov'],
+    ['*.uniprot.org', 'rest.uniprot.org', 'www.rcsb.org']
+  ])('asks for %s despite overlapping built-in rules', async (disabled, host, sibling) => {
+    const settings = normalizeNotebookNetworkSettings({ disabledOpenScienceDomains: [disabled] })
+    const inspect = (value: typeof settings): DestinationPolicy =>
+      new DestinationPolicy(
+        createRuntimeConfig({
+          policy: buildNotebookNetworkPolicy(value),
+          resources: { root: '/resources' }
+        })
+      )
+
+    expect.soft(await inspect(settings).inspect(host, 443)).toMatchObject({ kind: 'ask', host })
+    expect.soft(notebookNetworkSettingsAllowDomain(settings, host)).toBe(false)
+    expect(await inspect(settings).inspect(sibling, 443)).toMatchObject({ kind: 'allow' })
+
+    // A later explicit approval remains effective; turning off auto-allow is not a permanent ban.
+    const approved = { ...settings, allowedDomains: [host] }
+    expect(await inspect(approved).inspect(host, 443)).toMatchObject({ kind: 'allow' })
+    expect(notebookNetworkSettingsAllowDomain(approved, host)).toBe(true)
+  })
+})
 
 describe('notebook network policy', () => {
   it('enables every Open Science domain group by default', () => {

--- a/src/shared/notebook-network.ts
+++ b/src/shared/notebook-network.ts
@@ -23,6 +23,7 @@ export type NotebookNetworkSettings = Readonly<{
 
 export type NotebookNetworkPolicy = Readonly<{
   allowedDomains: readonly string[]
+  askDomains: readonly string[]
   deniedDomains: readonly string[]
   deniedDomainReasons: Readonly<Record<string, string>>
 }>
@@ -208,8 +209,11 @@ export const notebookNetworkSettingsAllowDomain = (
   hostname: string
 ): boolean => {
   const normalized = hostname.toLowerCase().replace(/\.$/, '')
-  return buildNotebookNetworkPolicy(settings).allowedDomains.some((pattern) =>
-    domainPatternMatches(pattern, normalized)
+  const policy = buildNotebookNetworkPolicy(settings)
+  return (
+    policy.allowedDomains.includes(normalized) ||
+    (!policy.askDomains.some((pattern) => domainPatternMatches(pattern, normalized)) &&
+      policy.allowedDomains.some((pattern) => domainPatternMatches(pattern, normalized)))
   )
 }
 
@@ -289,6 +293,15 @@ export const buildNotebookNetworkPolicy = (
 ): NotebookNetworkPolicy => {
   const disabledGroups = new Set(settings.disabledOpenScienceDomainGroups)
   const disabledDomains = new Set(settings.disabledOpenScienceDomains)
+  const askDomains = uniqueSorted(
+    OPEN_SCIENCE_DOMAIN_GROUPS.flatMap((group) =>
+      group.locked
+        ? []
+        : group.domains.filter(
+            (domain) => disabledGroups.has(group.id) || disabledDomains.has(domain)
+          )
+    )
+  )
   const builtIn = OPEN_SCIENCE_DOMAIN_GROUPS.filter(
     (group) => group.locked || !disabledGroups.has(group.id)
   )
@@ -296,11 +309,14 @@ export const buildNotebookNetworkPolicy = (
     .filter(
       (domain) =>
         OPEN_SCIENCE_DOMAIN_GROUPS.find((group) => group.domains.includes(domain))?.locked ||
-        !disabledDomains.has(domain)
+        !askDomains.some((pattern) => domainPatternMatches(pattern, domain))
     )
 
   return {
     allowedDomains: uniqueSorted([...builtIn, ...settings.allowedDomains]),
+    // Exact custom approvals override these automatic-access exclusions. Remove matching
+    // built-in exact rules above so they cannot masquerade as explicit approvals.
+    askDomains,
     deniedDomains: [],
     deniedDomainReasons: {}
   }


### PR DESCRIPTION
## Problem

Network settings could report permissions or saved state that did not match actual behavior:

| Trigger | User-visible consequence | Change |
| --- | --- | --- |
| Disable a built-in hostname or a narrower wildcard while an overlapping allow rule remains enabled | Requests still bypass approval | Route disabled automatic access through approval, while retaining explicit exact-host approvals |
| Save a different proxy after a successful or pending connectivity probe | The previous route's result remains visible | Invalidate cached and in-flight results on proxy changes, reprobe, and keep Check again available |
| Persist and apply settings successfully, then fail to read or publish a snapshot | A completed operation is reported as a failed save | Preserve the operation result; retain snapshot synchronization and fall back to the saved value when the subsequent read fails |
| Leave mirrors unconfigured while automatic probing selects a third-party mirror | The summary incorrectly promises public package hosts | Describe automatic selection, including CA-only configurations |
| Edit domains or proxy fields while a save is pending | A late response loses edits or confirms an unsaved visible value | Disable editable controls during saving and clear success feedback on later edits |
| Blur an invalid proxy URL in a translated interface | Validation text remains English | Translate the existing validation messages in all eight locales |

## Scope

The sandbox policy gains one optional runtime field, `askDomains`. Exact allow rules take precedence over approval rules; approval rules take precedence over wildcard automatic allows. Matching built-in exact rules are removed when automatic access is disabled, so they cannot masquerade as explicit approvals. Hard denies and non-public-address rejection retain priority. The shared link-access predicate and runtime gateway use the same behavior.

There are no persisted-field changes, database migrations, new dependencies, polling, persistent draft versions, or mirror-status IPC. Actual apply failures retain their existing rollback behavior. Snapshot publication failures are logged; another window may still need its next successful snapshot after a broadcast failure. This does not add durable event delivery.

## Acceptance criteria and validation

Twenty regression cases were run twice against unchanged base commit `8c5a03c2c29442bd59882558116c3b5d23e3d900` in an isolated worktree. Both runs failed all twenty cases for the reported behavior, with no setup or compilation failures. The checks use existing public boundaries with controlled DNS, latency, platform and transport dependencies; no production test seam was added.

| Behavior | Project-owned checks | Final result |
| --- | --- | --- |
| Domain precedence and live policy propagation | `src/shared/notebook-network.test.ts`; sandbox `address-policy`, `config`, `runtime-config`, and `index` suites; notebook sandbox owner; `SessionMessageLink.test.tsx` | Passed |
| Proxy-triggered reprobes and manual recheck | `network-store.test.ts`; `NetworkPanel.render.test.tsx` | Passed |
| Save results, projection recovery, rollback, and response ordering | Main Settings suites; `settings-preferences-slice.test.ts` | Passed |
| Automatic mirror summary | `mirror-probe.test.ts`; mirror-view, NetworkPanel i18n, and SettingsPage rendering suites | Passed |
| Pending-save editing and localized validation | Domain/proxy form rendering suites; `i18n/resources.test.ts` | Passed |

The final affected owner, adapter, and consumer set passed **5,058 tests**, with **4 skipped** (241 files passed, one skipped):

```sh
npm test -- src/main/logger.test.ts src/main/settings src/renderer/src/stores src/renderer/src/pages/settings src/shared/notebook-network.test.ts src/main/notebook/network-sandbox-owner.test.ts src/main/notebook/mirror-probe.test.ts packages/notebook-network-sandbox/src/address-policy.test.ts packages/notebook-network-sandbox/src/config.test.ts packages/notebook-network-sandbox/src/runtime-config.test.ts packages/notebook-network-sandbox/src/index.test.ts src/renderer/src/components/streamdown/SessionMessageLink.test.tsx src/renderer/src/i18n/resources.test.ts
```

These impact checks ran after the last material production edit. All main Settings consumers are included because snapshot projection is shared; the message-link suite is included because it consumes the domain predicate.

- `npm run typecheck`: passed for main, sandbox, and renderer.
- ESLint over all Git-tracked JavaScript/TypeScript files (`eslint --cache --no-warn-ignored` on `git ls-files`): passed.
- `git diff --check`: passed.
- The initial sandboxed tests could not listen on loopback ports (`listen EPERM`). The affected set above passed after scoped execution outside that sandbox. The full `npm test` attempt was interrupted after the same restriction; this is not a full-suite pass.
- Directory-wide lint encountered generated Playwright reports and unrelated, untracked investigation scripts. Those local artifacts were not modified.

The tests do not claim a real external proxy outage or fresh native end-to-end certification on every operating system. Platform-specific isolation mechanics and durable sandbox resources are unchanged.

## Review focus

Review approval precedence and exact-host overrides, the distinction between committed operations and failed projections, and preservation of existing revision-aware snapshot synchronization. UI changes intentionally freeze editing while saving rather than introducing draft merging.

## Rebase and CI validation

Rebased onto `main` at `c878904a2653743b363bbb25435c2d6ee97a8026`. Conflicts were append-only additions to eight locale catalogs; both upstream arXiv translations and this PR’s network-settings translations were preserved. The later upstream release and CLI commits rebased cleanly; range-diff confirms both PR patches are unchanged by that final rebase.

The failed Ubuntu portable shard reported one failing test: the existing main-process logger boundary check detected a direct console call in snapshot publication error handling. Reproduced the same assertion locally before changing code, then reused the central logger and its diagnostic error classification. No guard was weakened or new test seam added. The logger and snapshot/proxy suites passed all 96 tests after the fix.

The affected set above passed 5,058 tests with four skipped after conflict resolution and the logger fix. Locale formatting, all Git-tracked JavaScript/TypeScript lint, and main/sandbox/renderer typechecks passed. The subsequent upstream release and CLI commits do not modify these affected sources. Hosted CI is being rerun for the updated PR head.
