### PR TITLE
fix(preview): respect literature PDF version ownership

### DIFF
--- a/src/renderer/src/pages/workspace/ManagedFileDownloadButton.tsx
+++ b/src/renderer/src/pages/workspace/ManagedFileDownloadButton.tsx
@@ -51,7 +51,8 @@ const ManagedFileDownloadButtonState = ({
   const { t } = useTranslation()
   const { status, sizeLimitError } = download
 
-  const hasExplicitManagedVersion = Boolean(projectId && fileId && versionId)
+  const hasExplicitManagedVersion =
+    (source === 'artifact' || source === 'upload') && Boolean(projectId && fileId && versionId)
   const hasResolvedVersionContext =
     Boolean(latestVersionId) &&
     Number.isSafeInteger(versionNumber) &&

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -87,6 +87,7 @@ vi.mock('./ManagedVersionDiffContent', () => ({
 }))
 
 import { PreviewFileSurface } from './PreviewFileSurface'
+import { createPreviewFileItemFromPdfContext } from './preview-file-item'
 import { FOCUS_COMPOSER_EVENT } from './composer-focus-events'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
@@ -3213,6 +3214,45 @@ describe('PreviewFileSurface PDF context action matrix', () => {
     // Linking is "Read with agent": the composer takes focus so the user can ask immediately.
     expect(focusListener).toHaveBeenCalled()
     window.removeEventListener(FOCUS_COMPOSER_EVENT, focusListener)
+  })
+
+  it('opens a Reading Literature PDF without an Artifact version error', async () => {
+    selectPdfContextSession()
+    installPdfContextApi()
+    window.api.managedFileVersions.inspect = vi.fn().mockResolvedValue({
+      ok: false,
+      error: { code: 'FILE_NOT_FOUND', message: 'Managed Artifact was not found.' }
+    })
+    const readingItem = createPreviewFileItemFromPdfContext(
+      {
+        version: 1,
+        bindingId: 'literature-binding',
+        sourceKind: 'literature-attachment-version',
+        sourceFileId: 'attachment-1',
+        sourceVersionId: 'attachment-version-1',
+        name: 'paper.pdf',
+        mimeType: 'application/pdf',
+        sizeBytes: 4096,
+        checksum: 'pdf-checksum',
+        linkedAt: 1
+      },
+      'project-1'
+    )
+    await act(async () => {
+      root.render(<PreviewFileSurface item={readingItem} onClose={vi.fn()} />)
+    })
+
+    expect(container.querySelector('[data-testid="preview-content"]')).not.toBeNull()
+    const download = container.querySelector<HTMLButtonElement>('[aria-label="Download paper.pdf"]')
+    expect.soft(download?.disabled).toBe(false)
+    expect.soft(container.textContent).not.toContain('Managed Artifact was not found.')
+    expect.soft(window.api.managedFileVersions.inspect).not.toHaveBeenCalled()
+    await click(download)
+    expect(window.api.saveManagedFile).toHaveBeenCalledWith({
+      source: 'literature',
+      path: readingItem.path,
+      suggestedName: 'paper.pdf'
+    })
   })
 
   it('adds an immutable Literature PDF Version to the active Session context', async () => {

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
@@ -134,6 +134,38 @@ afterEach(async () => {
   vi.unstubAllGlobals()
 })
 
+it.each(['literature', 'local', 'notebook-input'] as const)(
+  'does not inspect %s identities as Artifacts, including after an Artifact preview',
+  async (source) => {
+    inspect.mockResolvedValue({ ok: true, value: snapshot('artifact', 1) })
+    const item = itemFor('artifact')
+    await render(item)
+    expect(workflow.inspect).toBeDefined()
+    expect(changedListeners.size).toBe(1)
+    inspect.mockClear()
+
+    await render({ ...item, source })
+    expect(inspect).not.toHaveBeenCalled()
+    expect(workflow.identity).toBeUndefined()
+    expect(workflow.inspect).toBeUndefined()
+    expect(workflow.inspectError).toBeUndefined()
+    expect(workflow.inspectLoading).toBe(false)
+    expect(workflow.controlsInspect).toBeUndefined()
+    expect(changedListeners.size).toBe(0)
+  }
+)
+
+it('retains the established default Artifact source', async () => {
+  inspect.mockResolvedValue({ ok: true, value: snapshot('artifact', 1) })
+  await render({ ...itemFor('artifact'), source: undefined })
+  expect(inspect).toHaveBeenCalledWith({
+    source: 'artifact',
+    projectId: 'project-1',
+    fileId: 'file-1'
+  })
+  expect(workflow.inspect?.source).toBe('artifact')
+})
+
 describe.each(['upload', 'artifact'] as const)('%s version inspection freshness', (source) => {
   it('refreshes the head, editable text and download context when the same file metadata changes', async () => {
     inspect.mockResolvedValueOnce({ ok: true, value: snapshot(source, 1) })

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -83,10 +83,10 @@ const useManagedVersionWorkflow = ({
     error?: string
   }>({})
   const activeDiffRequestId = useRef<string | undefined>(undefined)
-  const source: 'upload' | 'artifact' = item.source === 'upload' ? 'upload' : 'artifact'
+  const source = item.source ?? 'artifact'
   const identity = useMemo(
     () =>
-      projectId && item.managedFileId
+      (source === 'artifact' || source === 'upload') && projectId && item.managedFileId
         ? { source, projectId, fileId: item.managedFileId }
         : undefined,
     [item.managedFileId, projectId, source]


### PR DESCRIPTION
## Problem

Reopening a Literature PDF from a Reading session passed its attachment identity to the Artifact version inspector. The PDF remained readable, but Electron showed `Version check failed / Managed Artifact was not found / FILE_NOT_FOUND`. The header download also remained disabled while waiting for version metadata that Literature does not provide. The Literature conversion was introduced in #2236.

## Proposed change

Restrict version inspection and version-aware download prerequisites to Artifact and Upload sources. Preserve the established default Artifact source and Literature's existing attachment/version identity and path-based download. This fixes the shared Reading reopen/page-reveal paths instead of hiding backend errors.

The oversized notice reported in the screenshot already uses the compact shared ErrorNotice on main after #2246; this PR retains that presentation for genuine failures.

## Scope and non-goals

Two source guards, plus regression coverage. No API, architecture, dependency, data-model, field, enum/state, persisted-format, or migration changes. Existing restored Literature previews use the same guard; no historical-data rewrite is needed. No ACP protocol or provider-specific behavior changes.

## Acceptance criteria and validation

All checks below ran after the last material edit. No full local suite was run, as requested; PR CI is authoritative for broad/platform coverage. The impact manifest has no exact owner-module entry for these implementation paths, so this is an explicit consumer-based Test Impact Set, not an automatic affected-plan claim.

| Behavior | Check | Result |
| --- | --- | --- |
| Reading preview, download request, source transitions, Artifact/Upload history and pending metadata | `npx vitest run src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx src/renderer/src/pages/workspace/ManagedFileDownloadButton.test.tsx` | 193 passed |
| Preview identity and reveal, fullscreen, project files, fallback/Office consumers, compact errors and preview reader | Targeted Vitest: `preview-file-item`, `pdf-reading-reveal`, `FilePreviewDialog.versioning`, `ProjectFilesView`, `PreviewFallback`, `OfficePreview`, `preview-registry`, `error-notice`, `preview-file-reader` test files | 165 passed |
| Reading runtime consumer | `npx vitest run src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts -t 'PDF\|pdf\|Reading'` | 19 passed; 242 unrelated skipped |
| Renderer types and repository lint | `npm run typecheck:web`; `npm run lint`; `git diff --check` | Passed |

Regression evidence: the new surface test failed repeatedly on unchanged production code with the exact reported error, disabled download and no save request. The transition tests also failed before the guards and passed afterward. Tests use the existing public preview converter/surface and API doubles; no production test seam was added.

Visual/runtime evidence: imported a controlled two-page PDF through Literature UI, entered Read with agent, and used real session-save/PDF-link APIs to construct the durable post-link state without calling a model. In isolated Electron, reopening the PDF reproduced the error while PDF pages remained readable. After the fix the same PDF reopened without the error, download was enabled, and the real saved PDF's SHA-256 matched the original (only the native destination chooser was stubbed). Before/after screenshots were provided in the task.

Web does not expose `managedFileVersions.inspect` (Electron-only capability), so Web absence of the error was not treated as verification. No main-process/platform path or persistence logic changed; Windows/Linux and the full portable suite remain CI coverage. The live model/permission workflow was not exercised; the deterministic persisted binding boundary was used instead.

## Review focus

Check that unsupported sources never inherit Artifact version capabilities, while ordinary Artifact/Upload version safety and errors remain intact. An independent review found no actionable issues in the final diff and confirmed the consumer test mapping.
