### PR TITLE
fix(window-find): release overlays and restore find interactions

### DIFF
--- a/e2e/find-overlay.spec.ts
+++ b/e2e/find-overlay.spec.ts
@@ -1,0 +1,57 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures/electron-app'
+
+test.use({ windowMode: 'normal' })
+
+test('refocuses the open find overlay and follows app language changes', async ({
+  app
+}, testInfo) => {
+  const page = await app.completeOnboarding()
+  await page.getByRole('button', { name: 'New project' }).click()
+  const dialog = page.getByRole('dialog', { name: 'New project' })
+  await dialog.getByLabel('Name').fill('Find overlay project')
+  await dialog.getByRole('button', { name: 'Create project' }).click()
+  await expect(page.getByRole('heading', { name: 'New conversation' })).toBeVisible()
+
+  const modifiers = process.platform === 'darwin' ? (['meta'] as const) : (['control'] as const)
+  await app.pressMainWindowShortcut('F', [...modifiers])
+  await expect.poll(() => app.findOverlayIsVisible()).toBe(true)
+  await expect
+    .poll(() =>
+      page
+        .context()
+        .pages()
+        .some((candidate) => candidate.url().includes('/find-overlay/'))
+    )
+    .toBe(true)
+  const overlay = page
+    .context()
+    .pages()
+    .find((candidate) => candidate.url().includes('/find-overlay/'))!
+  const input = overlay.getByRole('textbox')
+  await expect(input).toBeFocused()
+
+  // Playwright emulates document focus for Electron pages. Blur the actual input to
+  // observe whether the repeated native shortcut reaches the overlay's show handler.
+  await input.evaluate((element) => element.blur())
+  await expect(input).not.toBeFocused()
+  await app.pressMainWindowShortcut('F', [...modifiers])
+  await expect(input).toBeFocused()
+
+  await page.evaluate(async () => {
+    await window.api.locale.setPreference({ preference: 'zh-Hans' })
+  })
+  await expect(input).toHaveAttribute('placeholder', '查找')
+  await expect(overlay.locator('html')).toHaveAttribute('lang', 'zh-Hans')
+  await expect(overlay.getByRole('button', { name: '上一个匹配项', exact: true })).toBeVisible()
+  await overlay.screenshot({ path: testInfo.outputPath('find-overlay-zh-Hans.png') })
+
+  await page.evaluate(async () => {
+    await window.api.locale.setPreference({ preference: 'ja' })
+  })
+  await expect(input).toHaveAttribute('placeholder', '検索')
+  await expect(overlay.locator('html')).toHaveAttribute('lang', 'ja')
+  await overlay.screenshot({ path: testInfo.outputPath('find-overlay-ja.png') })
+  await overlay.getByRole('button', { name: '検索を閉じる' }).click()
+  await expect.poll(() => app.findOverlayIsVisible()).toBe(false)
+})

--- a/resources/find-overlay/findOverlay.js
+++ b/resources/find-overlay/findOverlay.js
@@ -30,6 +30,23 @@ export function createFindOverlay(deps) {
   systemTheme?.addEventListener('change', onSystemThemeChange)
 
   const handleAppearance = (appearance) => {
+    const copy = appearance?.localization
+    if (copy) {
+      ownerDocument.documentElement.lang = copy.lang
+      ownerDocument.title = copy.findInWindow
+      input.placeholder = copy.placeholder
+      input.setAttribute('aria-label', copy.findText)
+      ownerDocument.querySelector('[role="search"]')?.setAttribute('aria-label', copy.findInWindow)
+      for (const [button, label, shortcut] of [
+        [prev, copy.previous, 'Shift+Enter'],
+        [next, copy.next, 'Enter'],
+        [close, copy.close, 'Esc']
+      ]) {
+        button.setAttribute('aria-label', label)
+        const tooltip = ownerDocument.getElementById(button.getAttribute('aria-describedby'))
+        if (tooltip) tooltip.textContent = `${label} (${shortcut})`
+      }
+    }
     followsSystem = appearance?.followsSystem === true
     const theme =
       followsSystem && systemTheme
@@ -94,6 +111,7 @@ export function createFindOverlay(deps) {
   }
 
   const onKeydown = (event) => {
+    if (event.isComposing) return
     if (event.key === 'Enter' && event.target === input) {
       event.preventDefault()
       if (event.shiftKey) {

--- a/resources/find-overlay/findOverlay.test.js
+++ b/resources/find-overlay/findOverlay.test.js
@@ -380,6 +380,22 @@ describe('createFindOverlay', () => {
     expect(ctx.api.findInPage).not.toHaveBeenCalled()
   })
 
+  it.each(['Enter', 'Escape'])('leaves composing %s to the input method', (key) => {
+    const overlay = createFindOverlay(ctx.deps)
+    ctx.input.value = 'pin'
+    const event = new KeyboardEvent('keydown', {
+      key,
+      isComposing: true,
+      bubbles: true,
+      cancelable: true
+    })
+    ctx.input.dispatchEvent(event)
+    expect.soft(event.defaultPrevented).toBe(false)
+    expect.soft(ctx.api.findInPage).not.toHaveBeenCalled()
+    expect.soft(ctx.api.closeFind).not.toHaveBeenCalled()
+    overlay.destroy()
+  })
+
   it('next/prev do nothing when the query is empty', () => {
     createFindOverlay(ctx.deps)
     ctx.next.dispatchEvent(new Event('click', { bubbles: true }))

--- a/src/main/find-overlay.test.ts
+++ b/src/main/find-overlay.test.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from 'node:events'
+import { registerFindOverlayOwner, resolveFindOverlayOwner } from './find-overlay-registry'
 
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
@@ -33,13 +34,13 @@ const HTML_PATH = '/r/find-overlay/index.html'
 
 type FindOverlayTestFakes = {
   view: {
-    webContents: { loadFile: Mock; send: Mock; focus: Mock }
+    webContents: { loadFile: Mock; send: Mock; focus: Mock; close: Mock; isDestroyed: Mock }
     setBounds: Mock
     setBackgroundColor: Mock
-    destroy: Mock
   }
   mainWindow: {
-    contentView: { addChildView: Mock }
+    contentView: { addChildView: Mock; removeChildView: Mock }
+    isDestroyed: () => boolean
     getContentBounds: () => { width: number; height: number }
     on: Mock
     removeListener: Mock
@@ -52,13 +53,19 @@ type FindOverlayTestFakes = {
 
 const createFakes = (): FindOverlayTestFakes => {
   const view = {
-    webContents: { loadFile: vi.fn(() => Promise.resolve()), send: vi.fn(), focus: vi.fn() },
+    webContents: {
+      loadFile: vi.fn(() => Promise.resolve()),
+      send: vi.fn(),
+      focus: vi.fn(),
+      close: vi.fn(),
+      isDestroyed: vi.fn(() => false)
+    },
     setBounds: vi.fn(),
-    setBackgroundColor: vi.fn(),
-    destroy: vi.fn()
+    setBackgroundColor: vi.fn()
   }
   const mainWindow = {
-    contentView: { addChildView: vi.fn() },
+    contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+    isDestroyed: () => false,
     getContentBounds: () => ({ width: 1000, height: 800 }),
     on: vi.fn(),
     removeListener: vi.fn(),
@@ -159,6 +166,8 @@ describe('find overlay manager', () => {
 
     expect(createView).toHaveBeenCalledTimes(1)
     expect(mainWindow.contentView.addChildView).toHaveBeenCalledTimes(1)
+    expect(mainWindow.contentView.removeChildView).not.toHaveBeenCalled()
+    expect(view.webContents.close).not.toHaveBeenCalled()
     expect(view.webContents.focus).toHaveBeenCalledTimes(1)
     expect(view.webContents.send).toHaveBeenCalledTimes(1)
     expect(view.webContents.send).toHaveBeenCalledWith(WINDOW_FIND_SHOW_CHANNEL, {
@@ -209,7 +218,7 @@ describe('find overlay manager', () => {
     failLoad?.(new Error('load failed'))
     await vi.waitFor(() => expect(manager.isOpen()).toBe(false))
 
-    expect(view.destroy).toHaveBeenCalledTimes(1)
+    expect(view.webContents.close).toHaveBeenCalledTimes(1)
     manager.open()
 
     expect(createView).toHaveBeenCalledTimes(2)
@@ -259,7 +268,8 @@ describe('find overlay manager', () => {
 
   it('removes its resize listener when the main window is destroyed', () => {
     const mainWindow = Object.assign(new EventEmitter(), {
-      contentView: { addChildView: vi.fn() },
+      contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      isDestroyed: () => false,
       getContentBounds: () => ({ width: 1000, height: 800 }),
       webContents: { focus: vi.fn(), send: vi.fn(), stopFindInPage: vi.fn() }
     })
@@ -273,5 +283,125 @@ describe('find overlay manager', () => {
     expect(mainWindow.listenerCount('resize')).toBe(1)
     expect(() => manager.destroy()).not.toThrow()
     expect(mainWindow.listenerCount('resize')).toBe(0)
+  })
+})
+
+describe('find overlay resource ownership', () => {
+  const setup = (
+    fail: boolean
+  ): {
+    manager: FindOverlayManager
+    attached: Set<object>
+    views: FindOverlayTestFakes['view'][]
+    removeChildView: Mock
+    mainWindow: FindOverlayTestFakes['mainWindow']
+  } => {
+    const attached = new Set<object>()
+    const views: Array<{
+      webContents: { loadFile: Mock; send: Mock; focus: Mock; close: Mock; isDestroyed: Mock }
+      setBounds: Mock
+      setBackgroundColor: Mock
+    }> = []
+    const { mainWindow } = createFakes()
+    const removeChildView = vi.fn((view: object) => attached.delete(view))
+    mainWindow.contentView = {
+      addChildView: vi.fn((view: object) => attached.add(view)),
+      removeChildView
+    }
+    const manager = createFindOverlayManager({
+      mainWindow,
+      createView: () => {
+        const view = {
+          webContents: {
+            loadFile: vi.fn(() =>
+              fail ? Promise.reject(new Error('load failed')) : Promise.resolve()
+            ),
+            send: vi.fn(),
+            focus: vi.fn(),
+            close: vi.fn(),
+            isDestroyed: vi.fn(() => false)
+          },
+          setBounds: vi.fn(),
+          setBackgroundColor: vi.fn()
+        }
+        views.push(view)
+        return view
+      },
+      preloadPath: PRELOAD_PATH,
+      overlayHtmlPath: HTML_PATH,
+      registerOwner: registerFindOverlayOwner
+    })
+    return { manager, attached, views, removeChildView, mainWindow }
+  }
+
+  it('releases failed views before repeated retries', async () => {
+    const { manager, attached, views, removeChildView } = setup(true)
+    for (let attempt = 0; attempt < 2; attempt++) {
+      manager.open()
+      await Promise.resolve()
+    }
+    expect(views).toHaveLength(2)
+    expect.soft(attached.size).toBe(0)
+    expect.soft(removeChildView).toHaveBeenCalledTimes(2)
+    for (const view of views) {
+      expect.soft(view.webContents.close).toHaveBeenCalledTimes(1)
+      expect.soft(resolveFindOverlayOwner(view.webContents)).toBeUndefined()
+    }
+  })
+
+  it('releases a loaded view and its owner on terminal destruction', async () => {
+    const { manager, attached, views, removeChildView } = setup(false)
+    manager.open()
+    await Promise.resolve()
+    manager.destroy()
+    manager.destroy()
+    expect.soft(attached.size).toBe(0)
+    expect.soft(removeChildView).toHaveBeenCalledTimes(1)
+    expect.soft(views[0].webContents.close).toHaveBeenCalledTimes(1)
+    expect.soft(resolveFindOverlayOwner(views[0].webContents)).toBeUndefined()
+  })
+})
+
+describe('find overlay terminal races', () => {
+  it('closes a loading view and ignores its late load completion', async () => {
+    const { manager, view } = createFakes()
+    let finishLoad!: () => void
+    view.webContents.loadFile.mockReturnValue(
+      new Promise<void>((resolve) => {
+        finishLoad = resolve
+      })
+    )
+    manager.open()
+    manager.destroy()
+    finishLoad()
+    await Promise.resolve()
+    expect(view.webContents.close).toHaveBeenCalledTimes(1)
+    expect(view.webContents.focus).not.toHaveBeenCalled()
+    expect(view.webContents.send).not.toHaveBeenCalled()
+    expect(manager.isOpen()).toBe(false)
+  })
+
+  it('does not access the content view after the parent window is destroyed', async () => {
+    const { manager, mainWindow, view } = createFakes()
+    manager.open()
+    await Promise.resolve()
+    mainWindow.isDestroyed = () => true
+    Object.defineProperty(mainWindow, 'contentView', {
+      get: () => {
+        throw new Error('Object has been destroyed')
+      }
+    })
+    manager.destroy()
+    expect(view.webContents.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not close webContents that Electron already destroyed', async () => {
+    const { manager, view, mainWindow } = createFakes()
+    manager.open()
+    await Promise.resolve()
+    view.webContents.isDestroyed.mockReturnValue(true)
+    manager.destroy()
+    expect(view.webContents.close).not.toHaveBeenCalled()
+    expect(mainWindow.contentView.removeChildView).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/main/find-overlay.ts
+++ b/src/main/find-overlay.ts
@@ -4,7 +4,7 @@ import {
   WINDOW_FIND_SHOW_CHANNEL,
   type WindowFindAppearance
 } from '../shared/window-controls'
-import type { FindOverlayOwner } from './find-overlay-registry'
+import { unregisterFindOverlayOwner, type FindOverlayOwner } from './find-overlay-registry'
 
 // Preferred geometry for the find overlay, in CSS pixels. 420px ~ 26rem at the app's 16px base.
 const OVERLAY_WIDTH = 420
@@ -33,17 +33,19 @@ type OverlayWebContents = {
   loadFile(path: string): Promise<void>
   send(channel: string, payload?: unknown): void
   focus(): void
+  close(): void
+  isDestroyed(): boolean
 }
 type OverlayView = {
   webContents: OverlayWebContents
   setBounds(bounds: { x: number; y: number; width: number; height: number }): void
   setBackgroundColor(color: string): void
-  destroy?(): void
 }
 
 // The main window the overlay searches and attaches to. Structural for the same testability reason.
 type OverlayMainWindow = {
-  contentView: { addChildView(view: OverlayView): void }
+  contentView: { addChildView(view: OverlayView): void; removeChildView(view: OverlayView): void }
+  isDestroyed(): boolean
   getContentBounds(): { width: number; height: number }
   on(event: 'resize', listener: () => void): void
   removeListener?(event: 'resize', listener: () => void): void
@@ -92,6 +94,16 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
   let opened = false
   let cachedAppearance = FALLBACK_APPEARANCE
 
+  const disposeView = (): void => {
+    const disposedView = view
+    view = null
+    loadPromise = null
+    if (!disposedView) return
+    unregisterFindOverlayOwner(disposedView.webContents)
+    if (!deps.mainWindow.isDestroyed()) deps.mainWindow.contentView.removeChildView(disposedView)
+    if (!disposedView.webContents.isDestroyed()) disposedView.webContents.close()
+  }
+
   const backgroundFor = (appearance: WindowFindAppearance): string =>
     appearance.theme === 'dark' ? DARK_BACKGROUND : LIGHT_BACKGROUND
 
@@ -116,7 +128,9 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
   }
 
   const appearancesEqual = (left: WindowFindAppearance, right: WindowFindAppearance): boolean =>
-    left.theme === right.theme && left.followsSystem === right.followsSystem
+    left.theme === right.theme &&
+    left.followsSystem === right.followsSystem &&
+    JSON.stringify(left.localization) === JSON.stringify(right.localization)
 
   const showLoadedView = (): void => {
     if (!opened || !view || loadPromise) return
@@ -150,8 +164,7 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
             if (loadPromise !== firstLoad) return
             loadPromise = null
             close()
-            pendingView.destroy?.()
-            if (view === pendingView) view = null
+            disposeView()
           }
         )
         deps.mainWindow.contentView.addChildView(view)
@@ -182,9 +195,7 @@ export const createFindOverlayManager = (deps: FindOverlayDeps): FindOverlayMana
       } else {
         deps.mainWindow.off?.('resize', onResize)
       }
-      view?.destroy?.()
-      view = null
-      loadPromise = null
+      disposeView()
       opened = false
     }
   }

--- a/src/renderer/src/hooks/useWindowFindAppearanceSync.overlay.test.tsx
+++ b/src/renderer/src/hooks/useWindowFindAppearanceSync.overlay.test.tsx
@@ -1,0 +1,135 @@
+// @vitest-environment jsdom
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { expect, it, vi } from 'vitest'
+import { createFindOverlayManager } from '../../../main/find-overlay'
+import { initI18n } from '../i18n'
+import { useWindowFindAppearanceSync } from './useWindowFindAppearanceSync'
+// @ts-expect-error The standalone browser module intentionally ships as plain JavaScript.
+import { createFindOverlay } from '../../../../resources/find-overlay/findOverlay.js'
+
+const { listeners, exposed } = vi.hoisted(() => ({
+  listeners: new Map<string, Set<(event: unknown, payload: unknown) => void>>(),
+  exposed: {
+    api: undefined as
+      | {
+          window: Pick<
+            Window['api']['window'],
+            | 'findInPage'
+            | 'clearFind'
+            | 'closeFind'
+            | 'onFindInPageResult'
+            | 'onShowWindowFind'
+            | 'onWindowFindAppearance'
+          >
+        }
+      | undefined
+  }
+}))
+vi.mock('electron', () => ({
+  contextBridge: {
+    exposeInMainWorld: (_key: string, api: typeof exposed.api) => {
+      exposed.api = api
+    }
+  },
+  ipcRenderer: {
+    on: (channel: string, listener: (event: unknown, payload: unknown) => void) => {
+      if (!listeners.has(channel)) listeners.set(channel, new Set())
+      listeners.get(channel)!.add(listener)
+    },
+    removeListener: (channel: string, listener: (event: unknown, payload: unknown) => void) =>
+      listeners.get(channel)?.delete(listener),
+    send: vi.fn()
+  }
+}))
+vi.mock('@/stores/theme-store', () => ({
+  useThemeStore: (selector: (state: { preference: string; resolvedTheme: string }) => unknown) =>
+    selector({ preference: 'light', resolvedTheme: 'light' })
+}))
+
+it('localizes the standalone page on open and on a live app language change', async () => {
+  await import('../../../preload/find-overlay')
+  const markup = new DOMParser().parseFromString(
+    readFileSync(resolve('resources/find-overlay/index.html'), 'utf8'),
+    'text/html'
+  )
+  const input = markup.querySelector('input')!
+  const prev = markup.getElementById('find-overlay-prev')!
+  const next = markup.getElementById('find-overlay-next')!
+  const close = markup.getElementById('find-overlay-close')!
+  const controller = createFindOverlay({
+    input,
+    prev,
+    next,
+    close,
+    count: markup.getElementById('find-overlay-count'),
+    api: exposed.api!.window,
+    storage: { getItem: () => null, setItem: vi.fn() }
+  })
+  const focus = vi.fn()
+  const manager = createFindOverlayManager({
+    mainWindow: {
+      contentView: { addChildView: vi.fn(), removeChildView: vi.fn() },
+      isDestroyed: () => false,
+      getContentBounds: () => ({ width: 1000, height: 800 }),
+      on: vi.fn(),
+      webContents: { focus: vi.fn(), send: vi.fn(), stopFindInPage: vi.fn() }
+    },
+    createView: () => ({
+      setBounds: vi.fn(),
+      setBackgroundColor: vi.fn(),
+      webContents: {
+        loadFile: async () => {},
+        focus,
+        close: vi.fn(),
+        isDestroyed: () => false,
+        send: (channel, payload) =>
+          listeners.get(channel)?.forEach((listener) => listener({}, payload))
+      }
+    }),
+    preloadPath: 'unused',
+    overlayHtmlPath: 'unused'
+  })
+  const previousApi = window.api
+  window.api = {
+    window: { announceWindowFindAppearance: manager.updateAppearance }
+  } as unknown as Window['api']
+  const container = document.createElement('div')
+  document.body.append(container)
+  const root = createRoot(container)
+  const Harness = (): null => {
+    useWindowFindAppearanceSync()
+    return null
+  }
+  const i18n = initI18n('zh-Hans')
+  try {
+    await act(async () => root.render(<Harness />))
+    manager.open()
+    await Promise.resolve()
+    expect.soft(markup.documentElement.lang).toBe('zh-Hans')
+    expect.soft(input.placeholder).toBe('查找')
+    expect.soft(input.getAttribute('aria-label')).toBe('查找文本')
+    expect.soft(prev.getAttribute('aria-label')).toBe('上一个匹配项')
+    expect
+      .soft(markup.getElementById('find-overlay-prev-tooltip')?.textContent)
+      .toBe('上一个匹配项 (Shift+Enter)')
+    focus.mockClear()
+    await act(async () => {
+      await i18n.changeLanguage('ja')
+    })
+    expect.soft(markup.documentElement.lang).toBe('ja')
+    expect.soft(input.placeholder).toBe('検索')
+    expect.soft(next.getAttribute('aria-label')).toBe('次の一致')
+    expect.soft(close.getAttribute('aria-label')).toBe('検索を閉じる')
+    expect(focus).not.toHaveBeenCalled()
+  } finally {
+    await act(async () => root.unmount())
+    controller.destroy()
+    manager.destroy()
+    container.remove()
+    window.api = previousApi
+    await i18n.changeLanguage('en')
+  }
+})

--- a/src/renderer/src/hooks/useWindowFindAppearanceSync.test.tsx
+++ b/src/renderer/src/hooks/useWindowFindAppearanceSync.test.tsx
@@ -49,7 +49,8 @@ describe('useWindowFindAppearanceSync', () => {
     await render()
     expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
       theme: 'light',
-      followsSystem: false
+      followsSystem: false,
+      localization: expect.any(Object)
     })
 
     theme.preference = 'dark'
@@ -57,7 +58,8 @@ describe('useWindowFindAppearanceSync', () => {
     await render()
     expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
       theme: 'dark',
-      followsSystem: false
+      followsSystem: false,
+      localization: expect.any(Object)
     })
 
     theme.preference = 'system'
@@ -65,14 +67,16 @@ describe('useWindowFindAppearanceSync', () => {
     await render()
     expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
       theme: 'light',
-      followsSystem: true
+      followsSystem: true,
+      localization: expect.any(Object)
     })
 
     theme.resolvedTheme = 'dark'
     await render()
     expect(announceWindowFindAppearance).toHaveBeenLastCalledWith({
       theme: 'dark',
-      followsSystem: true
+      followsSystem: true,
+      localization: expect.any(Object)
     })
   })
 })

--- a/src/renderer/src/hooks/useWindowFindAppearanceSync.ts
+++ b/src/renderer/src/hooks/useWindowFindAppearanceSync.ts
@@ -1,4 +1,6 @@
 import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { isLocale } from '../../../shared/locale'
 
 import { useThemeStore } from '@/stores/theme-store'
 
@@ -6,13 +8,24 @@ import { useThemeStore } from '@/stores/theme-store'
 // Push the resolved appearance whenever either half changes: main forwards it to the find overlay and
 // uses it to keep native appearance such as the macOS Dock icon synchronized with General > Theme.
 export const useWindowFindAppearanceSync = (): void => {
+  const { t, i18n } = useTranslation()
+  const lang = i18n.resolvedLanguage ?? i18n.language
   const preference = useThemeStore((state) => state.preference)
   const resolvedTheme = useThemeStore((state) => state.resolvedTheme)
 
   useEffect(() => {
     window.api.window.announceWindowFindAppearance?.({
       theme: resolvedTheme,
-      followsSystem: preference === 'system'
+      followsSystem: preference === 'system',
+      localization: {
+        lang: isLocale(lang) ? lang : 'en',
+        placeholder: t('Find'),
+        findText: t('Find text'),
+        findInWindow: t('Find in window'),
+        previous: t('Previous match'),
+        next: t('Next match'),
+        close: t('Close find')
+      }
     })
-  }, [preference, resolvedTheme])
+  }, [lang, preference, resolvedTheme, t])
 }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -4308,6 +4308,31 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(container.textContent).toContain('prefetched transcript sentinel')
   })
 
+  it('acknowledges every find show request in an unchanged conversation', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({
+            status: 'idle',
+            messages: [createMessage({ content: 'searchable text' })]
+          })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    })
+    await act(async () => showWindowFindListener?.())
+    expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
+    announceWindowFindContentReady.mockClear()
+    await act(async () => showWindowFindListener?.())
+    expect.soft(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
+    await act(async () => hideWindowFindListener?.())
+    announceWindowFindContentReady.mockClear()
+    await act(async () => showWindowFindListener?.())
+    expect(announceWindowFindContentReady).toHaveBeenCalledTimes(1)
+  })
+
   it('reveals the full transcript only while whole-window find is open', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const messages = Array.from({ length: 120 }, (_, index) =>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -734,10 +734,26 @@ const WorkspaceMessageScrollerImpl = ({
     undefined
   )
   const showWindowFind = useCallback((): void => {
+    const acknowledgedScope = windowFindAcknowledgedScopeRef.current
+    if (
+      acknowledgedScope &&
+      acknowledgedScope.scopeId === currentPresentationScopeId &&
+      presentationBarrierIndex < 0 &&
+      transcriptWindow.entries.length === conversationItems.length
+    ) {
+      window.api?.window?.announceWindowFindContentReady?.()
+      return
+    }
     windowFindAcknowledgedScopeRef.current = undefined
     setWindowFindOpen(true)
     revealFullTranscript()
-  }, [revealFullTranscript])
+  }, [
+    conversationItems.length,
+    currentPresentationScopeId,
+    presentationBarrierIndex,
+    revealFullTranscript,
+    transcriptWindow.entries.length
+  ])
   useEffect(() => {
     return window.api?.window?.onShowWindowFind?.(showWindowFind)
   }, [showWindowFind])

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4763,6 +4763,10 @@
     "Python commands": "Python-Befehle",
     "Python 3 commands": "Python-3-Befehle",
     "Node.js commands": "Node.js-Befehle",
-    "R scripts": "R-Skripte"
+    "R scripts": "R-Skripte",
+    "Find": "Suchen",
+    "Find text": "Text suchen",
+    "Find in window": "Im Fenster suchen",
+    "Close find": "Suche schließen"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4925,6 +4925,10 @@
     "Python commands": "Comandos de Python",
     "Python 3 commands": "Comandos de Python 3",
     "Node.js commands": "Comandos de Node.js",
-    "R scripts": "Scripts de R"
+    "R scripts": "Scripts de R",
+    "Find": "Buscar",
+    "Find text": "Buscar texto",
+    "Find in window": "Buscar en la ventana",
+    "Close find": "Cerrar búsqueda"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4925,6 +4925,10 @@
     "Python commands": "Commandes Python",
     "Python 3 commands": "Commandes Python 3",
     "Node.js commands": "Commandes Node.js",
-    "R scripts": "Scripts R"
+    "R scripts": "Scripts R",
+    "Find": "Rechercher",
+    "Find text": "Rechercher du texte",
+    "Find in window": "Rechercher dans la fenêtre",
+    "Close find": "Fermer la recherche"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4609,6 +4609,10 @@
     "Python commands": "Python コマンド",
     "Python 3 commands": "Python 3 コマンド",
     "Node.js commands": "Node.js コマンド",
-    "R scripts": "R スクリプト"
+    "R scripts": "R スクリプト",
+    "Find": "検索",
+    "Find text": "テキストを検索",
+    "Find in window": "ウィンドウ内を検索",
+    "Close find": "検索を閉じる"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4607,6 +4607,10 @@
     "Python commands": "Python 명령",
     "Python 3 commands": "Python 3 명령",
     "Node.js commands": "Node.js 명령",
-    "R scripts": "R 스크립트"
+    "R scripts": "R 스크립트",
+    "Find": "찾기",
+    "Find text": "텍스트 찾기",
+    "Find in window": "창에서 찾기",
+    "Close find": "찾기 닫기"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5058,6 +5058,10 @@
     "Python commands": "Команды Python",
     "Python 3 commands": "Команды Python 3",
     "Node.js commands": "Команды Node.js",
-    "R scripts": "Скрипты R"
+    "R scripts": "Скрипты R",
+    "Find": "Найти",
+    "Find text": "Найти текст",
+    "Find in window": "Найти в окне",
+    "Close find": "Закрыть поиск"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4609,6 +4609,10 @@
     "Python commands": "Python 命令",
     "Python 3 commands": "Python 3 命令",
     "Node.js commands": "Node.js 命令",
-    "R scripts": "R 脚本"
+    "R scripts": "R 脚本",
+    "Find": "查找",
+    "Find text": "查找文本",
+    "Find in window": "在窗口中查找",
+    "Close find": "关闭查找"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4609,6 +4609,10 @@
     "Python commands": "Python 命令",
     "Python 3 commands": "Python 3 命令",
     "Node.js commands": "Node.js 命令",
-    "R scripts": "R 指令碼"
+    "R scripts": "R 指令碼",
+    "Find": "尋找",
+    "Find text": "尋找文字",
+    "Find in window": "在視窗中尋找",
+    "Close find": "關閉尋找"
   }
 }

--- a/src/shared/window-controls.test.ts
+++ b/src/shared/window-controls.test.ts
@@ -104,6 +104,28 @@ describe('isFindInPageChord', () => {
 })
 
 describe('isWindowFindAppearance', () => {
+  it('accepts complete localization and rejects invalid renderer snapshots', () => {
+    const localization = {
+      lang: 'ja',
+      placeholder: '検索',
+      findText: '検索',
+      findInWindow: '検索',
+      previous: '前',
+      next: '次',
+      close: '閉じる'
+    }
+    const appearance = { theme: 'light', followsSystem: false, localization }
+    expect(isWindowFindAppearance(appearance)).toBe(true)
+    for (const invalid of [
+      null,
+      {},
+      { ...localization, lang: 'invalid' },
+      { ...localization, close: 1 }
+    ]) {
+      expect(isWindowFindAppearance({ ...appearance, localization: invalid })).toBe(false)
+    }
+  })
+
   it('accepts the typed light/dark appearance contract', () => {
     expect(isWindowFindAppearance({ theme: 'light', followsSystem: false })).toBe(true)
     expect(isWindowFindAppearance({ theme: 'dark', followsSystem: true })).toBe(true)

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -5,6 +5,7 @@
 // column) is open it closes that panel instead of the window. The main process intercepts the chord
 // and forwards it to the renderer, which decides whether to collapse the panel or close the window.
 
+import { isLocale, type Locale } from './locale'
 import type { ActiveSessionInfo } from './storage'
 
 // Renderer -> main: close the focused window (the fallback when no pane is open).
@@ -67,17 +68,36 @@ export type WindowFindResult = {
   finalUpdate: boolean
 }
 
+export type WindowFindLocalization = {
+  lang: Locale
+  placeholder: string
+  findText: string
+  findInWindow: string
+  previous: string
+  next: string
+  close: string
+}
+
 export type WindowFindAppearance = {
   theme: 'light' | 'dark'
   followsSystem: boolean
+  localization?: WindowFindLocalization
 }
 
 export const isWindowFindAppearance = (value: unknown): value is WindowFindAppearance => {
   if (!value || typeof value !== 'object') return false
   const appearance = value as Partial<WindowFindAppearance>
+  const localization = appearance.localization
   return (
     (appearance.theme === 'light' || appearance.theme === 'dark') &&
-    typeof appearance.followsSystem === 'boolean'
+    typeof appearance.followsSystem === 'boolean' &&
+    (localization === undefined ||
+      (localization !== null &&
+        typeof localization === 'object' &&
+        isLocale(localization.lang) &&
+        (['placeholder', 'findText', 'findInWindow', 'previous', 'next', 'close'] as const).every(
+          (key) => typeof localization[key] === 'string'
+        )))
   )
 }
 


### PR DESCRIPTION
## Problem

Failed find-overlay loads and terminal teardown retained attached views, live webContents and owner registrations. Repeating the find shortcut in an unchanged open transcript did not re-acknowledge readiness. Composing Enter/Escape triggered application commands, and the standalone page stayed English after app language changes.

## Proposed change

- Detach valid child views, unregister ownership and explicitly close live webContents through one disposal path. Normal close still hides and reuses the view.
- Re-acknowledge an already prepared transcript without bypassing initial expansion or presentation barriers.
- Leave composing keys to the input method; retain ordinary Enter/Shift+Enter navigation and Escape.
- Reuse the existing appearance channel for a transient language/copy snapshot. Translate the standalone document, input, accessible names and tooltips using all eight renderer catalogs.

## Scope and non-goals

No database/data-model changes, historical compatibility, persistence changes or new enum values. The only new data fields are optional in-memory presentation fields: language and six labels. No new IPC channel or translation framework. Query storage and composition-time live searching remain unchanged.

## Acceptance criteria and validation

Six regression cases failed twice against unchanged production code for the reported lifecycle, repeated-show, composition and localization behavior, then passed after the fixes. Localization exercises the real hook, manager, dedicated preload and standalone HTML/controller.

Checks ran after the last material production edit:

| Behavior / boundary | Check | Result |
| --- | --- | --- |
| Disposal, retry, parent teardown and delayed load | `src/main/find-overlay.test.ts` | Passed |
| Native shortcut handshake, sender validation and find-owner routing | `src/main/windows.test.ts`, `src/main/window-find-ipc.test.ts` | Passed |
| Dedicated/main preload and appearance contract | `src/preload/find-overlay.test.ts`, `src/preload/index.test.ts`, `src/preload/electron-renderer-contract-adapter.test.ts`, `src/shared/window-controls.test.ts` | Passed |
| IME and ordinary navigation | `resources/find-overlay/findOverlay.test.js` | Passed |
| Theme/language sync through standalone DOM | `useWindowFindAppearanceSync.test.tsx`, `useWindowFindAppearanceSync.overlay.test.tsx` | Passed |
| Repeated show, initial barriers and transcript consumers | `WorkspaceMessageScroller.interaction.test.tsx`, `WorkspaceMessageScroller.render.test.tsx`, `use-transcript-window.test.tsx` | Passed |
| Startup consumer fixture | `src/renderer/src/App.test.tsx` | Passed |
| Language state and all catalog guards | `locale-store.test.ts`, `src/renderer/src/i18n/resources.test.ts` | Passed |
| Main/sandbox and renderer types; repository lint | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint` | Passed |
| Real Electron repeated shortcut, live language and close | `npm run build:e2e`; `npx playwright test e2e/find-overlay.spec.ts` | Passed on macOS; Chinese/Japanese screenshots captured |

The scoped Vitest invocation ran the 16 listed files with `--maxWorkers=2`: 1279 tests passed. No full local suite was run, as requested by the maintainer. The impact classifier falls back to full for the standalone resources; exact-head PR CI remains authoritative. Windows/Linux native lanes are left to CI. No renderer RSS or OS input-method candidate-window measurements are claimed. Electron focus verification uses explicit input blur plus the existing native input helper because Playwright emulates page focus.

Rebased onto current main (`5c5bddc3`). Main now supplies a complete conversation graph in the App fixture, so the superseded test-only correction was dropped. The find-overlay implementation patch is unchanged by the rebase. The post-rebase App suite and full scoped set pass locally; there are no compute or data-model changes in this PR.

## Review focus

Confirm disposal remains separate from hide/reuse; repeat-show acknowledgment still honors scope and DOM barriers; localization stays a presentation snapshot and does not steal focus on language updates.
