### PR TITLE
fix(message-queue): validate send now and advance visible queue actions

### DIFF
--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -197,6 +197,176 @@ afterEach(() => {
 })
 
 describe('workspace message queue controller', () => {
+  it.each(['permission change', 'persistence block'] as const)(
+    'MQ01: does not abort automatic repair when send now encounters %s',
+    async (blocker) => {
+      let currentSession = { ...session(), fixLoopActive: true }
+      let persistenceBlocked = false
+      const input = options(currentSession, {
+        getSession: () => currentSession,
+        isPersistenceBlocked: () => persistenceBlocked
+      })
+      const hook = renderController(input)
+      mounted.push(hook)
+      act(() => hook.result.current.lifecycle.enqueue(admission('queued during repair')))
+      const itemId = hook.result.current.items[0].id
+
+      if (blocker === 'permission change') {
+        currentSession = { ...currentSession, permissionProfile: 'auto' }
+      } else {
+        persistenceBlocked = true
+      }
+      await act(async () => hook.result.current.actions.sendNow(itemId))
+
+      expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+      expect(hook.result.current.items[0]).toMatchObject(
+        blocker === 'permission change'
+          ? { phase: 'error', error: { kind: 'send' } }
+          : { phase: 'queued', deferredUntilIdle: true }
+      )
+      expect(input.abortFixLoop).not.toHaveBeenCalled()
+    }
+  )
+
+  it('MQ01: rechecks updated options after awaiting repair termination', async () => {
+    const currentSession = { ...session(), fixLoopActive: true }
+    let finishAbort!: () => void
+    const abortFixLoop = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          finishAbort = resolve
+        })
+    )
+    const steerFollowUp = vi.fn(async () => ({
+      injected: true as const,
+      transport: 'acp-steering' as const,
+      messageId: 'steered-message'
+    }))
+    const input = options(currentSession, { abortFixLoop })
+    input.runtime.steerFollowUp = steerFollowUp
+    const hook = renderController(input)
+    mounted.push(hook)
+    act(() => hook.result.current.lifecycle.enqueue(admission('wait for repair termination')))
+    let sending!: Promise<void>
+    act(() => {
+      sending = hook.result.current.actions.sendNow(hook.result.current.items[0].id)
+    })
+    expect(abortFixLoop).toHaveBeenCalledOnce()
+    hook.rerender({ ...input, isPersistenceBlocked: () => true })
+    await act(async () => {
+      finishAbort()
+      await sending
+    })
+    expect(steerFollowUp).not.toHaveBeenCalled()
+    expect(input.runtime.sendMessage).not.toHaveBeenCalled()
+    expect(hook.result.current.items[0]).toMatchObject({ phase: 'queued', deferredUntilIdle: true })
+  })
+
+  it.each([1, 3])(
+    'MQ03: advances past %i stale automatic heads after one background session update',
+    async (headCount) => {
+      let currentSession = { ...session(), agentBackendId: 'backend-a' }
+      let notifySessionChanged: (() => void) | undefined
+      const input = options(currentSession, {
+        promptInFlightSessionIds: [],
+        getSession: () => currentSession,
+        subscribeSessionChanges: (listener) => {
+          notifySessionChanged = listener
+          return () => {
+            notifySessionChanged = undefined
+          }
+        }
+      })
+      const hook = renderController(input)
+      mounted.push(hook)
+      let automatic!: Promise<{ sessionId: string; messageId: string } | undefined>
+      act(() => {
+        const completions = Array.from({ length: headCount }, (_, index) => {
+          return hook.result.current.lifecycle.enqueueApplication({
+            session: currentSession,
+            text: 'Analyze job-1.',
+            attribution: {
+              kind: 'application',
+              feature: 'compute',
+              purpose: 'job-completion-analysis',
+              deliveryKey: `compute_done:session-a:job-${index}`,
+              jobIds: ['job-1']
+            }
+          })
+        })
+        automatic = Promise.all(completions).then((results) => {
+          expect(results).toEqual(Array(headCount).fill(undefined))
+          return undefined
+        })
+        hook.result.current.lifecycle.enqueue(admission('user after automatic'))
+      })
+      hook.leaveWorkspace()
+      currentSession = { ...session('idle'), agentBackendId: 'backend-b' }
+      expect(notifySessionChanged).toBeTypeOf('function')
+      await act(async () => {
+        notifySessionChanged!()
+      })
+
+      await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
+      expect(input.runtime.sendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({ text: 'user after automatic' })
+      )
+      await expect(automatic).resolves.toBeUndefined()
+    }
+  )
+
+  it.each(['up', 'down'] as const)(
+    'MQ02: moves one visible neighbor %s across a hidden automatic item',
+    async (direction) => {
+      let currentSession = session()
+      const sendMessage = vi.fn(async (request: { text: string }) => {
+        currentSession = session('running')
+        return { sessionId: 'session-a', messageId: request.text }
+      })
+      const input = options(currentSession, {
+        promptInFlightSessionIds: [],
+        getSession: () => currentSession,
+        runtime: { sendMessage, cancelRun: vi.fn(async () => undefined) }
+      })
+      const hook = renderController(input)
+      mounted.push(hook)
+      act(() => {
+        hook.result.current.lifecycle.enqueue(admission('A'))
+        void hook.result.current.lifecycle.enqueueApplication({
+          session: currentSession,
+          text: 'Analyze job-1.',
+          attribution: {
+            kind: 'application',
+            feature: 'compute',
+            purpose: 'job-completion-analysis',
+            deliveryKey: 'compute_done:session-a:job-1',
+            jobIds: ['job-1']
+          }
+        })
+        hook.result.current.lifecycle.enqueue(admission('B'))
+      })
+      expect(hook.result.current.items.map((item) => item.text)).toEqual(['A', 'B'])
+      const itemId = hook.result.current.items[direction === 'up' ? 1 : 0].id
+      act(() => hook.result.current.actions.move(itemId, direction))
+
+      expect(hook.result.current.items.map((item) => item.text)).toEqual(['B', 'A'])
+
+      const announcement = hook.result.current.announcement
+      // A visible boundary must not move across a hidden item or announce a move.
+      act(() => hook.result.current.actions.move(itemId, direction))
+      expect(hook.result.current.announcement).toBe(announcement)
+      for (let count = 1; count <= 3; count++) {
+        currentSession = session('idle')
+        await act(async () => hook.rerender({ ...input }))
+        expect(sendMessage).toHaveBeenCalledTimes(count)
+        await act(async () => hook.rerender({ ...input }))
+      }
+      expect(sendMessage.mock.calls.map((call) => call[0].text)).toEqual(
+        direction === 'up' ? ['B', 'A', 'Analyze job-1.'] : ['Analyze job-1.', 'B', 'A']
+      )
+    }
+  )
+
   it('retains queued messages when the Workspace unmounts for Project navigation', () => {
     const input = options(session())
     const workspace = renderController(input)

--- a/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
@@ -13,6 +13,7 @@ import {
 import {
   WorkspaceMessageQueueOwner,
   type MessageQueueDispatch,
+  type MessageQueueItem,
   type WorkspaceMessageQueueControllerOptions
 } from './workspace-message-queue-owner'
 
@@ -43,25 +44,36 @@ const dispatchQueuedSession = (
       return
     }
   }
-  const item = owner.itemsFor(sessionId)[0]
-  if (!item || item.phase === 'sending' || item.phase === 'error') return
-  const contextError = queueItemContextError(session, item)
-  if (contextError) {
-    if (item.kind === 'application') {
-      const remaining = owner.itemsFor(sessionId).filter((candidate) => candidate.id !== item.id)
+  let item: MessageQueueItem | undefined
+  // Only skip terminal automatic heads; reserve at most one send per drain.
+  for (
+    let remainingHeads = owner.itemsFor(sessionId).length;
+    remainingHeads > 0;
+    remainingHeads--
+  ) {
+    const head = owner.itemsFor(sessionId)[0]
+    if (!head || head.phase === 'sending' || head.phase === 'error') return
+    const contextError = queueItemContextError(session, head)
+    if (!contextError) {
+      item = head
+      break
+    }
+    if (head.kind === 'application') {
+      const remaining = owner.itemsFor(sessionId).filter((candidate) => candidate.id !== head.id)
       if (remaining.length === 0) owner.queues.delete(sessionId)
       else owner.queues.set(sessionId, remaining)
       owner.emit()
-      item.application?.resolve(undefined)
-      return
+      head.application?.resolve(undefined)
+      continue
     }
-    owner.replaceItem(sessionId, item.id, {
+    owner.replaceItem(sessionId, head.id, {
       phase: 'error',
       error: contextError,
       deferredUntilIdle: false
     })
     return
   }
+  if (!item) return
   if (!current.isSpecialistReady(sessionId)) return
   if (!queueSessionIsSendable(current, session)) return
 
@@ -214,24 +226,12 @@ const sendQueuedItemNow = async (
     if (displacedDispatch && displacedDispatch.itemId !== itemId) {
       await displacedDispatch.completion
     }
-    const current = owner.resolveOptions(optionsRef.current)
-    const session = current.getSession(sessionId)
-    if (session?.fixLoopActive) {
-      await current.abortFixLoop({
-        projectId: session.projectId,
-        appSessionId: sessionId
-      })
-    }
-    const liveSession = current.getSession(sessionId)
-    if (liveSession) {
-      if (current.isPersistenceBlocked(sessionId)) {
-        owner.replaceItem(sessionId, itemId, {
-          phase: 'queued',
-          error: undefined,
-          deferredUntilIdle: true
-        })
-        owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.deferredUntilIdle)
-        return
+    let current = owner.resolveOptions(optionsRef.current)
+    let liveSession = current.getSession(sessionId)
+    const canContinue = (): boolean => {
+      if (!liveSession) {
+        owner.discardSession(sessionId, current.composer.discardSnapshot)
+        return false
       }
       const contextError = queueItemContextError(liveSession, item)
       if (contextError) {
@@ -240,26 +240,39 @@ const sendQueuedItemNow = async (
           error: contextError,
           deferredUntilIdle: false
         })
-        return
+        return false
       }
-      if (!current.isSpecialistReady(sessionId)) {
+      if (
+        current.isPersistenceBlocked(sessionId) ||
+        !current.isSpecialistReady(sessionId) ||
+        queuePermissionIsPending(current, liveSession) ||
+        liveSession.archivedAt !== undefined ||
+        !(current.isProjectActive?.(liveSession.projectId) ?? true) ||
+        liveSession.conversationGraphSyncBlocked ||
+        liveSession.compacting ||
+        liveSession.specialistBindingPending === true ||
+        current.isBarrierInFlight(sessionId) ||
+        current.isSideChatOpen(sessionId)
+      ) {
         owner.replaceItem(sessionId, itemId, {
           phase: 'queued',
           error: undefined,
           deferredUntilIdle: true
         })
         owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.deferredUntilIdle)
-        return
+        return false
       }
-      if (queuePermissionIsPending(current, liveSession)) {
-        owner.replaceItem(sessionId, itemId, {
-          phase: 'queued',
-          error: undefined,
-          deferredUntilIdle: true
-        })
-        owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.deferredUntilIdle)
-        return
-      }
+      return true
+    }
+    if (!canContinue()) return
+    if (liveSession?.fixLoopActive) {
+      await current.abortFixLoop({
+        projectId: liveSession.projectId,
+        appSessionId: sessionId
+      })
+      current = owner.resolveOptions(optionsRef.current)
+      liveSession = current.getSession(sessionId)
+      if (!canContinue()) return
     }
     const liveTurn = isQueueLiveTurn(liveSession)
     const referencedArtifacts = docToArtifactRefs(item.snapshot.doc)

--- a/src/renderer/src/pages/workspace/workspace-message-queue-projection.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-projection.ts
@@ -49,13 +49,18 @@ const moveQueuedItem = (
 ): void => {
   const queue = activeSessionQueue(owner, optionsRef.current.activeSession?.id)
   if (!queue) return
-  const items = [...queue.items]
+  const items = queue.items.filter((item) => item.kind === 'user')
   const index = items.findIndex((item) => item.id === itemId)
-  const target = direction === 'up' ? index - 1 : index + 1
-  if (index < 0 || target < 0 || target >= items.length) return
-  ;[items[index], items[target]] = [items[target], items[index]]
-  owner.queues.set(queue.sessionId, items)
-  owner.emit(queuedMessageMovedAnnouncement(direction))
+  const target = items[direction === 'up' ? index - 1 : index + 1]
+  if (index < 0 || !target) return
+  moveQueuedItemTo(
+    owner,
+    optionsRef,
+    itemId,
+    target.id,
+    direction === 'up' ? 'before' : 'after',
+    queuedMessageMovedAnnouncement(direction)
+  )
 }
 
 const moveQueuedItemTo = (
@@ -63,7 +68,8 @@ const moveQueuedItemTo = (
   optionsRef: MessageQueueOptionsRef,
   itemId: string,
   targetId: string,
-  edge: 'before' | 'after'
+  edge: 'before' | 'after',
+  announcement: string = MESSAGE_QUEUE_ANNOUNCEMENTS.reordered
 ): void => {
   const queue = activeSessionQueue(owner, optionsRef.current.activeSession?.id)
   if (!queue || itemId === targetId) return
@@ -74,7 +80,7 @@ const moveQueuedItemTo = (
   const target = items.findIndex((item) => item.id === targetId)
   items.splice(edge === 'after' ? target + 1 : target, 0, moved)
   owner.queues.set(queue.sessionId, items)
-  owner.emit(MESSAGE_QUEUE_ANNOUNCEMENTS.reordered)
+  owner.emit(announcement)
 }
 
 const removeQueuedItem = (


### PR DESCRIPTION
## Problem

Send now could request termination of automatic repair before discovering that the queued message was invalid or blocked (MQ01). In the background, discarding an obsolete automatic head did not advance the next user message without another event (MQ03). Keyboard reordering used hidden automatic entries as neighbors, so one keypress could announce a move without changing the visible list (MQ02).

## Proposed change

- Validate the captured context and current blockers before aborting repair; refresh options and session state and revalidate after the awaited abort.
- Skip obsolete automatic heads in a bounded loop, retaining the existing dispatch reservation and stopping at a blocked/error user head or one send.
- Resolve keyboard neighbors from visible user messages and reuse drag target insertion. For `[A, automatic X, B]`, B up gives `[B, A, X]` and A down gives `[X, B, A]`; both show `[B, A]`. Retain directional announcements and no-op visible boundaries.

## Scope and non-goals

Three renderer files only. No new fields, enum values, public controller API, architecture, persistence format, migrations, historical compatibility handling, dependencies, or agent protocol changes. Existing captured frame/active-branch checks remain in place. All four agent paths share this queue before runtime dispatch; adapter-specific protocols and history replay are unchanged.

## Acceptance criteria and validation

Seven regression cases failed against unchanged production code and passed after the fix, through the existing public controller/Provider harness without a new test seam. The original five cases failed twice before implementation. Added cases cover fresh options after awaiting abort and consecutive obsolete automatic heads. Ordering tests also assert the actual subsequent send order, including the hidden automatic entry.

Final local evidence, run after the last material edit:

| Behavior | Command/check | Result |
| --- | --- | --- |
| Send-now validation, background drain, keyboard/hidden-entry ordering; workspace consumers and session contracts | `npm run test:module -- workspace_page` | 30 files, 832 tests passed |
| Renderer type contracts | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |
| Real component keyboard behavior | ego-browser: real controller and queue components, one ArrowUp on B / ArrowDown on A | Visible order changes immediately to B,A and corresponding live-region text updates; screenshots captured |
| Patch hygiene | `git diff --check` | Passed |

`test:module -- workspace_page --explain` identifies the owner/contract set. `test:affected:explain -- --base origin/main --head HEAD` reports unknown ownership for the internal drain file and selects the full CI fallback. No classifier changes are included. The maintainer requested module-only local tests; PR CI remains authoritative for the complete and platform checks. No platform/persistence code changed, so no local migration or native packaging lanes were run.

Limits: abort/runtime calls are mocked; no model was started or stopped. The background regression mounts the real Provider/controller but not the complete production RuntimeBridge. Browser evidence uses an isolated fixture with production components, not the full Electron application. No real screen-reader speech verification. Unrelated later runtime events can recover the original background stall; this is not a claim of data loss or permanent deadlock.

## Review focus

Side-effect ordering around awaited repair termination, preservation of single-send ownership, and the shared keyboard/drag policy for hidden automatic entries. Independent review and exact-head CI should confirm the final evidence mapping before merge.
