### PR TITLE
fix(annotations): preserve evidence and restore source navigation

### DIFF
--- a/src/main/acp/interrupted-turn-continuation.test.ts
+++ b/src/main/acp/interrupted-turn-continuation.test.ts
@@ -108,53 +108,61 @@ describe('continueInterruptedTurn', () => {
     ])
   })
 
-  it('rebuilds current PDF region Evidence from the interrupted user turn', async () => {
-    const durable = session([
-      message('prompt-1', 'user', 'Explain this figure', {
-        annotations: [
-          {
-            id: 'pdf-region-1',
-            kind: 'pdf',
-            target: 'agent',
-            source: {
-              kind: 'upload-version',
-              projectId: 'project-1',
-              sessionId: 'session-1',
-              versionId: 'version-1',
-              name: 'paper.pdf',
-              path: 'upload-version:project-1/session-1/version-1',
-              checksum: 'a'.repeat(64)
-            },
-            selector: {
-              kind: 'region',
-              pageNumber: 2,
-              rect: { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
-              pageRotation: 0,
-              image: { mimeType: 'image/png', data: 'AQID', byteLength: 3 }
+  it.each([true, false])(
+    'rebuilds PDF region evidence after interruption with bitmap retained=%s',
+    async (withBitmap) => {
+      const durable = session([
+        message('prompt-1', 'user', 'Explain this figure', {
+          annotations: [
+            {
+              id: 'pdf-region-1',
+              kind: 'pdf',
+              target: 'agent',
+              source: {
+                kind: 'upload-version',
+                projectId: 'project-1',
+                sessionId: 'session-1',
+                versionId: 'version-1',
+                name: 'paper.pdf',
+                path: 'upload-version:project-1/session-1/version-1',
+                checksum: 'a'.repeat(64)
+              },
+              selector: {
+                kind: 'region',
+                pageNumber: 2,
+                rect: { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
+                pageRotation: 0,
+                ...(withBitmap
+                  ? { image: { mimeType: 'image/png' as const, data: 'AQID', byteLength: 3 } }
+                  : { imageOmissionReason: 'session-budget' as const })
+              }
             }
-          }
-        ]
-      })
-    ])
-    const startContinuation = vi.fn<(request: AcpPromptRequest) => Promise<void>>(async () => {})
+          ]
+        })
+      ])
+      const startContinuation = vi.fn<(request: AcpPromptRequest) => Promise<void>>(async () => {})
 
-    await continueInterruptedTurn(
-      {
-        runtime: {
-          getState: vi.fn(() => snapshot()),
-          getLatestUserPrompt: vi.fn(() => undefined),
-          startContinuation
+      await continueInterruptedTurn(
+        {
+          runtime: {
+            getState: vi.fn(() => snapshot()),
+            getLatestUserPrompt: vi.fn(() => undefined),
+            startContinuation
+          },
+          loadSession: vi.fn(async () => durable)
         },
-        loadSession: vi.fn(async () => durable)
-      },
-      { sessionId: 'session-1', projectId: 'project-1', promptMessageId: 'prompt-1' }
-    )
+        { sessionId: 'session-1', projectId: 'project-1', promptMessageId: 'prompt-1' }
+      )
 
-    const request = startContinuation.mock.calls[0][0]
-    expect(request.text).toContain('"type":"pdf-region"')
-    expect(request.currentImages).toEqual([{ mimeType: 'image/png', data: 'AQID', byteLength: 3 }])
-    expect(request.historyImages).toBeUndefined()
-  })
+      const request = startContinuation.mock.calls[0][0]
+      expect(request.text).toContain('"type":"pdf-region"')
+      expect(request.currentImages).toEqual(
+        withBitmap ? [{ mimeType: 'image/png', data: 'AQID', byteLength: 3 }] : undefined
+      )
+      if (!withBitmap) expect(request.text).toContain('"imageOmissionReason":"session-budget"')
+      expect(request.historyImages).toBeUndefined()
+    }
+  )
 
   it('reconstructs the hidden Save as skill turn after restart', async () => {
     const durable = session([

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3304,12 +3304,16 @@ describe('notebook runtime service', () => {
     it('queues overlapping shell calls in the same Session until the active command finishes', async () => {
       const root = await createStorageRoot()
       const entered: string[] = []
+      const firstStarted = createDeferred<void>()
+      const secondStarted = createDeferred<void>()
       const releases = new Map<string, () => void>()
       const execute = vi.fn<NotebookShellProcess['execute']>(
         ({ command }) =>
           new Promise((resolve) => {
             entered.push(command)
             releases.set(command, () => resolve({ stdout: command, stderr: '', exitCode: 0 }))
+            if (command === 'first') firstStarted.resolve(undefined)
+            if (command === 'second') secondStarted.resolve(undefined)
           })
       )
       const service = new NotebookRuntimeService({
@@ -3347,30 +3351,22 @@ describe('notebook runtime service', () => {
         provenanceContext: childContext
       })
 
-      await vi.waitFor(async () => {
-        const state = await service.state({
-          sessionId: 'session-1',
-          workspaceCwd: root
-        })
-        expect(state.runs).toHaveLength(2)
-      })
-      const queuedState = await service.state({
-        sessionId: 'session-1',
-        workspaceCwd: root
-      })
-      const queuedRun = queuedState.runs.at(-1)
-      if (queuedRun?.status !== 'queued') {
-        await vi.waitFor(() => expect(entered).toHaveLength(2))
-        for (const release of releases.values()) release()
-        await Promise.allSettled([first, second])
-      }
-      await vi.waitFor(() => expect(entered).toEqual(['first']))
-      expect(entered).toEqual(['first'])
-      expect(queuedRun).toMatchObject({ script: 'second', status: 'queued' })
-
       try {
+        // Filesystem preparation can exceed waitFor's default 1s under CI coverage.
+        // Observe process admission directly before checking the second call is still queued.
+        await firstStarted.promise
+        await vi.waitFor(
+          async () => {
+            const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })
+            expect(state.runs).toHaveLength(2)
+            expect(state.runs.at(-1)).toMatchObject({ script: 'second', status: 'queued' })
+          },
+          { timeout: 10_000 }
+        )
+        expect(entered).toEqual(['first'])
         releases.get('first')?.()
-        await vi.waitFor(() => expect(entered).toEqual(['first', 'second']))
+        await secondStarted.promise
+        expect(entered).toEqual(['first', 'second'])
         releases.get('second')?.()
 
         await expect(Promise.all([first, second])).resolves.toEqual([
@@ -3378,6 +3374,11 @@ describe('notebook runtime service', () => {
           { stdout: 'second', stderr: '', exitCode: 0 }
         ])
       } finally {
+        execute.mockImplementation(async ({ command }) => ({
+          stdout: command,
+          stderr: '',
+          exitCode: 0
+        }))
         for (const release of releases.values()) release()
         await Promise.allSettled([first, second])
       }

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -3,6 +3,8 @@ import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+
 const mocks = vi.hoisted(() => {
   // Captures the onOpenSession listener so tests can fire the notification nudge directly.
   const notificationNudgeBox: { current: (() => void) | undefined } = { current: undefined }
@@ -621,10 +623,12 @@ describe('App startup routing', () => {
         cwd: '/workspace/project-1',
         status: 'idle',
         messages: [],
-        conversationGraph: {
-          activeFrameId: 'frame-1',
-          frames: [{ id: 'frame-1', activeBranchId: 'branch-1' }]
-        },
+        conversationGraph: createLinearConversationGraph({
+          sessionId: 'session-1',
+          messages: [],
+          createdAt: 1,
+          updatedAt: 1
+        }),
         createdAt: 1,
         updatedAt: 1
       }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2719,6 +2719,7 @@ describe('workspace agent message sending', () => {
     await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledOnce())
     expect(sendPrompt.mock.calls[0]?.[1]).toContain('[Annotations]')
     expect(sendPrompt.mock.calls[0]?.[1]).toContain('The confidence intervals overlap.')
+    expect(sendPrompt.mock.calls[0]?.[1]).toContain(JSON.stringify(annotation.source))
     expect(useSessionStore.getState().sessions[0].messages[0]).toMatchObject({
       role: 'user',
       content: '',
@@ -2726,55 +2727,62 @@ describe('workspace agent message sending', () => {
     })
   })
 
-  it('dispatches a PDF region Evidence screenshot as current visual context', async () => {
-    const sendPrompt = vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
-    const runtime = {
-      state: createSnapshot(['transport-session-1']),
-      createSession: vi.fn(),
-      resumeSession: vi.fn(),
-      resetSessionContext: vi.fn(),
-      sendPrompt
-    }
-    const annotation = {
-      id: 'pdf-region-1',
-      kind: 'pdf' as const,
-      target: 'agent' as const,
-      source: {
-        kind: 'upload-version' as const,
-        projectId: 'project-1',
-        sessionId: 'transport-session-1',
-        versionId: 'version-1',
-        name: 'paper.pdf',
-        path: 'upload-version:project-1/transport-session-1/version-1',
-        checksum: 'a'.repeat(64)
-      },
-      selector: {
-        kind: 'region' as const,
-        pageNumber: 2,
-        rect: { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
-        pageRotation: 0,
-        image: { mimeType: 'image/png' as const, data: 'AQID', byteLength: 3 }
+  it.each([true, false])(
+    'dispatches PDF region evidence with bitmap retained=%s',
+    async (withBitmap) => {
+      const sendPrompt = vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+      const runtime = {
+        state: createSnapshot(['transport-session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn(),
+        sendPrompt
       }
+      const annotation = {
+        id: 'pdf-region-1',
+        kind: 'pdf' as const,
+        target: 'agent' as const,
+        source: {
+          kind: 'upload-version' as const,
+          projectId: 'project-1',
+          sessionId: 'transport-session-1',
+          versionId: 'version-1',
+          name: 'paper.pdf',
+          path: 'upload-version:project-1/transport-session-1/version-1',
+          checksum: 'a'.repeat(64)
+        },
+        selector: {
+          kind: 'region' as const,
+          pageNumber: 2,
+          rect: { x: 0.1, y: 0.2, width: 0.4, height: 0.3 },
+          pageRotation: 0,
+          ...(withBitmap
+            ? { image: { mimeType: 'image/png' as const, data: 'AQID', byteLength: 3 } }
+            : { imageOmissionReason: 'session-budget' as const })
+        }
+      }
+
+      await sendWorkspaceMessage(runtime, {
+        sessionId: 'transport-session-1',
+        text: 'Explain this figure.',
+        annotations: [annotation],
+        cwd: '/workspace/project',
+        projectId: 'project-1',
+        supportsImageInput: withBitmap
+      })
+
+      await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledOnce())
+      expect(sendPrompt.mock.calls[0]?.[1]).toContain('"type":"pdf-region"')
+      expect(sendPrompt.mock.calls[0]?.[1]).not.toContain('AQID')
+      expect(sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
+      expect(sendPrompt.mock.calls[0]?.[14]).toEqual(
+        withBitmap ? [{ mimeType: 'image/png', data: 'AQID', byteLength: 3 }] : undefined
+      )
+      if (!withBitmap)
+        expect(sendPrompt.mock.calls[0]?.[1]).toContain('"imageOmissionReason":"session-budget"')
+      expect(useSessionStore.getState().sessions[0].messages[0]?.annotations).toEqual([annotation])
     }
-
-    await sendWorkspaceMessage(runtime, {
-      sessionId: 'transport-session-1',
-      text: 'Explain this figure.',
-      annotations: [annotation],
-      cwd: '/workspace/project',
-      projectId: 'project-1',
-      supportsImageInput: true
-    })
-
-    await vi.waitFor(() => expect(sendPrompt).toHaveBeenCalledOnce())
-    expect(sendPrompt.mock.calls[0]?.[1]).toContain('"type":"pdf-region"')
-    expect(sendPrompt.mock.calls[0]?.[1]).not.toContain('AQID')
-    expect(sendPrompt.mock.calls[0]?.[7]).toBeUndefined()
-    expect(sendPrompt.mock.calls[0]?.[14]).toEqual([
-      { mimeType: 'image/png', data: 'AQID', byteLength: 3 }
-    ])
-    expect(useSessionStore.getState().sessions[0].messages[0]?.annotations).toEqual([annotation])
-  })
+  )
 
   it('rejects PDF region Evidence before mutation when no visual model is available', async () => {
     const sendPrompt = vi.fn()
@@ -11564,7 +11572,7 @@ describe('edit resend reply streaming', () => {
       annotations: [annotation]
     })
     expect(runtime.sendPrompt.mock.calls[0]?.[1]).toContain(
-      '"type":"quote","content":"Quoted evidence","instruction":"Updated note"'
+      '"type":"quote","content":"Quoted evidence","source":{"kind":"agent-message","sessionId":"session-1","messageId":"agent-1"},"instruction":"Updated note"'
     )
   })
 

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -690,7 +690,10 @@ const sendWorkspaceMessage = async (
     input.supportsImageInput !== true &&
     input.supportsImageRelay !== true &&
     annotations.some(
-      (annotation) => annotation.kind === 'pdf' && annotation.selector.kind === 'region'
+      (annotation) =>
+        annotation.kind === 'pdf' &&
+        annotation.selector.kind === 'region' &&
+        !!annotation.selector.image
     )
   ) {
     throw new Error(VISION_MODEL_NOT_CONFIGURED_MESSAGE)

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -1067,6 +1067,76 @@ describe('renderer session persistence bridge', () => {
     )
   })
 
+  it('does not invalidate a fresh archive action by saving the conflict refresh back', async () => {
+    let durable = createPersistedSession({ revision: 1 })
+    useSessionStore.getState().upsertPersistedSession(durable)
+    const api = createApi({
+      loadOne: vi.fn(async () => durable),
+      saveSession: vi.fn(async (session) => {
+        durable = { ...session, revision: (durable.revision ?? 0) + 1 }
+        return durable
+      })
+    })
+    const updateArchive = vi.fn(async (request: { expectedRevision: number }) => {
+      if (request.expectedRevision !== durable.revision) {
+        throw new SessionRevisionConflictError(request.expectedRevision, durable.revision ?? 0)
+      }
+      durable = { ...durable, revision: durable.revision + 1, archivedAt: 10 }
+      return durable
+    })
+    vi.stubGlobal('window', { api: { sessions: { ...api, updateArchive } } })
+    const save = createStoreSaver(api, useSessionStore.getState())
+    const request = { projectId: durable.projectId, sessionId: durable.id, archived: true }
+    try {
+      // Another client's edit makes the first menu snapshot stale.
+      durable = { ...durable, revision: 2 }
+      await expect(
+        useSessionStore.getState().updateSessionArchive({ ...request, expectedRevision: 1 })
+      ).rejects.toThrow('Session revision conflict')
+
+      // A newly opened menu captures the refreshed revision. Let the persistence subscriber
+      // drain while it is open, as happens on a slower desktop before the user clicks Archive.
+      const fresh = useSessionStore.getState().sessions[0]
+      await save(useSessionStore.getState())
+      await expect(
+        useSessionStore.getState().updateSessionArchive({
+          ...request,
+          expectedRevision: fresh.revision ?? 0
+        })
+      ).resolves.toMatchObject({ archivedAt: 10 })
+      expect(api.saveSession).not.toHaveBeenCalled()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('still saves local content when archive authority refreshes before the saver drains', async () => {
+    const durable = createPersistedSession({ revision: 1 })
+    useSessionStore.getState().upsertPersistedSession(durable)
+    const api = createApi()
+    const save = createStoreSaver(api, useSessionStore.getState())
+    const source = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().appendUserMessage({
+      sessionId: durable.id,
+      content: 'Keep this unsaved message',
+      cwd: durable.cwd,
+      projectId: durable.projectId
+    })
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: { ...durable, revision: 2 },
+      mode: 'archive-authority'
+    })
+    await save(useSessionStore.getState())
+
+    expect(api.saveSession).toHaveBeenCalledOnce()
+    expect(api.saveSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        messages: [expect.objectContaining({ content: 'Keep this unsaved message' })]
+      })
+    )
+  })
+
   it('does not echo an externally hydrated session back to persistence', async () => {
     const api = createApi()
     const save = createStoreSaver(api)

--- a/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx
@@ -77,6 +77,7 @@ describe('LiteratureFullTextLookup', () => {
     expect(await screen.findByText('Configured')).not.toBeNull()
     expect(saveEmail).toHaveBeenCalledWith({ contactEmail: 'research@lab.org' })
     expect(screen.queryByLabelText('Contact email')).toBeNull()
+    // Credential UI can update before the lookup effect starts the new search.
     await waitFor(() => expect(fullText).toHaveBeenCalledTimes(2))
     fireEvent.click(screen.getByRole('button', { name: 'Edit' }))
     fireEvent.click(screen.getByRole('button', { name: 'Remove email' }))
@@ -184,7 +185,7 @@ describe('LiteratureFullTextLookup', () => {
     expect(validate).toHaveBeenCalledWith({ apiKey: 'test-key' })
     expect(save).toHaveBeenCalledWith({ apiKey: 'test-key' })
     expect(screen.queryByLabelText('OpenAlex API key')).toBeNull()
-    expect(fullText).toHaveBeenCalledTimes(2)
+    await waitFor(() => expect(fullText).toHaveBeenCalledTimes(2))
   })
 
   it('keeps a rejected key editable and does not save or restart the search', async () => {

--- a/src/renderer/src/pages/workspace/annotations/AnnotationCards.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/AnnotationCards.test.tsx
@@ -3,6 +3,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { validateAnnotations, ANNOTATION_LIMITS } from '../../../../../shared/annotations'
 import type { Annotation, AnnotationValidationError } from '../../../../../shared/annotations'
 import {
   createInitialPreviewWorkbenchState,
@@ -127,6 +128,36 @@ describe('AnnotationCards image projection', () => {
     expect(container.textContent).toContain('Image point 1')
     expect(container.textContent).toContain('Point 1 at 500, 100')
     expect(container.textContent).toContain('Inspect the peak.')
+  })
+
+  it('shows retained PDF region metadata with an explicit missing-image message', async () => {
+    const region = pdfAnnotations[1]!
+    if (region.kind !== 'pdf' || region.selector.kind !== 'region')
+      throw new Error('Expected region fixture')
+    const omitted: Annotation = {
+      ...region,
+      note: 'Keep the evidence.',
+      selector: { ...region.selector, image: undefined, imageOmissionReason: 'session-budget' }
+    }
+    await act(async () => root.render(<AnnotationMessageCards annotations={[omitted]} />))
+    expect(container.textContent).toContain('results.pdf · Page 9')
+    expect(container.textContent).toContain('Keep the evidence.')
+    expect(container.textContent).toContain('Image not retained: session image budget reached.')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('reveals ordinary sent text and image sources through their card buttons', async () => {
+    const onReveal = vi.fn()
+    await act(async () =>
+      root.render(<AnnotationMessageCards annotations={annotations} onReveal={onReveal} />)
+    )
+    const buttons = container.querySelectorAll<HTMLButtonElement>(
+      'button[aria-label="Show annotation source"]'
+    )
+    expect(buttons).toHaveLength(2)
+    await act(async () => buttons[0].click())
+    await act(async () => buttons[1].click())
+    expect(onReveal.mock.calls.map(([annotation]) => annotation.id)).toEqual(['quote-1', 'point-1'])
   })
 
   it('renders PDF quotes and regions as distinct sent evidence cards that reveal their source', async () => {
@@ -402,6 +433,55 @@ describe('AnnotationCards image projection', () => {
     expect(document.body.querySelector('[data-annotation-note-editor]')).toBeNull()
     expect(document.activeElement).toBe(edit)
   })
+
+  it.each(['empty-note', 'payload-limit'] as const)(
+    'explains rejected image note edits: %s',
+    async (reason) => {
+      const point = annotations[1]!
+      const messageText =
+        reason === 'payload-limit' ? 'x'.repeat(ANNOTATION_LIMITS.messagePayload - 500) : ''
+      expect(validateAnnotations([point], messageText)).toBeUndefined()
+      const attempted = reason === 'empty-note' ? '' : 'x'.repeat(1_000)
+      const onUpdateNote = vi.fn((id: string, note: string) =>
+        validateAnnotations([{ ...point, id, note: note.trim() }], messageText)
+      )
+      await act(async () =>
+        root.render(
+          <AnnotationDraftCards
+            annotations={[point]}
+            disabled={false}
+            onUpdateNote={onUpdateNote}
+            onRemove={vi.fn()}
+          />
+        )
+      )
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Edit annotation note"]')!.click()
+      )
+      const editor = document.body.querySelector<HTMLElement>('[data-annotation-note-editor]')!
+      const textarea = editor.querySelector('textarea')!
+      await act(async () => {
+        Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+          textarea,
+          attempted
+        )
+        textarea.dispatchEvent(new InputEvent('input', { bubbles: true }))
+      })
+      await act(async () =>
+        Array.from(editor.querySelectorAll('button'))
+          .find((button) => button.textContent === 'Save')!
+          .click()
+      )
+      expect(onUpdateNote).toHaveBeenCalledWith(point.id, attempted)
+      expect(onUpdateNote.mock.results[0].value).toBe(
+        reason === 'empty-note' ? 'invalid' : 'payload-too-large'
+      )
+      expect(document.body.querySelector('[data-annotation-note-editor]')).not.toBeNull()
+      expect(textarea.value).toBe(attempted)
+      expect.soft(editor.querySelector('[role="alert"]')?.textContent).toBeTruthy()
+      expect.soft(textarea.getAttribute('aria-invalid')).toBe('true')
+    }
+  )
 
   it('closes after a successful save and stays open after a validation error', async () => {
     const onUpdateNote = vi.fn<(id: string, note: string) => AnnotationValidationError | undefined>(

--- a/src/renderer/src/pages/workspace/annotations/AnnotationCards.tsx
+++ b/src/renderer/src/pages/workspace/annotations/AnnotationCards.tsx
@@ -13,6 +13,7 @@ import type {
   SessionTextAnnotationItemType
 } from '../../../../../shared/annotations'
 import { prepareImagePointAnnotations } from './image-annotation-payload'
+import { annotationValidationMessage } from './annotation-validation-message'
 import { SentAnnotationCards, type SentAnnotationCardView } from './SentAnnotationCards'
 
 const sessionItemSourceLabel = (itemType: SessionTextAnnotationItemType, t: TFunction): string => {
@@ -117,16 +118,19 @@ const AnnotationDraftCards = ({
   const [hoveredId, setHoveredId] = useState<string>()
   const [editTooltipId, setEditTooltipId] = useState<string>()
   const [note, setNote] = useState('')
+  const [validationError, setValidationError] = useState<AnnotationValidationError>()
   const editButtons = useRef(new Map<string, HTMLButtonElement>())
   const imagePoints = new Map(
     prepareImagePointAnnotations(annotations).points.map((point) => [point.annotationId, point])
   )
   const closeEditor = (id: string): void => {
     setEditingId(undefined)
+    setValidationError(undefined)
     setTimeout(() => editButtons.current.get(id)?.focus(), 0)
   }
   const openEditor = (annotation: Annotation): void => {
     setEditingId(annotation.id)
+    setValidationError(undefined)
     setNote(annotation.note ?? '')
   }
   if (annotations.length === 0) return null
@@ -271,8 +275,26 @@ const AnnotationDraftCards = ({
                   value={note}
                   maxLength={2_000}
                   placeholder={t('Add context for the Agent')}
-                  onChange={(event) => setNote(event.target.value)}
+                  aria-invalid={!!validationError}
+                  aria-describedby={
+                    validationError ? `annotation-error-${annotation.id}` : undefined
+                  }
+                  onChange={(event) => {
+                    setNote(event.target.value)
+                    setValidationError(undefined)
+                  }}
                 />
+                {validationError ? (
+                  <p
+                    id={`annotation-error-${annotation.id}`}
+                    role="alert"
+                    className="text-xs text-destructive"
+                  >
+                    {annotation.kind === 'image-point' && !note.trim()
+                      ? t('Add a note for this image annotation')
+                      : annotationValidationMessage(validationError, t)}
+                  </p>
+                ) : null}
                 <div className="flex justify-end gap-2">
                   <Button
                     type="button"
@@ -286,7 +308,9 @@ const AnnotationDraftCards = ({
                     type="button"
                     size="sm"
                     onClick={() => {
-                      if (!onUpdateNote(annotation.id, note)) closeEditor(annotation.id)
+                      const error = onUpdateNote(annotation.id, note)
+                      setValidationError(error)
+                      if (!error) closeEditor(annotation.id)
                     }}
                   >
                     {t('Save')}

--- a/src/renderer/src/pages/workspace/annotations/ImagePointAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/ImagePointAnnotationSurface.test.tsx
@@ -8,7 +8,7 @@ import { createArtifactVersionLocator } from '../../../../../shared/artifact-pro
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 
 import { ImagePointAnnotationSurface } from './ImagePointAnnotationSurface'
-import { requestAnnotationReveal } from './annotation-reveal'
+import { requestAnnotationReveal, subscribeAnnotationReveal } from './annotation-reveal'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -45,6 +45,7 @@ describe('ImagePointAnnotationSurface', () => {
 
   afterEach(async () => {
     await act(async () => root.unmount())
+    subscribeAnnotationReveal(() => true)()
     container.remove()
   })
 
@@ -289,7 +290,7 @@ describe('ImagePointAnnotationSurface', () => {
     expect(onRemove).toHaveBeenCalledWith('point-existing')
   })
 
-  it('opens an existing pin preview when the composer reveals its source', async () => {
+  it.each(['draft', 'sent', 'late-mount'] as const)('opens a pin preview for %s', async (mode) => {
     const annotation = {
       id: 'point-reveal',
       kind: 'image-point',
@@ -307,15 +308,25 @@ describe('ImagePointAnnotationSurface', () => {
       point: { x: 0.5, y: 0.5 },
       naturalSize: { width: 800, height: 400 }
     } as const
+    if (mode === 'late-mount') await act(async () => requestAnnotationReveal(annotation))
     await renderSurface({
-      activeAnnotations: [annotation]
+      activeAnnotations: mode === 'draft' ? [annotation] : [],
+      onUpdateNote: vi.fn(),
+      onRemove: vi.fn()
     })
-
-    await act(async () => requestAnnotationReveal(annotation))
+    if (mode !== 'late-mount') await act(async () => requestAnnotationReveal(annotation))
     expect(document.querySelector('[data-image-annotation-preview]')?.textContent).toBe(
       'Revealed from composer'
     )
     expect(document.querySelector('textarea')).toBeNull()
+    if (mode !== 'draft') {
+      expect(
+        Array.from(document.querySelectorAll('button')).some(
+          (button) => button.textContent === 'Edit' || button.textContent === 'Delete'
+        )
+      ).toBe(false)
+      expect(onAdd).not.toHaveBeenCalled()
+    }
   })
 
   it('repositions normalized markers after the surface is resized', async () => {

--- a/src/renderer/src/pages/workspace/annotations/ImagePointAnnotationSurface.tsx
+++ b/src/renderer/src/pages/workspace/annotations/ImagePointAnnotationSurface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useLayoutEffect, useEffect, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -23,7 +23,10 @@ import {
   type ImagePointAnnotationSource
 } from './image-annotation-source'
 import { createAnnotationId } from './annotation-id'
-import { subscribeAnnotationReveal } from './annotation-reveal'
+import {
+  subscribeAnnotationReveal,
+  subscribeAnnotationRevealPreparation
+} from './annotation-reveal'
 import { useAnnotationSurfaceScale } from './use-annotation-surface-scale'
 
 const IMAGE_POINT_CLICK_THRESHOLD = 4
@@ -39,7 +42,7 @@ type PendingPoint = Readonly<{
 }>
 
 const sameImageVersion = (
-  annotation: ImagePointAnnotation,
+  annotation: Pick<ImagePointAnnotation, 'source'>,
   source: ImagePointAnnotationSource | undefined
 ): boolean =>
   !!source &&
@@ -88,32 +91,46 @@ const ImagePointAnnotationSurface = ({
         .map((annotation, index) => ({ annotation, number: index + 1 })),
     [activeAnnotations]
   )
-  const visibleAnnotations = numberedImageAnnotations.filter(({ annotation }) =>
-    sameImageVersion(annotation, source)
+  const visibleAnnotations = useMemo(
+    () => numberedImageAnnotations.filter(({ annotation }) => sameImageVersion(annotation, source)),
+    [numberedImageAnnotations, source]
+  )
+  const pendingIsDraft = visibleAnnotations.some(
+    ({ annotation }) => annotation.id === pending?.annotationId
   )
   const pendingNumber = numberedImageAnnotations.length + 1
   const displayNumber = pending?.number ?? pendingNumber
 
-  useEffect(
-    () =>
-      subscribeAnnotationReveal((annotationId) => {
-        const match = visibleAnnotations.find(({ annotation }) => annotation.id === annotationId)
-        if (!match) return false
-        focusReturnRef.current = surfaceRef.current
-        setPending({
-          annotationId: match.annotation.id,
-          number: match.number,
-          point: match.annotation.point,
-          source: match.annotation.source,
-          naturalSize: match.annotation.naturalSize
-        })
-        setNote(match.annotation.note)
-        setNoteRequired(false)
-        setPendingMode('preview')
-        return true
-      }),
-    [visibleAnnotations]
-  )
+  useLayoutEffect(() => {
+    let prepared: ImagePointAnnotation | undefined
+    const stopPreparation = subscribeAnnotationRevealPreparation((annotation) => {
+      prepared =
+        annotation.kind === 'image-point' && sameImageVersion(annotation, source)
+          ? annotation
+          : undefined
+    })
+    const stopReveal = subscribeAnnotationReveal((annotationId) => {
+      const match = visibleAnnotations.find(({ annotation }) => annotation.id === annotationId)
+      const annotation = match?.annotation ?? (prepared?.id === annotationId ? prepared : undefined)
+      if (!annotation || !naturalSize) return false
+      focusReturnRef.current = surfaceRef.current
+      setPending({
+        annotationId: annotation.id,
+        number: match?.number ?? 1,
+        point: annotation.point,
+        source: annotation.source,
+        naturalSize: annotation.naturalSize
+      })
+      setNote(annotation.note)
+      setNoteRequired(false)
+      setPendingMode('preview')
+      return true
+    })
+    return () => {
+      stopPreparation()
+      stopReveal()
+    }
+  }, [visibleAnnotations, source, naturalSize])
 
   const clearPending = (): void => {
     const focusReturn = focusReturnRef.current
@@ -301,7 +318,7 @@ const ImagePointAnnotationSurface = ({
           {number}
         </button>
       ))}
-      {pending ? (
+      {pending && sameImageVersion(pending, source) ? (
         <Popover open onOpenChange={(open) => !open && clearPending()}>
           <PopoverAnchor asChild>
             <span
@@ -364,7 +381,7 @@ const ImagePointAnnotationSurface = ({
               </>
             )}
             <div className="flex justify-end gap-2">
-              {pendingMode === 'preview' && pending.annotationId && onRemove ? (
+              {pendingMode === 'preview' && pendingIsDraft && pending.annotationId && onRemove ? (
                 <Button
                   type="button"
                   variant="ghost"
@@ -379,9 +396,15 @@ const ImagePointAnnotationSurface = ({
                 </Button>
               ) : null}
               {pendingMode === 'preview' ? (
-                <Button type="button" size="sm" onClick={() => setPendingMode('edit')}>
-                  {t('Edit')}
-                </Button>
+                pendingIsDraft ? (
+                  <Button type="button" size="sm" onClick={() => setPendingMode('edit')}>
+                    {t('Edit')}
+                  </Button>
+                ) : (
+                  <Button type="button" size="sm" onClick={clearPending}>
+                    {t('Close')}
+                  </Button>
+                )
               ) : (
                 <>
                   <Button

--- a/src/renderer/src/pages/workspace/annotations/SentAnnotationCards.tsx
+++ b/src/renderer/src/pages/workspace/annotations/SentAnnotationCards.tsx
@@ -35,7 +35,7 @@ type SentAnnotationCardView =
       content: string
       source: string
       note?: string
-      image: AcpMessageImage
+      image?: AcpMessageImage
     }>
 
 type SentAnnotationCardsProps = Readonly<{
@@ -129,12 +129,20 @@ const SentAnnotationCard = ({
             </span>
           </div>
           {region ? (
-            <span className="mt-2 grid grid-cols-[5rem_minmax(0,1fr)] gap-2">
-              <img
-                src={`data:${card.image.mimeType};base64,${card.image.data}`}
-                alt=""
-                className="h-14 w-20 rounded-md border border-border/70 bg-muted object-cover"
-              />
+            <span
+              className={`mt-2 ${card.image ? 'grid grid-cols-[5rem_minmax(0,1fr)] gap-2' : 'block space-y-1'}`}
+            >
+              {card.image ? (
+                <img
+                  src={`data:${card.image.mimeType};base64,${card.image.data}`}
+                  alt=""
+                  className="h-14 w-20 rounded-md border border-border/70 bg-muted object-cover"
+                />
+              ) : (
+                <span className="block text-xs text-muted-foreground">
+                  {t('Image not retained: session image budget reached.')}
+                </span>
+              )}
               <span className="line-clamp-3 self-center whitespace-pre-wrap break-words text-xs leading-5 text-foreground/90">
                 {card.content}
               </span>
@@ -175,11 +183,8 @@ const SentAnnotationCard = ({
     )
   }
   const imagePoint = card.kind === 'image-point'
-  return (
-    <article
-      data-side-chat-annotation-card={placement === 'message' ? undefined : 'true'}
-      className="rounded-lg border border-border/70 bg-background/70 p-2"
-    >
+  const content = (
+    <>
       <div className="flex items-center gap-1 text-xs font-semibold">
         {imagePoint ? (
           <MapPin className="size-3" aria-hidden="true" />
@@ -209,6 +214,25 @@ const SentAnnotationCard = ({
         </div>
       ) : null}
       {card.note ? <div className="mt-1 text-xs">{card.note}</div> : null}
+    </>
+  )
+  return (
+    <article
+      data-side-chat-annotation-card={placement === 'message' ? undefined : 'true'}
+      className="rounded-lg border border-border/70 bg-background/70"
+    >
+      {onActivate ? (
+        <button
+          type="button"
+          aria-label={t('Show annotation source')}
+          className="block w-full rounded-lg p-2 text-left transition-colors hover:bg-muted/70 focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50"
+          onClick={() => onActivate(card.id)}
+        >
+          {content}
+        </button>
+      ) : (
+        <div className="p-2">{content}</div>
+      )}
     </article>
   )
 }

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx
@@ -6,7 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { installCssHighlightsMock, type TestHighlightRegistry } from '@/test-utils/css-highlights'
 import type { TextAnnotation } from '../../../../../shared/annotations'
 import { WorkspaceToolCodeBlock } from '../WorkspaceToolCodeBlock'
-import { requestAnnotationReveal } from './annotation-reveal'
+import { requestAnnotationReveal, subscribeAnnotationReveal } from './annotation-reveal'
 import { TextAnnotationSurface } from './TextAnnotationSurface'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -17,6 +17,7 @@ const annotation = (id: string, quote: string): TextAnnotation => ({
   kind: 'text',
   target: 'agent',
   quote,
+  anchor: { position: { start: 0, end: quote.length }, suffix: ' then repeat' },
   source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }
 })
 
@@ -33,6 +34,7 @@ describe('TextAnnotationSurface highlight restoration', () => {
 
   afterEach(async () => {
     await act(async () => root.unmount())
+    subscribeAnnotationReveal(() => true)()
     vi.unstubAllGlobals()
     container.remove()
   })
@@ -56,8 +58,53 @@ describe('TextAnnotationSurface highlight restoration', () => {
     )
   }
 
+  it('retries a sent quote after its surface and asynchronous content mount', async () => {
+    const saved = annotation('late-quote', 'unique evidence')
+    await act(async () => requestAnnotationReveal(saved))
+    await renderSurface([], 'message-1', 'Loading content')
+    expect(container.textContent).toContain('The exact annotation location could not be found.')
+    expect(Array.from(highlights.get('agent-annotation-reveal') ?? [])).toHaveLength(0)
+    Element.prototype.scrollIntoView = vi.fn()
+    await renderSurface([], 'message-1', 'The unique evidence remains.')
+    expect(
+      Array.from(highlights.get('agent-annotation-reveal') ?? []).map((range) => range.toString())
+    ).toEqual([saved.quote])
+    expect(container.querySelector('[data-text-annotation-edit]')).toBeNull()
+    expect(container.textContent).not.toContain('The exact annotation location could not be found.')
+  })
+
+  it('does not guess an ambiguous historical quote or claim a different message source', async () => {
+    await renderSurface([])
+    await act(async () =>
+      requestAnnotationReveal({ ...annotation('legacy-quote', 'repeat'), anchor: undefined })
+    )
+    expect(container.textContent).toContain('The exact annotation location could not be found.')
+    expect(Array.from(highlights.get('agent-annotation-reveal') ?? [])).toHaveLength(0)
+    await renderSurface([], 'message-2', 'repeat')
+    expect(Array.from(highlights.get('agent-annotation-reveal') ?? [])).toHaveLength(0)
+    expect(container.textContent).not.toContain('The exact annotation location could not be found.')
+  })
+
+  it.each([true, false])('reveals a sent message quote with draft present=%s', async (inDraft) => {
+    const saved = annotation('history-quote', 'unique evidence')
+    await renderSurface(inDraft ? [saved] : [], 'message-1', 'The unique evidence remains.')
+    const scroll = vi.fn()
+    container.querySelector('p')!.scrollIntoView = scroll
+    await act(async () => requestAnnotationReveal(saved))
+    expect(
+      Array.from(highlights.get('agent-annotation-reveal') ?? []).map((range) => range.toString())
+    ).toContain(saved.quote)
+    expect(scroll).toHaveBeenCalled()
+  })
+
   it('rebuilds duplicate quote ranges deterministically after a virtualized remount', async () => {
-    const active = [annotation('first', 'repeat'), annotation('second', 'repeat')]
+    const active = [
+      annotation('first', 'repeat'),
+      {
+        ...annotation('second', 'repeat'),
+        anchor: { position: { start: 12, end: 18 }, prefix: 'repeat then ' }
+      }
+    ]
     await renderSurface(active)
 
     const firstMountRanges = Array.from(highlights.get('agent-annotation-draft') ?? [])
@@ -292,6 +339,7 @@ describe('TextAnnotationSurface note editor highlight', () => {
 
   afterEach(async () => {
     await act(async () => root.unmount())
+    subscribeAnnotationReveal(() => true)()
     vi.unstubAllGlobals()
     container.remove()
     window.getSelection()?.removeAllRanges()
@@ -562,6 +610,7 @@ describe('TextAnnotationSurface annotate trigger', () => {
 
   afterEach(async () => {
     await act(async () => root.unmount())
+    subscribeAnnotationReveal(() => true)()
     container.remove()
     window.getSelection()?.removeAllRanges()
   })

--- a/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.tsx
+++ b/src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.tsx
@@ -9,13 +9,19 @@ import type {
 } from '../../../../../shared/annotations'
 import { isBackwardSelection } from './annotation-trigger-anchor'
 import { createAnnotationId } from './annotation-id'
-import { revealTextAnnotationRange, subscribeAnnotationReveal } from './annotation-reveal'
+import {
+  revealTextAnnotationRange,
+  subscribeAnnotationReveal,
+  subscribeAnnotationRevealPreparation,
+  retryPendingAnnotationReveal
+} from './annotation-reveal'
 import {
   AnnotationDraftEditor,
   AnnotationMarkers,
   type AnnotationControl
 } from './TextAnnotationEditors'
 import {
+  textAnnotationAnchorForRange,
   quoteOccurrenceForRange,
   reconcileTextAnnotationRanges,
   retargetTextAnnotationRange
@@ -84,6 +90,7 @@ const TextAnnotationSurface = ({
   const selectionRef = useRef(selection)
   const [open, setOpen] = useState(false)
   const [note, setNote] = useState('')
+  const [revealUnavailable, setRevealUnavailable] = useState(false)
   const [annotationControls, setAnnotationControls] = useState<readonly AnnotationControl[]>([])
   const [hoveredAnnotationId, setHoveredAnnotationId] = useState<string>()
   const matchingAnnotations = useMemo(
@@ -189,19 +196,41 @@ const TextAnnotationSurface = ({
     return () => document.removeEventListener('pointerdown', onPointerDown, true)
   }, [clearDraft])
 
-  useEffect(
-    () =>
-      // The composer card reveals a quote by id; only the surface owning that
-      // annotation's range answers.
-      subscribeAnnotationReveal((annotationId) => {
-        if (!ownedHighlightIds.current.has(annotationId)) return false
-        const range = draftHighlightRanges.get(annotationId)
-        if (!range) return false
-        revealTextAnnotationRange(range)
-        return true
-      }),
-    []
-  )
+  useLayoutEffect(() => {
+    let prepared: TextAnnotation | undefined
+    const stopPreparation = subscribeAnnotationRevealPreparation((annotation) => {
+      prepared =
+        annotation.kind === 'text' && sourcesMatch(annotation.source, source)
+          ? annotation
+          : undefined
+      setRevealUnavailable(false)
+    })
+    const stopReveal = subscribeAnnotationReveal((id) => {
+      const annotation =
+        matchingAnnotations.find((entry) => entry.id === id) ??
+        (prepared?.id === id ? prepared : undefined)
+      const content = contentRef.current
+      if (!annotation || !content) return false
+      const range = reconcileTextAnnotationRanges(
+        content,
+        [annotation],
+        new Map(
+          Array.from(ownedHighlightIds.current).flatMap((id) => {
+            const range = draftHighlightRanges.get(id)
+            return range ? [[id, range] as const] : []
+          })
+        )
+      ).get(id)
+      setRevealUnavailable(!range)
+      if (!range) return false
+      revealTextAnnotationRange(range)
+      return true
+    })
+    return () => {
+      stopPreparation()
+      stopReveal()
+    }
+  }, [matchingAnnotations, source])
 
   const reconcileAnnotationHighlights = useCallback((): void => {
     const existing = new Map<string, Range>()
@@ -225,6 +254,7 @@ const TextAnnotationSurface = ({
       return
     }
     measureAnnotationControls()
+    retryPendingAnnotationReveal()
   }, [matchingAnnotations, measureAnnotationControls])
 
   useLayoutEffect(() => {
@@ -327,6 +357,7 @@ const TextAnnotationSurface = ({
       kind: 'text',
       target: 'agent',
       quote: selection.quote,
+      anchor: textAnnotationAnchorForRange(contentRef.current!, selection.range),
       ...(note.trim() ? { note: note.trim() } : {}),
       source
     }
@@ -365,6 +396,11 @@ const TextAnnotationSurface = ({
       <div ref={contentRef} className="contents">
         {children}
       </div>
+      {revealUnavailable ? (
+        <p role="status" className="text-xs text-muted-foreground">
+          {t('The exact annotation location could not be found.')}
+        </p>
+      ) : null}
       <AnnotationMarkers
         controls={annotationControls}
         hoveredAnnotationId={hoveredAnnotationId}

--- a/src/renderer/src/pages/workspace/annotations/annotation-reveal.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-reveal.test.ts
@@ -13,6 +13,8 @@ import {
   usePreviewWorkbenchStore,
   type PreviewFileItem
 } from '@/stores/preview-workbench-store'
+import { validateAnnotations, type PdfAnnotation } from '../../../../../shared/annotations'
+import { createLiteratureAttachmentVersionReference } from '../../../../../shared/literature'
 import type { Annotation } from '../../../../../shared/annotations'
 import { createUploadVersionReference } from '../../../../../shared/uploads'
 import { createManagedPreviewRequest } from '../previews/preview-file-reader'
@@ -57,6 +59,72 @@ describe('annotation reveal', () => {
     quote: 'quoted evidence',
     source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }
   })
+
+  it.each([false, true])(
+    'reveals a literature PDF with source tab already open=%s',
+    (alreadyOpen) => {
+      const annotation: PdfAnnotation = {
+        id: 'literature-quote',
+        kind: 'pdf',
+        target: 'agent',
+        source: {
+          kind: 'literature-attachment-version',
+          projectId: 'project-1',
+          versionId: 'literature-version-1',
+          name: 'paper.pdf',
+          checksum: 'a'.repeat(64),
+          path: createLiteratureAttachmentVersionReference('literature-version-1')
+        },
+        selector: {
+          kind: 'text',
+          pageNumber: 2,
+          exact: 'quoted evidence',
+          position: { start: 0, end: 15 },
+          quads: [{ x: 0.1, y: 0.1, width: 0.4, height: 0.03 }],
+          extractorVersion: 'pdfjs-5.4.624'
+        }
+      }
+      expect(validateAnnotations([annotation])).toBeUndefined()
+      if (alreadyOpen)
+        usePreviewWorkbenchStore.getState().upsertItem({
+          id: 'existing-literature',
+          type: 'file',
+          projectId: 'project-1',
+          sessionId: 'literature',
+          title: 'paper.pdf',
+          name: 'paper.pdf',
+          path: annotation.source.path,
+          source: 'literature',
+          format: 'pdf',
+          mimeType: 'application/pdf'
+        })
+      // Consume any prior pending request before attaching this case's observers.
+      subscribeAnnotationReveal(() => true)()
+      const prepare = vi.fn()
+      const reveal = vi.fn(() => true)
+      const offPrepare = subscribeAnnotationRevealPreparation(prepare)
+      const offReveal = subscribeAnnotationReveal(reveal)
+      try {
+        const before = usePreviewWorkbenchStore.getState().items
+        requestAnnotationReveal({
+          ...annotation,
+          source: { ...annotation.source, versionId: 'forged-version' }
+        })
+        expect(usePreviewWorkbenchStore.getState().items).toEqual(before)
+        expect(prepare).not.toHaveBeenCalled()
+        expect(reveal).not.toHaveBeenCalled()
+        requestAnnotationReveal(annotation)
+        expect.soft(usePreviewWorkbenchStore.getState().items).toHaveLength(1)
+        expect.soft(prepare).toHaveBeenCalledWith(annotation)
+        expect.soft(reveal).toHaveBeenCalledWith(annotation.id)
+        if (alreadyOpen)
+          expect(usePreviewWorkbenchStore.getState().items[0]?.id).toBe('existing-literature')
+      } finally {
+        offPrepare()
+        offReveal()
+      }
+    }
+  )
 
   it('scrolls to the range and flashes a stronger highlight', () => {
     revealTextAnnotationRange(textRange())

--- a/src/renderer/src/pages/workspace/annotations/annotation-reveal.ts
+++ b/src/renderer/src/pages/workspace/annotations/annotation-reveal.ts
@@ -37,7 +37,7 @@ const fileAnnotationSource = (
 
 const publishAnnotationReveal = (annotation: Annotation): void => {
   pendingRevealId = annotation.id
-  pendingRevealAnnotation = annotation.kind === 'pdf' ? annotation : undefined
+  pendingRevealAnnotation = annotation
   document.dispatchEvent(new CustomEvent(REVEAL_PREPARE_EVENT, { detail: annotation }))
   document.dispatchEvent(new CustomEvent(REVEAL_EVENT, { detail: annotation.id }))
 }
@@ -78,6 +78,11 @@ const managedAnnotationIdentity = (
 ): ManagedProjectFileAnnotationIdentity | null | undefined => {
   if (source.kind === 'project-file') {
     return resolveManagedProjectFileAnnotationIdentity(source)
+  }
+  if (source.kind === 'literature-attachment-version') {
+    return parseLiteratureAttachmentVersionReference(source.path) === source.versionId
+      ? undefined
+      : null
   }
   if (source.kind === 'artifact-version') {
     const artifact = parseArtifactVersionLocator(source.path)

--- a/src/renderer/src/pages/workspace/annotations/image-annotation-payload.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/image-annotation-payload.test.ts
@@ -111,7 +111,11 @@ describe('image annotation Agent payload projection', () => {
               y: 799,
               instruction: 'note for point-1'
             },
-            { type: 'quote', content: 'Compare this sentence.' },
+            {
+              type: 'quote',
+              content: 'Compare this sentence.',
+              source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }
+            },
             {
               type: 'image-point',
               source: {

--- a/src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts
+++ b/src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts
@@ -60,7 +60,7 @@ describe('text annotation range reconciliation', () => {
     surface.remove()
   })
 
-  it('drops deleted IDs and uses deterministic quote order only after a real remount', () => {
+  it('drops deleted IDs and leaves ambiguous legacy quotes unresolved after a real remount', () => {
     const first = surfaceWithDuplicates()
     const exactFirst = rangeAt(first.text, 0)
     const exactSecond = rangeAt(first.text, 12)
@@ -87,7 +87,7 @@ describe('text annotation range reconciliation', () => {
       ],
       existing
     )
-    expect(Array.from(fallback.values()).map((range) => range.startOffset)).toEqual([0, 12])
+    expect(fallback.size).toBe(0)
     remounted.surface.remove()
   })
 
@@ -98,13 +98,19 @@ describe('text annotation range reconciliation', () => {
 
     const result = reconcileTextAnnotationRanges(
       surface,
-      [{ id: 'point', quote: 'repeat' }],
+      [
+        {
+          id: 'point',
+          quote: 'repeat',
+          anchor: { position: { start: 12, end: 18 }, prefix: 'repeat then ' }
+        }
+      ],
       new Map([['point', stale]])
     )
 
     expect(result.get('point')).not.toBe(stale)
     expect(result.get('point')?.toString()).toBe('repeat')
-    expect(result.get('point')?.startOffset).toBe(7)
+    expect(result.get('point')?.startOffset).toBe(19)
     surface.remove()
   })
 

--- a/src/renderer/src/pages/workspace/annotations/text-annotation-range.ts
+++ b/src/renderer/src/pages/workspace/annotations/text-annotation-range.ts
@@ -1,4 +1,4 @@
-import type { PdfTextSelector } from '../../../../../shared/annotations'
+import type { PdfTextSelector, TextAnnotationAnchor } from '../../../../../shared/annotations'
 
 const collectSurfaceTextNodes = (surface: HTMLElement): Text[] => {
   const walker = document.createTreeWalker(surface, NodeFilter.SHOW_TEXT)
@@ -85,12 +85,63 @@ const quoteOccurrenceForRange = (surface: HTMLElement, quote: string, range: Ran
   }
 }
 
-type TextAnnotationRangeTarget = Readonly<{ id: string; quote: string }>
+type TextAnnotationRangeTarget = Readonly<{
+  id: string
+  quote: string
+  anchor?: TextAnnotationAnchor
+}>
 
 const rangeBelongsToSurface = (range: Range, surface: HTMLElement): boolean => {
   const ancestor = range.commonAncestorContainer
   const contained = ancestor.nodeType === Node.TEXT_NODE ? ancestor.parentNode : ancestor
   return contained !== null && surface.contains(contained)
+}
+
+const textAnnotationAnchorForRange = (
+  surface: HTMLElement,
+  range: Range
+): TextAnnotationAnchor | undefined => {
+  const nodes = collectSurfaceTextNodes(surface)
+  const text = concatenatedText(nodes)
+  const rawStart = rangeStartInSurfaceText(nodes, range)
+  const rawQuote = range.toString()
+  const quote = rawQuote.trim()
+  if (rawStart === undefined || !quote) return undefined
+  const start = rawStart + rawQuote.indexOf(quote)
+  const end = start + quote.length
+  if (text.slice(start, end) !== quote) return undefined
+  const prefix = text.slice(Math.max(0, start - PDF_TEXT_CONTEXT_LENGTH), start)
+  const suffix = text.slice(end, end + PDF_TEXT_CONTEXT_LENGTH)
+  return { position: { start, end }, ...(prefix ? { prefix } : {}), ...(suffix ? { suffix } : {}) }
+}
+
+const resolveTextAnnotationRange = (
+  surface: HTMLElement,
+  annotation: TextAnnotationRangeTarget
+): Range | undefined => {
+  const text = concatenatedText(collectSurfaceTextNodes(surface))
+  const { quote, anchor } = annotation
+  if (!quote) return undefined
+  const matches: { start: number; occurrence: number }[] = []
+  for (
+    let start = text.indexOf(quote);
+    start >= 0;
+    start = text.indexOf(quote, start + quote.length)
+  ) {
+    matches.push({ start, occurrence: matches.length })
+  }
+  const contextual = anchor
+    ? matches.filter(
+        ({ start }) =>
+          (anchor.prefix === undefined || text.slice(0, start).endsWith(anchor.prefix)) &&
+          (anchor.suffix === undefined ||
+            text.slice(start + quote.length).startsWith(anchor.suffix))
+      )
+    : []
+  const match =
+    (anchor && contextual.find(({ start }) => start === anchor.position.start)) ||
+    (contextual.length === 1 ? contextual[0] : matches.length === 1 ? matches[0] : undefined)
+  return match ? rangeForTextOccurrence(surface, quote, match.occurrence) : undefined
 }
 
 const reconcileTextAnnotationRanges = (
@@ -99,15 +150,12 @@ const reconcileTextAnnotationRanges = (
   existing: ReadonlyMap<string, Range>
 ): Map<string, Range> => {
   const next = new Map<string, Range>()
-  const occurrenceByQuote = new Map<string, number>()
   for (const annotation of annotations) {
-    const occurrence = occurrenceByQuote.get(annotation.quote) ?? 0
-    occurrenceByQuote.set(annotation.quote, occurrence + 1)
     const exact = existing.get(annotation.id)
     const range =
       exact && rangeBelongsToSurface(exact, surface) && exact.toString() === annotation.quote
         ? exact
-        : rangeForTextOccurrence(surface, annotation.quote, occurrence)
+        : resolveTextAnnotationRange(surface, annotation)
     if (range) next.set(annotation.id, range)
   }
   return next
@@ -220,6 +268,7 @@ const pdfTextSelectorForRange = (
 
 export {
   pdfTextSelectorForRange,
+  textAnnotationAnchorForRange,
   quoteOccurrenceForRange,
   rangeForTextOccurrence,
   reconcileTextAnnotationRanges,

--- a/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.test.tsx
@@ -12,7 +12,10 @@ import type {
 import { createArtifactVersionLocator } from '../../../../../shared/artifact-provenance'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 
-import { requestAnnotationReveal } from '../annotations/annotation-reveal'
+import {
+  requestAnnotationReveal,
+  subscribeAnnotationReveal
+} from '../annotations/annotation-reveal'
 import { HighlightedCodeLines } from '../HighlightedCodeLines'
 import { PreviewTextAnnotationSurface } from './PreviewTextAnnotationSurface'
 
@@ -109,6 +112,7 @@ describe('PreviewTextAnnotationSurface', () => {
 
   afterEach(async () => {
     await act(async () => root.unmount())
+    subscribeAnnotationReveal(() => true)()
     container.remove()
     window.getSelection()?.removeAllRanges()
     Reflect.deleteProperty(navigator, 'clipboard')
@@ -207,6 +211,43 @@ describe('PreviewTextAnnotationSurface', () => {
     )
     await act(async () => actions.at(-1)?.click())
   }
+
+  it('restores the selected second occurrence after creation and a serialized remount', async () => {
+    const onAddAnnotation = vi.fn<(annotation: Annotation) => undefined>(() => undefined)
+    await renderSurface({ onAddAnnotation, content: 'repeat then repeat' })
+    await selectRange(12, 18)
+    await confirmAnnotation()
+    expect(onAddAnnotation).toHaveBeenCalledTimes(1)
+    const saved: Annotation = JSON.parse(JSON.stringify(onAddAnnotation.mock.calls[0][0]))
+    expect(saved.kind === 'text' && saved.quote).toBe('repeat')
+    expect(Array.from(registeredRanges).map((range) => range.startOffset)).toContain(12)
+    await act(async () => root.unmount())
+    expect(registeredRanges.size).toBe(0)
+    root = createRoot(container)
+    await renderSurface({ activeAnnotations: [saved], content: 'repeat then repeat' })
+    expect(Array.from(registeredRanges).map((range) => range.startOffset)).toEqual([12])
+  })
+
+  it('reveals a sent file quote after the requested preview mounts', async () => {
+    const saved = annotation()
+    await act(async () => requestAnnotationReveal(saved))
+    Element.prototype.scrollIntoView = vi.fn()
+    await renderSurface()
+    expect(Array.from(registeredRanges).map((range) => range.toString())).toContain(saved.quote)
+    expect(container.querySelector('[data-text-annotation-edit]')).toBeNull()
+  })
+
+  it.each([true, false])('reveals a file quote with draft present=%s', async (inDraft) => {
+    const saved = annotation()
+    await renderSurface({ activeAnnotations: inDraft ? [saved] : [] })
+    const scroll = vi.fn()
+    container.querySelector('p')!.scrollIntoView = scroll
+    await act(async () => requestAnnotationReveal(saved))
+    expect(scroll).toHaveBeenCalled()
+    expect(Array.from(registeredRanges).some((range) => range.toString() === saved.quote)).toBe(
+      true
+    )
+  })
 
   it('creates a versioned project-file annotation only after confirmation', async () => {
     const onAddAnnotation = vi.fn<(annotation: Annotation) => undefined>(() => undefined)
@@ -711,7 +752,7 @@ describe('PreviewTextAnnotationSurface', () => {
     Reflect.deleteProperty(Range.prototype, 'getClientRects')
   })
 
-  it('preserves exact duplicate ranges until deletion and falls back only after reopening', async () => {
+  it('preserves exact duplicate ranges after deletion and reopening', async () => {
     const onAddAnnotation = vi.fn<(annotation: Annotation) => undefined>(() => undefined)
     const content = 'repeat then repeat'
     await renderSurface({ onAddAnnotation, content })
@@ -733,11 +774,17 @@ describe('PreviewTextAnnotationSurface', () => {
 
     await act(async () => root.render(<div>Preview closed</div>))
     await renderSurface({ activeAnnotations: [second], onAddAnnotation, content })
-    expect(Array.from(registeredRanges).map((range) => range.startOffset)).toEqual([0])
+    expect(Array.from(registeredRanges).map((range) => range.startOffset)).toEqual([12])
   })
 
   it('reprojects a Preview quote after content mutation and removes stale color when it disappears', async () => {
-    const active = [annotation({ id: 'content-update', quote: 'repeat' })]
+    const active = [
+      annotation({
+        id: 'content-update',
+        quote: 'repeat',
+        anchor: { position: { start: 0, end: 6 }, suffix: ' then repeat' }
+      })
+    ]
     await renderSurface({ activeAnnotations: active, content: 'repeat then repeat' })
     expect(Array.from(registeredRanges)[0]?.startOffset).toBe(0)
 

--- a/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.tsx
@@ -14,7 +14,9 @@ import { parseUploadVersionReference } from '../../../../../shared/uploads'
 import type { PreviewFileRendererProps } from './preview-types'
 import {
   revealTextAnnotationRange,
-  subscribeAnnotationReveal
+  subscribeAnnotationReveal,
+  subscribeAnnotationRevealPreparation,
+  retryPendingAnnotationReveal
 } from '../annotations/annotation-reveal'
 import { isBackwardSelection } from '../annotations/annotation-trigger-anchor'
 import { createAnnotationId } from '../annotations/annotation-id'
@@ -26,6 +28,7 @@ import {
 import type { AnnotationTriggerAction } from '../annotations/AnnotationTrigger'
 import {
   pdfTextSelectorForRange,
+  textAnnotationAnchorForRange,
   quoteOccurrenceForRange,
   reconcileTextAnnotationRanges,
   retargetTextAnnotationRange
@@ -274,6 +277,7 @@ export const PreviewTextAnnotationSurface = ({
   const selectionRef = useRef(selection)
   const [open, setOpen] = useState(false)
   const [note, setNote] = useState('')
+  const [revealUnavailable, setRevealUnavailable] = useState(false)
   const [copied, setCopied] = useState(false)
   const [annotationControls, setAnnotationControls] = useState<readonly AnnotationControl[]>([])
   const [hoveredAnnotationId, setHoveredAnnotationId] = useState<string>()
@@ -368,14 +372,12 @@ export const PreviewTextAnnotationSurface = ({
     }
     ownedRanges.current = reconcileTextAnnotationRanges(
       content,
-      matchingAnnotations.map((annotation) => ({
-        id: annotation.id,
-        quote: annotation.quote
-      })),
+      matchingAnnotations,
       ownedRanges.current
     )
     for (const range of ownedRanges.current.values()) highlight.add(range)
     measureAnnotationControls()
+    retryPendingAnnotationReveal()
   }, [matchingAnnotations, measureAnnotationControls])
 
   useLayoutEffect(() => {
@@ -528,18 +530,36 @@ export const PreviewTextAnnotationSurface = ({
     return () => document.removeEventListener('pointerdown', onPointerDown, true)
   }, [clearDraft])
 
-  useEffect(
-    () =>
-      // The composer card reveals a quote by id; only the surface owning that
-      // annotation's range answers.
-      subscribeAnnotationReveal((annotationId) => {
-        const range = ownedRanges.current.get(annotationId)
-        if (!range) return false
-        revealTextAnnotationRange(range)
-        return true
-      }),
-    []
-  )
+  useLayoutEffect(() => {
+    let prepared: TextAnnotation | undefined
+    const stopPreparation = subscribeAnnotationRevealPreparation((annotation) => {
+      prepared =
+        annotation.kind === 'text' &&
+        belongsToPreview(annotation, item, sourcePageNumber, annotationVersionId)
+          ? annotation
+          : undefined
+      setRevealUnavailable(false)
+    })
+    const stopReveal = subscribeAnnotationReveal((id) => {
+      if (annotationVersionPending) return false
+      const annotation =
+        matchingAnnotations.find((entry) => entry.id === id) ??
+        (prepared?.id === id ? prepared : undefined)
+      const content = contentRef.current
+      if (!annotation || !content) return false
+      const range = reconcileTextAnnotationRanges(content, [annotation], ownedRanges.current).get(
+        id
+      )
+      setRevealUnavailable(!range)
+      if (!range) return false
+      revealTextAnnotationRange(range)
+      return true
+    })
+    return () => {
+      stopPreparation()
+      stopReveal()
+    }
+  }, [matchingAnnotations, item, sourcePageNumber, annotationVersionId, annotationVersionPending])
 
   const add = (noteValue = note): void => {
     if (
@@ -575,6 +595,7 @@ export const PreviewTextAnnotationSurface = ({
           kind: 'text',
           target: 'agent',
           quote: selection.quote,
+          anchor: textAnnotationAnchorForRange(contentRef.current!, selection.range),
           ...(noteValue.trim() ? { note: noteValue.trim() } : {}),
           source: source!
         }
@@ -681,6 +702,11 @@ export const PreviewTextAnnotationSurface = ({
       <div ref={contentRef} className="contents">
         {children}
       </div>
+      {revealUnavailable ? (
+        <p role="status" className="text-xs text-muted-foreground">
+          {t('The exact annotation location could not be found.')}
+        </p>
+      ) : null}
       <AnnotationMarkers
         controls={annotationControls}
         hoveredAnnotationId={hoveredAnnotationId}

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -971,7 +971,7 @@ describe('workspace conversation controller', () => {
     await vi.waitFor(() =>
       expect(input.sideChat?.start).toHaveBeenCalledWith(
         'Compare these observations.\n\n[Annotations]\n' +
-          '{"items":[{"type":"quote","content":"The confidence intervals overlap.","instruction":"Explain this caveat."}]}'
+          '{"items":[{"type":"quote","content":"The confidence intervals overlap.","source":{"kind":"agent-message","sessionId":"session-a","messageId":"agent-message-a"},"instruction":"Explain this caveat."}]}'
       )
     )
 
@@ -998,7 +998,7 @@ describe('workspace conversation controller', () => {
     await vi.waitFor(() =>
       expect(input.sideChat?.start).toHaveBeenCalledWith(
         '[Annotations]\n' +
-          '{"items":[{"type":"quote","content":"The confidence intervals overlap.","instruction":"Explain this caveat."}]}'
+          '{"items":[{"type":"quote","content":"The confidence intervals overlap.","source":{"kind":"agent-message","sessionId":"session-a","messageId":"agent-message-a"},"instruction":"Explain this caveat."}]}'
       )
     )
     expect(input.composer.lifecycle.clearDraft).toHaveBeenCalledWith('session-a', 3)

--- a/src/shared/annotations.test.ts
+++ b/src/shared/annotations.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest'
 import {
   ANNOTATION_LIMITS,
   annotationPayloadText,
+  annotationRequiresImageInput,
   imageAnnotationSourceIsFixed,
   pdfAnnotationSourceIsFixed,
   parseSideChatAnnotationText,
@@ -86,7 +87,150 @@ const pdfRegionAnnotation = (): PdfAnnotation => ({
   }
 })
 
+describe('ordinary text source identity in Agent input', () => {
+  it.each(['file', 'message'] as const)(
+    'distinguishes identical quotes from different %s sources',
+    (kind) => {
+      const from = (label: string): TextAnnotation =>
+        textAnnotation({
+          quote: 'The value is 42.',
+          note: 'Correct the referenced source.',
+          source:
+            kind === 'file'
+              ? {
+                  kind: 'project-file',
+                  projectId: 'project-1',
+                  sessionId: 'session-1',
+                  name: `file-${label}.md`,
+                  versionId: `version-${label}`,
+                  path: `artifact-version:project-1/session-1/file-${label}/version-${label}`
+                }
+              : { kind: 'agent-message', sessionId: 'session-1', messageId: `message-${label}` }
+        })
+      const a = from('A')
+      const b = from('B')
+      expect(validateAnnotations([a])).toBeUndefined()
+      expect(validateAnnotations([b])).toBeUndefined()
+      const promptA = prepareAnnotationsForAgent('', [a])
+      const promptB = prepareAnnotationsForAgent('', [b])
+      expect(promptA.promptText).toContain(a.quote)
+      expect(promptB.promptText).toContain(b.quote)
+      expect(promptB).not.toEqual(promptA)
+    }
+  )
+})
+
 describe('annotations', () => {
+  it('restores bounded historical annotations even when new source metadata exceeds the send budget', () => {
+    const historical = Array.from({ length: 10 }, (_, index) =>
+      textAnnotation({
+        id: `history-${index}`,
+        quote: 'x'.repeat(940)
+      })
+    )
+    expect(validateAnnotations(historical)).toBe('payload-too-large')
+    expect(sanitizeAnnotations(historical)).toEqual(historical)
+  })
+
+  it('round-trips text anchors and rejects malformed anchor positions', () => {
+    const selected = textAnnotation({
+      quote: 'repeat',
+      anchor: {
+        position: { start: 12, end: 18 },
+        prefix: 'repeat then '
+      }
+    })
+    expect(sanitizeAnnotations(JSON.parse(JSON.stringify([selected])))).toEqual([selected])
+    expect(
+      sanitizeAnnotations([{ ...selected, anchor: { position: { start: 12, end: 17 } } }])
+    ).toEqual([])
+    expect(
+      sanitizeAnnotations([{ ...selected, anchor: { position: { start: -1, end: 5 } } }])
+    ).toEqual([])
+  })
+
+  it('prepares omitted PDF bitmaps explicitly and numbers only actual image attachments', () => {
+    const region = pdfRegionAnnotation()
+    const omitted: PdfAnnotation = {
+      ...region,
+      id: 'omitted',
+      selector: {
+        kind: 'region',
+        pageNumber: 6,
+        rect: { x: 0.2, y: 0.3, width: 0.4, height: 0.25 },
+        pageRotation: 0,
+        text: 'Figure 2.',
+        imageOmissionReason: 'session-budget'
+      }
+    }
+    expect(sanitizeAnnotations(JSON.parse(JSON.stringify([omitted])))).toEqual([omitted])
+    expect(annotationRequiresImageInput(omitted)).toBe(false)
+    const prepared = prepareAnnotationsForAgent('', [omitted, region])
+    expect(prepared.images).toEqual([{ mimeType: 'image/png', data: 'AQID', byteLength: 3 }])
+    const payload = JSON.parse(prepared.promptText.slice('[Annotations]\n'.length))
+    expect(payload.items[0]).toMatchObject({
+      type: 'pdf-region',
+      imageOmissionReason: 'session-budget',
+      source: { versionId: region.source.versionId, page: 6 }
+    })
+    expect(payload.items[0]).not.toHaveProperty('image')
+    expect(payload.items[1]).toMatchObject({ image: 1 })
+    expect(payload.items[1]).not.toHaveProperty('imageOmissionReason')
+    expect(
+      sanitizeAnnotations([
+        { ...omitted, selector: { ...omitted.selector, imageOmissionReason: 'unknown' } }
+      ])
+    ).toEqual([])
+    expect(
+      sanitizeAnnotations([
+        { ...omitted, selector: { ...omitted.selector, imageOmissionReason: undefined } }
+      ])
+    ).toEqual([])
+    expect(
+      sanitizeAnnotations([
+        { ...region, selector: { ...region.selector, imageOmissionReason: 'session-budget' } }
+      ])
+    ).toEqual([])
+  })
+
+  it('includes deduplicated immutable file references for ordinary text quotes', () => {
+    const annotation = textAnnotation({
+      source: {
+        kind: 'project-file',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        name: 'results.md',
+        versionId: 'version-1',
+        path: 'artifact-version:project-1/session-1/artifact-1/version-1'
+      }
+    })
+    const prepared = prepareAnnotationsForAgent('', [annotation, { ...annotation, id: 'another' }])
+    expect(prepared.referencedArtifacts).toEqual([
+      {
+        id: 'artifact-1',
+        sourceFileId: 'artifact-1',
+        name: 'results.md',
+        source: 'artifact',
+        versionId: 'version-1',
+        path: 'artifact-version:project-1/session-1/artifact-1/version-1'
+      }
+    ])
+    expect(
+      prepareAnnotationsForAgent('', [annotation], prepared.referencedArtifacts).referencedArtifacts
+    ).toEqual(prepared.referencedArtifacts)
+  })
+
+  it('still parses historical Side chat quotes without source metadata', () => {
+    expect(
+      parseSideChatAnnotationText(
+        '[Annotations]\n{"items":[{"type":"quote","content":"Evidence"}]}'
+      )
+    ).toEqual({
+      text: '',
+      items: [{ type: 'quote', content: 'Evidence' }]
+    })
+  })
+
   it('projects mixed annotations into canonical Side chat text without an image attachment', () => {
     const annotations: Annotation[] = [
       textAnnotation({ note: 'Explain this caveat.' }),
@@ -94,7 +238,7 @@ describe('annotations', () => {
     ]
     const expected =
       'Compare these observations.\n\n[Annotations]\n' +
-      '{"items":[{"type":"quote","content":"The confidence intervals overlap.","instruction":"Explain this caveat."},{"type":"image-point","source":{"kind":"artifact-version","artifactId":"artifact-1","versionId":"version-1","name":"figure.png"},"x":500,"y":200,"instruction":"Inspect the peak."}]}'
+      '{"items":[{"type":"quote","content":"The confidence intervals overlap.","source":{"kind":"agent-message","sessionId":"session-1","messageId":"message-1"},"instruction":"Explain this caveat."},{"type":"image-point","source":{"kind":"artifact-version","artifactId":"artifact-1","versionId":"version-1","name":"figure.png"},"x":500,"y":200,"instruction":"Inspect the peak."}]}'
 
     expect(sideChatAnnotationText('  Compare these observations.  ', annotations)).toBe(expected)
     expect(expected).not.toContain('imageAttachment')
@@ -104,6 +248,7 @@ describe('annotations', () => {
         {
           type: 'quote',
           content: 'The confidence intervals overlap.',
+          source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' },
           instruction: 'Explain this caveat.'
         },
         {
@@ -126,11 +271,17 @@ describe('annotations', () => {
     const projected = sideChatAnnotationText('', [textAnnotation()])
 
     expect(projected).toBe(
-      '[Annotations]\n{"items":[{"type":"quote","content":"The confidence intervals overlap."}]}'
+      '[Annotations]\n{"items":[{"type":"quote","content":"The confidence intervals overlap.","source":{"kind":"agent-message","sessionId":"session-1","messageId":"message-1"}}]}'
     )
     expect(parseSideChatAnnotationText(projected)).toEqual({
       text: '',
-      items: [{ type: 'quote', content: 'The confidence intervals overlap.' }]
+      items: [
+        {
+          type: 'quote',
+          content: 'The confidence intervals overlap.',
+          source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }
+        }
+      ]
     })
   })
 
@@ -164,7 +315,13 @@ describe('annotations', () => {
 
     expect(parseSideChatAnnotationText(projected)).toEqual({
       text: 'Explain the literal marker [Annotations]\n here.',
-      items: [{ type: 'quote', content: 'The confidence intervals overlap.' }]
+      items: [
+        {
+          type: 'quote',
+          content: 'The confidence intervals overlap.',
+          source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' }
+        }
+      ]
     })
   })
 
@@ -176,6 +333,7 @@ describe('annotations', () => {
             {
               type: 'quote',
               content: 'The confidence intervals overlap.',
+              source: { kind: 'agent-message', sessionId: 'session-1', messageId: 'message-1' },
               instruction: 'Explain this caveat.'
             }
           ]
@@ -350,7 +508,14 @@ describe('annotations', () => {
           items: [
             {
               type: 'quote',
-              content: 'The confidence intervals overlap.'
+              content: 'The confidence intervals overlap.',
+              source: {
+                kind: 'session-item',
+                sessionId: 'session-1',
+                itemId: 'activity-1',
+                itemType: 'tool-activity',
+                sectionId: 'output'
+              }
             }
           ]
         })

--- a/src/shared/annotations.ts
+++ b/src/shared/annotations.ts
@@ -5,9 +5,9 @@ import {
   sanitizeAcpMessageImage,
   type AcpMessageImage
 } from './acp'
-import { parseArtifactVersionLocator } from './artifact-provenance'
+import { createArtifactVersionLocator, parseArtifactVersionLocator } from './artifact-provenance'
 import { parseLiteratureAttachmentVersionReference } from './literature'
-import { parseUploadVersionReference } from './uploads'
+import { createUploadVersionReference, parseUploadVersionReference } from './uploads'
 
 export const ANNOTATION_LIMITS = Object.freeze({
   count: 10,
@@ -121,11 +121,14 @@ export type SessionTextAnnotationSource = Exclude<
   Readonly<{ kind: 'project-file'; projectId: string; path: string }>
 >
 
+export type TextAnnotationAnchor = Pick<PdfTextSelector, 'position' | 'prefix' | 'suffix'>
+
 export type TextAnnotation = Readonly<{
   id: string
   kind: 'text'
   target: 'agent'
   quote: string
+  anchor?: TextAnnotationAnchor
   note?: string
   source: TextAnnotationSource
 }>
@@ -174,8 +177,11 @@ export type PdfRegionSelector = Readonly<{
   rect: PdfNormalizedRect
   pageRotation: number
   text?: string
-  image: AcpMessageImage
-}>
+}> &
+  (
+    | Readonly<{ image: AcpMessageImage; imageOmissionReason?: never }>
+    | Readonly<{ image?: never; imageOmissionReason: 'session-budget' }>
+  )
 
 export type PdfAnnotation = Readonly<{
   id: string
@@ -198,7 +204,9 @@ export type Annotation = TextAnnotation | ImagePointAnnotation | PdfAnnotation
 
 export const annotationRequiresImageInput = (annotation: Annotation): boolean =>
   annotation.kind === 'image-point' ||
-  (annotation.kind === 'pdf' && annotation.selector.kind === 'region')
+  (annotation.kind === 'pdf' &&
+    annotation.selector.kind === 'region' &&
+    !!annotation.selector.image)
 
 export type PreparedImagePoint = Readonly<{
   annotationId: string
@@ -230,14 +238,16 @@ export type SideChatAnnotationItem =
   | Readonly<{
       type: 'quote'
       content: string
-      source?: Readonly<{
-        kind: 'pdf'
-        versionId: string
-        name: string
-        checksum: string
-        page: number
-        selector: Omit<PdfTextSelector, 'kind' | 'pageNumber' | 'exact'>
-      }>
+      source?:
+        | TextAnnotationSource
+        | Readonly<{
+            kind: 'pdf'
+            versionId: string
+            name: string
+            checksum: string
+            page: number
+            selector: Omit<PdfTextSelector, 'kind' | 'pageNumber' | 'exact'>
+          }>
       instruction?: string
     }>
   | Readonly<{
@@ -351,7 +361,9 @@ const sanitizePdfAnnotation = (
       typeof selector.pageRotation !== 'number' ||
       ![0, 90, 180, 270].includes(selector.pageRotation) ||
       (selector.text !== undefined && !text) ||
-      !image
+      (!image &&
+        !(selector.image === undefined && selector.imageOmissionReason === 'session-budget')) ||
+      (image !== undefined && selector.imageOmissionReason !== undefined)
     ) {
       return undefined
     }
@@ -367,7 +379,7 @@ const sanitizePdfAnnotation = (
         rect,
         pageRotation: selector.pageRotation,
         ...(text ? { text } : {}),
-        image
+        ...(image ? { image } : { imageOmissionReason: 'session-budget' as const })
       }
     }
   }
@@ -468,6 +480,27 @@ const sanitizeTextSource = (value: unknown): TextAnnotationSource | undefined =>
   return undefined
 }
 
+const sanitizeTextAnchor = (value: unknown, quote: string): TextAnnotationAnchor | undefined => {
+  if (!isRecord(value) || !isRecord(value.position)) return undefined
+  const { start, end } = value.position
+  if (
+    typeof start !== 'number' ||
+    !Number.isSafeInteger(start) ||
+    start < 0 ||
+    typeof end !== 'number' ||
+    !Number.isSafeInteger(end) ||
+    end !== start + quote.length ||
+    (value.prefix !== undefined && !boundedString(value.prefix, 256)) ||
+    (value.suffix !== undefined && !boundedString(value.suffix, 256))
+  )
+    return undefined
+  return {
+    position: { start, end },
+    ...(typeof value.prefix === 'string' ? { prefix: value.prefix } : {}),
+    ...(typeof value.suffix === 'string' ? { suffix: value.suffix } : {})
+  }
+}
+
 export const sanitizeAnnotation = (value: unknown): Annotation | undefined => {
   if (!isRecord(value) || value.target !== 'agent') return undefined
   const id = trimmed(value.id)
@@ -477,7 +510,17 @@ export const sanitizeAnnotation = (value: unknown): Annotation | undefined => {
     const source = sanitizeTextSource(value.source)
     const note = trimmed(value.note)
     if (!quote || !source) return undefined
-    return { id, kind: 'text', target: 'agent', quote, source, ...(note ? { note } : {}) }
+    const anchor = value.anchor === undefined ? undefined : sanitizeTextAnchor(value.anchor, quote)
+    if (value.anchor !== undefined && !anchor) return undefined
+    return {
+      id,
+      kind: 'text',
+      target: 'agent',
+      quote,
+      source,
+      ...(anchor ? { anchor } : {}),
+      ...(note ? { note } : {})
+    }
   }
   if (value.kind === 'pdf') return sanitizePdfAnnotation(value, id)
   if (value.kind === 'image-point' && isRecord(value.source) && isRecord(value.point)) {
@@ -568,7 +611,7 @@ export const sanitizeAnnotations = (value: unknown): Annotation[] => {
     annotations.push(annotation)
     if (annotations.length >= ANNOTATION_LIMITS.count) break
   }
-  return validateAnnotations(annotations) ? [] : annotations
+  return validateAnnotationData(annotations) ? [] : annotations
 }
 
 export const imageVersionKey = (source: ImagePointAnnotation['source']): string =>
@@ -688,7 +731,8 @@ const payloadItem = (
       }>
       rect: PdfNormalizedRect
       pageRotation: number
-      image: number
+      image?: number
+      imageOmissionReason?: 'session-budget'
       content?: string
       instruction?: string
     }>
@@ -715,6 +759,7 @@ const payloadItem = (
     return {
       type: 'quote',
       content: annotation.quote,
+      source: annotation.source,
       ...(annotation.note ? { instruction: annotation.note } : {})
     }
   }
@@ -722,7 +767,7 @@ const payloadItem = (
     const { selector } = annotation
     if (selector.kind === 'region') {
       const image = pdfRegionImages.get(annotation.id)
-      if (image === undefined) {
+      if (selector.image && image === undefined) {
         throw new Error(
           `PDF region annotation ${annotation.id} was not prepared for Agent context.`
         )
@@ -738,7 +783,7 @@ const payloadItem = (
         },
         rect: selector.rect,
         pageRotation: selector.pageRotation,
-        image,
+        ...(selector.image ? { image } : { imageOmissionReason: selector.imageOmissionReason }),
         ...(selector.text ? { content: selector.text } : {}),
         ...(annotation.note ? { instruction: annotation.note } : {})
       }
@@ -800,7 +845,11 @@ const annotationPayloadTextFromPrepared = (
   let regionImage = 0
   const regionImageByAnnotation = new Map<string, number>()
   for (const annotation of annotations) {
-    if (annotation.kind === 'pdf' && annotation.selector.kind === 'region') {
+    if (
+      annotation.kind === 'pdf' &&
+      annotation.selector.kind === 'region' &&
+      annotation.selector.image
+    ) {
       regionImage += 1
       regionImageByAnnotation.set(annotation.id, regionImage)
     }
@@ -817,7 +866,7 @@ const annotationPayloadTextFromPrepared = (
 
 const preparePdfRegionImages = (annotations: readonly Annotation[]): AcpMessageImage[] =>
   annotations.flatMap((annotation) =>
-    annotation.kind === 'pdf' && annotation.selector.kind === 'region'
+    annotation.kind === 'pdf' && annotation.selector.kind === 'region' && annotation.selector.image
       ? [annotation.selector.image]
       : []
   )
@@ -873,6 +922,12 @@ const sideChatAnnotationItem = (value: unknown): SideChatAnnotationItem | undefi
       ...(value.instruction === undefined ? [] : ['instruction'])
     ]
     const source = value.source
+    const textSource = sanitizeTextSource(source)
+    const validTextSource =
+      textSource &&
+      isRecord(source) &&
+      Object.keys(source).length === Object.keys(textSource).length &&
+      Object.entries(textSource).every(([key, entry]) => source[key] === entry)
     if (
       !hasExactKeys(value, keys) ||
       typeof value.content !== 'string' ||
@@ -883,6 +938,7 @@ const sideChatAnnotationItem = (value: unknown): SideChatAnnotationItem | undefi
           !value.instruction ||
           value.instruction.length > ANNOTATION_LIMITS.note)) ||
       (source !== undefined &&
+        !validTextSource &&
         (!isRecord(source) ||
           !hasExactKeys(source, ['kind', 'versionId', 'name', 'checksum', 'page', 'selector']) ||
           source.kind !== 'pdf' ||
@@ -1003,6 +1059,41 @@ export const parseSideChatAnnotationText = (
   }
 }
 
+const textAnnotationFileReferences = (annotations: readonly Annotation[]): ArtifactReference[] =>
+  annotations.flatMap((annotation): ArtifactReference[] => {
+    if (annotation.kind !== 'text' || annotation.source.kind !== 'project-file') return []
+    const source = annotation.source
+    const identity = resolveManagedProjectFileAnnotationIdentity(source)
+    const sessionId =
+      source.sessionId ??
+      parseArtifactVersionLocator(source.path)?.appSessionId ??
+      parseUploadVersionReference(source.path)?.sessionId
+    if (!identity || !sessionId) return []
+    const path =
+      identity.fileSource === 'artifact'
+        ? createArtifactVersionLocator({
+            projectId: source.projectId,
+            appSessionId: sessionId,
+            artifactId: identity.fileId,
+            versionId: identity.versionId
+          })
+        : createUploadVersionReference(identity.versionId, {
+            projectId: source.projectId,
+            sessionId,
+            fileId: identity.fileId
+          })
+    return [
+      {
+        id: identity.fileSource === 'artifact' ? identity.fileId : identity.versionId,
+        sourceFileId: identity.fileId,
+        name: source.name ?? source.path.split(/[\\/]/).at(-1)!,
+        path,
+        source: identity.fileSource,
+        versionId: identity.versionId
+      }
+    ]
+  })
+
 export const prepareAnnotationsForAgent = (
   text: string,
   annotations: readonly Annotation[],
@@ -1019,16 +1110,15 @@ export const prepareAnnotationsForAgent = (
   return {
     promptText,
     referencedArtifacts: mergeImageAnnotationReferences(
-      referencedArtifacts,
+      [...(referencedArtifacts ?? []), ...textAnnotationFileReferences(annotations)],
       preparedImages.attachments
     ),
     ...(regionImages.length > 0 ? { images: regionImages } : {})
   }
 }
 
-export const validateAnnotations = (
-  annotations: readonly Annotation[],
-  messageText = ''
+const validateAnnotationData = (
+  annotations: readonly Annotation[]
 ): AnnotationValidationError | undefined => {
   if (annotations.length > ANNOTATION_LIMITS.count) return 'too-many'
   let regionImageCount = 0
@@ -1048,7 +1138,11 @@ export const validateAnnotations = (
     ) {
       return 'quote-too-long'
     }
-    if (annotation.kind === 'pdf' && annotation.selector.kind === 'region') {
+    if (
+      annotation.kind === 'pdf' &&
+      annotation.selector.kind === 'region' &&
+      annotation.selector.image
+    ) {
       regionImageCount += 1
       regionImageBytes += annotation.selector.image.byteLength
     }
@@ -1060,6 +1154,15 @@ export const validateAnnotations = (
   ) {
     return 'payload-too-large'
   }
+  return undefined
+}
+
+export const validateAnnotations = (
+  annotations: readonly Annotation[],
+  messageText = ''
+): AnnotationValidationError | undefined => {
+  const error = validateAnnotationData(annotations)
+  if (error) return error
   if (annotationPayloadText(annotations).length > ANNOTATION_LIMITS.payload) {
     return 'payload-too-large'
   }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -355,6 +355,8 @@
     "Remove annotation": "Anmerkung entfernen",
     "Sent annotations": "Gesendete Anmerkungen",
     "Show annotation source": "Quelle der Anmerkung anzeigen",
+    "Image not retained: session image budget reached.": "Bild nicht gespeichert: Das Bildbudget der Sitzung ist ausgeschöpft.",
+    "The exact annotation location could not be found.": "Die genaue Position der Anmerkung konnte nicht gefunden werden.",
     "Source: {{source}}": "Quelle: {{source}}",
     "Text quote": "Textzitat",
     "The annotation note is too long.": "Die Notiz zur Anmerkung ist zu lang.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -476,6 +476,8 @@
     "Remove annotation": "Eliminar anotación",
     "Sent annotations": "Anotaciones enviadas",
     "Show annotation source": "Mostrar origen de la anotación",
+    "Image not retained: session image budget reached.": "Imagen no conservada: se alcanzó el límite de imágenes de la sesión.",
+    "The exact annotation location could not be found.": "No se pudo encontrar la ubicación exacta de la anotación.",
     "Source: {{source}}": "Origen: {{source}}",
     "PDF area": "Área de PDF",
     "PDF quote": "Cita de PDF",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -392,6 +392,8 @@
     "Remove annotation": "Supprimer l’annotation",
     "Sent annotations": "Annotations envoyées",
     "Show annotation source": "Afficher la source de l’annotation",
+    "Image not retained: session image budget reached.": "Image non conservée : la limite des images de la session est atteinte.",
+    "The exact annotation location could not be found.": "La position exacte de l’annotation est introuvable.",
     "Source: {{source}}": "Source : {{source}}",
     "PDF area": "Zone PDF",
     "PDF quote": "Citation PDF",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -382,6 +382,8 @@
     "Remove annotation": "注釈を削除",
     "Sent annotations": "送信済みの注釈",
     "Show annotation source": "注釈の参照元を表示",
+    "Image not retained: session image budget reached.": "セッションの画像容量の上限に達したため、画像は保存されていません。",
+    "The exact annotation location could not be found.": "注釈の正確な位置が見つかりませんでした。",
     "Source: {{source}}": "出典：{{source}}",
     "PDF area": "PDF 領域",
     "PDF quote": "PDF 引用",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -382,6 +382,8 @@
     "Remove annotation": "주석 제거",
     "Sent annotations": "전송된 주석",
     "Show annotation source": "주석 원본 표시",
+    "Image not retained: session image budget reached.": "세션 이미지 용량 한도에 도달하여 이미지가 보존되지 않았습니다.",
+    "The exact annotation location could not be found.": "주석의 정확한 위치를 찾을 수 없습니다.",
     "Source: {{source}}": "출처: {{source}}",
     "PDF area": "PDF 영역",
     "PDF quote": "PDF 인용문",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -397,6 +397,8 @@
     "Remove annotation": "Удалить аннотацию",
     "Sent annotations": "Отправленные аннотации",
     "Show annotation source": "Показать источник аннотации",
+    "Image not retained: session image budget reached.": "Изображение не сохранено: достигнут лимит изображений сеанса.",
+    "The exact annotation location could not be found.": "Не удалось найти точное положение аннотации.",
     "Source: {{source}}": "Источник: {{source}}",
     "PDF area": "Область PDF",
     "PDF quote": "Цитата из PDF",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -382,6 +382,8 @@
     "Remove annotation": "移除标注",
     "Sent annotations": "已发送的标注",
     "Show annotation source": "显示标注来源",
+    "Image not retained: session image budget reached.": "图片未保留：已达到会话图片容量上限。",
+    "The exact annotation location could not be found.": "无法找到标注的准确位置。",
     "Source: {{source}}": "来源：{{source}}",
     "PDF area": "PDF 区域",
     "PDF quote": "PDF 引文",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -382,6 +382,8 @@
     "Remove annotation": "移除標註",
     "Sent annotations": "已傳送的標註",
     "Show annotation source": "顯示標註來源",
+    "Image not retained: session image budget reached.": "圖片未保留：已達到工作階段圖片容量上限。",
+    "The exact annotation location could not be found.": "無法找到標註的確切位置。",
     "Source: {{source}}": "來源：{{source}}",
     "PDF area": "PDF 區域",
     "PDF quote": "PDF 引文",

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import { MAX_ACP_RUNTIME_EVENTS, MAX_ACP_SESSION_IMAGE_BYTES } from './acp'
+import { validateAnnotations, type PdfAnnotation } from './annotations'
 import { MAX_ELICITATION_OPTIONS_PER_FIELD } from './elicitation'
 
 import {
@@ -1542,6 +1543,92 @@ describe('upload message persistence', () => {
 })
 
 describe('message image persistence', () => {
+  it('preserves accepted PDF region evidence when previous images exhaust the session budget', () => {
+    const region: PdfAnnotation = {
+      id: 'small-region',
+      kind: 'pdf',
+      target: 'agent',
+      note: 'Inspect this evidence.',
+      source: {
+        kind: 'upload-version',
+        projectId: 'project-a',
+        sessionId: 'session-1',
+        versionId: 'version-1',
+        name: 'paper.pdf',
+        path: 'upload-version:project-a/session-1/version-1',
+        checksum: 'a'.repeat(64)
+      },
+      selector: {
+        kind: 'region',
+        pageNumber: 6,
+        pageRotation: 0,
+        rect: { x: 0.2, y: 0.3, width: 0.4, height: 0.25 },
+        text: 'Figure 2. Retrieval evaluator.',
+        image: { mimeType: 'image/png', data: 'AQID', byteLength: 3 }
+      }
+    }
+    expect(validateAnnotations([region])).toBeUndefined()
+    const data = 'A'.repeat(4 * 1024 * 1024)
+    const byteLength = (data.length * 3) / 4
+    const history: PersistedChatMessage[] = Array.from(
+      { length: MAX_ACP_SESSION_IMAGE_BYTES / byteLength },
+      (_, index) => ({
+        id: `image-message-${index}`,
+        role: 'agent',
+        content: '',
+        status: 'complete',
+        eventIds: [],
+        createdAt: index,
+        updatedAt: index,
+        images: [{ id: `image-${index}`, mimeType: 'image/png', data, byteLength }]
+      })
+    )
+    const evidence: PersistedChatMessage = {
+      id: 'evidence-message',
+      role: 'user',
+      content: '',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 10,
+      updatedAt: 10,
+      annotations: [region]
+    }
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-a',
+      title: 'PDF evidence',
+      cwd: '/workspace',
+      status: 'idle',
+      messages: [...history, evidence],
+      createdAt: 1,
+      updatedAt: 10
+    }
+    const control = createSessionFile({ ...session, messages: [evidence] }).session
+    expect(control.messages[0].annotations).toEqual([region])
+    expect(
+      history
+        .flatMap((message) => message.images ?? [])
+        .reduce((total, image) => total + image.byteLength, 0)
+    ).toBe(MAX_ACP_SESSION_IMAGE_BYTES)
+    const saved = createSessionFile(session).session
+    expect(session.messages.at(-1)?.annotations).toEqual([region])
+    // A successful save must not silently turn accepted evidence into an empty user message.
+    const expected = {
+      ...region,
+      selector: {
+        ...region.selector,
+        image: undefined,
+        imageOmissionReason: 'session-budget'
+      }
+    }
+    expect.soft(saved.messages.at(-1)?.annotations).toEqual([expected])
+    expect.soft(saved.conversationGraph?.messages.at(-1)?.annotations).toEqual([expected])
+    const restored = normalizeSessionFile(
+      JSON.parse(JSON.stringify({ version: SESSION_FILE_VERSION, session: saved }))
+    )
+    expect(restored?.messages.at(-1)?.annotations).toEqual([expected])
+  })
+
   it('keeps only bounded raster images with recomputed byte metadata', () => {
     const images = sanitizeMessageImages([
       { id: 'image-1', mimeType: 'image/png', data: 'AQID', byteLength: 999 },

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -3558,13 +3558,25 @@ export function sanitizeSessionMessageImages(session: PersistedChatSession): Per
         totalBytes += image.byteLength
         return true
       })
-      const annotations = (message.annotations ?? []).filter((annotation) => {
-        if (annotation.kind !== 'pdf' || annotation.selector.kind !== 'region') return true
+      const annotations = (message.annotations ?? []).map((annotation) => {
+        if (
+          annotation.kind !== 'pdf' ||
+          annotation.selector.kind !== 'region' ||
+          !annotation.selector.image
+        )
+          return annotation
         if (totalBytes + annotation.selector.image.byteLength > MAX_ACP_SESSION_IMAGE_BYTES) {
-          return false
+          return {
+            ...annotation,
+            selector: {
+              ...annotation.selector,
+              image: undefined,
+              imageOmissionReason: 'session-budget' as const
+            }
+          }
         }
         totalBytes += annotation.selector.image.byteLength
-        return true
+        return annotation
       })
       return {
         ...message,


### PR DESCRIPTION
## Problem

Six reproduced annotation failures lose evidence or break source navigation: the 24 MiB session image budget removes an entire PDF region, duplicate text loses its selected occurrence after remount, literature PDFs fail source resolution, sent text/image reveals depend on composer drafts (and lack activation buttons), ordinary quote prompts omit source identity, and rejected note edits show no error.

## Proposed change

- Preserve a PDF region's source, checksum, page/rectangle, extracted text and note when its bitmap exceeds the session budget; expose the missing bitmap in cards and replay payloads.
- Save a small optional text position/context anchor and resolve it after remount. For ambiguous historical text without an anchor, show an unavailable-location message.
- Validate literature locators through their existing parser. Pass historical annotations through the existing reveal preparation owner and expose accessible sent-card activation, including late mounts and read-only image pins.
- Include the existing source identity and managed file references in ordinary quote context. Preserve legacy source-free side-chat parsing.
- Display existing validation errors in the note editor, retaining the attempted input. Translate the two new messages across all eight locales.

## Scope and non-goals

Persisted additions: optional `TextAnnotation.anchor` (`position`, `prefix`, `suffix`), plus the PDF region alternative `imageOmissionReason: 'session-budget'` without `image`. This adds one literal omission reason; no independent state machine, database migration, new dependency, architecture layer or production test seam. The image budget is unchanged and remains applied to the canonical conversation graph before rebuilding its active projection.

Complete historical regions and unanchored text remain readable without rewriting stored sessions. Restoration validates stored data separately from outbound prompt size, so the additional source metadata does not delete formerly valid records. New sends still enforce the payload limit. Previously deleted evidence and ambiguous historical selections cannot be reconstructed. Old app versions may discard new anchors or reject image-less regions: downgrade compatibility is not included. Already-sent provider history is not rewritten.

## Acceptance criteria and validation

The final regression files were run twice against pristine production at `c878904a` in a separate detached worktree: both runs have the same **13 assertion failures and 3 passing controls** (other cases filtered). Failures match the six reported behaviors, including the real sent-card activation and late image mount. The regression tests use existing save/restore, preparation, mounted component and reveal boundaries.

The final local impact set combines the owner and consumer commands below with the CI follow-up checks. All selected checks are rerun after the final rebase; no full local `npm test` is run.

**Annotation owners, prompt/replay consumers, mounted history cards and i18n**

```sh
npx vitest run src/shared/annotations.test.ts src/shared/session-persistence.test.ts src/main/acp/interrupted-turn-continuation.test.ts src/renderer/src/i18n/resources.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceActivityGroup.annotations.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.annotations.test.tsx src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts src/renderer/src/pages/workspace/annotations/AnnotationCards.test.tsx src/renderer/src/pages/workspace/annotations/ImagePointAnnotationSurface.test.tsx src/renderer/src/pages/workspace/annotations/TextAnnotationSurface.test.tsx src/renderer/src/pages/workspace/annotations/annotation-reveal.test.ts src/renderer/src/pages/workspace/annotations/annotation-trigger-anchor.test.ts src/renderer/src/pages/workspace/annotations/image-annotation-geometry.test.ts src/renderer/src/pages/workspace/annotations/image-annotation-payload.test.ts src/renderer/src/pages/workspace/annotations/image-annotation-source-validation.test.ts src/renderer/src/pages/workspace/annotations/image-annotation-source.test.ts src/renderer/src/pages/workspace/annotations/text-annotation-range.test.ts src/renderer/src/pages/workspace/previews/PreviewTextAnnotationSurface.test.tsx
```

**Persistence/graph and prompt adapters**

```sh
npx vitest run src/shared/conversation-graph.test.ts src/main/acp/prompt-content-owner.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/session-persistence/claude-replay.test.ts src/main/session-persistence/repository.test.ts src/main/settings/responses-request-adapter.test.ts src/main/settings/responses-response-adapter.test.ts
```

**Claude/OpenCode and both Codex protocol adapters**

```sh
npx vitest run src/main/settings/native-responses-compatibility.test.ts src/main/settings/responses-bridge.test.ts src/main/settings/anthropic-provider-bridge.test.ts
```

**PDF preview and message actions**

```sh
npx vitest run src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
```

**Side-chat controller**

```sh
npx vitest run src/renderer/src/pages/workspace/use-side-chat-controller.test.ts
```

The automatic affected planner falls back to full for unknown ownership of `interrupted-turn-continuation.test.ts`. At the maintainer's explicit request, no full local `npm test` ran; the owner/interface/consumer mapping above supplements local validation, and exact-head PR Gate is authoritative. The loopback bridge suite required scoped execution outside the local sandbox after a listen `EPERM`; its rerun passes. No provider transport/subscription contract changed; all four execution paths are covered by their existing adapter fixtures plus shared preparation/continuation consumers. DOM reveal subscription timing, updates, cleanup and late mounting have mounted-component coverage.

Actual imported components were also exercised in ego-browser with labeled controlled data: rejected-note feedback, budget-exhausted evidence with literature activation, second-occurrence highlighting before/after remount, and a read-only historical image pin. Screenshots are delivered in the maintainer task; local fixture/evidence files are excluded from this PR. Native Electron packaging, OS-specific rendering and live paid-provider execution are not claimed by these checks.

## Review focus

Confirm the final evidence mapping covers the changed source/prompt and persistence contracts; review the mutually exclusive bitmap/omission representation, old-record handling, source/version checks, pending-reveal cleanup, and read-only history behavior. No automatic historical reconstruction, generic anchoring framework or external bitmap storage is introduced.


## Rebase and CI follow-up

Rebased onto `main` at `469b593b`. The eight locale conflicts retain all translations. This PR's two new keys are grouped with existing annotation copy, avoiding repeated conflicts with new entries appended to the catalogs. Annotation implementation and the Notebook test change are preserved.

The Notebook same-Session shell serialization test previously timed out before the injected process port started. A two-second delay at the existing repository running-transition boundary reproduced the same `[]` versus `['first']` failure twice. The test now waits for deferred process-entry notifications, retaining queued-state, execution-order and public-result assertions, with cleanup for failed assertions. The artificial delay is not committed; production scheduling is unchanged.

The repeated Windows archive conflict came from saving an authority refresh back as a local edit, advancing the durable revision while the fresh menu held the refresh revision. Latest main now includes the production repair in [#2268](https://github.com/aipoch/open-science/pull/2268), including startup hydration, streaming, dirty-content and stale-authority safeguards; both Windows E2E shards passed there. This branch adopts that implementation intact and adds only the public store/archive RPC/saver regression plus an unsaved-message control. The regression failed twice against unfixed production; both tests pass with the repair. No new persisted format, state, interaction or test seam is introduced by this CI follow-up.

The last CI's 25,575 passing tests and sole failure isolated another readiness assumption: the Unpaywall configuration button can render before the lookup effect dispatches the next search. Natural local repetitions reproduced this; delaying the third request handler at the existing mocked API boundary by 50 ms produced the same expected-3/actual-2 failure twice. Waiting for the request count passed under the same delay, and 200 normal-port repetitions passed. Latest main carries the Unpaywall assertion repair; this branch also waits for the equivalent OpenAlex refresh. The delay and repetition harness are not committed. Production behavior, data and interaction are unchanged.

This final test-only follow-up also runs:

```sh
npx vitest run src/renderer/src/pages/literature/LiteratureFullTextLookup.render.test.tsx src/renderer/src/pages/settings/CredentialsPanel.render.test.tsx src/renderer/src/pages/settings/CredentialsPanel.loading.render.test.tsx
```

Final rebase validation uses the union of the annotation owner/adapter/consumer commands above and these existing checks, with `--maxWorkers=2`:

```sh
npx vitest run src/main/notebook/runtime-service.test.ts src/main/notebook/run-terminalization.test.ts src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/stores/session-store.archive-order.test.ts src/renderer/src/stores/session-store.architecture.test.ts src/renderer/src/stores/session-store.test.ts src/renderer/src/stores/session-job-store.test.ts src/renderer/src/stores/archive-undo-store.test.ts src/renderer/src/pages/workspace/workspace-session-controller.test.ts src/renderer/src/pages/settings/ArchivedPanel.render.test.tsx
```

- Combined final impact set after the last material edit: **3,101 tests passed across 52 files**.
- `npm run typecheck`, `npm run lint`, `git diff --check`: passed after the final App fixture edit. `npm run build:e2e` passed on the final rebase; the subsequent change only repairs test data.
- `npx playwright test e2e/workspace-conversation.spec.ts --grep 'archives a completed session from its mobile sidebar actions' --repeat-each=2 --workers=1`: 2 passed on the final rebase build (macOS).

Full exact-head PR CI and independent review validate the final combined state; upstream or earlier-head results are not treated as proof of this head.

### App startup fixture repair

PR Gate run 34081400009 passed every platform lane but failed the Ubuntu App startup assertion expecting a background Compute analysis send. The unchanged test reproduced the same zero sends twice locally. Its hand-written conversation graph lacked `messages`, so the current recovery owner threw while looking up an analysis prompt. The fixture now uses the existing `createLinearConversationGraph` constructor; the original runtime-send and Home assertions remain unchanged. No production code, data format, enum, persistence or interaction changes.

The final impact set additionally covers the App consumer and Compute/admission owners:

```sh
npx vitest run src/renderer/src/App.test.tsx src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx src/renderer/src/lib/compute/WorkspaceComputeRecoveryBridge.render.test.tsx src/renderer/src/lib/compute/job-analysis-trigger.test.ts src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
```

The separate source-path review finding at https://github.com/aipoch/open-science/pull/2273#issuecomment-5564856559 is reproduced and awaits the maintainer's decision on outbound historical source information. It is not fixed or claimed resolved by this test-only follow-up.

Final validation after the App fixture edit: 3,043 tests passed in the sandbox; the 58 failures were exclusively loopback-listen `EPERM` in three adapter files. Rerunning those three files with scoped loopback permission passed all their tests, completing the 3,101-test union. Typechecks for Node, sandbox and web, lint, and diff checks pass. Full local `npm test` was not run. Exact-head CI and independent review remain authoritative and pending.
