### PR TITLE
fix(side-chat): preserve context and delivery through recovery

### DIFF
--- a/src/main/acp/side-chat-relay-owner.ts
+++ b/src/main/acp/side-chat-relay-owner.ts
@@ -30,6 +30,7 @@ type SideChatRelayMessage = Readonly<{
 
 type SideChatRelayClaim = Readonly<{
   messages: readonly SideChatRelayMessage[]
+  isCurrent: () => boolean
   commit: () => readonly SideChatRelayMessage[]
   restore: () => void
 }>
@@ -153,6 +154,7 @@ class SideChatRelayOwner {
     const ownsClaim = (): boolean => this.claims.get(parentSessionId) === token
     return {
       messages,
+      isCurrent: () => !settled && ownsClaim(),
       commit: () => {
         if (settled || !ownsClaim()) return []
         settled = true

--- a/src/main/side-chat/ipc.test.ts
+++ b/src/main/side-chat/ipc.test.ts
@@ -111,11 +111,14 @@ describe('Side chat IPC', () => {
     await handlers.get('side-chat:cancel')?.(undefined, { sideSessionId: 'side-1' } as never)
     await handlers.get('side-chat:close')?.(undefined, { sideSessionId: 'side-1' } as never)
 
-    expect(runtime.send).toHaveBeenCalledWith({
-      sideSessionId: 'side-1',
-      text: 'Follow up',
-      historyPreamble: expect.stringContaining('Latest Main output.')
-    })
+    expect(runtime.send).toHaveBeenCalledWith(
+      {
+        sideSessionId: 'side-1',
+        text: 'Follow up',
+        historyPreamble: expect.stringContaining('Latest Main output.')
+      },
+      expect.any(AbortController)
+    )
     expect(runtime.cancel).toHaveBeenCalledWith({ sideSessionId: 'side-1' })
     expect(runtime.close).toHaveBeenCalledWith({ sideSessionId: 'side-1' })
   })
@@ -237,4 +240,95 @@ describe('Side chat IPC', () => {
     expect(runtime.closeForParent).toHaveBeenCalledWith('main-1')
     expect(runtime.closeActiveForParent).not.toHaveBeenCalled()
   })
+})
+
+it('cancels a follow-up while the latest parent snapshot is still loading', async () => {
+  let loaded!: () => void
+  const loading = new Promise<void>((resolve) => {
+    loaded = resolve
+  })
+  const runtime = {
+    parentFor: () => ({ parentSessionId: 'main-1', projectId: 'project-1' }),
+    send: vi.fn(),
+    cancel: vi.fn()
+  }
+  registerSideChatIpcHandlers(runtime as never, {
+    loadParentSession: vi.fn(async () => {
+      await loading
+      return undefined
+    }),
+    hasLiveParentSession: () => true,
+    withParentAvailable: async (_sessionId, operation) => operation()
+  })
+  const sending = (
+    handlers.get('side-chat:send')!(undefined, {
+      sideSessionId: 'side-1',
+      text: 'Cancel this'
+    } as never) as Promise<unknown>
+  ).catch((error: unknown) => error)
+  await handlers.get('side-chat:cancel')!(undefined, { sideSessionId: 'side-1' } as never)
+  loaded()
+  await sending
+  expect(runtime.send).not.toHaveBeenCalled()
+})
+
+it('uses the selected Main branch when refreshing a follow-up snapshot', async () => {
+  const {
+    createLinearConversationGraph,
+    forkEditedConversationMessage,
+    synchronizeActiveConversationMessages
+  } = await import('../../shared/conversation-graph')
+  const { materializeSessionConversationGraph } = await import('../../shared/session-persistence')
+  const message = (
+    id: string
+  ): import('../../shared/session-persistence').PersistedChatMessage => ({
+    id,
+    role: 'user' as const,
+    content: id,
+    status: 'complete' as const,
+    eventIds: [],
+    createdAt: 1,
+    updatedAt: 1
+  })
+  const old = message('INACTIVE_BRANCH_RESULT')
+  const latest = message('SELECTED_BRANCH_RESULT')
+  const original = createLinearConversationGraph({
+    sessionId: 'main-1',
+    messages: [old],
+    createdAt: 1,
+    updatedAt: 1
+  })
+  const selected = synchronizeActiveConversationMessages(
+    forkEditedConversationMessage(original, old.id, 'selected-branch', 2),
+    [latest],
+    2
+  )
+  const parent = materializeSessionConversationGraph({
+    id: 'main-1',
+    projectId: 'project-1',
+    title: 'Main',
+    cwd: '.',
+    status: 'idle',
+    messages: [latest],
+    conversationGraph: selected,
+    createdAt: 1,
+    updatedAt: 2
+  })
+  expect(parent.conversationGraph.messages.map((entry) => entry.id)).toContain(old.id)
+  const runtime = {
+    parentFor: () => ({ parentSessionId: 'main-1', projectId: 'project-1' }),
+    send: vi.fn()
+  }
+  registerSideChatIpcHandlers(runtime as never, {
+    loadParentSession: async () => parent,
+    hasLiveParentSession: () => true,
+    withParentAvailable: async (_sessionId, operation) => operation()
+  })
+  await handlers.get('side-chat:send')!(undefined, {
+    sideSessionId: 'side-1',
+    text: 'Explain Main'
+  } as never)
+  const prompt = runtime.send.mock.lastCall?.[0].historyPreamble
+  expect(prompt).toContain('SELECTED_BRANCH_RESULT')
+  expect(prompt).not.toContain('INACTIVE_BRANCH_RESULT')
 })

--- a/src/main/side-chat/ipc.ts
+++ b/src/main/side-chat/ipc.ts
@@ -24,6 +24,7 @@ const registerSideChatIpcHandlers = (
   dependencies: SideChatIpcDependencies
 ): void => {
   const startingParents = new Set<string>()
+  const sends = new Map<string, { cancellation: AbortController; dispatching: boolean }>()
   const closeRequestedParents = new Set<string>()
   const loadAvailableParent = async (
     projectId: string,
@@ -59,22 +60,35 @@ const registerSideChatIpcHandlers = (
     }
   })
   ipcMainHandle('side-chat:send', async (_event, request: SideChatPromptRequest) => {
+    if (sends.has(request.sideSessionId)) throw new Error('A Side chat prompt is already running.')
     const parent = runtime.parentFor(request.sideSessionId)
     if (!parent) throw new Error('Side chat Session is not active.')
-    return dependencies.withParentAvailable(parent.parentSessionId, async () => {
-      const parentSession = await loadAvailableParent(parent.projectId, parent.parentSessionId)
-      const historyPreamble = parentSession
-        ? buildHistoryPreamble(parentSession.messages, {
-            target: 'codex-bridge',
-            budget: SIDE_CHAT_MESSAGE_LIMIT
-          })
-        : undefined
-      return runtime.send({ ...request, historyPreamble })
-    })
+    const send = { cancellation: new AbortController(), dispatching: false }
+    sends.set(request.sideSessionId, send)
+    try {
+      return await dependencies.withParentAvailable(parent.parentSessionId, async () => {
+        send.cancellation.signal.throwIfAborted()
+        const parentSession = await loadAvailableParent(parent.projectId, parent.parentSessionId)
+        send.cancellation.signal.throwIfAborted()
+        const historyPreamble = parentSession
+          ? buildHistoryPreamble(parentSession.messages, {
+              target: 'codex-bridge',
+              budget: SIDE_CHAT_MESSAGE_LIMIT
+            })
+          : undefined
+        send.dispatching = true
+        return runtime.send({ ...request, historyPreamble }, send.cancellation)
+      })
+    } finally {
+      if (sends.get(request.sideSessionId) === send) sends.delete(request.sideSessionId)
+    }
   })
-  ipcMainHandle('side-chat:cancel', (_event, request: SideChatSessionRequest) =>
-    runtime.cancel(request)
-  )
+  ipcMainHandle('side-chat:cancel', (_event, request: SideChatSessionRequest) => {
+    const send = sends.get(request.sideSessionId)
+    send?.cancellation.abort(new Error('Side chat prompt cancelled.'))
+    if (send && !send.dispatching) return
+    return runtime.cancel(request)
+  })
   ipcMainHandle('side-chat:close', (_event, request: SideChatCloseRequest) => {
     if ('sideSessionId' in request) return runtime.close(request)
     if (startingParents.has(request.parentSessionId)) {

--- a/src/main/side-chat/main-prompt-relay.test.ts
+++ b/src/main/side-chat/main-prompt-relay.test.ts
@@ -348,7 +348,7 @@ describe('main prompt side-chat relay', () => {
     expect(adapter.claim('main-1')?.historyPreamble).toContain('Advisory.')
   })
 
-  it('restores the in-memory claim when atomic durable commit fails', async () => {
+  it('holds an accepted claim when its durable commit fails', async () => {
     const relay = new SideChatRelayOwner({
       targetState: () => 'idle',
       appendRelay: async () => undefined
@@ -369,6 +369,165 @@ describe('main prompt side-chat relay', () => {
     })
 
     await expect(adapter.claim('main-1')?.commit('prompt-1')).rejects.toThrow('disk unavailable')
-    expect(adapter.claim('main-1')?.historyPreamble).toContain('Retry me.')
+    expect(adapter.claim('main-1')).toBeUndefined()
   })
+})
+
+it('does not requeue an advisory already accepted by Main when local commit fails', async () => {
+  const relay = new SideChatRelayOwner({
+    targetState: () => 'running',
+    appendRelay: async () => undefined
+  })
+  relay.bind({
+    sideSessionId: 'side-1',
+    sideChatId: 'chat-1',
+    parentSessionId: 'main-1',
+    projectId: 'project-1'
+  })
+  const queued = await relay.send({
+    sideSessionId: 'side-1',
+    target: 'main',
+    text: 'Use the latest result.'
+  })
+  const steerAdvisory = vi.fn(async () => ({
+    injected: true as const,
+    promptMessageId: 'accepted-main-prompt'
+  }))
+  const commitSideChatRelays = vi
+    .fn(async () => [])
+    .mockRejectedValueOnce(new Error('Session file is busy'))
+  const adapter = createMainPromptSideChatRelay({
+    relay,
+    steerAdvisory,
+    commitSideChatRelays,
+    onDelivered: vi.fn()
+  })
+  await adapter.tryInject('main-1', queued).catch(() => undefined)
+  expect(steerAdvisory).toHaveBeenCalledOnce()
+  expect(commitSideChatRelays).toHaveBeenCalledWith(
+    expect.objectContaining({
+      relayIds: [queued.messageId],
+      promptMessageId: 'accepted-main-prompt'
+    })
+  )
+  const nextTurn = adapter.claim('main-1')
+  expect(nextTurn?.includes(queued.messageId) ?? false).toBe(false)
+})
+
+it('retries only the accepted relay commit with the same prompt identity and publishes once', async () => {
+  const relay = new SideChatRelayOwner({
+    targetState: () => 'running',
+    appendRelay: async () => undefined
+  })
+  relay.bind({
+    sideSessionId: 'side-1',
+    sideChatId: 'chat-1',
+    parentSessionId: 'main-1',
+    projectId: 'project-1'
+  })
+  const queued = await relay.send({
+    sideSessionId: 'side-1',
+    target: 'main',
+    text: 'Keep this advice.'
+  })
+  const steerAdvisory = vi.fn(async () => ({
+    injected: true as const,
+    promptMessageId: 'original-prompt'
+  }))
+  const persisted = {
+    id: 'main-advisory',
+    role: 'user' as const,
+    content: 'Keep this advice.',
+    status: 'complete' as const,
+    eventIds: [],
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const commitSideChatRelays = vi
+    .fn(async () => [persisted])
+    .mockRejectedValueOnce(new Error('Disk full'))
+  const onDelivered = vi.fn()
+  const adapter = createMainPromptSideChatRelay({
+    relay,
+    steerAdvisory,
+    commitSideChatRelays,
+    onDelivered
+  })
+  await expect(adapter.tryInject('main-1', queued)).resolves.toMatchObject({
+    status: 'injected',
+    persistenceError: 'Disk full'
+  })
+  expect(onDelivered).not.toHaveBeenCalled()
+  await expect(adapter.tryInject('main-1', queued)).resolves.toMatchObject({ status: 'injected' })
+  expect(steerAdvisory).toHaveBeenCalledOnce()
+  expect(commitSideChatRelays).toHaveBeenCalledTimes(2)
+  expect(commitSideChatRelays.mock.calls[0]).toEqual(commitSideChatRelays.mock.calls[1])
+  expect(onDelivered).toHaveBeenCalledOnce()
+  expect(adapter.claim('main-1')).toBeUndefined()
+})
+
+it('keeps a next-turn accepted claim out of replay while coalescing commit retries', async () => {
+  const relay = new SideChatRelayOwner({
+    targetState: () => 'idle',
+    appendRelay: async () => undefined
+  })
+  relay.bind({
+    sideSessionId: 'side-1',
+    sideChatId: 'chat-1',
+    parentSessionId: 'main-1',
+    projectId: 'project-1'
+  })
+  await relay.send({ sideSessionId: 'side-1', target: 'main', text: 'Accepted advice.' })
+  let saved!: () => void
+  const saving = new Promise<void>((resolve) => {
+    saved = resolve
+  })
+  const commitSideChatRelays = vi
+    .fn(async () => {
+      await saving
+      return []
+    })
+    .mockRejectedValueOnce(new Error('Disk full'))
+  const adapter = createMainPromptSideChatRelay({
+    relay,
+    commitSideChatRelays,
+    onDelivered: vi.fn()
+  })
+  const delivery = adapter.claim('main-1')!
+  await expect(delivery.commit('main-prompt')).rejects.toThrow('Disk full')
+  delivery.restore()
+  expect(adapter.claim('main-1')).toBeUndefined()
+  expect(adapter.claim('main-1')).toBeUndefined()
+  expect(commitSideChatRelays).toHaveBeenCalledTimes(2)
+  saved()
+  await delivery.commit('different-prompt')
+  expect(commitSideChatRelays.mock.calls[1]).toEqual(commitSideChatRelays.mock.calls[0])
+  await delivery.commit('main-prompt')
+  expect(commitSideChatRelays).toHaveBeenCalledTimes(2)
+})
+
+it('drops an accepted pending claim when its parent has been released', async () => {
+  const relay = new SideChatRelayOwner({
+    targetState: () => 'idle',
+    appendRelay: async () => undefined
+  })
+  relay.bind({
+    sideSessionId: 'side-1',
+    sideChatId: 'chat-1',
+    parentSessionId: 'main-1',
+    projectId: 'project-1'
+  })
+  await relay.send({ sideSessionId: 'side-1', target: 'main', text: 'Old advice.' })
+  const commitSideChatRelays = vi.fn(async () => {
+    throw new Error('Disk full')
+  })
+  const adapter = createMainPromptSideChatRelay({
+    relay,
+    commitSideChatRelays,
+    onDelivered: vi.fn()
+  })
+  await expect(adapter.claim('main-1')!.commit('main-prompt')).rejects.toThrow('Disk full')
+  relay.releaseParent('main-1')
+  expect(adapter.claim('main-1')).toBeUndefined()
+  expect(commitSideChatRelays).toHaveBeenCalledOnce()
 })

--- a/src/main/side-chat/main-prompt-relay.ts
+++ b/src/main/side-chat/main-prompt-relay.ts
@@ -61,53 +61,96 @@ const selectAdvisoryCount = (messages: ReadonlyArray<{ id: string; text: string 
 const createMainPromptSideChatRelay = (
   options: MainPromptSideChatRelayOptions
 ): MainPromptSideChatRelay => {
+  // ponytail: receipts live only in this process; durable crash reconciliation needs a separate contract.
+  const pendingCommits = new Map<string, MainPromptSideChatRelayClaim>()
   const claim = (parentSessionId: string): MainPromptSideChatRelayClaim | undefined => {
-    const claim = options.relay.claim(parentSessionId, { selectCount: selectAdvisoryCount })
-    if (!claim) return undefined
-    return {
-      historyPreamble: formatAdvisories(claim.messages),
-      includes: (messageId) => claim.messages.some((message) => message.id === messageId),
-      restore: claim.restore,
-      commit: async (promptMessageId?: string): Promise<void> => {
-        const messages = claim.messages
-        if (messages.length === 0) return
-        if (!promptMessageId) {
-          claim.restore()
-          throw new Error(
-            'Main prompt message identity is required to deliver Side chat advisories.'
+    const pending = pendingCommits.get(parentSessionId)
+    if (pending) {
+      void pending.commit().catch((error) => {
+        log.warn('accepted advisory commit retry failed', { parentSessionId, error: String(error) })
+      })
+      return undefined
+    }
+    const claimed = options.relay.claim(parentSessionId, { selectCount: selectAdvisoryCount })
+    if (!claimed) return undefined
+    let acceptedPromptId: string | undefined
+    let writing: Promise<void> | undefined
+    let completed = false
+    const delivery: MainPromptSideChatRelayClaim = {
+      historyPreamble: formatAdvisories(claimed.messages),
+      includes: (messageId) => claimed.messages.some((message) => message.id === messageId),
+      restore: () => {
+        if (!acceptedPromptId) claimed.restore()
+      },
+      commit: (promptMessageId?: string): Promise<void> => {
+        if (completed) return Promise.resolve()
+        if (writing) return writing
+        acceptedPromptId ??= promptMessageId
+        if (!acceptedPromptId) {
+          claimed.restore()
+          return Promise.reject(
+            new Error('Main prompt message identity is required to deliver Side chat advisories.')
           )
         }
-        let persisted: readonly PersistedChatMessage[]
-        try {
-          persisted = await options.commitSideChatRelays({
+        if (!claimed.isCurrent()) {
+          pendingCommits.delete(parentSessionId)
+          completed = true
+          return Promise.resolve()
+        }
+        pendingCommits.set(parentSessionId, delivery)
+        const messages = claimed.messages
+        const persist = async (): Promise<void> => {
+          const persisted = await options.commitSideChatRelays({
             projectId: messages[0].projectId,
-            sessionId: messages[0].parentSessionId,
+            sessionId: parentSessionId,
             relayIds: messages.map((message) => message.id),
-            promptMessageId
+            promptMessageId: acceptedPromptId!
           })
-        } catch (error) {
-          claim.restore()
-          throw error
+          claimed.commit()
+          completed = true
+          if (pendingCommits.get(parentSessionId) === delivery)
+            pendingCommits.delete(parentSessionId)
+          log.info('relays delivered', {
+            parentSessionId,
+            relayCount: messages.length,
+            persistedMessageCount: persisted.length
+          })
+          for (const message of persisted) {
+            options.onDelivered({ parentSessionId, projectId: messages[0].projectId, message })
+          }
         }
-        claim.commit()
-        log.info('relays delivered', {
-          parentSessionId: messages[0].parentSessionId,
-          relayCount: messages.length,
-          persistedMessageCount: persisted.length
+        writing = persist().finally(() => {
+          writing = undefined
         })
-        for (const message of persisted) {
-          options.onDelivered({
-            parentSessionId: messages[0].parentSessionId,
-            projectId: messages[0].projectId,
-            message
-          })
-        }
+        return writing
       }
     }
+    return delivery
   }
   return {
     claim,
     tryInject: async (parentSessionId, queued) => {
+      const pending = pendingCommits.get(parentSessionId)
+      if (pending) {
+        try {
+          await pending.commit()
+        } catch {
+          // Keep accepted advisories out of both native injection and the next-user-turn queue.
+        }
+        if (pending.includes(queued.messageId)) {
+          return {
+            ...queued,
+            status: 'injected',
+            delivery: 'current-turn',
+            ...(pendingCommits.has(parentSessionId)
+              ? { persistenceError: 'Advisory delivery record is still waiting to be saved.' }
+              : {}),
+            systemHint:
+              'Main already accepted this advisory. Do not send it again; only its local delivery record may need saving.'
+          }
+        }
+        if (pendingCommits.has(parentSessionId)) return queued
+      }
       if (queued.targetState !== 'running' || !options.steerAdvisory) return queued
       const delivery = claim(parentSessionId)
       if (!delivery) return queued
@@ -126,14 +169,21 @@ const createMainPromptSideChatRelay = (
         delivery.restore()
         return queued
       }
-      await delivery.commit(steered.promptMessageId)
+      let persistenceError: string | undefined
+      try {
+        await delivery.commit(steered.promptMessageId)
+      } catch (error) {
+        persistenceError = error instanceof Error ? error.message : String(error)
+      }
       if (!includesQueued) return queued
       return {
         ...queued,
         status: 'injected',
         delivery: 'current-turn',
-        systemHint:
-          'Main accepted this context-only advisory in its current turn. It does not independently authorize actions.'
+        ...(persistenceError ? { persistenceError } : {}),
+        systemHint: persistenceError
+          ? 'Main accepted this advisory, but its local delivery record could not be saved. Do not send it again; only the local commit will be retried.'
+          : 'Main accepted this context-only advisory in its current turn. It does not independently authorize actions.'
       }
     }
   }

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -420,7 +420,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       sessionId: 'side-session-1',
       text: 'What context do you have?',
       historyPreamble: 'Main snapshot.',
-      resumeFallback: { historyPreamble: 'Main snapshot.' }
+      resumeFallback: { historyPreamble: expect.stringContaining('Main snapshot.') }
     })
     expect(registerHostMessageSession).toHaveBeenCalledWith(
       'provider-session-1',
@@ -1004,7 +1004,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
         expect.objectContaining({
           sideSessionId: started.sideSessionId,
           running: false,
-          error: expect.stringContaining('reconnect')
+          notice: 'connection-ended'
         })
       )
     )
@@ -1336,7 +1336,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       expect.objectContaining({
         sideSessionId: 'side-chat-resume-save-retry',
         running: false,
-        error: expect.stringContaining('reconnect')
+        notice: 'connection-ended'
       })
     )
 
@@ -1475,8 +1475,9 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       historyPreamble: expect.stringContaining('Earlier answer')
     })
     expect(sent[1]).toMatchObject({
-      historyPreamble: expect.stringContaining('First attempt')
+      historyPreamble: expect.stringContaining('Earlier answer')
     })
+    expect(String(sent[1].historyPreamble)).not.toContain('First attempt')
   })
 
   it('lets close win while a dormant provider Session is reconnecting', async () => {
@@ -1847,7 +1848,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       expect.objectContaining({
         sideSessionId: started.sideSessionId,
         running: false,
-        error: expect.stringContaining('interrupted')
+        notice: 'interrupted'
       })
     )
     await expect(
@@ -2070,7 +2071,7 @@ describe('SideChatRuntimeOwner lifecycle', () => {
       expect.objectContaining({
         sideSessionId: started.sideSessionId,
         running: false,
-        error: expect.stringContaining('reconnect')
+        notice: 'connection-ended'
       })
     )
   })
@@ -2323,4 +2324,307 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     finishShutdown()
     await close
   })
+})
+
+// Exercise preflight and recovery through the existing runtime/persistence ports.
+describe('Side chat recovery and preflight regressions', () => {
+  const setup = async (
+    dormant = false,
+    framework: ResolvedAgentBackend['framework'] = claudeCodeFramework
+  ): Promise<{
+    owner: SideChatRuntimeOwner
+    sideSessionId: string
+    persistence: ReturnType<typeof createPersistence>
+    onEvent: ReturnType<typeof vi.fn>
+    sendPrompt: ReturnType<
+      typeof vi.fn<
+        (request: {
+          sessionId: string
+          historyPreamble?: string
+        }) => Promise<{ stopReason: 'end_turn' }>
+      >
+    >
+    resumeSession: ReturnType<
+      typeof vi.fn<
+        () => Promise<{
+          sessionId: string
+          providerSessionId: string
+          frameworkId: ResolvedAgentBackend['framework']['id']
+          contextReset: boolean
+        }>
+      >
+    >
+    identity: {
+      sessionId: string
+      providerSessionId: string
+      frameworkId: ResolvedAgentBackend['framework']['id']
+      contextReset: boolean
+    }
+    accept: (sessionId: string) => void
+    emit: NonNullable<NonNullable<AcpRuntimeOptions['callbacks']>['onEvent']>
+  }> => {
+    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-reliability-'))
+    const persistence = createPersistence()
+    const onEvent = vi.fn()
+    let callbacks: AcpRuntimeOptions['callbacks']
+    const identity = {
+      sessionId: 'provider-reliability',
+      providerSessionId: 'provider-reliability',
+      frameworkId: framework.id,
+      contextReset: true
+    }
+    const resumeSession = vi.fn(async () => identity)
+    const sendPrompt = vi.fn(async (request: { sessionId: string; historyPreamble?: string }) => {
+      callbacks?.onProviderPromptAccepted?.(request.sessionId)
+      return { stopReason: 'end_turn' as const }
+    })
+    const owner = new SideChatRuntimeOwner({
+      appVersion: '0.25.1',
+      configRoot: temporaryRoot,
+      captureTarget: async () => ({ ...target, frameworkId: framework.id }),
+      resolveTarget: async () => backend(framework),
+      relay: createRelayOwner(),
+      persistence,
+      onEvent,
+      createRuntime: (options) => {
+        callbacks = options.callbacks
+        return {
+          createSession: vi.fn(async () => identity),
+          resumeSession,
+          sendPrompt,
+          cancelPrompt: vi.fn(async () => ({ stopReason: 'cancelled' })),
+          requestProviderReconnect: vi.fn(async () => undefined),
+          deleteSession: vi.fn(async () => ({ sessionIds: [] })),
+          respondToPermission: vi.fn(async () => undefined),
+          shutdownForQuit: vi.fn(async () => undefined)
+        } as never
+      }
+    })
+    let sideSessionId = 'side-reliability'
+    if (dormant) {
+      owner.hydrate([
+        {
+          projectId: 'project-1',
+          parentSessionId: 'main-reliability',
+          sideChat: {
+            version: 1,
+            id: sideSessionId,
+            lifecycle: 'interrupted',
+            frameworkId: framework.id,
+            providerSessionId: 'provider-old',
+            historyPreamble: 'Original Main snapshot.',
+            entries: [
+              {
+                id: 'assistant-earlier',
+                kind: 'message',
+                role: 'assistant',
+                text: 'Earlier side answer.'
+              }
+            ],
+            createdAt: 10,
+            updatedAt: 20
+          }
+        }
+      ])
+    } else {
+      sideSessionId = (
+        await owner.start({
+          parentSessionId: 'main-reliability',
+          projectId: 'project-1',
+          text: 'Initial question',
+          historyPreamble: 'Original Main snapshot.'
+        })
+      ).sideSessionId
+      await vi.waitFor(() => expect(owner.list().chats[0].running).toBe(false))
+      await vi.waitFor(() => expect(persistence.save.mock.calls.length).toBeGreaterThanOrEqual(2))
+    }
+    return {
+      owner,
+      sideSessionId,
+      persistence,
+      onEvent,
+      sendPrompt,
+      resumeSession,
+      identity,
+      accept: (sessionId: string) => callbacks?.onProviderPromptAccepted?.(sessionId),
+      emit: (
+        event: Parameters<NonNullable<NonNullable<AcpRuntimeOptions['callbacks']>['onEvent']>>[0]
+      ) => callbacks?.onEvent?.(event)
+    }
+  }
+
+  it.each(['dormant', 'reconnect'] as const)(
+    'preserves the latest Main snapshot when %s adopts fresh context',
+    async (mode) => {
+      const { owner, sideSessionId, sendPrompt, persistence } = await setup(mode === 'dormant')
+      if (mode === 'reconnect') {
+        await owner.send({
+          sideSessionId,
+          text: 'Normal follow-up',
+          historyPreamble: 'Main result before reconnect.'
+        })
+        await vi.waitFor(() => expect(owner.list().chats[0].running).toBe(false))
+        await owner.requestProviderReconnect()
+      }
+      await owner.send({
+        sideSessionId,
+        text: 'Explain the latest Main result',
+        historyPreamble: 'LATEST_MAIN_RESULT'
+      })
+      expect(sendPrompt.mock.lastCall?.[0].historyPreamble).toContain('LATEST_MAIN_RESULT')
+      expect(sendPrompt.mock.lastCall?.[0]).toMatchObject({
+        resumeFallback: { historyPreamble: expect.stringContaining('LATEST_MAIN_RESULT') }
+      })
+      expect(persistence.save.mock.lastCall?.[0].sideChat.historyPreamble).toContain(
+        'LATEST_MAIN_RESULT'
+      )
+    }
+  )
+
+  it('does not send a follow-up cancelled while dormant provider resume is pending', async () => {
+    const { owner, sideSessionId, sendPrompt, resumeSession, identity } = await setup(true)
+    const resumed = deferred<typeof identity>()
+    resumeSession.mockImplementationOnce(() => resumed.promise)
+    const sending = owner
+      .send({ sideSessionId, text: 'Do not send after cancellation' })
+      .catch((error: unknown) => error)
+    await vi.waitFor(() => expect(resumeSession).toHaveBeenCalledOnce())
+    const cancelled = await owner.cancel({ sideSessionId }).catch((error: unknown) => error)
+    resumed.resolve(identity)
+    await sending
+    expect.soft(cancelled).toBeUndefined()
+    expect(sendPrompt).not.toHaveBeenCalled()
+  })
+
+  it('does not send a follow-up cancelled while its transcript save is pending', async () => {
+    const { owner, sideSessionId, sendPrompt, persistence } = await setup()
+    const saveEntered = deferred<void>()
+    const saved = deferred<void>()
+    persistence.save.mockImplementationOnce(async (input) => {
+      saveEntered.resolve()
+      await saved.promise
+      return input.sideChat
+    })
+    const sending = owner
+      .send({ sideSessionId, text: 'Do not send after cancellation' })
+      .catch((error: unknown) => error)
+    await saveEntered.promise
+    await owner.cancel({ sideSessionId })
+    saved.resolve()
+    await sending
+    expect(sendPrompt).toHaveBeenCalledTimes(1)
+  })
+
+  it('publishes a streaming save failure and keeps the provider turn running', async () => {
+    const { owner, sideSessionId, sendPrompt, persistence, onEvent, emit, accept } = await setup()
+    const finished = deferred<{ stopReason: 'end_turn' }>()
+    sendPrompt.mockImplementationOnce((request) => {
+      accept(request.sessionId)
+      return finished.promise
+    })
+    const sending = owner
+      .send({ sideSessionId, text: 'Stream an answer' })
+      .catch((error: unknown) => error)
+    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledTimes(2))
+    persistence.save.mockRejectedValueOnce(new Error('Disk full while saving Side chat'))
+    onEvent.mockClear()
+    emit({
+      id: 'stream-event',
+      messageId: 'stream-message',
+      sessionId: 'provider-reliability',
+      timestamp: 30,
+      kind: 'message',
+      level: 'info',
+      role: 'assistant',
+      text: 'Still streaming'
+    })
+    await vi.waitFor(() => {
+      const snapshot = owner.list().chats[0]
+      expect(snapshot.persistenceError ?? snapshot.error).toContain('Disk full')
+    })
+    const snapshot = owner.list().chats[0]
+    const events = JSON.stringify(onEvent.mock.calls)
+    finished.resolve({ stopReason: 'end_turn' })
+    await sending
+    expect.soft(snapshot.running).toBe(true)
+    expect(events).toContain('Disk full while saving Side chat')
+  })
+  it('clears a streaming save error after a later save without stopping output', async () => {
+    const { owner, sideSessionId, persistence, sendPrompt, emit, accept, onEvent } = await setup()
+    const finished = deferred<{ stopReason: 'end_turn' }>()
+    sendPrompt.mockImplementationOnce((request) => {
+      accept(request.sessionId)
+      return finished.promise
+    })
+    await owner.send({ sideSessionId, text: 'Keep streaming' })
+    persistence.save.mockRejectedValueOnce(new Error('Disk temporarily full'))
+    const chunk = {
+      sessionId: 'provider-reliability',
+      timestamp: 1,
+      kind: 'message' as const,
+      level: 'info' as const,
+      role: 'assistant' as const,
+      messageId: 'answer',
+      text: 'More text'
+    }
+    emit({ ...chunk, id: 'chunk-first' })
+    await vi.waitFor(() =>
+      expect(owner.list().chats[0].persistenceError).toBe('Disk temporarily full')
+    )
+    emit({ ...chunk, id: 'chunk-next' })
+    await vi.waitFor(() => expect(owner.list().chats[0].persistenceError).toBeUndefined())
+    expect(owner.list().chats[0].running).toBe(true)
+    expect(onEvent.mock.lastCall?.[0]).toMatchObject({
+      event: { kind: 'persistence', error: undefined }
+    })
+    expect(onEvent.mock.lastCall?.[0].event.error).toBeUndefined()
+    finished.resolve({ stopReason: 'end_turn' })
+  })
+
+  it('preserves both context sources and labels within the replay budget', async () => {
+    const { owner, sideSessionId, sendPrompt } = await setup(true)
+    await owner.send({
+      sideSessionId,
+      text: 'Expand the analysis',
+      historyPreamble: 'Old Main details. '.repeat(1000) + 'LATEST_MAIN_RESULT'
+    })
+    const preamble = sendPrompt.mock.lastCall?.[0].historyPreamble ?? ''
+    expect(preamble.length).toBeLessThanOrEqual(SIDE_CHAT_MESSAGE_LIMIT)
+    expect(preamble).toContain('Main conversation snapshot:')
+    expect(preamble).toContain('LATEST_MAIN_RESULT')
+    expect(preamble).toContain('Side chat transcript before this follow-up:')
+    expect(preamble).toContain('Earlier side answer.')
+  })
+  it.each([
+    ['claude-code', claudeCodeFramework],
+    ['opencode', opencodeFramework],
+    ['codex', codexFramework]
+  ] as const)(
+    'refreshes a restored %s owner and prevents preflight cancellation from reaching its provider',
+    async (_name, framework) => {
+      const { owner, sideSessionId, sendPrompt, persistence } = await setup(true, framework)
+      await owner.send({
+        sideSessionId,
+        text: 'Latest context',
+        historyPreamble: 'LATEST_MAIN_RESULT'
+      })
+      expect(sendPrompt.mock.lastCall?.[0].historyPreamble).toContain('LATEST_MAIN_RESULT')
+      await vi.waitFor(() => expect(owner.list().chats[0].running).toBe(false))
+      const saved = deferred<void>()
+      const entered = deferred<void>()
+      persistence.save.mockImplementationOnce(async (input) => {
+        entered.resolve()
+        await saved.promise
+        return input.sideChat
+      })
+      const sending = owner
+        .send({ sideSessionId, text: 'Do not dispatch' })
+        .catch((error: unknown) => error)
+      await entered.promise
+      await owner.cancel({ sideSessionId })
+      saved.resolve()
+      await sending
+      expect(sendPrompt).toHaveBeenCalledTimes(1)
+    }
+  )
 })

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -148,9 +148,11 @@ type ActiveSideChat = {
   entrySequence: number
   running: boolean
   error?: string
+  persistenceError?: string
   reconnect?: Promise<void>
   turn?: Promise<PromptResponse>
   turnAccepted?: Deferred
+  turnAdmitted?: boolean
   closing: boolean
   frameworkId: PersistedSideChat['frameworkId']
   providerId?: string
@@ -235,15 +237,25 @@ const buildResumeFallback = (active: ActiveSideChat): string | undefined => {
     )
     .map((entry) => `${entry.role === 'user' ? 'User' : 'Assistant'}: ${entry.text}`)
     .join('\n\n')
-  const full = [
-    active.historyPreamble,
-    transcript ? `Side chat transcript before this follow-up:\n${transcript}` : undefined
+  const main = active.historyPreamble ?? ''
+  const mainHeader = 'Main conversation snapshot:\n'
+  const sideHeader = 'Side chat transcript before this follow-up:\n'
+  if (!main && !transcript) return undefined
+  const budget = SIDE_CHAT_MESSAGE_LIMIT - mainHeader.length - sideHeader.length - 2
+  // Keep both sources when either is long; short sources leave their unused budget to the other.
+  const mainBudget = Math.min(
+    main.length,
+    Math.max(Math.floor(budget / 2), budget - transcript.length)
+  )
+  const sideBudget = budget - mainBudget
+  const tail = (text: string, limit: number): string =>
+    text.length <= limit ? text : `[Earlier context truncated]\n${text.slice(-(limit - 28))}`
+  return [
+    main ? mainHeader + tail(main, mainBudget) : undefined,
+    transcript ? sideHeader + tail(transcript, sideBudget) : undefined
   ]
-    .filter((section): section is string => Boolean(section))
+    .filter(Boolean)
     .join('\n\n')
-  if (!full) return undefined
-  if (full.length <= SIDE_CHAT_MESSAGE_LIMIT) return full
-  return `[Earlier context truncated]\n${full.slice(-(SIDE_CHAT_MESSAGE_LIMIT - 28))}`
 }
 
 const boundedPersistedEntries = (entries: readonly SideChatEntry[]): SideChatEntry[] => {
@@ -283,6 +295,7 @@ class SideChatRuntimeOwner {
   private readonly startingByParent = new Map<string, StartingSideChat>()
   private readonly closingByParent = new Map<string, Promise<void>>()
   private readonly dispatches = new Set<Promise<void>>()
+  private readonly pendingDispatches = new Map<string, AbortController>()
   private readonly closeRequestedParents = new Set<string>()
   private readonly invalidatedParents = new Set<string>()
   private readonly invalidatedProjects = new Set<string>()
@@ -478,7 +491,10 @@ class SideChatRuntimeOwner {
           onPermissionRequest: (permission) =>
             this.handlePermission(runtimeRef.current, permission),
           onProviderPromptAccepted: (sideSessionId) => {
-            if (activeChat?.runtimeSessionId === sideSessionId) activeChat.turnAccepted?.resolve()
+            if (activeChat?.runtimeSessionId === sideSessionId) {
+              activeChat.turnAdmitted = true
+              activeChat.turnAccepted?.resolve()
+            }
           }
         }
       }
@@ -528,7 +544,7 @@ class SideChatRuntimeOwner {
         }
         throw new Error('Side chat closed before startup completed.')
       }
-      await this.dispatch({
+      await this.send({
         sideSessionId: sideChatId,
         text,
         historyPreamble: request.historyPreamble
@@ -561,11 +577,21 @@ class SideChatRuntimeOwner {
     }
   }
 
-  send(request: SideChatPromptRequest & Readonly<{ historyPreamble?: string }>): Promise<void> {
-    const dispatch = this.dispatch(request)
+  send(
+    request: SideChatPromptRequest & Readonly<{ historyPreamble?: string }>,
+    cancellation = new AbortController()
+  ): Promise<void> {
+    if (this.pendingDispatches.has(request.sideSessionId)) {
+      return Promise.reject(new Error('A Side chat prompt is already running.'))
+    }
+    this.pendingDispatches.set(request.sideSessionId, cancellation)
+    const dispatch = this.dispatch(request, cancellation.signal)
     this.dispatches.add(dispatch)
     const finish = (): void => {
       this.dispatches.delete(dispatch)
+      if (this.pendingDispatches.get(request.sideSessionId) === cancellation) {
+        this.pendingDispatches.delete(request.sideSessionId)
+      }
     }
     void dispatch.then(finish, finish)
     return dispatch
@@ -628,8 +654,11 @@ class SideChatRuntimeOwner {
   }
 
   async cancel(request: SideChatSessionRequest): Promise<void> {
-    const active = this.requireActive(request.sideSessionId)
-    if (active.turn) await active.runtime.cancelPrompt({ sessionId: active.runtimeSessionId })
+    const pending = this.pendingDispatches.get(request.sideSessionId)
+    pending?.abort(new Error('Side chat prompt cancelled.'))
+    const active = this.findActive(request.sideSessionId)
+    if (!active && !pending) throw new Error('Side chat Session is not active.')
+    if (active?.turn) await active.runtime.cancelPrompt({ sessionId: active.runtimeSessionId })
   }
 
   async close(request: SideChatSessionRequest): Promise<void> {
@@ -808,14 +837,19 @@ class SideChatRuntimeOwner {
   }
 
   private async dispatch(
-    request: SideChatPromptRequest & { historyPreamble?: string }
+    request: SideChatPromptRequest & { historyPreamble?: string },
+    signal: AbortSignal
   ): Promise<void> {
+    signal.throwIfAborted()
     const text = requirePromptText(request.text)
     const active = await this.ensureActive(request.sideSessionId)
+    signal.throwIfAborted()
     this.assertDispatchActive(active)
     if (active.turn || active.running) throw new Error('A Side chat prompt is already running.')
     await this.flushQueuedPersistence(active)
+    signal.throwIfAborted()
     this.assertDispatchActive(active)
+    if (request.historyPreamble !== undefined) active.historyPreamble = request.historyPreamble
     let historyPreamble = request.historyPreamble
     let needsReplay = active.needsReplay === true
     if (needsReplay) {
@@ -824,6 +858,7 @@ class SideChatRuntimeOwner {
     while (active.reconnect) {
       const reconnect = active.reconnect
       await reconnect
+      signal.throwIfAborted()
       this.assertDispatchActive(active)
       if (active.reconnect !== reconnect) continue
       const resumed = await active.runtime.resumeSession({
@@ -837,6 +872,7 @@ class SideChatRuntimeOwner {
         previousFrameworkId: active.frameworkId,
         ...(active.backendId ? { previousBackendId: active.backendId } : {})
       })
+      signal.throwIfAborted()
       this.assertDispatchActive(active)
       this.applyProviderIdentity(active, resumed)
       this.syncBridgeScopes(active)
@@ -847,6 +883,7 @@ class SideChatRuntimeOwner {
         historyPreamble = buildResumeFallback(active)
       }
       await this.persistActive(active, 'open')
+      signal.throwIfAborted()
       this.assertDispatchActive(active)
     }
     const resumeFallback = buildResumeFallback(active)
@@ -862,18 +899,26 @@ class SideChatRuntimeOwner {
     this.touch(active)
     try {
       await this.persistActive(active, 'open')
+      signal.throwIfAborted()
     } catch (error) {
       active.entries.pop()
       active.entrySequence -= 1
       active.running = false
-      active.error = error instanceof Error ? error.message : 'Side chat could not be saved.'
+      active.error = signal.aborted
+        ? undefined
+        : error instanceof Error
+          ? error.message
+          : 'Side chat could not be saved.'
       active.needsReplay = needsReplay
       this.touch(active)
+      if (signal.aborted) this.queuePersist(active, 'open')
       throw error
     }
+    signal.throwIfAborted()
     this.assertDispatchActive(active)
     const accepted = deferred()
     active.turnAccepted = accepted
+    active.turnAdmitted = false
     const turn = active.runtime.sendPrompt({
       sessionId: active.runtimeSessionId,
       text,
@@ -881,6 +926,11 @@ class SideChatRuntimeOwner {
       ...(resumeFallback ? { resumeFallback: { historyPreamble: resumeFallback } } : {})
     })
     active.turn = turn
+    const userEntryId = `user-${active.entrySequence}`
+    const removeUnadmittedEntry = (): void => {
+      if (active.turnAdmitted) return
+      active.entries = active.entries.filter((entry) => entry.id !== userEntryId)
+    }
     const finish = (): void => {
       if (this.activeByParent.get(active.parentSessionId) === active && active.turn === turn) {
         active.turn = undefined
@@ -889,6 +939,7 @@ class SideChatRuntimeOwner {
     }
     void turn.then(
       () => {
+        removeUnadmittedEntry()
         accepted.reject(new Error('Side chat prompt ended before provider admission.'))
         if (active.closing || this.activeByParent.get(active.parentSessionId) !== active) return
         if (active.running) {
@@ -899,6 +950,7 @@ class SideChatRuntimeOwner {
         finish()
       },
       (error) => {
+        removeUnadmittedEntry()
         accepted.reject(error)
         if (active.closing || this.activeByParent.get(active.parentSessionId) !== active) return
         active.running = false
@@ -1002,6 +1054,7 @@ class SideChatRuntimeOwner {
             this.handlePermission(runtimeRef.current, permission),
           onProviderPromptAccepted: (runtimeSessionId) => {
             if (activeChat?.runtimeSessionId === runtimeSessionId) {
+              activeChat.turnAdmitted = true
               activeChat.turnAccepted?.resolve()
             }
           }
@@ -1174,7 +1227,13 @@ class SideChatRuntimeOwner {
         })
       })
     active.persistTail = write
-    return write.then(() => persisted!)
+    return write.then(() => {
+      if (active.persistenceError) {
+        active.persistenceError = undefined
+        this.publishPersistenceState(active)
+      }
+      return persisted!
+    })
   }
 
   private registerBridgeScope(active: ActiveSideChat, bridge: HostMessageBridge): void {
@@ -1226,9 +1285,9 @@ class SideChatRuntimeOwner {
     void queued
       .catch((error) => {
         if (active.closing) return
-        active.running = false
-        active.error = error instanceof Error ? error.message : 'Side chat could not be saved.'
-        this.touch(active)
+        active.persistenceError =
+          error instanceof Error ? error.message : 'Side chat could not be saved.'
+        this.publishPersistenceState(active)
       })
       .finally(() => {
         if (active.queuedPersist === queued) active.queuedPersist = undefined
@@ -1428,12 +1487,6 @@ class SideChatRuntimeOwner {
     })
   }
 
-  private requireActive(sideSessionId: string): ActiveSideChat {
-    const active = this.findActive(sideSessionId)
-    if (active) return active
-    throw new Error('Side chat Session is not active.')
-  }
-
   private findActive(sideSessionId: string): ActiveSideChat | undefined {
     for (const active of this.activeByParent.values()) {
       if (active.sideSessionId === sideSessionId && !active.closing) return active
@@ -1477,6 +1530,17 @@ class SideChatRuntimeOwner {
     }
   }
 
+  private publishPersistenceState(active: ActiveSideChat): void {
+    if (active.closing || this.activeByParent.get(active.parentSessionId) !== active) return
+    this.options.onEvent({
+      revision: this.touch(active),
+      parentSessionId: active.parentSessionId,
+      projectId: active.projectId,
+      sideSessionId: active.sideSessionId,
+      event: { kind: 'persistence', error: active.persistenceError }
+    })
+  }
+
   private snapshotActive(active: ActiveSideChat): SideChatSnapshot {
     return {
       revision: active.revision,
@@ -1485,7 +1549,8 @@ class SideChatRuntimeOwner {
       sideSessionId: active.sideSessionId,
       entries: active.entries.map((entry) => ({ ...entry })),
       running: active.running,
-      ...(active.error ? { error: active.error } : {})
+      ...(active.error ? { error: active.error } : {}),
+      ...(active.persistenceError ? { persistenceError: active.persistenceError } : {})
     }
   }
 
@@ -1499,9 +1564,9 @@ class SideChatRuntimeOwner {
       entries: dormant.sideChat.entries.map((entry) => ({ ...entry })),
       running: false,
       ...(lifecycle === 'interrupted'
-        ? { error: 'Side chat was interrupted when the app closed. Send a Follow up to continue.' }
+        ? { notice: 'interrupted' as const }
         : lifecycle === 'error'
-          ? { error: 'Side chat connection ended. Send a Follow up to reconnect.' }
+          ? { notice: 'connection-ended' as const }
           : {})
     }
   }

--- a/src/renderer/src/components/ui/scroll-area.tsx
+++ b/src/renderer/src/components/ui/scroll-area.tsx
@@ -8,8 +8,11 @@ import { cn } from '@/lib/utils'
 function ScrollArea({
   className,
   children,
+  viewportRef,
   ...props
-}: React.ComponentProps<typeof ScrollAreaPrimitive.Root>): React.JSX.Element {
+}: React.ComponentProps<typeof ScrollAreaPrimitive.Root> & {
+  viewportRef?: React.Ref<HTMLDivElement>
+}): React.JSX.Element {
   return (
     <ScrollAreaPrimitive.Root
       data-slot="scroll-area"
@@ -17,6 +20,7 @@ function ScrollArea({
       {...props}
     >
       <ScrollAreaPrimitive.Viewport
+        ref={viewportRef}
         data-slot="scroll-area-viewport"
         className="size-full min-w-0 rounded-[inherit] transition-[color,box-shadow] outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 focus-visible:outline-1"
       >

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -3120,6 +3120,94 @@ describe('ConversationPanel composer intake', () => {
     expect(container.querySelector('[aria-label="Cancel Side chat response"]')).not.toBeNull()
   })
 
+  it('keeps earlier Side chat content visible when the user scrolls up during output', () => {
+    const sideChat = {
+      send: vi.fn(async () => true),
+      setDraft: vi.fn(),
+      cancel: vi.fn(),
+      close: vi.fn(),
+      view: {
+        generation: 1,
+        parentSessionId: 'session-existing',
+        projectId: 'project-a',
+        sideSessionId: 'side-scroll',
+        draft: '',
+        running: true,
+        entries: [
+          {
+            id: 'user-1',
+            kind: 'message' as const,
+            role: 'user' as const,
+            text: 'Explain this result'
+          }
+        ]
+      }
+    }
+    renderPanel({ sideChat })
+    const viewport = container.querySelector(
+      '[data-testid="side-chat-message-scroll"] [data-slot="scroll-area-viewport"]'
+    ) as HTMLDivElement
+    Object.defineProperties(viewport, {
+      scrollHeight: { configurable: true, value: 1200 },
+      clientHeight: { configurable: true, value: 300 }
+    })
+    viewport.scrollTop = 900
+    act(() => viewport.dispatchEvent(new Event('scroll', { bubbles: true })))
+    viewport.scrollTop = 200
+    act(() => viewport.dispatchEvent(new Event('scroll', { bubbles: true })))
+    renderPanel({
+      sideChat: {
+        ...sideChat,
+        view: {
+          ...sideChat.view,
+          entries: [
+            ...sideChat.view.entries,
+            {
+              id: 'assistant-1',
+              kind: 'message',
+              role: 'assistant',
+              text: 'More output while reading earlier content'
+            }
+          ]
+        }
+      }
+    })
+    expect(viewport.scrollTop).toBe(200)
+  })
+
+  it('translates Side chat tool completion while preserving the technical tool name', async () => {
+    const { i18next } = await import('../../i18n')
+    await act(async () => {
+      await i18next.changeLanguage('zh-Hans')
+    })
+    try {
+      renderPanel({
+        sideChat: {
+          send: vi.fn(async () => true),
+          setDraft: vi.fn(),
+          cancel: vi.fn(),
+          close: vi.fn(),
+          view: {
+            generation: 1,
+            parentSessionId: 'session-existing',
+            projectId: 'project-a',
+            sideSessionId: 'side-translated',
+            draft: '',
+            running: false,
+            entries: [{ id: 'tool-1', kind: 'tool', title: 'send_message', status: 'completed' }]
+          }
+        }
+      })
+      const panel = container.querySelector('[data-testid="side-chat-panel"]')!
+      expect(panel.textContent).toContain('send_message')
+      expect(panel.textContent).not.toContain('completed')
+    } finally {
+      await act(async () => {
+        await i18next.changeLanguage('en')
+      })
+    }
+  })
+
   it('presents complete user annotation text consistently and leaves invalid or assistant text raw', () => {
     const annotationText =
       'Compare these observations.\n\n[Annotations]\n' +
@@ -3246,6 +3334,7 @@ describe('ConversationPanel composer intake', () => {
           sideSessionId: 'side-1',
           draft: '',
           running: true,
+          persistenceError: 'Disk full',
           entries
         }
       }
@@ -3253,6 +3342,9 @@ describe('ConversationPanel composer intake', () => {
 
     expect(container.textContent).toContain('Historical answer')
     expect(container.textContent).not.toContain('Flow')
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain(
+      'Could not save Side chat: Disk full'
+    )
     expect(container.querySelectorAll('.agent-markdown-streaming')).toHaveLength(1)
 
     await act(async () => vi.advanceTimersByTimeAsync(496))

--- a/src/renderer/src/pages/workspace/SideChatPanel.tsx
+++ b/src/renderer/src/pages/workspace/SideChatPanel.tsx
@@ -24,6 +24,8 @@ import {
   type SideChatAnnotationItem
 } from '../../../../shared/annotations'
 
+import { useFollowScrollBottom } from './use-follow-scroll-bottom'
+
 import { ResizableBottomPanel } from './ResizableBottomPanel'
 import { SentAnnotationCards, type SentAnnotationCardView } from './annotations/SentAnnotationCards'
 import type { SideChatEntry, SideChatView } from './use-side-chat-controller'
@@ -151,7 +153,7 @@ const SideChatPanel = ({
   controls
 }: SideChatPanelProps): React.JSX.Element => {
   const { t } = useTranslation()
-  const messageScrollRef = useRef<HTMLDivElement>(null)
+  const messageViewportRef = useFollowScrollBottom(true)
   const followUpRef = useRef<HTMLTextAreaElement>(null)
   const [presentationState, setPresentationState] = useState<SideChatPresentationState>(() => ({
     generation: view.generation,
@@ -201,12 +203,6 @@ const SideChatPanel = ({
     [view.generation]
   )
 
-  useEffect(() => {
-    const messageScroll = messageScrollRef.current?.querySelector<HTMLElement>(
-      '[data-slot="scroll-area-viewport"]'
-    )
-    if (messageScroll) messageScroll.scrollTop = messageScroll.scrollHeight
-  }, [presentationBarrierIndex, view.entries, view.running, view.error])
   useEffect(() => {
     if (view.sideSessionId) followUpRef.current?.focus()
   }, [view.sideSessionId])
@@ -262,7 +258,7 @@ const SideChatPanel = ({
           className="relative min-h-0 flex-1 overflow-hidden"
         >
           <ScrollArea
-            ref={messageScrollRef}
+            viewportRef={messageViewportRef}
             data-testid="side-chat-message-scroll"
             className="h-full overscroll-contain text-[14px] leading-6"
           >
@@ -282,8 +278,20 @@ const SideChatPanel = ({
                       key={JSON.stringify([view.generation, entry.id])}
                       className="my-2 text-[12px] text-text-300"
                     >
-                      {entry.title}
-                      {entry.status ? ` · ${entry.status}` : ''}
+                      {entry.title === 'Tool' ? t('Tool') : entry.title}
+                      {entry.status
+                        ? ` · ${
+                            entry.status === 'completed'
+                              ? t('Completed')
+                              : entry.status === 'failed'
+                                ? t('Failed')
+                                : entry.status === 'in_progress'
+                                  ? t('Running')
+                                  : entry.status === 'pending'
+                                    ? t('Pending')
+                                    : entry.status
+                          }`
+                        : ''}
                     </div>
                   )
                 }
@@ -324,6 +332,11 @@ const SideChatPanel = ({
               })}
               {view.running && presentationBarrierIndex < 0 ? (
                 <div className="py-2 text-text-300">{t('Thinking…')}</div>
+              ) : null}
+              {view.persistenceError ? (
+                <div role="alert" className="py-2 text-[12px] text-danger-000">
+                  {t('Could not save Side chat: {{error}}', { error: view.persistenceError })}
+                </div>
               ) : null}
               {view.error && presentationBarrierIndex < 0 ? (
                 <div role="alert" className="py-2 text-[12px] text-danger-000">

--- a/src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
+++ b/src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
@@ -529,3 +529,305 @@ describe('Side chat renderer controller', () => {
     act(() => root.unmount())
   })
 })
+
+it('shows only one user message after a rejected follow-up is retried', async () => {
+  const snapshot = {
+    revision: 1,
+    chats: [
+      {
+        revision: 1,
+        parentSessionId: 'main-1',
+        projectId: 'project-1',
+        sideSessionId: 'side-1',
+        entries: [],
+        running: false
+      }
+    ]
+  }
+  const send = vi.fn(async () => undefined).mockRejectedValueOnce(new Error('Session file is busy'))
+  window.api = {
+    sideChat: {
+      list: vi.fn(async () => snapshot),
+      send,
+      onEvent: vi.fn(() => () => undefined),
+      onRelayDelivered: vi.fn(() => () => undefined)
+    }
+  } as unknown as Window['api']
+  const root = createRoot(document.createElement('div'))
+  let controller!: ReturnType<typeof useSideChatController>
+  const Harness = (): null => {
+    controller = useSideChatController({ sessionId: 'main-1', projectId: 'project-1' })
+    return null
+  }
+  try {
+    await act(async () =>
+      root.render(createElement(SideChatProvider, null, createElement(Harness)))
+    )
+    await act(async () => expect(await controller.send('Retry this exact question')).toBe(false))
+    await act(async () => expect(await controller.send('Retry this exact question')).toBe(true))
+    expect(
+      controller.view?.entries.filter(
+        (entry) =>
+          entry.kind === 'message' &&
+          entry.role === 'user' &&
+          entry.text === 'Retry this exact question'
+      )
+    ).toHaveLength(1)
+  } finally {
+    act(() => root.unmount())
+  }
+})
+
+it('localizes the restoration message in a non-English interface', async () => {
+  const { i18next } = await import('../../i18n')
+  await i18next.changeLanguage('zh-Hans')
+  const listed = deferred<{ revision: number; chats: [] }>()
+  window.api = {
+    sideChat: {
+      list: vi.fn(() => listed.promise),
+      onEvent: vi.fn(() => () => undefined),
+      onRelayDelivered: vi.fn(() => () => undefined)
+    }
+  } as unknown as Window['api']
+  const root = createRoot(document.createElement('div'))
+  let controller!: ReturnType<typeof useSideChatController>
+  const Harness = (): null => {
+    controller = useSideChatController({ sessionId: 'main-1', projectId: 'project-1' })
+    return null
+  }
+  try {
+    await act(async () =>
+      root.render(createElement(SideChatProvider, null, createElement(Harness)))
+    )
+    expect(controller.unavailableReason).toMatch(/[\u3400-\u9fff]/)
+  } finally {
+    await act(async () => {
+      listed.resolve({ revision: 1, chats: [] })
+      await listed.promise
+    })
+    act(() => root.unmount())
+    await i18next.changeLanguage('en')
+  }
+})
+
+it.each([
+  'restore-failed',
+  'closing',
+  'close-failed',
+  'connection-closed',
+  'interrupted-snapshot',
+  'cancelled-snapshot',
+  'electron-cancelled-snapshot'
+] as const)(
+  'localizes the owned %s notice while preserving diagnostic details',
+  async (scenario) => {
+    const { i18next } = await import('../../i18n')
+    await i18next.changeLanguage('zh-Hans')
+    const closed = deferred<void>()
+    let listener: ((event: never) => void) | undefined
+    const snapshot = {
+      revision: 1,
+      chats: [
+        {
+          revision: 1,
+          parentSessionId: 'main-1',
+          projectId: 'project-1',
+          sideSessionId: 'side-1',
+          entries: [],
+          running: false,
+          error:
+            scenario === 'cancelled-snapshot'
+              ? 'Side chat prompt cancelled.'
+              : scenario === 'electron-cancelled-snapshot'
+                ? "Error invoking remote method 'side-chat:send': Error: Side chat prompt cancelled."
+                : undefined,
+          ...(scenario === 'interrupted-snapshot'
+            ? {
+                notice: 'interrupted' as const
+              }
+            : {})
+        }
+      ]
+    }
+    window.api = {
+      sideChat: {
+        list: vi.fn(async () => {
+          if (scenario === 'restore-failed') throw new Error('diagnostic-detail')
+          return snapshot
+        }),
+        close: vi.fn(async () => {
+          if (scenario === 'close-failed') throw new Error('diagnostic-detail')
+          await closed.promise
+        }),
+        onEvent: vi.fn((callback) => {
+          listener = callback as never
+          return () => undefined
+        }),
+        onRelayDelivered: vi.fn(() => () => undefined)
+      }
+    } as unknown as Window['api']
+    const root = createRoot(document.createElement('div'))
+    let controller!: ReturnType<typeof useSideChatController>
+    const Harness = (): null => {
+      controller = useSideChatController({ sessionId: 'main-1', projectId: 'project-1' })
+      return null
+    }
+    try {
+      await act(async () =>
+        root.render(createElement(SideChatProvider, null, createElement(Harness)))
+      )
+      if (scenario === 'closing' || scenario === 'close-failed')
+        await act(async () => controller.close())
+      if (scenario === 'connection-closed')
+        act(() =>
+          listener?.({
+            revision: 2,
+            parentSessionId: 'main-1',
+            projectId: 'project-1',
+            sideSessionId: 'side-1',
+            event: { kind: 'closed', reason: 'connection-closed' }
+          } as never)
+        )
+      const notice = controller.unavailableReason ?? controller.view?.error
+      if (scenario === 'restore-failed' || scenario === 'close-failed')
+        expect(notice).toContain('diagnostic-detail')
+      expect(notice).toMatch(/[\u3400-\u9fff]/)
+    } finally {
+      await act(async () => {
+        closed.resolve()
+        await closed.promise
+      })
+      act(() => root.unmount())
+      await i18next.changeLanguage('en')
+    }
+  }
+)
+
+it('keeps an admitted follow-up when its IPC response fails', async () => {
+  const base = {
+    revision: 1,
+    parentSessionId: 'main-1',
+    projectId: 'project-1',
+    sideSessionId: 'side-1',
+    entries: [],
+    running: false
+  }
+  const list = vi.fn(async () => ({
+    revision: 2,
+    chats: [
+      {
+        ...base,
+        revision: 2,
+        running: true,
+        entries: [
+          {
+            id: 'user-authoritative',
+            kind: 'message' as const,
+            role: 'user' as const,
+            text: 'Already sent'
+          }
+        ]
+      }
+    ]
+  }))
+  list.mockResolvedValueOnce({ revision: 1, chats: [base] })
+  window.api = {
+    sideChat: {
+      list,
+      send: vi.fn(async () => {
+        throw new Error('Lost IPC response')
+      }),
+      onEvent: vi.fn(() => () => undefined),
+      onRelayDelivered: vi.fn(() => () => undefined)
+    }
+  } as unknown as Window['api']
+  const root = createRoot(document.createElement('div'))
+  let controller!: ReturnType<typeof useSideChatController>
+  const Harness = (): null => {
+    controller = useSideChatController({ sessionId: 'main-1', projectId: 'project-1' })
+    return null
+  }
+  try {
+    await act(async () =>
+      root.render(createElement(SideChatProvider, null, createElement(Harness)))
+    )
+    await act(async () => expect(await controller.send('Already sent')).toBe(true))
+    expect(controller.view).toMatchObject({
+      running: true,
+      entries: [{ id: 'user-authoritative', text: 'Already sent' }]
+    })
+  } finally {
+    act(() => root.unmount())
+  }
+})
+
+it('publishes save failure and recovery without replacing a pending follow-up or its running state', async () => {
+  const sent = deferred<void>()
+  let listener: ((event: never) => void) | undefined
+  window.api = {
+    sideChat: {
+      list: async () => ({
+        revision: 1,
+        chats: [
+          {
+            revision: 1,
+            parentSessionId: 'main-1',
+            projectId: 'project-1',
+            sideSessionId: 'side-1',
+            entries: [],
+            running: false
+          }
+        ]
+      }),
+      send: () => sent.promise,
+      onEvent: (callback: (event: never) => void) => {
+        listener = callback as never
+        return () => undefined
+      },
+      onRelayDelivered: () => () => undefined
+    }
+  } as unknown as Window['api']
+  const root = createRoot(document.createElement('div'))
+  let controller!: ReturnType<typeof useSideChatController>
+  const Harness = (): null => {
+    controller = useSideChatController({ sessionId: 'main-1', projectId: 'project-1' })
+    return null
+  }
+  try {
+    await act(async () =>
+      root.render(createElement(SideChatProvider, null, createElement(Harness)))
+    )
+    let sending!: Promise<boolean>
+    act(() => {
+      sending = controller.send('Pending follow-up')
+    })
+    const entries = controller.view!.entries
+    const envelope = { parentSessionId: 'main-1', projectId: 'project-1', sideSessionId: 'side-1' }
+    act(() =>
+      listener?.({
+        ...envelope,
+        revision: 2,
+        event: { kind: 'persistence', error: 'Disk full' }
+      } as never)
+    )
+    expect(controller.view).toMatchObject({ running: true, persistenceError: 'Disk full' })
+    expect(controller.view!.entries).toBe(entries)
+    act(() => listener?.({ ...envelope, revision: 3, event: { kind: 'persistence' } } as never))
+    expect(controller.view!.persistenceError).toBeUndefined()
+    expect(controller.view!.running).toBe(true)
+    act(() =>
+      listener?.({
+        ...envelope,
+        revision: 2,
+        event: { kind: 'persistence', error: 'Stale failure' }
+      } as never)
+    )
+    expect(controller.view!.persistenceError).toBeUndefined()
+    await act(async () => {
+      sent.resolve()
+      await sending
+    })
+  } finally {
+    act(() => root.unmount())
+  }
+})

--- a/src/renderer/src/pages/workspace/use-side-chat-controller.ts
+++ b/src/renderer/src/pages/workspace/use-side-chat-controller.ts
@@ -12,6 +12,8 @@ import {
   type SetStateAction
 } from 'react'
 
+import { useTranslation } from 'react-i18next'
+
 import { getAcpRuntimeEventText } from '../../../../shared/acp'
 import type { SideChatEntry, SideChatSnapshot } from '../../../../shared/side-chat'
 import type { ChatSession } from '@/stores/session-store'
@@ -27,6 +29,8 @@ type SideChatView = Readonly<{
   draft: string
   running: boolean
   error?: string
+  persistenceError?: string
+  notice?: SideChatSnapshot['notice']
 }>
 
 type SideChatController = Readonly<{
@@ -59,7 +63,10 @@ type SideChatRuntimeController = Readonly<{
 const SideChatContext = createContext<SideChatRuntimeController | undefined>(undefined)
 
 const errorText = (error: unknown): string =>
-  error instanceof Error ? error.message : String(error)
+  (error instanceof Error ? error.message : String(error)).replace(
+    /^Error invoking remote method 'side-chat:[^']+': (?:Error: )?/,
+    ''
+  )
 
 const hasMainConversation = (session: ChatSession | undefined): boolean =>
   Boolean(session?.messages.some((message) => message.role === 'user' && !message.relayedFrom))
@@ -68,6 +75,7 @@ const getLastSideChatUserEntryId = (entries: readonly SideChatEntry[]): string |
   entries.findLast((entry) => entry.kind === 'message' && entry.role === 'user')?.id
 
 const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
+  const { t } = useTranslation()
   const [views, setViews] = useState<ReadonlyMap<string, SideChatView>>(() => new Map())
   const [hydrated, setHydrated] = useState(() => !window.api?.sideChat?.list)
   const [hydrationError, setHydrationError] = useState<string>()
@@ -111,7 +119,9 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
         : current?.liveTurnUserEntryId,
       draft: current?.draft ?? '',
       running: snapshot.running,
-      error: snapshot.error
+      error: snapshot.error ? errorText(snapshot.error) : undefined,
+      persistenceError: snapshot.persistenceError,
+      notice: snapshot.notice
     }),
     []
   )
@@ -159,7 +169,7 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
         },
         (error) => {
           if (hydrationGenerationRef.current !== generation) return
-          setHydrationError(`Could not restore Side chats: ${errorText(error)}`)
+          setHydrationError(errorText(error))
           setHydrated(false)
         }
       )
@@ -190,11 +200,20 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
                   ...current,
                   revision,
                   running: false,
-                  error: 'Side chat connection ended. Send a Follow up to reconnect.'
+                  error: undefined,
+                  notice: 'connection-ended'
                 }
               : current
           )
         }
+        return
+      }
+      if (event.kind === 'persistence') {
+        update(envelope.parentSessionId, (current) =>
+          current?.sideSessionId === envelope.sideSessionId
+            ? { ...current, revision, persistenceError: event.error }
+            : current
+        )
         return
       }
       update(envelope.parentSessionId, (current) => {
@@ -268,7 +287,7 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
       hydrationGenerationRef.current += 1
       removeListener()
     }
-  }, [hydrate, update])
+  }, [hydrate, update, viewFromSnapshot])
 
   const retryHydration = useCallback((): void => hydrate(false), [hydrate])
 
@@ -346,6 +365,7 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
         ],
         liveTurnUserEntryId: userEntryId,
         running: true,
+        notice: undefined,
         error: undefined
       }
       update(parentSessionId, next)
@@ -353,15 +373,42 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
         await window.api.sideChat.send({ sideSessionId: current.sideSessionId, text })
         return true
       } catch (error) {
-        update(parentSessionId, (latest) =>
-          latest?.generation === current.generation
-            ? { ...latest, running: false, error: errorText(error) }
-            : latest
-        )
-        return false
+        // A rejected IPC call may have lost the response after admission. Reconcile first;
+        // never infer delivery from identical text or delete provider-owned transcript entries.
+        const failedTurnId = viewsRef.current.get(parentSessionId)?.liveTurnUserEntryId
+        let snapshots: Awaited<ReturnType<Window['api']['sideChat']['list']>> | undefined
+        try {
+          snapshots = await window.api.sideChat.list?.()
+        } catch {
+          // Keep the visible transcript if its authority cannot be read.
+        }
+        let admitted = false
+        update(parentSessionId, (latest) => {
+          if (latest?.generation !== current.generation) return latest
+          if (latest.liveTurnUserEntryId !== failedTurnId) {
+            admitted = latest.running
+            return latest
+          }
+          const snapshot = snapshots?.chats.find(
+            (chat) => chat.sideSessionId === current.sideSessionId
+          )
+          const lastRevision = revisionByParentRef.current.get(parentSessionId) ?? 0
+          if (snapshot && snapshot.revision >= lastRevision) {
+            revisionByParentRef.current.set(parentSessionId, snapshot.revision)
+            admitted = snapshot.running
+            const restored = viewFromSnapshot(snapshot, latest)
+            return { ...restored, error: admitted ? restored.error : errorText(error) }
+          }
+          if (snapshot || (latest.liveTurnUserEntryId !== userEntryId && latest.running)) {
+            admitted = latest.running
+            return latest
+          }
+          return { ...latest, running: false, error: errorText(error) }
+        })
+        return admitted
       }
     },
-    [update]
+    [update, viewFromSnapshot]
   )
 
   const cancel = useCallback(
@@ -410,7 +457,7 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
               latest ?? {
                 ...current,
                 running: false,
-                error: `Could not close Side chat: ${errorText(error)}`
+                error: t('Could not close Side chat: {{error}}', { error: errorText(error) })
               }
           )
         })
@@ -421,7 +468,7 @@ const useOwnedSideChatRuntime = (): SideChatRuntimeController => {
           setClosingParentSessionIds(next)
         })
     },
-    [update]
+    [t, update]
   )
 
   return useMemo<SideChatRuntimeController>(
@@ -458,15 +505,29 @@ const SideChatProvider = ({ children }: PropsWithChildren): ReactElement =>
 const useSideChatController = (
   parent: Readonly<{ sessionId: string; projectId: string }> | undefined
 ): SideChatController => {
+  const { t } = useTranslation()
   const runtime = useContext(SideChatContext)
   const candidate = parent ? runtime?.views.get(parent.sessionId) : undefined
-  const view = candidate?.projectId === parent?.projectId ? candidate : undefined
+  const owned = candidate?.projectId === parent?.projectId ? candidate : undefined
+  const view = owned
+    ? {
+        ...owned,
+        error:
+          owned.notice === 'interrupted'
+            ? t('Side chat was interrupted when the app closed. Send a Follow up to continue.')
+            : owned.notice === 'connection-ended'
+              ? t('Side chat connection ended. Send a Follow up to reconnect.')
+              : owned.error === 'Side chat prompt cancelled.'
+                ? t('Side chat prompt cancelled.')
+                : owned.error
+      }
+    : undefined
   const unavailableReason = runtime?.hydrationError
-    ? runtime.hydrationError
+    ? t('Could not restore Side chats: {{error}}', { error: runtime.hydrationError })
     : runtime && !runtime.hydrated
-      ? 'Restoring Side chats…'
+      ? t('Restoring Side chats…')
       : parent && runtime?.closingParentSessionIds.has(parent.sessionId)
-        ? 'Closing Side chat…'
+        ? t('Closing Side chat…')
         : undefined
 
   return {

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4711,6 +4711,14 @@
     "Direct PDF link": "Direkter PDF-Link",
     "arXiv identifier required": "arXiv-Kennung erforderlich",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Neueste PDF über die arXiv-Kennung. Kein API-Schlüssel erforderlich. Die Datei wird beim Herunterladen geprüft.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Fügen Sie eine DOI, PMID, PMCID oder arXiv-Kennung hinzu, um eine passende Volltext-PDF zu finden."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Fügen Sie eine DOI, PMID, PMCID oder arXiv-Kennung hinzu, um eine passende Volltext-PDF zu finden.",
+    "Could not close Side chat: {{error}}": "Side-Chat konnte nicht geschlossen werden: {{error}}",
+    "Could not restore Side chats: {{error}}": "Side-Chats konnten nicht wiederhergestellt werden: {{error}}",
+    "Restoring Side chats…": "Side-Chats werden wiederhergestellt…",
+    "Closing Side chat…": "Side-Chat wird geschlossen…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "Der Side-Chat wurde beim Schließen der App unterbrochen. Senden Sie eine weitere Nachricht, um fortzufahren.",
+    "Side chat connection ended. Send a Follow up to reconnect.": "Die Verbindung zum Side-Chat wurde beendet. Senden Sie eine weitere Nachricht, um die Verbindung wiederherzustellen.",
+    "Side chat prompt cancelled.": "Side-Chat-Anfrage abgebrochen.",
+    "Could not save Side chat: {{error}}": "Side-Chat konnte nicht gespeichert werden: {{error}}"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4872,6 +4872,14 @@
     "Direct PDF link": "Enlace directo al PDF",
     "arXiv identifier required": "Se requiere un identificador de arXiv",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "PDF más reciente mediante el identificador de arXiv. No requiere clave de API. El archivo se verifica al descargarlo.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Añada un DOI, PMID, PMCID o identificador de arXiv para encontrar un PDF de texto completo correspondiente."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Añada un DOI, PMID, PMCID o identificador de arXiv para encontrar un PDF de texto completo correspondiente.",
+    "Could not close Side chat: {{error}}": "No se pudo cerrar el chat lateral: {{error}}",
+    "Could not restore Side chats: {{error}}": "No se pudieron restaurar los chats laterales: {{error}}",
+    "Restoring Side chats…": "Restaurando chats laterales…",
+    "Closing Side chat…": "Cerrando chat lateral…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "El chat lateral se interrumpió al cerrar la aplicación. Envíe otro mensaje para continuar.",
+    "Side chat connection ended. Send a Follow up to reconnect.": "La conexión del chat lateral finalizó. Envíe otro mensaje para volver a conectarse.",
+    "Side chat prompt cancelled.": "Solicitud del chat lateral cancelada.",
+    "Could not save Side chat: {{error}}": "No se pudo guardar el chat lateral: {{error}}"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4872,6 +4872,14 @@
     "Direct PDF link": "Lien direct vers le PDF",
     "arXiv identifier required": "Identifiant arXiv requis",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Dernier PDF via l’identifiant arXiv. Aucune clé API requise. Le fichier est vérifié lors du téléchargement.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Ajoutez un DOI, PMID, PMCID ou identifiant arXiv pour trouver un PDF du texte intégral correspondant."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Ajoutez un DOI, PMID, PMCID ou identifiant arXiv pour trouver un PDF du texte intégral correspondant.",
+    "Could not close Side chat: {{error}}": "Impossible de fermer la discussion parallèle : {{error}}",
+    "Could not restore Side chats: {{error}}": "Impossible de restaurer les discussions parallèles : {{error}}",
+    "Restoring Side chats…": "Restauration des discussions parallèles…",
+    "Closing Side chat…": "Fermeture de la discussion parallèle…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "La discussion parallèle a été interrompue à la fermeture de l’application. Envoyez un nouveau message pour continuer.",
+    "Side chat connection ended. Send a Follow up to reconnect.": "La connexion à la discussion parallèle a été interrompue. Envoyez un nouveau message pour vous reconnecter.",
+    "Side chat prompt cancelled.": "Demande de discussion parallèle annulée.",
+    "Could not save Side chat: {{error}}": "Impossible d’enregistrer la discussion parallèle : {{error}}"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4558,6 +4558,14 @@
     "Direct PDF link": "PDF への直接リンク",
     "arXiv identifier required": "arXiv 識別子が必要です",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "arXiv 識別子から最新の PDF を取得します。API キーは不要です。ダウンロード時にファイルを検証します。",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI、PMID、PMCID または arXiv 識別子を追加して、一致する全文 PDF を検索します。"
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI、PMID、PMCID または arXiv 識別子を追加して、一致する全文 PDF を検索します。",
+    "Could not close Side chat: {{error}}": "サイドチャットを閉じられませんでした：{{error}}",
+    "Could not restore Side chats: {{error}}": "サイドチャットを復元できませんでした：{{error}}",
+    "Restoring Side chats…": "サイドチャットを復元中…",
+    "Closing Side chat…": "サイドチャットを終了中…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "アプリの終了時にサイドチャットが中断されました。続けるには追加のメッセージを送信してください。",
+    "Side chat connection ended. Send a Follow up to reconnect.": "サイドチャットの接続が終了しました。再接続するには追加のメッセージを送信してください。",
+    "Side chat prompt cancelled.": "サイドチャットのリクエストをキャンセルしました。",
+    "Could not save Side chat: {{error}}": "サイドチャットを保存できませんでした：{{error}}"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4556,6 +4556,14 @@
     "Direct PDF link": "PDF 직접 링크",
     "arXiv identifier required": "arXiv 식별자 필요",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "arXiv 식별자로 최신 PDF를 가져옵니다. API 키가 필요하지 않습니다. 다운로드할 때 파일을 검증합니다.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI, PMID, PMCID 또는 arXiv 식별자를 추가하여 일치하는 전문 PDF를 찾으세요."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "DOI, PMID, PMCID 또는 arXiv 식별자를 추가하여 일치하는 전문 PDF를 찾으세요.",
+    "Could not close Side chat: {{error}}": "사이드 채팅을 닫지 못했습니다: {{error}}",
+    "Could not restore Side chats: {{error}}": "사이드 채팅을 복원하지 못했습니다: {{error}}",
+    "Restoring Side chats…": "사이드 채팅 복원 중…",
+    "Closing Side chat…": "사이드 채팅 닫는 중…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "앱이 닫힐 때 사이드 채팅이 중단되었습니다. 계속하려면 후속 메시지를 보내세요.",
+    "Side chat connection ended. Send a Follow up to reconnect.": "사이드 채팅 연결이 종료되었습니다. 다시 연결하려면 후속 메시지를 보내세요.",
+    "Side chat prompt cancelled.": "사이드 채팅 요청이 취소되었습니다.",
+    "Could not save Side chat: {{error}}": "사이드 채팅을 저장하지 못했습니다: {{error}}"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5004,6 +5004,14 @@
     "Direct PDF link": "Прямая ссылка на PDF",
     "arXiv identifier required": "Требуется идентификатор arXiv",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "Последний PDF по идентификатору arXiv. API-ключ не требуется. Файл проверяется при скачивании.",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Добавьте DOI, PMID, PMCID или идентификатор arXiv, чтобы найти подходящий PDF полного текста."
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "Добавьте DOI, PMID, PMCID или идентификатор arXiv, чтобы найти подходящий PDF полного текста.",
+    "Could not close Side chat: {{error}}": "Не удалось закрыть боковой чат: {{error}}",
+    "Could not restore Side chats: {{error}}": "Не удалось восстановить боковые чаты: {{error}}",
+    "Restoring Side chats…": "Восстановление боковых чатов…",
+    "Closing Side chat…": "Закрытие бокового чата…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "Боковой чат был прерван при закрытии приложения. Отправьте новое сообщение, чтобы продолжить.",
+    "Side chat connection ended. Send a Follow up to reconnect.": "Соединение с боковым чатом завершено. Отправьте новое сообщение, чтобы подключиться снова.",
+    "Side chat prompt cancelled.": "Запрос бокового чата отменён.",
+    "Could not save Side chat: {{error}}": "Не удалось сохранить боковой чат: {{error}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4558,6 +4558,14 @@
     "Direct PDF link": "PDF 直链",
     "arXiv identifier required": "需要 arXiv 标识符",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "通过 arXiv 标识符获取最新 PDF。无需 API 密钥，下载时会校验文件。",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "添加 DOI、PMID、PMCID 或 arXiv 标识符以查找匹配的全文 PDF。"
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "添加 DOI、PMID、PMCID 或 arXiv 标识符以查找匹配的全文 PDF。",
+    "Could not close Side chat: {{error}}": "无法关闭侧边聊天：{{error}}",
+    "Could not restore Side chats: {{error}}": "无法恢复侧边聊天：{{error}}",
+    "Restoring Side chats…": "正在恢复侧边聊天…",
+    "Closing Side chat…": "正在关闭侧边聊天…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "应用关闭时，侧边聊天已中断。发送追问以继续。",
+    "Side chat connection ended. Send a Follow up to reconnect.": "侧边聊天连接已结束。发送追问以重新连接。",
+    "Side chat prompt cancelled.": "已取消侧边聊天请求。",
+    "Could not save Side chat: {{error}}": "无法保存侧边聊天：{{error}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4558,6 +4558,14 @@
     "Direct PDF link": "PDF 直接連結",
     "arXiv identifier required": "需要 arXiv 識別碼",
     "Latest PDF via arXiv identifier. No API key required. The file is checked when downloaded.": "透過 arXiv 識別碼取得最新 PDF。無需 API 金鑰，下載時會驗證檔案。",
-    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "新增 DOI、PMID、PMCID 或 arXiv 識別碼以尋找相符的全文 PDF。"
+    "Add a DOI, PMID, PMCID or arXiv identifier to find a matching full-text PDF.": "新增 DOI、PMID、PMCID 或 arXiv 識別碼以尋找相符的全文 PDF。",
+    "Could not close Side chat: {{error}}": "無法關閉側邊聊天：{{error}}",
+    "Could not restore Side chats: {{error}}": "無法還原側邊聊天：{{error}}",
+    "Restoring Side chats…": "正在還原側邊聊天…",
+    "Closing Side chat…": "正在關閉側邊聊天…",
+    "Side chat was interrupted when the app closed. Send a Follow up to continue.": "應用程式關閉時，側邊聊天已中斷。傳送追問以繼續。",
+    "Side chat connection ended. Send a Follow up to reconnect.": "側邊聊天連線已結束。傳送追問以重新連線。",
+    "Side chat prompt cancelled.": "已取消側邊聊天請求。",
+    "Could not save Side chat: {{error}}": "無法儲存側邊聊天：{{error}}"
   }
 }

--- a/src/shared/side-chat.ts
+++ b/src/shared/side-chat.ts
@@ -13,6 +13,7 @@ export type SideChatSendMessageResult = Readonly<{
   targetState: SideChatTargetState
   delivery: 'next-user-turn' | 'current-turn'
   persisted: true
+  persistenceError?: string
   systemHint: string
 }>
 
@@ -51,6 +52,8 @@ export type SideChatSnapshot = Readonly<{
   entries: readonly SideChatEntry[]
   running: boolean
   error?: string
+  persistenceError?: string
+  notice?: 'interrupted' | 'connection-ended'
 }>
 
 export type SideChatSnapshotList = Readonly<{
@@ -68,7 +71,10 @@ export type SideChatRuntimeEvent = Readonly<{
   parentSessionId: string
   projectId: string
   sideSessionId: string
-  event: import('./acp').AcpRuntimeEvent | SideChatLifecycleEvent
+  event:
+    | import('./acp').AcpRuntimeEvent
+    | SideChatLifecycleEvent
+    | Readonly<{ kind: 'persistence'; error?: string }>
 }>
 
 export type SideChatRelayDeliveredEvent = Readonly<{


### PR DESCRIPTION
## Problem

Side chat recovery could replay an old main-conversation snapshot, and Stop could miss a send waiting for resume or persistence. Rejected follow-ups left duplicate ordinary bubbles. Accepted main advisories became eligible for delivery again when their local commit failed. Streaming save failures also hid the warning and misreported the provider as stopped; output forced readers to the bottom and several owned notices bypassed translation.

## Proposed change

- Refresh the existing main snapshot before replay, preserve both main and side provenance within the existing context budget, and retain the selected parent branch.
- Carry an in-memory cancellation identity through IPC preflight and runtime waits. Reconcile rejected optimistic follow-ups against the authoritative transcript and remove entries rejected before provider admission.
- Retain accepted advisory identities in this process and retry only their local commit, with coalesced retries and one delivery notification. Report acceptance separately from a save failure.
- Publish revisioned persistence errors/recovery independently of provider execution; keep Stop available and show save warnings immediately, including during text animation.
- Reuse scroll following that pauses on upward scrolling and resumes at the bottom. Translate owned notices and tool statuses in all eight locales while retaining technical names and diagnostic details.

## Scope and non-goals

No dependencies, database columns, schema migration, persisted lifecycle/status values, or persisted file-version changes. Existing `historyPreamble`, transcript entries, and relay commits are updated through their current owners. New nonpersisted projections are `persistenceError`, `notice` (`interrupted` / `connection-ended`), and the revisioned `persistence` event; cancellation, admission, and pending-commit bookkeeping remain in memory.

Historical data needs no migration or reinterpretation. Existing duplicate bubbles are not deduplicated by text. Provider acceptance followed by a process crash before the receipt is saved remains unresolved: durable delivery attempts, historical uncertain-delivery policy, and cross-restart reconciliation are explicitly deferred. This change does not claim exactly-once delivery.

## Acceptance criteria and validation

Before production edits, 15 regression cases failed identically in two runs while 190 existing controls passed. Additional IPC parent-read cancellation and UI warning/wrapped-error probes also failed before their fixes. Assertions inspect provider prompts/calls, authoritative snapshots, relay claims, subscriptions, and mounted UI through existing public boundaries; no production test seam was added.

After the last material edit, the final focused Vitest set passed **1,737 tests**, with no failures or skips. Node (including sandbox) and Web typechecks, full repository lint, and `git diff --check` also passed.

| Changed boundary | Final owner, contract, and consumer validation |
| --- | --- |
| Runtime, IPC, recovery and active parent branch | Entire `src/main/side-chat`; `provider-session-resumer`, `session-resume-policy`, `runtime-coordinator`, `history-preamble` |
| Relay acceptance and durable linkage | `side-chat-relay-owner`, `main-prompt-relay`, `native-follow-up`, `native-follow-up-workflow`, `prompt-turn-workflow`, session-persistence `coordinator` and `repository` |
| Events, snapshots, Electron and Web transport | `application-events`, `renderer-contract-catalog`, `renderer-surface-matrix`, preload `index`, Web `api-installer`, `use-side-chat-controller` |
| Panel, scrolling, text animation and locale catalogs | `ConversationPanel.interaction`, `use-follow-scroll-bottom`, `i18n/resources` |

CodeGraph consumer inspection was combined with behavioral tests for IPC names, acceptance callbacks, subscriptions and persisted contracts. Runtime owner regressions cover Claude Code, OpenCode and Codex; existing resumer/policy/coordinator suites cover the Codex Responses and bridge execution paths. These are controlled provider-port tests, not paid live provider requests.

The affected-test explain plan selects full fallback because `side-chat-relay-owner.ts` has no declared module owner. At the maintainer's explicit request, the complete local suite was not run; the mapped owner/contract/consumer set above is local evidence, and PR CI supplies full/platform validation. No ownership manifest or classifier was changed.

Real Chromium verification mounted the product controller/panel with isolated data: upward wheel scrolling held position while content grew; returning fully to the bottom restored following; a save failure left Stop available and recovery cleared the warning; connection and tool-status text rendered in Chinese. Screenshots were supplied in the task. This does not substitute for packaged Electron or cross-platform certification.

## Review focus

Admission versus transport failure, cancellation after asynchronous preflight boundaries, preservation of accepted relay identity, save-error event ordering, and the explicitly bounded process-local crash guarantee.
