### PR TITLE
fix(conversation): preserve intent and context across message revisions

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -121,6 +121,48 @@ const clickPermissionDecision = async (page: Page, decision: 'allow' | 'deny'): 
   })
 }
 
+test('explains disabled revision navigation while a turn is running', async ({ app }, testInfo) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await createProject(page)
+
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill(USER_MESSAGE)
+  await expect(page.getByRole('button', { name: 'Send message' })).toBeEnabled()
+  await page.getByRole('button', { name: 'Send message' }).click()
+
+  const conversation = page.getByRole('region', { name: 'Conversation' })
+  await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(conversation.getByText(AGENT_REPLY, { exact: true })).toBeVisible()
+  // Reply text can arrive before the Agent turn ends. Wait for Main to observe completion
+  // before editing history and restarting, which otherwise can open a native quit dialog.
+  await expect.poll(() => page.evaluate(() => window.api.storage.detectActive())).toEqual([])
+
+  await conversation.getByText(USER_MESSAGE, { exact: true }).hover()
+  await conversation.getByRole('button', { name: 'Edit message' }).click()
+  await conversation.getByRole('textbox', { name: 'Edit message' }).fill(EDITED_USER_MESSAGE)
+  await conversation.getByRole('button', { name: 'Send', exact: true }).click()
+
+  const previous = conversation.getByRole('button', { name: 'Previous message revision' })
+  await expect(previous).toBeEnabled()
+  await page
+    .getByRole('textbox', { name: 'Ask anything' })
+    .fill('Run the ordered slow tool journey.')
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await expect(page.getByTestId('composer-queue-submit')).toBeVisible()
+  await expect(previous).toBeDisabled()
+  const explanation = 'Message revisions are unavailable while this session is busy or blocked.'
+  const trigger = previous.locator('..')
+  await trigger.focus()
+  await expect(page.getByRole('tooltip', { name: explanation })).toBeVisible()
+  await page.screenshot({ path: testInfo.outputPath('revision-navigation-running.png') })
+  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText('2/2')
+  await expect(previous).toBeEnabled()
+  await previous.click()
+  await expect(conversation.getByText(USER_MESSAGE, { exact: true })).toBeVisible()
+  await expect(conversation.getByLabel('Message revision', { exact: true })).toHaveText('1/2')
+  await page.screenshot({ path: testInfo.outputPath('revision-navigation-idle.png') })
+})
+
 test('edits and navigates message revisions that persist after relaunch', async ({ app }) => {
   await app.completeOnboarding()
   let page = await app.configureFakeAgent()

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -2659,6 +2659,47 @@ describe('workspace agent message sending', () => {
     })
   })
 
+  it.each(['plan-first', undefined] as const)(
+    'inherits the source turn intent on edit resend: %s',
+    async (turnIntent) => {
+      const runtime = {
+        state: createSnapshot(['transport-session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+      }
+      await sendWorkspaceMessage(runtime, {
+        sessionId: 'transport-session-1',
+        text: 'analyze this dataset',
+        cwd: '/workspace/project',
+        projectId: 'project-1',
+        turnIntent
+      })
+      await flushRuntimeTasks()
+      const source = useSessionStore.getState().sessions[0].messages[0]
+      expect(source.turnIntent).toBe(turnIntent)
+      expect(runtime.sendPrompt.mock.calls[0]?.[11]).toBe(turnIntent)
+      useSessionStore.getState().finishRun('transport-session-1')
+      runtime.sendPrompt.mockClear()
+
+      await expect(
+        resendEditedWorkspaceMessage(runtime, {
+          sessionId: 'transport-session-1',
+          messageId: source.id,
+          text: 'analyze the revised dataset'
+        })
+      ).resolves.toBe(true)
+      await flushRuntimeTasks()
+
+      const revised = useSessionStore.getState().sessions[0].messages.at(-1)
+      expect(revised?.content).toBe('analyze the revised dataset')
+      expect(runtime.sendPrompt).toHaveBeenCalledOnce()
+      expect.soft(revised?.turnIntent).toBe(turnIntent)
+      expect.soft(runtime.sendPrompt.mock.calls[0]?.[11]).toBe(turnIntent)
+    }
+  )
+
   it('forwards and durably stores Plan first for an existing Session', async () => {
     const runtime = {
       state: createSnapshot(['transport-session-1']),

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -1162,6 +1162,8 @@ const resendEditedWorkspaceMessage = async (
         forcedSkillIds: input.forcedSkillIds,
         referencedArtifacts: input.referencedArtifacts,
         pdfContext: sourceMessage.pdfContext,
+        turnIntent:
+          sourceMessage.turnIntent === 'plan-first' ? sourceMessage.turnIntent : undefined,
         agentFrameworkId: options.agentFrameworkId,
         agentBackendId: options.agentBackendId,
         agentModel: options.agentModel,

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts
@@ -76,6 +76,82 @@ describe('branchWorkspaceSessionFromMessage', () => {
     )
   })
 
+  it.each(['stay', 'switch', 'delete-source', 'archive-source'])(
+    'restores only an available source without overriding user navigation: %s',
+    async (selectionAction) => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'source-session',
+        content: 'question',
+        cwd: '/workspace/project',
+        projectId: 'project-1'
+      })
+      const answer = useSessionStore.getState().appendAgentMessageChunk({
+        sessionId: 'source-session',
+        streamId: 'answer',
+        eventId: 'answer',
+        content: 'answer'
+      })!
+      useSessionStore.getState().finishRun('source-session')
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'other-session',
+        content: 'other question',
+        cwd: '/workspace/project',
+        projectId: 'project-1'
+      })
+      useSessionStore.getState().finishRun('other-session')
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) => ({
+          ...session,
+          updatedAt: session.id === 'source-session' ? 1 : 2
+        }))
+      }))
+      useSessionStore.getState().selectSession('source-session')
+      let rejectCreation!: (error: Error) => void
+      const failure = new Error('backend offline')
+      const createSession = vi.fn(
+        () =>
+          new Promise<never>((_, reject) => {
+            rejectCreation = reject
+          })
+      )
+      const pending = branchWorkspaceSessionFromMessage(
+        { createSession },
+        {
+          sourceSessionId: 'source-session',
+          sourceMessageId: answer.messageId
+        }
+      )
+      const rejection = expect(pending).rejects.toBe(failure)
+      await vi.waitFor(() => expect(createSession).toHaveBeenCalledOnce())
+      expect(useSessionStore.getState().selectedSessionId).not.toBe('source-session')
+      if (selectionAction === 'switch') useSessionStore.getState().selectSession('other-session')
+      if (selectionAction === 'delete-source')
+        useSessionStore.getState().deleteSession('source-session')
+      if (selectionAction === 'archive-source')
+        useSessionStore.setState((state) => ({
+          sessions: state.sessions.map((session) =>
+            session.id === 'source-session' ? { ...session, archivedAt: 3 } : session
+          )
+        }))
+      rejectCreation(failure)
+      await rejection
+
+      expect(
+        useSessionStore
+          .getState()
+          .sessions.map((session) => session.id)
+          .sort()
+      ).toEqual(
+        selectionAction === 'delete-source'
+          ? ['other-session']
+          : ['other-session', 'source-session']
+      )
+      expect(useSessionStore.getState().selectedSessionId).toBe(
+        selectionAction === 'stay' ? 'source-session' : 'other-session'
+      )
+    }
+  )
+
   it('reports branch size failures against the durable source Session', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'source-session',

--- a/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.ts
@@ -212,6 +212,18 @@ export const branchWorkspaceSessionFromMessage = async (
     } else if (createdSessionId && runtime.deleteSession) {
       await runtime.deleteSession(createdSessionId).catch(() => undefined)
     }
+    const store = useSessionStore.getState()
+    const source = store.sessions.find((session) => session.id === input.sourceSessionId)
+    if (
+      (store.selectedSessionId === failedSessionId ||
+        store.selectedSessionId === pending.sessionId) &&
+      source &&
+      source.projectId === pendingSession.projectId &&
+      !source.isPending &&
+      source.archivedAt === undefined
+    ) {
+      store.selectSession(source.id)
+    }
     useSessionStore.getState().deleteSession(failedSessionId)
     if (failedSessionId !== pending.sessionId)
       useSessionStore.getState().deleteSession(pending.sessionId)

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -152,6 +152,7 @@ type WorkspaceMessageItemProps = {
   revisionNavigation?: {
     index: number
     total: number
+    disabledReason?: string
     onPrevious?: () => void
     onNext?: () => void
   }
@@ -1824,16 +1825,29 @@ const WorkspaceMessageItemImpl = ({
                           data-slot="user-message-revision-navigation"
                           className="flex items-center gap-0.5 text-[13px] text-text-100"
                         >
-                          <UserMessageActionTooltip label={t('Previous message revision')}>
-                            <button
-                              type="button"
-                              className={userMessageActionButtonClassName}
-                              aria-label={t('Previous message revision')}
-                              disabled={!revisionNavigation.onPrevious || !canEditMessage}
-                              onClick={revisionNavigation.onPrevious}
+                          <UserMessageActionTooltip
+                            label={
+                              revisionNavigation.disabledReason ?? t('Previous message revision')
+                            }
+                          >
+                            <span
+                              tabIndex={revisionNavigation.disabledReason ? 0 : undefined}
+                              aria-label={revisionNavigation.disabledReason}
                             >
-                              <ChevronLeft className="size-3.5" aria-hidden="true" />
-                            </button>
+                              <button
+                                type="button"
+                                className={userMessageActionButtonClassName}
+                                aria-label={t('Previous message revision')}
+                                disabled={
+                                  !revisionNavigation.onPrevious ||
+                                  !canEditMessage ||
+                                  Boolean(revisionNavigation.disabledReason)
+                                }
+                                onClick={revisionNavigation.onPrevious}
+                              >
+                                <ChevronLeft className="size-3.5" aria-hidden="true" />
+                              </button>
+                            </span>
                           </UserMessageActionTooltip>
                           <GitBranch
                             data-slot="user-message-revision-icon"
@@ -1843,16 +1857,27 @@ const WorkspaceMessageItemImpl = ({
                           <span aria-label={t('Message revision')} className="min-w-7 text-center">
                             {revisionNavigation.index + 1}/{revisionNavigation.total}
                           </span>
-                          <UserMessageActionTooltip label={t('Next message revision')}>
-                            <button
-                              type="button"
-                              className={userMessageActionButtonClassName}
-                              aria-label={t('Next message revision')}
-                              disabled={!revisionNavigation.onNext || !canEditMessage}
-                              onClick={revisionNavigation.onNext}
+                          <UserMessageActionTooltip
+                            label={revisionNavigation.disabledReason ?? t('Next message revision')}
+                          >
+                            <span
+                              tabIndex={revisionNavigation.disabledReason ? 0 : undefined}
+                              aria-label={revisionNavigation.disabledReason}
                             >
-                              <ChevronRight className="size-3.5" aria-hidden="true" />
-                            </button>
+                              <button
+                                type="button"
+                                className={userMessageActionButtonClassName}
+                                aria-label={t('Next message revision')}
+                                disabled={
+                                  !revisionNavigation.onNext ||
+                                  !canEditMessage ||
+                                  Boolean(revisionNavigation.disabledReason)
+                                }
+                                onClick={revisionNavigation.onNext}
+                              >
+                                <ChevronRight className="size-3.5" aria-hidden="true" />
+                              </button>
+                            </span>
                           </UserMessageActionTooltip>
                         </div>
                       </>
@@ -2001,6 +2026,7 @@ const areRevisionNavigationsEqual = (
     next !== undefined &&
     previous.index === next.index &&
     previous.total === next.total &&
+    previous.disabledReason === next.disabledReason &&
     (previous.onPrevious === undefined) === (next.onPrevious === undefined) &&
     (previous.onNext === undefined) === (next.onNext === undefined))
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -4250,11 +4250,15 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(running.status).toBe('running')
     const branchId = running.conversationGraph!.frames[0].activeBranchId
     useSessionStore.setState({ sessions: [{ ...running, activeRun: undefined, ...blocked }] })
+    const onSendEditedMessage = vi.fn()
     const Parent = (): React.JSX.Element => {
       const activeSession = useSessionStore((state) => state.sessions[0])
       return (
         <WorkspaceMessageEditStateProvider canEditMessage={true}>
-          <WorkspaceMessageScroller activeSession={activeSession} onSendEditedMessage={vi.fn()} />
+          <WorkspaceMessageScroller
+            activeSession={activeSession}
+            onSendEditedMessage={onSendEditedMessage}
+          />
         </WorkspaceMessageEditStateProvider>
       )
     }
@@ -4288,6 +4292,13 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         }))
       }))
     })
+    expect(previous().disabled).toBe(false)
+    await act(async () => useSessionStore.getState().setBranchSwitchBlocked('session-1', true))
+    expect(previous().disabled).toBe(true)
+    expect(
+      container.querySelector<HTMLButtonElement>('[aria-label="Edit message"]')?.disabled
+    ).toBe(false)
+    await act(async () => useSessionStore.getState().setBranchSwitchBlocked('session-1', false))
     expect(previous().disabled).toBe(false)
     await act(async () => previous().click())
     expect(useSessionStore.getState().sessions[0].messages[0].content).toBe('Original prompt')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -4221,6 +4221,78 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(rawOutputReads).toBeLessThanOrEqual(itemCount * 8)
   })
 
+  it.each([
+    { status: 'running' as const },
+    { status: 'idle' as const, compacting: true },
+    { status: 'idle' as const, fixLoopActive: true },
+    { status: 'idle' as const, branchSwitchBlocked: true },
+    { status: 'idle' as const, conversationGraphSyncBlocked: true },
+    { status: 'waiting-for-user' as const },
+    { status: 'waiting-permission' as const },
+    { status: 'waiting-plan-approval' as const }
+  ])('disables revision navigation while editing remains available: %j', async (blocked) => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const { WorkspaceMessageEditStateProvider } = await import('./workspace-message-edit-state')
+    useSessionStore.setState({
+      sessions: [
+        createSession({
+          status: 'idle',
+          messages: [createMessage({ id: 'original', content: 'Original prompt' })]
+        })
+      ],
+      selectedSessionId: 'session-1'
+    })
+    useSessionStore.getState().truncateSessionFromMessage('session-1', 'original')
+    useSessionStore
+      .getState()
+      .appendUserMessage({ sessionId: 'session-1', content: 'Edited prompt' })
+    const running = useSessionStore.getState().sessions[0]
+    expect(running.status).toBe('running')
+    const branchId = running.conversationGraph!.frames[0].activeBranchId
+    useSessionStore.setState({ sessions: [{ ...running, activeRun: undefined, ...blocked }] })
+    const Parent = (): React.JSX.Element => {
+      const activeSession = useSessionStore((state) => state.sessions[0])
+      return (
+        <WorkspaceMessageEditStateProvider canEditMessage={true}>
+          <WorkspaceMessageScroller activeSession={activeSession} onSendEditedMessage={vi.fn()} />
+        </WorkspaceMessageEditStateProvider>
+      )
+    }
+    root = createRoot(container)
+    await act(async () => root.render(<Parent />))
+    const previous = (): HTMLButtonElement => {
+      const button = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Previous message revision"]'
+      )
+      if (!button) throw new Error('Previous revision button missing')
+      return button
+    }
+    expect(
+      container.querySelector<HTMLButtonElement>('[aria-label="Edit message"]')?.disabled
+    ).toBe(false)
+    expect.soft(previous().disabled).toBe(true)
+    await act(async () => previous().click())
+    expect(useSessionStore.getState().sessions[0].conversationGraph!.frames[0].activeBranchId).toBe(
+      branchId
+    )
+
+    await act(async () => {
+      useSessionStore.getState().finishRun('session-1')
+      useSessionStore.setState((state) => ({
+        sessions: state.sessions.map((session) => ({
+          ...session,
+          compacting: false,
+          fixLoopActive: false,
+          branchSwitchBlocked: false,
+          conversationGraphSyncBlocked: false
+        }))
+      }))
+    })
+    expect(previous().disabled).toBe(false)
+    await act(async () => previous().click())
+    expect(useSessionStore.getState().sessions[0].messages[0].content).toBe('Original prompt')
+  })
+
   it('renders a long conversation graph without rescanning it for every visible revision', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const itemCount = 240

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -441,6 +441,19 @@ const WorkspaceMessageScrollerImpl = ({
           onError: onAnnotationError
         }
       : undefined
+  const revisionNavigationDisabledReason =
+    activeSession &&
+    (activeSession.activeRun ||
+      activeSession.status === 'running' ||
+      activeSession.status === 'waiting-for-user' ||
+      activeSession.status === 'waiting-permission' ||
+      activeSession.status === 'waiting-plan-approval' ||
+      activeSession.fixLoopActive ||
+      activeSession.compacting ||
+      activeSession.branchSwitchBlocked ||
+      activeSession.conversationGraphSyncBlocked)
+      ? t('Message revisions are unavailable while this session is busy or blocked.')
+      : undefined
   const currentProjectId = activeSession?.projectId
   const statusAllowsScrollToFirstMessage = Boolean(
     activeSession &&
@@ -1446,6 +1459,7 @@ const WorkspaceMessageScrollerImpl = ({
                         ? {
                             index: revisionIndex,
                             total: revisions.length,
+                            disabledReason: revisionNavigationDisabledReason,
                             onPrevious: activateRevision(revisionIndex - 1),
                             onNext: activateRevision(revisionIndex + 1)
                           }

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1894,14 +1894,9 @@ const areSessionsEqualForTranscript = (
   if (Object.is(previous, next)) return true
   if (!previous || !next) return false
 
-  // WorkspacePage mirrors reviewer activity into this transient operation gate. It changes the
-  // ChatSession object identity but is not rendered by the transcript, so compare every other field.
-  const previousKeys = Object.keys(previous).filter(
-    (key) => key !== 'branchSwitchBlocked'
-  ) as Array<keyof ChatSession>
-  const nextKeys = Object.keys(next).filter((key) => key !== 'branchSwitchBlocked') as Array<
-    keyof ChatSession
-  >
+  // Branch-switch blocking is visible in revision controls even when the transcript is unchanged.
+  const previousKeys = Object.keys(previous) as Array<keyof ChatSession>
+  const nextKeys = Object.keys(next) as Array<keyof ChatSession>
 
   return (
     previousKeys.length === nextKeys.length &&

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -1866,6 +1866,7 @@
     "Preview {{title}}": "Vorschau {{title}}",
     "Preview — matches the list and picker.": "Vorschau – entspricht der Liste und Auswahl.",
     "Previous Artifact version": "Vorherige Artefaktversion",
+    "Message revisions are unavailable while this session is busy or blocked.": "Nachrichtenversionen sind nicht verfügbar, solange diese Sitzung beschäftigt oder blockiert ist.",
     "Previous message revision": "Vorherige Nachrichtenüberarbeitung",
     "Previous page": "Vorherige Seite",
     "Previous preview page": "Vorherige Vorschauseite",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -2051,6 +2051,7 @@
     "Preview {{title}}": "Vista previa {{title}}",
     "Preview — matches the list and picker.": "Vista previa: coincide con la lista y el selector.",
     "Previous Artifact version": "Versión anterior del artefacto",
+    "Message revisions are unavailable while this session is busy or blocked.": "Las versiones de mensajes no están disponibles mientras esta sesión esté ocupada o bloqueada.",
     "Previous message revision": "Revisión del mensaje anterior",
     "Previous page": "Página anterior",
     "Previous preview page": "Página de vista previa anterior",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -2051,6 +2051,7 @@
     "Preview {{title}}": "Aperçu {{title}}",
     "Preview — matches the list and picker.": "Aperçu : correspond à la liste et au sélecteur.",
     "Previous Artifact version": "Version précédente de l'artefact",
+    "Message revisions are unavailable while this session is busy or blocked.": "Les versions des messages ne sont pas disponibles lorsque cette session est occupée ou bloquée.",
     "Previous message revision": "Révision du message précédent",
     "Previous page": "Page précédente",
     "Previous preview page": "Page d'aperçu précédente",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1982,6 +1982,7 @@
     "Preview {{title}}": "{{title}} をプレビュー",
     "Preview — matches the list and picker.": "プレビュー — リストとピッカーの表示と一致します。",
     "Previous Artifact version": "以前のアーティファクトのバージョン",
+    "Message revisions are unavailable while this session is busy or blocked.": "このセッションが処理中またはブロックされている間は、メッセージのバージョンを切り替えられません。",
     "Previous message revision": "以前のメッセージのリビジョン",
     "Previous page": "前のページ",
     "Previous preview page": "前のプレビューページ",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1993,6 +1993,7 @@
     "Preview {{title}}": "{{title}} 미리보기",
     "Preview — matches the list and picker.": "미리보기 — 목록 및 선택기와 일치합니다.",
     "Previous Artifact version": "이전 아티팩트 버전",
+    "Message revisions are unavailable while this session is busy or blocked.": "이 세션이 처리 중이거나 차단된 동안에는 메시지 버전을 전환할 수 없습니다.",
     "Previous message revision": "이전 메시지 개정판",
     "Previous page": "이전 페이지",
     "Previous preview page": "이전 미리보기 페이지",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -2054,6 +2054,7 @@
     "Preview {{title}}": "Предпросмотр {{title}}",
     "Preview — matches the list and picker.": "Предпросмотр соответствует списку и средству выбора.",
     "Previous Artifact version": "Предыдущая версия артефакта",
+    "Message revisions are unavailable while this session is busy or blocked.": "Версии сообщений недоступны, пока этот сеанс занят или заблокирован.",
     "Previous message revision": "Предыдущий выпуск сообщения",
     "Previous page": "Предыдущая страница",
     "Previous preview page": "Предыдущая страница предпросмотра",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -2069,6 +2069,7 @@
     "Preview {{title}}": "预览 {{title}}",
     "Preview — matches the list and picker.": "预览 — 与列表和选择器一致。",
     "Previous Artifact version": "上一个 Artifact 版本",
+    "Message revisions are unavailable while this session is busy or blocked.": "此会话忙碌或受阻时，无法切换消息版本。",
     "Previous message revision": "上一个消息版本",
     "Previous page": "上一页",
     "Previous preview page": "上一预览页",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -2066,6 +2066,7 @@
     "Preview {{title}}": "預覽 {{title}}",
     "Preview — matches the list and picker.": "預覽 — 與清單和選擇器一致。",
     "Previous Artifact version": "上一個 Artifact 版本",
+    "Message revisions are unavailable while this session is busy or blocked.": "此工作階段忙碌或受阻時，無法切換訊息版本。",
     "Previous message revision": "上一個訊息版本",
     "Previous page": "上一頁",
     "Previous preview page": "上一預覽頁",


### PR DESCRIPTION
## Problem

Editing and resending a Plan first message drops its turn intent. During an active run, revision navigation looks enabled because queueing an edit is allowed, although the store correctly refuses a branch switch. A failed child-session creation can select an unrelated newer session instead of returning to the source.

## Proposed change

- Preserve the source message's existing Plan first intent through the shared edit-resend owner, including queued revisions. Internal save-as-skill intent remains outside the ordinary prompt contract.
- Derive navigation blocking from existing session state, carry a disabled explanation to revision controls, and expose it on hover or keyboard focus. Include branch-switch blocking in transcript memoization so an otherwise-idle session updates immediately. Preserve queued editing and the store's switching protection. Translate the explanation in all eight locales.
- Restore an available source before removing the failed child only if that child is still selected after asynchronous cleanup. Preserve deliberate navigation and existing durable-cleanup failure behavior.

## Scope and non-goals

No new persisted fields, lifecycle enums, schema migration, graph model, provider protocol, or subscription contract. The existing turnIntent field is retained on new revisions; historical messages without it remain unset and existing revisions are not backfilled. Navigation availability is derived UI data. Generic session deletion selection rules are unchanged.

Claude Code, OpenCode, Codex Responses, and Codex bridge continue through the existing shared turn-reminder preparation and framework prefix delivery. Codex routes share buildSessionSetup. No provider-specific send/replay or event subscription path is added.

## Acceptance criteria and validation

Before production changes, the real orchestration/store/transcript tests were run twice: three tests failed for exactly the reported outcomes, with the user-navigation control passing. Normal Plan first sending retained both fields; switching succeeded after finishRun. No production test seam was added. Independent review identified a memoized gate-transition omission; with stable test callbacks, eight transition cases failed before the comparator fix and passed afterward.

Final behavior-to-check mapping (checks cover the final implementation):

| Behavior | Command / project-owned checks | Result |
| --- | --- | --- |
| Edit intent, child cleanup, runtime lifecycle and subscriptions | `npm run test:module -- workspace_runtime` | 495 passed |
| Queue dispatch, conversation controller and store consumers | `npm run test:module -- workspace_page` | 825 passed |
| Blocked navigation, tooltip/actions and branch protection | Targeted `WorkspaceMessageScroller.interaction`, `WorkspaceMessageScroller.render`, `WorkspaceMessageItem.actions`, `WorkspaceMessageItem.tooltips` suites; store consumer suite | 182 UI tests passed; store passed |
| Main turn reminder and supported framework delivery | Targeted `prompt-turn-workflow`, `claude-code`, `opencode`, `codex` suites | Passed; Codex process tests rerun outside sandbox after ps EPERM |
| Translation completeness | `npm test -- src/renderer/src/i18n/resources.test.ts` | Passed |
| Renderer/main contracts and style | `npm run typecheck:web`, `npm run typecheck:node`, `npm run lint` | Passed |
| Real navigation explanation, switch after completion and restart persistence | `npm run build:e2e`; `npm run test:e2e -- e2e/workspace-conversation.spec.ts -g 'explains disabled revision navigation|edits and navigates message revisions'` | 2 passed on macOS Electron |

The module explain plans select renderer state and workspace consumers. Additional UI and framework suites cover the changed presentation interface and downstream reminder delivery. The automatic affected plan conservatively requests full CI because the E2E path is unclassified; no classifier or ownership manifest was widened. Per maintainer instruction, no full local Vitest run was performed. Exact-head PR CI remains authoritative for complete and cross-platform coverage. No live provider calls were made; framework tests use controlled boundaries. No new path handling or storage format requires migration testing.

## Review focus

Check separation of queued editing from immediate revision navigation, memoization of the disabled reason, and the selection check after asynchronous failure cleanup. The source-deleted, source-archived and user-switched cases must retain fallback/user selection. Screenshots are generated by the Electron test as revision-navigation-running.png and revision-navigation-idle.png.
