### PR TITLE
fix(composer): preserve drafts and referenced attachments

### DIFF
--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -1,3 +1,4 @@
+import { WorkspaceComposerDraftsProvider } from './pages/workspace/workspace-composer-drafts'
 import { memo, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -225,31 +226,33 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           ? writeErrorAlert
           : null}
         <WorkspaceAgentRuntimeProvider onSessionSizeLimit={sessions.reportSessionSizeLimit}>
-          <WorkspaceMessageQueueProvider>
-            <WorkspaceComputeRecoveryBridge enabled={sessions.isReady} />
-            <WorkspaceMessageQueueRuntimeBridge
-              persistenceBlockedSessionIds={sessions.persistenceBlockedSessionIds}
-            />
-            {events.navigation.view === 'home' ? (
-              <HomePage
-                canDeleteProjects={sessions.canDeleteSessionsAndProjects}
-                hasCompleteSessionCatalog={sessions.hasCompleteSessionCatalog}
-                catalogRecovery={sessions.catalogRecovery}
-                onOpenGlobalSearch={events.globalSearch.open}
-              />
-            ) : events.navigation.view === 'library' ? (
-              <StableLiteratureLibraryPage />
-            ) : (
-              <WorkspacePage
-                isSessionPersistenceHydrated={sessions.isHydrated}
-                isSessionPersistenceReady={sessions.isReady}
+          <WorkspaceComposerDraftsProvider>
+            <WorkspaceMessageQueueProvider>
+              <WorkspaceComputeRecoveryBridge enabled={sessions.isReady} />
+              <WorkspaceMessageQueueRuntimeBridge
                 persistenceBlockedSessionIds={sessions.persistenceBlockedSessionIds}
-                onSessionSizeLimit={sessions.reportSessionSizeLimit}
-                canDeleteConversations={sessions.canDeleteSessionsAndProjects}
-                isPreviewPresentationActive={isBasePresentationActive}
               />
-            )}
-          </WorkspaceMessageQueueProvider>
+              {events.navigation.view === 'home' ? (
+                <HomePage
+                  canDeleteProjects={sessions.canDeleteSessionsAndProjects}
+                  hasCompleteSessionCatalog={sessions.hasCompleteSessionCatalog}
+                  catalogRecovery={sessions.catalogRecovery}
+                  onOpenGlobalSearch={events.globalSearch.open}
+                />
+              ) : events.navigation.view === 'library' ? (
+                <StableLiteratureLibraryPage />
+              ) : (
+                <WorkspacePage
+                  isSessionPersistenceHydrated={sessions.isHydrated}
+                  isSessionPersistenceReady={sessions.isReady}
+                  persistenceBlockedSessionIds={sessions.persistenceBlockedSessionIds}
+                  onSessionSizeLimit={sessions.reportSessionSizeLimit}
+                  canDeleteConversations={sessions.canDeleteSessionsAndProjects}
+                  isPreviewPresentationActive={isBasePresentationActive}
+                />
+              )}
+            </WorkspaceMessageQueueProvider>
+          </WorkspaceComposerDraftsProvider>
         </WorkspaceAgentRuntimeProvider>
         <LifecycleToast
           notice={events.lifecycle.notice}

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, createElement } from 'react'
+import { act, createElement, StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -25,6 +25,7 @@ import {
   type ComposerDoc,
   type ComposerPastedTextNode
 } from './composer/composer-doc'
+import { WorkspaceComposerDraftsProvider } from './workspace-composer-drafts'
 import { useWorkspaceComposerController } from './workspace-composer-controller'
 import type { ComposerHistoryEntry } from './composer/composer-history'
 
@@ -85,12 +86,15 @@ type ControllerHook = {
     session: Parameters<typeof useWorkspaceComposerController>[0]['activeSession']
   ) => void
   setCustomizePrefill: (prefill: CustomizePrefillIntent) => void
+  remount: () => void
   unmount: () => void
 }
 
 const renderController = (
   uploadApi = uploads(),
-  loadSkills = vi.fn().mockResolvedValue(undefined),
+  loadSkills: Parameters<
+    typeof useWorkspaceComposerController
+  >[0]['historyPolicy']['loadSkills'] = vi.fn().mockResolvedValue(undefined),
   historyEntries: ComposerHistoryEntry[] = [],
   // Pass null to exercise the new-conversation draft (no active Session); undefined selects the
   // default Session.
@@ -98,7 +102,11 @@ const renderController = (
     id: 'session-a',
     projectId: 'project'
   },
-  onSessionSizeLimit?: (sessionId: string) => void
+  onSessionSizeLimit?: (sessionId: string) => void,
+  historyPolicy: Partial<
+    Parameters<typeof useWorkspaceComposerController>[0]['historyPolicy']
+  > = {},
+  strictMode = false
 ): ControllerHook => {
   let currentDraftKey = 'session-a'
   let selectedActiveSession = activeSession ?? undefined
@@ -125,7 +133,8 @@ const renderController = (
         specialistCatalogReady: true,
         specialistId: undefined,
         loadSkills,
-        loadSpecialists: vi.fn().mockResolvedValue(undefined)
+        loadSpecialists: vi.fn().mockResolvedValue(undefined),
+        ...historyPolicy
       },
       canStageAttachments: true,
       supportsImageInput: true,
@@ -134,8 +143,13 @@ const renderController = (
     })
     return null
   }
-  const render = (): void => {
-    act(() => root.render(createElement(Harness)))
+  const render = (visible = true): void => {
+    const tree = createElement(
+      WorkspaceComposerDraftsProvider,
+      null,
+      visible ? createElement(Harness) : null
+    )
+    act(() => root.render(strictMode ? createElement(StrictMode, null, tree) : tree))
   }
   render()
   return {
@@ -154,6 +168,10 @@ const renderController = (
       currentDraftKey = 'new:project'
       render()
     },
+    remount: (): void => {
+      render(false)
+      render()
+    },
     unmount: (): void => act(() => root.unmount())
   }
 }
@@ -168,6 +186,225 @@ afterEach(() => {
 })
 
 describe('workspace composer controller', () => {
+  it('DF-01 retains both conversation drafts and annotations after route remount', () => {
+    const hook = renderController()
+    mounted.push(hook)
+    act(() => hook.result.current.actions.changeDoc(textDoc('A unsent')))
+    act(() => hook.result.current.actions.addAnnotation(annotation()))
+    hook.selectDraft('session-b')
+    act(() => hook.result.current.actions.changeDoc(textDoc('B unsent')))
+    hook.selectDraft('session-a')
+    expect(hook.result.current.view.doc).toEqual(textDoc('A unsent'))
+    hook.remount()
+    expect(hook.result.current.view.doc).toEqual(textDoc('A unsent'))
+    expect(hook.result.current.view.annotations).toEqual([annotation()])
+    hook.selectDraft('session-b')
+    expect(hook.result.current.view.doc).toEqual(textDoc('B unsent'))
+  })
+
+  it('retains drafts across repeated StrictMode route remounts and clears a sent draft', () => {
+    const hook = renderController(undefined, undefined, [], undefined, undefined, {}, true)
+    mounted.push(hook)
+    act(() => hook.result.current.actions.changeDoc(textDoc('strict draft')))
+    act(() => hook.result.current.actions.addAnnotation(annotation()))
+    hook.remount()
+    hook.remount()
+    expect(hook.result.current.view.doc).toEqual(textDoc('strict draft'))
+    expect(hook.result.current.view.annotations).toEqual([annotation()])
+    const snapshot = hook.result.current.lifecycle.captureSend()
+    act(() =>
+      expect(hook.result.current.lifecycle.clearDraft(snapshot.draftKey, snapshot.version)).toBe(
+        true
+      )
+    )
+    hook.remount()
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
+    expect(hook.result.current.view.annotations).toEqual([])
+  })
+
+  it('does not resurrect a deleted draft or its failed send after route remount', () => {
+    const hook = renderController()
+    mounted.push(hook)
+    act(() => hook.result.current.actions.changeDoc(textDoc('deleted draft')))
+    const snapshot = hook.result.current.lifecycle.captureSend()
+    expect(hook.result.current.lifecycle.beginSessionDeletion('session-a')).toBe(true)
+    act(() => hook.result.current.lifecycle.settleSessionDeletion('session-a', true))
+    hook.remount()
+    act(() => expect(hook.result.current.lifecycle.restoreFailedSend(snapshot)).toBe(false))
+    expect(hook.result.current.view.doc).toEqual(emptyDoc)
+  })
+
+  it('DF-01 parks the scratch rather than the browsed history item', () => {
+    const hook = renderController(uploads(), undefined, [
+      { id: 'recent', messageId: 'recent', doc: textDoc('history prompt') }
+    ])
+    mounted.push(hook)
+    act(() => hook.result.current.actions.changeDoc(textDoc('scratch before history')))
+    act(() => expect(hook.result.current.actions.navigateHistory('previous')).toBe(true))
+    hook.remount()
+    expect(hook.result.current.view.doc).toEqual(textDoc('scratch before history'))
+  })
+
+  it('DF-01 retains completed pending attachments and the draft version across remount', async () => {
+    const api = uploads(vi.fn().mockResolvedValue(pendingAttachment))
+    const hook = renderController(api)
+    mounted.push(hook)
+    act(() =>
+      hook.result.current.actions.stageFiles([
+        new File(['abc'], 'draft.txt', { type: 'text/plain' })
+      ])
+    )
+    await flushAsyncWork()
+    act(() => hook.result.current.actions.changeDoc(textDoc('unsent with file')))
+    const snapshot = hook.result.current.lifecycle.captureSend()
+    hook.remount()
+    expect(hook.result.current.view.attachments).toEqual([pendingAttachment])
+    expect(hook.result.current.lifecycle.captureSend().version).toBe(snapshot.version)
+    expect(api.deleteUpload).not.toHaveBeenCalled()
+  })
+
+  it('DF-01 retains unfinished pasted text as editable text after cancelling the route upload', async () => {
+    const pending = deferred<UploadedAttachment | null>()
+    const api = uploads(vi.fn(() => pending.promise))
+    const hook = renderController(api)
+    mounted.push(hook)
+    const node: ComposerPastedTextNode = {
+      type: 'pasted-text',
+      id: 'paste-remount',
+      text: 'long payload'
+    }
+    act(() => hook.result.current.actions.stagePastedText(pastedDoc(node), node))
+    await flushAsyncWork()
+    hook.remount()
+    expect(docToText(hook.result.current.view.doc)).toBe('before long payload after')
+    expect(hook.result.current.view.transfers).toEqual([])
+    expect(api.abortTransfer).toHaveBeenCalled()
+    await act(async () => pending.resolve(pendingAttachment))
+    await flushAsyncWork()
+    expect(hook.result.current.view.attachments).toEqual([])
+    expect(docToText(hook.result.current.view.doc)).toBe('before long payload after')
+  })
+
+  it.each(['skill', 'specialist'] as const)(
+    'DF-02 preserves the outgoing draft on %s customization',
+    (goal) => {
+      const hook = renderController()
+      mounted.push(hook)
+      act(() => hook.result.current.actions.changeDoc(textDoc('Session A unsent work')))
+      hook.setCustomizePrefill({ requestId: 1, projectId: 'project', goal })
+      expect(docToText(hook.result.current.view.doc)).not.toBe('Session A unsent work')
+      hook.selectDraft('session-a')
+      expect(hook.result.current.view.doc).toEqual(textDoc('Session A unsent work'))
+    }
+  )
+
+  it.each(['down', 'switch'] as const)(
+    'DF-03 retains the scratch and cursor when a skill history entry is loading (%s)',
+    (recovery) => {
+      const hook = renderController(
+        uploads(),
+        () => new Promise(() => {}),
+        [
+          { id: 'recent', messageId: 'recent', doc: textDoc('recent prompt') },
+          {
+            id: 'older',
+            messageId: 'older',
+            doc: { nodes: [{ type: 'skill', id: 'skill-a', name: 'Skill A' }] }
+          }
+        ],
+        undefined,
+        undefined,
+        { skillCatalogReady: false, refreshSkillCatalog: true }
+      )
+      mounted.push(hook)
+      act(() => hook.result.current.actions.changeDoc(textDoc('original scratch')))
+      act(() => expect(hook.result.current.actions.navigateHistory('previous')).toBe(true))
+      act(() => expect(hook.result.current.actions.navigateHistory('previous')).toBe(false))
+      expect(hook.result.current.view.historyStatus).toContain('loading')
+      expect(hook.result.current.view.doc).toEqual(textDoc('recent prompt'))
+      if (recovery === 'down') {
+        act(() => expect(hook.result.current.actions.navigateHistory('next')).toBe(true))
+      } else {
+        hook.selectDraft('session-b')
+        hook.selectDraft('session-a')
+      }
+      expect(hook.result.current.view.doc).toEqual(textDoc('original scratch'))
+    }
+  )
+
+  const pendingAttachment: UploadedAttachment = {
+    id: 'upload-df',
+    sessionId: '.pending',
+    name: 'draft.txt',
+    originalName: 'draft.txt',
+    path: '/uploads/.pending/draft.txt',
+    mimeType: 'text/plain',
+    size: 3
+  }
+
+  it.each(['active', 'background'] as const)(
+    'DF-04 keeps a pending attachment still referenced after a failed send conflict (%s)',
+    async (owner) => {
+      const api = uploads(vi.fn().mockResolvedValue(pendingAttachment))
+      const hook = renderController(api)
+      mounted.push(hook)
+      act(() =>
+        hook.result.current.actions.stageFiles([
+          new File(['abc'], 'draft.txt', { type: 'text/plain' })
+        ])
+      )
+      await flushAsyncWork()
+      act(() => hook.result.current.actions.addAnnotation(annotation()))
+      const snapshot = hook.result.current.lifecycle.captureSend()
+      act(() => hook.result.current.actions.changeDoc(textDoc('new draft')))
+      if (owner === 'background') hook.selectDraft('session-b')
+      act(() => expect(hook.result.current.lifecycle.restoreFailedSend(snapshot)).toBe(false))
+      if (owner === 'background') hook.selectDraft('session-a')
+      expect(hook.result.current.view.doc).toEqual(textDoc('new draft'))
+      expect(hook.result.current.view.attachments).toEqual([pendingAttachment])
+      expect(api.deleteUpload).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['remove', 'cancel'] as const)(
+    'DF-05 preserves text undo and redo after attachment %s',
+    async (action) => {
+      const pending = deferred<UploadedAttachment | null>()
+      const api = uploads(
+        vi.fn(() => (action === 'remove' ? Promise.resolve(pendingAttachment) : pending.promise))
+      )
+      const hook = renderController(api)
+      mounted.push(hook)
+      act(() =>
+        hook.result.current.actions.stageFiles([
+          new File(['abc'], 'draft.txt', { type: 'text/plain' })
+        ])
+      )
+      await flushAsyncWork()
+      act(() => hook.result.current.actions.changeDoc(textDoc('original text')))
+      act(() => hook.result.current.actions.changeDoc(textDoc('edited text')))
+      act(() => {
+        if (action === 'remove')
+          hook.result.current.actions.removeAttachment(hook.result.current.view.attachments[0])
+        else hook.result.current.actions.cancelTransfer(hook.result.current.view.transfers[0])
+      })
+      await flushAsyncWork()
+      act(() => expect(hook.result.current.actions.undo()).toBe(true))
+      expect(hook.result.current.view.doc).toEqual(textDoc('original text'))
+      expect(hook.result.current.view.attachments).toEqual([])
+      expect(hook.result.current.view.transfers).toEqual([])
+      act(() => expect(hook.result.current.actions.redo()).toBe(true))
+      expect(hook.result.current.view.doc).toEqual(textDoc('edited text'))
+      expect(hook.result.current.view.attachments).toEqual([])
+      expect(hook.result.current.view.transfers).toEqual([])
+      if (action === 'cancel') {
+        await act(async () => pending.resolve(pendingAttachment))
+        await flushAsyncWork()
+        expect(hook.result.current.view.attachments).toEqual([])
+      }
+    }
+  )
+
   it('starts a Reading mutation for a newly selected Session after the previous Session settles', async () => {
     const sourceA = {
       sourceKind: 'upload-version' as const,

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -23,6 +23,7 @@ import {
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
 
+import { useWorkspaceComposerDrafts } from './workspace-composer-drafts'
 import type { ComposerUploadTransfer } from './composer-upload-transfer'
 import {
   docIsEmpty,
@@ -195,18 +196,22 @@ const useWorkspaceComposerController = ({
   uploads,
   onSessionSizeLimit
 }: WorkspaceComposerControllerInput): WorkspaceComposerController => {
-  const [queuedEdit, setQueuedEdit] = useState<ComposerDraft['queuedEdit']>()
-  const queuedEditRef = useRef<ComposerDraft['queuedEdit']>(undefined)
+  const { draftsRef, versionsRef, deletedDraftKeysRef } = useWorkspaceComposerDrafts()
+  // Read the parked memory snapshot once at mount; subsequent edits use live controller state.
+  // eslint-disable-next-line react-hooks/refs
+  const [initialDraft] = useState(() => draftsRef.current[currentDraftKey] ?? blank())
+  const [queuedEdit, setQueuedEdit] = useState(initialDraft.queuedEdit)
+  const queuedEditRef = useRef<ComposerDraft['queuedEdit']>(initialDraft.queuedEdit)
   const setActiveQueuedEdit = useCallback((intent: ComposerDraft['queuedEdit']): void => {
     queuedEditRef.current = intent
     setQueuedEdit(intent)
   }, [])
-  const [doc, setDoc] = useState<ComposerDoc>(emptyDoc)
-  const [annotations, setAnnotations] = useState<Annotation[]>([])
+  const [doc, setDoc] = useState<ComposerDoc>(initialDraft.doc)
+  const [annotations, setAnnotations] = useState<Annotation[]>(initialDraft.annotations)
   const [historyBrowsingKey, setHistoryBrowsingKey] = useState<string>()
   const [historyStatus, setHistoryStatus] = useState('')
   const [skillCatalogReady, setSkillCatalogReady] = useState(historyPolicy.skillCatalogReady)
-  const [appliedCustomizePrefill, setAppliedCustomizePrefill] = useState<CustomizePrefillIntent>()
+  const appliedCustomizePrefillRef = useRef<CustomizePrefillIntent>(undefined)
   const [caretRequest, setCaretRequest] = useState<{
     key: number
     position: ComposerCaretPosition
@@ -214,11 +219,10 @@ const useWorkspaceComposerController = ({
   const activeDraftKeyRef = useRef(currentDraftKey)
   const docRef = useRef(doc)
   const annotationsRef = useRef(annotations)
-  const [automaticReadingEnabled, setAutomaticReadingEnabled] = useState(true)
-  const automaticReadingEnabledRef = useRef(true)
-  const draftsRef = useRef<Record<string, ComposerDraft>>({})
-  const versionsRef = useRef<Record<string, number>>({})
-  const deletedDraftKeysRef = useRef(new Set<string>())
+  const [automaticReadingEnabled, setAutomaticReadingEnabled] = useState(
+    initialDraft.automaticReadingEnabled
+  )
+  const automaticReadingEnabledRef = useRef(initialDraft.automaticReadingEnabled)
   const historyRef = useRef<Record<string, ComposerHistoryNavigation>>({})
   const caretRequestKeyRef = useRef(0)
   const durableReadingContext = activeSession?.runtimeContext?.pdfContext
@@ -263,9 +267,12 @@ const useWorkspaceComposerController = ({
     setCaretRequest({ key: caretRequestKeyRef.current, position })
   }, [])
 
-  const markChanged = useCallback((draftKey = activeDraftKeyRef.current): void => {
-    versionsRef.current[draftKey] = (versionsRef.current[draftKey] ?? 0) + 1
-  }, [])
+  const markChanged = useCallback(
+    (draftKey = activeDraftKeyRef.current): void => {
+      versionsRef.current[draftKey] = (versionsRef.current[draftKey] ?? 0) + 1
+    },
+    [versionsRef]
+  )
 
   const clearHistory = useCallback((draftKey: string): void => {
     delete historyRef.current[draftKey]
@@ -274,6 +281,7 @@ const useWorkspaceComposerController = ({
   }, [])
 
   const uploadController = useWorkspaceComposerUploadController({
+    initialDraft,
     activeDraftKeyRef,
     docRef,
     annotationsRef,
@@ -308,14 +316,35 @@ const useWorkspaceComposerController = ({
     beginUndoTransaction
   } = uploadController.actions
   const {
+    captureDraftAttachments,
     activateDraftAttachments,
     clearActiveAttachments,
     setActiveAttachments,
-    deleteAttachmentFiles,
+    releaseHistoryResources,
     hasUnfinishedTransfers,
     beginSessionDeletion,
     settleSessionDeletion
   } = uploadController.lifecycle
+  useLayoutEffect(() => {
+    const drafts = draftsRef.current
+    const deletedDraftKeys = deletedDraftKeysRef.current
+    const history = historyRef.current
+    // Remove the parked copy: active attachments must have only their live owner.
+    delete draftsRef.current[activeDraftKeyRef.current]
+    return () => {
+      const draftKey = activeDraftKeyRef.current
+      if (!deletedDraftKeys.has(draftKey)) {
+        drafts[draftKey] = {
+          doc: history[draftKey]?.scratch ?? docRef.current,
+          annotations: annotationsRef.current,
+          ...captureDraftAttachments(),
+          queuedEdit: queuedEditRef.current,
+          automaticReadingEnabled: automaticReadingEnabledRef.current
+        }
+      }
+    }
+  }, [draftsRef, deletedDraftKeysRef, captureDraftAttachments])
+
   const pendingPdfContextSelection = usePreviewWorkbenchStore((state) =>
     !activeSession && activeProjectId
       ? state.pendingPdfContextByProject[activeProjectId]
@@ -691,33 +720,6 @@ const useWorkspaceComposerController = ({
     [activeProjectId, pendingReadingSelections, removeAttachment]
   )
 
-  if (
-    pendingCustomizePrefill !== undefined &&
-    pendingCustomizePrefill.projectId === activeProjectId &&
-    currentDraftKey === newConversationDraftKey &&
-    appliedCustomizePrefill?.requestId !== pendingCustomizePrefill.requestId
-  ) {
-    setAppliedCustomizePrefill(pendingCustomizePrefill)
-    setHistoryBrowsingKey(undefined)
-    setHistoryStatus('')
-    setDoc(buildCustomizePrefillDoc(pendingCustomizePrefill.goal))
-    onCustomizePrefillApplied()
-  }
-
-  useLayoutEffect(() => {
-    if (appliedCustomizePrefill?.projectId === activeProjectId) {
-      delete historyRef.current[newConversationDraftKey]
-      clearPastedTextUndo(newConversationDraftKey)
-      clearUndo(newConversationDraftKey)
-    }
-  }, [
-    activeProjectId,
-    appliedCustomizePrefill,
-    clearPastedTextUndo,
-    clearUndo,
-    newConversationDraftKey
-  ])
-
   useLayoutEffect(() => {
     docRef.current = doc
   }, [doc])
@@ -741,7 +743,7 @@ const useWorkspaceComposerController = ({
     }
   }, [loadSkills, refreshSkillCatalog])
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     const previousDraftKey = activeDraftKeyRef.current
     if (currentDraftKey === previousDraftKey) return
 
@@ -763,25 +765,22 @@ const useWorkspaceComposerController = ({
     setHistoryStatus('')
     setCaretRequest(undefined)
 
-    const customizePrefillPending =
-      currentDraftKey === newConversationDraftKey &&
-      pendingCustomizePrefill !== undefined &&
-      pendingCustomizePrefill.projectId === activeProjectId
     const nextDraft = draftsRef.current[currentDraftKey] ?? blank()
-    if (!customizePrefillPending) setActiveDoc(nextDraft.doc)
+    setActiveDoc(nextDraft.doc)
     setActiveAnnotations(nextDraft.annotations)
     activateDraftAttachments(nextDraft)
     setActiveAutomaticReadingEnabled(nextDraft.automaticReadingEnabled)
     setActiveQueuedEdit(nextDraft.queuedEdit)
     activeDraftKeyRef.current = currentDraftKey
+    delete draftsRef.current[currentDraftKey]
   }, [
     activeProjectId,
     annotations,
     attachments,
     currentDraftKey,
     doc,
-    newConversationDraftKey,
-    pendingCustomizePrefill,
+    deletedDraftKeysRef,
+    draftsRef,
     setActiveAutomaticReadingEnabled,
     setActiveQueuedEdit,
     activateDraftAttachments,
@@ -790,11 +789,41 @@ const useWorkspaceComposerController = ({
     transfers
   ])
 
+  // Save the outgoing draft and activate the target before applying its prefill.
+  useLayoutEffect(() => {
+    if (
+      !pendingCustomizePrefill ||
+      pendingCustomizePrefill.projectId !== activeProjectId ||
+      currentDraftKey !== newConversationDraftKey ||
+      appliedCustomizePrefillRef.current?.requestId === pendingCustomizePrefill.requestId
+    )
+      return
+    appliedCustomizePrefillRef.current = pendingCustomizePrefill
+    clearHistory(currentDraftKey)
+    clearPastedTextUndo(currentDraftKey)
+    clearUndo(currentDraftKey)
+    markChanged(currentDraftKey)
+    setActiveDoc(buildCustomizePrefillDoc(pendingCustomizePrefill.goal))
+    onCustomizePrefillApplied()
+  }, [
+    activeProjectId,
+    clearHistory,
+    clearPastedTextUndo,
+    clearUndo,
+    currentDraftKey,
+    markChanged,
+    newConversationDraftKey,
+    onCustomizePrefillApplied,
+    pendingCustomizePrefill,
+    setActiveDoc
+  ])
+
   const navigateHistory = useCallback(
     (direction: 'previous' | 'next'): boolean => {
       if (queuedEditRef.current || attachments.length > 0 || transfers.length > 0) return false
 
       let navigation = historyRef.current[currentDraftKey]
+      const previousCursorId = navigation?.cursorId
       if (!navigation) {
         if (direction === 'next' || historyEntries.length === 0) return false
         navigation = {
@@ -829,7 +858,8 @@ const useWorkspaceComposerController = ({
         (!ready ||
           (historyPolicy.specialistId !== undefined && !historyPolicy.specialistCatalogReady))
       ) {
-        delete historyRef.current[currentDraftKey]
+        if (previousCursorId) navigation.cursorId = previousCursorId
+        else delete historyRef.current[currentDraftKey]
         if (!ready) {
           void historyPolicy
             .loadSkills()
@@ -1043,7 +1073,8 @@ const useWorkspaceComposerController = ({
       durableReadingBindings,
       pendingReadingSelections,
       pdfReadingPosition,
-      stagedReadingContexts
+      stagedReadingContexts,
+      versionsRef
     ]
   )
   const clearDraft = useCallback(
@@ -1064,6 +1095,8 @@ const useWorkspaceComposerController = ({
       return true
     },
     [
+      draftsRef,
+      versionsRef,
       clearActiveAttachments,
       clearHistory,
       clearPastedTextUndo,
@@ -1078,7 +1111,8 @@ const useWorkspaceComposerController = ({
   const restoreFailedSend = useCallback(
     (snapshot: ComposerSendSnapshot, preserveOnConflict = false): boolean => {
       if (deletedDraftKeysRef.current.has(snapshot.draftKey)) {
-        if (!preserveOnConflict) deleteAttachmentFiles(snapshot.attachments)
+        if (!preserveOnConflict)
+          releaseHistoryResources([{ attachments: snapshot.attachments, attachmentTransfers: [] }])
         return false
       }
       if (
@@ -1095,7 +1129,7 @@ const useWorkspaceComposerController = ({
         !preserveOnConflict &&
         (versionsRef.current[snapshot.draftKey] ?? 0) !== snapshot.version
       ) {
-        deleteAttachmentFiles(snapshot.attachments)
+        releaseHistoryResources([{ attachments: snapshot.attachments, attachmentTransfers: [] }])
         return false
       }
       if (preserveOnConflict) markChanged(snapshot.draftKey)
@@ -1122,12 +1156,15 @@ const useWorkspaceComposerController = ({
     },
     [
       attachments.length,
+      draftsRef,
+      versionsRef,
+      deletedDraftKeysRef,
       clearUndo,
       clearPastedTextUndo,
       clearHistory,
       markChanged,
       setActiveQueuedEdit,
-      deleteAttachmentFiles,
+      releaseHistoryResources,
       setActiveAttachments,
       setActiveAnnotations,
       setActiveDoc,
@@ -1145,7 +1182,7 @@ const useWorkspaceComposerController = ({
       attachments: [],
       automaticReadingEnabled: true
     }),
-    [currentDraftKey]
+    [currentDraftKey, versionsRef]
   )
   // Stable identity across renders: the transcript memo compares the annotation callbacks it
   // receives, so an inline closure here would defeat that memo on every composer re-render.
@@ -1242,7 +1279,8 @@ const useWorkspaceComposerController = ({
       captureRevision,
       clearDraft,
       restoreFailedSend,
-      discardSnapshot: (snapshot) => deleteAttachmentFiles(snapshot.attachments),
+      discardSnapshot: (snapshot) =>
+        releaseHistoryResources([{ attachments: snapshot.attachments, attachmentTransfers: [] }]),
       hasUnfinishedTransfers,
       beginSessionDeletion,
       settleSessionDeletion: (draftKey, deleted): void => {

--- a/src/renderer/src/pages/workspace/workspace-composer-drafts.tsx
+++ b/src/renderer/src/pages/workspace/workspace-composer-drafts.tsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useState, type ReactNode, type ReactElement } from 'react'
+
+import type { ComposerDraft } from './workspace-composer-upload-controller'
+
+type ComposerDraftOwner = {
+  draftsRef: { current: Record<string, ComposerDraft> }
+  versionsRef: { current: Record<string, number> }
+  deletedDraftKeysRef: { current: Set<string> }
+}
+
+const createDraftOwner = (): ComposerDraftOwner => ({
+  draftsRef: { current: {} as Record<string, ComposerDraft> },
+  versionsRef: { current: {} as Record<string, number> },
+  deletedDraftKeysRef: { current: new Set<string>() }
+})
+
+const ComposerDraftsContext = createContext<ComposerDraftOwner | null>(null)
+
+// Renderer-memory only. The owner survives route changes without retaining WorkspacePage.
+export const WorkspaceComposerDraftsProvider = ({
+  children
+}: {
+  children?: ReactNode
+}): ReactElement => {
+  const [owner] = useState(createDraftOwner)
+  return <ComposerDraftsContext.Provider value={owner}>{children}</ComposerDraftsContext.Provider>
+}
+
+// The context and its hook form one small owner module.
+// eslint-disable-next-line react-refresh/only-export-components
+export const useWorkspaceComposerDrafts = (): ComposerDraftOwner => {
+  const owner = useContext(ComposerDraftsContext)
+  const [localOwner] = useState(createDraftOwner)
+  return owner ?? localOwner
+}

--- a/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-upload-controller.ts
@@ -60,6 +60,7 @@ export type ComposerUploadApi = UploadStagingApi & {
 }
 
 type WorkspaceComposerUploadControllerInput = {
+  initialDraft: ComposerDraft
   activeDraftKeyRef: { current: string }
   docRef: { current: ComposerDoc }
   annotationsRef: { current: Annotation[] }
@@ -109,10 +110,11 @@ type WorkspaceComposerUploadController = {
     ) => ComposerUndoTransaction
   }
   lifecycle: {
+    captureDraftAttachments: () => ComposerDeletionCleanup
     activateDraftAttachments: (draft: ComposerDraft) => void
     clearActiveAttachments: () => void
     setActiveAttachments: (attachments: UploadedAttachment[]) => void
-    deleteAttachmentFiles: (attachments: UploadedAttachment[]) => void
+    releaseHistoryResources: (snapshots: readonly ComposerDeletionCleanup[]) => void
     hasUnfinishedTransfers: (draftKey: string) => boolean
     beginSessionDeletion: (draftKey: string) => boolean
     settleSessionDeletion: (draftKey: string, deleted: boolean) => void
@@ -145,6 +147,7 @@ export const unfinishedComposerUpload = (transfer: ComposerUploadTransfer): bool
   transfer.status !== 'error'
 
 export const useWorkspaceComposerUploadController = ({
+  initialDraft,
   activeDraftKeyRef,
   docRef,
   annotationsRef,
@@ -162,8 +165,10 @@ export const useWorkspaceComposerUploadController = ({
   automaticReadingEnabledRef,
   setActiveAutomaticReadingEnabled
 }: WorkspaceComposerUploadControllerInput): WorkspaceComposerUploadController => {
-  const [attachments, setAttachments] = useState<UploadedAttachment[]>([])
-  const [transfers, setTransfers] = useState<ComposerUploadTransfer[]>([])
+  const [attachments, setAttachments] = useState<UploadedAttachment[]>(initialDraft.attachments)
+  const [transfers, setTransfers] = useState<ComposerUploadTransfer[]>(
+    initialDraft.attachmentTransfers
+  )
   const { t } = useTranslation()
   const [error, setErrorText] = useState<string | null>(null)
   const [errorDetail, setErrorDetail] = useState<string>()
@@ -172,7 +177,7 @@ export const useWorkspaceComposerUploadController = ({
     setErrorDetail(undefined)
   }, [])
   const attachmentsRef = useRef(attachments)
-  const transfersRef = useRef<ComposerUploadTransfer[]>([])
+  const transfersRef = useRef<ComposerUploadTransfer[]>(initialDraft.attachmentTransfers)
   const controllersRef = useRef<Record<string, AbortController>>({})
   const cancelledTransfersRef = useRef(new Set<string>())
   const deletionCleanupRef = useRef<Record<string, ComposerDeletionCleanup>>({})
@@ -201,6 +206,13 @@ export const useWorkspaceComposerUploadController = ({
       setActiveTransfers(update(transfersRef.current))
     },
     [setActiveTransfers]
+  )
+  const captureDraftAttachments = useCallback(
+    (): ComposerDeletionCleanup => ({
+      attachments: attachmentsRef.current,
+      attachmentTransfers: transfersRef.current
+    }),
+    []
   )
   const clearPastedTextUndo = useCallback(
     (draftKey = activeDraftKeyRef.current): void => {
@@ -242,6 +254,16 @@ export const useWorkspaceComposerUploadController = ({
         if (!retainedAttachmentPaths.has(path))
           void uploads.deleteUpload({ path }).catch(() => undefined)
       }
+      // Upload jobs belong to this mounted controller. Retain completed uploads, but
+      // turn unfinished long pastes back into editable text before parking the draft.
+      for (const draft of Object.values(draftsRef.current)) {
+        for (const transfer of draft.attachmentTransfers) {
+          if (transfer.pastedTextId) {
+            draft.doc = restorePastedTextNode(draft.doc, transfer.pastedTextId)?.doc ?? draft.doc
+          }
+        }
+        draft.attachmentTransfers = []
+      }
       transferFilesRef.current = {}
     },
     [draftsRef, uploads]
@@ -272,7 +294,7 @@ export const useWorkspaceComposerUploadController = ({
     [annotationsRef, automaticReadingEnabledRef, docRef, readingContextSourcesRef]
   )
   const releaseHistoryResources = useCallback(
-    (snapshots: readonly ComposerHistorySnapshot[]): void => {
+    (snapshots: readonly ComposerDeletionCleanup[]): void => {
       if (snapshots.length === 0) return
       const retainedAttachmentPaths = new Set(attachmentsRef.current.map(({ path }) => path))
       const retainedTransferIds = new Set(transfersRef.current.map(({ transferId }) => transferId))
@@ -1156,7 +1178,12 @@ export const useWorkspaceComposerUploadController = ({
       }
       const draftKey = activeDraftKeyRef.current
       clearPastedTextUndo(draftKey)
-      clearUndo(draftKey)
+      reconcileHistorySnapshots(draftKey, (snapshot) => ({
+        ...snapshot,
+        attachmentTransfers: snapshot.attachmentTransfers.filter(
+          (candidate) => candidate.transferId !== transfer.transferId
+        )
+      }))
       markChanged(draftKey)
       cancelledTransfersRef.current.add(transfer.transferId)
       controllersRef.current[transfer.transferId]?.abort()
@@ -1180,7 +1207,7 @@ export const useWorkspaceComposerUploadController = ({
     [
       activeDraftKeyRef,
       clearPastedTextUndo,
-      clearUndo,
+      reconcileHistorySnapshots,
       docRef,
       markChanged,
       removePastedText,
@@ -1200,7 +1227,10 @@ export const useWorkspaceComposerUploadController = ({
         return
       }
       clearPastedTextUndo()
-      clearUndo()
+      reconcileHistorySnapshots(activeDraftKeyRef.current, (snapshot) => ({
+        ...snapshot,
+        attachments: snapshot.attachments.filter((item) => item.id !== attachment.id)
+      }))
       markChanged()
       updateActiveAttachments((current) => current.filter((item) => item.id !== attachment.id))
       const cleanup = deletionCleanupRef.current[activeDraftKeyRef.current]
@@ -1214,7 +1244,7 @@ export const useWorkspaceComposerUploadController = ({
     [
       activeDraftKeyRef,
       clearPastedTextUndo,
-      clearUndo,
+      reconcileHistorySnapshots,
       docRef,
       markChanged,
       removePastedText,
@@ -1321,10 +1351,11 @@ export const useWorkspaceComposerUploadController = ({
       beginUndoTransaction
     },
     lifecycle: {
+      captureDraftAttachments,
       activateDraftAttachments,
       clearActiveAttachments,
       setActiveAttachments,
-      deleteAttachmentFiles,
+      releaseHistoryResources,
       hasUnfinishedTransfers,
       beginSessionDeletion,
       settleSessionDeletion


### PR DESCRIPTION
## Problem and behavior

Unsent Composer work could disappear when navigating to Home or the literature library, be overwritten by customization prefill, or lose its scratch recovery point while skill history was loading. Failed sends could also delete pending attachments still referenced by a newer draft, and removing or cancelling an ordinary attachment erased unrelated text undo history.

This change:
- Keeps `ComposerDraft` and version ownership in a renderer-memory provider above route switching, without retaining WorkspacePage. Completed attachments survive navigation; unfinished uploads are cancelled and unfinished long pastes return to editable text.
- Saves the outgoing draft before activating a target draft and applying skill/specialist customization prefill.
- Preserves scratch and the displayed history cursor while catalogs are loading.
- Reuses resource ownership checks when releasing failed/discarded send snapshots.
- Removes deleted attachment/transfer references from undo and redo snapshots while preserving unrelated edits.

No database/schema changes, new dependencies, or navigation confirmation dialogs. Reload/restart recovery, background upload continuation, and complete cross-route undo history are outside this change.

## Validation

- Added 12 regression cases through the real Composer controller's public operations. All failed on the original implementation for the reported reasons and passed after the fixes.
- Added checks for repeated StrictMode remounts, clearing a sent draft, and rejection of late failed sends into a deleted draft.
- On the PR branch: Composer, conversation, message queue, App, and i18n guard suites; renderer typecheck; ESLint; diff whitespace check.
- Earlier full `npm test`: 25,796 passed; sandbox restrictions caused failures in 71 files. All 71 files passed outside the sandbox (2,467 tests passed, 35 skipped).
- No full Electron navigation click-through or actual restart test was performed.
