### PR TITLE
fix(compute-host): preserve concurrent profile and authentication updates

### DIFF
--- a/src/main/compute/compute-auth-owner.test.ts
+++ b/src/main/compute/compute-auth-owner.test.ts
@@ -958,3 +958,33 @@ describe('Compute authentication identity-change application handler', () => {
     })
   })
 })
+
+it('validates and persists SSH configuration without adding a port override', async () => {
+  const host = {
+    ...publicHost(),
+    sshOverrides: { user: 'before' },
+    authentication: { ...publicHost().authentication!, mode: 'ssh_config' as const }
+  }
+  const validateSshConfig = vi
+    .fn<(candidate: ComputeHost) => Promise<void>>()
+    .mockResolvedValue(undefined)
+  const changeAuthentication = vi.fn(async () => host)
+  const owner = new ComputeAuthOwner({
+    repository: authRepository({ get: vi.fn(async () => host), changeAuthentication }),
+    vault: credentialVault(),
+    passwordAdapter: {} as PasswordSshAdapter,
+    validateSshConfig
+  })
+  await owner.changeAuthentication({
+    providerId: host.providerId,
+    expectedRevision: 1,
+    operationId: 'inherit-port',
+    authenticationMode: 'ssh_config',
+    username: 'after'
+  } as ChangeComputeHostAuthenticationRequest)
+  expect(validateSshConfig.mock.calls[0]?.[0]).toMatchObject({ sshOverrides: { user: 'after' } })
+  expect(
+    (validateSshConfig.mock.calls[0]?.[0] as unknown as ComputeHost).sshOverrides?.port
+  ).toBeUndefined()
+  expect(changeAuthentication).toHaveBeenCalledWith(expect.objectContaining({ port: undefined }))
+})

--- a/src/main/compute/compute-auth-owner.ts
+++ b/src/main/compute/compute-auth-owner.ts
@@ -57,7 +57,7 @@ type ChangeComputeHostAuthenticationPersistence = Readonly<{
   requestFingerprint: string
   authenticationMode: ComputeAuthenticationMode
   username: string | undefined
-  port: number
+  port?: number
   identityFile?: string
   ciphertext?: Buffer
   verifiedAt: Date
@@ -331,7 +331,13 @@ class ComputeAuthOwner {
     if (!Number.isInteger(request.expectedRevision) || request.expectedRevision < 1) {
       throw new ComputeConnectionError('credential_conflict')
     }
-    if (!Number.isInteger(request.port) || request.port < 1 || request.port > 65_535) {
+    if (
+      (request.authenticationMode === 'password' || request.port !== undefined) &&
+      (request.port === undefined ||
+        !Number.isInteger(request.port) ||
+        request.port < 1 ||
+        request.port > 65_535)
+    ) {
       throw new ComputeConnectionError(
         'unsupported_auth_configuration',
         'Port must be an integer from 1 through 65535.'
@@ -366,7 +372,7 @@ class ComputeAuthOwner {
     const hasMaterialChange =
       host.authentication?.mode !== request.authenticationMode ||
       host.sshOverrides?.user !== username ||
-      (host.sshOverrides?.port ?? 22) !== request.port ||
+      host.sshOverrides?.port !== request.port ||
       (request.authenticationMode === 'ssh_config' && currentIdentityFile !== identityFile)
     if (!hasMaterialChange) return host
     if (await this.dependencies.hasBlockingJobs?.(providerId)) {

--- a/src/main/compute/compute-host-profile-concurrency.test.ts
+++ b/src/main/compute/compute-host-profile-concurrency.test.ts
@@ -1,0 +1,152 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false, getAppPath: () => process.cwd(), getPath: () => tmpdir() }
+}))
+
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { ComputeHostRepository } from './repository'
+import { ComputeHostProfileOwner } from './compute-host-profile-owner'
+import type { ComputeConnectionBrokerAcquirer } from './connection-broker'
+
+let root: string
+let client: ReturnType<typeof createProjectDbClient>
+let repository: ComputeHostRepository
+const providerId = 'ssh:cluster'
+const output = {
+  exitCode: 0,
+  stdout: 'os=Linux\ncpus=8\nsbatch=no\nqsub=no\nbsub=no\nscratch=/auto/scratch',
+  stderr: '',
+  timedOut: false,
+  truncated: false
+}
+const owner = (run = vi.fn(async () => output)): ComputeHostProfileOwner =>
+  new ComputeHostProfileOwner(
+    { acquire: async () => ({ run }) } as unknown as ComputeConnectionBrokerAcquirer,
+    repository
+  )
+
+beforeEach(async () => {
+  root = await mkdtemp(join(tmpdir(), 'host-profile-'))
+  client = createProjectDbClient(root)
+  await migrateApplicationDatabase(client)
+  repository = new ComputeHostRepository(async () => client)
+  await repository.create({ sshAlias: 'cluster', detailsDoc: 'base' })
+})
+afterEach(async () => {
+  await client?.$disconnect()
+  if (root) await rm(root, { recursive: true, force: true })
+})
+
+// Hold the first two public reads until both writers have the same database snapshot.
+const synchronizeReads = (): void => {
+  const get = repository.get.bind(repository)
+  let arrivals = 0
+  let release!: () => void
+  const ready = new Promise<void>((resolve) => {
+    release = resolve
+  })
+  vi.spyOn(repository, 'get').mockImplementation(async (id) => {
+    const host = await get(id)
+    if (++arrivals <= 2) {
+      if (arrivals === 2) release()
+      await ready
+    }
+    return host
+  })
+}
+
+it('rejects one simultaneous replacement instead of acknowledging a lost save', async () => {
+  synchronizeReads()
+  const service = owner()
+  const results = await Promise.allSettled(
+    ['first', 'second'].map((text) =>
+      service.replaceDetails(providerId, { text, oldText: 'base', author: 'user' })
+    )
+  )
+  expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+  expect(results.find((result) => result.status === 'rejected')).toMatchObject({
+    reason: expect.objectContaining({ message: expect.stringMatching(/conflict|old_text/i) })
+  })
+})
+
+it('preserves both simultaneous appends', async () => {
+  synchronizeReads()
+  const service = owner()
+  await Promise.all(
+    ['first', 'second'].map((text) => service.appendDetails(providerId, { text, author: 'agent' }))
+  )
+  expect((await repository.get(providerId))?.detailsDoc.split('\n').sort()).toEqual([
+    'base',
+    'first',
+    'second'
+  ])
+})
+
+it('rechecks the length limit after a competing append', async () => {
+  await client.computeHost.update({
+    where: { providerId },
+    data: { detailsDoc: 'x'.repeat(32760) }
+  })
+  synchronizeReads()
+  const service = owner()
+  const results = await Promise.allSettled(
+    ['first', 'second'].map((text) => service.appendDetails(providerId, { text, author: 'agent' }))
+  )
+  expect(results.filter((result) => result.status === 'fulfilled')).toHaveLength(1)
+  expect(results.find((result) => result.status === 'rejected')).toMatchObject({
+    reason: expect.objectContaining({ message: expect.stringContaining('32768') })
+  })
+})
+
+it('preserves a scratch path pinned while the remote probe is running', async () => {
+  const service = owner(
+    vi.fn(async () => {
+      await repository.updateScratchPinned(providerId, '/user/pinned')
+      return output
+    })
+  )
+  await service.probe(providerId)
+  expect(await repository.get(providerId)).toMatchObject({
+    scratchPinned: true,
+    scratchRoot: '/user/pinned'
+  })
+})
+
+it('rejects probe side effects after authentication changes between SSH completion and persistence', async () => {
+  const persist = repository.updateProbeResult.bind(repository)
+  vi.spyOn(repository, 'updateProbeResult').mockImplementation(async (...args) => {
+    await client.computeHost.update({
+      where: { providerId },
+      data: { authenticationRevision: { increment: 1 } }
+    })
+    return persist(...args)
+  })
+  const error = await owner()
+    .probe(providerId)
+    .then(
+      () => undefined,
+      (error: unknown) => error
+    )
+  expect(await repository.get(providerId)).toMatchObject({
+    probeResult: undefined,
+    scratchRoot: undefined
+  })
+  expect(error).toMatchObject({ code: 'credential_conflict' })
+})
+
+it.each([2, 0])(
+  'does not report incomplete remote output as a successful probe (exit %s)',
+  async (exitCode) => {
+    const result = await owner(
+      vi.fn(async () => ({ ...output, exitCode, stdout: '', stderr: 'sh: syntax error' }))
+    ).probe(providerId)
+    expect(result.ok).toBe(false)
+    expect(result.detectedScheduler).toBeUndefined()
+    expect(result.errorTail).toContain('syntax error')
+    expect((await repository.get(providerId))?.probeResult?.ok).toBe(false)
+  }
+)

--- a/src/main/compute/compute-host-profile-owner.test.ts
+++ b/src/main/compute/compute-host-profile-owner.test.ts
@@ -53,15 +53,13 @@ const makeRepo = (
 ): {
   repo: ComputeHostRepository
   updateProbeResult: ReturnType<typeof vi.fn>
-  updateScratchRoot: ReturnType<typeof vi.fn>
   updateDetails: ReturnType<typeof vi.fn>
   updateScratchPinned: ReturnType<typeof vi.fn>
   clearScratchRoot: ReturnType<typeof vi.fn>
   updateConcurrencyLimit: ReturnType<typeof vi.fn>
 } => {
-  const updateProbeResult = vi.fn(() => Promise.resolve())
-  const updateScratchRoot = vi.fn(() => Promise.resolve())
-  const updateDetails = vi.fn(() => Promise.resolve())
+  const updateProbeResult = vi.fn(() => Promise.resolve(true))
+  const updateDetails = vi.fn(() => Promise.resolve(true))
   const updateScratchPinned = vi.fn(() => Promise.resolve())
   const clearScratchRoot = vi.fn(() => Promise.resolve())
   const updateConcurrencyLimit = vi.fn(() => Promise.resolve())
@@ -71,7 +69,6 @@ const makeRepo = (
     create: vi.fn(),
     delete: vi.fn(),
     updateProbeResult,
-    updateScratchRoot,
     updateDetails,
     updateScratchPinned,
     clearScratchRoot,
@@ -80,7 +77,6 @@ const makeRepo = (
   return {
     repo,
     updateProbeResult,
-    updateScratchRoot,
     updateDetails,
     updateScratchPinned,
     clearScratchRoot,
@@ -195,7 +191,9 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       observedHost.providerId,
       expect.objectContaining({ authenticationRevision: 7 }),
-      'scheduler_cluster'
+      'scheduler_cluster',
+      'host-1',
+      '/gpfs/scratch/user123'
     )
   })
 
@@ -207,7 +205,7 @@ describe('ComputeHostProfileOwner.probe', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, updateProbeResult, updateScratchRoot } = makeRepo()
+    const { repo, updateProbeResult } = makeRepo()
     const service = new ComputeHostProfileOwner(runner, repo)
 
     const result = await service.probe('ssh:biowulf')
@@ -223,10 +221,12 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       'ssh:biowulf',
       expect.objectContaining({ ok: true, cpus: 64 }),
-      'scheduler_cluster'
+      'scheduler_cluster',
+      'host-1',
+      '/gpfs/scratch/user123'
     )
-    // scratchRoot should be set because scratchPinned=false and scratch is provided.
-    expect(updateScratchRoot).toHaveBeenCalledWith('ssh:biowulf', '/gpfs/scratch/user123')
+    // The repository applies the current pinned state atomically.
+    expect(updateProbeResult.mock.calls[0]?.[4]).toBe('/gpfs/scratch/user123')
   })
 
   it('returns ok:false and maps exit 255 to host_unreachable (connection failure)', async () => {
@@ -237,7 +237,7 @@ describe('ComputeHostProfileOwner.probe', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, updateProbeResult, updateScratchRoot } = makeRepo()
+    const { repo, updateProbeResult } = makeRepo()
     const service = new ComputeHostProfileOwner(runner, repo)
 
     const result = await service.probe('ssh:biowulf')
@@ -249,9 +249,10 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       'ssh:biowulf',
       expect.objectContaining({ ok: false }),
-      'direct_ssh'
+      'direct_ssh',
+      'host-1'
     )
-    expect(updateScratchRoot).not.toHaveBeenCalled()
+    expect(updateProbeResult.mock.calls[0]?.[4]).toBeUndefined()
   })
 
   it('returns ok:false on timeout and sets timedOut flag', async () => {
@@ -271,7 +272,8 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       'ssh:biowulf',
       expect.objectContaining({ ok: false }),
-      'direct_ssh'
+      'direct_ssh',
+      'host-1'
     )
   })
 
@@ -305,7 +307,8 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       'ssh:biowulf',
       expect.objectContaining({ ok: false, authenticationCode: 'authentication_failed' }),
-      'direct_ssh'
+      'direct_ssh',
+      'host-1'
     )
   })
 
@@ -476,11 +479,13 @@ describe('ComputeHostProfileOwner.probe', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       'ssh:biowulf',
       expect.objectContaining({ ok: true }),
-      'direct_ssh'
+      'direct_ssh',
+      'host-1',
+      undefined
     )
   })
 
-  it('does NOT update scratchRoot when scratchPinned=true', async () => {
+  it('passes automatic scratch discovery to persistence even when the initial host is pinned', async () => {
     const runner = makeFakeRunner({
       exitCode: 0,
       stdout: SLURM_STDOUT,
@@ -489,12 +494,12 @@ describe('ComputeHostProfileOwner.probe', () => {
       timedOut: false
     })
     const pinnedHost = sampleHost({ scratchPinned: true, scratchRoot: '/my/custom/scratch' })
-    const { repo, updateScratchRoot } = makeRepo(pinnedHost)
+    const { repo, updateProbeResult } = makeRepo(pinnedHost)
     const service = new ComputeHostProfileOwner(runner, repo)
 
     await service.probe('ssh:biowulf')
 
-    expect(updateScratchRoot).not.toHaveBeenCalled()
+    expect(updateProbeResult.mock.calls[0]?.[4]).toBe('/gpfs/scratch/user123')
   })
 
   it('does NOT update scratchRoot when $SCRATCH is empty', async () => {
@@ -506,12 +511,12 @@ describe('ComputeHostProfileOwner.probe', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, updateScratchRoot } = makeRepo()
+    const { repo, updateProbeResult } = makeRepo()
     const service = new ComputeHostProfileOwner(runner, repo)
 
     await service.probe('ssh:biowulf')
 
-    expect(updateScratchRoot).not.toHaveBeenCalled()
+    expect(updateProbeResult.mock.calls[0]?.[4]).toBeUndefined()
   })
 
   it('does NOT persist an invalid $SCRATCH value from a successful probe', async () => {
@@ -532,11 +537,11 @@ describe('ComputeHostProfileOwner.probe', () => {
       truncated: false,
       timedOut: false
     })
-    const { repo, updateScratchRoot } = makeRepo()
+    const { repo, updateProbeResult } = makeRepo()
     const service = new ComputeHostProfileOwner(runner, repo)
 
     await expect(service.probe('ssh:biowulf')).resolves.toMatchObject({ ok: true })
-    expect(updateScratchRoot).not.toHaveBeenCalled()
+    expect(updateProbeResult.mock.calls[0]?.[4]).toBeUndefined()
   })
 
   it('does NOT write detailsDoc', async () => {
@@ -671,7 +676,13 @@ describe('ComputeHostProfileOwner.replaceDetails', () => {
       oldText: 'hello world',
       author: 'user'
     })
-    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', 'hello friend', 'user')
+    expect(updateDetails).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      'hello friend',
+      'user',
+      'host-1',
+      'hello world'
+    )
   })
 
   it('returns error and does not write when oldText does not match', async () => {
@@ -705,7 +716,13 @@ describe('ComputeHostProfileOwner.replaceDetails', () => {
       oldText: 'original text',
       author: 'agent'
     })
-    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', 'new text', 'agent')
+    expect(updateDetails).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      'new text',
+      'agent',
+      'host-1',
+      'original text'
+    )
   })
 })
 
@@ -852,7 +869,13 @@ describe('ComputeHostProfileOwner.appendDetails', () => {
 
     await service.appendDetails('ssh:biowulf', { text: '## Note\nhello', author: 'agent' })
 
-    expect(updateDetails).toHaveBeenCalledWith('ssh:biowulf', '## Note\nhello', 'agent')
+    expect(updateDetails).toHaveBeenCalledWith(
+      'ssh:biowulf',
+      '## Note\nhello',
+      'agent',
+      'host-1',
+      ''
+    )
   })
 
   it('appends text with a newline separator when doc is non-empty', async () => {
@@ -871,7 +894,9 @@ describe('ComputeHostProfileOwner.appendDetails', () => {
     expect(updateDetails).toHaveBeenCalledWith(
       'ssh:biowulf',
       '## Resources\ncpus: 4\n## Note\nhello',
-      'agent'
+      'agent',
+      'host-1',
+      '## Resources\ncpus: 4'
     )
   })
 

--- a/src/main/compute/compute-host-profile-owner.ts
+++ b/src/main/compute/compute-host-profile-owner.ts
@@ -59,7 +59,9 @@ export const parseProbeOutput = (stdout: string): ProbeScriptOutput => {
         ? 'pbs'
         : values['bsub'] === 'yes'
           ? 'lsf'
-          : 'none'
+          : ['sbatch', 'qsub', 'bsub'].every((key) => values[key] === 'no')
+            ? 'none'
+            : undefined
 
   return {
     os: values['os'] || undefined,
@@ -138,7 +140,9 @@ export class ComputeHostProfileOwner {
         authenticationCode: failure.code,
         authenticationRevision
       }
-      await this.repository.updateProbeResult(providerId, result, 'direct_ssh')
+      if (!(await this.repository.updateProbeResult(providerId, result, host.shape, host.id))) {
+        throw new ComputeConnectionError('credential_conflict')
+      }
       return result
     }
     let connection
@@ -212,11 +216,32 @@ export class ComputeHostProfileOwner {
         authenticationCode: failure.code,
         authenticationRevision
       }
-      await this.repository.updateProbeResult(providerId, result, 'direct_ssh')
+      if (!(await this.repository.updateProbeResult(providerId, result, host.shape, host.id))) {
+        throw new ComputeConnectionError('credential_conflict')
+      }
       return result
     }
 
     const parsed = parseProbeOutput(runResult.stdout)
+    if (
+      runResult.exitCode !== 0 ||
+      runResult.truncated ||
+      !parsed.os ||
+      !parsed.detectedScheduler
+    ) {
+      const result: ProbeResult = {
+        ok: false,
+        probedAt,
+        exitCode: runResult.exitCode,
+        authenticationRevision,
+        errorTail:
+          runResult.stderr.trim().slice(-2048) || 'Resource probe did not return complete output.'
+      }
+      if (!(await this.repository.updateProbeResult(providerId, result, host.shape, host.id))) {
+        throw new ComputeConnectionError('credential_conflict')
+      }
+      return result
+    }
     const shape =
       parsed.detectedScheduler && parsed.detectedScheduler !== 'none'
         ? 'scheduler_cluster'
@@ -234,17 +259,24 @@ export class ComputeHostProfileOwner {
       detectedScheduler: parsed.detectedScheduler
     }
 
-    await this.repository.updateProbeResult(providerId, result, shape)
-    if (!host.scratchPinned && parsed.scratchEnv) {
-      let safeScratchRoot: string | undefined
+    let safeScratchRoot: string | undefined
+    if (parsed.scratchEnv) {
       try {
         safeScratchRoot = assertSafeScratchRoot(parsed.scratchEnv)
       } catch {
-        // Ignore an unusable remote value without hiding persistence failures for valid paths.
+        // Invalid remote paths do not invalidate otherwise usable resource information.
       }
-      if (safeScratchRoot !== undefined) {
-        await this.repository.updateScratchRoot(providerId, safeScratchRoot)
-      }
+    }
+    if (
+      !(await this.repository.updateProbeResult(
+        providerId,
+        result,
+        shape,
+        host.id,
+        safeScratchRoot
+      ))
+    ) {
+      throw new ComputeConnectionError('credential_conflict')
     }
     return result
   }
@@ -281,22 +313,42 @@ export class ComputeHostProfileOwner {
         `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (got ${text.length}).`
       )
     }
-    await this.repository.updateDetails(providerId, text, author)
+    if (!(await this.repository.updateDetails(providerId, text, author, host.id, oldText))) {
+      throw new Error(
+        'details_conflict: old_text does not match the current details document. Reload and merge your draft.'
+      )
+    }
   }
 
   async appendDetails(
     providerId: string,
     { text, author }: { text: string; author: DetailsAuthor }
   ): Promise<void> {
-    const host = await this.repository.get(providerId)
-    if (!host) throw hostNotFound(providerId)
-    const newDoc = host.detailsDoc ? `${host.detailsDoc}\n${text}` : text
-    if (newDoc.length > DETAILS_DOC_MAX_LENGTH) {
-      throw new Error(
-        `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (appended doc would be ${newDoc.length}).`
+    const initialHost = await this.repository.get(providerId)
+    if (!initialHost) throw hostNotFound(providerId)
+    let host = initialHost
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const newDoc = host.detailsDoc ? `${host.detailsDoc}\n${text}` : text
+      if (newDoc.length > DETAILS_DOC_MAX_LENGTH) {
+        throw new Error(
+          `Details must be ${DETAILS_DOC_MAX_LENGTH} characters or fewer (appended doc would be ${newDoc.length}).`
+        )
+      }
+      if (
+        await this.repository.updateDetails(
+          providerId,
+          newDoc,
+          author,
+          initialHost.id,
+          host.detailsDoc
+        )
       )
+        return
+      const current = await this.repository.get(providerId)
+      if (!current || current.id !== initialHost.id) throw hostNotFound(providerId)
+      host = current
     }
-    await this.repository.updateDetails(providerId, newDoc, author)
+    throw new Error('details_conflict: concurrent edits prevented appending. Retry the append.')
   }
 
   async setScratchRoot(providerId: string, path: string): Promise<void> {

--- a/src/main/compute/compute-probe-script.test.ts
+++ b/src/main/compute/compute-probe-script.test.ts
@@ -16,7 +16,7 @@ describe('compute probe shell protocol', () => {
       const host = { providerId: 'ssh:probe', scratchPinned: true } as ComputeHost
       const repository = {
         get: vi.fn(async () => host),
-        updateProbeResult: vi.fn()
+        updateProbeResult: vi.fn(async () => true)
       } as unknown as ComputeHostRepository
       const broker = {
         acquire: async () => ({

--- a/src/main/compute/compute-service.test.ts
+++ b/src/main/compute/compute-service.test.ts
@@ -54,8 +54,8 @@ const makeRepo = (
   clearScratchRoot: ReturnType<typeof vi.fn>
   updateConcurrencyLimit: ReturnType<typeof vi.fn>
 } => {
-  const updateProbeResult = vi.fn(() => Promise.resolve())
-  const updateDetails = vi.fn(() => Promise.resolve())
+  const updateProbeResult = vi.fn(() => Promise.resolve(true))
+  const updateDetails = vi.fn(() => Promise.resolve(true))
   const updateScratchPinned = vi.fn(() => Promise.resolve())
   const clearScratchRoot = vi.fn(() => Promise.resolve())
   const updateConcurrencyLimit = vi.fn(() => Promise.resolve())
@@ -137,14 +137,25 @@ describe('ComputeService host profile facade', () => {
     expect(updateProbeResult).toHaveBeenCalledWith(
       'ssh:biowulf',
       expect.objectContaining({ ok: true, cpus: 4 }),
-      'scheduler_cluster'
+      'scheduler_cluster',
+      'host-1',
+      undefined
     )
-    expect(updateDetails).toHaveBeenNthCalledWith(1, 'ssh:biowulf', 'replacement', 'user')
+    expect(updateDetails).toHaveBeenNthCalledWith(
+      1,
+      'ssh:biowulf',
+      'replacement',
+      'user',
+      'host-1',
+      'current details'
+    )
     expect(updateDetails).toHaveBeenNthCalledWith(
       2,
       'ssh:biowulf',
       'current details\nappendix',
-      'agent'
+      'agent',
+      'host-1',
+      'current details'
     )
     expect(updateScratchPinned).toHaveBeenCalledWith('ssh:biowulf', '/portable/scratch')
     expect(clearScratchRoot).toHaveBeenCalledWith('ssh:biowulf')

--- a/src/main/compute/electron-ipc-adapter.ts
+++ b/src/main/compute/electron-ipc-adapter.ts
@@ -84,11 +84,15 @@ const changeComputeHostAuthenticationRequestSchema = z
     operationId: z.string(),
     authenticationMode: z.enum(['ssh_config', 'password']),
     username: z.string().optional(),
-    port: finiteNumberSchema,
+    port: finiteNumberSchema.optional(),
     identityFile: z.string().optional(),
     password: z.string().optional()
   })
-  .strict() satisfies z.ZodType<ChangeComputeHostAuthenticationRequest>
+  .strict()
+  .refine((request) => request.authenticationMode === 'ssh_config' || request.port !== undefined, {
+    path: ['port'],
+    message: 'Port is required for password authentication.'
+  }) satisfies z.ZodType<ChangeComputeHostAuthenticationRequest>
 
 const deleteComputeHostRequestSchema = z
   .object({ providerId: z.string() })

--- a/src/main/compute/ipc.test.ts
+++ b/src/main/compute/ipc.test.ts
@@ -2420,6 +2420,49 @@ describe('installComputeIpcHandlers', () => {
     await rm(storageRoot, { recursive: true, force: true })
   })
 
+  it.each([{}, { port: undefined }])(
+    'forwards an inherited SSH port through Electron IPC: %j',
+    async (port) => {
+      const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
+      const changeAuthentication = vi
+        .spyOn(module.handlers, 'changeAuthentication')
+        .mockResolvedValue({ ok: true, host: sampleHost() })
+      installComputeModule(module)
+      const request = {
+        providerId: 'ssh:biowulf',
+        expectedRevision: 1,
+        operationId: 'inherit-port',
+        authenticationMode: 'ssh_config',
+        username: 'researcher',
+        ...port
+      }
+
+      await expect(invokeHandler('compute:change-authentication', request)).resolves.toMatchObject({
+        ok: true
+      })
+      expect(changeAuthentication).toHaveBeenCalledWith(request)
+      expect(changeAuthentication.mock.calls[0][0].port).toBeUndefined()
+    }
+  )
+
+  it('rejects an omitted password-authentication port before invoking the owner', async () => {
+    const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
+    const changeAuthentication = vi.spyOn(module.handlers, 'changeAuthentication')
+    installComputeModule(module)
+
+    await expect(
+      invokeHandler('compute:change-authentication', {
+        providerId: 'ssh:biowulf',
+        expectedRevision: 1,
+        operationId: 'password-port',
+        authenticationMode: 'password',
+        username: 'researcher',
+        password: 'secret'
+      })
+    ).rejects.toThrow(/invalid.*compute:change-authentication/i)
+    expect(changeAuthentication).not.toHaveBeenCalled()
+  })
+
   it('registers every compute:* channel that the renderer can invoke', () => {
     const module = createComputeIpcModule(mockRepository({}), mockJobRepo({}))
     installComputeModule(module)

--- a/src/main/compute/repository.test.ts
+++ b/src/main/compute/repository.test.ts
@@ -303,9 +303,15 @@ describe('compute host repository', () => {
       const { client, computeHost } = createMockClient({})
       const repository = new ComputeHostRepository(() => Promise.resolve(client))
 
-      await expect(repository.updateScratchRoot('ssh:biowulf', scratchRoot)).rejects.toThrow(
-        /scratch root/i
-      )
+      await expect(
+        repository.updateProbeResult(
+          'ssh:biowulf',
+          { ok: true, probedAt: '', exitCode: 0, errorTail: null, authenticationRevision: 1 },
+          'direct_ssh',
+          'host-1',
+          scratchRoot
+        )
+      ).rejects.toThrow(/scratch root/i)
       expect(computeHost.update).not.toHaveBeenCalled()
     }
   )
@@ -628,7 +634,12 @@ describe('compute host repository', () => {
     const update = vi.fn()
     const updateMany = vi.fn(async () => ({ count: 0 }))
     const repository = new ComputeHostRepository(
-      async () => ({ computeHost: { update, updateMany } }) as unknown as ComputeHostClient
+      async () =>
+        ({
+          computeHost: { update, updateMany },
+          $transaction: async (fn: (tx: unknown) => unknown) =>
+            fn({ computeHost: { update, updateMany } })
+        }) as unknown as ComputeHostClient
     )
     const staleProbe = {
       ok: true as const,
@@ -640,10 +651,10 @@ describe('compute host repository', () => {
     }
 
     await expect(
-      repository.updateProbeResult('ssh:biowulf', staleProbe, 'direct_ssh')
-    ).resolves.toBeUndefined()
+      repository.updateProbeResult('ssh:biowulf', staleProbe, 'direct_ssh', 'host-1')
+    ).resolves.toBe(false)
     expect(updateMany).toHaveBeenCalledWith({
-      where: { providerId: 'ssh:biowulf', authenticationRevision: 1 },
+      where: { id: 'host-1', providerId: 'ssh:biowulf', authenticationRevision: 1 },
       data: {
         probeResult: JSON.stringify({ schemaVersion: 1, ...staleProbe }),
         shape: 'direct_ssh'

--- a/src/main/compute/repository.ts
+++ b/src/main/compute/repository.ts
@@ -742,62 +742,53 @@ class ComputeHostRepository {
     )
   }
 
-  // Writes the structured probe snapshot and inferred shape. Never touches detailsDoc (design.md §4).
+  // Commit the observed identity's snapshot and automatic path in one persistence boundary.
   async updateProbeResult(
     providerId: string,
     result: ProbeResult,
-    shape: ComputeHostShape
-  ): Promise<void> {
+    shape: ComputeHostShape,
+    hostId: string,
+    scratchRoot?: string
+  ): Promise<boolean> {
+    if (!Number.isInteger(result.authenticationRevision)) return false
+    const safeScratchRoot =
+      scratchRoot === undefined ? undefined : assertSafeScratchRoot(scratchRoot)
     const client = await this.getClient()
-
-    if (Number.isInteger(result.authenticationRevision)) {
-      await client.computeHost.updateMany({
-        where: { providerId, authenticationRevision: result.authenticationRevision },
-        data: {
-          probeResult: serializeProbeResult(result),
-          shape
-        }
-      })
-      return
-    }
-    await client.computeHost.update({
-      where: { providerId },
-      data: {
-        probeResult: serializeProbeResult(result),
-        shape
+    return client.$transaction(async (transaction) => {
+      const where = {
+        id: hostId,
+        providerId,
+        authenticationRevision: result.authenticationRevision
       }
+      const updated = await transaction.computeHost.updateMany({
+        where,
+        data: { probeResult: serializeProbeResult(result), ...(result.ok ? { shape } : {}) }
+      })
+      if (updated.count !== 1) return false
+      if (result.ok && safeScratchRoot !== undefined) {
+        await transaction.computeHost.updateMany({
+          where: { ...where, scratchPinned: false },
+          data: { scratchRoot: safeScratchRoot }
+        })
+      }
+      return true
     })
   }
 
-  // Updates scratchRoot when the probe reads $SCRATCH and scratchPinned is false. Probe callers
-  // must check scratchPinned before calling (ComputeService.probe does this).
-  async updateScratchRoot(providerId: string, scratchRoot: string): Promise<void> {
-    const safeScratchRoot = assertSafeScratchRoot(scratchRoot)
-    const client = await this.getClient()
-
-    await client.computeHost.update({
-      where: { providerId },
-      data: { scratchRoot: safeScratchRoot }
-    })
-  }
-
-  // Writes detailsDoc and records who edited it (user or agent) and when. Called by
-  // ComputeService.replaceDetails (UI + agent-facing). Never called by probe.
+  // Compare and write atomically; author metadata belongs only to the accepted save.
   async updateDetails(
     providerId: string,
     detailsDoc: string,
-    author: DetailsAuthor
-  ): Promise<void> {
+    author: DetailsAuthor,
+    hostId: string,
+    oldText: string
+  ): Promise<boolean> {
     const client = await this.getClient()
-
-    await client.computeHost.update({
-      where: { providerId },
-      data: {
-        detailsDoc,
-        detailsUpdatedBy: author,
-        detailsUpdatedAt: new Date()
-      }
+    const updated = await client.computeHost.updateMany({
+      where: { id: hostId, providerId, detailsDoc: oldText },
+      data: { detailsDoc, detailsUpdatedBy: author, detailsUpdatedAt: new Date() }
     })
+    return updated.count === 1
   }
 
   // Updates scratchRoot and sets scratchPinned=true. Called when the user explicitly sets a

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -3903,8 +3903,19 @@ describe('LiteratureLibraryPage', () => {
   })
 
   it('filters and moves the current view to Trash', async () => {
-    search.mockImplementation((request: { scope: string }) =>
-      Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })
+    let resolveFilteredSearch!: (page: { entries: (typeof libraryItem)[] }) => void
+    const filteredSearch = new Promise<{ entries: (typeof libraryItem)[] }>((resolve) => {
+      resolveFilteredSearch = resolve
+    })
+    search.mockImplementation(
+      (request: { scope: string; filter?: { yearFrom?: number; hasFullText?: boolean } }) => {
+        if (request.filter?.yearFrom === 2020 && request.filter.hasFullText === true) {
+          return filteredSearch
+        }
+        return Promise.resolve(
+          request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] }
+        )
+      }
     )
 
     render(<LiteratureLibraryPage />)
@@ -3929,7 +3940,11 @@ describe('LiteratureLibraryPage', () => {
       )
     )
 
-    fireEvent.click(screen.getByLabelText('Select Corrective Retrieval Augmented Generation'))
+    // The search call can be observed before its response renders the filtered row.
+    setTimeout(() => resolveFilteredSearch({ entries: [libraryItem] }), 0)
+    fireEvent.click(
+      await screen.findByLabelText('Select Corrective Retrieval Augmented Generation')
+    )
     expect(screen.queryByLabelText('Sort references')).toBeNull()
     expect(screen.getByRole('button', { name: 'Clear selection' })).not.toBeNull()
     const actionRail = document.querySelector<HTMLElement>('[data-slot="literature-action-rail"]')

--- a/src/renderer/src/pages/settings/ComputeHostAuthenticationDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostAuthenticationDetail.tsx
@@ -52,7 +52,9 @@ export function ComputeHostAuthenticationDetail({
   const currentRevision = host.authentication?.revision ?? 1
   const [mode, setMode] = useState<ComputeAuthenticationMode>(currentMode)
   const [username, setUsername] = useState(host.sshOverrides?.user ?? '')
-  const [port, setPort] = useState(String(host.sshOverrides?.port ?? 22))
+  const [port, setPort] = useState(
+    String(host.sshOverrides?.port ?? (currentMode === 'password' ? 22 : ''))
+  )
   const identityFile = host.sshOverrides?.identityFile ?? ''
   const [password, setPassword] = useState('')
   const [busy, setBusy] = useState(false)
@@ -81,7 +83,7 @@ export function ComputeHostAuthenticationDetail({
     if (!isEditing) {
       setMode(currentMode)
       setUsername(host.sshOverrides?.user ?? '')
-      setPort(String(host.sshOverrides?.port ?? 22))
+      setPort(String(host.sshOverrides?.port ?? (currentMode === 'password' ? 22 : '')))
     }
   }
 
@@ -109,7 +111,7 @@ export function ComputeHostAuthenticationDetail({
     onEditingChange(false)
     setMode(currentMode)
     setUsername(host.sshOverrides?.user ?? '')
-    setPort(String(host.sshOverrides?.port ?? 22))
+    setPort(String(host.sshOverrides?.port ?? (currentMode === 'password' ? 22 : '')))
     setPassword('')
     setValidationError(undefined)
   }
@@ -118,18 +120,22 @@ export function ComputeHostAuthenticationDetail({
     setPassword('')
     setFeedback(undefined)
     setValidationError(undefined)
+    if (nextMode === 'password' && !port.trim()) setPort('22')
     setMode(nextMode)
     setAuthenticationOperation(undefined)
   }
 
   const save = async (): Promise<void> => {
-    const parsedPort = Number(port)
+    const parsedPort = mode === 'ssh_config' && !port.trim() ? undefined : Number(port)
     const normalizedUsername = username.trim() || undefined
     if (mode === 'password' && !normalizedUsername) {
       setValidationError({ field: 'username', text: t('Username is required.') })
       return
     }
-    if (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65_535) {
+    if (
+      parsedPort !== undefined &&
+      (!Number.isInteger(parsedPort) || parsedPort < 1 || parsedPort > 65_535)
+    ) {
       setValidationError({
         field: 'port',
         text: t('Port must be an integer from 1 through 65535.')
@@ -140,7 +146,7 @@ export function ComputeHostAuthenticationDetail({
       mode === 'ssh_config' ? identityFile.trim() || undefined : undefined
     const modeChanged = mode !== currentMode
     const usernameChanged = normalizedUsername !== (host.sshOverrides?.user || undefined)
-    const portChanged = parsedPort !== (host.sshOverrides?.port ?? 22)
+    const portChanged = parsedPort !== host.sshOverrides?.port
     const identityFileChanged =
       mode === 'ssh_config' &&
       normalizedIdentityFile !== (host.sshOverrides?.identityFile || undefined)
@@ -235,7 +241,10 @@ export function ComputeHostAuthenticationDetail({
             <dt className="text-muted-foreground">{t('Username')}</dt>
             <dd className="col-span-2">{host.sshOverrides?.user || t('From SSH configuration')}</dd>
             <dt className="text-muted-foreground">{t('Port')}</dt>
-            <dd className="col-span-2">{host.sshOverrides?.port ?? 22}</dd>
+            <dd className="col-span-2">
+              {host.sshOverrides?.port ??
+                (currentMode === 'password' ? 22 : t('From SSH configuration'))}
+            </dd>
             <dt className="text-muted-foreground">
               {currentMode === 'password' ? t('Saved password') : t('Credential')}
             </dt>
@@ -356,6 +365,7 @@ export function ComputeHostAuthenticationDetail({
             <Label htmlFor="compute-detail-port">{t('Port')}</Label>
             <Input
               id="compute-detail-port"
+              placeholder={mode === 'ssh_config' ? t('From SSH configuration') : undefined}
               inputMode="numeric"
               value={port}
               onChange={(event) => {

--- a/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
@@ -1306,3 +1306,85 @@ describe('ComputeHostDetail', () => {
     expect(container.querySelector('[data-compute-authentication-alert]')).toBeNull()
   })
 })
+
+it.each([undefined, 2222])(
+  'saves an inherited SSH port when editing or clearing the override (%s)',
+  async (initialPort) => {
+    const changeAuthentication = vi.fn().mockResolvedValue(host())
+    useComputeStore.setState({
+      hosts: [
+        host({ sshOverrides: { user: 'before', ...(initialPort ? { port: initialPort } : {}) } })
+      ],
+      changeAuthentication
+    })
+    await act(async () => root.render(<ComputeHostDetail providerId="ssh:biowulf" />))
+    const section = Array.from(
+      container.querySelectorAll<HTMLElement>('[data-slot="settings-section"]')
+    ).find((section) => section.querySelector('h3')?.textContent === 'Configuration')!
+    act(() =>
+      Array.from(section.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === 'Edit')!
+        .click()
+    )
+    const enter = (id: string, value: string): void => {
+      const input = container.querySelector<HTMLInputElement>(id)!
+      act(() => {
+        Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')!.set!.call(
+          input,
+          value
+        )
+        input.dispatchEvent(new Event('input', { bubbles: true }))
+      })
+    }
+    enter('#compute-detail-username', 'after')
+    if (initialPort) enter('#compute-detail-port', '')
+    await act(async () =>
+      Array.from(section.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === 'Test and save')!
+        .click()
+    )
+    expect(changeAuthentication).toHaveBeenCalledOnce()
+    expect(changeAuthentication.mock.calls[0][0].port).toBeUndefined()
+  }
+)
+
+it('keeps the draft and reloads a merge base after a details conflict', async () => {
+  stubDetailsGet('base')
+  const saveDetails = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('details_conflict: old_text does not match'))
+  useComputeStore.setState({ hosts: [host({ detailsDoc: 'base' })], saveDetails })
+  await act(async () => root.render(<ComputeHostDetail providerId="ssh:biowulf" />))
+  const section = Array.from(
+    container.querySelectorAll<HTMLElement>('[data-slot="settings-section"]')
+  ).find((section) => section.querySelector('h3')?.textContent === 'Details')!
+  const click = async (text: string): Promise<void> => {
+    await act(async () =>
+      Array.from(section.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === text)!
+        .click()
+    )
+  }
+  await click('Edit')
+  const draft = section.querySelector('textarea')!
+  act(() => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+      draft,
+      'my draft'
+    )
+    draft.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  await click('Save')
+  expect(draft.value).toBe('my draft')
+  stubDetailsGet('other writer')
+  expect(
+    Array.from(section.querySelectorAll('button')).some(
+      (button) => button.textContent?.trim() === 'Reload'
+    )
+  ).toBe(true)
+  await click('Reload')
+  expect(draft.value).toBe('my draft')
+  expect(section.textContent).toContain('other writer')
+  await click('Save')
+  expect(saveDetails).toHaveBeenLastCalledWith('ssh:biowulf', 'my draft', 'other writer')
+})

--- a/src/renderer/src/pages/settings/ComputeHostDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.tsx
@@ -177,6 +177,8 @@ export function ComputeHostDetail({
   const [detailsDoc, setDetailsDoc] = useState<string>('')
   const [originalDoc, setOriginalDoc] = useState<string>('')
   const [isEditingDetails, setIsEditingDetails] = useState(false)
+  const [detailsConflict, setDetailsConflict] = useState(false)
+  const [mergeBase, setMergeBase] = useState<string | undefined>()
   const [detailsSaving, setDetailsSaving] = useState(false)
   const [detailsError, setDetailsError] = useState<DetailError | undefined>(undefined)
   const [isSkeleton, setIsSkeleton] = useState(false)
@@ -219,7 +221,7 @@ export function ComputeHostDetail({
 
   // Load the details doc (with skeleton synthesis) when the host is first available.
   useEffect(() => {
-    if (!host || detailsLoadedRef.current) return
+    if (!host || detailsLoadedRef.current || isEditingDetails) return
     detailsLoadedRef.current = true
 
     window.api.compute
@@ -234,7 +236,7 @@ export function ComputeHostDetail({
         setDetailsDoc(host.detailsDoc ?? '')
         setOriginalDoc(host.detailsDoc ?? '')
       })
-  }, [host, providerId])
+  }, [host, providerId, isEditingDetails])
 
   useEffect(() => {
     if (host?.authentication?.mode !== 'password') return
@@ -302,9 +304,30 @@ export function ComputeHostDetail({
     setDetailsError(undefined)
     try {
       await saveDetails(providerId, detailsDoc, originalDoc)
+      setDetailsConflict(false)
+      setMergeBase(undefined)
       setOriginalDoc(detailsDoc)
       setIsSkeleton(false)
       setIsEditingDetails(false)
+    } catch (err) {
+      setDetailsConflict(
+        /details_conflict|old_text/.test(err instanceof Error ? err.message : String(err))
+      )
+      setDetailsError(failure(err, 'Failed to save details.'))
+    } finally {
+      setDetailsSaving(false)
+    }
+  }
+
+  const reloadDetailsForMerge = async (): Promise<void> => {
+    setDetailsSaving(true)
+    try {
+      const { doc, isSkeleton: skeleton } = await window.api.compute.detailsGet(providerId)
+      setOriginalDoc(skeleton ? '' : doc)
+      setIsSkeleton(skeleton)
+      setMergeBase(doc)
+      setDetailsConflict(false)
+      setDetailsError(undefined)
     } catch (err) {
       setDetailsError(failure(err, 'Failed to save details.'))
     } finally {
@@ -313,6 +336,8 @@ export function ComputeHostDetail({
   }
 
   const handleDetailsCancel = (): void => {
+    setDetailsConflict(false)
+    setMergeBase(undefined)
     setDetailsDoc(originalDoc)
     setDetailsError(undefined)
     setIsEditingDetails(false)
@@ -810,6 +835,26 @@ export function ComputeHostDetail({
       >
         {isEditingDetails ? (
           <div className="flex flex-col gap-2">
+            {detailsConflict ? (
+              <Button
+                type="button"
+                variant="outline"
+                disabled={detailsSaving}
+                onClick={() => void reloadDetailsForMerge()}
+              >
+                {t('Reload')}
+              </Button>
+            ) : null}
+            {detailsConflict || mergeBase !== undefined ? (
+              <p className="text-xs text-muted-foreground">
+                {t(
+                  'Your draft is preserved. Reload the current details, then merge them into your draft before saving.'
+                )}
+              </p>
+            ) : null}
+            {mergeBase !== undefined ? (
+              <pre className="whitespace-pre-wrap rounded border p-3 text-xs">{mergeBase}</pre>
+            ) : null}
             <textarea
               className="min-h-[160px] w-full resize-y rounded-md border border-input bg-background px-3 py-2 font-mono text-xs focus:outline-none focus:ring-2 focus:ring-ring"
               value={detailsDoc}
@@ -848,7 +893,9 @@ export function ComputeHostDetail({
                   type="button"
                   size="sm"
                   onClick={() => void handleDetailsSave()}
-                  disabled={detailsSaving || detailsDoc.length > DETAILS_DOC_MAX_LENGTH}
+                  disabled={
+                    detailsSaving || detailsConflict || detailsDoc.length > DETAILS_DOC_MAX_LENGTH
+                  }
                   aria-busy={detailsSaving}
                 >
                   {detailsSaving ? t('Saving…') : t('Save')}

--- a/src/shared/compute.ts
+++ b/src/shared/compute.ts
@@ -233,9 +233,9 @@ export type ChangeComputeHostAuthenticationRequest = Readonly<{
   expectedRevision: number
   operationId: string
   authenticationMode: ComputeAuthenticationMode
-  // Absent in ssh_config mode: the User (and port fallback) then come from ~/.ssh/config.
+  // Absent overrides in ssh_config mode inherit User and Port from ~/.ssh/config.
   username?: string
-  port: number
+  port?: number
   identityFile?: string
   password?: string
 }>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -100,6 +100,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Ihr Entwurf bleibt erhalten. Laden Sie die aktuellen Details neu und führen Sie sie vor dem Speichern mit Ihrem Entwurf zusammen.",
     "Project: {{name}}": "Projekt: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Für diese Plattform ist kein Installationsprogramm verfügbar. Laden Sie es manuell herunter, um andere Installationsmöglichkeiten zu prüfen.",
     "Latest saved version": "Zuletzt gespeicherte Version",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Se conserva su borrador. Vuelva a cargar los detalles actuales y combínelos con su borrador antes de guardar.",
     "Project: {{name}}": "Proyecto: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "No hay un instalador disponible para esta plataforma. Descargue manualmente para consultar otras opciones de instalación.",
     "Latest saved version": "Última versión guardada",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -101,6 +101,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Votre brouillon est conservé. Rechargez les détails actuels, puis fusionnez-les avec votre brouillon avant de sauvegarder.",
     "Project: {{name}}": "Projet : {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Aucun programme d’installation n’est disponible pour cette plateforme. Consultez le téléchargement manuel pour découvrir d’autres options d’installation.",
     "Latest saved version": "Dernière version enregistrée",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "下書きは保持されています。現在の説明を再読み込みし、下書きに統合してから保存してください。",
     "Project: {{name}}": "プロジェクト：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "このプラットフォーム用のインストーラーはありません。手動ダウンロードのページで他のインストール方法を確認してください。",
     "Latest saved version": "最後に保存されたバージョン",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "초안이 보존됩니다. 현재 설명을 다시 불러온 후 초안에 병합하고 저장하세요.",
     "Project: {{name}}": "프로젝트: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "이 플랫폼에서 사용할 수 있는 설치 프로그램이 없습니다. 수동 다운로드 페이지에서 다른 설치 방법을 확인하세요.",
     "Latest saved version": "최근 저장된 버전",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Черновик сохранён. Загрузите актуальное описание и объедините его с черновиком перед сохранением.",
     "Project: {{name}}": "Проект: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Установщик для этой платформы недоступен. Перейдите к ручной загрузке, чтобы узнать о других вариантах установки.",
     "Latest saved version": "Последняя сохранённая версия",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "草稿已保留。请重新加载当前说明，将其合并到草稿后再保存。",
     "Project: {{name}}": "项目：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "此平台暂无可用的安装包。请前往手动下载页面查看其他安装选项。",
     "Latest saved version": "最新保存的版本",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -99,6 +99,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "草稿已保留。請重新載入目前說明，將其合併至草稿後再儲存。",
     "Project: {{name}}": "專案：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "此平台暫無可用的安裝套件。請前往手動下載頁面查看其他安裝選項。",
     "Latest saved version": "最新儲存的版本",


### PR DESCRIPTION
Concurrent details saves could both report success while one document disappeared; probes could overwrite a newly pinned scratch path or write an old identity's path after authentication changed. Remote shell failures were also treated as successful resource detection, and editing an SSH-config host silently changed an inherited port to an explicit 22.

- Compare and write details by stable host ID and old text in one database update. Append retries this comparison at most five times, rereading and checking the length limit each time. Conflicts preserve the editor draft and offer a reload-and-manual-merge path.
- Persist probe results and automatic scratch paths in one transaction, matching stable host ID and authentication revision. Automatic paths additionally require the current stored pinned flag to be false. Rejected probes return an explicit conflict.
- Require a successful exit and usable OS/scheduler output. Missing scheduler checks remain unknown; only explicit negative checks mean no scheduler. Failed probes retain bounded diagnostics and do not change the existing host shape. The latest failed snapshot replaces resource metrics rather than presenting old metrics as newly verified.
- Keep SSH-config ports optional through the renderer, request type, authentication comparison, validation candidate, and persistence. A blank field restores SSH configuration inheritance; password authentication still requires a valid explicit port.

No database columns, migrations, dependencies, or architectural layers are added. This uses existing host identity, authentication revision, and document text. UI changes are limited to draft conflict recovery and inherited-port display/input; no automatic merge or history system is introduced.

Validation: deterministic regression tests were run on the original implementation twice and reproduced lost replacements/appends, length-limit races, both scratch races, invalid successful probes, and inherited-port changes. An additional authentication-owner test rejected an omitted SSH port on the original code. The draft recovery test failed because no reload action existed. All now pass. The concurrency tests use a real migrated SQLite database, existing public owner/repository methods, and the existing broker boundary; no production test seam was added.

Targeted tests (including all locale guards), TypeScript checks, and lint passed. Full-suite result recorded below.

The sandboxed full `npm test` run completed with 25,649 passing tests and 689 failures across 70 files; representative failures were `listen EPERM` for local TCP/Unix sockets and `spawnSync ps EPERM`. All changed-file regressions passed. All 70 failed files passed when rerun with the local socket/process permissions those tests require: 2,404 tests passed and 35 skipped. The initial full run plus this retry covers the complete suite; this is not a claim that the sandboxed run itself passed.
