### PR TITLE
fix(composer): preserve draft intent during mention selection

### DIFF
--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
+import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { BookOpenText, FolderOpen } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -39,6 +39,8 @@ export type PickedMention = PickedArtifact | LiteratureReference | LiteratureSco
 // document while mounted.
 type ArtifactMentionPopupProps = {
   query: string
+  selectionKey?: object | null
+  composingRef?: React.RefObject<boolean>
   listboxId?: string
   onActiveOptionIdChange?: (optionId: string | undefined) => void
   onSelect: (ref: PickedMention) => void
@@ -70,6 +72,8 @@ const SECTION_LIBRARY_KEY = 'Library'
 
 export const ArtifactMentionPopup = ({
   query,
+  composingRef,
+  selectionKey,
   listboxId,
   onActiveOptionIdChange,
   onSelect,
@@ -243,6 +247,7 @@ export const ArtifactMentionPopup = ({
 
   const selectRow = useCallback(
     async (row: ArtifactRow): Promise<void> => {
+      const revision = ++selectionRevisionRef.current
       if (
         (row.tag === 'library' || row.tag === 'library-scope' || row.tag === 'collection-scope') &&
         row.picked
@@ -254,7 +259,6 @@ export const ArtifactMentionPopup = ({
         setSelectionError(t('Could not resolve file version.'))
         return
       }
-      const revision = ++selectionRevisionRef.current
       setSelectionError(undefined)
       const inspect = window.api.managedFileVersions?.inspect
       if (!inspect) {
@@ -296,16 +300,17 @@ export const ArtifactMentionPopup = ({
     [onSelect, t]
   )
 
-  useEffect(
+  useLayoutEffect(
     () => () => {
       selectionRevisionRef.current += 1
     },
-    []
+    [query, selectionKey, activeProjectId]
   )
 
   // Handle navigation keys at the document level while mounted, since focus stays in the editor.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.isComposing || composingRef?.current) return
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         if (matches.length > 0) setActiveIndex((safeIndex + 1) % matches.length)
@@ -335,7 +340,7 @@ export const ArtifactMentionPopup = ({
 
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [matches, safeIndex, selectRow, onClose])
+  }, [matches, safeIndex, selectRow, onClose, composingRef])
 
   // Split the flat match list back into its sections, preserving the flat highlight index.
   const uploadMatches = matches.filter((row) => row.tag === 'upload')

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -363,7 +363,7 @@ describe('ComposerEditor mention input safety', () => {
     expect(editor().querySelector('[data-mention-type]')).not.toBeNull()
   })
 
-  it.each(['another token', 'cancel', 'replace draft', 'new selection'])(
+  it.each(['another token', 'cancel', 'replace draft', 'switch session', 'new selection'])(
     'ignores an earlier file lookup after %s',
     async (change) => {
       const inspect = vi.mocked(window.api.managedFileVersions.inspect)
@@ -375,7 +375,7 @@ describe('ComposerEditor mention input safety', () => {
             resolve = done
           })
       )
-      renderEditor()
+      renderEditor({ mentionPreviewContext: { sessionId: 'session-1', projectId: 'default' } })
       await typeQuery(change === 'another token' ? '@seq @seq' : '@seq')
       dispatchKey(editor(), 'Enter')
       let expected = '@seq'
@@ -387,8 +387,16 @@ describe('ComposerEditor mention input safety', () => {
         expected = '@seq @seq'
       } else if (change === 'cancel') {
         dispatchKey(editor(), 'Escape')
+      } else if (change === 'switch session') {
+        renderEditor({
+          doc: { nodes: [{ type: 'text', text: '@seq' }] },
+          mentionPreviewContext: { sessionId: 'session-2', projectId: 'default' }
+        })
       } else if (change === 'replace draft') {
-        renderEditor({ doc: { nodes: [{ type: 'text', text: '@seq new draft' }] } })
+        renderEditor({
+          doc: { nodes: [{ type: 'text', text: '@seq new draft' }] },
+          mentionPreviewContext: { sessionId: 'session-1', projectId: 'default' }
+        })
         // Preserve the query while replacing the controlled draft through public props.
         act(() => {
           setCaret(editor().firstChild!, 4)

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -314,6 +314,136 @@ const flushProjectFiles = async (): Promise<void> => {
   })
 }
 
+describe('ComposerEditor mention input safety', () => {
+  const typeQuery = async (text: string): Promise<void> => {
+    act(() => {
+      editor().textContent = text
+      setCaret(editor().firstChild!, text.length)
+      editor().dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await flushProjectFiles()
+  }
+
+  it.each(['/lit', '@seq', '#'])(
+    'preserves %s while Enter confirms IME composition',
+    async (query) => {
+      renderEditor()
+      await typeQuery(query)
+      expect(document.body.querySelector('[role="option"]')).not.toBeNull()
+      act(() => {
+        editor().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+      })
+      dispatchKey(editor(), 'Enter', { isComposing: true })
+      await flushProjectFiles()
+      expect(editor().querySelector('[data-mention-type]')).toBeNull()
+      expect(editor().textContent).toBe(query)
+      expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+    }
+  )
+
+  it.each(
+    ['/lit', '@seq', '#'].flatMap((query) =>
+      ['Enter', 'ArrowDown', 'ArrowUp', 'Escape', 'Tab'].map((key) => ({ query, key }))
+    )
+  )('leaves $key to composition for $query without a native flag', async ({ query, key }) => {
+    renderEditor()
+    await typeQuery(query)
+    const active = editor().getAttribute('aria-activedescendant')
+    act(() => editor().dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true })))
+    const event = new KeyboardEvent('keydown', { key, bubbles: true, cancelable: true })
+    act(() => editor().dispatchEvent(event))
+    await flushProjectFiles()
+    expect(event.defaultPrevented).toBe(false)
+    expect(editor().textContent).toBe(query)
+    expect(editor().getAttribute('aria-activedescendant')).toBe(active)
+    expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+    act(() => editor().dispatchEvent(new CompositionEvent('compositionend', { bubbles: true })))
+    dispatchKey(editor(), 'Enter')
+    await flushProjectFiles()
+    expect(editor().querySelector('[data-mention-type]')).not.toBeNull()
+  })
+
+  it.each(['another token', 'cancel', 'replace draft', 'new selection'])(
+    'ignores an earlier file lookup after %s',
+    async (change) => {
+      const inspect = vi.mocked(window.api.managedFileVersions.inspect)
+      const result = await inspect({ source: 'upload', projectId: 'default', fileId: 'up-1' })
+      let resolve!: (value: typeof result) => void
+      inspect.mockImplementationOnce(
+        () =>
+          new Promise((done) => {
+            resolve = done
+          })
+      )
+      renderEditor()
+      await typeQuery(change === 'another token' ? '@seq @seq' : '@seq')
+      dispatchKey(editor(), 'Enter')
+      let expected = '@seq'
+      if (change === 'another token') {
+        act(() => {
+          setCaret(editor().firstChild!, 4)
+          document.dispatchEvent(new Event('selectionchange'))
+        })
+        expected = '@seq @seq'
+      } else if (change === 'cancel') {
+        dispatchKey(editor(), 'Escape')
+      } else if (change === 'replace draft') {
+        renderEditor({ doc: { nodes: [{ type: 'text', text: '@seq new draft' }] } })
+        // Preserve the query while replacing the controlled draft through public props.
+        act(() => {
+          setCaret(editor().firstChild!, 4)
+          document.dispatchEvent(new Event('selectionchange'))
+        })
+        expected = '@seq new draft'
+      } else {
+        await typeQuery('@report')
+        dispatchKey(editor(), 'Enter')
+        await flushProjectFiles()
+        expected = '@report.pdf'
+      }
+      await act(async () => resolve(result))
+      expect(editor().textContent).toBe(expected)
+      expect(editor().querySelectorAll('[data-mention-type]')).toHaveLength(
+        change === 'new selection' ? 1 : 0
+      )
+    }
+  )
+
+  it('preserves a newer file query when an earlier version lookup finishes', async () => {
+    const inspect = vi.mocked(window.api.managedFileVersions.inspect)
+    const result = await inspect({ source: 'upload', projectId: 'default', fileId: 'up-1' })
+    let resolve!: (value: typeof result) => void
+    inspect.mockClear()
+    inspect.mockImplementationOnce(
+      () =>
+        new Promise((done) => {
+          resolve = done
+        })
+    )
+    renderEditor()
+    await typeQuery('@seq')
+    expect(document.body.querySelector('[role="option"]')?.textContent).toContain('sequence.csv')
+    dispatchKey(editor(), 'Enter')
+    expect(inspect).toHaveBeenCalledOnce()
+    await typeQuery('@report')
+    expect(document.body.querySelector('[role="option"]')?.textContent).toContain('report.pdf')
+    await act(async () => resolve(result))
+    expect(editor().textContent).toBe('@report')
+    expect(editor().querySelector('[data-mention-type]')).toBeNull()
+  })
+
+  it.each([
+    ['/does-not-exist', 'No matching skills'],
+    ['#999999999', 'No matching sessions']
+  ])('explains empty suggestions for %s', async (query, message) => {
+    renderEditor()
+    await typeQuery(query)
+    expect(document.body.querySelector('[role="listbox"]')).not.toBeNull()
+    expect(document.body.querySelectorAll('[role="option"]')).toHaveLength(0)
+    expect(document.body.textContent).toContain(message)
+  })
+})
+
 describe('ComposerEditor', () => {
   it('shows the placeholder when the doc is empty and hides it once there is content', () => {
     renderEditor({ doc: emptyDoc })

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -496,6 +496,22 @@ export const ComposerEditor = ({
   const mentionPopupOpen = mention.active || artifactMention.active || sessionMention.active
   const undoCaretRef = useRef<ComposerCaretPosition | undefined>(undefined)
 
+  const { cancel: cancelSkillMention } = mention
+  const { cancel: cancelArtifactMention } = artifactMention
+  const { cancel: cancelSessionMention } = sessionMention
+
+  // Different Sessions can have identical draft text and therefore reuse the same DOM token.
+  useLayoutEffect(() => {
+    cancelSkillMention()
+    cancelArtifactMention()
+    cancelSessionMention()
+  }, [
+    mentionPreviewContext?.sessionId,
+    cancelSkillMention,
+    cancelArtifactMention,
+    cancelSessionMention
+  ])
+
   // Read the live DOM back into a doc and notify the parent.
   const emitDocFromDom = useCallback((): void => {
     const root = editorRef.current

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -812,8 +812,9 @@ export const ComposerEditor = ({
   const handleSelectSkill = (skill: SkillView): void => {
     const root = editorRef.current
     undoCaretRef.current = root ? currentCaretPosition(root) : undefined
-    mention.replaceTokenWith({ type: 'skill', id: skill.id, name: skill.displayName })
-    mention.cancel()
+    if (!mention.replaceTokenWith({ type: 'skill', id: skill.id, name: skill.displayName })) {
+      undoCaretRef.current = undefined
+    }
   }
 
   // Replace the active `@query` token with an artifact chip, then close the popup.
@@ -821,29 +822,29 @@ export const ComposerEditor = ({
     const root = editorRef.current
     undoCaretRef.current = root ? currentCaretPosition(root) : undefined
     if ('type' in ref && (ref.type === 'literature' || ref.type === 'literature-scope')) {
-      artifactMention.replaceTokenWith(ref)
-      artifactMention.cancel()
+      if (!artifactMention.replaceTokenWith(ref)) undoCaretRef.current = undefined
       return
     }
     const artifact = ref as PickedArtifact
-    artifactMention.replaceTokenWith({
-      type: 'artifact',
-      id: artifact.id,
-      sourceFileId: artifact.sourceFileId,
-      name: artifact.name,
-      path: artifact.path,
-      source: artifact.source,
-      mimeType: artifact.mimeType,
-      versionId: artifact.versionId
-    })
-    artifactMention.cancel()
+    if (
+      !artifactMention.replaceTokenWith({
+        type: 'artifact',
+        id: artifact.id,
+        sourceFileId: artifact.sourceFileId,
+        name: artifact.name,
+        path: artifact.path,
+        source: artifact.source,
+        mimeType: artifact.mimeType,
+        versionId: artifact.versionId
+      })
+    )
+      undoCaretRef.current = undefined
   }
 
   const handleSelectSession = (session: PickedSession): void => {
     const root = editorRef.current
     undoCaretRef.current = root ? currentCaretPosition(root) : undefined
-    sessionMention.replaceTokenWith(session)
-    sessionMention.cancel()
+    if (!sessionMention.replaceTokenWith(session)) undoCaretRef.current = undefined
   }
 
   return (
@@ -906,6 +907,7 @@ export const ComposerEditor = ({
       ) : null}
       {mention.active ? (
         <SkillMentionPopup
+          composingRef={composingRef}
           query={mention.query}
           allowedSkillIds={allowedSkillIds}
           listboxId={mentionListboxId}
@@ -916,7 +918,9 @@ export const ComposerEditor = ({
       ) : null}
       {artifactMention.active ? (
         <ArtifactMentionPopup
+          composingRef={composingRef}
           query={artifactMention.query}
+          selectionKey={artifactMention.selectionKey}
           onSelect={handleSelectArtifact}
           onClose={artifactMention.cancel}
           listboxId={mentionListboxId}
@@ -925,6 +929,7 @@ export const ComposerEditor = ({
       ) : null}
       {sessionMention.active ? (
         <SessionMentionPopup
+          composingRef={composingRef}
           query={sessionMention.query}
           onSelect={handleSelectSession}
           onClose={sessionMention.cancel}

--- a/src/renderer/src/pages/workspace/composer/SessionMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SessionMentionPopup.tsx
@@ -14,6 +14,7 @@ export type PickedSession = SessionReference
 
 type SessionMentionPopupProps = {
   query: string
+  composingRef?: React.RefObject<boolean>
   listboxId?: string
   onActiveOptionIdChange?: (optionId: string | undefined) => void
   onSelect: (session: PickedSession) => void
@@ -34,6 +35,7 @@ type SessionRow = PickedSession & {
 // rows sort first; picking a row snapshots only global Session identity plus its current title.
 export const SessionMentionPopup = ({
   query,
+  composingRef,
   listboxId,
   onActiveOptionIdChange,
   onSelect,
@@ -136,6 +138,7 @@ export const SessionMentionPopup = ({
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.isComposing || composingRef?.current) return
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         if (matches.length > 0) setActiveIndex((safeIndex + 1) % matches.length)
@@ -161,7 +164,7 @@ export const SessionMentionPopup = ({
 
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [matches, onClose, onSelect, safeIndex])
+  }, [matches, onClose, onSelect, safeIndex, composingRef])
 
   return (
     <div className="absolute bottom-full left-0 z-50 mb-1 flex max-h-[min(55vh,24rem)] min-w-[320px] max-w-[440px] flex-col overflow-hidden rounded-xl border-0.5 border-border-200 bg-bg-000 p-1.5 shadow-[0_4px_16px_hsl(var(--always-black)/10%)]">
@@ -172,6 +175,11 @@ export const SessionMentionPopup = ({
         aria-label={t('Sessions')}
         className="min-h-0 flex-1 overflow-y-auto"
       >
+        {matches.length === 0 && (
+          <li role="presentation" className="px-2 py-3 text-sm text-text-300">
+            <div role="status">{t('No matching sessions')}</div>
+          </li>
+        )}
         {matches.map((session, index) => {
           const isActive = index === safeIndex
           return (
@@ -216,12 +224,16 @@ export const SessionMentionPopup = ({
         })}
       </ul>
       <div className="mt-1 -mx-1.5 -mb-1.5 flex shrink-0 items-center gap-3 border-t border-border-300 px-3.5 pt-1.5 pb-2 text-[11px] text-text-400 select-none">
-        <span>
-          <span className="text-text-300">↑↓</span> {t('navigate')}
-        </span>
-        <span>
-          <span className="text-text-300">Enter / Tab</span> {t('select')}
-        </span>
+        {matches.length > 0 && (
+          <>
+            <span>
+              <span className="text-text-300">↑↓</span> {t('navigate')}
+            </span>
+            <span>
+              <span className="text-text-300">Enter / Tab</span> {t('select')}
+            </span>
+          </>
+        )}
         <span>
           <span className="text-text-300">Esc</span> {t('close')}
         </span>

--- a/src/renderer/src/pages/workspace/composer/SessionMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SessionMentionPopup.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { SearchX } from 'lucide-react'
 
 import type { SessionReference } from '../../../../../shared/session-persistence'
 import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
@@ -167,8 +168,10 @@ export const SessionMentionPopup = ({
   }, [matches, onClose, onSelect, safeIndex, composingRef])
 
   return (
-    <div className="absolute bottom-full left-0 z-50 mb-1 flex max-h-[min(55vh,24rem)] min-w-[320px] max-w-[440px] flex-col overflow-hidden rounded-xl border-0.5 border-border-200 bg-bg-000 p-1.5 shadow-[0_4px_16px_hsl(var(--always-black)/10%)]">
-      <div className="shrink-0 px-2 py-1 text-xs font-medium text-text-300">{t('Sessions')}</div>
+    <div className="absolute bottom-full left-0 z-50 mb-1 flex max-h-[min(55vh,24rem)] w-max min-w-[min(320px,100%)] max-w-[min(440px,100%)] flex-col overflow-hidden rounded-xl border-0.5 border-border-200 bg-bg-000 p-1.5 shadow-[0_4px_16px_hsl(var(--always-black)/10%)]">
+      {matches.length > 0 && (
+        <div className="shrink-0 px-2 py-1 text-xs font-medium text-text-300">{t('Sessions')}</div>
+      )}
       <ul
         id={resolvedListboxId}
         role="listbox"
@@ -176,8 +179,19 @@ export const SessionMentionPopup = ({
         className="min-h-0 flex-1 overflow-y-auto"
       >
         {matches.length === 0 && (
-          <li role="presentation" className="px-2 py-3 text-sm text-text-300">
-            <div role="status">{t('No matching sessions')}</div>
+          <li role="presentation" className="flex min-h-18 items-center gap-3 px-3 py-3.5">
+            <span
+              aria-hidden="true"
+              className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-bg-200 text-text-100"
+            >
+              <SearchX className="size-4" />
+            </span>
+            <div
+              role="status"
+              className="min-w-0 flex-1 text-sm font-medium leading-5 text-text-000"
+            >
+              {t('No matching sessions')}
+            </div>
           </li>
         )}
         {matches.map((session, index) => {
@@ -223,19 +237,28 @@ export const SessionMentionPopup = ({
           )
         })}
       </ul>
-      <div className="mt-1 -mx-1.5 -mb-1.5 flex shrink-0 items-center gap-3 border-t border-border-300 px-3.5 pt-1.5 pb-2 text-[11px] text-text-400 select-none">
+      <div className="mt-1 -mx-1.5 -mb-1.5 flex shrink-0 items-center justify-end gap-3 border-t border-border-200 bg-bg-200/40 px-3 py-1.5 text-[11px] text-text-100 select-none">
         {matches.length > 0 && (
           <>
             <span>
-              <span className="text-text-300">↑↓</span> {t('navigate')}
+              <kbd className="rounded border border-border-200 bg-bg-000 px-1 py-0.5 font-sans text-[10px] font-medium">
+                ↑↓
+              </kbd>{' '}
+              {t('navigate')}
             </span>
             <span>
-              <span className="text-text-300">Enter / Tab</span> {t('select')}
+              <kbd className="rounded border border-border-200 bg-bg-000 px-1 py-0.5 font-sans text-[10px] font-medium">
+                Enter / Tab
+              </kbd>{' '}
+              {t('select')}
             </span>
           </>
         )}
         <span>
-          <span className="text-text-300">Esc</span> {t('close')}
+          <kbd className="rounded border border-border-200 bg-bg-000 px-1 py-0.5 font-sans text-[10px] font-medium">
+            Esc
+          </kbd>{' '}
+          {t('close')}
         </span>
       </div>
     </div>

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.render.test.tsx
@@ -8,6 +8,7 @@ import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-
 
 let container: HTMLDivElement
 let root: Root
+const loadSkills = useSettingsStore.getState().loadSkills
 
 const seedSkills = [
   {
@@ -42,6 +43,7 @@ const seedSkills = [
 beforeEach(() => {
   useSettingsStore.setState({
     ...createInitialSettingsState(),
+    loadSkills,
     skills: seedSkills
   })
   container = document.createElement('div')
@@ -53,6 +55,7 @@ afterEach(() => {
   act(() => root.unmount())
   container.remove()
   document.body.innerHTML = ''
+  vi.restoreAllMocks()
 })
 
 const options = (): HTMLElement[] =>
@@ -318,5 +321,64 @@ describe('SkillMentionPopup', () => {
     const marks = Array.from(document.body.querySelectorAll('mark'))
     expect(marks).toHaveLength(1)
     expect(marks[0].textContent?.toLowerCase()).toBe('lit')
+  })
+})
+
+describe('SkillMentionPopup catalog feedback', () => {
+  const renderPopup = (): void => {
+    act(() => root.render(<SkillMentionPopup query="" onSelect={vi.fn()} onClose={vi.fn()} />))
+  }
+
+  it('shows loading until the first catalog request settles', async () => {
+    useSettingsStore.setState({ skills: [], skillsLoaded: false })
+    let resolve!: () => void
+    vi.spyOn(useSettingsStore.getState(), 'loadSkills').mockImplementationOnce(
+      () =>
+        new Promise<void>((done) => {
+          resolve = done
+        })
+    )
+    renderPopup()
+    expect(document.body.textContent).toContain('Loading skills…')
+    expect(document.body.textContent).not.toContain('navigate')
+    await act(async () => {
+      useSettingsStore.setState({ skills: [], skillsLoaded: true })
+      resolve()
+    })
+    expect(document.body.textContent).toContain('No skills available')
+  })
+
+  it('shows a failed catalog request and retries successfully', async () => {
+    useSettingsStore.setState({ skills: [], skillsLoaded: false })
+    const load = vi
+      .spyOn(useSettingsStore.getState(), 'loadSkills')
+      .mockRejectedValueOnce(new Error('catalog unavailable'))
+      .mockImplementationOnce(async () => {
+        useSettingsStore.setState({ skills: seedSkills, skillsLoaded: true })
+      })
+    renderPopup()
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(document.body.textContent).toContain('Could not load skills')
+    const retry = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Retry'
+    )
+    expect(retry).toBeDefined()
+    await act(async () => retry!.click())
+    expect(load).toHaveBeenCalledTimes(2)
+    expect(options()).toHaveLength(2)
+    expect(document.body.textContent).not.toContain('Could not load skills')
+  })
+
+  it('explains when every catalog skill is unavailable', () => {
+    useSettingsStore.setState({
+      skills: seedSkills.map((skill) => ({ ...skill, available: false })),
+      skillsLoaded: true
+    })
+    renderPopup()
+    expect(options()).toHaveLength(0)
+    expect(document.body.textContent).toContain('No skills available')
+    expect(document.body.textContent).not.toContain('navigate')
   })
 })

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -1,5 +1,8 @@
 import { useEffect, useId, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { CircleAlert, LoaderCircle, PackageOpen, RotateCw, SearchX } from 'lucide-react'
+
+import { Button } from '@/components/ui/button'
 
 import type { SkillSource, SkillView } from '../../../../../shared/settings'
 import { useSettingsStore } from '@/stores/settings-store'
@@ -165,9 +168,16 @@ export const SkillMentionPopup = ({
 
   const loading = skills.length === 0 && !skillsLoaded && !loadError
   const failed = skills.length === 0 && !skillsLoaded && loadError
+  const StatusIcon = loading
+    ? LoaderCircle
+    : failed
+      ? CircleAlert
+      : visibleSkills.length === 0
+        ? PackageOpen
+        : SearchX
 
   return (
-    <div className="absolute bottom-full left-0 mb-1 z-50 flex flex-col bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
+    <div className="absolute bottom-full left-0 mb-1 z-50 flex flex-col bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 w-max min-w-[min(320px,100%)] max-w-[min(440px,100%)] max-h-[min(45vh,18rem)] overflow-hidden">
       <ul
         id={resolvedListboxId}
         role="listbox"
@@ -175,8 +185,19 @@ export const SkillMentionPopup = ({
         className="min-h-0 flex-1 overflow-y-auto"
       >
         {matches.length === 0 && (
-          <li role="presentation" className="px-2 py-3 text-sm text-text-300">
-            <div role={failed ? 'alert' : 'status'}>
+          <li role="presentation" className="flex min-h-18 items-center gap-3 px-3 py-3.5">
+            <span
+              aria-hidden="true"
+              className={`flex size-8 shrink-0 items-center justify-center rounded-lg ${failed ? 'bg-status-warning-surface text-status-warning-foreground dark:bg-status-warning-dark-surface dark:text-status-warning-dark-foreground' : 'bg-bg-200 text-text-100'}`}
+            >
+              <StatusIcon
+                className={`size-4${loading ? ' animate-spin motion-reduce:animate-none' : ''}`}
+              />
+            </span>
+            <div
+              role={failed ? 'alert' : 'status'}
+              className="min-w-0 flex-1 text-sm font-medium leading-5 text-text-000"
+            >
               {loading
                 ? t('Loading skills…')
                 : failed
@@ -186,17 +207,19 @@ export const SkillMentionPopup = ({
                     : t('No matching skills')}
             </div>
             {failed && (
-              <button
+              <Button
                 type="button"
-                className="mt-2 rounded px-2 py-1 text-text-100 hover:bg-bg-200"
+                variant="outline"
+                size="sm"
                 onMouseDown={(event) => event.preventDefault()}
                 onClick={() => {
                   setLoadError(false)
                   setRetryAttempt((attempt) => attempt + 1)
                 }}
               >
+                <RotateCw aria-hidden="true" />
                 {t('Retry')}
-              </button>
+              </Button>
             )}
           </li>
         )}
@@ -232,19 +255,28 @@ export const SkillMentionPopup = ({
           )
         })}
       </ul>
-      <div className="mt-1 -mx-1.5 -mb-1.5 shrink-0 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
+      <div className="mt-1 -mx-1.5 -mb-1.5 flex shrink-0 items-center justify-end gap-3 border-t border-border-200 bg-bg-200/40 px-3 py-1.5 text-[11px] text-text-100 select-none">
         {matches.length > 0 && (
           <>
             <span>
-              <span className="text-text-300">↑↓</span> {t('navigate')}
+              <kbd className="rounded border border-border-200 bg-bg-000 px-1 py-0.5 font-sans text-[10px] font-medium">
+                ↑↓
+              </kbd>{' '}
+              {t('navigate')}
             </span>
             <span>
-              <span className="text-text-300">Enter / Tab</span> {t('select')}
+              <kbd className="rounded border border-border-200 bg-bg-000 px-1 py-0.5 font-sans text-[10px] font-medium">
+                Enter / Tab
+              </kbd>{' '}
+              {t('select')}
             </span>
           </>
         )}
         <span>
-          <span className="text-text-300">Esc</span> {t('close')}
+          <kbd className="rounded border border-border-200 bg-bg-000 px-1 py-0.5 font-sans text-[10px] font-medium">
+            Esc
+          </kbd>{' '}
+          {t('close')}
         </span>
       </div>
     </div>

--- a/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/SkillMentionPopup.tsx
@@ -19,6 +19,7 @@ const TIER_DESCRIPTION = 0
 // editor, so this listens for navigation keys on document while mounted rather than owning focus.
 type SkillMentionPopupProps = {
   query: string
+  composingRef?: React.RefObject<boolean>
   allowedSkillIds?: readonly string[]
   listboxId?: string
   onActiveOptionIdChange?: (optionId: string | undefined) => void
@@ -36,6 +37,7 @@ const SOURCE_LABEL_KEYS = {
 
 export const SkillMentionPopup = ({
   query,
+  composingRef,
   allowedSkillIds,
   listboxId,
   onActiveOptionIdChange,
@@ -44,15 +46,31 @@ export const SkillMentionPopup = ({
 }: SkillMentionPopupProps): React.JSX.Element | null => {
   const { t } = useTranslation()
   const skills = useSettingsStore((state) => state.skills)
+  const skillsLoaded = useSettingsStore((state) => state.skillsLoaded)
+  const [loadError, setLoadError] = useState(false)
+  const [retryAttempt, setRetryAttempt] = useState(0)
   const loadSkills = useSettingsStore((state) => state.loadSkills)
   const generatedListboxId = useId()
   const resolvedListboxId = listboxId ?? generatedListboxId
 
-  // The skill list is loaded lazily by the Settings panel; the composer may open before that ever ran,
-  // so hydrate it here when empty. Cheap and idempotent — the store keeps the result after the first load.
+  // Catalog ownership stays in the store; only this popup's retry feedback is local.
   useEffect(() => {
-    if (skills.length === 0) void loadSkills()
-  }, [skills.length, loadSkills])
+    if (skillsLoaded || skills.length > 0) return
+    let cancelled = false
+    void loadSkills().catch(() => {
+      if (!cancelled) setLoadError(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [skillsLoaded, skills.length, loadSkills, retryAttempt])
+
+  const visibleSkills = useMemo(() => {
+    const allowed = allowedSkillIds ? new Set(allowedSkillIds) : undefined
+    return skills.filter(
+      (skill) => skill.available !== false && (allowed ? allowed.has(skill.id) : skill.enabled)
+    )
+  }, [skills, allowedSkillIds])
 
   // Rank the query best-first: fuzzy subsequence against the name (so "cg" finds "clinical-genomics"),
   // falling back to a plain substring in the description. Names always outrank description-only hits;
@@ -60,11 +78,6 @@ export const SkillMentionPopup = ({
   // Empty query shows every skill in its original order.
   const matches = useMemo<SkillMatch[]>(() => {
     const needle = query.trim()
-    const allowed = allowedSkillIds ? new Set(allowedSkillIds) : undefined
-    const availableSkills = skills.filter((skill) => skill.available !== false)
-    const visibleSkills = allowed
-      ? availableSkills.filter((skill) => allowed.has(skill.id))
-      : availableSkills.filter((skill) => skill.enabled)
     if (needle.length === 0) return visibleSkills.map((skill) => ({ skill, positions: [] }))
 
     const descNeedle = needle.toLowerCase()
@@ -90,7 +103,7 @@ export const SkillMentionPopup = ({
         .sort((a, b) => b.tier - a.tier || b.score - a.score)
         .map(({ skill, positions }) => ({ skill, positions }))
     )
-  }, [skills, query, allowedSkillIds])
+  }, [visibleSkills, query])
 
   const [activeIndex, setActiveIndex] = useState(0)
 
@@ -120,6 +133,7 @@ export const SkillMentionPopup = ({
   // Handle navigation keys at the document level while mounted, since focus stays in the editor.
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.isComposing || composingRef?.current) return
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         if (matches.length > 0) setActiveIndex((safeIndex + 1) % matches.length)
@@ -147,7 +161,10 @@ export const SkillMentionPopup = ({
 
     document.addEventListener('keydown', onKeyDown)
     return () => document.removeEventListener('keydown', onKeyDown)
-  }, [matches, safeIndex, onSelect, onClose])
+  }, [matches, safeIndex, onSelect, onClose, composingRef])
+
+  const loading = skills.length === 0 && !skillsLoaded && !loadError
+  const failed = skills.length === 0 && !skillsLoaded && loadError
 
   return (
     <div className="absolute bottom-full left-0 mb-1 z-50 flex flex-col bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
@@ -157,6 +174,32 @@ export const SkillMentionPopup = ({
         aria-label={t('Skill suggestions')}
         className="min-h-0 flex-1 overflow-y-auto"
       >
+        {matches.length === 0 && (
+          <li role="presentation" className="px-2 py-3 text-sm text-text-300">
+            <div role={failed ? 'alert' : 'status'}>
+              {loading
+                ? t('Loading skills…')
+                : failed
+                  ? t('Could not load skills')
+                  : visibleSkills.length === 0
+                    ? t('No skills available')
+                    : t('No matching skills')}
+            </div>
+            {failed && (
+              <button
+                type="button"
+                className="mt-2 rounded px-2 py-1 text-text-100 hover:bg-bg-200"
+                onMouseDown={(event) => event.preventDefault()}
+                onClick={() => {
+                  setLoadError(false)
+                  setRetryAttempt((attempt) => attempt + 1)
+                }}
+              >
+                {t('Retry')}
+              </button>
+            )}
+          </li>
+        )}
         {matches.map(({ skill, positions }, index) => {
           const isActive = index === safeIndex
           return (
@@ -190,12 +233,16 @@ export const SkillMentionPopup = ({
         })}
       </ul>
       <div className="mt-1 -mx-1.5 -mb-1.5 shrink-0 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
-        <span>
-          <span className="text-text-300">↑↓</span> {t('navigate')}
-        </span>
-        <span>
-          <span className="text-text-300">Enter / Tab</span> {t('select')}
-        </span>
+        {matches.length > 0 && (
+          <>
+            <span>
+              <span className="text-text-300">↑↓</span> {t('navigate')}
+            </span>
+            <span>
+              <span className="text-text-300">Enter / Tab</span> {t('select')}
+            </span>
+          </>
+        )}
         <span>
           <span className="text-text-300">Esc</span> {t('close')}
         </span>

--- a/src/renderer/src/pages/workspace/composer/useMentionTrigger.ts
+++ b/src/renderer/src/pages/workspace/composer/useMentionTrigger.ts
@@ -35,10 +35,13 @@ type UseMentionTriggerOptions = {
 
 type UseMentionTriggerResult = MentionState & {
   cancel: () => void
-  replaceTokenWith: (node: ComposerNode) => void
+  selectionKey: object | null
+  replaceTokenWith: (node: ComposerNode) => boolean
 }
 
-const INACTIVE: MentionState = { active: false, query: '', anchorRect: null }
+type Token = { node: Node; offset: number; text: string }
+type TriggerState = MentionState & { token: Token | null }
+const INACTIVE: TriggerState = { active: false, query: '', anchorRect: null, token: null }
 
 // Read the text preceding the caret within its text node. A preceding chip (or any element) acts as a
 // clean word boundary, so a trigger at the start of a post-chip text node opens a fresh mention — this
@@ -70,7 +73,7 @@ export const useMentionTrigger = ({
   disabled = false,
   onStateChange
 }: UseMentionTriggerOptions): UseMentionTriggerResult => {
-  const [state, setState] = useState<MentionState>(INACTIVE)
+  const [state, setState] = useState<TriggerState>(INACTIVE)
 
   // Refs keep the latest state and callback available to event handlers without re-subscribing.
   const stateRef = useRef(state)
@@ -79,12 +82,13 @@ export const useMentionTrigger = ({
     onStateChangeRef.current = onStateChange
   }, [onStateChange])
 
-  const emit = useCallback((next: MentionState): void => {
+  const emit = useCallback((next: TriggerState): void => {
     const prev = stateRef.current
     if (
       prev.active === next.active &&
       prev.query === next.query &&
-      prev.anchorRect === next.anchorRect
+      prev.anchorRect === next.anchorRect &&
+      prev.token === next.token
     ) {
       return
     }
@@ -108,7 +112,14 @@ export const useMentionTrigger = ({
     if (!match.active) return emit(INACTIVE)
 
     const rect = computeAnchorRect(anchorNode, anchorOffset, trigger.length + match.query.length)
-    emit({ active: true, query: match.query, anchorRect: rect })
+    // Preserve identity across placement-only updates, invalidate it when the input token changes.
+    const previous = stateRef.current.token
+    const text = anchorNode.textContent ?? ''
+    const token =
+      previous?.node === anchorNode && previous.offset === anchorOffset && previous.text === text
+        ? previous
+        : { node: anchorNode, offset: anchorOffset, text }
+    emit({ active: true, query: match.query, anchorRect: rect, token })
   }, [editorRef, trigger, disabled, emit])
 
   // Subscribe to selection and input changes while enabled; reset on teardown or disable.
@@ -128,17 +139,25 @@ export const useMentionTrigger = ({
 
   // Replace the active trigger token with a chip or text node and place the caret after it.
   const replaceTokenWith = useCallback(
-    (node: ComposerNode): void => {
+    (node: ComposerNode): boolean => {
+      // An async picker retains this render's token; never apply it to a newer selection.
+      const token = state.token
+      if (!token || token !== stateRef.current.token || disabled) return false
       const editor = editorRef.current
       const selection = window.getSelection()
-      if (!editor || !selection || selection.rangeCount === 0) return
+      if (!editor || !selection || selection.rangeCount === 0 || !selection.isCollapsed)
+        return false
       const { anchorNode, anchorOffset } = selection
-      if (!anchorNode || anchorNode.nodeType !== Node.TEXT_NODE || !editor.contains(anchorNode)) {
-        return
-      }
+      if (
+        anchorNode !== token.node ||
+        anchorOffset !== token.offset ||
+        anchorNode.textContent !== token.text ||
+        !editor.contains(anchorNode)
+      )
+        return false
 
       const match = detectTrigger(textBeforeCaretIn(anchorNode, anchorOffset), trigger)
-      if (!match.active) return
+      if (!match.active) return false
 
       // Delete the `<trigger><query>` run ending at the caret.
       const tokenLength = trigger.length + match.query.length
@@ -170,9 +189,11 @@ export const useMentionTrigger = ({
       emit(INACTIVE)
       // Let the editor re-read its DOM into the doc model.
       editor.dispatchEvent(new Event('input', { bubbles: true }))
+      return true
     },
-    [editorRef, trigger, emit]
+    [editorRef, trigger, emit, state.token, disabled]
   )
 
-  return { ...state, cancel, replaceTokenWith }
+  const { token, ...mentionState } = state
+  return { ...mentionState, selectionKey: token, cancel, replaceTokenWith }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4763,6 +4763,10 @@
     "Find": "Suchen",
     "Find text": "Text suchen",
     "Find in window": "Im Fenster suchen",
-    "Close find": "Suche schließen"
+    "Close find": "Suche schließen",
+    "Loading skills…": "Fähigkeiten werden geladen…",
+    "Could not load skills": "Fähigkeiten konnten nicht geladen werden",
+    "No skills available": "Keine Fähigkeiten verfügbar",
+    "No matching sessions": "Keine passenden Sitzungen"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4925,6 +4925,10 @@
     "Find": "Buscar",
     "Find text": "Buscar texto",
     "Find in window": "Buscar en la ventana",
-    "Close find": "Cerrar búsqueda"
+    "Close find": "Cerrar búsqueda",
+    "Loading skills…": "Cargando habilidades…",
+    "Could not load skills": "No se pudieron cargar las habilidades",
+    "No skills available": "No hay habilidades disponibles",
+    "No matching sessions": "No hay sesiones coincidentes"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4925,6 +4925,10 @@
     "Find": "Rechercher",
     "Find text": "Rechercher du texte",
     "Find in window": "Rechercher dans la fenêtre",
-    "Close find": "Fermer la recherche"
+    "Close find": "Fermer la recherche",
+    "Loading skills…": "Chargement des compétences…",
+    "Could not load skills": "Impossible de charger les compétences",
+    "No skills available": "Aucune compétence disponible",
+    "No matching sessions": "Aucune session correspondante"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4609,6 +4609,10 @@
     "Find": "検索",
     "Find text": "テキストを検索",
     "Find in window": "ウィンドウ内を検索",
-    "Close find": "検索を閉じる"
+    "Close find": "検索を閉じる",
+    "Loading skills…": "スキルを読み込み中…",
+    "Could not load skills": "スキルを読み込めませんでした",
+    "No skills available": "利用可能なスキルはありません",
+    "No matching sessions": "一致するセッションはありません"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4607,6 +4607,10 @@
     "Find": "찾기",
     "Find text": "텍스트 찾기",
     "Find in window": "창에서 찾기",
-    "Close find": "찾기 닫기"
+    "Close find": "찾기 닫기",
+    "Loading skills…": "스킬 로딩 중…",
+    "Could not load skills": "스킬을 불러오지 못했습니다",
+    "No skills available": "사용 가능한 스킬 없음",
+    "No matching sessions": "일치하는 세션 없음"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5058,6 +5058,10 @@
     "Find": "Найти",
     "Find text": "Найти текст",
     "Find in window": "Найти в окне",
-    "Close find": "Закрыть поиск"
+    "Close find": "Закрыть поиск",
+    "Loading skills…": "Загрузка навыков…",
+    "Could not load skills": "Не удалось загрузить навыки",
+    "No skills available": "Нет доступных навыков",
+    "No matching sessions": "Нет совпадающих сессий"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4609,6 +4609,10 @@
     "Find": "查找",
     "Find text": "查找文本",
     "Find in window": "在窗口中查找",
-    "Close find": "关闭查找"
+    "Close find": "关闭查找",
+    "Loading skills…": "正在加载技能…",
+    "Could not load skills": "无法加载技能",
+    "No skills available": "没有可用技能",
+    "No matching sessions": "没有匹配的会话"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4609,6 +4609,10 @@
     "Find": "尋找",
     "Find text": "尋找文字",
     "Find in window": "在視窗中尋找",
-    "Close find": "關閉尋找"
+    "Close find": "關閉尋找",
+    "Loading skills…": "正在載入技能…",
+    "Could not load skills": "無法載入技能",
+    "No skills available": "沒有可用技能",
+    "No matching sessions": "沒有符合的會話"
   }
 }


### PR DESCRIPTION
## Problem

Confirming IME composition while mention suggestions are open can insert a Skill, file or Session chip prematurely. A file-version lookup can also finish after the user changes the query or caret and overwrite the newer token. Empty Skill and Session suggestions provide no explanation, and initial Skill loading failures offer no recovery.

## Proposed change

- Keep composition keys with the IME using native event state and the editor's existing synchronous composition ref.
- Invalidate pending file selections when query, token identity, Project or menu lifetime changes. Validate the originating DOM token before replacement so stale callbacks cannot edit or dismiss a newer query.
- Show translated empty-result, Skill loading and failure feedback with retry; hide navigation/selection hints when there are no choices. Compact status icons, stronger text hierarchy, the existing outline Button, and keyboard-key hints keep these states consistent with the workspace.

## Scope and non-goals

Renderer-only change. No dependencies, architecture replacement, database/schema changes, persisted fields, historical migrations or compatibility layer. The added token snapshot and retry/error state live only in renderer memory; no business-state enum is added. Previously saved incorrect references are not reconstructed.

## Acceptance criteria and validation

Regression tests exercise the real ComposerEditor through DOM input/selection/composition events and the existing inspect API boundary; no production test seam was introduced. The final tests were rerun against unchanged baseline production code: **26 failed with the reported behavior and 57 passed**. A subsequent same-text Session-switch regression also failed before adding the Session-context cancellation guard. Menu cancellation and consecutive selection were already protected and remain covered. New failure paths include another same-query token, controlled draft replacement, identical-text Session switching, missing native composition flags, and Skill catalog feedback/retry.

Checks against the final production change:

| Behavior | Project-owned command | Result |
| --- | --- | --- |
| Mention input, stale selection, catalog feedback; composer consumers and translations | `npm test -- src/renderer/src/pages/workspace/composer src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageItem.mentions.test.tsx src/renderer/src/i18n/resources.test.ts` | 20 files, 1,272 tests passed |
| Renderer interfaces | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |
| Exact diff impact explanation | `npm run test:affected:explain -- --base origin/main --head HEAD` | Full fallback: mention popup has no declared module owner |

The direct editor consumers were included because token replacement behavior changed. Main/preload contracts, storage and platform code are unchanged. Per maintainer instruction, the full local suite was not run; PR CI is authoritative for the classifier's full fallback and platform checks. CodeGraph provided baseline consumer relationships; its worktree warning was accounted for by inspecting the actual changed-worktree references.

Rebased onto latest requested `main` (`5c5bddc3`) without conflicts. The final style pass uses [Primer empty-state hierarchy](https://primer.style/product/ui-patterns/empty-states/) and [shadcn Command presentation](https://ui.shadcn.com/docs/components/radix/command) as references while retaining project tokens and component ownership.

Browser verification mounted the real editor with project CSS and isolated fixture data in ego-browser. Skill empty, Session empty, Skill loading and Skill failure states were inspected and captured, including light/dark themes, keyboard focus and 320/375/414/768px widths without horizontal overflow. This is component-preview and synthetic-event verification, **not native Chinese/Japanese IME end-to-end certification**. Platform IME behavior remains an explicitly uncovered manual acceptance area.

## Review focus

Check token lifetime/selection validation, ordinary post-composition keyboard selection, error retry behavior and preservation of the existing Skill scope rules. Independent review and required exact-head CI remain the final acceptance gate.
