### PR TITLE
fix(granted-folders): serialize renderer mutations

### DIFF
--- a/src/renderer/src/stores/granted-folders-store.test.ts
+++ b/src/renderer/src/stores/granted-folders-store.test.ts
@@ -142,4 +142,123 @@ describe('granted-folders-store', () => {
       expect(useGrantedFoldersStore.getState().loaded).toBe(loaded)
     }
   )
+
+  it('finishes each removal before submitting the next so removed roots stay absent', async () => {
+    const a = createRoot({ id: 'a' })
+    const b = createRoot({ id: 'b' })
+    let authority = [a, b]
+    const releaseFirst = Promise.withResolvers<void>()
+    const firstStarted = Promise.withResolvers<void>()
+    const removeGrantedRoot = vi.fn(async ({ id }: { id: string }) => {
+      authority = authority.filter((root) => root.id !== id)
+      const snapshot = [...authority]
+      if (id === a.id) {
+        firstStarted.resolve()
+        await releaseFirst.promise
+      }
+      return snapshot
+    })
+    setLocalFsApi({ removeGrantedRoot })
+    useGrantedFoldersStore.setState({ roots: authority, loaded: true })
+
+    const first = useGrantedFoldersStore.getState().remove(a.id)
+    const second = useGrantedFoldersStore.getState().remove(b.id)
+    await firstStarted.promise
+    const callsBeforeRelease = removeGrantedRoot.mock.calls.length
+    releaseFirst.resolve()
+    expect(await first).toEqual([b])
+    expect(await second).toEqual([])
+    expect(removeGrantedRoot.mock.calls).toEqual([[{ id: a.id }], [{ id: b.id }]])
+    expect(useGrantedFoldersStore.getState().roots).toEqual(authority)
+    expect(authority).toEqual([])
+    expect(callsBeforeRelease).toBe(1)
+  })
+
+  it('orders grant, access change and removal together and publishes before the next call', async () => {
+    const granted = createRoot()
+    const writable = createRoot({ access: 'rw' })
+    const grantReply = Promise.withResolvers<GrantedLocalRoot[]>()
+    const grantStarted = Promise.withResolvers<void>()
+    const grantRoot = vi.fn(() => {
+      grantStarted.resolve()
+      return grantReply.promise
+    })
+    const setGrantedRootAccess = vi.fn(async () => {
+      expect(useGrantedFoldersStore.getState().roots).toEqual([granted])
+      return [writable]
+    })
+    const removeGrantedRoot = vi.fn(async () => {
+      expect(useGrantedFoldersStore.getState().roots).toEqual([writable])
+      return []
+    })
+    setLocalFsApi({ grantRoot, setGrantedRootAccess, removeGrantedRoot })
+
+    const first = useGrantedFoldersStore.getState().grant(granted.path, 'ro')
+    const second = useGrantedFoldersStore.getState().setAccess(granted.id, 'rw')
+    const third = useGrantedFoldersStore.getState().remove(granted.id)
+    await grantStarted.promise
+    expect(setGrantedRootAccess).not.toHaveBeenCalled()
+    expect(removeGrantedRoot).not.toHaveBeenCalled()
+    grantReply.resolve([granted])
+    expect(await first).toEqual([granted])
+    expect(await second).toEqual([writable])
+    expect(await third).toEqual([])
+    expect(setGrantedRootAccess).toHaveBeenCalledWith({ id: granted.id, access: 'rw' })
+    expect(removeGrantedRoot).toHaveBeenCalledWith({ id: granted.id })
+    expect(useGrantedFoldersStore.getState().roots).toEqual([])
+  })
+
+  it.each(['reject', 'throw'] as const)(
+    'preserves the failed caller error and processes the next mutation after %s',
+    async (failure) => {
+      const existing = [createRoot()]
+      const error = new Error('permission denied')
+      const grantRoot = vi.fn(() => {
+        if (failure === 'throw') throw error
+        return Promise.reject(error)
+      })
+      const removeGrantedRoot = vi.fn(async () => {
+        expect(useGrantedFoldersStore.getState().roots).toBe(existing)
+        return []
+      })
+      setLocalFsApi({ grantRoot, removeGrantedRoot })
+      useGrantedFoldersStore.setState({ roots: existing, loaded: true })
+      const failed = useGrantedFoldersStore.getState().grant('/data/new', 'ro')
+      const rejection = expect(failed).rejects.toBe(error)
+      const next = useGrantedFoldersStore.getState().remove(existing[0].id)
+      await rejection
+      expect(await next).toEqual([])
+      expect(grantRoot).toHaveBeenCalledTimes(1)
+      expect(removeGrantedRoot).toHaveBeenCalledTimes(1)
+      expect(useGrantedFoldersStore.getState().roots).toEqual([])
+    }
+  )
+
+  it('fences a refresh started while a mutation waits in the queue', async () => {
+    const firstReply = Promise.withResolvers<GrantedLocalRoot[]>()
+    const secondReply = Promise.withResolvers<GrantedLocalRoot[]>()
+    const secondStarted = Promise.withResolvers<void>()
+    const staleRead = Promise.withResolvers<GrantedLocalRoot[]>()
+    const root = createRoot()
+    const writable = createRoot({ access: 'rw' })
+    setLocalFsApi({
+      grantRoot: vi.fn(() => firstReply.promise),
+      setGrantedRootAccess: vi.fn(() => {
+        secondStarted.resolve()
+        return secondReply.promise
+      }),
+      listGrantedRoots: vi.fn(() => staleRead.promise)
+    })
+    const first = useGrantedFoldersStore.getState().grant(root.path, 'ro')
+    const second = useGrantedFoldersStore.getState().setAccess(root.id, 'rw')
+    const refresh = useGrantedFoldersStore.getState().refresh()
+    firstReply.resolve([root])
+    await first
+    await secondStarted.promise
+    secondReply.resolve([writable])
+    await second
+    staleRead.resolve([])
+    expect(await refresh).toEqual([writable])
+    expect(useGrantedFoldersStore.getState().roots).toEqual([writable])
+  })
 })

--- a/src/renderer/src/stores/granted-folders-store.ts
+++ b/src/renderer/src/stores/granted-folders-store.ts
@@ -28,6 +28,7 @@ export const createInitialGrantedFoldersState = (): GrantedFoldersStoreData => (
 export const useGrantedFoldersStore = create<GrantedFoldersStore>((set, get) => {
   let mutationRevision = 0
   let refreshSequence = 0
+  let mutationQueue: Promise<void> = Promise.resolve()
 
   const apply = (roots: GrantedLocalRoot[]): GrantedLocalRoot[] => {
     set({ roots, loaded: true })
@@ -37,6 +38,16 @@ export const useGrantedFoldersStore = create<GrantedFoldersStore>((set, get) => 
   const applyMutation = (roots: GrantedLocalRoot[]): GrantedLocalRoot[] => {
     mutationRevision += 1
     return apply(roots)
+  }
+
+  // Full-list responses must publish in submission order within this renderer.
+  const mutate = (operation: () => Promise<GrantedLocalRoot[]>): Promise<GrantedLocalRoot[]> => {
+    const result = mutationQueue.then(operation).then(applyMutation)
+    mutationQueue = result.then(
+      () => undefined,
+      () => undefined
+    )
+    return result
   }
 
   return {
@@ -53,12 +64,11 @@ export const useGrantedFoldersStore = create<GrantedFoldersStore>((set, get) => 
 
     // Rejections carry a user-presentable message from main; callers surface them and the store
     // keeps the previous list.
-    grant: async (path, access) =>
-      applyMutation(await window.api.localFs.grantRoot({ path, access })),
+    grant: (path, access) => mutate(() => window.api.localFs.grantRoot({ path, access })),
 
-    setAccess: async (id, access) =>
-      applyMutation(await window.api.localFs.setGrantedRootAccess({ id, access })),
+    setAccess: (id, access) =>
+      mutate(() => window.api.localFs.setGrantedRootAccess({ id, access })),
 
-    remove: async (id) => applyMutation(await window.api.localFs.removeGrantedRoot({ id }))
+    remove: (id) => mutate(() => window.api.localFs.removeGrantedRoot({ id }))
   }
 })


### PR DESCRIPTION
## Problem

Removing two granted folders from the Composer menu could restore a removed row when an older full-list mutation response arrived last. Different rows can be submitted while another row is pending.

## Proposed change

Order grant, access changes and removals through one renderer-store Promise queue. Publish each result before invoking the next mutation, preserve each caller's original error, and continue after failure. Keep the existing refresh generation and mutation-revision guards.

## Scope and non-goals

Follow-up to #2261, confined to the granted-folders store. No new dependency, enum, persisted field, database migration, historical compatibility layer, or IPC/RPC change. The queue is transient and per renderer; pending UI now includes waiting for prior folder mutations. Cross-window synchronization, transport timeout policy, and global permission convergence are outside this change.

## Acceptance criteria and validation

Checks ran after the last material source edit:

- Ordered removal, mixed mutation types, original error identity, continuation after rejection/synchronous throw, and refresh fencing -> `npx vitest run src/renderer/src/stores/granted-folders-store.test.ts` -> 14 passed; independently rerun during Spec review.
- Owner, authority contracts, and real consumers -> `npx vitest run --maxWorkers=1 src/renderer/src/stores/granted-folders-store.test.ts src/main/local-fs src/shared/local-fs.test.ts src/renderer/src/pages/workspace/ComposerYourFilesMenu.interaction.test.tsx src/renderer/src/pages/workspace/ProjectFilesView.test.tsx src/renderer/src/pages/workspace/GrantFolderAccessDialog.layers.test.tsx src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx` -> 9 files / 214 passed.
- Renderer typing -> `npm run typecheck:web` -> passed with a branch-matched, privately generated Prisma client; shared installed client was stale for baseline Project.archiveRevision. No dependency download or shared-client regeneration.
- Standards/build -> `npm run lint`, `npm run build:web`, and `git diff --check` -> passed.
- Independent Standards and Spec reviews -> 0 actionable findings; final impact mapping confirmed.
- Built localhost Web UI with isolated storage: granted two empty temporary folders through real API, held the first removal response after its real deletion, clicked both removal buttons. Both rows were pending while only one API request had been sent. Releasing the first response admitted the second request; both rows disappeared and a real authority query returned an empty list. Screenshots captured; response wrapper restored and browser task closed. Same-origin Bearer authentication isolated test-browser cookie interference. No model calls or daily project data were used.

The first test selection under simultaneous builds hit a React setup timeout and a 5-second Prisma transaction expiry; limiting local workers passed without assertion or timeout changes. No full local suite was run per maintainer instruction. Main/preload, protocol, persistent formats and platform-specific implementation are unchanged; exact-head PR CI supplies complete and platform lanes. Browser verification controls response timing within one renderer and is not independent-process stress evidence.

## Review focus

The queue must include cache publication, not merely request completion. A rejected mutation must reject its own caller without poisoning later operations. All three mutation entry points must share the same queue.
