### PR TITLE
fix(artifacts): recover finalization across plan review feedback

### DIFF
--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -56,10 +56,9 @@ type ArtifactProvenanceFinalizationRecoveryOptions = {
   >
 }
 
-// Resolves the agent message owning the prepared prompt turn's output. It prefers a single message
-// before the next user prompt on the declared Branch and Runtime Segment, and past that boundary
-// accepts only a message the durable Session already claims; choosing a latest message (or
-// accepting multiple unclaimed candidates) could attach a crashed run to a later turn.
+// Prefer a complete durable claim on the declared Branch and Runtime Segment over the prompt-window
+// heuristic: an in-turn user feedback Message can separate commentary from the real output owner.
+// Only an entirely unclaimed run may fall back to a single Message before the next user prompt.
 const inferDurableFinalizationMessageId = (
   session: PersistedChatSession,
   context: PreparedArtifactFinalizationContext,
@@ -87,28 +86,29 @@ const inferDurableFinalizationMessageId = (
     message.agentFrameId === context.agentFrameId &&
     message.introducedOnBranchId === context.messageBranchId &&
     message.runtimeSegmentId === context.runtimeSegmentId
-  const turnCandidates = path.slice(promptIndex + 1, turnEnd).filter(ownsRunOutput)
-  let message = turnCandidates.length === 1 ? turnCandidates[0] : undefined
-  if (!message) {
-    // A turn may contain commentary before its result, and a Session Plan persists review feedback
-    // as a durable user Message inside the still-open turn, so the owner can also follow that
-    // prompt boundary. Use durable attachments to distinguish the owner, but reject even a partial
-    // competing claim anywhere in the Session graph/projection.
-    const candidates =
-      turnCandidates.length > 0 ? turnCandidates : path.slice(promptIndex + 1).filter(ownsRunOutput)
-    const claimedMessageIds = new Set(
-      [...session.messages, ...(session.conversationGraph?.messages ?? [])]
-        .filter((candidate) => candidate.artifactIds?.some((id) => versionIds.includes(id)))
-        .map((candidate) => candidate.id)
-    )
+  const claimedMessageIds = new Set(
+    [...session.messages, ...(session.conversationGraph?.messages ?? [])]
+      .filter((candidate) => candidate.artifactIds?.some((id) => versionIds.includes(id)))
+      .map((candidate) => candidate.id)
+  )
+  let message: (typeof path)[number] | undefined
+  if (claimedMessageIds.size > 0) {
+    // Even a partial or competing claim blocks heuristic fallback. Otherwise an unrelated single
+    // commentary Message could permanently acquire a Version already attached to its real owner.
     if (claimedMessageIds.size !== 1) return undefined
-    message = candidates.find((candidate) => claimedMessageIds.has(candidate.id))
+    message = path
+      .slice(promptIndex + 1)
+      .find((candidate) => ownsRunOutput(candidate) && claimedMessageIds.has(candidate.id))
     if (
       !message ||
       !versionIds.every((id) => isArtifactLinkedToDurableMessage(session, message!.id, id))
     ) {
       return undefined
     }
+  } else {
+    const turnCandidates = path.slice(promptIndex + 1, turnEnd).filter(ownsRunOutput)
+    if (turnCandidates.length !== 1) return undefined
+    message = turnCandidates[0]
   }
 
   validateDurableMessageOwnership(session, { ...context, messageId: message.id })

--- a/src/main/artifacts/provenance-finalization-recovery.ts
+++ b/src/main/artifacts/provenance-finalization-recovery.ts
@@ -56,9 +56,10 @@ type ArtifactProvenanceFinalizationRecoveryOptions = {
   >
 }
 
-// Resolves the agent message owning the prepared prompt turn's output. It deliberately considers
-// only messages before the next user prompt on the declared Branch and Runtime Segment; choosing a
-// latest message (or accepting multiple candidates) could attach a crashed run to a later turn.
+// Resolves the agent message owning the prepared prompt turn's output. It prefers a single message
+// before the next user prompt on the declared Branch and Runtime Segment, and past that boundary
+// accepts only a message the durable Session already claims; choosing a latest message (or
+// accepting multiple unclaimed candidates) could attach a crashed run to a later turn.
 const inferDurableFinalizationMessageId = (
   session: PersistedChatSession,
   context: PreparedArtifactFinalizationContext,
@@ -81,19 +82,20 @@ const inferDurableFinalizationMessageId = (
     .slice(promptIndex + 1)
     .findIndex((message) => message.role === 'user')
   const turnEnd = followingUserOffset < 0 ? path.length : promptIndex + 1 + followingUserOffset
-  const candidates = path
-    .slice(promptIndex + 1, turnEnd)
-    .filter(
-      (message) =>
-        message.role === 'agent' &&
-        message.agentFrameId === context.agentFrameId &&
-        message.introducedOnBranchId === context.messageBranchId &&
-        message.runtimeSegmentId === context.runtimeSegmentId
-    )
-  let message = candidates.length === 1 ? candidates[0] : undefined
-  if (candidates.length > 1) {
-    // A turn may contain commentary before its result. Use durable attachments to distinguish the
-    // owner, but reject even a partial competing claim anywhere in the Session graph/projection.
+  const ownsRunOutput = (message: (typeof path)[number]): boolean =>
+    message.role === 'agent' &&
+    message.agentFrameId === context.agentFrameId &&
+    message.introducedOnBranchId === context.messageBranchId &&
+    message.runtimeSegmentId === context.runtimeSegmentId
+  const turnCandidates = path.slice(promptIndex + 1, turnEnd).filter(ownsRunOutput)
+  let message = turnCandidates.length === 1 ? turnCandidates[0] : undefined
+  if (!message) {
+    // A turn may contain commentary before its result, and a Session Plan persists review feedback
+    // as a durable user Message inside the still-open turn, so the owner can also follow that
+    // prompt boundary. Use durable attachments to distinguish the owner, but reject even a partial
+    // competing claim anywhere in the Session graph/projection.
+    const candidates =
+      turnCandidates.length > 0 ? turnCandidates : path.slice(promptIndex + 1).filter(ownsRunOutput)
     const claimedMessageIds = new Set(
       [...session.messages, ...(session.conversationGraph?.messages ?? [])]
         .filter((candidate) => candidate.artifactIds?.some((id) => versionIds.includes(id)))
@@ -108,7 +110,6 @@ const inferDurableFinalizationMessageId = (
       return undefined
     }
   }
-  if (!message) return undefined
 
   validateDurableMessageOwnership(session, { ...context, messageId: message.id })
   return message.id

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -17,7 +17,7 @@ import {
   ARTIFACT_FINALIZATION_INVALID_PROOF,
   type ReconcilePendingArtifactsRequest
 } from '../../shared/artifacts'
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { PersistedChatMessage, PersistedChatSession } from '../../shared/session-persistence'
 import { createPngBytes, createPngInlineSource } from '../artifacts/artifact-test-fixtures'
 import { ProvenanceMessageSnapshotRepository } from '../artifacts/provenance-message-snapshot'
 import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
@@ -460,6 +460,91 @@ describe('artifact finalization startup recovery', () => {
     await expect(coordinator.retryArtifactFinalization(request)).resolves.toMatchObject({
       artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
     })
+  })
+
+  it('recovers the run after Plan review feedback interleaves a user Message', async () => {
+    const { session, versions, coordinator, request } = await prepareAttachedRecovery()
+    const feedback: PersistedChatMessage = {
+      id: 'plan-feedback-1',
+      role: 'user',
+      content: 'tighten step 2',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const messages = [session.messages[0], feedback, ...session.messages.slice(1)]
+    session.messages = messages
+    session.conversationGraph = createLinearConversationGraph({
+      sessionId: SESSION_ID,
+      messages: messages.map(
+        ({ id, role, content, status, eventIds, createdAt, updatedAt, artifactIds }) => ({
+          id,
+          role,
+          content,
+          status,
+          eventIds,
+          createdAt,
+          updatedAt,
+          artifactIds
+        })
+      ),
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 3
+    })
+    await sessions.saveSession(session)
+
+    await expect(coordinator.retryArtifactFinalization(request)).resolves.toMatchObject({
+      artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: versions[0].versionId } })
+    ).resolves.toMatchObject({
+      state: 'finalized',
+      messageId: 'message-1',
+      managedVisibleAt: expect.any(Date)
+    })
+    await expect(
+      client.artifactLineage.findUniqueOrThrow({ where: { id: versions[0].artifactId } })
+    ).resolves.toMatchObject({ currentVersionId: versions[0].versionId })
+  })
+
+  it('leaves an unclaimed run unresolved when a user Message interleaves the turn', async () => {
+    const { session, coordinator, request } = await prepareAttachedRecovery()
+    const feedback: PersistedChatMessage = {
+      id: 'plan-feedback-1',
+      role: 'user',
+      content: 'tighten step 2',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const messages = [session.messages[0], feedback, ...session.messages.slice(1)]
+    session.artifacts = []
+    for (const message of messages) message.artifactIds = undefined
+    session.messages = messages
+    session.conversationGraph = createLinearConversationGraph({
+      sessionId: SESSION_ID,
+      messages: messages.map(({ id, role, content, status, eventIds, createdAt, updatedAt }) => ({
+        id,
+        role,
+        content,
+        status,
+        eventIds,
+        createdAt,
+        updatedAt
+      })),
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 3
+    })
+    await sessions.saveSession(session)
+
+    await expect(coordinator.retryArtifactFinalization(request)).rejects.toThrow(
+      'Native Artifact finalization remains unresolved.'
+    )
   })
 
   it('replays an explicitly requested finalized Version that is already linked', async () => {

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -297,14 +297,15 @@ describe('artifact finalization startup recovery', () => {
     }
   )
 
-  it.each([
-    'missing-metadata',
-    'partial-run',
-    'competing-owner',
-    'missing-projection',
-    'later-turn'
-  ] as const)('keeps ambiguous recovery unpublished with %s', async (scenario) => {
-    const { session, versions, provenance, compatibility } = await prepareAttachedRecovery(2)
+  it.each(
+    (['missing-metadata', 'partial-run', 'competing-owner', 'missing-projection'] as const).flatMap(
+      (scenario) => [false, true].map((earlierMessage) => ({ scenario, earlierMessage }))
+    )
+  )('keeps ambiguous recovery unpublished with %j', async ({ scenario, earlierMessage }) => {
+    const { session, versions, provenance, compatibility } = await prepareAttachedRecovery(
+      2,
+      earlierMessage
+    )
     const graph = session.conversationGraph!
     const owner = graph.messages.find((message) => message.id === 'message-1')!
     if (scenario === 'missing-metadata') session.artifacts = []
@@ -312,30 +313,8 @@ describe('artifact finalization startup recovery', () => {
       owner.artifactIds = [versions[0].versionId]
       session.messages.at(-1)!.artifactIds = owner.artifactIds
     }
-    if (scenario === 'competing-owner') graph.messages[1].artifactIds = [versions[0].versionId]
+    if (scenario === 'competing-owner') graph.messages[0].artifactIds = [versions[0].versionId]
     if (scenario === 'missing-projection') session.messages.at(-1)!.artifactIds = []
-    if (scenario === 'later-turn') {
-      graph.messages.push(
-        {
-          ...owner,
-          id: 'next-prompt',
-          role: 'user',
-          status: 'complete',
-          artifactIds: undefined,
-          revisionRootMessageId: 'next-prompt',
-          parentMessageId: owner.id
-        },
-        {
-          ...owner,
-          id: 'later-owner',
-          revisionRootMessageId: 'later-owner',
-          parentMessageId: 'next-prompt'
-        }
-      )
-      graph.branches[0].headMessageId = 'later-owner'
-      owner.artifactIds = []
-      session.messages.at(-1)!.artifactIds = []
-    }
     const result = await provenance.reconcileSession(PROJECT_ID, SESSION_ID, session)
     expect(result.unresolvedNativeFinalizationRunIds).toContain(RUN_ID)
     for (const version of versions) {
@@ -356,6 +335,46 @@ describe('artifact finalization startup recovery', () => {
     expect(pending).toHaveLength(2)
     for (const file of pending)
       expect(await readFile(file.path)).toEqual(createPngBytes('recovered bytes'))
+  })
+
+  it('prefers a complete durable claim after a later prompt over the turn window', async () => {
+    const { session, versions, coordinator, request } = await prepareAttachedRecovery()
+    const owner = session.messages.at(-1)!
+    // A complete durable claim is authoritative even when an ordinary user prompt intervenes.
+    // An unclaimed later Message must never be inferred from its position alone.
+    session.messages.push(
+      {
+        ...owner,
+        id: 'next-prompt',
+        role: 'user',
+        content: 'another task',
+        status: 'complete',
+        artifactIds: undefined
+      },
+      { ...owner, id: 'later-owner' }
+    )
+    owner.artifactIds = undefined
+    session.conversationGraph = createLinearConversationGraph({
+      sessionId: SESSION_ID,
+      messages: session.messages,
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 3
+    })
+    await sessions.saveSession(session)
+    const retry = { ...request, messageId: 'later-owner' }
+    const recovered = await coordinator.retryArtifactFinalization(retry)
+    expect(recovered).toMatchObject({
+      artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
+    })
+    await expect(
+      client.artifactVersion.findUniqueOrThrow({ where: { id: versions[0].versionId } })
+    ).resolves.toMatchObject({
+      state: 'finalized',
+      messageId: 'later-owner',
+      managedVisibleAt: expect.any(Date)
+    })
+    await expect(coordinator.retryArtifactFinalization(retry)).resolves.toEqual(recovered)
   })
 
   it('uses the attached owner even when another assistant message follows it', async () => {
@@ -462,53 +481,74 @@ describe('artifact finalization startup recovery', () => {
     })
   })
 
-  it('recovers the run after Plan review feedback interleaves a user Message', async () => {
-    const { session, versions, coordinator, request } = await prepareAttachedRecovery()
-    const feedback: PersistedChatMessage = {
-      id: 'plan-feedback-1',
-      role: 'user',
-      content: 'tighten step 2',
-      status: 'complete',
-      eventIds: [],
-      createdAt: 2,
-      updatedAt: 2
-    }
-    const messages = [session.messages[0], feedback, ...session.messages.slice(1)]
-    session.messages = messages
-    session.conversationGraph = createLinearConversationGraph({
-      sessionId: SESSION_ID,
-      messages: messages.map(
-        ({ id, role, content, status, eventIds, createdAt, updatedAt, artifactIds }) => ({
-          id,
-          role,
-          content,
-          status,
-          eventIds,
-          createdAt,
-          updatedAt,
-          artifactIds
-        })
-      ),
-      frameworkId: 'codex',
-      createdAt: 1,
-      updatedAt: 3
-    })
-    await sessions.saveSession(session)
+  it.each([0, 1, 2])(
+    'recovers the run after Plan review feedback interleaves a user Message after %i commentary messages',
+    async (commentaryCount) => {
+      const { session, versions, coordinator, request, handlers } = await prepareAttachedRecovery()
+      const feedback: PersistedChatMessage = {
+        id: 'plan-feedback-1',
+        role: 'user',
+        content: 'tighten step 2',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 2,
+        updatedAt: 2
+      }
+      const commentary = Array.from({ length: commentaryCount }, (_, index) => ({
+        ...session.messages[1],
+        id: `before-feedback-${index}`
+      }))
+      const messages = [session.messages[0], ...commentary, feedback, ...session.messages.slice(1)]
+      session.messages = messages
+      session.conversationGraph = createLinearConversationGraph({
+        sessionId: SESSION_ID,
+        messages: messages.map(
+          ({ id, role, content, status, eventIds, createdAt, updatedAt, artifactIds }) => ({
+            id,
+            role,
+            content,
+            status,
+            eventIds,
+            createdAt,
+            updatedAt,
+            artifactIds
+          })
+        ),
+        frameworkId: 'codex',
+        createdAt: 1,
+        updatedAt: 3
+      })
+      await sessions.saveSession(session)
+      const identity = {
+        projectId: PROJECT_ID,
+        fileId: versions[0].artifactId,
+        path: versions[0].path
+      }
+      await expect(handlers.readPreview(identity)).rejects.toMatchObject({
+        code: 'VERSION_NOT_FOUND',
+        message: 'Managed file has no published version.'
+      })
 
-    await expect(coordinator.retryArtifactFinalization(request)).resolves.toMatchObject({
-      artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
-    })
-    await expect(
-      client.artifactVersion.findUniqueOrThrow({ where: { id: versions[0].versionId } })
-    ).resolves.toMatchObject({
-      state: 'finalized',
-      messageId: 'message-1',
-      managedVisibleAt: expect.any(Date)
-    })
-    await expect(
-      client.artifactLineage.findUniqueOrThrow({ where: { id: versions[0].artifactId } })
-    ).resolves.toMatchObject({ currentVersionId: versions[0].versionId })
-  })
+      await expect.soft(coordinator.retryArtifactFinalization(request)).resolves.toMatchObject({
+        artifacts: [expect.objectContaining({ versionId: versions[0].versionId })]
+      })
+      await expect(
+        client.artifactVersion.findUniqueOrThrow({ where: { id: versions[0].versionId } })
+      ).resolves.toMatchObject({
+        state: 'finalized',
+        messageId: 'message-1',
+        managedVisibleAt: expect.any(Date)
+      })
+      await expect(
+        client.artifactLineage.findUniqueOrThrow({ where: { id: versions[0].artifactId } })
+      ).resolves.toMatchObject({ currentVersionId: versions[0].versionId })
+      await expect(
+        handlers.readPreview({ ...identity, encoding: 'base64' })
+      ).resolves.toMatchObject({
+        content: createPngBytes('recovered bytes').toString('base64')
+      })
+    }
+  )
 
   it('leaves an unclaimed run unresolved when a user Message interleaves the turn', async () => {
     const { session, coordinator, request } = await prepareAttachedRecovery()


### PR DESCRIPTION
## Problem

Retrying a pending Artifact publication failed with `Native Artifact finalization remains unresolved`, and the generated file stayed unreadable with `Managed file has no published version` (#2184).

`inferDurableFinalizationMessageId` in `src/main/artifacts/provenance-finalization-recovery.ts` closes its candidate window at the next user Message on the Branch, so it only considers agent Messages between the run's prompt and that boundary. A Session Plan persists review feedback as a durable user Message inside the still-open turn (`persistUserMessage` in `src/main/session-plan/plan-service.ts`), so the agent Message that owns the run's Versions sits past the boundary and the window resolves to no candidate at all. The run stays in `unresolvedNativeFinalizationRunIds` and `reconciliation-owner.ts` throws. Nothing about that state changes between attempts, so the retry affordance fails identically forever. The second symptom is the same defect: the run never reaches `activateFinalizedRun`, so `managedVisibleAt` stays null and the lineage head never advances, which is exactly the state `managed-file-versions/service.ts` reports as having no published version.

## Proposed change

Resolve the owner from a unique, complete durable attachment claim before using the prompt-window heuristic. The owner must be an agent Message after the declared prompt on the same Branch, Frame, and Runtime Segment. All run Versions must be attached consistently in Session metadata and every present owner projection. Any partial, competing, or inconsistent claim blocks recovery instead of falling back to an unrelated commentary Message.

A complete claim remains authoritative across an intervening user Message, including an ordinary later prompt; the previous later-turn rejection contract is deliberately updated. This avoids making ownership depend on whether zero, one, or several commentary Messages precede Plan feedback. If no Message claims any run Version, retain the existing single-candidate window before the next user prompt and never infer an unclaimed owner beyond it.

`validateDurableMessageOwnership`, exact Version-set proof, existing ownership-conflict checks, and publication ordering remain in place.

## Scope and non-goals

One private recovery function and its integration tests. No new field, enum, API, IPC method, schema, migration, persisted format, dependency, or UI change.

Recovery still writes existing Version ownership/publication fields, compatibility publication files, and Lineage visibility through the existing owners. Pending historical runs with sufficient evidence may recover through existing retry/startup paths; already-finalized incorrectly bound Versions are not automatically reassigned or migrated.

## Acceptance criteria and validation

The original regression failed on main with `Native Artifact finalization remains unresolved` and passes with the fix. Two additional message-order regressions failed consistently on the author's commit `f7d9a54c`: one commentary before feedback caused an empty retry result and a Version bound to that commentary; two commentary Messages left the Version unresolved. The tests use the public coordinator retry API, real SQLite, filesystem storage, and the public managed preview reader. No production test seam was added.

The expanded guard cases also ran red before the follow-up fix. All final checks below ran after the last material edit.

| Behavior | Command | Result |
| --- | --- | --- |
| Recovery, ownership guards, later-prompt policy and public preview | `npm test -- src/main/session-persistence/artifact-finalization-recovery.integration.test.ts` | 39 passed |
| Provenance + Session persistence owners/contracts and direct read/preview consumers | Deduplicated module plan below | 39 files / 2,386 passed |
| Main-process types | `npm run typecheck:node` | Passed |
| Lint and formatting | `npm run lint`; Prettier check on both changed files; `git diff --check` | Passed |

<details>
<summary>Reproduce the selected module test run</summary>

```sh
node --input-type=module - <<'JS'
import { createModuleTestPlan, executeModuleTestPlan } from './scripts/ci/module-test-impact.mjs'
const plans = ['artifact_provenance', 'session_persistence'].map(id => createModuleTestPlan(id))
const extras = [
  'src/main/managed-file-versions/service.integration.test.ts',
  'src/main/managed-file-preview.test.ts',
  'src/main/managed-preview-resources.test.ts',
  'src/renderer/src/lib/session-persistence/session-persistence.test.ts'
]
const plan = {
  ...plans[0],
  modules: plans.flatMap(p => p.modules),
  testFiles: [...new Set([...plans.flatMap(p => p.testFiles), ...extras])].sort(),
  reasonChains: [...plans.flatMap(p => p.reasonChains),
    'Artifact publication -> managed read/preview consumers',
    'Session recovery -> renderer persistence consumer']
}
process.exitCode = executeModuleTestPlan(plan, {
  testArguments: ['--maxWorkers=2', '--no-file-parallelism']
})
JS
```

This uses the repository-owned module selector/executor, deduplicates shared tests, and adds the direct publication readers. No global configuration, ownership manifest, or public interface changed, so local selection stays with these two modules and their consumers.

</details>

The shared persistence owner is used by claude-code, opencode, codex-response, and codex-bridge. These checks exercise durable message shapes, not live provider turns; no ACP wire, permission, subscription, or launcher behavior changes. The original Windows packaged interaction has not been replayed locally. Windows/macOS build and E2E breadth is left to the selected PR CI lanes; skipped checks are not claimed as verification. No full local test suite was run.

An independent review confirmed the ownership checks and final Test Impact Set.

## Review focus

The explicit contract is complete durable ownership over the prompt-window heuristic, with no fallback from partial or conflicting evidence. Confirm that the ordinary-later-prompt acceptance, retained unclaimed-run boundary, and exclusion of historical finalized reassignment match the intended recovery policy.
