### PR TITLE
fix(workspace): synchronize tooltips and preserve archive authority

### DIFF
--- a/src/main/notebook/package-manager.test.ts
+++ b/src/main/notebook/package-manager.test.ts
@@ -139,6 +139,11 @@ describe('defaultSpawn (fail-closed spawn hooks)', () => {
             `const { spawn } = require('node:child_process');`,
             `const { writeFileSync } = require('node:fs');`,
             `const descendant = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 15000)']);`,
+            // Keep the fixture parent alive to reap its child on POSIX. Otherwise simultaneous
+            // SIGTERM can orphan the child and make success depend on the runner's init reaping it.
+            // Ignoring the parent's signal also ensures killing only the parent cannot pass.
+            `process.on('SIGTERM', () => {});`,
+            `descendant.on('exit', () => process.exit(0));`,
             `writeFileSync(process.env.DESCENDANT_PID_PATH, String(descendant.pid));`,
             `setTimeout(() => {}, 15000);`
           ].join('')

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -20,6 +20,7 @@ import type { ActivePlanProjection } from '../../../../shared/session-plan/contr
 import { toRuntimeUploadedAttachment } from '../../../../shared/uploads'
 import {
   createInitialSessionState,
+  getExternallyHydratedSessionAuthority,
   isExternallyHydratedSession,
   toPersistedSession,
   useSessionStore
@@ -1076,6 +1077,155 @@ describe('renderer session persistence bridge', () => {
     expect(api.saveSession).not.toHaveBeenCalled()
   })
 
+  it.each([undefined, 100])(
+    'does not echo archive authority (archivedAt=%s) back to persistence',
+    async (archivedAt) => {
+      const base = createPersistedSession({ revision: 42 })
+      useSessionStore.getState().hydrateSessions([base])
+      let durable = { ...base, revision: 43, archivedAt }
+      const api = createApi({
+        loadOne: vi.fn(async () => durable),
+        saveSession: vi.fn(async (submitted: PersistedChatSession) => {
+          if (submitted.revision !== durable.revision) {
+            throw new SessionRevisionConflictError(submitted.revision ?? 0, durable.revision)
+          }
+          durable = {
+            ...submitted,
+            revision: durable.revision + 1,
+            archivedAt: submitted.archivedAt
+          }
+          return durable
+        })
+      })
+      const save = createStoreSaver(api, useSessionStore.getState())
+      const source = useSessionStore.getState().sessions[0]
+
+      useSessionStore.getState().applyDurableSessionProjection({
+        source,
+        session: durable,
+        mode: 'archive-authority'
+      })
+      await save(useSessionStore.getState())
+
+      expect(
+        durable.revision,
+        'Refreshing archive authority must not create another revision'
+      ).toBe(43)
+      expect(api.saveSession).not.toHaveBeenCalled()
+      expect(useSessionStore.getState().sessions[0].revision).toBe(43)
+    }
+  )
+
+  it('still saves a local edit after refreshing archive authority', async () => {
+    const base = createPersistedSession({ revision: 42 })
+    useSessionStore.getState().hydrateSessions([base])
+    const api = createApi({ loadOne: vi.fn(async () => ({ ...base, revision: 43 })) })
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().renameSession(base.id, 'Local edit')
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: { ...base, revision: 43 },
+      mode: 'archive-authority'
+    })
+
+    expect(isExternallyHydratedSession(useSessionStore.getState().sessions[0])).toBe(false)
+    await save(useSessionStore.getState())
+    expect(api.saveSession).toHaveBeenCalledWith(expect.objectContaining({ title: 'Local edit' }), {
+      conflictRebaseFields: ['title']
+    })
+  })
+
+  it('does not echo archive refresh for the full session loaded with startup summaries', async () => {
+    const base = createPersistedSession({ revision: 42 })
+    useSessionStore.getState().hydrateSessionSummaries(
+      [
+        {
+          id: base.id,
+          projectId: base.projectId!,
+          title: base.title,
+          number: 1,
+          status: 'idle',
+          presentedStatus: 'idle',
+          revision: 42,
+          pinned: false,
+          activeMessageCount: 0,
+          artifactCount: 0,
+          filesRevision: 0,
+          createdAt: base.createdAt,
+          updatedAt: base.updatedAt,
+          needsStartupRecovery: false
+        }
+      ],
+      base
+    )
+    const api = createApi()
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().applyDurableSessionProjection({
+      source: useSessionStore.getState().sessions[0],
+      session: { ...base, revision: 43 },
+      mode: 'archive-authority'
+    })
+    await save(useSessionStore.getState())
+    expect(api.saveSession).not.toHaveBeenCalled()
+  })
+
+  it('still saves an unsaved title on an externally hydrated archive projection', async () => {
+    const base = createPersistedSession({ revision: 42 })
+    useSessionStore.getState().hydrateSessions([base])
+    const api = createApi()
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().renameSession(base.id, 'Local edit')
+    useSessionStore.getState().upsertPersistedSession({ ...base, revision: 43 })
+    const source = useSessionStore.getState().sessions[0]
+    expect(isExternallyHydratedSession(source)).toBe(true)
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: { ...base, revision: 44 },
+      mode: 'archive-authority'
+    })
+    await save(useSessionStore.getState())
+    expect(api.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ title: 'Local edit', revision: 44 }),
+      { conflictRebaseFields: ['title'] }
+    )
+  })
+
+  it('retains newer authority while persisting a context reset from a delayed archive receipt', async () => {
+    const base = createPersistedSession({ revision: 43 })
+    useSessionStore.getState().hydrateSessions([base])
+    const api = createApi()
+    const save = createStoreSaver(api, useSessionStore.getState())
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: { ...base, revision: 42, archivedAt: 100, branchContextResetRequired: true },
+      mode: 'archive-authority'
+    })
+    const projected = useSessionStore.getState().sessions[0]
+    expect(projected.archivedAt).toBeUndefined()
+    expect(getExternallyHydratedSessionAuthority(projected)?.revision).toBe(43)
+    await save(useSessionStore.getState())
+    expect(api.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({ revision: 43, branchContextResetRequired: true })
+    )
+  })
+
+  it('honors a forced save after archive authority refresh', async () => {
+    const base = createPersistedSession({ revision: 42 })
+    useSessionStore.getState().hydrateSessions([base])
+    const api = createApi()
+    const save = createStoreSaver(api, useSessionStore.getState())
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: { ...base, revision: 43 },
+      mode: 'archive-authority'
+    })
+    await save(useSessionStore.getState(), { forceTargets: new Set(['session:session-1']) })
+    expect(api.saveSession).toHaveBeenCalledWith(expect.objectContaining({ revision: 43 }))
+  })
+
   it('saves only the session whose reference changed', async () => {
     const api = createApi()
     const save = createStoreSaver(api)
@@ -1095,51 +1245,59 @@ describe('renderer session persistence bridge', () => {
     )
   })
 
-  it('persists in-flight streaming text that Session identity stability keeps out of Messages', async () => {
-    useSessionStore.getState().appendUserMessage({
-      sessionId: 'session-1',
-      content: 'Stream a response',
-      cwd: '/workspace/project',
-      projectId: 'project-a'
-    })
-    useSessionStore.getState().appendAgentMessageChunk({
-      sessionId: 'session-1',
-      streamId: 'assistant-1',
-      eventId: 'event-1',
-      content: 'Hello'
-    })
-    const api = createApi()
-    const save = createStoreSaver(api, useSessionStore.getState())
+  it.each([false, true])(
+    'persists identity-stable streaming text after hydration=%s',
+    async (hydrate) => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Stream a response',
+        cwd: '/workspace/project',
+        projectId: 'project-a'
+      })
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'session-1',
+        streamId: 'assistant-1',
+        eventId: 'event-1',
+        content: 'Hello'
+      })
+      if (hydrate) {
+        useSessionStore
+          .getState()
+          .hydrateSessions([toPersistedSession(useSessionStore.getState().sessions[0])])
+      }
+      const api = createApi()
+      const save = createStoreSaver(api, useSessionStore.getState())
 
-    // Pure text-growth ticks hold the new text in the streaming slice only; the Session object,
-    // its messages array, and the saver's identity diff all stay unchanged.
-    useSessionStore.getState().appendAgentMessageChunk({
-      sessionId: 'session-1',
-      streamId: 'assistant-1',
-      eventId: 'event-2',
-      content: ' world'
-    })
-    const state = useSessionStore.getState()
-    expect(state.sessions[0].messages.at(-1)?.content).toBe('Hello')
-    await save(state)
+      // Pure text-growth ticks hold the new text in the streaming slice only; the Session object,
+      // its messages array, and the saver's identity diff all stay unchanged.
+      useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'session-1',
+        streamId: 'assistant-1',
+        eventId: 'event-2',
+        content: ' world'
+      })
+      const state = useSessionStore.getState()
+      expect(state.sessions[0].messages.at(-1)?.content).toBe('Hello')
+      await save(state)
 
-    expect(api.saveSession).toHaveBeenCalledTimes(1)
-    const persisted = vi.mocked(api.saveSession).mock.calls[0][0]
-    expect(persisted.messages.find((message) => message.role === 'agent')).toMatchObject({
-      content: 'Hello world',
-      eventIds: ['event-1', 'event-2']
-    })
+      expect(api.saveSession).toHaveBeenCalledTimes(1)
+      const persisted = vi.mocked(api.saveSession).mock.calls[0][0]
+      expect(persisted.messages.find((message) => message.role === 'agent')).toMatchObject({
+        content: 'Hello world',
+        eventIds: ['event-1', 'event-2']
+      })
 
-    // A crash after the turn ends must still find the complete terminal Message on disk.
-    useSessionStore.getState().finishRun('session-1')
-    await save(useSessionStore.getState())
-    const terminal = vi.mocked(api.saveSession).mock.calls.at(-1)![0]
-    expect(terminal.messages.find((message) => message.role === 'agent')).toMatchObject({
-      content: 'Hello world',
-      status: 'complete',
-      eventIds: ['event-1', 'event-2']
-    })
-  })
+      // A crash after the turn ends must still find the complete terminal Message on disk.
+      useSessionStore.getState().finishRun('session-1')
+      await save(useSessionStore.getState())
+      const terminal = vi.mocked(api.saveSession).mock.calls.at(-1)![0]
+      expect(terminal.messages.find((message) => message.role === 'agent')).toMatchObject({
+        content: 'Hello world',
+        status: 'complete',
+        eventIds: ['event-1', 'event-2']
+      })
+    }
+  )
 
   it('reports only changed safe fields for stale-graph conflict rebasing', async () => {
     const persisted = materializeSessionConversationGraph(

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1136,6 +1136,38 @@ describe('renderer session persistence bridge', () => {
     })
   })
 
+  it.each([false, true])(
+    'persists a pin-only edit after fallback hydration (refresh=%s)',
+    async (refresh) => {
+      const base = createPersistedSession({ revision: 42, pinned: false })
+      useSessionStore.getState().hydrateSessions([base])
+      const api = createApi()
+      const save = createStoreSaver(api, useSessionStore.getState())
+      const hydrated = useSessionStore.getState().sessions[0]
+      expect(isExternallyHydratedSession(hydrated)).toBe(true)
+
+      useSessionStore.getState().togglePinned(base.id)
+      if (refresh) {
+        useSessionStore.getState().applyDurableSessionProjection({
+          source: useSessionStore.getState().sessions[0],
+          session: { ...base, revision: 43 },
+          mode: 'archive-authority'
+        })
+      }
+      expect(useSessionStore.getState().sessions[0]).not.toBe(hydrated)
+      expect(isExternallyHydratedSession(useSessionStore.getState().sessions[0])).toBe(false)
+      await save(useSessionStore.getState())
+
+      expect(api.saveSession).toHaveBeenCalledOnce()
+      expect(api.saveSession).toHaveBeenCalledWith(expect.objectContaining({ pinned: true }), {
+        conflictRebaseFields: ['pinned']
+      })
+      const durable = await vi.mocked(api.saveSession).mock.results[0].value
+      useSessionStore.getState().hydrateSessions([durable])
+      expect(useSessionStore.getState().sessions[0].pinned).toBe(true)
+    }
+  )
+
   it('does not echo archive refresh for the full session loaded with startup summaries', async () => {
     const base = createPersistedSession({ revision: 42 })
     useSessionStore.getState().hydrateSessionSummaries(

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -1554,6 +1554,7 @@ const createStoreSaver = (
           isForced ||
           streamingDirtySessionIds.has(session.id)) &&
         (isForced ||
+          streamingDirtySessionIds.has(session.id) ||
           !isExternallyHydratedSession(session) ||
           hasUnsavedLocalTitle ||
           hasUnsavedContextReset) &&

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -59,6 +59,7 @@ import { WorkspaceContextCompactionActivityRow } from './WorkspaceContextCompact
 import { WorkspacePlanActivityRecord } from './WorkspacePlanActivityRecord'
 import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 import { WorkspaceAssistantTurnCompletion, WorkspaceMessageItem } from './WorkspaceMessageItem'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { createWorkspaceConversationTimeline } from './workspace-conversation-timeline'
 import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 import { ArtifactSourcesPanel } from './ArtifactSourcesPanel'
@@ -376,134 +377,136 @@ const ProvenanceMessagesTimeline = ({
   )
 
   return (
-    <MessageScrollerProvider
-      key={`${sessionId}:${snapshot.items.at(-1)?.id ?? 'empty'}`}
-      autoScroll
-      defaultScrollPosition="last-anchor"
-      scrollPreviousItemPeek={64}
-    >
-      <MessageScroller className="min-h-0 bg-bg-000">
-        <MessageScrollerViewport aria-label={t('Provenance messages')}>
-          <MessageScrollerContent className="gap-0 px-4">
-            <div className="mx-auto w-full max-w-4xl pb-4">
-              {conversationItems.map((conversationItem) => {
-                if (conversationItem.type === 'message') {
-                  return (
-                    <WorkspaceMessageItem
-                      key={conversationItem.id}
-                      message={conversationItem.message}
-                      staticParts={projectedById.get(conversationItem.message.id)?.parts}
-                      onPreviewArtifact={ignoreArtifactPreview}
-                      onPreviewUploadAttachment={ignoreUploadPreview}
-                      onOpenSkillMention={ignoreSkillOpen}
-                      onPreviewMentionArtifact={ignoreMentionPreview}
-                      artifacts={[]}
-                      showUserActions={false}
-                      showAssistantFooter={conversationItem.message.role !== 'agent'}
-                      contentPaddingClassName="px-0 md:px-0"
-                    />
-                  )
-                }
+    <TooltipProvider key={sessionId} delayDuration={200} skipDelayDuration={300}>
+      <MessageScrollerProvider
+        key={`${sessionId}:${snapshot.items.at(-1)?.id ?? 'empty'}`}
+        autoScroll
+        defaultScrollPosition="last-anchor"
+        scrollPreviousItemPeek={64}
+      >
+        <MessageScroller className="min-h-0 bg-bg-000">
+          <MessageScrollerViewport aria-label={t('Provenance messages')}>
+            <MessageScrollerContent className="gap-0 px-4">
+              <div className="mx-auto w-full max-w-4xl pb-4">
+                {conversationItems.map((conversationItem) => {
+                  if (conversationItem.type === 'message') {
+                    return (
+                      <WorkspaceMessageItem
+                        key={conversationItem.id}
+                        message={conversationItem.message}
+                        staticParts={projectedById.get(conversationItem.message.id)?.parts}
+                        onPreviewArtifact={ignoreArtifactPreview}
+                        onPreviewUploadAttachment={ignoreUploadPreview}
+                        onOpenSkillMention={ignoreSkillOpen}
+                        onPreviewMentionArtifact={ignoreMentionPreview}
+                        artifacts={[]}
+                        showUserActions={false}
+                        showAssistantFooter={conversationItem.message.role !== 'agent'}
+                        contentPaddingClassName="px-0 md:px-0"
+                      />
+                    )
+                  }
 
-                if (conversationItem.type === 'turn-completion') {
-                  return (
-                    <MessageScrollerItem
-                      key={conversationItem.id}
-                      messageId={conversationItem.id}
-                      className="min-w-0"
-                    >
-                      <div className="pb-1">
-                        <WorkspaceAssistantTurnCompletion
-                          message={conversationItem.message}
-                          turnStartedAt={
-                            conversationItem.message.responseToMessageId
-                              ? messageCreatedAtById.get(
-                                  conversationItem.message.responseToMessageId
-                                )
-                              : undefined
-                          }
-                        />
-                      </div>
-                    </MessageScrollerItem>
-                  )
-                }
-
-                // Artifact provenance builds its immutable transcript from persisted messages and
-                // activities only, so no coordinator lifecycle or durable Subagent command rows
-                // are supplied here. Derived config-change dividers are render-time annotations,
-                // not provenance records, and are skipped as well.
-                if (
-                  conversationItem.type === 'handoff' ||
-                  conversationItem.type === 'subagent-message' ||
-                  conversationItem.type === 'session-config-change'
-                )
-                  return null
-
-                if (conversationItem.type === 'plan-activity') {
-                  return (
-                    <WorkspacePlanActivityRecord
-                      key={conversationItem.id}
-                      activity={conversationItem.activity}
-                      contentPaddingClassName="px-0 md:px-0"
-                    />
-                  )
-                }
-
-                if (conversationItem.type === 'compaction-activity') {
-                  return (
-                    <WorkspaceContextCompactionActivityRow
-                      key={conversationItem.id}
-                      activity={conversationItem.activity}
-                      contentPaddingClassName="px-0 md:px-0"
-                    />
-                  )
-                }
-
-                if (conversationItem.type === 'activity') {
-                  return (
-                    <MessageScrollerItem
-                      key={conversationItem.id}
-                      messageId={conversationItem.id}
-                      className="min-w-0"
-                    >
-                      <div className="py-3">
-                        {conversationItem.activity.elicitation ? (
-                          <WorkspaceElicitationCard
-                            elicitation={conversationItem.activity.elicitation}
+                  if (conversationItem.type === 'turn-completion') {
+                    return (
+                      <MessageScrollerItem
+                        key={conversationItem.id}
+                        messageId={conversationItem.id}
+                        className="min-w-0"
+                      >
+                        <div className="pb-1">
+                          <WorkspaceAssistantTurnCompletion
+                            message={conversationItem.message}
+                            turnStartedAt={
+                              conversationItem.message.responseToMessageId
+                                ? messageCreatedAtById.get(
+                                    conversationItem.message.responseToMessageId
+                                  )
+                                : undefined
+                            }
                           />
-                        ) : null}
-                      </div>
-                    </MessageScrollerItem>
-                  )
-                }
+                        </div>
+                      </MessageScrollerItem>
+                    )
+                  }
 
-                return (
-                  <WorkspaceActivityGroup
-                    key={conversationItem.id}
-                    group={conversationItem}
-                    isExpanded={!collapsedGroups.has(conversationItem.id)}
-                    onToggleGroup={(groupId) =>
-                      setCollapsedGroups((current) => {
-                        const next = new Set(current)
-                        if (next.has(groupId)) next.delete(groupId)
-                        else next.add(groupId)
-                        return next
-                      })
-                    }
-                    expansionOverrides={expandedRows}
-                    contentPaddingClassName="px-0 md:px-0"
-                    onToggleRow={(activityId, nextExpanded) =>
-                      setExpandedRows((current) => ({ ...current, [activityId]: nextExpanded }))
-                    }
-                  />
-                )
-              })}
-            </div>
-          </MessageScrollerContent>
-        </MessageScrollerViewport>
-        <MessageScrollerButton className="z-10 border-border-200 bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
-      </MessageScroller>
-    </MessageScrollerProvider>
+                  // Artifact provenance builds its immutable transcript from persisted messages and
+                  // activities only, so no coordinator lifecycle or durable Subagent command rows
+                  // are supplied here. Derived config-change dividers are render-time annotations,
+                  // not provenance records, and are skipped as well.
+                  if (
+                    conversationItem.type === 'handoff' ||
+                    conversationItem.type === 'subagent-message' ||
+                    conversationItem.type === 'session-config-change'
+                  )
+                    return null
+
+                  if (conversationItem.type === 'plan-activity') {
+                    return (
+                      <WorkspacePlanActivityRecord
+                        key={conversationItem.id}
+                        activity={conversationItem.activity}
+                        contentPaddingClassName="px-0 md:px-0"
+                      />
+                    )
+                  }
+
+                  if (conversationItem.type === 'compaction-activity') {
+                    return (
+                      <WorkspaceContextCompactionActivityRow
+                        key={conversationItem.id}
+                        activity={conversationItem.activity}
+                        contentPaddingClassName="px-0 md:px-0"
+                      />
+                    )
+                  }
+
+                  if (conversationItem.type === 'activity') {
+                    return (
+                      <MessageScrollerItem
+                        key={conversationItem.id}
+                        messageId={conversationItem.id}
+                        className="min-w-0"
+                      >
+                        <div className="py-3">
+                          {conversationItem.activity.elicitation ? (
+                            <WorkspaceElicitationCard
+                              elicitation={conversationItem.activity.elicitation}
+                            />
+                          ) : null}
+                        </div>
+                      </MessageScrollerItem>
+                    )
+                  }
+
+                  return (
+                    <WorkspaceActivityGroup
+                      key={conversationItem.id}
+                      group={conversationItem}
+                      isExpanded={!collapsedGroups.has(conversationItem.id)}
+                      onToggleGroup={(groupId) =>
+                        setCollapsedGroups((current) => {
+                          const next = new Set(current)
+                          if (next.has(groupId)) next.delete(groupId)
+                          else next.add(groupId)
+                          return next
+                        })
+                      }
+                      expansionOverrides={expandedRows}
+                      contentPaddingClassName="px-0 md:px-0"
+                      onToggleRow={(activityId, nextExpanded) =>
+                        setExpandedRows((current) => ({ ...current, [activityId]: nextExpanded }))
+                      }
+                    />
+                  )
+                })}
+              </div>
+            </MessageScrollerContent>
+          </MessageScrollerViewport>
+          <MessageScrollerButton className="z-10 border-border-200 bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3" />
+        </MessageScroller>
+      </MessageScrollerProvider>
+    </TooltipProvider>
   )
 }
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -12,7 +12,16 @@ import type { ChatMessage } from '@/stores/session-store'
 import type { SendEditedMessage } from './workspace-edited-message'
 import type { EditAnnotationTarget } from './WorkspaceMessageItem'
 import type { Annotation, TextAnnotation } from '../../../../shared/annotations'
-import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WorkspaceMessageItem as MessageItem } from './WorkspaceMessageItem'
+
+const WorkspaceMessageItem = (
+  props: React.ComponentProps<typeof MessageItem>
+): React.JSX.Element => (
+  <TooltipProvider delayDuration={200}>
+    <MessageItem {...props} />
+  </TooltipProvider>
+)
 
 const { requestPdfReadingReveal } = vi.hoisted(() => ({ requestPdfReadingReveal: vi.fn() }))
 vi.mock('./pdf-reading-reveal', () => ({ requestPdfReadingReveal }))

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.containment.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.containment.test.tsx
@@ -8,7 +8,16 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage } from '@/stores/session-store'
 
-import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WorkspaceMessageItem as MessageItem } from './WorkspaceMessageItem'
+
+const WorkspaceMessageItem = (
+  props: React.ComponentProps<typeof MessageItem>
+): React.JSX.Element => (
+  <TooltipProvider delayDuration={200}>
+    <MessageItem {...props} />
+  </TooltipProvider>
+)
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, StrictMode } from 'react'
+import { fireEvent } from '@testing-library/react'
 import { createRoot, type Root } from 'react-dom/client'
 import type { JSX, PropsWithChildren } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -8,7 +9,16 @@ import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-
 import { useNavigationStore } from '@/stores/navigation-store'
 import type { ChatMessage } from '@/stores/session-store'
 
-import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WorkspaceMessageItem as MessageItem } from './WorkspaceMessageItem'
+
+const WorkspaceMessageItem = (
+  props: React.ComponentProps<typeof MessageItem>
+): React.JSX.Element => (
+  <TooltipProvider delayDuration={200}>
+    <MessageItem {...props} />
+  </TooltipProvider>
+)
 
 const { artifactPreview } = vi.hoisted(() => ({
   artifactPreview: vi.fn(() => null)
@@ -612,7 +622,7 @@ describe('WorkspaceMessageItem turn token usage', () => {
     expect(document.body.textContent).not.toContain('Input 12,345')
 
     await act(async () => {
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      usageTrigger?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
       await Promise.resolve()
     })
 
@@ -625,7 +635,9 @@ describe('WorkspaceMessageItem turn token usage', () => {
     expect(usagePopover?.textContent).toContain('Cache678')
     expect(usagePopover?.textContent).toContain('Output90')
     expect(usagePopover?.textContent).toContain('Total13,113')
-    expect(usagePopover?.getAttribute('aria-label')).toBe('Token usage for this response')
+    expect(usagePopover?.querySelector('[role="tooltip"]')?.textContent).toContain(
+      'Token usage for this response: Input 12,345, Cache 678, Output 90; Total 13,113 tokens'
+    )
     expect(usagePopover?.className).toContain('border-border')
     expect(usagePopover?.className).toContain('bg-popover')
     expect(usagePopover?.className).toContain('shadow-menu')
@@ -700,7 +712,7 @@ describe('WorkspaceMessageItem turn token usage', () => {
       '[data-slot="turn-token-usage"] button'
     )
     await act(async () => {
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      usageTrigger?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
       await Promise.resolve()
     })
 
@@ -753,7 +765,7 @@ describe('WorkspaceMessageItem turn token usage', () => {
       '[data-slot="turn-token-usage"] button'
     )
     await act(async () => {
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      usageTrigger?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
       await Promise.resolve()
     })
 
@@ -783,7 +795,7 @@ describe('WorkspaceMessageItem turn token usage', () => {
       '[data-slot="turn-token-usage"] button'
     )
     await act(async () => {
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      usageTrigger?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
       await Promise.resolve()
     })
 
@@ -824,24 +836,20 @@ describe('WorkspaceMessageItem turn token usage', () => {
       '[data-slot="turn-token-usage"] button'
     )
     act(() => {
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
+      usageTrigger?.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }))
     })
 
     const usagePopover = document.body.querySelector('[data-slot="turn-token-usage-popover"]')
     act(() => {
-      usageTrigger?.dispatchEvent(
-        new MouseEvent('pointerout', { bubbles: true, relatedTarget: usagePopover })
-      )
-      usagePopover?.dispatchEvent(
-        new MouseEvent('pointerover', { bubbles: true, relatedTarget: usageTrigger })
-      )
+      fireEvent.pointerLeave(usageTrigger!)
+      fireEvent.pointerMove(usagePopover!, { pointerType: 'mouse' })
       vi.advanceTimersByTime(100)
     })
     expect(document.body.querySelector('[data-slot="turn-token-usage-popover"]')).not.toBeNull()
 
     act(() => {
-      usagePopover?.dispatchEvent(new MouseEvent('pointerout', { bubbles: true }))
-      vi.advanceTimersByTime(100)
+      fireEvent.pointerLeave(usagePopover!)
+      fireEvent.pointerMove(document.body, { pointerType: 'mouse', clientX: 1000, clientY: 1000 })
     })
     expect(document.body.querySelector('[data-slot="turn-token-usage-popover"]')).toBeNull()
   })
@@ -889,10 +897,8 @@ describe('WorkspaceMessageItem turn token usage', () => {
     expect(document.body.querySelector('[data-slot="turn-token-usage-popover"]')).toBeNull()
   })
 
-  it('clears a pending Usage close when the token summary unmounts', async () => {
+  it('cancels pending Calls hover when the token summary unmounts', async () => {
     vi.useFakeTimers()
-    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout')
-    const clearTimeoutSpy = vi.spyOn(globalThis, 'clearTimeout')
     await renderMessageItem(
       createMessage({
         role: 'agent',
@@ -901,23 +907,17 @@ describe('WorkspaceMessageItem turn token usage', () => {
         turnUsage: { inputTokens: 12_345, cacheTokens: 678, outputTokens: 90 }
       })
     )
-
-    const usageTrigger = container.querySelector<HTMLButtonElement>(
-      '[data-slot="turn-token-usage"] button'
-    )
+    const trigger = container.querySelector('[data-slot="turn-token-usage"] button')!
     act(() => {
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerover', { bubbles: true }))
-      usageTrigger?.dispatchEvent(new MouseEvent('pointerout', { bubbles: true }))
+      fireEvent.pointerMove(trigger, { pointerType: 'mouse' })
     })
-    const closeTimerIndex = setTimeoutSpy.mock.calls.findLastIndex(([, delay]) => delay === 100)
-    const closeTimer = setTimeoutSpy.mock.results[closeTimerIndex]?.value
-    expect(closeTimer).toBeDefined()
-
     await renderMessageItem(
       createMessage({ role: 'agent', content: 'Done without totals', completedAt: 1710000126000 })
     )
-
-    expect(clearTimeoutSpy).toHaveBeenCalledWith(closeTimer)
+    act(() => {
+      vi.advanceTimersByTime(201)
+    })
+    expect(document.body.querySelector('[data-slot="turn-token-usage-popover"]')).toBeNull()
   })
 
   it('shows failed time and elapsed run time even when token totals are absent', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tooltips.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tooltips.test.tsx
@@ -1,0 +1,104 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WorkspaceAssistantTurnCompletion } from './WorkspaceMessageItem'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+const renderGroup = (): ReturnType<typeof render> =>
+  render(
+    <TooltipProvider delayDuration={200} skipDelayDuration={300}>
+      {['first', 'second'].map((id) => (
+        <WorkspaceAssistantTurnCompletion
+          key={id}
+          message={{
+            id,
+            role: 'agent',
+            content: 'Done',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1710000000000,
+            updatedAt: 1710000001000,
+            completedAt: 1710000001000,
+            turnUsage: { inputTokens: 12, cacheTokens: 3, outputTokens: 4 }
+          }}
+          canBranchInNewSession
+          onBranchInNewSession={() => {}}
+        />
+      ))}
+    </TooltipProvider>
+  )
+const advance = async (ms: number): Promise<void> => {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms)
+  })
+}
+const hover = (element: Element): void => {
+  fireEvent.pointerOver(element, { pointerType: 'mouse' })
+  fireEvent.pointerMove(element, { pointerType: 'mouse' })
+}
+const leave = (element: Element): void => {
+  fireEvent.pointerLeave(element)
+  fireEvent.pointerMove(document.body, { pointerType: 'mouse', clientX: 1000, clientY: 1000 })
+}
+afterEach(() => {
+  cleanup()
+  vi.useRealTimers()
+})
+
+it('shares the skip window across messages and restores the initial delay after leaving', async () => {
+  vi.useFakeTimers()
+  const view = renderGroup()
+  const [first, second] = view.getAllByRole('button', { name: 'Copy message' })
+  hover(first)
+  await advance(199)
+  expect(first.getAttribute('data-state')).toBe('closed')
+  await advance(1)
+  expect(first.getAttribute('data-state')).toBe('delayed-open')
+  leave(first)
+  hover(second)
+  await advance(0)
+  expect(second.getAttribute('data-state')).toBe('instant-open')
+  leave(second)
+  await advance(301)
+  hover(first)
+  await advance(199)
+  expect(first.getAttribute('data-state')).toBe('closed')
+  await advance(1)
+  expect(first.getAttribute('data-state')).toBe('delayed-open')
+})
+
+it('delays Calls initially and shares its warm window with the timestamp and actions', async () => {
+  vi.useFakeTimers()
+  const view = renderGroup()
+  const calls = view.getAllByRole('button', { name: 'Token usage for this response' })[0]
+  hover(calls)
+  await advance(199)
+  expect(document.querySelector('[data-slot="turn-token-usage-popover"]')).toBeNull()
+  await advance(1)
+  expect(document.querySelector('[data-slot="turn-token-usage-popover"]')).not.toBeNull()
+  leave(calls)
+  const timestamp = view.container.querySelector('time')!
+  expect(timestamp.hasAttribute('title')).toBe(false)
+  hover(timestamp)
+  await advance(0)
+  expect(timestamp.getAttribute('data-state')).toBe('instant-open')
+  leave(timestamp)
+  const copy = view.getAllByRole('button', { name: 'Copy message' })[1]
+  hover(copy)
+  await advance(0)
+  expect(copy.getAttribute('data-state')).toBe('instant-open')
+})
+
+it('opens Calls on click or keyboard focus and dismisses it with Escape', async () => {
+  const view = renderGroup()
+  const calls = view.getAllByRole('button', { name: 'Token usage for this response' })[0]
+  fireEvent.click(calls)
+  expect(document.querySelector('[data-slot="turn-token-usage-popover"]')).not.toBeNull()
+  fireEvent.keyDown(calls, { key: 'Escape' })
+  expect(document.querySelector('[data-slot="turn-token-usage-popover"]')).toBeNull()
+  fireEvent.focus(calls)
+  expect(document.querySelector('[data-slot="turn-token-usage-popover"]')).not.toBeNull()
+})

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1,8 +1,7 @@
 import { useSmoothStreamingContent } from '@/components/streamdown/use-smooth-streaming-content'
 import { ErrorNotice } from '@/components/error-notice'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
-import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
 import { cn, formatByteSize } from '@/lib/utils'
 import { useNavigationStore } from '@/stores/navigation-store'
@@ -30,16 +29,7 @@ import {
   Loader2,
   Pencil
 } from 'lucide-react'
-import {
-  memo,
-  useEffect,
-  useId,
-  useLayoutEffect,
-  useRef,
-  useState,
-  type FocusEvent,
-  type ReactNode
-} from 'react'
+import { memo, useEffect, useId, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatDisplayNumber } from '@/lib/locale-format'
 import type { ArtifactPreviewResult } from '../../../../shared/artifacts'
@@ -197,9 +187,18 @@ const MessageTimestamp = ({
   const formatDate = useDateTimeFormat()
 
   return (
-    <time dateTime={date.toISOString()} title={formatDate(date, 'full')}>
-      {label} {formatDate(date)}
-    </time>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <time
+          dateTime={date.toISOString()}
+          tabIndex={0}
+          className="rounded-sm focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+        >
+          {label} {formatDate(date)}
+        </time>
+      </TooltipTrigger>
+      <TooltipContent>{formatDate(date, 'full')}</TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -241,11 +240,6 @@ const TurnTokenUsage = ({
   const provider = providers?.find((candidate) => candidate.id === providerId)
   const kindKey = provider ? providerKindKey(provider.type, provider.vendorId) : undefined
   const model = runtimeIdentity?.model?.trim()
-  const contentId = useId()
-  const triggerRef = useRef<HTMLButtonElement | null>(null)
-  const contentRef = useRef<HTMLDivElement | null>(null)
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
-  const openedFromPointerRef = useRef(false)
   const accessibleLabel = usage
     ? t('Token usage for this response')
     : t('Token usage unavailable for this response')
@@ -275,60 +269,18 @@ const TurnTokenUsage = ({
         })
       : t('Token usage breakdown unavailable')
 
-  const keepOpen = (): void => {
-    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
-    closeTimerRef.current = undefined
-  }
-
-  const scheduleClose = (): void => {
-    keepOpen()
-    closeTimerRef.current = setTimeout(() => {
-      const focused = document.activeElement
-      if (triggerRef.current?.contains(focused) || contentRef.current?.contains(focused)) return
-      setOpen(false)
-    }, 100)
-  }
-
-  const handleBlur = (event: FocusEvent<HTMLElement>): void => {
-    const next = event.relatedTarget
-    if (triggerRef.current?.contains(next) || contentRef.current?.contains(next)) return
-    scheduleClose()
-  }
-
-  useEffect(
-    () => () => {
-      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
-    },
-    []
-  )
-
   return (
-    <Popover open={open} onOpenChange={setOpen}>
-      <PopoverAnchor asChild>
-        <span data-slot="turn-token-usage" className="inline-flex whitespace-nowrap">
+    <Tooltip open={open} onOpenChange={setOpen}>
+      <span data-slot="turn-token-usage" className="inline-flex whitespace-nowrap">
+        <TooltipTrigger asChild>
           <button
-            ref={triggerRef}
             type="button"
             aria-label={accessibleLabel}
-            aria-haspopup="dialog"
             aria-expanded={open}
-            aria-controls={open ? contentId : undefined}
             className="inline-flex touch-manipulation items-center gap-1 border-b border-dashed border-current pb-px leading-none transition-colors duration-150 motion-reduce:transition-none hover:text-text-100 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
-            onPointerEnter={() => {
-              openedFromPointerRef.current = true
-              keepOpen()
-              setOpen(true)
-            }}
-            onPointerLeave={scheduleClose}
-            onFocus={() => {
-              openedFromPointerRef.current = false
-              keepOpen()
-              setOpen(true)
-            }}
-            onBlur={handleBlur}
-            onClick={() => {
-              openedFromPointerRef.current = false
-              keepOpen()
+            onClick={(event) => {
+              // Calls is read-only detail; retain explicit click/touch access to the hover content.
+              event.preventDefault()
               setOpen(true)
             }}
           >
@@ -340,24 +292,15 @@ const TurnTokenUsage = ({
             />
             {t('Calls')}
           </button>
-        </span>
-      </PopoverAnchor>
-      <PopoverContent
-        ref={contentRef}
-        id={contentId}
+        </TooltipTrigger>
+      </span>
+      <TooltipContent
         data-slot="turn-token-usage-popover"
-        aria-label={accessibleLabel}
+        aria-label={`${accessibleLabel}: ${breakdownLabel}`}
         side="top"
         align="center"
         sideOffset={8}
         className="w-48 max-w-[calc(100vw-2rem)] rounded-lg border border-border bg-popover p-2.5 text-[12px] text-popover-foreground shadow-menu"
-        onPointerEnter={keepOpen}
-        onPointerLeave={scheduleClose}
-        onFocusCapture={keepOpen}
-        onBlurCapture={handleBlur}
-        onOpenAutoFocus={(event) => {
-          if (openedFromPointerRef.current) event.preventDefault()
-        }}
       >
         <div className="flex items-center justify-between gap-3">
           <div className="flex items-center gap-1.5">
@@ -489,8 +432,8 @@ const TurnTokenUsage = ({
             ) : null}
           </div>
         ) : null}
-      </PopoverContent>
-    </Popover>
+      </TooltipContent>
+    </Tooltip>
   )
 }
 
@@ -570,7 +513,7 @@ const WorkspaceAssistantTurnCompletion = ({
       className="mt-3 flex items-center gap-x-3 whitespace-nowrap text-[11px] leading-4 text-text-000/70 tabular-nums"
     >
       {message.status === 'complete' && onBranchInNewSession ? (
-        <TooltipProvider delayDuration={200}>
+        <>
           <div data-slot="assistant-message-actions" className="flex items-center gap-0.5">
             <UserMessageActionTooltip label={copied ? t('Copied') : t('Copy message')}>
               <button
@@ -598,7 +541,7 @@ const WorkspaceAssistantTurnCompletion = ({
               </button>
             </UserMessageActionTooltip>
           </div>
-        </TooltipProvider>
+        </>
       ) : null}
       {terminalDate ? <MessageTimestamp label={terminalLabel} date={terminalDate} /> : null}
       {terminalDate && turnStartedDate ? (
@@ -1626,7 +1569,7 @@ const WorkspaceMessageItemImpl = ({
   )
 
   return (
-    <TooltipProvider delayDuration={200}>
+    <>
       <MessageScrollerItem
         key={message.id}
         messageId={message.id}
@@ -1992,7 +1935,7 @@ const WorkspaceMessageItemImpl = ({
           />
         ) : null}
       </MessageScrollerItem>
-    </TooltipProvider>
+    </>
   )
 }
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -52,6 +52,7 @@ import { JobDetailModal } from '@/components/JobDetailModal'
 import { extractJobIdFromActivity } from '@/components/job-binding-utils'
 import { MessageScrollerItem } from '@/components/ui/message-scroller'
 import { Button } from '@/components/ui/button'
+import { TooltipProvider } from '@/components/ui/tooltip'
 import { ReviewerCard } from '@/components/ReviewerCard'
 import { WorkspaceActivityGroup } from './WorkspaceActivityGroup'
 import { WorkspaceContextCompactionActivityRow } from './WorkspaceContextCompactionActivityRow'
@@ -1268,7 +1269,11 @@ const WorkspaceMessageScrollerImpl = ({
   }
 
   return (
-    <>
+    <TooltipProvider
+      key={activeSession?.id ?? 'empty-conversation'}
+      delayDuration={200}
+      skipDelayDuration={300}
+    >
       <MessageScrollerProvider
         key={activeSession?.id ?? 'empty-conversation'}
         autoScroll
@@ -1846,7 +1851,7 @@ const WorkspaceMessageScrollerImpl = ({
           onClose={handleCloseModal}
         />
       )}
-    </>
+    </TooltipProvider>
   )
 }
 

--- a/src/renderer/src/pages/workspace/artifact-publication-preview.integration.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-publication-preview.integration.test.tsx
@@ -32,7 +32,16 @@ import { createCachedImageFetchResponse } from './previews/cached-preview-image.
 import { ArtifactRunRegistry } from '../../../../main/artifacts/run-registry'
 import { ManagedFileVersionService } from '../../../../main/managed-file-versions/service'
 import { ManagedPreviewResources } from '../../../../main/managed-preview-resources'
-import { WorkspaceMessageItem } from './WorkspaceMessageItem'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WorkspaceMessageItem as MessageItem } from './WorkspaceMessageItem'
+
+const WorkspaceMessageItem = (
+  props: React.ComponentProps<typeof MessageItem>
+): React.JSX.Element => (
+  <TooltipProvider delayDuration={200}>
+    <MessageItem {...props} />
+  </TooltipProvider>
+)
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -612,7 +612,11 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
   hydrateSessions: (sessions, manifest, selection) => {
     const hydrated = [...sessions]
       .sort((left, right) => right.updatedAt - left.updatedAt)
-      .map(hydrateSession)
+      .map((session) => {
+        const hydrated = hydrateSession(session)
+        markExternallyHydratedSession(hydrated, session)
+        return hydrated
+      })
     const hasExplicitSelection = selection !== undefined
     const requestedSelection = hasExplicitSelection ? selection.sessionId : manifest?.lastSessionId
     const selectedSessionId = hydrated.some((session) => session.id === requestedSelection)
@@ -630,7 +634,10 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       .sort((left, right) => right.updatedAt - left.updatedAt)
       .map((summary) => {
         const authority = selectedById.get(summary.id)
-        return authority ? hydrateSession(authority) : hydrateSessionSummary(summary)
+        if (!authority) return hydrateSessionSummary(summary)
+        const hydrated = hydrateSession(authority)
+        markExternallyHydratedSession(hydrated, authority)
+        return hydrated
       })
     const hasExplicitSelection = selection !== undefined
     const requestedSelection = hasExplicitSelection ? selection.sessionId : manifest?.lastSessionId
@@ -825,6 +832,17 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       if (mode === 'archive-authority') {
         const projected = archive
         if (projected === current) return state
+        const previousAuthority = externallyHydratedSessionAuthorities.get(current)
+        if (previousAuthority) {
+          // Refreshing archive metadata is not a local edit. Preserve dirty sessions as dirty,
+          // and do not let a delayed receipt replace a newer persistence acknowledgement.
+          markExternallyHydratedSession(
+            projected,
+            sessionRevision(previousAuthority) > sessionRevision(session)
+              ? previousAuthority
+              : session
+          )
+        }
         return {
           sessions: state.sessions.map((candidate) =>
             candidate === current ? projected : candidate


### PR DESCRIPTION
## Problem

Message controls used separate tooltip timing owners: crossing messages restarted the delay, timestamps used browser titles, and Calls opened immediately. PR CI also exposed a redundant Session save after archive conflict refresh, which advanced the revision again and created another conflict window, plus a POSIX installer-abort test fixture that depended on orphan reaping.

## Proposed change

- Share one Radix TooltipProvider per transcript, including provenance, with a 200ms initial delay and a 300ms skip window. Include timestamps and hoverable Calls details; retain click/touch, keyboard focus, Escape, and pointer transit into details.
- Preserve existing persistence-authority provenance through initial full hydration and clean archive projections. Retain the newest acknowledgement on delayed receipts. Keep local edits, unsaved titles/context resets, forced saves, and identity-stable streaming text eligible for persistence. Keep archive revision checks and explicit retry behavior unchanged.
- Keep the installer fixture parent alive until its descendant exits so POSIX reaping does not depend on the runner init process. Retain both process-disappearance assertions and production fail-closed guards.

## Scope and non-goals

No new dependency, public interface, data field, enum, schema, migration, or historical-data compatibility requirement. Persistence change: avoid redundant whole-Session writes from authority refreshes; actual local changes still save. No ACP/provider protocol, IPC, database format, or production process teardown change. Calls changes accessibility semantics from dialog to tooltip; its accessible description includes the usage breakdown. CI workflow and E2E assertions are unchanged.

## Acceptance criteria and validation

Checks below ran after the last material edit to their respective implementation. Full local `npm test` was intentionally not run per maintainer request; latest-head CI remains authoritative for full portable and platform validation.

- Tooltip timing, accessibility, transcript/provenance consumers and i18n -> final combined targeted Vitest run of 12 files -> 1,186 tests passed. Files: `WorkspaceMessageItem.{actions,containment,mentions,tooltips}.test.tsx`, `WorkspaceMessageScroller.render.test.tsx`, `artifact-publication-preview.integration.test.tsx`, `workspace-components.test.tsx`, `ConversationPanel.interaction.test.tsx`, `SubagentReleaseSurfaces.render.test.tsx`, `ArtifactProvenanceMessages.integration.test.tsx`, `ArtifactProvenancePanel.render.test.tsx` under `src/renderer/src/pages/workspace/`, plus `src/renderer/src/i18n/resources.test.ts`.
- Archive echo prevention, initial full/summary hydration, dirty and marked titles, stale receipt/context reset, forced saves, streaming/terminal persistence and archive consumers -> `npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/stores/session-store.archive-order.test.ts src/renderer/src/stores/session-store.test.ts src/renderer/src/pages/workspace/workspace-session-controller.test.ts src/renderer/src/stores/archive-undo-store.test.ts` -> 367 tests passed. The echo regression failed before the fix (expected revision 43, received 44); the hydrated streaming regression also demonstrated the need to retain streaming writes.
- Renderer types and source conventions -> `npm run typecheck:web`, `npm run lint`, changed-file Prettier and `git diff --check` -> passed.
- Build and original archive journey -> `npm run build:e2e`; `npx playwright test e2e/workspace-conversation.spec.ts --grep 'archives a completed session from its mobile sidebar actions'` -> passed on macOS. Successful archive screenshot captured locally; temporary screenshot code removed.
- Installer abort fixture -> targeted package-manager, process-tree and provisioner-runtime Vitest suites -> 137 passed; cancellation repeated 10/10; `npm run typecheck:node`, lint and formatting passed. Subsequent Ubuntu CI portable shards and coverage passed on cac6916b.
- Real tooltip pointer behavior -> Chromium Web fixture with actual WorkspaceMessageScroller and production CSS -> first tooltip ~214ms, subsequent controls across messages ~5–12ms, reset after >300ms away, Calls content remains hoverable. Screenshots captured; temporary fixture removed.

Independent review confirmed the final dependency/test mapping and found no blockers. Archive controller and Undo consumers are included because both consume Session authority; streaming is included because it changes independently of Session object identity. Backend format/migration and ACP framework matrices are excluded because their contracts are unchanged. Windows archive E2E must pass on the new head before merge; local macOS success does not establish Windows success. Native screen-reader and touch-device behavior were not manually exercised.

## Review focus

Transcript provider ownership, Calls accessibility, and preservation of clean-versus-dirty persistence provenance without suppressing streaming writes. Do not weaken archive revision guards or replace explicit retry with automatic replay.

## Review follow-up

The review concern that fallback hydration suppresses pin-only edits was checked against the real store/saver path. `togglePinned` creates a new Session object; its prior WeakMap authority marker does not transfer, so it is saved. Added regression cases verify both direct pin changes and pin changes followed by archive refresh, including rehydration of the saved snapshot. Both passed without a production change. Independent review confirmed this mechanism and coverage. After this final test-only edit, the same five focused suites passed 367 tests; renderer typecheck, lint, Prettier and diff checks passed. All platform checks including both Windows E2E shards and PR Gate passed on production head 7bfc370c; await exact-head CI and review for the additional test commit before merge.
