### PR TITLE
fix(preview): restore tab action feedback and focus

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1697,6 +1697,28 @@ describe('PreviewPanel', () => {
   })
 
   it.each(['download', 'copy-path', 'save-as-artifact'])(
+    'clears the failure after %s succeeds from the menu',
+    async (command) => {
+      const operation = vi.fn().mockRejectedValueOnce(new Error('File operation denied'))
+      Object.assign(navigator, { clipboard: { writeText: operation } })
+      if (command === 'download') window.api.saveManagedFile = operation
+      if (command === 'save-as-artifact') window.api.uploads.stageLocalPath = operation
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({ source: 'local' }))
+      await renderPanel()
+
+      await openTabContextMenu(0)
+      await clickMenuCommand(command)
+      expect(container.querySelector('[data-testid="preview-tab-action-error"]')).not.toBeNull()
+
+      operation.mockResolvedValue({ saved: true })
+      await openTabContextMenu(0)
+      await clickMenuCommand(command)
+      expect(operation).toHaveBeenCalledTimes(2)
+      expect(container.querySelector('[data-testid="preview-tab-action-error"]')).toBeNull()
+    }
+  )
+
+  it.each(['download', 'copy-path', 'save-as-artifact'])(
     'disables the same menu command while %s is being retried',
     async (command) => {
       let finish!: () => void

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1696,6 +1696,47 @@ describe('PreviewPanel', () => {
     }
   })
 
+  it.each(['download', 'copy-path', 'save-as-artifact'])(
+    'disables the same menu command while %s is being retried',
+    async (command) => {
+      let finish!: () => void
+      const operation = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('Permission denied'))
+        .mockImplementation(
+          () =>
+            new Promise<void>((resolve) => {
+              finish = resolve
+            })
+        )
+      Object.assign(navigator, { clipboard: { writeText: operation } })
+      if (command === 'download') window.api.saveManagedFile = operation
+      if (command === 'save-as-artifact') window.api.uploads.stageLocalPath = operation
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({ source: 'local' }))
+      await renderPanel()
+      await openTabContextMenu(0)
+      await clickMenuCommand(command)
+      const retry = container.querySelector<HTMLButtonElement>(
+        '[data-testid="preview-tab-action-error"] button:last-child'
+      )!
+      await act(async () => retry.click())
+      expect(operation).toHaveBeenCalledTimes(2)
+      try {
+        await openTabContextMenu(0)
+        const menuAction = document.body.querySelector(`[data-action-id="${command}"]`)
+        expect(menuAction?.getAttribute('aria-disabled')).toBe('true')
+        await clickMenuCommand(command)
+        expect(operation).toHaveBeenCalledTimes(2)
+      } finally {
+        await act(async () => finish())
+      }
+      await openTabContextMenu(0)
+      expect(
+        document.body.querySelector(`[data-action-id="${command}"]`)?.getAttribute('aria-disabled')
+      ).not.toBe('true')
+    }
+  )
+
   it('focuses the remaining active tab after closing the focused tab from its menu', async () => {
     await renderTwoFileTabs()
     container.querySelector<HTMLButtonElement>('[role="tab"]')!.focus()

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1738,4 +1738,126 @@ describe('PreviewPanel', () => {
       composer.remove()
     }
   })
+  it.each([false, true])(
+    'discards a previous project action failure (late rejection: %s)',
+    async (late) => {
+      useNavigationStore.setState({ activeProjectId: 'project-a' })
+      usePreviewWorkbenchStore.getState().activateProject('project-a')
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+        createFileItem({
+          source: 'local',
+          projectId: 'project-a'
+        })
+      )
+      let reject!: (error: Error) => void
+      const save = vi.fn(
+        () =>
+          new Promise<never>((_, fail) => {
+            reject = fail
+          })
+      )
+      window.api.uploads.stageLocalPath = save
+      await renderPanel()
+      await openTabContextMenu(0)
+      await clickMenuCommand('save-as-artifact')
+      expect(save).toHaveBeenCalledWith(expect.objectContaining({ projectId: 'project-a' }))
+      const rejectSave = async (): Promise<void> => {
+        await act(async () => reject(new Error('Project A save failed')))
+      }
+      if (!late) {
+        await rejectSave()
+        expect(container.querySelector('[data-testid="preview-tab-action-error"]')).not.toBeNull()
+      }
+      await act(async () => {
+        useNavigationStore.setState({ activeProjectId: 'project-b' })
+        usePreviewWorkbenchStore.getState().activateProject('project-b')
+      })
+      if (late) await rejectSave()
+      expect(container.querySelector('[data-testid="preview-tab-action-error"]')).toBeNull()
+      await act(async () => {
+        useNavigationStore.setState({ activeProjectId: 'project-a' })
+        usePreviewWorkbenchStore.getState().activateProject('project-a')
+      })
+      expect(container.querySelector('[data-testid="preview-tab-action-error"]')).toBeNull()
+      expect(save).toHaveBeenCalledTimes(1)
+    }
+  )
+
+  it('rejects a stale retry click after navigation changes projects', async () => {
+    useNavigationStore.setState({ activeProjectId: 'project-a' })
+    usePreviewWorkbenchStore.getState().activateProject('project-a')
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({ source: 'local' }))
+    const save = vi.fn().mockRejectedValue(new Error('Project A save failed'))
+    window.api.uploads.stageLocalPath = save
+    await renderPanel()
+    await openTabContextMenu(0)
+    await clickMenuCommand('save-as-artifact')
+    const retry = container.querySelector<HTMLButtonElement>(
+      '[data-testid="preview-tab-action-error"] button'
+    )!
+    expect(retry).not.toBeNull()
+    await act(async () => {
+      useNavigationStore.setState({ activeProjectId: 'project-b' })
+      retry.click()
+    })
+    expect(save).toHaveBeenCalledTimes(1)
+  })
+  it('keeps retry progress scoped to the current project failure', async () => {
+    let finishA: (() => void) | undefined
+    let finishB: (() => void) | undefined
+    const save = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Project A save failed'))
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishA = resolve
+          })
+      )
+      .mockRejectedValueOnce(new Error('Project B save failed'))
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishB = resolve
+          })
+      )
+    window.api.uploads.stageLocalPath = save
+    const openProject = (projectId: string): void => {
+      useNavigationStore.setState({ activeProjectId: projectId })
+      usePreviewWorkbenchStore.getState().activateProject(projectId)
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+        createFileItem({
+          source: 'local',
+          projectId,
+          id: projectId
+        })
+      )
+    }
+    const retryButton = (): HTMLButtonElement =>
+      container.querySelector<HTMLButtonElement>('[data-testid="preview-tab-action-error"] button')!
+    openProject('project-a')
+    await renderPanel()
+    try {
+      await openTabContextMenu(0)
+      await clickMenuCommand('save-as-artifact')
+      await act(async () => retryButton().click())
+      expect(save).toHaveBeenCalledTimes(2)
+      await act(async () => openProject('project-b'))
+      await openTabContextMenu(0)
+      await clickMenuCommand('save-as-artifact')
+      expect(save).toHaveBeenCalledTimes(3)
+      expect(retryButton().disabled).toBe(false)
+      await act(async () => retryButton().click())
+      expect(save).toHaveBeenCalledTimes(4)
+      await act(async () => finishA?.())
+      expect(retryButton().disabled).toBe(true)
+      await act(async () => finishB?.())
+      expect(container.querySelector('[data-testid="preview-tab-action-error"]')).toBeNull()
+    } finally {
+      await act(async () => {
+        finishA?.()
+        finishB?.()
+      })
+    }
+  })
 })

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1307,6 +1307,80 @@ describe('PreviewPanel', () => {
     window.removeEventListener(FOCUS_COMPOSER_EVENT, focusListener)
   })
 
+  it('disables the PDF tab command while linking is pending', async () => {
+    let finish!: () => void
+    const linkPdfContext = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        })
+    )
+    usePreviewWorkbenchStore.getState().activateProject('project-1')
+    window.api.sessions = {
+      linkPdfContext,
+      unlinkPdfContext: vi.fn()
+    } as unknown as Window['api']['sessions']
+    window.api.artifacts = {
+      getLineage: vi.fn().mockResolvedValue(undefined)
+    } as unknown as Window['api']['artifacts']
+    useSessionStore.setState({
+      sessions: [
+        {
+          id: 'session-1',
+          projectId: 'project-1',
+          title: 'Session',
+          cwd: '/workspace',
+          status: 'idle',
+          messages: [],
+          runtimeContext: { version: 1, revision: 1 },
+          createdAt: 1,
+          updatedAt: 1
+        } as ChatSession
+      ],
+      selectedSessionId: 'session-1'
+    })
+    const focusListener = vi.fn()
+    window.addEventListener(FOCUS_COMPOSER_EVENT, focusListener)
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+      createFileItem({
+        format: 'pdf',
+        title: 'paper.pdf',
+        name: 'paper.pdf',
+        artifactId: 'artifact-1',
+        selectedVersionId: 'version-1',
+        path: 'artifact-version:project-1/session-1/artifact-1/version-1'
+      })
+    )
+    await renderPanel()
+
+    await openTabContextMenu(0)
+    expect(menuCommands()[0]).toBe('toggle-pdf-context')
+    expect(
+      document.body.querySelector('[data-action-id="toggle-pdf-context"]')?.textContent
+    ).toContain('Read with agent')
+
+    await clickMenuCommand('toggle-pdf-context')
+
+    try {
+      expect(linkPdfContext).toHaveBeenCalledTimes(1)
+      await openTabContextMenu(0)
+      const command = document.body.querySelector('[data-action-id="toggle-pdf-context"]')
+      expect(command).not.toBeNull()
+      expect(command?.getAttribute('aria-disabled')).toBe('true')
+      await clickMenuCommand('toggle-pdf-context')
+      expect(linkPdfContext).toHaveBeenCalledTimes(1)
+    } finally {
+      await act(async () => finish())
+      window.removeEventListener(FOCUS_COMPOSER_EVENT, focusListener)
+    }
+    await openTabContextMenu(0)
+    expect(
+      document.body
+        .querySelector('[data-action-id="toggle-pdf-context"]')
+        ?.getAttribute('aria-disabled')
+    ).not.toBe('true')
+  })
+
   it('routes the PDF tab command through the Composer Reading history port when provided', async () => {
     const linkPdfContext = vi.fn()
     const onLinkReadingContext = vi.fn().mockResolvedValue(undefined)
@@ -1551,5 +1625,117 @@ describe('PreviewPanel', () => {
     expect(stageLocalPath).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'notes.md', sourcePath: '/tmp/notes.md' })
     )
+  })
+  it.each([
+    ['download', 'Could not download this file.'],
+    ['copy-path', 'Could not copy the file path.'],
+    ['save-as-artifact', 'Could not save this file as an artifact.']
+  ])('shows a retryable failure for %s from an inactive tab', async (command, title) => {
+    const failure = new Error('File operation denied')
+    const rejectOperation = vi.fn().mockRejectedValue(failure)
+    const log = vi.spyOn(console, 'error').mockImplementation(() => {})
+    Object.assign(navigator, { clipboard: { writeText: rejectOperation } })
+    if (command === 'download') window.api.saveManagedFile = rejectOperation
+    if (command === 'save-as-artifact') window.api.uploads.stageLocalPath = rejectOperation
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'local-file',
+        source: 'local',
+        name: 'notes.png',
+        title: 'notes.png',
+        path: '/workspace/notes.png'
+      })
+    )
+    await renderPanel()
+    try {
+      await openTabContextMenu(1)
+      await clickMenuCommand(command)
+      expect(rejectOperation).toHaveBeenCalledTimes(1)
+      expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-1')
+      expect(document.body.querySelector('[role="menu"]')).toBeNull()
+      const notice = container.querySelector('[data-testid="preview-tab-action-error"]')
+      expect(notice?.closest('[hidden]')).toBeNull()
+      expect(notice?.querySelector('[role="alert"]')?.textContent).toContain(title)
+      expect(document.body.textContent).toContain(title)
+      expect(document.body.textContent).toContain(failure.message)
+      const retry = Array.from(document.body.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Try again' || button.textContent === 'Retry'
+      )
+      expect(retry).toBeDefined()
+      // Retry still targets the original file after its tab has been removed.
+      await act(async () => usePreviewWorkbenchStore.getState().removeItem('local-file'))
+      await act(async () => retry!.click())
+      expect(rejectOperation).toHaveBeenCalledTimes(2)
+      expect(document.body.textContent).toContain(title)
+      let finish!: () => void
+      rejectOperation.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            finish = resolve
+          })
+      )
+      await act(async () => retry!.click())
+      expect(retry!.disabled).toBe(true)
+      await act(async () => retry!.click())
+      expect(rejectOperation).toHaveBeenCalledTimes(3)
+      const request = rejectOperation.mock.calls[2][0]
+      if (command === 'copy-path') expect(request).toBe('/workspace/notes.png')
+      else
+        expect(request).toEqual(
+          expect.objectContaining(
+            command === 'download'
+              ? { path: '/workspace/notes.png' }
+              : { sourcePath: '/workspace/notes.png' }
+          )
+        )
+      await act(async () => finish())
+      expect(document.body.textContent).not.toContain(title)
+    } finally {
+      log.mockRestore()
+    }
+  })
+
+  it('focuses the remaining active tab after closing the focused tab from its menu', async () => {
+    await renderTwoFileTabs()
+    container.querySelector<HTMLButtonElement>('[role="tab"]')!.focus()
+    await openTabContextMenu(0)
+    await clickMenuCommand('close')
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('item-2')
+    const remaining = document.getElementById('preview-tab-item-2')
+    expect(remaining).not.toBeNull()
+    expect(document.activeElement).toBe(remaining)
+  })
+  it('keeps download cancellation silent', async () => {
+    vi.mocked(window.api.saveManagedFile).mockResolvedValue({ saved: false })
+    await renderTwoFileTabs()
+    await openTabContextMenu(0)
+    await clickMenuCommand('download')
+    expect(window.api.saveManagedFile).toHaveBeenCalledTimes(1)
+    expect(container.querySelector('[data-testid="preview-tab-action-error"]')).toBeNull()
+  })
+
+  it('hands focus to the composer after the last tab is closed from its menu', async () => {
+    const composer = document.createElement('textarea')
+    document.body.appendChild(composer)
+    const focusComposer = (): void => composer.focus()
+    window.addEventListener(FOCUS_COMPOSER_EVENT, focusComposer)
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    await renderPanel()
+    try {
+      await openTabContextMenu(0)
+      await clickMenuCommand('close')
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+      })
+      expect(usePreviewWorkbenchStore.getState().items).toHaveLength(0)
+      expect(document.activeElement).toBe(composer)
+    } finally {
+      window.removeEventListener(FOCUS_COMPOSER_EVENT, focusComposer)
+      composer.remove()
+    }
   })
 })

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1923,4 +1923,60 @@ describe('PreviewPanel', () => {
       })
     }
   })
+
+  it('keeps each concurrent retry disabled in its tab menu', async () => {
+    let finishFirst!: () => void
+    let finishSecond!: () => void
+    const save = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('First save failed'))
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishFirst = resolve
+          })
+      )
+      .mockRejectedValueOnce(new Error('Second save failed'))
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishSecond = resolve
+          })
+      )
+    window.api.uploads.stageLocalPath = save
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({ source: 'local' }))
+    usePreviewWorkbenchStore.getState().upsertItem(
+      createFileItem({
+        id: 'second-local-file',
+        source: 'local',
+        name: 'second.txt',
+        title: 'second.txt',
+        path: '/workspace/second.txt'
+      })
+    )
+    await renderPanel()
+    const retryButton = (): HTMLButtonElement =>
+      container.querySelector<HTMLButtonElement>('[data-testid="preview-tab-action-error"] button')!
+
+    try {
+      await openTabContextMenu(0)
+      await clickMenuCommand('save-as-artifact')
+      await act(async () => retryButton().click())
+      await openTabContextMenu(1)
+      await clickMenuCommand('save-as-artifact')
+      await act(async () => retryButton().click())
+
+      await openTabContextMenu(0)
+      expect(
+        document.body
+          .querySelector('[data-action-id="save-as-artifact"]')
+          ?.getAttribute('aria-disabled')
+      ).toBe('true')
+    } finally {
+      await act(async () => {
+        finishFirst?.()
+        finishSecond?.()
+      })
+    }
+  })
 })

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -94,6 +94,7 @@ const PREVIEW_TAB_EDGE_INSET = 8
 const PreviewTabActionTarget = ({
   item,
   tabCount,
+  retryPending,
   onPdfContextError,
   onLinkReadingContext,
   onUnlinkReadingContext,
@@ -101,6 +102,7 @@ const PreviewTabActionTarget = ({
 }: {
   item: PreviewItem
   tabCount: number
+  retryPending?: PreviewTabActionError
   onPdfContextError?: (message: string | null) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
   onUnlinkReadingContext?: PreviewInteractionPort['onUnlinkReadingContext']
@@ -118,6 +120,7 @@ const PreviewTabActionTarget = ({
   )
   const context: PreviewTabActionContext = {
     tabCount,
+    retryPending,
     pdfContextPending: pdfAction?.pending,
     ...(pdfAction && !pdfAction.disabled ? { pdfContext: pdfAction.state } : {})
   }
@@ -213,6 +216,7 @@ const PreviewTab = ({
   containerRef,
   tabRef,
   tabCount,
+  retryPending,
   onPdfContextError,
   onLinkReadingContext,
   onUnlinkReadingContext,
@@ -225,6 +229,7 @@ const PreviewTab = ({
   containerRef: (element: HTMLDivElement | null) => void
   tabRef: (element: HTMLButtonElement | null) => void
   tabCount: number
+  retryPending?: PreviewTabActionError
   onPdfContextError?: (message: string | null) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
   onUnlinkReadingContext?: PreviewInteractionPort['onUnlinkReadingContext']
@@ -247,6 +252,7 @@ const PreviewTab = ({
       <PreviewTabActionTarget
         item={tab}
         tabCount={tabCount}
+        retryPending={retryPending}
         onPdfContextError={onPdfContextError}
         onLinkReadingContext={onLinkReadingContext}
         onUnlinkReadingContext={onUnlinkReadingContext}
@@ -309,6 +315,7 @@ const PreviewTab = ({
 // Horizontal, scrollable strip of every file the user has asked to preview this session.
 const PreviewTabBar = ({
   tabs,
+  retryPending,
   activeItemId,
   onActivate,
   onClose,
@@ -317,6 +324,7 @@ const PreviewTabBar = ({
   onUnlinkReadingContext
 }: {
   tabs: PreviewItem[]
+  retryPending?: PreviewTabActionError
   activeItemId: string | undefined
   onActivate: (id: string) => void
   onClose: (id: string) => boolean
@@ -417,6 +425,7 @@ const PreviewTabBar = ({
             tabRefs.current[index] = element
           }}
           tabCount={tabs.length}
+          retryPending={retryPending}
           onPdfContextError={onPdfContextError}
           onLinkReadingContext={onLinkReadingContext}
           onUnlinkReadingContext={onUnlinkReadingContext}
@@ -711,7 +720,8 @@ const PreviewPanelSurface = ({
               actionFailure.fileName,
               actionFailure.retry,
               error,
-              actionFailure.projectId
+              actionFailure.projectId,
+              actionFailure.itemId
             )
           : current
       )
@@ -765,6 +775,7 @@ const PreviewPanelSurface = ({
           >
             <PreviewTabBar
               tabs={items}
+              retryPending={retryPending?.projectId === activeProjectId ? retryPending : undefined}
               activeItemId={activeItemId}
               onActivate={activateItem}
               onClose={removeItem}

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -686,13 +686,20 @@ const PreviewPanelSurface = ({
   ...annotationPort
 }: PreviewPanelSurfaceProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const [actionFailure, setActionFailure] = useState<PreviewTabActionError>()
-  const [retryPending, setRetryPending] = useState(false)
-  const retryPendingRef = useRef(false)
+  useEffect(() => setActionFailure(undefined), [activeProjectId])
+  const [retryPending, setRetryPending] = useState<PreviewTabActionError>()
+  const retryPendingRef = useRef<PreviewTabActionError | undefined>(undefined)
   const retryAction = async (): Promise<void> => {
-    if (!actionFailure || retryPendingRef.current) return
-    retryPendingRef.current = true
-    setRetryPending(true)
+    if (
+      !actionFailure ||
+      retryPendingRef.current === actionFailure ||
+      actionFailure.projectId !== useNavigationStore.getState().activeProjectId
+    )
+      return
+    retryPendingRef.current = actionFailure
+    setRetryPending(actionFailure)
     try {
       await actionFailure.retry()
       setActionFailure((current) => (current === actionFailure ? undefined : current))
@@ -703,13 +710,14 @@ const PreviewPanelSurface = ({
               actionFailure.command,
               actionFailure.fileName,
               actionFailure.retry,
-              error
+              error,
+              actionFailure.projectId
             )
           : current
       )
     } finally {
-      retryPendingRef.current = false
-      setRetryPending(false)
+      if (retryPendingRef.current === actionFailure) retryPendingRef.current = undefined
+      setRetryPending((current) => (current === actionFailure ? undefined : current))
     }
   }
 
@@ -736,8 +744,11 @@ const PreviewPanelSurface = ({
     <ActionMenuProvider
       testId="preview-tab-context-menu"
       onActionError={(error) => {
-        if (error instanceof PreviewTabActionError) setActionFailure(error)
-        else console.error('Failed to execute preview tab action', error)
+        if (error instanceof PreviewTabActionError) {
+          // An operation from a previous project can reject after its tabs have unmounted.
+          if (error.projectId === useNavigationStore.getState().activeProjectId)
+            setActionFailure(error)
+        } else console.error('Failed to execute preview tab action', error)
       }}
     >
       <aside
@@ -763,7 +774,7 @@ const PreviewPanelSurface = ({
             />
           </div>
         ) : null}
-        {actionFailure ? (
+        {actionFailure && actionFailure.projectId === activeProjectId ? (
           <div
             className="mx-2 my-2 max-h-[50%] shrink-0 overflow-y-auto"
             data-testid="preview-tab-action-error"
@@ -783,7 +794,7 @@ const PreviewPanelSurface = ({
               primaryButton={{
                 label: t('Retry'),
                 onClick: () => void retryAction(),
-                loading: retryPending
+                loading: retryPending === actionFailure
               }}
               secondaryButton={{ label: t('Close'), onClick: () => setActionFailure(undefined) }}
             />

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -94,7 +94,7 @@ const PREVIEW_TAB_EDGE_INSET = 8
 const PreviewTabActionTarget = ({
   item,
   tabCount,
-  retryPending,
+  retryPendingKeys,
   onPdfContextError,
   onFileActionSuccess,
   onLinkReadingContext,
@@ -103,7 +103,7 @@ const PreviewTabActionTarget = ({
 }: {
   item: PreviewItem
   tabCount: number
-  retryPending?: PreviewTabActionError
+  retryPendingKeys?: ReadonlySet<string>
   onPdfContextError?: (message: string | null) => void
   onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
@@ -122,7 +122,7 @@ const PreviewTabActionTarget = ({
   )
   const context: PreviewTabActionContext = {
     tabCount,
-    retryPending,
+    retryPendingKeys,
     pdfContextPending: pdfAction?.pending,
     ...(pdfAction && !pdfAction.disabled ? { pdfContext: pdfAction.state } : {})
   }
@@ -244,7 +244,7 @@ const PreviewTab = ({
   containerRef,
   tabRef,
   tabCount,
-  retryPending,
+  retryPendingKeys,
   onPdfContextError,
   onFileActionSuccess,
   onLinkReadingContext,
@@ -258,7 +258,7 @@ const PreviewTab = ({
   containerRef: (element: HTMLDivElement | null) => void
   tabRef: (element: HTMLButtonElement | null) => void
   tabCount: number
-  retryPending?: PreviewTabActionError
+  retryPendingKeys?: ReadonlySet<string>
   onPdfContextError?: (message: string | null) => void
   onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
@@ -282,7 +282,7 @@ const PreviewTab = ({
       <PreviewTabActionTarget
         item={tab}
         tabCount={tabCount}
-        retryPending={retryPending}
+        retryPendingKeys={retryPendingKeys}
         onPdfContextError={onPdfContextError}
         onFileActionSuccess={onFileActionSuccess}
         onLinkReadingContext={onLinkReadingContext}
@@ -346,7 +346,7 @@ const PreviewTab = ({
 // Horizontal, scrollable strip of every file the user has asked to preview this session.
 const PreviewTabBar = ({
   tabs,
-  retryPending,
+  retryPendingKeys,
   activeItemId,
   onActivate,
   onClose,
@@ -356,7 +356,7 @@ const PreviewTabBar = ({
   onUnlinkReadingContext
 }: {
   tabs: PreviewItem[]
-  retryPending?: PreviewTabActionError
+  retryPendingKeys?: ReadonlySet<string>
   activeItemId: string | undefined
   onActivate: (id: string) => void
   onClose: (id: string) => boolean
@@ -458,7 +458,7 @@ const PreviewTabBar = ({
             tabRefs.current[index] = element
           }}
           tabCount={tabs.length}
-          retryPending={retryPending}
+          retryPendingKeys={retryPendingKeys}
           onPdfContextError={onPdfContextError}
           onFileActionSuccess={onFileActionSuccess}
           onLinkReadingContext={onLinkReadingContext}
@@ -732,8 +732,8 @@ const PreviewPanelSurface = ({
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const [actionFailure, setActionFailure] = useState<PreviewTabActionError>()
   useEffect(() => setActionFailure(undefined), [activeProjectId])
-  const [retryPending, setRetryPending] = useState<PreviewTabActionError>()
-  const retryPendingRef = useRef<PreviewTabActionError | undefined>(undefined)
+  const [retryPendingKeys, setRetryPendingKeys] = useState<ReadonlySet<string>>(() => new Set())
+  const retryPendingKeysRef = useRef(new Set<string>())
   const clearActionFailure = (command: PreviewTabActionCommand, item: PreviewItem): void => {
     setActionFailure((current) =>
       current &&
@@ -747,12 +747,12 @@ const PreviewPanelSurface = ({
   const retryAction = async (): Promise<void> => {
     if (
       !actionFailure ||
-      retryPendingRef.current === actionFailure ||
+      retryPendingKeysRef.current.has(actionFailure.retryKey) ||
       actionFailure.projectId !== useNavigationStore.getState().activeProjectId
     )
       return
-    retryPendingRef.current = actionFailure
-    setRetryPending(actionFailure)
+    retryPendingKeysRef.current.add(actionFailure.retryKey)
+    setRetryPendingKeys((current) => new Set(current).add(actionFailure.retryKey))
     try {
       await actionFailure.retry()
       setActionFailure((current) => (current === actionFailure ? undefined : current))
@@ -765,13 +765,19 @@ const PreviewPanelSurface = ({
               actionFailure.retry,
               error,
               actionFailure.projectId,
-              actionFailure.itemId
+              actionFailure.itemId,
+              actionFailure.retryKey
             )
           : current
       )
     } finally {
-      if (retryPendingRef.current === actionFailure) retryPendingRef.current = undefined
-      setRetryPending((current) => (current === actionFailure ? undefined : current))
+      retryPendingKeysRef.current.delete(actionFailure.retryKey)
+      setRetryPendingKeys((current) => {
+        if (!current.has(actionFailure.retryKey)) return current
+        const next = new Set(current)
+        next.delete(actionFailure.retryKey)
+        return next
+      })
     }
   }
 
@@ -819,7 +825,7 @@ const PreviewPanelSurface = ({
           >
             <PreviewTabBar
               tabs={items}
-              retryPending={retryPending?.projectId === activeProjectId ? retryPending : undefined}
+              retryPendingKeys={retryPendingKeys}
               onFileActionSuccess={clearActionFailure}
               activeItemId={activeItemId}
               onActivate={activateItem}
@@ -850,7 +856,7 @@ const PreviewPanelSurface = ({
               primaryButton={{
                 label: t('Retry'),
                 onClick: () => void retryAction(),
-                loading: retryPending === actionFailure
+                loading: retryPendingKeys.has(actionFailure.retryKey)
               }}
               secondaryButton={{ label: t('Close'), onClick: () => setActionFailure(undefined) }}
             />

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -96,6 +96,7 @@ const PreviewTabActionTarget = ({
   tabCount,
   retryPending,
   onPdfContextError,
+  onFileActionSuccess,
   onLinkReadingContext,
   onUnlinkReadingContext,
   children
@@ -104,6 +105,7 @@ const PreviewTabActionTarget = ({
   tabCount: number
   retryPending?: PreviewTabActionError
   onPdfContextError?: (message: string | null) => void
+  onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
   onUnlinkReadingContext?: PreviewInteractionPort['onUnlinkReadingContext']
   children: React.ReactElement
@@ -142,10 +144,36 @@ const PreviewTabActionTarget = ({
     activeProjectId
   }
   const bindings = createPreviewTabActionBindings(context, deps)
-  const pdfContextBinding = bindings['toggle-pdf-context']
-  const focusAwareBindings = pdfContextBinding
+  const successAwareBindings = onFileActionSuccess
     ? {
         ...bindings,
+        download: {
+          ...bindings.download,
+          execute: async (invocation: PreviewItem) => {
+            await bindings.download?.execute(invocation)
+            onFileActionSuccess('download', invocation)
+          }
+        },
+        'copy-path': {
+          ...bindings['copy-path'],
+          execute: async (invocation: PreviewItem) => {
+            await bindings['copy-path']?.execute(invocation)
+            onFileActionSuccess('copy-path', invocation)
+          }
+        },
+        'save-as-artifact': {
+          ...bindings['save-as-artifact'],
+          execute: async (invocation: PreviewItem) => {
+            await bindings['save-as-artifact']?.execute(invocation)
+            onFileActionSuccess('save-as-artifact', invocation)
+          }
+        }
+      }
+    : bindings
+  const pdfContextBinding = successAwareBindings['toggle-pdf-context']
+  const focusAwareBindings = pdfContextBinding
+    ? {
+        ...successAwareBindings,
         'toggle-pdf-context': {
           ...pdfContextBinding,
           execute: (invocation: PreviewItem) => {
@@ -154,7 +182,7 @@ const PreviewTabActionTarget = ({
           }
         }
       }
-    : bindings
+    : successAwareBindings
 
   return (
     <ActionMenuTarget<PreviewTabActionCommand, PreviewItem>
@@ -218,6 +246,7 @@ const PreviewTab = ({
   tabCount,
   retryPending,
   onPdfContextError,
+  onFileActionSuccess,
   onLinkReadingContext,
   onUnlinkReadingContext,
   onActivate,
@@ -231,6 +260,7 @@ const PreviewTab = ({
   tabCount: number
   retryPending?: PreviewTabActionError
   onPdfContextError?: (message: string | null) => void
+  onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
   onUnlinkReadingContext?: PreviewInteractionPort['onUnlinkReadingContext']
   onActivate: (id: string) => void
@@ -254,6 +284,7 @@ const PreviewTab = ({
         tabCount={tabCount}
         retryPending={retryPending}
         onPdfContextError={onPdfContextError}
+        onFileActionSuccess={onFileActionSuccess}
         onLinkReadingContext={onLinkReadingContext}
         onUnlinkReadingContext={onUnlinkReadingContext}
       >
@@ -320,6 +351,7 @@ const PreviewTabBar = ({
   onActivate,
   onClose,
   onPdfContextError,
+  onFileActionSuccess,
   onLinkReadingContext,
   onUnlinkReadingContext
 }: {
@@ -329,6 +361,7 @@ const PreviewTabBar = ({
   onActivate: (id: string) => void
   onClose: (id: string) => boolean
   onPdfContextError?: (message: string | null) => void
+  onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
   onLinkReadingContext?: PreviewInteractionPort['onLinkReadingContext']
   onUnlinkReadingContext?: PreviewInteractionPort['onUnlinkReadingContext']
 }): React.JSX.Element => {
@@ -427,6 +460,7 @@ const PreviewTabBar = ({
           tabCount={tabs.length}
           retryPending={retryPending}
           onPdfContextError={onPdfContextError}
+          onFileActionSuccess={onFileActionSuccess}
           onLinkReadingContext={onLinkReadingContext}
           onUnlinkReadingContext={onUnlinkReadingContext}
           onActivate={onActivate}
@@ -700,6 +734,16 @@ const PreviewPanelSurface = ({
   useEffect(() => setActionFailure(undefined), [activeProjectId])
   const [retryPending, setRetryPending] = useState<PreviewTabActionError>()
   const retryPendingRef = useRef<PreviewTabActionError | undefined>(undefined)
+  const clearActionFailure = (command: PreviewTabActionCommand, item: PreviewItem): void => {
+    setActionFailure((current) =>
+      current &&
+      current.projectId === activeProjectId &&
+      current.itemId === item.id &&
+      current.command === command
+        ? undefined
+        : current
+    )
+  }
   const retryAction = async (): Promise<void> => {
     if (
       !actionFailure ||
@@ -776,6 +820,7 @@ const PreviewPanelSurface = ({
             <PreviewTabBar
               tabs={items}
               retryPending={retryPending?.projectId === activeProjectId ? retryPending : undefined}
+              onFileActionSuccess={clearActionFailure}
               activeItemId={activeItemId}
               onActivate={activateItem}
               onClose={removeItem}

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -7,6 +7,8 @@ import { dialogOverlayClassName, dialogPanelClassName } from '@/components/ui/di
 import { ActionMenuProvider, ActionMenuTarget } from '@/components/action-menu'
 import { ResizablePanel } from '@/components/ui/resizable'
 import { cn } from '@/lib/utils'
+import { errorDetail } from '@/lib/error-detail'
+import { ErrorNotice } from '@/components/error-notice'
 import { useNavigationStore } from '@/stores/navigation-store'
 import type {
   PreviewFileItem,
@@ -23,6 +25,7 @@ import {
   createPreviewTabActionBindings,
   getPreviewTabActionRecipe,
   PREVIEW_TAB_ACTION_CATALOG,
+  PreviewTabActionError,
   type PreviewTabActionCommand,
   type PreviewTabActionContext,
   type PreviewTabActionDeps
@@ -34,6 +37,7 @@ import { PreviewToolContent } from './previews/PreviewToolContent'
 import type { RestoredPlanResponder } from './session-plan/SessionPlanSurfaces'
 import { useHorizontalScrollFade } from './use-horizontal-scroll-fade'
 import { usePdfContextAction } from './use-pdf-context-action'
+import { requestComposerFocus } from './composer-focus-events'
 
 type PreviewPanelProps = PreviewInteractionPort & {
   panelRef: React.Ref<PanelImperativeHandle>
@@ -114,6 +118,7 @@ const PreviewTabActionTarget = ({
   )
   const context: PreviewTabActionContext = {
     tabCount,
+    pdfContextPending: pdfAction?.pending,
     ...(pdfAction && !pdfAction.disabled ? { pdfContext: pdfAction.state } : {})
   }
   const stageLocalPath = window.api.uploads?.stageLocalPath
@@ -165,7 +170,12 @@ const PreviewTabActionTarget = ({
         const composerFocusRequested = composerFocusRequestedRef.current
         composerFocusRequestedRef.current = false
         if (!composerFocusRequested) {
-          document.getElementById(getPreviewTabId(item.id))?.focus()
+          const activeId = usePreviewWorkbenchStore.getState().activeItemId
+          const target =
+            document.getElementById(getPreviewTabId(item.id)) ??
+            (activeId ? document.getElementById(getPreviewTabId(activeId)) : null)
+          if (target) target.focus()
+          else requestComposerFocus()
         }
       }}
       asChild
@@ -675,6 +685,34 @@ const PreviewPanelSurface = ({
   onUnlinkReadingContext,
   ...annotationPort
 }: PreviewPanelSurfaceProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const [actionFailure, setActionFailure] = useState<PreviewTabActionError>()
+  const [retryPending, setRetryPending] = useState(false)
+  const retryPendingRef = useRef(false)
+  const retryAction = async (): Promise<void> => {
+    if (!actionFailure || retryPendingRef.current) return
+    retryPendingRef.current = true
+    setRetryPending(true)
+    try {
+      await actionFailure.retry()
+      setActionFailure((current) => (current === actionFailure ? undefined : current))
+    } catch (error) {
+      setActionFailure((current) =>
+        current === actionFailure
+          ? new PreviewTabActionError(
+              actionFailure.command,
+              actionFailure.fileName,
+              actionFailure.retry,
+              error
+            )
+          : current
+      )
+    } finally {
+      retryPendingRef.current = false
+      setRetryPending(false)
+    }
+  }
+
   const items = usePreviewWorkbenchStore((state) => state.items)
   const activeItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const panelState = usePreviewWorkbenchStore((state) => state.panelState)
@@ -695,7 +733,13 @@ const PreviewPanelSurface = ({
       : (activeItem?.id ?? 'empty')
 
   return (
-    <ActionMenuProvider testId="preview-tab-context-menu">
+    <ActionMenuProvider
+      testId="preview-tab-context-menu"
+      onActionError={(error) => {
+        if (error instanceof PreviewTabActionError) setActionFailure(error)
+        else console.error('Failed to execute preview tab action', error)
+      }}
+    >
       <aside
         id="right-panel"
         className={cn(
@@ -716,6 +760,32 @@ const PreviewPanelSurface = ({
               onPdfContextError={onPdfContextError}
               onLinkReadingContext={onLinkReadingContext}
               onUnlinkReadingContext={onUnlinkReadingContext}
+            />
+          </div>
+        ) : null}
+        {actionFailure ? (
+          <div
+            className="mx-2 my-2 max-h-[50%] shrink-0 overflow-y-auto"
+            data-testid="preview-tab-action-error"
+          >
+            <ErrorNotice
+              role="alert"
+              tone="amber"
+              title={
+                actionFailure.command === 'copy-path'
+                  ? t('Could not copy the file path.')
+                  : actionFailure.command === 'download'
+                    ? t('Could not download this file.')
+                    : t('Could not save this file as an artifact.')
+              }
+              description={actionFailure.fileName}
+              errorCode={errorDetail(actionFailure.cause)}
+              primaryButton={{
+                label: t('Retry'),
+                onClick: () => void retryAction(),
+                loading: retryPending
+              }}
+              secondaryButton={{ label: t('Close'), onClick: () => setActionFailure(undefined) }}
             />
           </div>
         ) : null}

--- a/src/renderer/src/pages/workspace/preview-tab-actions.test.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.test.ts
@@ -237,14 +237,10 @@ describe('runPreviewTabAction', () => {
     })
   })
 
-  it('logs instead of throwing when a download fails', async () => {
-    const deps = createDeps({ saveManagedFile: vi.fn().mockRejectedValue(new Error('disk full')) })
-    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
-
-    runPreviewTabAction('download', createFileItem({}), deps)
-    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled())
-
-    consoleError.mockRestore()
+  it('propagates a download rejection to the menu owner', async () => {
+    const failure = new Error('disk full')
+    const deps = createDeps({ saveManagedFile: vi.fn().mockRejectedValue(failure) })
+    await expect(runPreviewTabAction('download', createFileItem({}), deps)).rejects.toBe(failure)
   })
 
   it('copies a local file path to the clipboard', async () => {

--- a/src/renderer/src/pages/workspace/preview-tab-actions.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.ts
@@ -134,7 +134,7 @@ const retryableFileBinding = (
   pendingKeys?: ReadonlySet<string>
 ): ActionMenuBinding<PreviewItem> => ({
   disabled: (item) =>
-    pendingKeys?.has(getPreviewTabActionRetryKey(command, item, deps.activeProjectId)),
+    pendingKeys?.has(getPreviewTabActionRetryKey(command, item, deps.activeProjectId)) ?? false,
   execute: async (item) => {
     const retry = async (): Promise<void> => {
       await runPreviewTabAction(command, item, deps)

--- a/src/renderer/src/pages/workspace/preview-tab-actions.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.ts
@@ -32,7 +32,7 @@ export const PREVIEW_TAB_ACTION_CATALOG: Record<PreviewTabActionCommand, ActionM
 
 export type PreviewTabActionContext = {
   tabCount: number
-  retryPending?: PreviewTabActionError
+  retryPendingKeys?: ReadonlySet<string>
   // Set by the host (which owns the stores) for linkable PDF file tabs; drives the leading
   // Read-with-agent command's label.
   pdfContextPending?: boolean
@@ -108,18 +108,33 @@ export class PreviewTabActionError extends Error {
     readonly retry: () => Promise<void>,
     cause: unknown,
     readonly projectId: string | undefined,
-    readonly itemId: string
+    readonly itemId: string,
+    readonly retryKey: string
   ) {
     super('Preview tab action failed', { cause })
   }
 }
 
+export const getPreviewTabActionRetryKey = (
+  command: PreviewTabActionCommand,
+  item: PreviewItem,
+  projectId: string | undefined
+): string =>
+  JSON.stringify([
+    projectId ?? null,
+    item.id,
+    command,
+    item.type === 'file' ? item.path : null,
+    item.type === 'file' ? (item.selectedVersionId ?? null) : null
+  ])
+
 const retryableFileBinding = (
   command: PreviewTabActionCommand,
   deps: PreviewTabActionDeps,
-  pending?: PreviewTabActionError
+  pendingKeys?: ReadonlySet<string>
 ): ActionMenuBinding<PreviewItem> => ({
-  disabled: (item) => pending?.itemId === item.id && pending.command === command,
+  disabled: (item) =>
+    pendingKeys?.has(getPreviewTabActionRetryKey(command, item, deps.activeProjectId)),
   execute: async (item) => {
     const retry = async (): Promise<void> => {
       await runPreviewTabAction(command, item, deps)
@@ -133,7 +148,8 @@ const retryableFileBinding = (
         retry,
         error,
         deps.activeProjectId,
-        item.id
+        item.id,
+        getPreviewTabActionRetryKey(command, item, deps.activeProjectId)
       )
     }
   }
@@ -148,9 +164,9 @@ export const createPreviewTabActionBindings = (
     execute: (item) => runPreviewTabAction('close-others', item, deps),
     disabled: context.tabCount <= 1
   },
-  download: retryableFileBinding('download', deps, context.retryPending),
-  'copy-path': retryableFileBinding('copy-path', deps, context.retryPending),
-  'save-as-artifact': retryableFileBinding('save-as-artifact', deps, context.retryPending),
+  download: retryableFileBinding('download', deps, context.retryPendingKeys),
+  'copy-path': retryableFileBinding('copy-path', deps, context.retryPendingKeys),
+  'save-as-artifact': retryableFileBinding('save-as-artifact', deps, context.retryPendingKeys),
   ...(context.pdfContext && deps.togglePdfContext
     ? {
         'toggle-pdf-context': {

--- a/src/renderer/src/pages/workspace/preview-tab-actions.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.ts
@@ -32,6 +32,7 @@ export const PREVIEW_TAB_ACTION_CATALOG: Record<PreviewTabActionCommand, ActionM
 
 export type PreviewTabActionContext = {
   tabCount: number
+  retryPending?: PreviewTabActionError
   // Set by the host (which owns the stores) for linkable PDF file tabs; drives the leading
   // Read-with-agent command's label.
   pdfContextPending?: boolean
@@ -106,7 +107,8 @@ export class PreviewTabActionError extends Error {
     readonly fileName: string,
     readonly retry: () => Promise<void>,
     cause: unknown,
-    readonly projectId: string | undefined
+    readonly projectId: string | undefined,
+    readonly itemId: string
   ) {
     super('Preview tab action failed', { cause })
   }
@@ -114,8 +116,10 @@ export class PreviewTabActionError extends Error {
 
 const retryableFileBinding = (
   command: PreviewTabActionCommand,
-  deps: PreviewTabActionDeps
+  deps: PreviewTabActionDeps,
+  pending?: PreviewTabActionError
 ): ActionMenuBinding<PreviewItem> => ({
+  disabled: (item) => pending?.itemId === item.id && pending.command === command,
   execute: async (item) => {
     const retry = async (): Promise<void> => {
       await runPreviewTabAction(command, item, deps)
@@ -123,7 +127,14 @@ const retryableFileBinding = (
     try {
       await retry()
     } catch (error) {
-      throw new PreviewTabActionError(command, item.title, retry, error, deps.activeProjectId)
+      throw new PreviewTabActionError(
+        command,
+        item.title,
+        retry,
+        error,
+        deps.activeProjectId,
+        item.id
+      )
     }
   }
 })
@@ -137,9 +148,9 @@ export const createPreviewTabActionBindings = (
     execute: (item) => runPreviewTabAction('close-others', item, deps),
     disabled: context.tabCount <= 1
   },
-  download: retryableFileBinding('download', deps),
-  'copy-path': retryableFileBinding('copy-path', deps),
-  'save-as-artifact': retryableFileBinding('save-as-artifact', deps),
+  download: retryableFileBinding('download', deps, context.retryPending),
+  'copy-path': retryableFileBinding('copy-path', deps, context.retryPending),
+  'save-as-artifact': retryableFileBinding('save-as-artifact', deps, context.retryPending),
   ...(context.pdfContext && deps.togglePdfContext
     ? {
         'toggle-pdf-context': {

--- a/src/renderer/src/pages/workspace/preview-tab-actions.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.ts
@@ -105,7 +105,8 @@ export class PreviewTabActionError extends Error {
     readonly command: PreviewTabActionCommand,
     readonly fileName: string,
     readonly retry: () => Promise<void>,
-    cause: unknown
+    cause: unknown,
+    readonly projectId: string | undefined
   ) {
     super('Preview tab action failed', { cause })
   }
@@ -122,7 +123,7 @@ const retryableFileBinding = (
     try {
       await retry()
     } catch (error) {
-      throw new PreviewTabActionError(command, item.title, retry, error)
+      throw new PreviewTabActionError(command, item.title, retry, error, deps.activeProjectId)
     }
   }
 })

--- a/src/renderer/src/pages/workspace/preview-tab-actions.ts
+++ b/src/renderer/src/pages/workspace/preview-tab-actions.ts
@@ -34,6 +34,7 @@ export type PreviewTabActionContext = {
   tabCount: number
   // Set by the host (which owns the stores) for linkable PDF file tabs; drives the leading
   // Read-with-agent command's label.
+  pdfContextPending?: boolean
   pdfContext?: PdfContextLinkState
 }
 
@@ -98,6 +99,34 @@ export const getPreviewTabActionRecipe = (
     ])
 }
 
+// Carries the original operation across tab switches or removal without changing the shared menu.
+export class PreviewTabActionError extends Error {
+  constructor(
+    readonly command: PreviewTabActionCommand,
+    readonly fileName: string,
+    readonly retry: () => Promise<void>,
+    cause: unknown
+  ) {
+    super('Preview tab action failed', { cause })
+  }
+}
+
+const retryableFileBinding = (
+  command: PreviewTabActionCommand,
+  deps: PreviewTabActionDeps
+): ActionMenuBinding<PreviewItem> => ({
+  execute: async (item) => {
+    const retry = async (): Promise<void> => {
+      await runPreviewTabAction(command, item, deps)
+    }
+    try {
+      await retry()
+    } catch (error) {
+      throw new PreviewTabActionError(command, item.title, retry, error)
+    }
+  }
+})
+
 export const createPreviewTabActionBindings = (
   context: PreviewTabActionContext,
   deps: PreviewTabActionDeps
@@ -107,15 +136,14 @@ export const createPreviewTabActionBindings = (
     execute: (item) => runPreviewTabAction('close-others', item, deps),
     disabled: context.tabCount <= 1
   },
-  download: { execute: (item) => runPreviewTabAction('download', item, deps) },
-  'copy-path': { execute: (item) => runPreviewTabAction('copy-path', item, deps) },
-  'save-as-artifact': {
-    execute: (item) => runPreviewTabAction('save-as-artifact', item, deps)
-  },
+  download: retryableFileBinding('download', deps),
+  'copy-path': retryableFileBinding('copy-path', deps),
+  'save-as-artifact': retryableFileBinding('save-as-artifact', deps),
   ...(context.pdfContext && deps.togglePdfContext
     ? {
         'toggle-pdf-context': {
           execute: (item: PreviewItem) => runPreviewTabAction('toggle-pdf-context', item, deps),
+          disabled: context.pdfContextPending,
           labelKey: context.pdfContext === 'remove' ? 'Remove PDF from context' : 'Read with agent',
           icon: context.pdfContext === 'remove' ? Link2Off : BookOpen
         }
@@ -168,15 +196,11 @@ export const runPreviewTabAction = (
   }
 
   if (command === 'download') {
-    return downloadManagedFile(item, deps).catch((error: unknown) => {
-      console.error(`Failed to download ${item.name} from the tab menu`, error)
-    })
+    return downloadManagedFile(item, deps)
   }
 
   if (command === 'copy-path') {
-    return deps
-      .copyText(item.path)
-      .catch((error: unknown) => console.error(`Failed to copy the path of ${item.name}`, error))
+    return deps.copyText(item.path)
   }
 
   if (command === 'save-as-artifact') {
@@ -192,8 +216,5 @@ export const runPreviewTabAction = (
         ...(deps.activeProjectId ? { projectId: deps.activeProjectId } : {})
       })
       .then(() => undefined)
-      .catch((error: unknown) => {
-        console.error(`Failed to save ${item.name} as an artifact from the tab menu`, error)
-      })
   }
 }


### PR DESCRIPTION
## Problem

Preview tab downloads, clipboard writes, and artifact saves swallowed API failures, so the menu closed without visible feedback. Closing the focused tab left DOM focus on the body. A pending PDF reading-context request still appeared executable when its tab menu was reopened.

## Proposed change

- Propagate file-action rejection to the shared menu provider. A preview-local error carries the original operation to a panel-level, dismissible ErrorNotice with existing translated titles, file identity, diagnostics, and Retry. Inactive or subsequently closed tabs retain a usable retry within their original project; changing projects clears the notice, drops late failures from other projects, and blocks stale retry clicks. Retry progress belongs to its failure and cannot block another project; retry clicks and the corresponding tab menu command are disabled while awaiting completion. Download cancellation remains silent.
- Restore focus to the original tab, then the active remaining tab, then the existing composer focus event. Preserve PDF commands' composer handoff.
- Pass the existing PDF pending boolean to the tab action binding's disabled condition.

The initial full CI run exposed a pre-existing App conversation-graph fixture failure, also reproduced at the original base. Main now contains the complete fixture correction, so the duplicate test-only commit was dropped when resolving the branch conflict.

## Scope and non-goals

Four preview renderer source/test files. No shared-provider API change, new dependency, global task manager, database field, new business enum, persisted format, migration, or historical compatibility path. Only transient failure/retry UI state (including the originating project and tab IDs) and a derived pending property are added. Existing save and PDF persistence operations are unchanged.

## Acceptance criteria and validation

Before production edits, five public-behavior cases in the existing real PreviewPanel/Radix harness failed identically in two runs: three missing failure titles after confirmed API calls/menu dismissal, body focus after confirmed store selection repair, and missing aria-disabled while a real hook request remained pending. No production test seam was added. All five now pass.

After the final retry-menu fix and rebase, the targeted Vitest files below were rerun together (1,161 passed), the workspace module was rerun separately (825 passed), and typecheck/lint passed:

| Behavior | Command | Result |
| --- | --- | --- |
| Failure visibility on inactive tabs, retry after tab removal, retry failure/success and deduplication, cancellation, focus restoration/fallback and PDF handoff/pending | `npx vitest run src/renderer/src/pages/workspace/PreviewPanel.test.tsx src/renderer/src/pages/workspace/preview-tab-actions.test.ts` | 77 passed |
| Shared menu contracts, ErrorNotice, content-menu consumers, preview store, translations | `npx vitest run src/renderer/src/components/action-menu src/renderer/src/components/error-notice.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx src/renderer/src/stores/preview-workbench-store.test.ts src/renderer/src/i18n/resources.test.ts` | 1,019 passed |
| App startup/background analysis fixture | `npx vitest run src/renderer/src/App.test.tsx` | 65 passed; failed identically on the exact base before the fixture correction |
| Workspace composition and representative consumers | `npm run test:module -- workspace_page` (plan inspected with `--explain`) | 825 passed across 30 files |
| Renderer types | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |
| Patch whitespace | `git diff --check` | Passed |

Manual browser validation used the real PreviewPanel and styling in an isolated local fixture with injected file/API data: actual right-click, visible inactive-tab failure, successful retry dismissal, disabled pending PDF action, project-switch notice removal, and a disabled artifact-save menu command during retry. Screenshots were captured locally for the maintainer; this is not full Electron E2E coverage.

`npm run test:affected:explain -- --base origin/main --head HEAD` reports a full fallback because PreviewPanel.test.tsx has no module owner in the current manifest. The maintainer explicitly requested module-local validation rather than the full local suite; the final PR CI plan remains authoritative. Main/preload, iframe coordinate handling, persistence, and path normalization are unchanged, so no local native/platform or migration lane was run. Independent review identified project-switch leakage in the first implementation. Four additional public-behavior regressions reproduced retained notices, late rejections, stale retry clicks, and retry-progress leakage before their fix; all now pass. A subsequent independent review identified executable menu commands during a pending retry. Three additional real-menu regressions failed identically twice before the fix and now pass. CI and independent review of the final retry correction remain pending. The maintainer has explicitly requested that this PR not be merged.

## Review focus

Original-operation capture for retry, preservation of PDF composer focus, and visibility of failures from inactive tabs. Confirm the final behavior-to-check mapping before marking the change verified.
