### PR TITLE
fix(conversation-export): preserve reviewed content and export outcomes

### DIFF
--- a/src/main/session-persistence/conversation-export.test.ts
+++ b/src/main/session-persistence/conversation-export.test.ts
@@ -344,6 +344,84 @@ describe('conversation export service', () => {
     expect(removeDirectory).toHaveBeenCalledWith('/tmp/open-science-conversation-export-test')
   })
 
+  it.each(['page loading', 'font readiness'])(
+    'bounds %s with the PDF generation deadline',
+    async (stage) => {
+      vi.useFakeTimers()
+      let release!: () => void
+      const blocked = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const dependency = stage === 'page loading' ? loadFile : executeJavaScript
+      dependency.mockReturnValue(blocked)
+      const outcome = vi.fn()
+      const promise = createService({
+        exportLimits: {
+          maxMessages: 10,
+          maxImageBase64Bytes: 1_000_000,
+          maxHtmlBytes: 1_000_000,
+          pdfPrintTimeoutMs: 20
+        }
+      })
+        .exportConversation({ projectId: 'project-1', sessionId: 'session-1', format: 'pdf' })
+        .then(outcome, outcome)
+      try {
+        await vi.advanceTimersByTimeAsync(120)
+        expect(dependency).toHaveBeenCalledOnce()
+        expect(outcome).toHaveBeenCalledWith(
+          expect.objectContaining({ message: expect.stringMatching(/timed out/i) })
+        )
+        expect(destroy).toHaveBeenCalledOnce()
+        expect(removeDirectory).toHaveBeenCalledOnce()
+        expect(printToPDF).not.toHaveBeenCalled()
+        release()
+        await vi.advanceTimersByTimeAsync(0)
+        expect(printToPDF).not.toHaveBeenCalled()
+      } finally {
+        release()
+        await promise
+        vi.useRealTimers()
+      }
+    }
+  )
+
+  it('reports a published PDF as saved even when temporary HTML cleanup fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'conversation-export-cleanup-'))
+    const destination = join(root, 'export.pdf')
+    createTempDirectory.mockResolvedValue(root)
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destination })
+    const cleanupError = new Error('EBUSY: temporary HTML cleanup failed')
+    removeDirectory.mockRejectedValue(cleanupError)
+    try {
+      const outcome = await createService({ publishUserFile: productionPublishUserFile, writeFile })
+        .exportConversation({ projectId: 'project-1', sessionId: 'session-1', format: 'pdf' })
+        .catch((error: unknown) => error)
+      // A real file was published; only print rendering is substituted with deterministic bytes.
+      expect(await readFile(destination)).toEqual(Buffer.from('pdf'))
+      expect(outcome).toEqual({ saved: true, filePath: destination })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+      vi.restoreAllMocks()
+    }
+  })
+
+  it('preserves the generation error when temporary cleanup also fails', async () => {
+    const failure = new Error('print failed')
+    printToPDF.mockRejectedValue(failure)
+    removeDirectory.mockRejectedValue(new Error('EBUSY'))
+    try {
+      await expect(
+        createService().exportConversation({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          format: 'pdf'
+        })
+      ).rejects.toBe(failure)
+    } finally {
+      vi.restoreAllMocks()
+    }
+  })
+
   it('destroys the print window when PDF generation fails', async () => {
     showSaveDialog.mockResolvedValue({ canceled: false, filePath: '/downloads/export.pdf' })
     printToPDF.mockRejectedValue(new Error('print failed'))

--- a/src/main/session-persistence/conversation-export.ts
+++ b/src/main/session-persistence/conversation-export.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 
 import {
   createConversationExportDocument,
+  hashConversationExportContent,
   renderConversationHtml,
   renderConversationMarkdown,
   sanitizeExportFilename,
@@ -17,6 +18,9 @@ import { hasCurrentRunningDelegatedAttempt } from '../../shared/delegated-work-p
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { englishNativeTranslator, type NativeTranslator } from '../locale/main-process-messages'
 import { publishUserFile } from '../user-file-publisher'
+import { createLogger, diagnosticErrorFields } from '../logger'
+
+const log = createLogger('conversation-export')
 
 type ConversationExportPrintWindow = {
   loadFile(path: string): Promise<void>
@@ -89,6 +93,9 @@ const assertExportConversationRequest = (
     typeof request.sessionId !== 'string' ||
     request.sessionId.length === 0 ||
     (request.format !== 'markdown' && request.format !== 'pdf') ||
+    (request.expectedContentHash !== undefined &&
+      (typeof request.expectedContentHash !== 'string' ||
+        !/^[a-f0-9]{64}$/.test(request.expectedContentHash))) ||
     (selectedPromptMessageIds !== undefined &&
       (!Array.isArray(selectedPromptMessageIds) ||
         selectedPromptMessageIds.length === 0 ||
@@ -158,6 +165,14 @@ const createConversationExportService = (
       const request = assertExportConversationRequest(rawRequest)
       const session = await deps.loadSession(request.projectId, request.sessionId)
       if (!session) throw new Error('Conversation not found.')
+      if (
+        request.expectedContentHash !== undefined &&
+        request.expectedContentHash !== (await hashConversationExportContent(session))
+      ) {
+        throw new Error(
+          deps.translate('The conversation changed. Close and reopen export to review it.')
+        )
+      }
       if (
         deps.isSessionActive(request.projectId, request.sessionId) ||
         hasCurrentRunningDelegatedAttempt(session) ||
@@ -240,21 +255,26 @@ const createConversationExportService = (
 
         const printWindow = deps.createPrintWindow()
         try {
-          await printWindow.loadFile(htmlPath)
-          await printWindow.webContents.executeJavaScript(
-            'document.fonts ? document.fonts.ready.then(() => true) : true'
-          )
+          let generationFinished = false
           const pdf = await printToPdfWithTimeout(
-            printWindow.webContents.printToPDF({
-              pageSize: 'A4',
-              printBackground: true,
-              margins: {
-                top: 0.2,
-                bottom: 0.2,
-                left: 0.2,
-                right: 0.2
-              }
-            }),
+            (async () => {
+              await printWindow.loadFile(htmlPath)
+              if (generationFinished) throw new Error('PDF generation already ended.')
+              await printWindow.webContents.executeJavaScript(
+                'document.fonts ? document.fonts.ready.then(() => true) : true'
+              )
+              if (generationFinished) throw new Error('PDF generation already ended.')
+              return printWindow.webContents.printToPDF({
+                pageSize: 'A4',
+                printBackground: true,
+                margins: {
+                  top: 0.2,
+                  bottom: 0.2,
+                  left: 0.2,
+                  right: 0.2
+                }
+              })
+            })(),
             deps.exportLimits.pdfPrintTimeoutMs,
             () =>
               new Error(
@@ -262,7 +282,9 @@ const createConversationExportService = (
                   'Conversation PDF export timed out. Select fewer conversation turns.'
                 )
               )
-          )
+          ).finally(() => {
+            generationFinished = true
+          })
           await deps.publishUserFile(dialogResult.filePath, (temporaryPath) =>
             deps.writeFile(temporaryPath, pdf)
           )
@@ -271,7 +293,14 @@ const createConversationExportService = (
           printWindow.destroy()
         }
       } finally {
-        await deps.removeDirectory(tempDirectory)
+        try {
+          await deps.removeDirectory(tempDirectory)
+        } catch (error) {
+          log.warn(
+            'Failed to remove conversation export temporary directory',
+            diagnosticErrorFields(error)
+          )
+        }
       }
     }
   }

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -615,6 +615,10 @@ describe('App startup routing', () => {
 
   it('keeps the remote-job analysis owner active while Home is presented', async () => {
     mocks.settings.isLoaded = true
+    // The durable claim can finish after the next timer turn on a busy CI worker.
+    mocks.compute.jobsTransitionAnalysis.mockImplementationOnce(
+      () => new Promise((resolve) => setTimeout(() => resolve([]), 50))
+    )
     mocks.sessions = [
       {
         id: 'session-1',

--- a/src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx
@@ -1,10 +1,24 @@
 // @vitest-environment jsdom
 import { act } from 'react'
+import { webcrypto } from 'node:crypto'
+import { waitFor } from '@testing-library/react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ChatSession } from '@/stores/session-store'
 import { ConversationExportDialog } from './ConversationExportDialog'
+import {
+  saveSessionInOrder,
+  resetSessionPersistenceWriteFailuresForTests
+} from '@/lib/session-persistence/session-persistence'
+import { createConversationExportService } from '../../../../main/session-persistence/conversation-export'
+
+vi.mock('electron', () => ({
+  app: {},
+  BrowserWindow: vi.fn(),
+  dialog: {},
+  ipcMain: { handle: vi.fn() }
+}))
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -70,12 +84,15 @@ describe('ConversationExportDialog', () => {
     container = document.createElement('div')
     document.body.appendChild(container)
     root = createRoot(container)
+    vi.stubGlobal('crypto', webcrypto)
   })
 
   afterEach(() => {
     act(() => root.unmount())
     document.body.innerHTML = ''
     vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    resetSessionPersistenceWriteFailuresForTests()
   })
 
   it('defaults to the whole PDF export and omits a selection field', async () => {
@@ -103,13 +120,14 @@ describe('ConversationExportDialog', () => {
 
     await act(async () => {
       confirm?.click()
-      await Promise.resolve()
+      await waitFor(() => expect(onExport).toHaveBeenCalled())
     })
 
     expect(onExport).toHaveBeenCalledWith({
       projectId: 'project-1',
       sessionId: 'session-1',
-      format: 'pdf'
+      format: 'pdf',
+      expectedContentHash: expect.stringMatching(/^[a-f0-9]{64}$/)
     })
     expect(onClose).not.toHaveBeenCalled()
   })
@@ -147,7 +165,7 @@ describe('ConversationExportDialog', () => {
 
     await act(async () => {
       confirm?.click()
-      await Promise.resolve()
+      await waitFor(() => expect(onExport).toHaveBeenCalled())
     })
     expect(onClose).not.toHaveBeenCalled()
     expect(document.body.textContent).toContain('2 of 2 selected')
@@ -155,14 +173,152 @@ describe('ConversationExportDialog', () => {
       projectId: 'project-1',
       sessionId: 'session-1',
       format: 'markdown',
+      expectedContentHash: expect.stringMatching(/^[a-f0-9]{64}$/),
       selectedPromptMessageIds: ['prompt-1', 'prompt-2']
     })
 
     await act(async () => {
       confirm?.click()
-      await Promise.resolve()
+      await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
     })
     expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it.each(['delayed', 'failed', 'changed after saving'] as const)(
+    'never exports an old saved answer when persistence is %s',
+    async (mode) => {
+      const session = createSession({ messages: createSession().messages.slice(0, 2) })
+      session.messages[1] = { ...session.messages[1], content: 'NEW answer reviewed in the dialog' }
+      let durable = {
+        ...session,
+        messages: session.messages.map((message) =>
+          message.role === 'agent' ? { ...message, content: 'Old saved answer' } : message
+        )
+      }
+      let release!: () => void
+      const blocked = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const saveSession = vi.fn(async (next: ChatSession) => {
+        await blocked
+        if (mode === 'failed') throw new Error('Disk is full')
+        durable =
+          mode === 'changed after saving'
+            ? {
+                ...next,
+                messages: next.messages.map((message) =>
+                  message.role === 'agent'
+                    ? { ...message, content: 'An answer from another writer' }
+                    : message
+                )
+              }
+            : next
+        return next
+      })
+      vi.stubGlobal('api', undefined)
+      Object.defineProperty(window, 'api', {
+        configurable: true,
+        value: { sessions: { saveSession } }
+      })
+      const pendingSave = saveSessionInOrder(session).catch(() => undefined)
+      const writeFile = vi.fn().mockResolvedValue(undefined)
+      const service = createConversationExportService({
+        loadSession: async () => durable,
+        isSessionActive: () => false,
+        showSaveDialog: async () => ({ canceled: false, filePath: '/in-memory/export.md' }),
+        getDownloadsPath: () => '/in-memory',
+        writeFile,
+        publishUserFile: async (path, write) => {
+          await write(path)
+        }
+      })
+      const onClose = vi.fn()
+      act(() =>
+        root.render(
+          <ConversationExportDialog
+            session={session}
+            currentSession={session}
+            onClose={onClose}
+            onExport={service.exportConversation}
+          />
+        )
+      )
+      act(() => findControl('radio', 'Selected')?.click())
+      expect(document.body.textContent).toContain('NEW answer reviewed in the dialog')
+      act(() => findControl('checkbox', 'Compare the papers')?.click())
+      act(() => findControl('radio', 'Markdown')?.click())
+      try {
+        await act(async () => {
+          document.body
+            .querySelector<HTMLButtonElement>('[data-testid="conversation-export-confirm"]')
+            ?.click()
+        })
+        await act(async () => {
+          release()
+          await pendingSave
+        })
+        await waitFor(() => {
+          const confirm = document.body.querySelector<HTMLButtonElement>(
+            '[data-testid="conversation-export-confirm"]'
+          )
+          expect(confirm?.disabled).toBe(false)
+        })
+        if (mode !== 'delayed') {
+          expect(writeFile).not.toHaveBeenCalled()
+          expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+            mode === 'failed' ? 'Disk is full' : 'The conversation changed.'
+          )
+          expect(onClose).not.toHaveBeenCalled()
+        } else {
+          expect(writeFile).toHaveBeenCalledWith(
+            '/in-memory/export.md',
+            expect.stringContaining('NEW answer reviewed in the dialog')
+          )
+          expect(writeFile.mock.calls[0]?.[1]).not.toContain('Old saved answer')
+        }
+      } finally {
+        release()
+        await pendingSave
+      }
+    }
+  )
+
+  it('does not count removed turns when reopening the same conversation', async () => {
+    const session = createSession({ messages: createSession().messages.slice(0, 2) })
+    const onExport = vi.fn().mockResolvedValue({ saved: false })
+    const render = (snapshot: ChatSession | undefined): void => {
+      root.render(
+        <ConversationExportDialog
+          session={snapshot}
+          currentSession={snapshot}
+          onClose={vi.fn()}
+          onExport={onExport}
+        />
+      )
+    }
+    act(() => render(session))
+    act(() => findControl('radio', 'Selected')?.click())
+    act(() => findControl('checkbox', 'Compare the papers')?.click())
+    expect(document.body.textContent).toContain('1 of 1 selected')
+    act(() => render(undefined))
+    const replacement = createSession({
+      messages: session.messages.map((message) => ({ ...message, id: `${message.id}-new` }))
+    })
+    act(() => render(replacement))
+    act(() => findControl('radio', 'Selected')?.click())
+    expect(findControl('checkbox', 'Compare the papers')?.getAttribute('aria-checked')).toBe(
+      'false'
+    )
+    expect(document.body.textContent).toContain('0 of 1 selected')
+    expect(findControl('checkbox', 'Select all')?.getAttribute('aria-checked')).toBe('false')
+    const confirm = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="conversation-export-confirm"]'
+    )
+    expect(confirm?.disabled).toBe(true)
+    await act(async () => {
+      confirm?.click()
+    })
+    expect(onExport).not.toHaveBeenCalled()
   })
 
   it('keeps long message previews inside the vertical scroll surface', () => {
@@ -242,8 +398,8 @@ describe('ConversationExportDialog', () => {
     )
     await act(async () => {
       confirm?.click()
-      await Promise.resolve()
     })
+    await waitFor(() => expect(document.body.querySelector('[role="alert"]')).not.toBeNull())
     expect(document.body.querySelector('[role="alert"]')?.textContent).toContain('Disk is full')
 
     act(() => {

--- a/src/renderer/src/pages/workspace/ConversationExportDialog.tsx
+++ b/src/renderer/src/pages/workspace/ConversationExportDialog.tsx
@@ -13,10 +13,12 @@ import {
 } from '@/components/ui/dialog-chrome'
 import { useRetainedDialogValue } from '@/components/ui/use-retained-dialog-value'
 import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
+import { flushSessionPersistence } from '@/lib/session-persistence/session-persistence'
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 import {
   createConversationExportDocument,
+  hashConversationExportContent,
   createConversationExportTurns,
   type ConversationExportFormat,
   type ExportConversationRequest,
@@ -69,12 +71,24 @@ const ConversationExportDialogContent = ({
     const current = createConversationExportDocument(currentSession, 0)
     return JSON.stringify(snapshot) !== JSON.stringify(current)
   }, [currentSession, session])
-  const allSelected = turns.length > 0 && selectedPromptIds.size === turns.length
-  const partlySelected = selectedPromptIds.size > 0 && !allSelected
+  const validSelectedPromptIds = turns.flatMap((turn) =>
+    selectedPromptIds.has(turn.promptMessageId) ? [turn.promptMessageId] : []
+  )
+  const selectedCount = validSelectedPromptIds.length
+  const [wasOpen, setWasOpen] = useState(open)
+  if (wasOpen !== open) {
+    setWasOpen(open)
+    if (open) {
+      setSelectedPromptIds(new Set())
+      setError(undefined)
+    }
+  }
+  const allSelected = turns.length > 0 && selectedCount === turns.length
+  const partlySelected = selectedCount > 0 && !allSelected
   const unavailable = currentSession
     ? projectPresentedSessionActionability(currentSession).activity !== 'inactive'
     : true
-  const noSelection = scope === 'selected' && selectedPromptIds.size === 0
+  const noSelection = scope === 'selected' && selectedCount === 0
   const disabled = unavailable || conversationChanged || noSelection || isExporting
 
   const toggleTurn = (promptMessageId: string): void => {
@@ -102,15 +116,16 @@ const ConversationExportDialogContent = ({
     setIsExporting(true)
     setError(undefined)
     try {
+      const expectedContentHash = await hashConversationExportContent(session)
+      await flushSessionPersistence()
       const result = await exporter({
         projectId: session.projectId,
         sessionId: session.id,
         format,
+        expectedContentHash,
         ...(scope === 'selected'
           ? {
-              selectedPromptMessageIds: turns.flatMap((turn) =>
-                selectedPromptIds.has(turn.promptMessageId) ? [turn.promptMessageId] : []
-              )
+              selectedPromptMessageIds: validSelectedPromptIds
             }
           : {})
       })
@@ -248,7 +263,7 @@ const ConversationExportDialogContent = ({
                     </h2>
                     <p className="mt-0.5 text-xs text-muted-foreground">
                       {t('{{selected}} of {{total}} selected', {
-                        selected: selectedPromptIds.size,
+                        selected: selectedCount,
                         total: turns.length
                       })}
                     </p>

--- a/src/shared/conversation-export.test.ts
+++ b/src/shared/conversation-export.test.ts
@@ -108,6 +108,32 @@ describe('conversation export projection', () => {
     expect(sanitizeExportMarkdown(code)).toBe(code)
   })
 
+  it.each([
+    '> ~~~xml\n> <think>literal</think>\n> ~~~',
+    '> ```xml\n> <think>literal</think>\n> ```',
+    '> > ~~~xml\n> > <think>literal</think>\n> > ~~~',
+    '- first\n- second\n\n  > ~~~xml\n  > <think>literal</think>\n  > ~~~',
+    '> ~~~xml\r\n> <think>literal</think>\r\n> ~~~',
+    '> ~~~xml\n> <think>literal',
+    '> 😀 example\n>\n> ~~~xml\n> <think>literal</think>\n> ~~~',
+    '- XML example:\n\n  ~~~xml\n  <think>literal</think>\n  ~~~'
+  ])('preserves literal reasoning tags in nested fenced code: %s', (content) => {
+    const session = createSession()
+    session.messages = [{ ...session.messages[1], content }]
+    expect(createConversationExportDocument(session, 0).messages[0].markdown).toBe(content)
+  })
+
+  it('filters reasoning around quoted code without changing the code source', () => {
+    const code = '> ~~~xml\n> <think>literal</think>\n> ~~~'
+    expect(
+      sanitizeExportMarkdown(`<think>private</think>\n\n${code}\n\n<think>private</think>`)
+    ).toBe(code)
+    expect(sanitizeExportMarkdown(`<think>private\n${code}\n</think>\n\nConclusion.`)).toBe(
+      'Conclusion.'
+    )
+    expect(sanitizeExportMarkdown(`> <think>private</think>\n>\n${code}`)).toBe(`> \n>\n${code}`)
+  })
+
   it('still removes real reasoning that contains code', () => {
     expect(
       sanitizeExportMarkdown('<think>private\n```txt\nsecret\n```\n</think>\n\nConclusion.')

--- a/src/shared/conversation-export.test.ts
+++ b/src/shared/conversation-export.test.ts
@@ -77,6 +77,43 @@ describe('conversation export projection', () => {
     expect(sanitizeExportMarkdown('before <think>unfinished private reasoning')).toBe('before')
   })
 
+  it.each(['user', 'agent'] as const)(
+    'preserves executable whitespace in %s code exports',
+    (role) => {
+      const session = createSession()
+      const code = '```python\nvalue = """first\n\n\nsecond"""\nassert value.count("\\n") == 3\n```'
+      session.messages = [{ ...session.messages[0], role, content: code }]
+      const document = createConversationExportDocument(session, 0)
+      expect(document.messages[0].markdown).toBe(code)
+      expect(renderConversationMarkdown(document)).toContain(code)
+      expect(renderConversationHtml(document)).toContain('first\n\n\nsecond')
+    }
+  )
+
+  it('preserves literal reasoning tags in code and the scientific conclusion after them', () => {
+    const content =
+      'The literal tag `<think>` begins the XML example.\n\nThe measured result is 42.'
+    const session = createSession()
+    session.messages = [{ ...session.messages[1], content }]
+    expect(createConversationExportDocument(session, 0).messages[0].markdown).toBe(content)
+  })
+
+  it.each([
+    '```xml\n<think>literal</think>\n```',
+    '~~~~xml\n<think>literal\n~~~~~',
+    '```xml\n<think>literal',
+    '    <think>literal</think>\n    second line',
+    'Use ``a `<think>` tag`` in the example.'
+  ])('preserves Markdown code tokens verbatim: %s', (code) => {
+    expect(sanitizeExportMarkdown(code)).toBe(code)
+  })
+
+  it('still removes real reasoning that contains code', () => {
+    expect(
+      sanitizeExportMarkdown('<think>private\n```txt\nsecret\n```\n</think>\n\nConclusion.')
+    ).toBe('Conclusion.')
+  })
+
   it('projects only user-facing active messages and attachment names', () => {
     const document = createConversationExportDocument(createSession(), 1_710_000_003_000)
 

--- a/src/shared/conversation-export.ts
+++ b/src/shared/conversation-export.ts
@@ -1,4 +1,4 @@
-import { Lexer, Marked, Renderer, Tokenizer } from 'marked'
+import { Lexer, Marked, Renderer, Tokenizer, type Token } from 'marked'
 
 import {
   isHiddenControlMessage,
@@ -55,7 +55,7 @@ export type ConversationExportTurn = {
   messages: PersistedChatMessage[]
 }
 
-const THINK_BLOCK_PATTERN = /^<think\b[^>]*>[\s\S]*?(?:<\/think\s*>|$)/i
+const THINK_BLOCK_PATTERN = /^<think\b[^>]*>/i
 const UNSAFE_FILENAME_CHARACTERS = /[<>:"/\\|?*]+/g
 const RENDERER_AUTO_TITLE_PREFIX_LENGTH = 48
 const HEADLESS_AUTO_TITLE_MAX_LENGTH = 60
@@ -168,15 +168,72 @@ const getMessageAttachments = (
   return attachments
 }
 
+// Markdown containers remove quote/list prefixes before tokenizing their children. Map each
+// de-prefixed line back to its original line so code ranges preserve the source byte-for-byte.
+const exportCodeRanges = (content: string): Array<{ start: number; end: number }> => {
+  const ranges: Array<{ start: number; end: number }> = []
+  const mapLines = (text: string, raw: string, positions: number[]): number[] => {
+    const lines = raw.split('\n')
+    let rawOffset = 0
+    const textLines = text.split('\n')
+    return textLines.flatMap((line, index) => {
+      const original = lines[index] ?? ''
+      const column = original.lastIndexOf(line)
+      const mapped = Array.from(
+        { length: line.length },
+        (_, i) => positions[rawOffset + Math.max(column, 0) + i]
+      )
+      if (index < textLines.length - 1) mapped.push(positions[rawOffset + original.length])
+      rawOffset += original.length + 1
+      return mapped
+    })
+  }
+  const visit = (tokens: Token[], positions: number[]): void => {
+    let offset = 0
+    for (const token of tokens) {
+      const mapped = positions.slice(offset, offset + token.raw.length)
+      if (token.type === 'code' && mapped.length) {
+        ranges.push({ start: mapped[0], end: mapped[mapped.length - 1] + 1 })
+      } else if (token.type === 'blockquote') {
+        visit(token.tokens ?? [], mapLines(token.text, token.raw, mapped))
+      } else if (token.type === 'list') {
+        let itemOffset = 0
+        for (const item of token.items) {
+          const itemPositions = mapped.slice(itemOffset, itemOffset + item.raw.length)
+          visit(item.tokens, mapLines(item.text, item.raw, itemPositions))
+          itemOffset += item.raw.length
+        }
+      }
+      offset += token.raw.length
+    }
+  }
+  const positions: number[] = []
+  const normalized = content.replace(/\r\n|\r|[^\r]/g, (character, offset: number) => {
+    positions.push(offset)
+    return character.startsWith('\r') ? '\n' : character
+  })
+  visit(Lexer.lex(normalized), positions)
+  return ranges
+}
+
 // Reuse Markdown's code/escape tokenizers so literal tags cannot open a reasoning block.
 // Consume a real reasoning block in one step, including any code inside that private block.
 export const sanitizeExportMarkdown = (content: string): string => {
   const tokenizer = new Tokenizer()
   new Lexer({ tokenizer }) // Initializes the tokenizer's Markdown grammar.
+  const codeRanges = exportCodeRanges(content)
+  let rangeIndex = 0
   const parts: { raw: string; code: boolean }[] = []
   let offset = 0
   while (offset < content.length) {
-    const remaining = content.slice(offset)
+    while (codeRanges[rangeIndex]?.end <= offset) rangeIndex += 1
+    const range = codeRanges[rangeIndex]
+    if (range && offset >= range.start) {
+      parts.push({ raw: content.slice(offset, range.end), code: true })
+      offset = range.end
+      continue
+    }
+    const remaining = content.slice(offset, range?.start)
     const lineStart = offset === 0 || content[offset - 1] === '\n'
     const code =
       (lineStart && (tokenizer.fences(remaining) ?? tokenizer.code(remaining))) ||
@@ -186,9 +243,16 @@ export const sanitizeExportMarkdown = (content: string): string => {
       offset += code.raw.length
       continue
     }
-    const thought = THINK_BLOCK_PATTERN.exec(remaining)
+    const thought = THINK_BLOCK_PATTERN.exec(content.slice(offset))
     if (thought) {
-      offset += thought[0].length
+      // A closing tag inside a fenced example belongs to the example, not the outer block.
+      const closing = /<\/think\s*>/gi
+      closing.lastIndex = offset + thought[0].length
+      let end: RegExpExecArray | null
+      do {
+        end = closing.exec(content)
+      } while (end && codeRanges.some((code) => end!.index >= code.start && end!.index < code.end))
+      offset = end ? closing.lastIndex : content.length
       continue
     }
     const raw =

--- a/src/shared/conversation-export.ts
+++ b/src/shared/conversation-export.ts
@@ -1,4 +1,4 @@
-import { Marked, Renderer } from 'marked'
+import { Lexer, Marked, Renderer, Tokenizer } from 'marked'
 
 import {
   isHiddenControlMessage,
@@ -16,6 +16,8 @@ export type ExportConversationRequest = {
   sessionId: string
   format: ConversationExportFormat
   selectedPromptMessageIds?: string[]
+  // Preview-based callers bind the export to the content the user reviewed.
+  expectedContentHash?: string
 }
 
 export type ExportConversationResult = {
@@ -53,7 +55,7 @@ export type ConversationExportTurn = {
   messages: PersistedChatMessage[]
 }
 
-const THINK_BLOCK_PATTERN = /<think\b[^>]*>[\s\S]*?(?:<\/think\s*>|$)/gi
+const THINK_BLOCK_PATTERN = /^<think\b[^>]*>[\s\S]*?(?:<\/think\s*>|$)/i
 const UNSAFE_FILENAME_CHARACTERS = /[<>:"/\\|?*]+/g
 const RENDERER_AUTO_TITLE_PREFIX_LENGTH = 48
 const HEADLESS_AUTO_TITLE_MAX_LENGTH = 60
@@ -166,12 +168,52 @@ const getMessageAttachments = (
   return attachments
 }
 
-const normalizeExportMarkdown = (content: string): string =>
-  content.replace(/\n{3,}/g, '\n\n').trim()
+// Reuse Markdown's code/escape tokenizers so literal tags cannot open a reasoning block.
+// Consume a real reasoning block in one step, including any code inside that private block.
+export const sanitizeExportMarkdown = (content: string): string => {
+  const tokenizer = new Tokenizer()
+  new Lexer({ tokenizer }) // Initializes the tokenizer's Markdown grammar.
+  const parts: { raw: string; code: boolean }[] = []
+  let offset = 0
+  while (offset < content.length) {
+    const remaining = content.slice(offset)
+    const lineStart = offset === 0 || content[offset - 1] === '\n'
+    const code =
+      (lineStart && (tokenizer.fences(remaining) ?? tokenizer.code(remaining))) ||
+      tokenizer.codespan(remaining)
+    if (code) {
+      parts.push({ raw: code.raw, code: true })
+      offset += code.raw.length
+      continue
+    }
+    const thought = THINK_BLOCK_PATTERN.exec(remaining)
+    if (thought) {
+      offset += thought[0].length
+      continue
+    }
+    const raw =
+      tokenizer.escape(remaining)?.raw ?? /^[^`<\\\n]+/.exec(remaining)?.[0] ?? remaining[0]
+    const last = parts.at(-1)
+    if (last && !last.code) last.raw += raw
+    else parts.push({ raw, code: false })
+    offset += raw.length
+  }
+  if (parts[0] && !parts[0].code) parts[0].raw = parts[0].raw.trimStart()
+  const last = parts.at(-1)
+  if (last && !last.code) last.raw = last.raw.trimEnd()
+  return parts.map((part) => part.raw).join('')
+}
 
-// Removes provider-private reasoning blocks while preserving ordinary Markdown and HTML.
-export const sanitizeExportMarkdown = (content: string): string =>
-  normalizeExportMarkdown(content.replace(THINK_BLOCK_PATTERN, ''))
+// A precondition only: Main still renders its own durable Session, never renderer-supplied data.
+export const hashConversationExportContent = async (
+  session: PersistedChatSession
+): Promise<string> => {
+  const bytes = new TextEncoder().encode(
+    JSON.stringify(createConversationExportDocument(session, 0))
+  )
+  const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
+  return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
+}
 
 export const sanitizeExportFilename = (title: string): string => {
   const sanitized = removeControlCharacters(title)
@@ -277,9 +319,7 @@ export const createConversationExportDocument = (
       role: message.role === 'agent' ? 'assistant' : 'user',
       createdAt: message.createdAt,
       markdown:
-        message.role === 'agent'
-          ? sanitizeExportMarkdown(message.content)
-          : normalizeExportMarkdown(message.content),
+        message.role === 'agent' ? sanitizeExportMarkdown(message.content) : message.content,
       attachments: getMessageAttachments(message, artifactsById),
       images: (message.images ?? []).map(({ mimeType, data }) => ({ mimeType, data }))
     }))

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "Die Konversation wurde geändert. Schließen Sie den Export und öffnen Sie ihn erneut, um die aktuelle Fassung zu prüfen.",
     "Cancel": "Abbrechen",
     "Stay": "In der App bleiben",
     "Retry saving": "Speichern erneut versuchen",
@@ -1208,7 +1209,6 @@
     "No response yet": "Noch keine Antwort",
     "Attachments: {{total}}": "Anhänge: {{total}}",
     "Wait for the conversation to finish before exporting it.": "Warten Sie, bis die Konversation beendet ist, bevor Sie sie exportieren.",
-    "The conversation changed. Close and reopen export to review it.": "Die Konversation wurde geändert. Schließen Sie den Export und öffnen Sie ihn erneut, um die aktuelle Fassung zu prüfen.",
     "Select content to export.": "Wählen Sie den zu exportierenden Inhalt aus.",
     "The entire conversation will be exported.": "Die gesamte Konversation wird exportiert.",
     "Only selected content will be exported.": "Es werden nur ausgewählte Inhalte exportiert.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "La conversación cambió. Cierre y vuelva a abrir la exportación para revisarla.",
     "Approval needed": "Se necesita aprobación",
     "Cancel": "Cancelar",
     "Stay": "Permanecer en la aplicación",
@@ -1317,7 +1318,6 @@
     "No response yet": "Aún no hay respuesta",
     "Attachments: {{total}}": "Adjuntos: {{total}}",
     "Wait for the conversation to finish before exporting it.": "Espere a que finalice la conversación antes de exportarla.",
-    "The conversation changed. Close and reopen export to review it.": "La conversación cambió. Cierre y vuelva a abrir la exportación para revisarla.",
     "Select content to export.": "Seleccione el contenido para exportar.",
     "The entire conversation will be exported.": "Se exportará toda la conversación.",
     "Only HTTPS sources can be previewed": "Solo se pueden previsualizar fuentes HTTPS",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "La conversation a changé. Fermez puis rouvrez l’exportation pour la vérifier.",
     "Approval needed": "Approbation nécessaire",
     "Cancel": "Annuler",
     "Stay": "Rester dans l’application",
@@ -1316,7 +1317,6 @@
     "No response yet": "Pas encore de réponse",
     "Attachments: {{total}}": "Pièces jointes : {{total}}",
     "Wait for the conversation to finish before exporting it.": "Attendez la fin de la conversation avant de l’exporter.",
-    "The conversation changed. Close and reopen export to review it.": "La conversation a changé. Fermez puis rouvrez l’exportation pour la vérifier.",
     "Select content to export.": "Sélectionnez le contenu à exporter.",
     "The entire conversation will be exported.": "La conversation entière sera exportée.",
     "Only selected content will be exported.": "Seul le contenu sélectionné sera exporté.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "会話が変更されました。内容を確認するには、エクスポートを閉じて再度開いてください。",
     "Approval needed": "承認が必要です",
     "Cancel": "キャンセル",
     "Stay": "アプリに留まる",
@@ -1261,7 +1262,6 @@
     "No response yet": "まだ応答はありません",
     "Attachments: {{total}}": "添付ファイル：{{total}}",
     "Wait for the conversation to finish before exporting it.": "会話が終了してからエクスポートしてください。",
-    "The conversation changed. Close and reopen export to review it.": "会話が変更されました。内容を確認するには、エクスポートを閉じて再度開いてください。",
     "Select content to export.": "エクスポートするコンテンツを選択してください。",
     "The entire conversation will be exported.": "会話全体をエクスポートします。",
     "Only selected content will be exported.": "選択したコンテンツのみをエクスポートします。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "대화가 변경되었습니다. 내용을 검토하려면 내보내기를 닫았다가 다시 여세요.",
     "Approval needed": "승인 필요",
     "Cancel": "취소",
     "Stay": "앱에 머물기",
@@ -1281,7 +1282,6 @@
     "No response yet": "아직 응답 없음",
     "Attachments: {{total}}": "첨부 파일: {{total}}",
     "Wait for the conversation to finish before exporting it.": "대화가 끝난 후 내보내세요.",
-    "The conversation changed. Close and reopen export to review it.": "대화가 변경되었습니다. 내용을 검토하려면 내보내기를 닫았다가 다시 여세요.",
     "Select content to export.": "내보낼 콘텐츠를 선택하세요.",
     "The entire conversation will be exported.": "전체 대화를 내보냅니다.",
     "Only selected content will be exported.": "선택한 콘텐츠만 내보냅니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "Диалог изменён. Закройте и снова откройте окно экспорта, чтобы проверить его.",
     "Approval needed": "Требуется разрешение",
     "Cancel": "Отмена",
     "Stay": "Остаться в приложении",
@@ -1313,7 +1314,6 @@
     "Response without text": "Ответ без текста",
     "No response yet": "Ответа пока нет",
     "Attachments: {{total}}": "Вложения: {{total}}",
-    "The conversation changed. Close and reopen export to review it.": "Диалог изменён. Закройте и снова откройте окно экспорта, чтобы проверить его.",
     "Wait for the conversation to finish before exporting it.": "Дождитесь завершения диалога перед экспортом.",
     "Select content to export.": "Выберите содержимое для экспорта.",
     "The entire conversation will be exported.": "Весь диалог будет экспортирован.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "对话已发生变化。请关闭并重新打开导出以检查内容。",
     "Approval needed": "需要批准",
     "Cancel": "取消",
     "Stay": "留在应用中",
@@ -1347,7 +1348,6 @@
     "No response yet": "暂无回复",
     "Attachments: {{total}}": "附件：{{total}}",
     "Wait for the conversation to finish before exporting it.": "请等待对话结束后再导出。",
-    "The conversation changed. Close and reopen export to review it.": "对话已发生变化。请关闭并重新打开导出以检查内容。",
     "Select content to export.": "请选择要导出的内容。",
     "The entire conversation will be exported.": "将导出整个对话。",
     "Only selected content will be exported.": "仅导出已选内容。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1,5 +1,6 @@
 {
   "common": {
+    "The conversation changed. Close and reopen export to review it.": "對話已發生變更。請關閉並重新開啟匯出以檢查內容。",
     "Approval needed": "需要批准",
     "Cancel": "取消",
     "Stay": "留在應用程式中",
@@ -1346,7 +1347,6 @@
     "No response yet": "尚無回覆",
     "Attachments: {{total}}": "附件：{{total}}",
     "Wait for the conversation to finish before exporting it.": "請等待對話結束後再匯出。",
-    "The conversation changed. Close and reopen export to review it.": "對話已發生變更。請關閉並重新開啟匯出以檢查內容。",
     "Select content to export.": "請選擇要匯出的內容。",
     "The entire conversation will be exported.": "將匯出完整對話。",
     "Only selected content will be exported.": "僅匯出已選內容。",


### PR DESCRIPTION
A conversation export could succeed with an older saved answer than the one reviewed in the dialog, rewrite executable Markdown examples, or report the wrong PDF outcome. Reopening the same conversation could also retain selected turns that no longer exist.

- Flush pending session persistence before exporting and compare a SHA-256 digest of the reviewed export projection with the durable content. Save failures remain visible; changed content requires renewed review. Main continues to generate documents from its own stored Session.
- Preserve message whitespace and Markdown code tokens while retaining the filtering of actual reasoning blocks.
- Apply one PDF deadline to page loading, font readiness, and printing. Destroy the dedicated window on timeout and prevent late preparation tasks from continuing to print. Time spent choosing a Save As destination is excluded.
- Log temporary-directory cleanup failures through the central logger without replacing a successful publication or the original generation error.
- Clear turn selections on reopening, and derive counts, select-all state, button availability, and submitted IDs from the currently available turns. Canceling Save As still preserves the current selection.

The only request-contract addition is the optional `expectedContentHash` precondition, always supplied by the preview dialog. There are no persisted Session fields, database migrations, new dependencies, or global conversation locks. The existing reviewed error translation is shared through the common namespace in all eight translated locales.

Validation:

- Eleven behavioral regression cases failed consistently in two runs against the original production code, with failures matching the reported output, waiting, cleanup, and selection problems; they pass with the fixes.
- Export projection, real dialog/persistence/service integration, host-frame consumers, locale guards, and central logger checks pass after rebasing onto current main.
- Type checking, changed-file ESLint, formatting, and diff whitespace checks pass.
- Full `npm test` was run. The sandboxed run passed 25,701 tests but failed local socket, port, and subprocess-dependent suites, and caught a direct-console diagnostic that this patch subsequently corrected. Retrying all 71 failed files outside that sandbox passed 69 files. The runtime installer's 200 ms diagnostic timeout case then passed in isolation with both original and fixed production code. Three Micromamba package-cache integration cases still fail with the same filesystem access denial on the unmodified baseline; this PR does not change their sandbox policy.

The cleanup regression uses the real filesystem and file publisher with deterministic substitute print bytes. These tests do not claim real Electron IPC or PDF visual-rendering validation.


CI follow-up: rebased onto current main and fixed the Home background-analysis test race. A delayed durable claim reproduces the original zero-send assertion failure; the test now waits for the actual runtime dispatch rather than one zero-delay timer turn. App and export regression suites pass together (119 tests), with formatting and ESLint passing.
