### PR TITLE
fix(permissions): clarify saved grants and preserve undo window

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -975,6 +975,20 @@ colors communicate a successful or failed probe/migration result.
 
 #### Connectors panel
 
+- Remembered permission rows identify Connector tools by the current Connector display name,
+  public server ID, and exact tool name. The name opens the existing Connector Settings route in
+  active, policy-covered, and blocked states. Revoke accessible names also include the scope.
+- Command-group grants may retain a reviewed `approvalSummary` for an exact known prefix. It is
+  display metadata and never participates in authorization. Raw commands, paths, arguments, and
+  qualifier digests remain outside the permission-list IPC projection. Historical and unsupported
+  groups explicitly show that command details are unavailable, with creation time when present;
+  they are not silently backfilled, revoked, or reapproved.
+- Permission scope prefixes, qualifier categories, policy explanations, tooltips, and accessible
+  names are localized in the renderer; Connector/tool identities and user-authored names remain
+  literal. The Restore defaults button derives its completed appearance from the latest missing
+  count. Permission revoke resolves slow metadata before committing so response construction does
+  not spend the Registry-owned Undo window; an unavailable Undo reports that no restore occurred.
+
 - Local MCP arguments use one multiline text field. Editing replaces the argument list with one element per line, preserving spaces and blank lines; an empty field clears the list. Until the field is edited, preserve the original array, including empty values and embedded line breaks. Explain the replacement semantics when saved arguments contain embedded line breaks. Omitted arguments retain the stored array while the transport stays on stdio, including redacted historical values; credential availability restrictions remain in force. Template import/export preserves literal arrays, and the command preview quotes each element to show its boundary.
 - Tool permission controls in a bundled Connector detail remain disabled until the current tool permission save settles. Failed saves restore interactivity and retain the existing inline error feedback.
 - Credentials distinguish a pending list read, a failed read, an empty result and a deleted entry. Failed reads retain saved rows and use the shared ErrorNotice with Retry. All credential reads, mutation snapshots and compensating refreshes use one renderer coordinator; overlapping mutations finish with a fresh authoritative list.

--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -272,8 +272,13 @@ test('keeps home actions and content inside compact viewports', async ({ app }) 
       .toBe(true)
     await expect(cards.first()).toHaveCSS('cursor', 'pointer')
 
-    const firstCardBox = await cards.first().boundingBox()
-    const secondCardBox = await cards.nth(1).boundingBox()
+    // Read both cards in one browser task so a responsive reflow cannot split the measurements.
+    const [firstCardBox, secondCardBox] = await cards.evaluateAll((elements) =>
+      elements.slice(0, 2).map((element) => {
+        const { x, y, width, height } = element.getBoundingClientRect()
+        return { x, y, width, height }
+      })
+    )
     expect(firstCardBox?.x).toBeCloseTo(expectedInset, 0)
     expect(firstCardBox?.width).toBeCloseTo(expectedCardWidth, 0)
     expect((firstCardBox?.x ?? 0) + (firstCardBox?.width ?? 0)).toBeLessThanOrEqual(

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -200,6 +200,7 @@ model PermissionGrant {
   scopeKind      String
   projectId      String?
   sessionId      String?
+  approvalSummary String?
   fingerprint    String    @unique
   revision       Int       @default(1)
   createdAt      DateTime?

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -128,6 +128,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0031_project_archive_revision',
     checksum: '77d0476e02c6993e54772e2a17908b62a6998c540c56d826a691fe358ac1093a'
+  },
+  {
+    id: '0032_permission_approval_summary',
+    checksum: '84b4035c8bd97ac41a7d08e630b6af9205cff6012e1ae02e5e9dbaaf25979c66'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -74,6 +74,7 @@ const rebuildComputeJobWithoutAnalysisConstraints = async (
 }
 
 const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<void> => {
+  await client.$executeRawUnsafe('ALTER TABLE "PermissionGrant" DROP COLUMN "approvalSummary"')
   await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
   for (const table of [
     'ArtifactLiteratureManifest',
@@ -101,7 +102,7 @@ const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<v
 
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.slice(-9).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+    expect(MIGRATION_MANIFEST.slice(-10).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
@@ -137,6 +138,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0031_project_archive_revision',
         checksum: '77d0476e02c6993e54772e2a17908b62a6998c540c56d826a691fe358ac1093a'
+      },
+      {
+        id: '0032_permission_approval_summary',
+        checksum: '84b4035c8bd97ac41a7d08e630b6af9205cff6012e1ae02e5e9dbaaf25979c66'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -175,7 +180,7 @@ describe('packaged database migration ledger smoke', () => {
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary')`
       )
 
       await migrateApplicationDatabase(client)
@@ -211,7 +216,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -245,7 +250,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -343,7 +348,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
@@ -424,7 +429,7 @@ describe('packaged database migration ledger smoke', () => {
            '0027_project_session_defaults',
            '0028_database_numeric_and_null_constraints',
            '0029_compute_host_execution_mode',
-           '0030_literature_foundation', '0031_project_archive_revision'
+           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0031_project_archive_revision'
+const CURRENT_MIGRATION_ID = '0032_permission_approval_summary'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -309,7 +309,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -324,6 +324,7 @@ describe('agent memory project scope migration', () => {
       '0028_database_numeric_and_null_constraints',
       '0029_compute_host_execution_mode',
       '0030_literature_foundation',
+      '0031_project_archive_revision',
       CURRENT_MIGRATION_ID
     )
 
@@ -343,6 +344,7 @@ describe('agent memory project scope migration', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
+        '0031_project_archive_revision',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -215,7 +215,8 @@ describe('application database (integration)', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
 
@@ -244,7 +245,8 @@ describe('application database (integration)', () => {
       'sessionId',
       'fingerprint',
       'revision',
-      'createdAt'
+      'createdAt',
+      'approvalSummary'
     ])
 
     await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
@@ -1275,7 +1277,8 @@ describe('application database (integration)', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -26,7 +26,7 @@ describe('Compute Job operation migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -45,7 +45,7 @@ describe('Compute Job operation migration', () => {
       client.$queryRawUnsafe<Array<{ id: string }>>(
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 1`
       )
-    ).resolves.toEqual([{ id: '0031_project_archive_revision' }])
+    ).resolves.toEqual([{ id: '0032_permission_approval_summary' }])
   })
 
   it('adds a constrained operation sidecar without rebuilding historical ComputeJob rows', async () => {

--- a/src/main/database/compute-job-remote-cleanup-migration.test.ts
+++ b/src/main/database/compute-job-remote-cleanup-migration.test.ts
@@ -73,10 +73,11 @@ describe('Compute Job remote cleanup migration', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0025_managed_file_version_foundation',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -78,10 +78,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0015_session_model_call_usage',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/content-blob-migration.test.ts
+++ b/src/main/database/content-blob-migration.test.ts
@@ -69,7 +69,11 @@ describe('Content blob migration', () => {
     )
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      applied: ['0030_literature_foundation', '0031_project_archive_revision']
+      applied: [
+        '0030_literature_foundation',
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
+      ]
     })
     await expect(
       client.literatureIdentifier.findMany({ orderBy: { id: 'asc' }, select: { itemId: true } })
@@ -141,9 +145,13 @@ describe('Content blob migration', () => {
         applied:
           schema === 'pre-ledger'
             ? MIGRATION_MANIFEST.map(({ id }) => id)
-            : ['0030_literature_foundation', '0031_project_archive_revision'],
+            : [
+                '0030_literature_foundation',
+                '0031_project_archive_revision',
+                '0032_permission_approval_summary'
+              ],
         from: schema === 'pre-ledger' ? null : '0029_compute_host_execution_mode',
-        to: '0031_project_archive_revision'
+        to: '0032_permission_approval_summary'
       })
 
       await expect(

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -170,10 +170,11 @@ describe('database JSON constraints migration', () => {
           '0028_database_numeric_and_null_constraints',
           '0029_compute_host_execution_mode',
           '0030_literature_foundation',
-          '0031_project_archive_revision'
+          '0031_project_archive_revision',
+          '0032_permission_approval_summary'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0031_project_archive_revision'
+        to: '0032_permission_approval_summary'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -370,9 +370,10 @@ describe('D02/D04 persisted database boundaries', () => {
           migrationId,
           '0029_compute_host_execution_mode',
           '0030_literature_foundation',
-          '0031_project_archive_revision'
+          '0031_project_archive_revision',
+          '0032_permission_approval_summary'
         ],
-        to: '0031_project_archive_revision'
+        to: '0032_permission_approval_summary'
       })
       // Literature adds contentBlobId to version rows while preserving their original fields.
       expect(await Promise.all(tables.map(readRows))).toMatchObject(before)

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -123,7 +123,8 @@ describe('database startup logging', () => {
               '0028_database_numeric_and_null_constraints',
               '0029_compute_host_execution_mode',
               '0030_literature_foundation',
-              '0031_project_archive_revision'
+              '0031_project_archive_revision',
+              '0032_permission_approval_summary'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -147,6 +147,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     "scopeKind" TEXT NOT NULL,
     "projectId" TEXT,
     "sessionId" TEXT,
+    "approvalSummary" TEXT,
     "fingerprint" TEXT NOT NULL,
     "revision" INTEGER NOT NULL DEFAULT 1,
     "createdAt" DATETIME,

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -475,10 +475,11 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: null,
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -491,8 +492,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0031_project_archive_revision',
-      to: '0031_project_archive_revision'
+      from: '0032_permission_approval_summary',
+      to: '0032_permission_approval_summary'
     })
   })
 
@@ -593,7 +594,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(
@@ -678,7 +680,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -723,7 +726,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -777,10 +780,11 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -862,10 +866,11 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$queryRaw<
@@ -988,7 +993,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0031_project_archive_revision'
+      migrationId: '0032_permission_approval_summary'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -1005,7 +1010,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual({
       adoptedLegacy: false,
       applied: ['9997_test_suffix'],
-      from: '0031_project_archive_revision',
+      from: '0032_permission_approval_summary',
       to: '9997_test_suffix'
     })
     await expect(
@@ -1044,6 +1049,7 @@ describe('application database migrations', () => {
       { id: '0029_compute_host_execution_mode' },
       { id: '0030_literature_foundation' },
       { id: '0031_project_archive_revision' },
+      { id: '0032_permission_approval_summary' },
       { id: '9997_test_suffix' }
     ])
   })
@@ -1127,10 +1133,11 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     expect(backupEvents).toEqual([
       {
@@ -1215,7 +1222,8 @@ describe('application database migrations', () => {
       { id: '0028_database_numeric_and_null_constraints' },
       { id: '0029_compute_host_execution_mode' },
       { id: '0030_literature_foundation' },
-      { id: '0031_project_archive_revision' }
+      { id: '0031_project_archive_revision' },
+      { id: '0032_permission_approval_summary' }
     ])
   })
 
@@ -1340,6 +1348,7 @@ describe('application database migrations', () => {
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
         '0031_project_archive_revision',
+        '0032_permission_approval_summary',
         '9997_test_suffix'
       ],
       to: '9997_test_suffix'
@@ -1477,7 +1486,7 @@ describe('application database migrations', () => {
       adoptedLegacy: false,
       applied: MIGRATION_MANIFEST.slice(computePasswordAuthIndex).map(({ id }) => id),
       from: '0009_vision_evidence',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$queryRaw<Array<{ projectId: string }>>`
@@ -1596,7 +1605,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(
@@ -1724,7 +1734,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1804,7 +1815,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(
@@ -1887,7 +1899,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -2004,7 +2017,8 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ]
     })
     await expect(
@@ -2527,8 +2541,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0030_literature_foundation.backup',
       'open-science.db.before-0031_project_archive_revision.backup',
+      'open-science.db.before-0032_permission_approval_summary.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -2828,10 +2842,11 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ currentVersionId: string | null }>>(
@@ -2890,7 +2905,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -2953,10 +2968,11 @@ describe('application database migrations', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -1,3 +1,4 @@
+import { permissionApprovalSummaryMigration } from './migrations/0032-permission-approval-summary'
 import { projectArchiveRevisionMigration } from './migrations/0031-project-archive-revision'
 import { createHash } from 'node:crypto'
 import { access, rename, rm } from 'node:fs/promises'
@@ -685,6 +686,17 @@ const MIGRATION_MANIFEST = [
       projectArchiveRevisionMigration.statements,
       projectArchiveRevisionMigration.verifiers,
       projectArchiveRevisionMigration.operations
+    ),
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...permissionApprovalSummaryMigration,
+    checksum: checksumMigrationPayload(
+      permissionApprovalSummaryMigration.id,
+      permissionApprovalSummaryMigration.statements,
+      permissionApprovalSummaryMigration.verifiers,
+      permissionApprovalSummaryMigration.operations
     ),
     backupOnApply: 'required',
     backupRetention: 'retain'

--- a/src/main/database/migrations/0032-permission-approval-summary.ts
+++ b/src/main/database/migrations/0032-permission-approval-summary.ts
@@ -1,0 +1,10 @@
+/* Immutable 0032 migration snapshot. Do not regenerate after release. */
+const permissionApprovalSummaryMigration = {
+  id: '0032_permission_approval_summary',
+  statements: ['ALTER TABLE "PermissionGrant" ADD COLUMN "approvalSummary" TEXT'] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'column-exists', version: 1, table: 'PermissionGrant', column: 'approvalSummary' }
+  ] as const
+}
+export { permissionApprovalSummaryMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -90,10 +90,11 @@ describe('notification attention metadata migration', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0006_database_domain_constraints',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/permission-approval-summary.test.ts
+++ b/src/main/database/permission-approval-summary.test.ts
@@ -1,0 +1,54 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import { createProjectDbClient } from '../projects/prisma-client'
+import { createPermissionGrantRegistry } from '../permission-grants/registry'
+import {
+  capabilityFromLegacyCategory,
+  commandPrefixPermissionCategory
+} from '../permission-grants/capability'
+import { migrateApplicationDatabase } from './migration-service'
+
+it('upgrades historical permissions without inferring descriptions or changing authority', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'permission-summary-migration-'))
+  const client = createProjectDbClient(root)
+  try {
+    await migrateApplicationDatabase(client)
+    const registry = await createPermissionGrantRegistry({ getClient: async () => client })
+    const capability = capabilityFromLegacyCategory(
+      commandPrefixPermissionCategory(['git', 'status'])!
+    )!
+    const grant = await registry.remember({ capability, scope: { kind: 'global' } })
+    await client.$executeRawUnsafe('ALTER TABLE "PermissionGrant" DROP COLUMN "approvalSummary"')
+    await client.$executeRawUnsafe(
+      'DELETE FROM "_open_science_migrations" WHERE id = \'0032_permission_approval_summary\''
+    )
+    const before = await client.$queryRawUnsafe(
+      'SELECT id, capabilityKind, capabilityKey, qualifierMode, qualifierValue, scopeKind, projectId, sessionId, fingerprint, revision, createdAt FROM "PermissionGrant"'
+    )
+    await expect(
+      migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
+    ).resolves.toMatchObject({ applied: ['0032_permission_approval_summary'] })
+    const after = await client.$queryRawUnsafe<Array<Record<string, unknown>>>(
+      'SELECT * FROM "PermissionGrant"'
+    )
+    expect(
+      after.map(({ approvalSummary, ...row }) => {
+        expect(approvalSummary).toBeNull()
+        return row
+      })
+    ).toEqual(before)
+    const reopened = await createPermissionGrantRegistry({ getClient: async () => client })
+    expect((await reopened.resolve(capability, {}))?.grant.id).toBe(grant.id)
+    // Remembering an existing grant must not silently backfill or reapprove it.
+    expect(await reopened.remember({ capability, scope: { kind: 'global' } })).not.toHaveProperty(
+      'approvalSummary'
+    )
+    expect(await client.$queryRawUnsafe('PRAGMA foreign_key_check')).toEqual([])
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+  } finally {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/src/main/database/project-archive-revision.test.ts
+++ b/src/main/database/project-archive-revision.test.ts
@@ -33,11 +33,13 @@ describe('Project archive revision', () => {
     // Reconstruct the immediately preceding released schema and ledger, including real row data.
     await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
     await client.$executeRawUnsafe(
-      'DELETE FROM "_open_science_migrations" WHERE id = \'0031_project_archive_revision\''
+      'DELETE FROM "_open_science_migrations" WHERE id >= \'0031_project_archive_revision\''
     )
     await expect(
       migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
-    ).resolves.toMatchObject({ applied: ['0031_project_archive_revision'] })
+    ).resolves.toMatchObject({
+      applied: ['0031_project_archive_revision', '0032_permission_approval_summary']
+    })
     expect(
       await client.$queryRawUnsafe(
         'SELECT "id", "archivedAt", "updatedAt" FROM "Project" ORDER BY "id"'

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -68,10 +68,11 @@ describe('Project Session defaults migration', () => {
         '0028_database_numeric_and_null_constraints',
         '0029_compute_host_execution_mode',
         '0030_literature_foundation',
-        '0031_project_archive_revision'
+        '0031_project_archive_revision',
+        '0032_permission_approval_summary'
       ],
       from: '0026_compute_job_remote_cleanup',
-      to: '0031_project_archive_revision'
+      to: '0032_permission_approval_summary'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(

--- a/src/main/permission-grants/approval-summary.ts
+++ b/src/main/permission-grants/approval-summary.ts
@@ -1,0 +1,33 @@
+import type { PermissionCapability } from '../../shared/permission-grants'
+import { commandPrefixPermissionCategory } from './capability'
+
+// Exact, reviewed prefixes only. Never accept display text from a provider or persist arbitrary
+// argv. Matching the complete digest prevents a path/argument variant from inheriting a misleading
+// description. New summaries do not change matching authority or backfill historical grants.
+const REVIEWED_PREFIXES: ReadonlyArray<readonly [readonly string[], string]> = [
+  [['git', 'status'], 'Git: working tree status'],
+  [['git', 'diff'], 'Git: changes'],
+  [['git', 'log'], 'Git: commit history'],
+  [['git', 'show'], 'Git: object details'],
+  [['git', 'add'], 'Git: stage changes'],
+  [['git', 'commit'], 'Git: create commits'],
+  [['npm', 'test'], 'npm: run tests'],
+  [['npm', 'run'], 'npm: run scripts'],
+  [['python'], 'Python commands'],
+  [['python3'], 'Python 3 commands'],
+  [['node'], 'Node.js commands'],
+  [['Rscript'], 'R scripts']
+]
+const summaries = new Map(
+  REVIEWED_PREFIXES.map(([prefix, summary]) => [
+    commandPrefixPermissionCategory(prefix)!.slice('shell-group:'.length),
+    summary
+  ])
+)
+
+export const approvalSummaryFor = (capability: PermissionCapability): string | undefined =>
+  capability.kind === 'execution' &&
+  capability.key === 'exec:agent/shell' &&
+  capability.qualifier?.mode === 'category'
+    ? summaries.get(capability.qualifier.value)
+    : undefined

--- a/src/main/permission-grants/catalog.test.ts
+++ b/src/main/permission-grants/catalog.test.ts
@@ -2,8 +2,28 @@ import { describe, expect, it } from 'vitest'
 
 import { projectPermissionGrantSnapshot } from './catalog'
 import { DEFAULT_GLOBAL_PERMISSION_CAPABILITIES } from './defaults'
+import { capabilityFromLegacyCategory, commandPrefixPermissionCategory } from './capability'
 
 describe('permission grant renderer projection', () => {
+  it('does not export a provider-supplied or mismatched approval summary', () => {
+    const capability = capabilityFromLegacyCategory(
+      commandPrefixPermissionCategory(['git', 'status'])!
+    )!
+    for (const approvalSummary of ['token=secret', 'Git: changes']) {
+      const projected = projectPermissionGrantSnapshot([
+        {
+          id: 'summary',
+          revision: 1,
+          capability,
+          approvalSummary,
+          scope: { kind: 'global' }
+        }
+      ])
+      expect(projected.grants[0]).not.toHaveProperty('approvalSummary')
+      expect(JSON.stringify(projected)).not.toContain(approvalSummary)
+    }
+  })
+
   it('projects whether every default Global grant is present', () => {
     const records = DEFAULT_GLOBAL_PERMISSION_CAPABILITIES.map((capability, index) => ({
       id: `default-${index}`,

--- a/src/main/permission-grants/catalog.ts
+++ b/src/main/permission-grants/catalog.ts
@@ -7,6 +7,8 @@ import type {
   PermissionGrantView
 } from '../../shared/permission-grants'
 import { missingDefaultGlobalPermissionCapabilities } from './defaults'
+import { approvalSummaryFor } from './approval-summary'
+import { CONNECTOR_CATALOG } from '../connectors/catalog'
 
 type PermissionGrantNames = {
   projects?: ReadonlyMap<string, string>
@@ -129,7 +131,11 @@ const connectorProjection = (
   policy: ConnectorPolicySnapshot | undefined
 ): Pick<
   PermissionGrantView,
-  'connectorServerId' | 'connectorToolName' | 'effectiveState' | 'policyHint'
+  | 'connectorServerId'
+  | 'connectorDisplayName'
+  | 'connectorToolName'
+  | 'effectiveState'
+  | 'policyHint'
 > => {
   if (record.capability.kind !== 'mcp_tool') return {}
   const match = /^mcp:([^/]+)\/(.+)$/.exec(record.capability.key)
@@ -137,7 +143,10 @@ const connectorProjection = (
   const [, serverId, toolName] = match
   const custom = policy?.customMcpServers?.find((server) => server.id === serverId)
   const isBundled = policy?.bundledConnectorIds?.includes(serverId) ?? false
-  if (!custom && !isBundled) return {}
+  if (!custom && !isBundled)
+    return serverId.startsWith('open-science-')
+      ? {}
+      : { connectorServerId: serverId, connectorDisplayName: serverId, connectorToolName: toolName }
   const aliases = custom ? [custom.name] : [serverId]
   const hasToolPolicy = (entries: readonly string[] | undefined): boolean =>
     aliases.some((alias) => entries?.includes(`${alias}/${toolName}`)) ?? false
@@ -151,6 +160,10 @@ const connectorProjection = (
 
   return {
     connectorServerId: serverId,
+    connectorDisplayName:
+      custom?.displayName ||
+      CONNECTOR_CATALOG.find((connector) => connector.id === serverId)?.displayName ||
+      serverId,
     connectorToolName: toolName,
     effectiveState: blocked ? 'blocked_by_policy' : covered ? 'covered_by_policy' : 'active',
     ...(blocked
@@ -185,6 +198,20 @@ const projectGrantRecord = (
     ...(qualifierLabelFor(record) ? { qualifierLabel: qualifierLabelFor(record) } : {}),
     scopeKind: scope.kind,
     scopeLabel,
+    scopeName: (scope.kind === 'project' ? projectName : sessionName) ?? null,
+    ...(record.capability.qualifier
+      ? {
+          qualifierKind:
+            record.capability.qualifier.mode === 'category' &&
+            record.capability.kind === 'execution' &&
+            record.capability.qualifier.value.startsWith('argv-prefix:sha256:v1:')
+              ? ('command_group' as const)
+              : record.capability.qualifier.mode
+        }
+      : {}),
+    ...(record.approvalSummary && record.approvalSummary === approvalSummaryFor(record.capability)
+      ? { approvalSummary: record.approvalSummary }
+      : {}),
     ...(coveredBy ? { coveredBy } : {}),
     ...connectorProjection(record, names.connectorPolicy),
     ...(scope.kind === 'global' ? {} : { projectId: scope.projectId }),
@@ -221,6 +248,7 @@ const projectPermissionGrantMutation = (
 ): PermissionGrantMutationView => ({
   ...projectPermissionGrantSnapshot(result.grants, names, metadata),
   ...(result.receipt ? { receipt: result.receipt } : {}),
+  ...(result.restoredCount !== undefined ? { restoredCount: result.restoredCount } : {}),
   conflicts: result.conflicts
 })
 

--- a/src/main/permission-grants/ipc.test.ts
+++ b/src/main/permission-grants/ipc.test.ts
@@ -54,6 +54,7 @@ describe('permission grant IPC', () => {
   it('shares one application-owned projection between IPC and application commands', async () => {
     const registry = {
       list: vi.fn().mockResolvedValue([]),
+      listCached: vi.fn().mockReturnValue([]),
       subscribe: vi.fn(() => vi.fn())
     } as unknown as PermissionGrantRegistry
     const owner = createPermissionGrantProjectionController({
@@ -160,6 +161,7 @@ describe('permission grant IPC', () => {
     let listener: (() => void) | undefined
     const registry = {
       list: vi.fn().mockResolvedValue([]),
+      listCached: vi.fn().mockReturnValue([]),
       remember: vi.fn(),
       revoke: vi.fn().mockResolvedValue({ grants: [], conflicts: [] }),
       extendUndo: vi.fn().mockResolvedValue({

--- a/src/main/permission-grants/projection-controller.test.ts
+++ b/src/main/permission-grants/projection-controller.test.ts
@@ -5,6 +5,49 @@ import type { PermissionGrantRegistry } from './registry'
 import { createPermissionGrantProjectionController } from './projection-controller'
 
 describe('Permission Grant projection controller', () => {
+  it('does not wait for metadata again when it changes during a revoke commit', async () => {
+    let registryChanged: (() => void) | undefined
+    const projects = { list: vi.fn().mockResolvedValue([{ id: 'p', name: 'Old name' }]) }
+    const remaining = {
+      id: 'other',
+      revision: 1,
+      capability: { kind: 'file_operation', key: 'file:read' },
+      scope: { kind: 'project', projectId: 'p' }
+    }
+    const controller: ReturnType<typeof createPermissionGrantProjectionController> =
+      createPermissionGrantProjectionController({
+        registry: {
+          listCached: () => [remaining],
+          subscribe: (listener: () => void) => {
+            registryChanged = listener
+            return () => undefined
+          },
+          revoke: async () => {
+            controller.invalidateProjection()
+            registryChanged?.()
+            return {
+              grants: [],
+              conflicts: [],
+              receipt: { undoToken: 'receipt', expiresAt: 8000, revokedCount: 1 }
+            }
+          }
+        } as unknown as PermissionGrantRegistry,
+        projects,
+        sessions: { metadataSnapshot: async () => ({ sessions: [], isComplete: true }) },
+        publishChanged: vi.fn()
+      })
+    const result = await controller.revoke({ grants: [{ id: 'revoked', revision: 1 }] })
+    expect(projects.list).toHaveBeenCalledOnce()
+    expect(result).toMatchObject({
+      version: 2,
+      grants: [{ id: 'other', scopeName: null }],
+      incompleteStores: ['projects', 'sessions', 'connector_policy'],
+      receipt: { undoToken: 'receipt' }
+    })
+    expect(JSON.stringify(result)).not.toContain('Old name')
+    controller.dispose()
+  })
+
   it('owns one Registry subscription and versions projections before publishing changes', async () => {
     let registryChanged: (() => void) | undefined
     const registry = {
@@ -94,6 +137,7 @@ describe('Permission Grant projection controller', () => {
     })
     const registry = {
       list: vi.fn().mockResolvedValue([]),
+      listCached: vi.fn().mockReturnValue([]),
       revoke,
       subscribe: vi.fn((listener: () => void) => {
         registryChanged = listener

--- a/src/main/permission-grants/projection-controller.ts
+++ b/src/main/permission-grants/projection-controller.ts
@@ -126,7 +126,33 @@ const createPermissionGrantProjectionController = (
     request: PermissionGrantRevokeRequest
   ): Promise<PermissionGrantMutationView> => {
     validateRevokeRequest(request)
-    return mutationSnapshot(await options.registry.revoke(request))
+    // Resolve display metadata before committing the revoke: no storage I/O may consume the
+    // user-visible receipt window after the Registry creates it.
+    let preparedVersion: number
+    let metadata: Awaited<ReturnType<typeof names>>
+    do {
+      preparedVersion = version
+      metadata = await names()
+    } while (preparedVersion !== version)
+    const result = await options.registry.revoke(request)
+    // Another mutation or metadata invalidation during the commit makes these names uncertain.
+    // Return the current cache with honest missing details; the changed event refreshes metadata.
+    const expectedVersion = preparedVersion + (result.receipt ? 1 : 0)
+    if (version !== expectedVersion) {
+      metadata = {
+        projects: new Map(),
+        sessions: new Map(),
+        incompleteStores: ['projects', 'sessions', 'connector_policy']
+      }
+    }
+    return projectPermissionGrantMutation(
+      { ...result, grants: options.registry.listCached() },
+      metadata,
+      {
+        version,
+        incompleteStores: metadata.incompleteStores
+      }
+    )
   }
   const extendUndo = async (
     request: PermissionGrantUndoExtendRequest

--- a/src/main/permission-grants/registry.test.ts
+++ b/src/main/permission-grants/registry.test.ts
@@ -7,6 +7,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { createPermissionGrantRegistry, PermissionGrantTargetUnavailableError } from './registry'
+import { createPermissionGrantProjectionController } from './projection-controller'
+import { capabilityFromLegacyCategory, commandPrefixPermissionCategory } from './capability'
 
 let storageRoot: string | undefined
 let clients: PrismaClient[] = []
@@ -31,6 +33,83 @@ const openClient = async (): Promise<PrismaClient> => {
 }
 
 describe('PermissionGrantRegistry', () => {
+  it('persists only reviewed command-group summaries across reopen and Undo', async () => {
+    const client = await openClient()
+    let registry = await createPermissionGrantRegistry({ getClient: async () => client })
+    const capability = capabilityFromLegacyCategory(
+      commandPrefixPermissionCategory(['git', 'status'])!
+    )!
+    const grant = await registry.remember({ capability, scope: { kind: 'global' } })
+    expect(grant).toMatchObject({ approvalSummary: 'Git: working tree status' })
+    registry = await createPermissionGrantRegistry({ getClient: async () => client })
+    expect(await registry.list()).toMatchObject([{ approvalSummary: 'Git: working tree status' }])
+    const revoked = await registry.revoke({ grants: [grant] })
+    expect(
+      (await registry.restore({ undoToken: revoked.receipt!.undoToken })).grants
+    ).toMatchObject([{ approvalSummary: 'Git: working tree status' }])
+    for (const prefix of [
+      ['git', 'status', '/private/research'],
+      ['custom-cli', 'private-value']
+    ]) {
+      const unknown = await registry.remember({
+        capability: capabilityFromLegacyCategory(commandPrefixPermissionCategory(prefix)!)!,
+        scope: { kind: 'global' }
+      })
+      expect(unknown).not.toHaveProperty('approvalSummary')
+    }
+    const persisted = await client.$queryRawUnsafe(
+      'SELECT "approvalSummary" FROM "PermissionGrant"'
+    )
+    expect(JSON.stringify(persisted)).not.toMatch(/private|custom-cli/)
+  })
+
+  it('PG02 provides a usable Undo window after slow revoke-response metadata reads', async () => {
+    const client = await openClient()
+    let now = Date.parse('2026-09-07T00:00:00Z')
+    const registry = await createPermissionGrantRegistry({
+      getClient: async () => client,
+      now: () => new Date(now)
+    })
+    const grant = await registry.remember({
+      capability: { kind: 'file_operation', key: 'file:read' },
+      scope: { kind: 'global' }
+    })
+    let delayed = false
+    const controller = createPermissionGrantProjectionController({
+      registry,
+      projects: {
+        list: async () => {
+          if (!delayed) {
+            now += 9000
+            delayed = true
+          }
+          return []
+        }
+      },
+      sessions: { metadataSnapshot: async () => ({ sessions: [], isComplete: true }) },
+      publishChanged: vi.fn()
+    })
+    try {
+      const result = await controller.revoke({
+        grants: [{ id: grant.id, revision: grant.revision }]
+      })
+      expect(delayed).toBe(true)
+      expect(result.receipt).toBeDefined()
+      expect(result.grants).toEqual([])
+      expect(await client.$queryRawUnsafe('SELECT "id" FROM "PermissionGrant"')).toEqual([])
+      expect.soft(result.receipt!.expiresAt - now).toBeGreaterThanOrEqual(8000)
+      const request = { undoToken: result.receipt!.undoToken }
+      expect.soft(await controller.extendUndo(request)).toBeDefined()
+      const restored = await controller.restore(request)
+      expect.soft(restored.grants.map((row) => row.id)).toContain(grant.id)
+      expect(await client.$queryRawUnsafe('SELECT "id" FROM "PermissionGrant"')).toEqual([
+        { id: grant.id }
+      ])
+    } finally {
+      controller.dispose()
+    }
+  })
+
   it('reacquires the shared client after an exclusive database disconnect', async () => {
     const firstClient = await openClient()
     let retired = false

--- a/src/main/permission-grants/registry.ts
+++ b/src/main/permission-grants/registry.ts
@@ -1,4 +1,5 @@
 import { createHash, randomUUID } from 'node:crypto'
+import { approvalSummaryFor } from './approval-summary'
 
 import type { Prisma, PrismaClient } from '@prisma/client'
 
@@ -30,6 +31,7 @@ type PermissionGrantRow = {
   projectId: string | null
   sessionId: string | null
   fingerprint: string
+  approvalSummary: string | null
   revision: number | bigint
   createdAt: Date | string | null
 }
@@ -155,6 +157,9 @@ const recordFromRow = (row: PermissionGrantRow): PermissionGrantRecord => ({
   capability: capabilityFromRow(row),
   scope: scopeFromRow(row),
   ...(row.createdAt ? { createdAt: new Date(row.createdAt).getTime() } : {}),
+  ...(row.approvalSummary && row.approvalSummary === approvalSummaryFor(capabilityFromRow(row))
+    ? { approvalSummary: row.approvalSummary }
+    : {}),
   revision: Number(row.revision)
 })
 
@@ -322,8 +327,8 @@ const createPermissionGrantRegistry = async (
           await transaction.$executeRawUnsafe(
             `INSERT OR IGNORE INTO "PermissionGrant" (
               "id", "capabilityKind", "capabilityKey", "qualifierMode", "qualifierValue",
-              "scopeKind", "projectId", "sessionId", "fingerprint", "revision", "createdAt"
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?)`,
+              "scopeKind", "projectId", "sessionId", "fingerprint", "revision", "createdAt", "approvalSummary"
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 1, ?, ?)`,
             createId(),
             command.capability.kind,
             command.capability.key,
@@ -333,7 +338,8 @@ const createPermissionGrantRegistry = async (
             target.projectId,
             target.sessionId,
             fingerprint,
-            createdAt
+            createdAt,
+            approvalSummaryFor(command.capability) ?? null
           )
           const [persisted] = await transaction.$queryRawUnsafe<PermissionGrantRow[]>(
             'SELECT * FROM "PermissionGrant" WHERE "fingerprint" = ? LIMIT 1',
@@ -422,11 +428,11 @@ const createPermissionGrantRegistry = async (
       return runMutation(async () => {
         const receipt = receipts.get(command.undoToken)
         if (!receipt) {
-          return { grants: sortedRecords(records.values()), conflicts: [] }
+          return { grants: sortedRecords(records.values()), conflicts: [], restoredCount: 0 }
         }
         if (receipt.expiresAt <= now().getTime()) {
           receipts.delete(command.undoToken)
-          return { grants: sortedRecords(records.values()), conflicts: [] }
+          return { grants: sortedRecords(records.values()), conflicts: [], restoredCount: 0 }
         }
 
         const liveRows: PermissionGrantRow[] = []
@@ -447,8 +453,8 @@ const createPermissionGrantRegistry = async (
             await transaction.$executeRawUnsafe(
               `INSERT OR IGNORE INTO "PermissionGrant" (
                 "id", "capabilityKind", "capabilityKey", "qualifierMode", "qualifierValue",
-                "scopeKind", "projectId", "sessionId", "fingerprint", "revision", "createdAt"
-              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+                "scopeKind", "projectId", "sessionId", "fingerprint", "revision", "createdAt", "approvalSummary"
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
               row.id,
               row.capabilityKind,
               row.capabilityKey,
@@ -459,7 +465,8 @@ const createPermissionGrantRegistry = async (
               row.sessionId,
               row.fingerprint,
               revision,
-              row.createdAt
+              row.createdAt,
+              row.approvalSummary
             )
             const [persisted] = await transaction.$queryRawUnsafe<PermissionGrantRow[]>(
               'SELECT * FROM "PermissionGrant" WHERE "fingerprint" = ? LIMIT 1',
@@ -473,7 +480,11 @@ const createPermissionGrantRegistry = async (
         receipts.delete(command.undoToken)
         for (const row of restoredRows) records.set(row.fingerprint, recordFromRow(row))
         if (restoredRows.length > 0) publish()
-        return { grants: sortedRecords(records.values()), conflicts }
+        return {
+          grants: sortedRecords(records.values()),
+          conflicts,
+          restoredCount: restoredRows.length
+        }
       })
     },
 

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { literatureItemInputSchema, type LiteratureItemView } from '../../../../shared/literature'
 import { LiteratureFullTextLookup } from './LiteratureFullTextLookup'
@@ -77,12 +77,12 @@ describe('LiteratureFullTextLookup', () => {
     expect(await screen.findByText('Configured')).not.toBeNull()
     expect(saveEmail).toHaveBeenCalledWith({ contactEmail: 'research@lab.org' })
     expect(screen.queryByLabelText('Contact email')).toBeNull()
-    expect(fullText).toHaveBeenCalledTimes(2)
+    await waitFor(() => expect(fullText).toHaveBeenCalledTimes(2))
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     fireEvent.click(screen.getByRole('button', { name: 'Remove email' }))
     await screen.findByRole('button', { name: 'Configure Unpaywall' })
     expect(saveEmail).toHaveBeenLastCalledWith({ contactEmail: '' })
-    expect(fullText).toHaveBeenCalledTimes(3)
+    await waitFor(() => expect(fullText).toHaveBeenCalledTimes(3))
   })
 
   it.each(['pmc-unavailable', 'unpaywall-unavailable'])(

--- a/src/renderer/src/pages/settings/PermissionsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/PermissionsPanel.render.test.tsx
@@ -1,9 +1,27 @@
 // @vitest-environment jsdom
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { PermissionGrantSnapshot } from '../../../../shared/permission-grants'
+import type {
+  PermissionGrantRecord,
+  PermissionGrantSnapshot
+} from '../../../../shared/permission-grants'
+import { projectPermissionGrantSnapshot } from '../../../../main/permission-grants/catalog'
+import { createPermissionGrantRegistry } from '../../../../main/permission-grants/registry'
+import {
+  createProjectDbClient,
+  migrateApplicationDatabase
+} from '../../../../main/projects/prisma-client'
+import { DEFAULT_GLOBAL_PERMISSION_CAPABILITIES } from '../../../../main/permission-grants/defaults'
+import {
+  capabilityFromLegacyCategory,
+  commandPrefixPermissionCategory
+} from '../../../../main/permission-grants/capability'
+import { i18next } from '@/i18n'
 import { usePermissionGrantsStore } from '@/stores/permission-grants-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { PermissionsPanel } from './PermissionsPanel'
@@ -63,10 +81,11 @@ beforeEach(() => {
   )
 })
 
-afterEach(() => {
+afterEach(async () => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
+  await i18next.changeLanguage('en')
 })
 
 const setPermissionApi = (api: Partial<Window['api']['permissions']>): void => {
@@ -77,6 +96,219 @@ const setPermissionApi = (api: Partial<Window['api']['permissions']>): void => {
 }
 
 describe('PermissionsPanel', () => {
+  it('PG01 distinguishes active same-name tools and opens each owning Connector', async () => {
+    const servers = [
+      { id: 'chemistry', name: 'chemistry-tools', displayName: 'Chemistry lab', enabled: true },
+      { id: 'biology', name: 'biology-tools', displayName: 'Biology lab', enabled: true }
+    ]
+    const records: PermissionGrantRecord[] = servers.map((server) => ({
+      id: `grant-${server.id}`,
+      revision: 1,
+      capability: { kind: 'mcp_tool', key: `mcp:${server.id}/search` },
+      scope: { kind: 'global' }
+    }))
+    const projected = projectPermissionGrantSnapshot(records, {
+      connectorPolicy: {
+        customMcpServers: servers,
+        askToolIds: servers.map((server) => `${server.name}/search`)
+      }
+    })
+    expect(projected.grants.map((grant) => grant.effectiveState)).toEqual(['active', 'active'])
+    const onOpenConnector = vi.fn()
+    setPermissionApi({ list: vi.fn().mockResolvedValue(projected) })
+    await act(async () => root.render(<PermissionsPanel onOpenConnector={onOpenConnector} />))
+
+    const rows = Array.from(container.querySelectorAll<HTMLElement>('[data-slot="permission-row"]'))
+    expect(rows).toHaveLength(2)
+    for (const record of records) expect(container.textContent).not.toContain(record.id)
+    expect.soft(new Set(rows.map((row) => row.textContent)).size).toBe(2)
+    const revokeNames = rows.map((row) =>
+      row.querySelector('[aria-label^="Revoke "]')?.getAttribute('aria-label')
+    )
+    expect.soft(new Set(revokeNames).size).toBe(2)
+    for (const [index, server] of servers.entries()) {
+      const row = rows[index]
+      expect.soft(row.textContent).toContain(server.displayName)
+      const details = Array.from(row.querySelectorAll<HTMLButtonElement>('button')).find(
+        (button) => !button.getAttribute('aria-label')?.startsWith('Revoke ')
+      )
+      expect.soft(details).toBeDefined()
+      await act(async () => details?.click())
+      expect.soft(onOpenConnector).toHaveBeenCalledWith(server.id)
+    }
+  })
+
+  it('PG01 distinguishes real command groups without exposing their digests', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'permission-row-'))
+    const client = createProjectDbClient(directory)
+    try {
+      await migrateApplicationDatabase(client)
+      const registry = await createPermissionGrantRegistry({
+        getClient: async () => client,
+        now: () => new Date('2026-09-07T00:00:00Z')
+      })
+      const records: PermissionGrantRecord[] = []
+      for (const prefix of [
+        ['git', 'status'],
+        ['git', 'diff']
+      ]) {
+        const capability = capabilityFromLegacyCategory(commandPrefixPermissionCategory(prefix)!)!
+        records.push(await registry.remember({ capability, scope: { kind: 'global' } }))
+      }
+      const projected = projectPermissionGrantSnapshot(records)
+      expect(records[0].capability).not.toEqual(records[1].capability)
+      expect(JSON.stringify(projected)).not.toContain('sha256')
+      setPermissionApi({ list: vi.fn().mockResolvedValue(projected) })
+      await act(async () => root.render(<PermissionsPanel />))
+
+      const rows = Array.from(
+        container.querySelectorAll<HTMLElement>('[data-slot="permission-row"]')
+      )
+      expect(rows).toHaveLength(2)
+      expect.soft(new Set(rows.map((row) => row.textContent)).size).toBe(2)
+      expect
+        .soft(
+          new Set(
+            rows.map((row) =>
+              row.querySelector('[aria-label^="Revoke "]')?.getAttribute('aria-label')
+            )
+          ).size
+        )
+        .toBe(2)
+      expect(rows.map((row) => row.textContent).join(' ')).toContain('Git: working tree status')
+      expect(rows.map((row) => row.textContent).join(' ')).toContain('Git: changes')
+      for (const record of records) expect(container.textContent).not.toContain(record.id)
+      expect(projected.grants.map((grant) => grant.approvalSummary)).toEqual([
+        'Git: working tree status',
+        'Git: changes'
+      ])
+    } finally {
+      await client.$disconnect()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
+  it('PG03 offers Restore defaults again after revoking a restored default', async () => {
+    const records: PermissionGrantRecord[] = DEFAULT_GLOBAL_PERMISSION_CAPABILITIES.map(
+      (capability, index) => ({
+        id: `default-${index}`,
+        revision: 1,
+        capability,
+        scope: { kind: 'global' }
+      })
+    )
+    const missing = projectPermissionGrantSnapshot(
+      records.slice(1),
+      {},
+      { version: 1, incompleteStores: [] }
+    )
+    const complete = projectPermissionGrantSnapshot(
+      records,
+      {},
+      { version: 2, incompleteStores: [] }
+    )
+    const missingAgain = { ...missing, version: 3 }
+    setPermissionApi({
+      list: vi.fn().mockResolvedValue(missing),
+      restoreDefaults: vi.fn().mockResolvedValue({ ...complete, restoredCount: 1 }),
+      revoke: vi.fn().mockResolvedValue({
+        ...missingAgain,
+        conflicts: [],
+        receipt: { undoToken: 'pg03', expiresAt: Date.now() + 8000, revokedCount: 1 }
+      })
+    })
+    await act(async () => root.render(<PermissionsPanel />))
+    const restore = container.querySelector<HTMLButtonElement>('[aria-label="Restore defaults"]')
+    expect(restore).not.toBeNull()
+    await act(async () => restore!.click())
+    expect(
+      container.querySelector<HTMLButtonElement>('[aria-label="Defaults restored"]')?.disabled
+    ).toBe(true)
+    const revoke = container.querySelector<HTMLButtonElement>(
+      `[aria-label^="Revoke ${complete.grants[0].capabilityLabel}"]`
+    )
+    expect(revoke).not.toBeNull()
+    await act(async () => revoke!.click())
+
+    expect(usePermissionGrantsStore.getState().missingDefaultGlobalGrantCount).toBe(1)
+    expect.soft(container.querySelector('[aria-label="Defaults restored"]')).toBeNull()
+    const restoreAgain = container.querySelector<HTMLButtonElement>(
+      '[aria-label="Restore defaults"]'
+    )
+    expect(restoreAgain).not.toBeNull()
+    expect(restoreAgain!.disabled).toBe(false)
+  })
+
+  it('keeps historical command groups explicit without claiming to know their commands', async () => {
+    const projected = projectPermissionGrantSnapshot([
+      {
+        id: 'historical',
+        revision: 1,
+        createdAt: Date.UTC(2026, 8, 7),
+        capability: capabilityFromLegacyCategory(
+          commandPrefixPermissionCategory(['git', 'status'])!
+        )!,
+        scope: { kind: 'global' }
+      }
+    ])
+    setPermissionApi({ list: vi.fn().mockResolvedValue(projected) })
+    await act(async () => root.render(<PermissionsPanel />))
+    const row = container.querySelector('[data-slot="permission-row"]')!
+    expect(row.textContent).toContain('Command details unavailable for this permission')
+    expect(row.textContent).toContain('Approved ')
+    expect(row.textContent).not.toContain('Git: working tree status')
+    expect(row.textContent).not.toContain('historical')
+  })
+
+  it.each(['zh-Hans', 'zh-Hant'] as const)(
+    'PG04 localizes projected row details in %s while preserving user names',
+    async (locale) => {
+      const projected = projectPermissionGrantSnapshot(
+        [
+          {
+            id: 'localized',
+            revision: 1,
+            capability: {
+              kind: 'mcp_tool',
+              key: 'mcp:chemistry/search',
+              qualifier: { mode: 'any' }
+            },
+            scope: { kind: 'project', projectId: 'research' }
+          }
+        ],
+        {
+          projects: new Map([['research', '研究项目']]),
+          connectorPolicy: {
+            customMcpServers: [
+              {
+                id: 'chemistry',
+                name: 'chemistry-tools',
+                displayName: 'Chemistry lab',
+                enabled: true
+              }
+            ]
+          }
+        }
+      )
+      await i18next.changeLanguage(locale)
+      setPermissionApi({ list: vi.fn().mockResolvedValue(projected) })
+      await act(async () => root.render(<PermissionsPanel onOpenConnector={vi.fn()} />))
+
+      const row = container.querySelector<HTMLElement>('[data-slot="permission-row"]')!
+      expect(row).not.toBeNull()
+      expect(row.textContent).toContain('研究项目')
+      expect
+        .soft(row.textContent)
+        .toContain(locale === 'zh-Hans' ? '项目：研究项目' : '專案：研究项目')
+      expect.soft(row.textContent).not.toContain('Any call')
+      expect.soft(row.textContent).not.toContain('Project:')
+      expect
+        .soft(row.textContent)
+        .not.toContain('Allowed by Connector policy even without this permission')
+      expect.soft(row.querySelector('[title]')?.getAttribute('title')).not.toContain('Project:')
+    }
+  )
+
   it('separates the new-conversation default from remembered permissions', async () => {
     setPermissionApi({
       list: vi.fn().mockResolvedValue({
@@ -272,7 +504,9 @@ describe('PermissionsPanel', () => {
     expect(document.body.textContent).toContain('python')
     expect(document.body.textContent).toContain('any call')
     expect(document.body.textContent).toContain('Project: Example project')
-    expect(document.body.querySelector('[aria-label="Revoke python"]')).not.toBeNull()
+    expect(
+      document.body.querySelector('[aria-label="Revoke python · Project: Example project"]')
+    ).not.toBeNull()
     expect(document.body.querySelector('h3')?.className).toContain('text-base')
     const permissionRow = document.body.querySelector<HTMLElement>('[data-slot="permission-row"]')
     expect(permissionRow?.className).toContain('min-h-11')
@@ -293,7 +527,9 @@ describe('PermissionsPanel', () => {
     expect(document.body.textContent).toContain('Shell')
     expect(document.body.textContent).toContain('Session: Analyze samples')
     expect(document.body.textContent).toContain('Also allowed for this project')
-    expect(document.body.querySelector('[aria-label="Revoke Shell"]')).not.toBeNull()
+    expect(
+      document.body.querySelector('[aria-label="Revoke Shell · Session: Analyze samples"]')
+    ).not.toBeNull()
   })
 
   it('opens the owning session from a session scope chip', async () => {
@@ -326,7 +562,9 @@ describe('PermissionsPanel', () => {
     await act(async () => root.render(<PermissionsPanel />))
 
     await act(async () => {
-      document.body.querySelector<HTMLButtonElement>('[aria-label="Revoke Shell"]')?.click()
+      document.body
+        .querySelector<HTMLButtonElement>('[aria-label="Revoke Shell · Session: Analyze samples"]')
+        ?.click()
     })
 
     expect(revoke).toHaveBeenCalledWith({ grants: [{ id: 'grant-1', revision: 1 }] })
@@ -345,12 +583,16 @@ describe('PermissionsPanel', () => {
     await act(async () => root.render(<PermissionsPanel />))
 
     await act(async () => {
-      document.body.querySelector<HTMLButtonElement>('[aria-label="Revoke Shell"]')?.click()
+      document.body
+        .querySelector<HTMLButtonElement>('[aria-label="Revoke Shell · Session: Analyze samples"]')
+        ?.click()
     })
 
     expect(document.body.querySelector('[role="alert"]')?.textContent).toContain('database locked')
     expect(document.body.textContent).toContain('Shell')
-    expect(document.body.querySelector('[aria-label="Revoke Shell"]')).not.toBeNull()
+    expect(
+      document.body.querySelector('[aria-label="Revoke Shell · Session: Analyze samples"]')
+    ).not.toBeNull()
   })
 
   it('shows Connector policy coverage and links to the owning Connector', async () => {
@@ -402,7 +644,9 @@ describe('PermissionsPanel', () => {
       document.body.querySelector<HTMLButtonElement>('[aria-label*="Revoke all"]')?.disabled
     ).toBe(true)
     expect(
-      document.body.querySelector<HTMLButtonElement>('[aria-label="Revoke Shell"]')?.disabled
+      document.body.querySelector<HTMLButtonElement>(
+        '[aria-label="Revoke Shell · Session: Analyze samples"]'
+      )?.disabled
     ).toBeFalsy()
   })
 })

--- a/src/renderer/src/pages/settings/PermissionsPanel.tsx
+++ b/src/renderer/src/pages/settings/PermissionsPanel.tsx
@@ -115,6 +115,18 @@ const PERMISSION_PROFILES: ReadonlyArray<{
 const permissionProfileLabel = (profile: PermissionProfileId): string =>
   PERMISSION_PROFILES.find((candidate) => candidate.id === profile)?.label ?? 'Ask for approval'
 
+const permissionScopeLabel = (
+  grant: PermissionGrantView,
+  t: ReturnType<typeof useTranslation>['t']
+): string => {
+  if (grant.scopeKind === 'global') return t('Global')
+  // Source compatibility for an older host. Current projections always supply scopeName.
+  if (grant.scopeName === undefined) return grant.scopeLabel
+  return grant.scopeKind === 'project'
+    ? t('Project: {{name}}', { name: grant.scopeName ?? t('Unknown project') })
+    : t('Session: {{name}}', { name: grant.scopeName ?? t('Unknown session') })
+}
+
 const PermissionRow = ({
   grant,
   onRevoke,
@@ -126,7 +138,40 @@ const PermissionRow = ({
   onOpenConnector?: (serverId: string) => void
   onOpenSession?: (sessionId: string) => void
 }): React.JSX.Element => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const scopeLabel = permissionScopeLabel(grant, t)
+  const connectorName =
+    grant.connectorDisplayName && grant.connectorDisplayName !== grant.connectorServerId
+      ? `${grant.connectorDisplayName} (${grant.connectorServerId})`
+      : grant.connectorServerId
+  const title = connectorName
+    ? `${connectorName} · ${grant.connectorToolName ?? grant.capabilityLabel}`
+    : t(grant.capabilityLabel)
+  const qualifierLabel =
+    grant.qualifierKind === 'any'
+      ? t('Any call')
+      : grant.qualifierKind === 'exact'
+        ? t('Specific input')
+        : grant.qualifierKind === 'command_group'
+          ? t('Command group')
+          : grant.qualifierLabel
+  const summary = grant.approvalSummary ? t(grant.approvalSummary) : undefined
+  const createdLabel =
+    grant.qualifierKind === 'command_group' && grant.createdAt !== undefined
+      ? t('Approved {{date}}', {
+          date: new Intl.DateTimeFormat(i18n.language, {
+            dateStyle: 'medium',
+            timeStyle: 'medium'
+          }).format(grant.createdAt)
+        })
+      : undefined
+  const revokeName = [title, summary, scopeLabel, createdLabel].filter(Boolean).join(' · ')
+  const policyHint =
+    grant.effectiveState === 'blocked_by_policy'
+      ? t('Blocked in Connectors; this permission is currently inactive')
+      : grant.effectiveState === 'covered_by_policy'
+        ? t('Allowed by Connector policy even without this permission')
+        : undefined
   const sessionId = grant.scopeKind === 'session' ? grant.sessionId : undefined
   const scopeClassName =
     'col-start-1 row-start-2 max-w-full justify-self-start truncate rounded-md bg-muted px-2 py-1 text-sm text-muted-foreground sm:col-start-2 sm:row-start-1 sm:max-w-80'
@@ -138,11 +183,28 @@ const PermissionRow = ({
     >
       <div className="min-w-0">
         <div>
-          <span className="text-sm text-foreground">{t(grant.capabilityLabel)}</span>
-          {grant.qualifierLabel ? (
-            <span className="ml-2 text-sm text-muted-foreground">{grant.qualifierLabel}</span>
+          {grant.connectorServerId && grant.effectiveState && onOpenConnector ? (
+            <button
+              type="button"
+              className="rounded-sm text-left text-sm text-foreground underline-offset-2 hover:underline focus-visible:ring-3 focus-visible:ring-ring/50"
+              aria-label={t('Open {{name}}', { name: title })}
+              onClick={() => onOpenConnector(grant.connectorServerId!)}
+            >
+              {title}
+            </button>
+          ) : (
+            <span className="text-sm text-foreground">{title}</span>
+          )}
+          {qualifierLabel ? (
+            <span className="ml-2 text-sm text-muted-foreground">{qualifierLabel}</span>
           ) : null}
         </div>
+        {grant.qualifierKind === 'command_group' ? (
+          <p className="mt-0.5 text-xs text-muted-foreground">
+            {summary ?? t('Command details unavailable for this permission')}
+            {createdLabel ? <span className="ml-2">{createdLabel}</span> : null}
+          </p>
+        ) : null}
         {grant.coveredBy ? (
           <p className="mt-0.5 text-xs text-muted-foreground">
             {t('Also allowed {{scope}}', {
@@ -150,7 +212,7 @@ const PermissionRow = ({
             })}
           </p>
         ) : null}
-        {grant.policyHint ? (
+        {policyHint ? (
           <button
             type="button"
             className="mt-0.5 block rounded-sm text-left text-xs text-muted-foreground underline-offset-2 outline-none transition-colors duration-150 motion-reduce:transition-none hover:underline focus-visible:ring-3 focus-visible:ring-ring/50"
@@ -158,27 +220,27 @@ const PermissionRow = ({
               grant.connectorServerId ? onOpenConnector?.(grant.connectorServerId) : undefined
             }
           >
-            {grant.policyHint}
+            {policyHint}
           </button>
         ) : null}
       </div>
       {sessionId && onOpenSession ? (
         <button
           type="button"
-          title={grant.scopeLabel}
-          aria-label={t('Open {{scope}}', { scope: grant.scopeLabel })}
+          title={scopeLabel}
+          aria-label={t('Open {{scope}}', { scope: scopeLabel })}
           className={`${scopeClassName} cursor-pointer transition-colors duration-150 motion-reduce:transition-none outline-none hover:bg-accent hover:text-accent-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50`}
           onClick={() => onOpenSession(sessionId)}
         >
-          {grant.scopeLabel}
+          {scopeLabel}
         </button>
       ) : (
-        <span title={grant.scopeLabel} className={scopeClassName}>
-          {grant.scopeLabel}
+        <span title={scopeLabel} className={scopeClassName}>
+          {scopeLabel}
         </span>
       )}
       <SettingsIconAction
-        label={t('Revoke {{name}}', { name: t(grant.capabilityLabel) })}
+        label={t('Revoke {{name}}', { name: revokeName })}
         icon={X}
         danger
         className="relative col-start-2 row-span-2 row-start-1 size-8 shrink-0 opacity-100 transition-opacity duration-150 motion-reduce:transition-none before:absolute before:-inset-1.5 before:content-[''] sm:col-start-3 sm:row-span-1 [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 [@media(hover:hover)]:focus-visible:opacity-100"
@@ -329,7 +391,13 @@ const PermissionsPanel = ({
               </p>
             </div>
             <RestoreDefaultPermissionsButton
-              state={defaultsComplete ? 'success' : restoreDefaultsState}
+              state={
+                defaultsComplete
+                  ? 'success'
+                  : restoreDefaultsState === 'success'
+                    ? 'idle'
+                    : restoreDefaultsState
+              }
               disabled={defaultsComplete || status === 'loading'}
               onRestore={() => void restoreDefaults()}
             />

--- a/src/renderer/src/stores/permission-grants-store.test.ts
+++ b/src/renderer/src/stores/permission-grants-store.test.ts
@@ -41,6 +41,35 @@ beforeEach(() => {
 })
 
 describe('permission grants store', () => {
+  it('reports an unavailable Undo instead of silently treating a zero restore as success', async () => {
+    usePermissionGrantsStore.setState({
+      undo: {
+        token: 'expired-in-main',
+        expiresAt: Date.now() + 8000,
+        messageKey: 'Revoked permission'
+      }
+    })
+    setPermissionApi({
+      restore: vi.fn().mockResolvedValue({
+        ...snapshot,
+        version: 2,
+        grants: [],
+        counts: { all: 0, global: 0, project: 0, session: 0 },
+        conflicts: [],
+        restoredCount: 0
+      })
+    })
+    await usePermissionGrantsStore.getState().restore()
+    expect(usePermissionGrantsStore.getState()).toMatchObject({
+      isRestoring: false,
+      grants: [],
+      undo: {
+        canRestore: false,
+        messageKey: 'Permission could not be restored: Undo is no longer available'
+      }
+    })
+  })
+
   it('reuses a snapshot for 60 seconds and supports an event-driven forced refresh', async () => {
     const list = vi.fn().mockResolvedValue(snapshot)
     setPermissionApi({ list })

--- a/src/renderer/src/stores/permission-grants-store.ts
+++ b/src/renderer/src/stores/permission-grants-store.ts
@@ -190,10 +190,18 @@ const withoutPendingRevocations = (snapshot: PermissionGrantSnapshot): Permissio
 }
 
 const applyAuthoritativeSnapshot = (
-  state: PermissionGrantSnapshot,
+  state: PermissionGrantsStore,
   incoming: PermissionGrantSnapshot
-): PermissionGrantSnapshot =>
-  withoutPendingRevocations(incoming.version < state.version ? snapshotFromState(state) : incoming)
+): PermissionGrantSnapshot & Partial<Pick<PermissionGrantsStore, 'restoreDefaultsState'>> => ({
+  ...withoutPendingRevocations(
+    incoming.version < state.version ? snapshotFromState(state) : incoming
+  ),
+  ...(incoming.version >= state.version &&
+  (incoming.missingDefaultGlobalGrantCount ?? 0) > 0 &&
+  state.restoreDefaultsState === 'success'
+    ? { restoreDefaultsState: 'idle' as const }
+    : {})
+})
 
 const allUndoItems = (state: Pick<PermissionGrantsStore, 'undo' | 'undoQueue'>): PermissionUndo[] =>
   [state.undo, ...state.undoQueue].filter((item): item is PermissionUndo => Boolean(item))
@@ -385,6 +393,27 @@ const usePermissionGrantsStore = create<PermissionGrantsStore>((set, get) => ({
     set({ isRestoring: true, error: undefined })
     try {
       const result = await window.api.permissions.restore({ undoToken: undo.token })
+      if (result.restoredCount === 0 && result.conflicts.length === 0) {
+        set((state) => ({
+          ...applyAuthoritativeSnapshot(state, mutationState(result)),
+          ...nextUndoState(
+            allUndoItems(state).map((item) =>
+              item.token === undo.token
+                ? {
+                    ...item,
+                    expiresAt: Date.now() + 5_000,
+                    canRestore: false,
+                    messageKey: 'Permission could not be restored: Undo is no longer available',
+                    messageParams: {},
+                    translatedMessageParams: []
+                  }
+                : item
+            )
+          ),
+          isRestoring: false
+        }))
+        return
+      }
       const targetUnavailable = result.conflicts.filter(
         (conflict) => conflict.reason === 'target-unavailable'
       ).length

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4740,6 +4740,27 @@
     "{{count}} tagged resources are currently unavailable._other": "{{count}} getaggte Ressourcen sind derzeit nicht verfügbar.",
     "{{count}} tagged resources are currently unavailable._one": "{{count}} getaggte Ressource ist derzeit nicht verfügbar.",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "Die Zugriffsberechtigung ist abgelaufen. Öffnen Sie den Web-Link erneut in Open Science auf dem Hostcomputer oder kehren Sie zur Einstiegsseite für den Fernzugriff zurück, um die Kopplung zu wiederholen.",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "Das Ergebnis des Vorgangs konnte nicht bestätigt werden. Er wird möglicherweise noch ausgeführt. Stellen Sie die Verbindung wieder her und prüfen Sie seinen Status, bevor Sie es erneut versuchen."
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "Das Ergebnis des Vorgangs konnte nicht bestätigt werden. Er wird möglicherweise noch ausgeführt. Stellen Sie die Verbindung wieder her und prüfen Sie seinen Status, bevor Sie es erneut versuchen.",
+    "Any call": "Beliebiger Aufruf",
+    "Specific input": "Bestimmte Eingabe",
+    "Command group": "Befehlsgruppe",
+    "Session: {{name}}": "Sitzung: {{name}}",
+    "Approved {{date}}": "Freigegeben am {{date}}",
+    "Command details unavailable for this permission": "Befehlsdetails für diese Berechtigung sind nicht verfügbar",
+    "Blocked in Connectors; this permission is currently inactive": "In Konnektoren blockiert; diese Berechtigung ist derzeit inaktiv",
+    "Allowed by Connector policy even without this permission": "Auch ohne diese Berechtigung durch die Konnektor-Richtlinie erlaubt",
+    "Permission could not be restored: Undo is no longer available": "Berechtigung konnte nicht wiederhergestellt werden: Rückgängig ist nicht mehr verfügbar",
+    "Git: working tree status": "Git: Status des Arbeitsverzeichnisses",
+    "Git: changes": "Git: Änderungen",
+    "Git: commit history": "Git: Commit-Verlauf",
+    "Git: object details": "Git: Objektdetails",
+    "Git: stage changes": "Git: Änderungen vormerken",
+    "Git: create commits": "Git: Commits erstellen",
+    "npm: run tests": "npm: Tests ausführen",
+    "npm: run scripts": "npm: Skripte ausführen",
+    "Python commands": "Python-Befehle",
+    "Python 3 commands": "Python-3-Befehle",
+    "Node.js commands": "Node.js-Befehle",
+    "R scripts": "R-Skripte"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4902,6 +4902,27 @@
     "{{count}} tagged resources are currently unavailable._other": "{{count}} recursos etiquetados no están disponibles actualmente.",
     "{{count}} tagged resources are currently unavailable._one": "{{count}} recurso etiquetado no está disponible actualmente.",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "La autorización de acceso ha caducado. Vuelva a abrir el enlace Web desde Open Science en el equipo anfitrión o regrese a la página de acceso remoto para volver a emparejar.",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "No se ha podido confirmar el resultado de la operación. Es posible que siga en curso. Vuelva a conectarse y compruebe su estado antes de intentarlo de nuevo."
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "No se ha podido confirmar el resultado de la operación. Es posible que siga en curso. Vuelva a conectarse y compruebe su estado antes de intentarlo de nuevo.",
+    "Any call": "Cualquier llamada",
+    "Specific input": "Entrada específica",
+    "Command group": "Grupo de comandos",
+    "Session: {{name}}": "Sesión: {{name}}",
+    "Approved {{date}}": "Aprobado el {{date}}",
+    "Command details unavailable for this permission": "Los detalles de los comandos de este permiso no están disponibles",
+    "Blocked in Connectors; this permission is currently inactive": "Bloqueado en Conectores; este permiso está inactivo",
+    "Allowed by Connector policy even without this permission": "Permitido por la política del Conector incluso sin este permiso",
+    "Permission could not be restored: Undo is no longer available": "No se pudo restaurar el permiso: ya no se puede deshacer",
+    "Git: working tree status": "Git: estado del árbol de trabajo",
+    "Git: changes": "Git: diferencias",
+    "Git: commit history": "Git: historial de commits",
+    "Git: object details": "Git: detalles de objetos",
+    "Git: stage changes": "Git: preparar cambios",
+    "Git: create commits": "Git: crear commits",
+    "npm: run tests": "npm: ejecutar pruebas",
+    "npm: run scripts": "npm: ejecutar scripts",
+    "Python commands": "Comandos de Python",
+    "Python 3 commands": "Comandos de Python 3",
+    "Node.js commands": "Comandos de Node.js",
+    "R scripts": "Scripts de R"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4902,6 +4902,27 @@
     "{{count}} tagged resources are currently unavailable._other": "{{count}} ressources associées à ce tag sont actuellement indisponibles.",
     "{{count}} tagged resources are currently unavailable._one": "{{count}} ressource associée à ce tag est actuellement indisponible.",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "L’autorisation d’accès a expiré. Rouvrez le lien Web depuis Open Science sur l’ordinateur hôte, ou revenez à la page d’accès distant pour effectuer un nouvel appairage.",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "Le résultat de l’opération n’a pas pu être confirmé. Elle est peut-être encore en cours. Reconnectez-vous et vérifiez son état avant de réessayer."
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "Le résultat de l’opération n’a pas pu être confirmé. Elle est peut-être encore en cours. Reconnectez-vous et vérifiez son état avant de réessayer.",
+    "Any call": "Tout appel",
+    "Specific input": "Entrée spécifique",
+    "Command group": "Groupe de commandes",
+    "Session: {{name}}": "Session : {{name}}",
+    "Approved {{date}}": "Approuvé le {{date}}",
+    "Command details unavailable for this permission": "Les détails des commandes de cette autorisation sont indisponibles",
+    "Blocked in Connectors; this permission is currently inactive": "Bloqué dans les Connecteurs ; cette autorisation est actuellement inactive",
+    "Allowed by Connector policy even without this permission": "Autorisé par la politique du Connecteur même sans cette autorisation",
+    "Permission could not be restored: Undo is no longer available": "Impossible de rétablir l’autorisation : l’annulation n’est plus disponible",
+    "Git: working tree status": "Git : état du répertoire de travail",
+    "Git: changes": "Git : différences",
+    "Git: commit history": "Git : historique des commits",
+    "Git: object details": "Git : détails des objets",
+    "Git: stage changes": "Git : indexer les modifications",
+    "Git: create commits": "Git : créer des commits",
+    "npm: run tests": "npm : exécuter les tests",
+    "npm: run scripts": "npm : exécuter les scripts",
+    "Python commands": "Commandes Python",
+    "Python 3 commands": "Commandes Python 3",
+    "Node.js commands": "Commandes Node.js",
+    "R scripts": "Scripts R"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4586,6 +4586,27 @@
     "Tag assignments are preserved.": "タグの関連付けは保持されています。",
     "{{count}} tagged resources are currently unavailable._other": "タグ付けされたリソース {{count}} 件は現在利用できません。",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "アクセス認証の有効期限が切れました。ホスト側の Open Science から Web リンクを開き直すか、リモートアクセスの入口ページに戻って再度ペアリングしてください。",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "操作結果を確認できませんでした。操作はまだ実行中の可能性があります。再接続して状態を確認してから、再試行してください。"
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "操作結果を確認できませんでした。操作はまだ実行中の可能性があります。再接続して状態を確認してから、再試行してください。",
+    "Any call": "すべての呼び出し",
+    "Specific input": "特定の入力",
+    "Command group": "コマンドグループ",
+    "Session: {{name}}": "セッション：{{name}}",
+    "Approved {{date}}": "承認日時：{{date}}",
+    "Command details unavailable for this permission": "この権限のコマンド詳細は利用できません",
+    "Blocked in Connectors; this permission is currently inactive": "コネクタでブロックされています。この権限は現在無効です",
+    "Allowed by Connector policy even without this permission": "この権限がなくてもコネクタのポリシーで許可されています",
+    "Permission could not be restored: Undo is no longer available": "権限を復元できませんでした。元に戻す機能は利用できません",
+    "Git: working tree status": "Git：作業ツリーの状態",
+    "Git: changes": "Git：変更の差分",
+    "Git: commit history": "Git：コミット履歴",
+    "Git: object details": "Git：オブジェクトの詳細",
+    "Git: stage changes": "Git：変更のステージング",
+    "Git: create commits": "Git：コミットの作成",
+    "npm: run tests": "npm：テストの実行",
+    "npm: run scripts": "npm：スクリプトの実行",
+    "Python commands": "Python コマンド",
+    "Python 3 commands": "Python 3 コマンド",
+    "Node.js commands": "Node.js コマンド",
+    "R scripts": "R スクリプト"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4584,6 +4584,27 @@
     "Tag assignments are preserved.": "태그 연결은 유지됩니다.",
     "{{count}} tagged resources are currently unavailable._other": "태그가 지정된 리소스 {{count}}개를 현재 사용할 수 없습니다.",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "접근 인증이 만료되었습니다. 호스트 컴퓨터의 Open Science에서 Web 링크를 다시 열거나 원격 접근 시작 페이지로 돌아가 다시 페어링하세요.",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "작업 결과를 확인할 수 없습니다. 작업이 아직 실행 중일 수 있습니다. 다시 연결하여 상태를 확인한 후 재시도하세요."
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "작업 결과를 확인할 수 없습니다. 작업이 아직 실행 중일 수 있습니다. 다시 연결하여 상태를 확인한 후 재시도하세요.",
+    "Any call": "모든 호출",
+    "Specific input": "특정 입력",
+    "Command group": "명령 그룹",
+    "Session: {{name}}": "세션: {{name}}",
+    "Approved {{date}}": "승인 일시: {{date}}",
+    "Command details unavailable for this permission": "이 권한의 명령 세부 정보를 사용할 수 없습니다",
+    "Blocked in Connectors; this permission is currently inactive": "커넥터에서 차단됨. 이 권한은 현재 비활성 상태입니다",
+    "Allowed by Connector policy even without this permission": "이 권한이 없어도 커넥터 정책에 따라 허용됩니다",
+    "Permission could not be restored: Undo is no longer available": "권한을 복원할 수 없습니다. 실행 취소를 더 이상 사용할 수 없습니다",
+    "Git: working tree status": "Git: 작업 트리 상태",
+    "Git: changes": "Git: 변경 사항 비교",
+    "Git: commit history": "Git: 커밋 기록",
+    "Git: object details": "Git: 객체 세부 정보",
+    "Git: stage changes": "Git: 변경 사항 스테이징",
+    "Git: create commits": "Git: 커밋 생성",
+    "npm: run tests": "npm: 테스트 실행",
+    "npm: run scripts": "npm: 스크립트 실행",
+    "Python commands": "Python 명령",
+    "Python 3 commands": "Python 3 명령",
+    "Node.js commands": "Node.js 명령",
+    "R scripts": "R 스크립트"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5035,6 +5035,27 @@
     "{{count}} tagged resources are currently unavailable._other": "{{count}} ресурса с тегом сейчас недоступны.",
     "{{count}} tagged resources are currently unavailable._one": "{{count}} ресурс с тегом сейчас недоступен.",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "Срок действия разрешения на доступ истёк. Снова откройте веб-ссылку из Open Science на главном компьютере или вернитесь на страницу удалённого доступа для повторного сопряжения.",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "Не удалось подтвердить результат операции. Возможно, она ещё выполняется. Подключитесь снова и проверьте её состояние перед повторной попыткой."
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "Не удалось подтвердить результат операции. Возможно, она ещё выполняется. Подключитесь снова и проверьте её состояние перед повторной попыткой.",
+    "Any call": "Любой вызов",
+    "Specific input": "Определённые входные данные",
+    "Command group": "Группа команд",
+    "Session: {{name}}": "Сеанс: {{name}}",
+    "Approved {{date}}": "Утверждено {{date}}",
+    "Command details unavailable for this permission": "Сведения о командах для этого разрешения недоступны",
+    "Blocked in Connectors; this permission is currently inactive": "Заблокировано в Коннекторах; это разрешение сейчас неактивно",
+    "Allowed by Connector policy even without this permission": "Разрешено политикой Коннектора даже без этого разрешения",
+    "Permission could not be restored: Undo is no longer available": "Не удалось восстановить разрешение: отмена больше недоступна",
+    "Git: working tree status": "Git: состояние рабочего дерева",
+    "Git: changes": "Git: различия",
+    "Git: commit history": "Git: история коммитов",
+    "Git: object details": "Git: сведения об объектах",
+    "Git: stage changes": "Git: индексировать изменения",
+    "Git: create commits": "Git: создавать коммиты",
+    "npm: run tests": "npm: запуск тестов",
+    "npm: run scripts": "npm: запуск скриптов",
+    "Python commands": "Команды Python",
+    "Python 3 commands": "Команды Python 3",
+    "Node.js commands": "Команды Node.js",
+    "R scripts": "Скрипты R"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4586,6 +4586,27 @@
     "Tag assignments are preserved.": "标签关联已保留。",
     "{{count}} tagged resources are currently unavailable._other": "{{count}} 个已关联资源暂不可用。",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "访问授权已失效。请从主机上的 Open Science 重新打开 Web 链接，或返回远程访问入口页面重新配对。",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "无法确认操作结果。操作可能仍在进行。请重新连接并检查其状态，然后再决定是否重试。"
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "无法确认操作结果。操作可能仍在进行。请重新连接并检查其状态，然后再决定是否重试。",
+    "Any call": "任何调用",
+    "Specific input": "特定输入",
+    "Command group": "命令组",
+    "Session: {{name}}": "会话：{{name}}",
+    "Approved {{date}}": "批准于 {{date}}",
+    "Command details unavailable for this permission": "此权限的命令详情不可用",
+    "Blocked in Connectors; this permission is currently inactive": "已在连接器中阻止；此权限当前无效",
+    "Allowed by Connector policy even without this permission": "即使没有此权限，连接器策略仍允许调用",
+    "Permission could not be restored: Undo is no longer available": "无法恢复权限：撤销恢复已不可用",
+    "Git: working tree status": "Git：工作区状态",
+    "Git: changes": "Git：变更差异",
+    "Git: commit history": "Git：提交历史",
+    "Git: object details": "Git：对象详情",
+    "Git: stage changes": "Git：暂存变更",
+    "Git: create commits": "Git：创建提交",
+    "npm: run tests": "npm：运行测试",
+    "npm: run scripts": "npm：运行脚本",
+    "Python commands": "Python 命令",
+    "Python 3 commands": "Python 3 命令",
+    "Node.js commands": "Node.js 命令",
+    "R scripts": "R 脚本"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4586,6 +4586,27 @@
     "Tag assignments are preserved.": "標籤關聯已保留。",
     "{{count}} tagged resources are currently unavailable._other": "{{count}} 個已關聯資源暫時無法使用。",
     "Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.": "存取授權已失效。請從主機上的 Open Science 重新開啟 Web 連結，或返回遠端存取入口頁面重新配對。",
-    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "無法確認操作結果。操作可能仍在進行。請重新連線並檢查其狀態，再決定是否重試。"
+    "The operation result could not be confirmed. It may still be running. Reconnect and check its status before trying again.": "無法確認操作結果。操作可能仍在進行。請重新連線並檢查其狀態，再決定是否重試。",
+    "Any call": "任何呼叫",
+    "Specific input": "特定輸入",
+    "Command group": "命令群組",
+    "Session: {{name}}": "工作階段：{{name}}",
+    "Approved {{date}}": "核准於 {{date}}",
+    "Command details unavailable for this permission": "此權限的命令詳細資訊無法使用",
+    "Blocked in Connectors; this permission is currently inactive": "已在連接器中封鎖；此權限目前無效",
+    "Allowed by Connector policy even without this permission": "即使沒有此權限，連接器原則仍允許呼叫",
+    "Permission could not be restored: Undo is no longer available": "無法還原權限：復原功能已無法使用",
+    "Git: working tree status": "Git：工作目錄狀態",
+    "Git: changes": "Git：變更差異",
+    "Git: commit history": "Git：提交歷程",
+    "Git: object details": "Git：物件詳細資訊",
+    "Git: stage changes": "Git：暫存變更",
+    "Git: create commits": "Git：建立提交",
+    "npm: run tests": "npm：執行測試",
+    "npm: run scripts": "npm：執行指令碼",
+    "Python commands": "Python 命令",
+    "Python 3 commands": "Python 3 命令",
+    "Node.js commands": "Node.js 命令",
+    "R scripts": "R 指令碼"
   }
 }

--- a/src/shared/permission-grants.ts
+++ b/src/shared/permission-grants.ts
@@ -30,6 +30,7 @@ export type PermissionGrantRecord = {
   capability: PermissionCapability
   scope: PermissionGrantScope
   createdAt?: number
+  approvalSummary?: string
   revision: number
 }
 
@@ -80,6 +81,7 @@ export type PermissionGrantMutationConflict = {
 export type PermissionGrantMutationResult = {
   grants: PermissionGrantRecord[]
   receipt?: PermissionGrantUndoReceipt
+  restoredCount?: number
   conflicts: PermissionGrantMutationConflict[]
 }
 
@@ -102,12 +104,17 @@ export type PermissionGrantView = {
   capabilityKind: PermissionCapabilityKind
   capabilityLabel: string
   qualifierLabel?: string
+  qualifierKind?: 'any' | 'exact' | 'category' | 'command_group'
+  approvalSummary?: string
   scopeKind: PermissionGrantScope['kind']
   scopeLabel: string
+  // null means the current host could not resolve the user-authored name.
+  scopeName?: string | null
   // A broader matching grant that remains effective after this exact row is revoked.
   coveredBy?: 'global' | 'project'
   effectiveState?: 'active' | 'covered_by_policy' | 'blocked_by_policy'
   policyHint?: string
+  connectorDisplayName?: string
   connectorServerId?: string
   connectorToolName?: string
   projectId?: string
@@ -143,6 +150,7 @@ export type PermissionGrantUndoExtendRequest = {
 
 export type PermissionGrantMutationView = PermissionGrantSnapshot & {
   receipt?: PermissionGrantUndoReceipt
+  restoredCount?: number
   conflicts: PermissionGrantMutationConflict[]
 }
 


### PR DESCRIPTION
## Problem

PG01–PG04: saved permissions can have indistinguishable target labels, slow revoke-response metadata can exhaust Undo before delivery, restoring defaults leaves stale success after another revoke, and row details remain English in translated interfaces.

## Proposed change

- Identify Connector rows and revoke controls with the Connector name, public server identity, exact tool, and scope; open the existing Connector Settings route even when the grant is active.
- Persist an optional reviewed command-group description, show its creation time, and explicitly disclose unavailable descriptions for historical or unsupported groups. Registry derives descriptions only for complete matches against 12 fixed, reviewed prefixes; raw commands, argument variants, paths, and qualifier digests do not enter the projection. Matching authority is unchanged.
- Read metadata before the revoke commit and return the current Registry cache immediately with the receipt. Mark concurrently invalidated metadata incomplete; retain expiry and owner-deletion guards. Report zero restores through the existing non-restorable Undo notice.
- Derive default-button appearance from the current missing count and clear stale success on newer snapshots. Compose scope, qualifier, policy, tooltip, and accessible copy in the renderer, with all eight locales updated.

## Scope and non-goals

**Persistence/compatibility:** migration `0032_permission_approval_summary` adds nullable `PermissionGrant.approvalSummary`. Existing rows remain valid with null descriptions; no backfill, automatic revoke, or reapproval. Reviewed descriptions survive reopen and Undo. Unsupported/historical groups still cannot be semantically distinguished from their hashes alone; the UI states that limitation. This does not add a general audit log or approval-source relationship.

**State/contracts:** no new authorization or receipt lifecycle states. Display DTO fields add `scopeName`, `connectorDisplayName`, `qualifierKind` (`any`, `exact`, `category`, `command_group`), and `approvalSummary`; restoration results optionally include a numeric count. Existing IPC/application command ownership and channels remain unchanged. Optional fields preserve older-host source compatibility.

## Acceptance criteria and validation

Final functional changes were checked locally with the following impact set; subsequent CI-discovered script and test corrections were checked with their focused suites and lint after the last edit.

| Behavior | Command / project-owned check | Result |
| --- | --- | --- |
| PG01–PG04 reproduction | `npm test -- src/main/permission-grants/registry.test.ts src/renderer/src/pages/settings/PermissionsPanel.render.test.tsx -t 'PG0[1-4]'` on unchanged base `4d1046fc` | Same final 6 regressions fail in two runs, for the reported reasons |
| Corrected behavior | Same command on this branch | 6 pass |
| Persistence, migration, owner/adapter/UI contracts | Focused `npm test --` over `src/main/database`, `src/main/permission-grants`, PermissionsPanel, permission store, Undo Snackbar, i18n guard, ACP broker/Claude/OpenCode/Codex adapters, shared renderer contracts, preload, Web installer, and application command composition/wiring | 48 files / 1,803 tests pass |
| Packaged ledger and asynchronous literature retry | `npm test -- scripts/database-migration-ledger-smoke.test.ts src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx` | 27 pass; packaged ledger first reproduced locally with 7 failures |
| Last controller test cleanup | `npm test -- src/main/permission-grants/projection-controller.test.ts` | Pass |
| Runtime types | `npm run typecheck` | Node, sandbox, Web pass |
| Lint and schema | `npm run lint`; `npm run db:schema:check`; `git diff --check` | Pass |
| UI | ego-browser with real components/catalog projections and isolated fixture responses | English/Chinese screenshots captured; actual restore-then-revoke returns the enabled Restore defaults button |

The broker checks cover Claude, OpenCode, codex-response, and codex-bridge identities reaching the shared Registry. Migration tests verify existing authority, timestamps, relationships, null legacy summaries, idempotency, and Undo. Existing test expectations listing the migration suffix were updated for 0032.

The committed-head `test:affected:explain` selects the full plan because `prisma/schema.prisma` is not mapped to a narrow module. The maintainer explicitly requested module-focused local tests and the full suite on PR CI, so the local impact set above was run and the complete plan is left to CI. No full local suite or packaged Windows/Linux UI run is claimed. Screenshots use test data, not the user's database. CI and independent review remain required.

Initial CI also exposed the packaged migration certification list still ending at 0031; its immutable checksum list and historical fixtures now include 0032. An unrelated literature test asserted the asynchronous retry call immediately after the configuration label rendered; it now waits for the call count without changing product behavior.

## Review focus

- Privacy and truthful scope of reviewed summaries; unsupported and historical records remain explicitly limited.
- No post-commit metadata I/O before delivering Undo; coherent cached grant revisions and conservative handling of invalidated names.
- Nullable migration preserves existing grants and keeps display metadata out of fingerprints and matching.

## Rebase validation

Rebased onto `main` at `0771378e` at the maintainer's request. The eight locale append conflicts preserve both the upstream Web authorization/recovery messages and the permission strings. `git range-diff` confirms only locale insertion context changed; all three PR commits, including the compact-home geometry sampling fix, are retained without logic changes.

After resolving conflicts, focused permission owner/controller, PermissionsPanel, store, Undo Snackbar, eight-locale guard, approval-summary migration, packaged ledger, literature-render, and Web API installer suites passed (19 files / 1,139 tests). `npm run typecheck`, `npm run lint`, and `git diff --check` passed. Full verification remains on the new-head PR CI.

## macOS visual CI follow-up

The latest full CI at `508a70fb` passed all portable shards, coverage, Windows E2E, native checks, and macOS functional/workspace/accessibility checks. The compact-home visual geometry test failed once (card y coordinates 152 versus 148) and passed its retry, which correctly failed the lane under `--fail-on-flaky-tests`. The failure screenshot shows the cards aligned; trace records separate bounding-box calls.

The test now reads both rectangles in one browser task, preventing a responsive reflow between coordinate samples. All geometry assertions and tolerances are unchanged; no product code, snapshots, fixed delays, or CI retry policy changed. The original local test passed 3 runs (the CI failure was intermittent). After the edit, the targeted Electron test passed 10 consecutive runs with `--fail-on-flaky-tests`; `npm run build:e2e`, `npm run typecheck:node`, `npm run lint`, and `git diff --check` passed.

