### PR TITLE
fix(workspace): block background resizing behind preview modals

### DIFF
--- a/e2e/workspace-files.spec.ts
+++ b/e2e/workspace-files.spec.ts
@@ -328,6 +328,43 @@ test.describe('Workspace dividers', () => {
   })
 
   for (const side of ['left', 'right'] as const) {
+    test(`${side} divider ignores the bottom edge while a file preview is expanded`, async ({
+      app
+    }, testInfo) => {
+      const page = app.page
+      const handle = page.getByRole('separator', {
+        name: `Resize ${side} panel`,
+        includeHidden: true
+      })
+      const original = (await handle.boundingBox())!
+      await page.getByRole('button', { name: 'Open full screen preview of resize.txt' }).click()
+      const modal = page.getByRole('dialog', { name: 'Preview resize.txt' })
+      await expect(modal).toBeVisible()
+      const x = original.x + original.width / 2
+      const y = original.y + original.height - 2
+      await page.mouse.move(x, y)
+      await expect(handle).not.toHaveAttribute('data-separator', 'hover')
+      expect(
+        await page.locator('body').evaluate((element) => getComputedStyle(element).cursor)
+      ).not.toMatch(/resize/)
+      await page.screenshot({ path: testInfo.outputPath(`${side}-modal-isolation.png`) })
+      await page.mouse.down()
+      await page.mouse.move(x - 60, y, { steps: 5 })
+      await page.mouse.up()
+      expect((await handle.boundingBox())!.x).toBeCloseTo(original.x, 0)
+      // Releasing on the backdrop can dismiss the modal through its normal click behavior.
+      if (await modal.isVisible()) {
+        await modal.getByRole('button', { name: 'Close preview of resize.txt' }).click()
+      }
+      await expect(modal).toBeHidden()
+      await page.mouse.move(x, y)
+      await expect(handle).toHaveAttribute('data-separator', 'hover')
+      await page.mouse.down()
+      await page.mouse.move(x + (side === 'left' ? 60 : -60), y, { steps: 5 })
+      await page.mouse.up()
+      expect(Math.abs((await handle.boundingBox())!.x - original.x)).toBeGreaterThan(30)
+    })
+
     test(`${side} workspace divider responds to arrow keys after reopening`, async ({ app }) => {
       const page = app.page
       await page.emulateMedia({ reducedMotion: 'reduce' })

--- a/src/renderer/src/components/ui/resizable.modal-isolation.test.tsx
+++ b/src/renderer/src/components/ui/resizable.modal-isolation.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment jsdom
+import { act, createRef, type ComponentProps } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './resizable'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      observe = vi.fn()
+      unobserve = vi.fn()
+      disconnect = vi.fn()
+    }
+  )
+  vi.spyOn(HTMLElement.prototype, 'offsetWidth', 'get').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.hasAttribute('data-separator') ? 1 : this.hasAttribute('data-panel') ? 500 : 1000
+  })
+  vi.spyOn(HTMLElement.prototype, 'offsetLeft', 'get').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    return this.id === 'right' || this.hasAttribute('data-separator') ? 500 : 0
+  })
+  vi.spyOn(HTMLElement.prototype, 'getBoundingClientRect').mockImplementation(function (
+    this: HTMLElement
+  ) {
+    const x = this.id === 'right' || this.hasAttribute('data-separator') ? 500 : 0
+    return new DOMRect(x, 0, this.hasAttribute('data-separator') ? 1 : 500, 800)
+  })
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+
+const renderPanels = (props: ComponentProps<typeof ResizablePanelGroup> = {}): void => {
+  root.render(
+    <ResizablePanelGroup orientation="horizontal" {...props}>
+      <ResizablePanel id="left" defaultSize="50%" />
+      <ResizableHandle />
+      <ResizablePanel id="right" defaultSize="50%" />
+    </ResizablePanelGroup>
+  )
+}
+
+const hoverDivider = (): void => {
+  // Native inert retargets pointer events outside the isolated subtree, including to body.
+  document.body.dispatchEvent(
+    new MouseEvent('pointermove', {
+      bubbles: true,
+      clientX: 500,
+      clientY: 799
+    })
+  )
+}
+
+it('ignores background divider hover while inert and restores resizing after isolation ends', async () => {
+  await act(async () => renderPanels())
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).toBe('hover')
+
+  await act(async () => container.setAttribute('inert', ''))
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).not.toBe(
+    'hover'
+  )
+  await act(async () => {
+    document.body.dispatchEvent(
+      new MouseEvent('pointerdown', {
+        bubbles: true,
+        clientX: 500,
+        clientY: 799,
+        buttons: 1
+      })
+    )
+  })
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).not.toBe(
+    'active'
+  )
+  await act(async () => {
+    document.body.dispatchEvent(new MouseEvent('pointerup', { bubbles: true }))
+  })
+
+  await act(async () => container.removeAttribute('inert'))
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).toBe('hover')
+})
+
+it('preserves an explicit disabled prop after initial inert isolation ends and forwards the element ref', async () => {
+  const elementRef = createRef<HTMLDivElement>()
+  container.setAttribute('inert', '')
+  await act(async () => renderPanels({ disabled: true, elementRef }))
+  expect(elementRef.current).toBe(container.querySelector('[data-group]'))
+  await act(async () => container.removeAttribute('inert'))
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).not.toBe(
+    'hover'
+  )
+
+  await act(async () => renderPanels({ elementRef }))
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).toBe('hover')
+})
+
+it('keeps a group inside a modal interactive', async () => {
+  container.setAttribute('role', 'dialog')
+  container.setAttribute('aria-modal', 'true')
+  await act(async () => renderPanels())
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).toBe('hover')
+})
+
+it('ignores background divider hover while an inline preview is expanded as a modal', async () => {
+  await act(async () => renderPanels())
+  const dialog = document.createElement('section')
+  dialog.setAttribute('role', 'dialog')
+  dialog.setAttribute('aria-modal', 'true')
+  await act(async () => container.querySelector('#right')!.appendChild(dialog))
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).not.toBe(
+    'hover'
+  )
+
+  await act(async () => dialog.removeAttribute('aria-modal'))
+  await act(async () => hoverDivider())
+  expect(container.querySelector('[data-separator]')?.getAttribute('data-separator')).toBe('hover')
+})

--- a/src/renderer/src/components/ui/resizable.tsx
+++ b/src/renderer/src/components/ui/resizable.tsx
@@ -6,10 +6,43 @@ import { cn } from '@/lib/utils'
 
 function ResizablePanelGroup({
   className,
+  disabled,
+  elementRef,
   ...props
 }: React.ComponentProps<typeof Group>): React.JSX.Element {
+  const groupElementRef = React.useRef<HTMLDivElement>(null)
+  const [isModalBlocked, setIsModalBlocked] = React.useState(false)
+
+  React.useImperativeHandle(elementRef, () => groupElementRef.current!, [])
+  React.useLayoutEffect(() => {
+    const element = groupElementRef.current
+    if (!element) return
+
+    // Document hit-testing bypasses inert and also sees inline modal content as part of this group.
+    // Groups inside a modal remain usable; only its containing or isolated background groups stop.
+    const syncModalBlocked = (): void =>
+      setIsModalBlocked(
+        element.closest('[inert]') !== null ||
+          element.querySelector('[aria-modal="true"]:not([data-state="closed"])') !== null
+      )
+    const observer = new MutationObserver(syncModalBlocked)
+    observer.observe(element, {
+      subtree: true,
+      childList: true,
+      attributes: true,
+      attributeFilter: ['inert', 'aria-modal', 'data-state']
+    })
+    for (let ancestor = element.parentElement; ancestor; ancestor = ancestor.parentElement) {
+      observer.observe(ancestor, { attributes: true, attributeFilter: ['inert'] })
+    }
+    syncModalBlocked()
+    return () => observer.disconnect()
+  }, [])
+
   return (
     <Group
+      elementRef={groupElementRef}
+      disabled={disabled || isModalBlocked}
       data-slot="resizable-panel-group"
       className={cn('flex h-full w-full', className)}
       {...props}


### PR DESCRIPTION
## Problem

An expanded Workspace preview remains inside the resizable group. The panel library handles document-level pointer events and treats the modal/backdrop as part of that group: moving along the bottom edge shows a resize cursor, and dragging changes the background column width. Document-level hit testing can also bypass an inert background used by the separate file-preview dialog.

## Proposed change

Make the shared resizable group disable its existing library resize registration while it contains an open modal or belongs to an inert subtree. Restore resizing when that condition ends, while preserving an explicit disabled prop and the element ref. Groups inside a modal remain interactive. The existing preview dialog retains inert through its exit animation, so its isolation lifetime remains authoritative.

## Scope and non-goals

- Renderer interaction fix; no layout redesign or new dependency.
- No historical-data compatibility or migration changes.
- No new enum values or persisted state. One transient boolean derives whether the current DOM blocks background resizing.
- The shared consumers are Workspace panel layout and Notebook preview; no main/preload/API contract changes.

## Acceptance criteria and validation

The following checks passed after the last production change; the final modal E2E tests also passed after their last test edit:

| Behavior / integration | Check | Result |
| --- | --- | --- |
| Real library ignores inert background and inline modal hover/drag, restores hover, retains explicit disabled/ref behavior, permits groups inside modals | `npx vitest run src/renderer/src/components/ui/resizable.modal-isolation.test.tsx` | 4 passed |
| Shared handle styling and PreviewPanel, FilePreviewDialog lifecycle/escape/versioning, NotebookPreview consumers | Above test plus `resizable.test.tsx`, `PreviewPanel.test.tsx`, `FilePreviewDialog.{lifecycle,escape,versioning}.test.tsx`, `NotebookPreview.gate.render.test.tsx` | 7 files, 125 tests passed |
| Workspace module, state and consumer contracts | `npm run test:module -- workspace_page` | 30 files, 814 tests passed |
| Both actual file-preview dividers ignore bottom-edge hover/drag and restore normal dragging | `npx playwright test e2e/workspace-files.spec.ts --grep 'divider ignores the bottom edge'` | 2 passed; screenshots captured |
| Adjacent keyboard registration behavior | Same spec with `--grep 'divider responds to arrow keys after reopening'` | 2 passed |
| Renderer integration | `npm run typecheck:web`; `npm run lint`; `npm run build:web`; `npm run build:e2e` | Passed |

A real Web browser reproduced an 80px background divider movement before the fix. Repeating the gesture after the fix left its x coordinate at 846.203125 with an ordinary cursor. The final concrete local-file scenario used the repository's isolated Electron fixture because the Web test instance did not initially expose local file browsing. E2E saves `left-modal-isolation.png` and `right-modal-isolation.png`.

Independent Standards and Spec reviews found no actionable issues and confirmed the final test-impact mapping.

The automatic affected-test plan falls back to full validation for the E2E path. Per maintainer request, a full local Vitest suite was not run; required PR CI is authoritative. Local verification used macOS; remaining platform coverage is left to CI. No persistence or backend platform lanes are needed for the implementation itself.

## Review focus

DOM isolation lifetime, containing versus contained modal groups, and preserved resize behavior after dismissal.
