### PR TITLE
fix(compute): preserve analysis identity during recovery

### DIFF
--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -1278,6 +1278,14 @@ describe('ComputeJob repository (SQLite integration)', () => {
       repo.transitionAnalysis({
         sessionId: 'session-1',
         jobIds: ['job-failed'],
+        messageId: 'replacement-analysis',
+        state: 'dispatched'
+      })
+    ).rejects.toThrow(/does not match its durable dispatch/)
+    await expect(
+      repo.transitionAnalysis({
+        sessionId: 'session-1',
+        jobIds: ['job-failed'],
         messageId: 'different-message',
         state: 'succeeded'
       })

--- a/src/renderer/src/lib/compute/job-analysis-trigger.test.ts
+++ b/src/renderer/src/lib/compute/job-analysis-trigger.test.ts
@@ -35,6 +35,7 @@ const makeJob = (
 
 const createDeps = (overrides: Partial<JobAnalysisTriggerDeps> = {}): JobAnalysisTriggerDeps => ({
   sendPrompt: vi.fn(async (sessionId, _text, messageId) => ({ sessionId, messageId })),
+  preparePrompt: vi.fn(async (_sessionId, text) => text),
   flushPersistence: vi.fn().mockResolvedValue(undefined),
   createMessageId: vi.fn().mockReturnValue('msg-1'),
   transitionAnalysis: vi.fn().mockResolvedValue(undefined),
@@ -46,6 +47,8 @@ const createDeps = (overrides: Partial<JobAnalysisTriggerDeps> = {}): JobAnalysi
 })
 
 const flushMicrotasks = async (): Promise<void> => {
+  await Promise.resolve()
+  await Promise.resolve()
   await Promise.resolve()
   await Promise.resolve()
   await Promise.resolve()
@@ -118,11 +121,11 @@ describe('createJobAnalysisTrigger — immediate send', () => {
 
     // onTurnEnd should have been called to register a callback
     expect(deps.onTurnEnd).toHaveBeenCalledTimes(1)
-    const [sessionId, callback] = (deps.onTurnEnd as ReturnType<typeof vi.fn>).mock.calls[0] as [
-      string,
-      (outcome: 'succeeded' | 'failed' | 'cancelled') => void
-    ]
+    const [sessionId, messageId, callback] = (deps.onTurnEnd as ReturnType<typeof vi.fn>).mock
+      .calls[0] as [string, string, (outcome: 'succeeded' | 'failed' | 'cancelled') => void]
     expect(sessionId).toBe('sess-1')
+
+    expect(messageId).toBe('msg-1')
 
     // Simulate turn completion by invoking the callback
     callback('succeeded')
@@ -153,7 +156,7 @@ describe('createJobAnalysisTrigger — immediate send', () => {
         .mockResolvedValue([
           makeJob({ analysis_state: 'dispatched', analysis_message_id: 'msg-1' })
         ]),
-      onTurnEnd: vi.fn((_sessionId, callback) => {
+      onTurnEnd: vi.fn((_sessionId, _messageId, callback) => {
         turnEndCallback = callback
       })
     })
@@ -205,7 +208,7 @@ describe('createJobAnalysisTrigger — immediate send', () => {
     const deps = createDeps({
       transitionAnalysis,
       getJobsForSession: vi.fn().mockResolvedValue([]),
-      onTurnEnd: vi.fn((_sessionId, callback) => {
+      onTurnEnd: vi.fn((_sessionId, _messageId, callback) => {
         turnEndCallback = callback
       })
     })
@@ -446,7 +449,7 @@ describe('createJobAnalysisTrigger — queuing', () => {
         .mockReturnValueOnce('msg-1')
         .mockReturnValueOnce('msg-2'),
       transitionAnalysis,
-      onTurnEnd: vi.fn((_sessionId, callback) => {
+      onTurnEnd: vi.fn((_sessionId, _messageId, callback) => {
         turnEndCallbacks.push(callback)
       })
     })
@@ -486,7 +489,7 @@ describe('createJobAnalysisTrigger — queuing', () => {
   it('serializes recovered and pending analysis batches for the same session', async () => {
     const turnEndCallbacks: Array<(outcome: 'succeeded' | 'failed' | 'cancelled') => void> = []
     const deps = createDeps({
-      onTurnEnd: vi.fn((_sessionId, callback) => {
+      onTurnEnd: vi.fn((_sessionId, _messageId, callback) => {
         turnEndCallbacks.push(callback)
       })
     })
@@ -562,4 +565,115 @@ describe('createJobAnalysisTrigger — cross-session isolation', () => {
     const [sessionId] = (deps.sendPrompt as ReturnType<typeof vi.fn>).mock.calls[0] as [string]
     expect(sessionId).toBe('sess-xyz')
   })
+})
+
+describe('createJobAnalysisTrigger — recovery reads', () => {
+  it('backs off unknown outcomes and cancels the retry on disposal', async () => {
+    vi.useFakeTimers()
+    const getTurnState = vi.fn().mockRejectedValue(new Error('Temporary read failure'))
+    const deps = createDeps({ getTurnState })
+    const trigger = createJobAnalysisTrigger(deps)
+    const job = makeJob({ analysis_state: 'dispatched', analysis_message_id: 'saved-message' })
+    trigger.onJobDone(job)
+    await flushMicrotasks()
+    expect(getTurnState).toHaveBeenCalledTimes(1)
+    for (const [index, delay] of [1000, 2000, 4000, 8000, 16000, 30000, 30000].entries()) {
+      trigger.onJobDone(job)
+      await vi.advanceTimersByTimeAsync(delay - 1)
+      expect(getTurnState).toHaveBeenCalledTimes(index + 1)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(getTurnState).toHaveBeenCalledTimes(index + 2)
+    }
+    expect(deps.transitionAnalysis).not.toHaveBeenCalled()
+    expect(deps.sendPrompt).not.toHaveBeenCalled()
+    trigger.dispose()
+    await vi.advanceTimersByTimeAsync(60000)
+    expect(getTurnState).toHaveBeenCalledTimes(8)
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('keeps new pending jobs out of a claimed batch after a preparation read failure', async () => {
+    vi.useFakeTimers()
+    let rejectRead!: (error: Error) => void
+    const preparePrompt = vi
+      .fn<JobAnalysisTriggerDeps['preparePrompt']>()
+      .mockImplementationOnce(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRead = reject
+          })
+      )
+      .mockImplementation(async (_sessionId, text) => text)
+    const callbacks: Array<(outcome: 'succeeded' | 'failed' | 'cancelled') => void> = []
+    const deps = createDeps({
+      preparePrompt,
+      createMessageId: vi
+        .fn()
+        .mockReturnValueOnce('first-message')
+        .mockReturnValueOnce('second-message'),
+      onTurnEnd: vi.fn((_sessionId, _messageId, callback) => {
+        callbacks.push(callback)
+      })
+    })
+    const trigger = createJobAnalysisTrigger(deps)
+    trigger.onJobDone(makeJob({ job_id: 'first-job' }))
+    await flushMicrotasks()
+    trigger.onJobDone(makeJob({ job_id: 'second-job' }))
+    rejectRead(new Error('Temporary Session read failure'))
+    await flushMicrotasks()
+    expect(deps.sendPrompt).not.toHaveBeenCalled()
+    await vi.advanceTimersByTimeAsync(1000)
+    expect(deps.sendPrompt).toHaveBeenCalledExactlyOnceWith(
+      'sess-1',
+      expect.stringContaining('first-job'),
+      'first-message',
+      ['first-job']
+    )
+    callbacks[0]!('succeeded')
+    await flushMicrotasks()
+    await flushMicrotasks()
+    expect(deps.sendPrompt).toHaveBeenLastCalledWith(
+      'sess-1',
+      expect.stringContaining('second-job'),
+      'second-message',
+      ['second-job']
+    )
+    expect(deps.transitionAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'dispatched',
+        messageId: 'first-message',
+        jobIds: ['first-job']
+      })
+    )
+    expect(deps.transitionAnalysis).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'dispatched',
+        messageId: 'second-message',
+        jobIds: ['second-job']
+      })
+    )
+    trigger.dispose()
+  })
+
+  it.each(['succeeded', 'failed', 'cancelled'] as const)(
+    'settles a recovered %s outcome once without sending another prompt',
+    async (outcome) => {
+      const deps = createDeps({ getTurnState: vi.fn().mockResolvedValue(outcome) })
+      const trigger = createJobAnalysisTrigger(deps)
+      trigger.onJobDone(
+        makeJob({ analysis_state: 'dispatched', analysis_message_id: 'saved-message' })
+      )
+      await flushMicrotasks()
+      await flushMicrotasks()
+      expect(deps.transitionAnalysis).toHaveBeenCalledExactlyOnceWith({
+        sessionId: 'sess-1',
+        messageId: 'saved-message',
+        jobIds: ['job-1'],
+        state: outcome
+      })
+      expect(deps.sendPrompt).not.toHaveBeenCalled()
+      expect(deps.onTurnEnd).not.toHaveBeenCalled()
+      trigger.dispose()
+    }
+  )
 })

--- a/src/renderer/src/lib/compute/job-analysis-trigger.ts
+++ b/src/renderer/src/lib/compute/job-analysis-trigger.ts
@@ -70,6 +70,14 @@ export type JobAnalysisTriggerDeps = {
     messageId: string,
     jobIds: readonly string[]
   ) => Promise<{ sessionId: string; messageId: string } | undefined>
+  // Read-only preparation: reuse durable content before admission. Read failures are retryable;
+  // undefined rejects an invalid Session/batch identity without calling the runtime.
+  preparePrompt: (
+    sessionId: string,
+    text: string,
+    messageId: string,
+    jobIds: readonly string[]
+  ) => Promise<string | undefined>
   // The Session Message and terminal response must be durable before settling the Compute claim.
   flushPersistence: () => Promise<void>
   createMessageId: () => string
@@ -83,9 +91,10 @@ export type JobAnalysisTriggerDeps = {
     | 'running'
     | Exclude<ComputeJobAnalysisState, 'dispatched'>
     | Promise<'missing' | 'running' | Exclude<ComputeJobAnalysisState, 'dispatched'>>
-  // Registers a one-shot callback for when the given session's turn reaches a terminal state.
+  // Registers a one-shot callback for the specified analysis Message's terminal outcome.
   onTurnEnd: (
     sessionId: string,
+    messageId: string,
     callback: (outcome: Exclude<ComputeJobAnalysisState, 'dispatched'>) => void
   ) => void
   // Structured logger; receives a tag and a detail message for observability.
@@ -97,6 +106,7 @@ type PendingBatch = {
   messageId?: string
   // The Message ID is chosen, but its durable dispatched transition may not have committed yet.
   claimPending?: boolean
+  readRetryDelayMs?: number
   jobs: Map<string, JobSummary>
 }
 
@@ -130,12 +140,12 @@ export const createJobAnalysisTrigger = (deps: JobAnalysisTriggerDeps): JobAnaly
   const claimRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
   const settlementRetryTimers = new Map<string, ReturnType<typeof setTimeout>>()
 
-  const scheduleClaimRetry = (key: string): void => {
+  const scheduleClaimRetry = (key: string, delayMs = transitionRetryDelayMs): void => {
     if (disposed || claimRetryTimers.has(key)) return
     const timer = setTimeout(() => {
       claimRetryTimers.delete(key)
       scheduleFlush(key)
-    }, transitionRetryDelayMs)
+    }, delayMs)
     claimRetryTimers.set(key, timer)
   }
 
@@ -307,7 +317,16 @@ export const createJobAnalysisTrigger = (deps: JobAnalysisTriggerDeps): JobAnaly
   ): void => {
     if (disposed) return
     awaitingTurnEnd.set(key, { batch, sessionId, messageId, jobIds })
-    deps.onTurnEnd(sessionId, (outcome) => void onTurnEndCallback(key, outcome))
+    deps.onTurnEnd(sessionId, messageId, (outcome) => void onTurnEndCallback(key, outcome))
+  }
+
+  const retryRead = (batch: PendingBatch): void => {
+    // A committed claim must not absorb newer jobs waiting under the Session's pending key.
+    const key = `${batch.sessionId}\u0000${batch.messageId}`
+    pendingBatches.set(key, batch)
+    const delayMs = batch.readRetryDelayMs ?? transitionRetryDelayMs
+    batch.readRetryDelayMs = Math.min(delayMs * 2, 30_000)
+    scheduleClaimRetry(key, delayMs)
   }
 
   const flushBatch = async (key: string): Promise<void> => {
@@ -342,7 +361,7 @@ export const createJobAnalysisTrigger = (deps: JobAnalysisTriggerDeps): JobAnaly
       } catch (err) {
         if (disposed) return
         deps.log('analysis-turn:reconcile-failed', `session=${sessionId} error=${String(err)}`)
-        await settle(key, batch, sessionId, messageId, jobIds, 'failed')
+        retryRead(batch)
         return
       }
       if (recoveredState !== 'missing' && recoveredState !== 'running') {
@@ -358,6 +377,7 @@ export const createJobAnalysisTrigger = (deps: JobAnalysisTriggerDeps): JobAnaly
         await deps.transitionAnalysis({ sessionId, jobIds, messageId, state: 'dispatched' })
         if (disposed) return
         batch.claimPending = false
+        batch.messageId = messageId
       } catch (err) {
         if (disposed) return
         deps.log('analysis-turn:claim-failed', `session=${sessionId} error=${String(err)}`)
@@ -375,7 +395,26 @@ export const createJobAnalysisTrigger = (deps: JobAnalysisTriggerDeps): JobAnaly
 
     deps.log('analysis-turn:sending', `session=${sessionId} jobs=[${jobIds.join(',')}]`)
 
-    const prompt = buildAnalysisPrompt(jobsToSend)
+    let prompt: string | undefined
+    try {
+      prompt = await deps.preparePrompt(
+        sessionId,
+        buildAnalysisPrompt(jobsToSend),
+        messageId,
+        jobIds
+      )
+      if (disposed) return
+    } catch (err) {
+      if (disposed) return
+      deps.log('analysis-turn:prepare-failed', `session=${sessionId} error=${String(err)}`)
+      retryRead(batch)
+      return
+    }
+    batch.readRetryDelayMs = undefined
+    if (prompt === undefined) {
+      await settle(key, batch, sessionId, messageId, jobIds, 'failed')
+      return
+    }
 
     let result: Awaited<ReturnType<typeof deps.sendPrompt>>
 

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx
@@ -8,6 +8,8 @@ import type { PersistedChatSession } from '../../../../shared/session-persistenc
 import { createInitialSessionJobState, useSessionJobStore } from '../../stores/session-job-store'
 import { createInitialSessionState, useSessionStore } from '../../stores/session-store'
 import { useJobAnalysisEffect } from './useJobAnalysisEffect'
+import { buildAnalysisPrompt } from './job-analysis-trigger'
+import { sendWorkspaceMessage } from '../acp/workspace-runtime-command-owner'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -40,14 +42,45 @@ describe('useJobAnalysisEffect persistence readiness', () => {
   let root: Root
   type AnalysisSendMessage = Parameters<typeof useJobAnalysisEffect>[0]['sendMessage']
 
-  const sendMessage = vi.fn(async (input: Parameters<AnalysisSendMessage>[0]) => {
-    const sessionId = input.sessionId ?? 'session-1'
+  const recordAnalysisRun = (input: Parameters<AnalysisSendMessage>[0]): void => {
+    const messageId = input.messageId ?? 'message-1'
     useSessionStore.setState((state) => ({
       sessions: state.sessions.map((session) =>
-        session.id === sessionId ? { ...session, status: 'running' } : session
+        session.id === (input.sessionId ?? 'session-1')
+          ? {
+              ...session,
+              status: 'running',
+              activeRun: { promptMessageId: messageId, startedAt: 1400 },
+              messages: [
+                ...session.messages.filter((message) => message.id !== messageId),
+                {
+                  id: messageId,
+                  role: 'user',
+                  content: input.text,
+                  status: 'complete',
+                  eventIds: [],
+                  createdAt: 1400,
+                  updatedAt: 1400
+                },
+                {
+                  id: `${messageId}-reply`,
+                  role: 'agent',
+                  responseToMessageId: messageId,
+                  content: 'Analysis in progress',
+                  status: 'streaming',
+                  eventIds: [],
+                  createdAt: 1500,
+                  updatedAt: 1500
+                }
+              ]
+            }
+          : session
       )
     }))
-    return { sessionId, messageId: input.messageId ?? 'message-1' }
+  }
+  const sendMessage = vi.fn(async (input: Parameters<AnalysisSendMessage>[0]) => {
+    recordAnalysisRun(input)
+    return { sessionId: input.sessionId ?? 'session-1', messageId: input.messageId ?? 'message-1' }
   })
   const jobsPendingNotification = vi.fn().mockResolvedValue([makeCompletedJob()])
   const jobsMarkConsumed = vi.fn().mockResolvedValue(undefined)
@@ -88,7 +121,9 @@ describe('useJobAnalysisEffect persistence readiness', () => {
         ...(request.state === 'succeeded' ? { notification_consumed_at: 1500 } : {})
       })
     ])
-    jobsList.mockClear()
+    jobsList
+      .mockReset()
+      .mockImplementation(async () => [...useSessionJobStore.getState().jobsById.values()])
     loadOne.mockReset().mockResolvedValue(undefined)
     useSessionJobStore.setState({
       ...createInitialSessionJobState(),
@@ -125,6 +160,461 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     vi.useRealTimers()
     act(() => root.unmount())
     container.remove()
+  })
+
+  it.each([
+    'unchanged input',
+    'reordered jobs',
+    'changed output files',
+    'missing attribution',
+    'inactive branch'
+  ])('reuses the saved batch prompt through runtime admission after %s', async (change) => {
+    const messageId = 'analysis-saved-batch'
+    const first = makeCompletedJob({ job_id: 'first-job', featured_files: ['original.csv'] })
+    const second = makeCompletedJob({ job_id: 'second-job' })
+    const originalText = buildAnalysisPrompt([first, second])
+    const recovered =
+      change === 'reordered jobs'
+        ? [second, first]
+        : change === 'changed output files'
+          ? [{ ...first, featured_files: ['new.csv', 'original.csv'] }, second]
+          : [first, second]
+    jobsPendingNotification.mockResolvedValueOnce(
+      recovered.map((job) => ({
+        ...job,
+        analysis_state: 'dispatched',
+        analysis_message_id: messageId
+      }))
+    )
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        messages: [
+          {
+            id: messageId,
+            role: 'user',
+            content: originalText,
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1400,
+            updatedAt: 1400,
+            attribution: {
+              kind: 'application',
+              feature: 'compute',
+              purpose: 'job-completion-analysis',
+              deliveryKey: 'compute_done:session-1:first-job,second-job',
+              jobIds: ['first-job', 'second-job']
+            }
+          }
+        ]
+      }))
+    }))
+    if (change === 'missing attribution') {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) => ({
+          ...session,
+          messages: session.messages.map((message) => ({ ...message, attribution: undefined }))
+        }))
+      }))
+    }
+    if (change === 'inactive branch') {
+      useSessionStore.getState().finishRun('session-1')
+      useSessionStore.getState().truncateSessionFromMessage('session-1', messageId)
+      expect(useSessionStore.getState().sessions[0]!.messages).toEqual([])
+    }
+    const runtime: Parameters<typeof sendWorkspaceMessage>[0] = {
+      state: {
+        status: 'connected',
+        cwd: '/workspace/project-a',
+        sessionIds: ['session-1'],
+        events: [],
+        pendingPermissions: [],
+        permissionProfiles: {},
+        permissionGrants: {},
+        contextUsageBySession: {},
+        promptInFlight: false,
+        promptInFlightSessionIds: []
+      },
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn(),
+      sendPrompt: vi.fn().mockResolvedValue(undefined)
+    }
+    window.api.sessions.saveSession = vi.fn(async (session) => session)
+    const admission = vi.fn<AnalysisSendMessage>((input) =>
+      sendWorkspaceMessage(runtime, {
+        ...input,
+        agentFrameworkId: 'claude-code'
+      })
+    )
+
+    await act(async () => root.render(<Probe enabled onSendMessage={admission} />))
+
+    expect(admission).toHaveBeenCalledOnce()
+    expect
+      .soft(await admission.mock.results[0]?.value)
+      .toEqual({ sessionId: 'session-1', messageId })
+    expect.soft(admission.mock.calls[0]?.[0].text).toBe(originalText)
+    expect.soft(runtime.sendPrompt).toHaveBeenCalledOnce()
+    expect(jobsTransitionAnalysis).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'failed' })
+    )
+  })
+
+  it('settles the completed analysis independently of a later failing user turn', async () => {
+    jobsPendingNotification.mockResolvedValueOnce([])
+    let accept!: () => void
+    let analysisMessageId!: string
+    const admission = vi.fn<AnalysisSendMessage>((input) => {
+      analysisMessageId = input.messageId!
+      return new Promise((resolve) => {
+        accept = () => resolve({ sessionId: 'session-1', messageId: analysisMessageId })
+      })
+    })
+    await act(async () => root.render(<Probe enabled onSendMessage={admission} />))
+    await act(async () => useSessionJobStore.getState().applyUpdate(makeCompletedJob()))
+    expect(admission).toHaveBeenCalledOnce()
+    await act(async () => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) => ({
+          ...session,
+          status: 'running',
+          activeRun: { promptMessageId: 'later-user-message', startedAt: 1600 },
+          messages: [
+            {
+              id: analysisMessageId,
+              role: 'user',
+              content: admission.mock.calls[0]![0].text,
+              status: 'complete',
+              eventIds: [],
+              createdAt: 1400,
+              updatedAt: 1400
+            },
+            {
+              id: 'analysis-reply',
+              role: 'agent',
+              responseToMessageId: analysisMessageId,
+              content: 'Completed analysis',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 1500,
+              updatedAt: 1500
+            },
+            {
+              id: 'later-user-message',
+              role: 'user',
+              content: 'An unrelated request',
+              status: 'complete',
+              eventIds: [],
+              createdAt: 1600,
+              updatedAt: 1600
+            }
+          ]
+        }))
+      }))
+      accept()
+    })
+    await act(async () => {
+      useSessionStore.getState().failRun('session-1', 'Later turn failed')
+    })
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        messageId: analysisMessageId,
+        state: 'succeeded'
+      })
+    )
+    expect(jobsTransitionAnalysis).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'failed' })
+    )
+  })
+
+  it('retries a transient recovered Session read without terminalizing the analysis', async () => {
+    vi.useFakeTimers()
+    const messageId = 'analysis-read-retry'
+    jobsPendingNotification.mockResolvedValueOnce([
+      makeCompletedJob({
+        analysis_state: 'dispatched',
+        analysis_message_id: messageId
+      })
+    ])
+    const session = useSessionStore.getState().sessions[0]!
+    useSessionStore.setState({ sessions: [{ ...session, contentLoaded: false }] })
+    loadOne.mockRejectedValueOnce(new Error('Temporary local read failure')).mockResolvedValue({
+      ...session,
+      messages: [
+        {
+          id: messageId,
+          role: 'user',
+          content: 'Saved analysis',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1400,
+          updatedAt: 1400
+        },
+        {
+          id: 'saved-reply',
+          role: 'agent',
+          responseToMessageId: messageId,
+          content: 'Done',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1500,
+          updatedAt: 1500
+        }
+      ]
+    })
+    await act(async () => root.render(<Probe enabled />))
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsTransitionAnalysis).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'failed' })
+    )
+    expect(loadOne).toHaveBeenCalledTimes(2)
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({ messageId, state: 'succeeded' })
+    )
+  })
+
+  it('preserves cancellation when a recovered analysis has a partial error reply', async () => {
+    const messageId = 'analysis-cancelled-with-output'
+    jobsPendingNotification.mockResolvedValueOnce([
+      makeCompletedJob({
+        analysis_state: 'dispatched',
+        analysis_message_id: messageId
+      })
+    ])
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        status: 'error',
+        resumeRecovery: { kind: 'resume-required', cause: 'cancelled', promptMessageId: messageId },
+        messages: [
+          {
+            id: messageId,
+            role: 'user',
+            content: 'Saved analysis',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1400,
+            updatedAt: 1400
+          },
+          {
+            id: 'partial-reply',
+            role: 'agent',
+            responseToMessageId: messageId,
+            content: 'Partial analysis',
+            status: 'error',
+            eventIds: [],
+            createdAt: 1500,
+            updatedAt: 1500
+          }
+        ]
+      }))
+    }))
+    await act(async () => root.render(<Probe enabled />))
+
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({ messageId, state: 'cancelled' })
+    )
+  })
+
+  it.each([
+    'wrong job',
+    'wrong session',
+    'wrong message',
+    'incomplete batch',
+    'wrong role',
+    'wrong attribution'
+  ])('rejects reuse of a saved prompt with %s', async (mismatch) => {
+    const messageId = 'analysis-bound'
+    const job = makeCompletedJob({ analysis_state: 'dispatched', analysis_message_id: messageId })
+    jobsPendingNotification.mockResolvedValueOnce([job])
+    jobsList.mockResolvedValue([
+      {
+        ...job,
+        ...(mismatch === 'wrong job' ? { job_id: 'different-job' } : {}),
+        ...(mismatch === 'wrong session' ? { session_id: 'different-session' } : {}),
+        ...(mismatch === 'wrong message' ? { analysis_message_id: 'different-message' } : {})
+      },
+      ...(mismatch === 'incomplete batch' ? [{ ...job, job_id: 'unscanned-job' }] : [])
+    ])
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        messages: [
+          {
+            id: messageId,
+            role: mismatch === 'wrong role' ? 'agent' : 'user',
+            content: 'Saved original',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1400,
+            updatedAt: 1400,
+            ...(mismatch === 'wrong attribution'
+              ? {
+                  attribution: {
+                    kind: 'application' as const,
+                    feature: 'compute' as const,
+                    purpose: 'job-completion-analysis' as const,
+                    deliveryKey: 'compute_done:session-1:other-job',
+                    jobIds: ['other-job']
+                  }
+                }
+              : {})
+          }
+        ]
+      }))
+    }))
+    await act(async () => root.render(<Probe enabled />))
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({ messageId, state: 'failed' })
+    )
+  })
+
+  it('reads completed analysis on an inactive branch without switching the visible branch', async () => {
+    const messageId = 'analysis-inactive-complete'
+    recordAnalysisRun({ sessionId: 'session-1', messageId, text: 'Saved analysis' })
+    useSessionStore.getState().finishRun('session-1')
+    useSessionStore.getState().truncateSessionFromMessage('session-1', messageId)
+    const graph = useSessionStore.getState().sessions[0]!.conversationGraph
+    jobsPendingNotification.mockResolvedValueOnce([
+      makeCompletedJob({ analysis_state: 'dispatched', analysis_message_id: messageId })
+    ])
+    await act(async () => root.render(<Probe enabled />))
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({ messageId, state: 'succeeded' })
+    )
+    expect(useSessionStore.getState().sessions[0]!.conversationGraph).toBe(graph)
+    expect(useSessionStore.getState().sessions[0]!.messages).toEqual([])
+  })
+
+  it('ignores unrelated outcomes while the matching analysis has no terminal evidence', async () => {
+    jobsPendingNotification.mockResolvedValueOnce([])
+    await act(async () => root.render(<Probe enabled />))
+    await act(async () => useSessionJobStore.getState().applyUpdate(makeCompletedJob()))
+    const messageId = sendMessage.mock.calls[0]![0].messageId!
+    await act(async () => {
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) => ({
+          ...session,
+          status: 'error',
+          activeRun: undefined,
+          resumeRecovery: {
+            kind: 'resume-required',
+            cause: 'cancelled',
+            promptMessageId: 'unrelated-message'
+          }
+        }))
+      }))
+    })
+    expect(jobsTransitionAnalysis).toHaveBeenCalledTimes(1)
+    await act(async () => {
+      useSessionStore.getState().interruptRun('session-1', 'cancelled', 'Stopped', messageId)
+    })
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({ messageId, state: 'cancelled' })
+    )
+    const count = jobsTransitionAnalysis.mock.calls.length
+    await act(async () => useSessionStore.getState().finishRun('session-1'))
+    expect(jobsTransitionAnalysis).toHaveBeenCalledTimes(count)
+  })
+
+  it.each(['succeeded', 'failed'] as const)(
+    'settles an observed analysis %s even when it produced no text reply',
+    async (outcome) => {
+      jobsPendingNotification.mockResolvedValueOnce([])
+      const admission = vi.fn<AnalysisSendMessage>(async (input) => {
+        recordAnalysisRun(input)
+        useSessionStore.setState((state) => ({
+          sessions: state.sessions.map((session) => ({
+            ...session,
+            messages: session.messages.filter((message) => message.role !== 'agent')
+          }))
+        }))
+        return { sessionId: 'session-1', messageId: input.messageId! }
+      })
+      await act(async () => root.render(<Probe enabled onSendMessage={admission} />))
+      await act(async () => useSessionJobStore.getState().applyUpdate(makeCompletedJob()))
+      expect(admission).toHaveBeenCalledOnce()
+      await act(async () => {
+        if (outcome === 'failed')
+          useSessionStore.getState().failRun('session-1', 'Provider failed before output')
+        else useSessionStore.getState().finishRun('session-1')
+      })
+      expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          messageId: admission.mock.calls[0]![0].messageId,
+          state: outcome
+        })
+      )
+    }
+  )
+
+  it('waits for a rearmed analysis despite an old partial error reply', async () => {
+    const messageId = 'analysis-rearmed'
+    recordAnalysisRun({ sessionId: 'session-1', messageId, text: 'Saved analysis' })
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        messages: session.messages.map((message) =>
+          message.role === 'agent' ? { ...message, status: 'error' } : message
+        )
+      }))
+    }))
+    jobsPendingNotification.mockResolvedValueOnce([
+      makeCompletedJob({ analysis_state: 'dispatched', analysis_message_id: messageId })
+    ])
+    await act(async () => root.render(<Probe enabled />))
+    expect(sendMessage).not.toHaveBeenCalled()
+    expect(jobsTransitionAnalysis).not.toHaveBeenCalled()
+    await act(async () =>
+      useSessionStore.getState().interruptRun('session-1', 'cancelled', 'Stopped', messageId)
+    )
+    expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
+      expect.objectContaining({ state: 'cancelled' })
+    )
+  })
+
+  it('retries a failed batch read with the saved message identity', async () => {
+    vi.useFakeTimers()
+    const messageId = 'analysis-batch-read'
+    const job = makeCompletedJob({ analysis_state: 'dispatched', analysis_message_id: messageId })
+    jobsPendingNotification.mockResolvedValueOnce([job])
+    jobsList
+      .mockRejectedValueOnce(new Error('Temporary batch read failure'))
+      .mockResolvedValue([job])
+    useSessionStore.setState((state) => ({
+      sessions: state.sessions.map((session) => ({
+        ...session,
+        messages: [
+          {
+            id: messageId,
+            role: 'user',
+            content: 'Saved original',
+            status: 'complete',
+            eventIds: [],
+            createdAt: 1400,
+            updatedAt: 1400
+          }
+        ]
+      }))
+    }))
+    await act(async () => root.render(<Probe enabled />))
+    expect(jobsTransitionAnalysis).not.toHaveBeenCalled()
+    expect(sendMessage).not.toHaveBeenCalled()
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000)
+    })
+    expect(sendMessage).toHaveBeenCalledExactlyOnceWith(
+      expect.objectContaining({ messageId, text: 'Saved original' })
+    )
+    expect(jobsTransitionAnalysis).not.toHaveBeenCalled()
   })
 
   it('does not start job analysis while Session persistence is not ready', async () => {
@@ -205,13 +695,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     )
 
     await act(async () => root.render(<Probe enabled={false} />))
-    act(() => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'idle' } : session
-        )
-      }))
-    })
+    act(() => useSessionStore.getState().finishRun('session-1'))
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 
     expect(sendMessage).toHaveBeenCalledOnce()
@@ -236,11 +720,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
       ]
     })
     const firstSend = vi.fn<AnalysisSendMessage>(async (input) => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'running' } : session
-        )
-      }))
+      recordAnalysisRun(input)
       return { sessionId: 'session-1', messageId: input.messageId ?? 'message-1' }
     })
     const replacementSend = vi.fn<AnalysisSendMessage>(async (input) => ({
@@ -254,13 +734,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     expect(firstSend).toHaveBeenCalledOnce()
 
     await act(async () => root.render(<Probe enabled onSendMessage={replacementSend} />))
-    act(() => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'idle' } : session
-        )
-      }))
-    })
+    act(() => useSessionStore.getState().finishRun('session-1'))
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 
     expect(firstSend).toHaveBeenCalledOnce()
@@ -273,16 +747,8 @@ describe('useJobAnalysisEffect persistence readiness', () => {
   it('settles when the analysis turn ends before its completion listener is registered', async () => {
     jobsPendingNotification.mockResolvedValueOnce([])
     const immediateSend = vi.fn<AnalysisSendMessage>(async (input) => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'running' } : session
-        )
-      }))
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'idle' } : session
-        )
-      }))
+      recordAnalysisRun(input)
+      useSessionStore.getState().finishRun('session-1')
       return { sessionId: 'session-1', messageId: input.messageId ?? 'message-1' }
     })
 
@@ -370,18 +836,22 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     await act(async () => Promise.resolve())
 
     expect(sendMessage).not.toHaveBeenCalled()
-    expect(useSessionStore.getState().sessions[0]?.messages).toEqual([
-      expect.objectContaining({ id: 'local-message', content: 'A newer local edit' })
-    ])
+    expect(useSessionStore.getState().sessions[0]?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'local-message', content: 'A newer local edit' })
+      ])
+    )
 
     await act(async () => {
       await vi.advanceTimersByTimeAsync(250)
     })
 
     expect(sendMessage).toHaveBeenCalledOnce()
-    expect(useSessionStore.getState().sessions[0]?.messages).toEqual([
-      expect.objectContaining({ id: 'local-message', content: 'A newer local edit' })
-    ])
+    expect(useSessionStore.getState().sessions[0]?.messages).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ id: 'local-message', content: 'A newer local edit' })
+      ])
+    )
   })
 
   it('recovers pending analysis across all Sessions from the App-level owner', async () => {
@@ -462,7 +932,9 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     expect(hydratedBackground).toMatchObject({
       cwd: '/workspace/project-a',
       agentConfiguration: persistedBackground.agentConfiguration,
-      messages: [{ id: 'earlier-message', content: 'Earlier question' }]
+      messages: expect.arrayContaining([
+        expect.objectContaining({ id: 'earlier-message', content: 'Earlier question' })
+      ])
     })
   })
 
@@ -520,18 +992,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 
     expect(sendMessage).toHaveBeenCalledOnce()
-    act(() => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'running' } : session
-        )
-      }))
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'idle' } : session
-        )
-      }))
-    })
+    act(() => useSessionStore.getState().finishRun('session-1'))
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 
     expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(
@@ -554,20 +1015,7 @@ describe('useJobAnalysisEffect persistence readiness', () => {
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 
     expect(sendMessage).toHaveBeenCalledOnce()
-    act(() => {
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1' ? { ...session, status: 'running' } : session
-        )
-      }))
-      useSessionStore.setState((state) => ({
-        sessions: state.sessions.map((session) =>
-          session.id === 'session-1'
-            ? { ...session, status: 'error', error: 'Analysis turn failed' }
-            : session
-        )
-      }))
-    })
+    act(() => useSessionStore.getState().failRun('session-1', 'Analysis turn failed'))
     await act(async () => new Promise((resolve) => setTimeout(resolve, 0)))
 
     expect(jobsTransitionAnalysis).toHaveBeenLastCalledWith(

--- a/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
+++ b/src/renderer/src/lib/compute/useJobAnalysisEffect.ts
@@ -20,7 +20,8 @@ import {
 import { useSessionJobStore } from '../../stores/session-job-store'
 import { useSessionStore, type ChatSession } from '../../stores/session-store'
 import { createJobAnalysisTrigger } from '../compute/job-analysis-trigger'
-import type { ComputeJobAnalysisState } from '../../../../shared/compute'
+import { isComputeJobCompletionAttribution } from '../../../../shared/session-persistence'
+import type { JobAnalysisTriggerDeps } from './job-analysis-trigger'
 
 type AdmitMessageFn = (input: {
   session: ChatSession
@@ -62,6 +63,57 @@ const durableSessionAcceptsAnalysis = (
   session: Pick<ChatSession, 'status' | 'activeRun'>
 ): boolean =>
   (session.status === 'idle' || session.status === 'error') && session.activeRun === undefined
+
+const findAnalysisPrompt = (
+  session: ChatSession,
+  messageId: string
+): ChatSession['messages'][number] | undefined =>
+  session.messages.find((message) => message.id === messageId) ??
+  session.conversationGraph?.messages.find((message) => message.id === messageId)
+
+const analysisTurnState = (
+  session: ChatSession | undefined,
+  messageId: string,
+  previousSession?: ChatSession
+): Awaited<ReturnType<JobAnalysisTriggerDeps['getTurnState']>> => {
+  if (!session) return 'missing'
+  const prompt = findAnalysisPrompt(session, messageId)
+  if (!prompt) return 'missing'
+  if (prompt.role !== 'user') return 'failed'
+  // A rearmed prompt may still have an older partial response. Its live run owns completion.
+  if (session.activeRun?.promptMessageId === messageId) return 'running'
+  const recovery =
+    session.resumeRecovery?.promptMessageId === messageId ? session.resumeRecovery : undefined
+  if (recovery?.cause === 'cancelled') return 'cancelled'
+  const graphPrompt = session.conversationGraph?.messages.find(
+    (message) => message.id === messageId
+  )
+  const visibleIds = new Set(session.messages.map((message) => message.id))
+  const responses = [
+    ...(session.conversationGraph?.messages.filter(
+      (message) =>
+        !visibleIds.has(message.id) &&
+        message.agentFrameId === graphPrompt?.agentFrameId &&
+        message.introducedOnBranchId === graphPrompt?.introducedOnBranchId
+    ) ?? []),
+    ...session.messages
+  ].filter((message) => message.role === 'agent' && message.responseToMessageId === messageId)
+  const response = responses.at(-1)
+  if (response?.status === 'complete') return 'succeeded'
+  if (response?.status === 'error') return 'failed'
+  if (recovery && recovery.cause !== 'app-restart') return 'failed'
+  // A live run can end without producing text. Only an observed transition of this exact run
+  // identifies that outcome; a terminal Session snapshot alone is not completion evidence.
+  if (
+    previousSession?.activeRun?.promptMessageId === messageId &&
+    !session.activeRun &&
+    !session.resumeRecovery
+  ) {
+    if (session.status === 'idle') return 'succeeded'
+    if (session.status === 'error') return 'failed'
+  }
+  return 'missing'
+}
 
 // Subscribes to all done-state compute:job-updated broadcasts and runs the analysis turn trigger.
 // Also scans every Session for pending notifications on startup (restart recovery path).
@@ -126,12 +178,42 @@ export const useJobAnalysisEffect = ({
     }
 
     const trigger = createJobAnalysisTrigger({
-      sendPrompt: async (sessionId, text, messageId, jobIds) => {
-        if (!isActive) return undefined
-        // CLI Tasks commit their terminal Session snapshot after the ACP stop event. The renderer
-        // can observe that stop first, so use the durable idle snapshot as the admission boundary;
-        // otherwise an application prompt can append from stale state and race the Task commit.
+      preparePrompt: async (sessionId, text, messageId, jobIds) => {
+        // CLI Tasks commit their terminal Session after the ACP stop event. Keep the durable idle
+        // boundary before admission, but let the trigger retry a failed read without failing a turn.
         const session = await loadAnalysisSession(sessionId, true)
+        if (!isActive || !session) return undefined
+        const prompt = findAnalysisPrompt(session, messageId)
+        if (!prompt) return text
+        if (prompt.role !== 'user') return undefined
+        const jobs = await window.api.compute.jobsList({ sessionId })
+        if (!isActive) return undefined
+        const batch = jobs.filter((job) => job.analysis_message_id === messageId)
+        if (
+          batch.length !== jobIds.length ||
+          batch.some(
+            (job) =>
+              job.session_id !== sessionId ||
+              job.analysis_state !== 'dispatched' ||
+              !jobIds.includes(job.job_id)
+          )
+        )
+          return undefined
+        if (
+          prompt.attribution &&
+          (!isComputeJobCompletionAttribution(prompt.attribution) ||
+            prompt.attribution.deliveryKey !==
+              `compute_done:${sessionId}:${[...jobIds].sort().join(',')}` ||
+            prompt.attribution.jobIds.length !== jobIds.length ||
+            prompt.attribution.jobIds.some((jobId) => !jobIds.includes(jobId)))
+        )
+          return undefined
+        return prompt.content
+      },
+      sendPrompt: async (sessionId, text, messageId, jobIds) => {
+        const session = useSessionStore
+          .getState()
+          .sessions.find((candidate) => candidate.id === sessionId)
         if (!isActive || !session) return undefined
         return admitLatestMessage({
           session,
@@ -169,50 +251,33 @@ export const useJobAnalysisEffect = ({
       },
       getTurnState: async (sessionId, messageId) => {
         const session = await loadAnalysisSession(sessionId)
-        if (!session) return 'missing'
-        const prompt = session.messages.find((message) => message.id === messageId)
-        if (!prompt) return 'missing'
-        const response = session.messages.find(
-          (message) => message.role === 'agent' && message.responseToMessageId === messageId
-        )
-        if (response?.status === 'complete') return 'succeeded'
-        if (response?.status === 'error') return 'failed'
-        if (session.resumeRecovery?.promptMessageId === messageId) {
-          if (session.resumeRecovery.cause === 'cancelled') return 'cancelled'
-          if (session.resumeRecovery.cause === 'app-restart') return 'missing'
-          return 'failed'
-        }
-        if (session.activeRun?.promptMessageId === messageId) return 'running'
-        return 'missing'
+        return analysisTurnState(session, messageId)
       },
-      onTurnEnd: (sessionId, callback) => {
-        // Keep runtime completion listeners inside the same readiness lifecycle as dispatch.
+      onTurnEnd: (sessionId, messageId, callback) => {
         let settled = false
-        const settleIfTerminal = (state: ReturnType<typeof useSessionStore.getState>): void => {
-          if (settled) return
+        let unsubscribe = (): void => undefined
+        const settleIfTerminal = (
+          state: ReturnType<typeof useSessionStore.getState>,
+          previousState?: ReturnType<typeof useSessionStore.getState>
+        ): void => {
+          if (settled || !isActive) return
           const session = state.sessions.find((candidate) => candidate.id === sessionId)
-          if (!session) return
-          if (
-            session.status !== 'running' &&
-            session.status !== 'waiting-for-user' &&
-            session.status !== 'waiting-permission' &&
-            session.status !== 'waiting-plan-approval'
-          ) {
-            settled = true
-            unsubscribe()
-            turnEndUnsubscribes.delete(unsubscribe)
-            const outcome: Exclude<ComputeJobAnalysisState, 'dispatched'> =
-              session.status === 'idle'
-                ? 'succeeded'
-                : session.resumeRecovery?.cause === 'cancelled'
-                  ? 'cancelled'
-                  : 'failed'
-            if (isActive) callback(outcome)
-          }
+          const outcome = analysisTurnState(
+            session,
+            messageId,
+            previousState?.sessions.find((candidate) => candidate.id === sessionId)
+          )
+          if (outcome === 'missing' || outcome === 'running') return
+          settled = true
+          unsubscribe()
+          turnEndUnsubscribes.delete(unsubscribe)
+          callback(outcome)
         }
-        const unsubscribe = useSessionStore.subscribe(settleIfTerminal)
-        // Close the subscribe/check race when a fast turn ended before listener registration.
+        settleIfTerminal(useSessionStore.getState())
+        if (settled) return
+        unsubscribe = useSessionStore.subscribe(settleIfTerminal)
         turnEndUnsubscribes.add(unsubscribe)
+        // Reconcile again after subscription; only this Message can complete the batch.
         settleIfTerminal(useSessionStore.getState())
       },
       log: (tag, message) => {


### PR DESCRIPTION
## Problem

Completed compute analysis can be marked failed during recovery when regenerated prompt content differs from its saved stable message, a later user turn supplies the terminal status, or a temporary Session read fails. Cancellation after partial output can also be recorded as failure.

## Proposed change

- Reuse the saved prompt after validating its existing durable job/session/message binding; preserve the runtime role/content admission guard and support messages on inactive branches or without attribution.
- Reconcile and observe completion by message ID using shared outcome classification. Matching cancellation takes precedence over partial error output. Live no-text outcomes require an observed transition of the matching active run.
- Retry recovery/preparation reads with the same committed batch identity and capped backoff. Keep later pending jobs separate and cancel retries on disposal.

## Scope and non-goals

Only the existing renderer hook/trigger and regression tests change. No database fields, migrations, persisted formats, state enum values, new services or UI changes. Existing unsorted saved prompts remain recoverable; previously misclassified historical terminal jobs are not bulk repaired. Confirmed model failure/cancellation is not automatically rerun. Persistently unreadable storage remains pending with retries/logging; no new alert is added.

## Acceptance criteria and validation

The five original regression cases failed twice on unchanged production code with matching failures, then passed after the fix. Re-running the original production files against the updated fixtures again produced five expected failures plus the passing unchanged-input admission control. No live model was called.

Checks after the final material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Saved content admission, message-specific completion, cancellation, read retries, cleanup and batch isolation | `npm test -- src/renderer/src/lib/compute/job-analysis-trigger.test.ts src/renderer/src/lib/compute/useJobAnalysisEffect.render.test.tsx` | 62 passed |
| Compute owner and Workspace consumer contracts, stable runtime admission, Session graph and persistence authority | `executeModuleTestPlan` expanded to `npm test -- <84 selected test files> --maxWorkers=4`; union of `compute_service`, `workspace_page`, and explicit runtime/store/graph/attribution contracts | 2,496 passed; 6 skipped |
| Provider recovery policy, including Codex Responses and Bridge | `npm test -- src/main/acp/provider-session-resumer.test.ts src/main/acp/session-resume-policy.test.ts --maxWorkers=2` | 99 passed |
| Affected process types and style | `npm run typecheck:web`, `npm run typecheck:node`, `npm run lint`, changed-file Prettier and `git diff --check` | Passed |

The module union includes `useWorkspaceAgentRuntime.test.ts`, `workspace-events.test.ts`, `session-store.test.ts`, `session-persistence/ipc.test.ts`, and `conversation-graph.test.ts` as explicit contracts. The renderer implementation is shared by execution paths; no provider protocol or Electron/Web adapter changes were made. The SQLite assertion confirms that a genuine failed claim remains terminal and cannot be redispatched with a new identity.

Local socket tests required execution outside the sandbox after EPERM failures. The six skips are the Windows askpass test and five opt-in live SSH job tests. No full local suite or live-provider/SSH certification is claimed; selected cross-platform PR CI remains authoritative.

## Review focus

Batch ownership without relying on renderer-originated attribution; inactive-branch result lookup; no unrelated-turn settlement; retry identity/cleanup without absorbing later pending jobs.
