### PR TITLE
feat(renderer): add source/rendered toggle to mermaid block actions

### DIFF
--- a/src/renderer/src/components/streamdown/install-streamdown.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.ts
@@ -12,6 +12,7 @@ import {
   STREAMDOWN_TABLE_FULLSCREEN_SELECTOR
 } from './dom-selectors'
 import { resolveLanguageIconPath } from './language-icons'
+import { installMermaidViewToggle } from './mermaid-view-toggle'
 
 const saveBlobFile = (request: SaveBlobFileRequest): Promise<SaveBlobFileResult> =>
   window.api.saveBlobFile(request)
@@ -808,7 +809,8 @@ const installStreamdown = (): (() => void) => {
       installFullscreenDialogAdapter(),
       installTableActions(),
       installTableFullscreenFix(),
-      installCodeLanguageBadges()
+      installCodeLanguageBadges(),
+      installMermaidViewToggle()
     )
   }
 

--- a/src/renderer/src/components/streamdown/mermaid-runtime.test.ts
+++ b/src/renderer/src/components/streamdown/mermaid-runtime.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@streamdown/mermaid', () => {
+  const render = vi.fn(async (id: string) => ({
+    svg: `<svg id="${id}" xmlns="http://www.w3.org/2000/svg"></svg>`
+  }))
+  const instance = { initialize: vi.fn(), render }
+  const upstreamPlugin = {
+    name: 'mermaid' as const,
+    type: 'diagram' as const,
+    language: 'mermaid',
+    getMermaid: vi.fn(() => instance)
+  }
+  return {
+    createMermaidPlugin: vi.fn(() => upstreamPlugin),
+    mermaid: upstreamPlugin,
+    __instance: instance
+  }
+})
+
+import { mermaid } from './mermaid-runtime'
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const instance = ((await import('@streamdown/mermaid')) as any).__instance as {
+  render: ReturnType<typeof vi.fn>
+}
+import {
+  getMermaidSource,
+  MERMAID_RENDER_ID_ATTRIBUTE,
+  rememberMermaidSource
+} from './mermaid-source-registry'
+
+beforeEach(() => {
+  instance.render.mockClear()
+})
+
+describe('mermaid source-tracking plugin', () => {
+  it('keeps the upstream plugin identity fields', () => {
+    expect(mermaid.name).toBe('mermaid')
+    expect(mermaid.type).toBe('diagram')
+    expect(mermaid.language).toBe('mermaid')
+  })
+
+  it('records the source by render id and stamps the id onto the svg', async () => {
+    const api = mermaid.getMermaid({ theme: 'default' })
+
+    const result = await api.render('mermaid-1-test', 'graph TD; A-->B')
+
+    expect(getMermaidSource('mermaid-1-test')).toBe('graph TD; A-->B')
+    expect(result.svg).toContain(`${MERMAID_RENDER_ID_ATTRIBUTE}="mermaid-1-test"`)
+    expect(result.svg).toContain('<svg')
+  })
+
+  it('remembers the source even when rendering fails', async () => {
+    instance.render.mockRejectedValueOnce(new Error('parse error'))
+    const api = mermaid.getMermaid()
+
+    await expect(api.render('mermaid-2-test', 'not a diagram')).rejects.toThrow('parse error')
+    expect(getMermaidSource('mermaid-2-test')).toBe('not a diagram')
+  })
+})
+
+describe('mermaid source registry', () => {
+  it('evicts the oldest entries beyond the cap', () => {
+    for (let index = 0; index < 120; index += 1) {
+      rememberMermaidSource(`evict-${index}`, `source ${index}`)
+    }
+
+    expect(getMermaidSource('evict-0')).toBeUndefined()
+    expect(getMermaidSource('evict-119')).toBe('source 119')
+  })
+
+  it('re-remembering an id refreshes its recency', () => {
+    rememberMermaidSource('keep', 'first')
+    for (let index = 0; index < 100; index += 1) {
+      rememberMermaidSource(`filler-${index}`, `filler ${index}`)
+    }
+    rememberMermaidSource('keep', 'second')
+    for (let index = 0; index < 20; index += 1) {
+      rememberMermaidSource(`tail-${index}`, `tail ${index}`)
+    }
+
+    expect(getMermaidSource('keep')).toBe('second')
+  })
+})

--- a/src/renderer/src/components/streamdown/mermaid-runtime.ts
+++ b/src/renderer/src/components/streamdown/mermaid-runtime.ts
@@ -1,1 +1,30 @@
-export { mermaid } from '@streamdown/mermaid'
+import { createMermaidPlugin, type DiagramPlugin, type MermaidInstance } from '@streamdown/mermaid'
+
+import { MERMAID_RENDER_ID_ATTRIBUTE, rememberMermaidSource } from './mermaid-source-registry'
+
+// Stamps the render id onto the SVG root so the DOM layer can look the source up again.
+const annotateSvg = (svg: string, renderId: string): string =>
+  svg.replace('<svg', `<svg ${MERMAID_RENDER_ID_ATTRIBUTE}="${renderId}"`)
+
+const wrapInstance = (instance: MermaidInstance): MermaidInstance => ({
+  initialize: (config) => instance.initialize(config),
+  render: async (renderId, source) => {
+    // Remembered even when rendering fails: the error panel can fall back to the same source.
+    rememberMermaidSource(renderId, source)
+    const result = await instance.render(renderId, source)
+    return { ...result, svg: annotateSvg(result.svg, renderId) }
+  }
+})
+
+// Same plugin as the upstream default export, with per-render source capture layered on.
+const createSourceTrackingPlugin = (): DiagramPlugin => {
+  const plugin = createMermaidPlugin()
+  return {
+    ...plugin,
+    getMermaid: (config) => wrapInstance(plugin.getMermaid(config))
+  }
+}
+
+const mermaid = createSourceTrackingPlugin()
+
+export { mermaid }

--- a/src/renderer/src/components/streamdown/mermaid-source-registry.ts
+++ b/src/renderer/src/components/streamdown/mermaid-source-registry.ts
@@ -1,0 +1,24 @@
+// Streamdown never puts the mermaid fence's source text into the DOM — it lives only in React
+// props. The view toggle needs it at the DOM layer, so the mermaid plugin wrapper in
+// mermaid-runtime.ts records every rendered chart here, keyed by the render id that is also
+// stamped onto the SVG as MERMAID_RENDER_ID_ATTRIBUTE.
+
+const MAX_REMEMBERED_SOURCES = 100
+
+const MERMAID_RENDER_ID_ATTRIBUTE = 'data-mermaid-render-id'
+
+const sourcesByRenderId = new Map<string, string>()
+
+const rememberMermaidSource = (renderId: string, source: string): void => {
+  sourcesByRenderId.delete(renderId)
+  sourcesByRenderId.set(renderId, source)
+  while (sourcesByRenderId.size > MAX_REMEMBERED_SOURCES) {
+    const oldest = sourcesByRenderId.keys().next().value
+    if (oldest === undefined) break
+    sourcesByRenderId.delete(oldest)
+  }
+}
+
+const getMermaidSource = (renderId: string): string | undefined => sourcesByRenderId.get(renderId)
+
+export { MERMAID_RENDER_ID_ATTRIBUTE, getMermaidSource, rememberMermaidSource }

--- a/src/renderer/src/components/streamdown/mermaid-view-toggle.test.ts
+++ b/src/renderer/src/components/streamdown/mermaid-view-toggle.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { initI18n, i18next } from '@/i18n'
+
+import { rememberMermaidSource } from './mermaid-source-registry'
+import { installMermaidViewToggle } from './mermaid-view-toggle'
+
+const SOURCE = 'graph TD; A-->B'
+
+const flushMutations = (): Promise<void> => Promise.resolve()
+
+const createMermaidBlock = (
+  renderId?: string
+): { block: HTMLElement; actions: HTMLElement; body: HTMLElement; diagram?: HTMLElement } => {
+  const root = document.createElement('div')
+  root.className = 'agent-markdown-root'
+  const block = document.createElement('div')
+  block.dataset.streamdown = 'mermaid-block'
+  const header = document.createElement('div')
+  const actions = document.createElement('div')
+  actions.dataset.streamdown = 'mermaid-block-actions'
+  const body = document.createElement('div')
+  let diagram: HTMLElement | undefined
+  if (renderId) {
+    diagram = document.createElement('div')
+    diagram.dataset.streamdown = 'mermaid'
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('data-mermaid-render-id', renderId)
+    diagram.appendChild(svg)
+    body.appendChild(diagram)
+  }
+  block.append(header, actions, body)
+  root.appendChild(block)
+  document.body.appendChild(root)
+  return { block, actions, body, diagram }
+}
+
+const findToggle = (actions: HTMLElement): HTMLButtonElement | null =>
+  actions.querySelector('[data-mermaid-view-toggle]')
+
+let uninstall: (() => void) | undefined
+
+beforeEach(async () => {
+  await initI18n('en')
+  uninstall = installMermaidViewToggle()
+})
+
+afterEach(() => {
+  uninstall?.()
+  uninstall = undefined
+  document.body.innerHTML = ''
+})
+
+describe('installMermaidViewToggle', () => {
+  it('adds a toggle to the action bar once a sourced diagram exists', async () => {
+    rememberMermaidSource('r-1', SOURCE)
+    const { actions } = createMermaidBlock('r-1')
+    await flushMutations()
+
+    const toggle = findToggle(actions)
+    expect(toggle).not.toBeNull()
+    expect(toggle?.title).toBe('View source')
+    expect(toggle?.getAttribute('aria-pressed')).toBe('false')
+    expect(toggle?.disabled).toBe(false)
+  })
+
+  it('waits for the rendered diagram before adding the toggle', async () => {
+    const { actions, body } = createMermaidBlock()
+    await flushMutations()
+    expect(findToggle(actions)).toBeNull()
+
+    rememberMermaidSource('r-2', SOURCE)
+    const diagram = document.createElement('div')
+    diagram.dataset.streamdown = 'mermaid'
+    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg')
+    svg.setAttribute('data-mermaid-render-id', 'r-2')
+    diagram.appendChild(svg)
+    body.appendChild(diagram)
+    await flushMutations()
+
+    expect(findToggle(actions)).not.toBeNull()
+  })
+
+  it('toggles between the source and the rendered diagram', async () => {
+    rememberMermaidSource('r-3', SOURCE)
+    const { actions, body, diagram } = createMermaidBlock('r-3')
+    await flushMutations()
+    const toggle = findToggle(actions)
+    expect(toggle).not.toBeNull()
+
+    toggle?.click()
+
+    const sourceView = body.querySelector('[data-mermaid-source-view]')
+    expect(sourceView?.textContent).toBe(SOURCE)
+    expect(diagram?.style.display).toBe('none')
+    expect(toggle?.title).toBe('View diagram')
+    expect(toggle?.getAttribute('aria-pressed')).toBe('true')
+
+    toggle?.click()
+
+    expect(body.querySelector('[data-mermaid-source-view]')).toBeNull()
+    expect(diagram?.style.display).toBe('')
+    expect(toggle?.title).toBe('View source')
+  })
+
+  it('refreshes a visible source view when the diagram re-renders', async () => {
+    rememberMermaidSource('r-4', SOURCE)
+    const { actions, body } = createMermaidBlock('r-4')
+    await flushMutations()
+    findToggle(actions)?.click()
+    expect(body.querySelector('[data-mermaid-source-view]')?.textContent).toBe(SOURCE)
+
+    rememberMermaidSource('r-5', 'graph TD; C-->D')
+    body.querySelector('svg')?.setAttribute('data-mermaid-render-id', 'r-5')
+    await flushMutations()
+
+    expect(body.querySelector('[data-mermaid-source-view]')?.textContent).toBe('graph TD; C-->D')
+  })
+
+  it('disables the toggle when the diagram is replaced by an error panel', async () => {
+    rememberMermaidSource('r-6', SOURCE)
+    const { actions, body } = createMermaidBlock('r-6')
+    await flushMutations()
+    expect(findToggle(actions)?.disabled).toBe(false)
+
+    body.querySelector('[data-streamdown="mermaid"]')?.remove()
+    await flushMutations()
+
+    expect(findToggle(actions)?.disabled).toBe(true)
+  })
+
+  it('translates the label when the language changes', async () => {
+    rememberMermaidSource('r-7', SOURCE)
+    const { actions } = createMermaidBlock('r-7')
+    await flushMutations()
+    expect(findToggle(actions)?.title).toBe('View source')
+
+    await i18next.changeLanguage('de')
+    expect(findToggle(actions)?.title).toBe('Quelle ansehen')
+
+    await i18next.changeLanguage('zh-Hans')
+    expect(findToggle(actions)?.title).toBe('查看源码')
+  })
+
+  it('restores the source view and removes buttons on uninstall', async () => {
+    rememberMermaidSource('r-8', SOURCE)
+    const { actions, body, diagram } = createMermaidBlock('r-8')
+    await flushMutations()
+    findToggle(actions)?.click()
+    expect(body.querySelector('[data-mermaid-source-view]')).not.toBeNull()
+
+    uninstall?.()
+    uninstall = undefined
+
+    expect(findToggle(actions)).toBeNull()
+    expect(body.querySelector('[data-mermaid-source-view]')).toBeNull()
+    expect(diagram?.style.display).toBe('')
+  })
+})

--- a/src/renderer/src/components/streamdown/mermaid-view-toggle.ts
+++ b/src/renderer/src/components/streamdown/mermaid-view-toggle.ts
@@ -1,0 +1,143 @@
+import { i18next } from '@/i18n'
+
+import { getMermaidSource, MERMAID_RENDER_ID_ATTRIBUTE } from './mermaid-source-registry'
+
+const AGENT_MARKDOWN_ROOT_SELECTOR = '.agent-markdown-root'
+const MERMAID_BLOCK_SELECTOR = '[data-streamdown="mermaid-block"]'
+const MERMAID_ACTIONS_SELECTOR = `${AGENT_MARKDOWN_ROOT_SELECTOR} [data-streamdown="mermaid-block-actions"]`
+
+const TOGGLE_ATTRIBUTE = 'data-mermaid-view-toggle'
+const DECORATED_ATTRIBUTE = 'data-view-toggle-decorated'
+const VIEW_ATTRIBUTE = 'data-mermaid-view'
+const SOURCE_VIEW_ATTRIBUTE = 'data-mermaid-source-view'
+
+const BUTTON_CLASS =
+  'cursor-pointer p-1 text-muted-foreground transition-all hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50'
+const SOURCE_VIEW_CLASS =
+  'm-0 max-h-[480px] overflow-auto whitespace-pre p-4 font-mono text-[13px] leading-5'
+
+const CODE_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M8 6L2 12l6 6M16 6l6 6-6 6"/></svg>'
+const EYE_ICON =
+  '<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7Z"/><circle cx="12" cy="12" r="3"/></svg>'
+
+const getDiagramBody = (block: HTMLElement): HTMLElement | null => {
+  const last = block.lastElementChild
+  return last instanceof HTMLElement ? last : null
+}
+
+const currentSource = (block: HTMLElement): string | undefined => {
+  const renderId = block
+    .querySelector(`svg[${MERMAID_RENDER_ID_ATTRIBUTE}]`)
+    ?.getAttribute(MERMAID_RENDER_ID_ATTRIBUTE)
+  return renderId ? getMermaidSource(renderId) : undefined
+}
+
+const syncButton = (button: HTMLButtonElement, block: HTMLElement): void => {
+  const showingSource = block.getAttribute(VIEW_ATTRIBUTE) === 'source'
+  button.innerHTML = showingSource ? EYE_ICON : CODE_ICON
+  const label = i18next.t(showingSource ? 'View diagram' : 'View source')
+  button.title = label
+  button.setAttribute('aria-label', label)
+  button.setAttribute('aria-pressed', String(showingSource))
+  button.disabled = !showingSource && currentSource(block) === undefined
+}
+
+const showSource = (block: HTMLElement): void => {
+  if (block.getAttribute(VIEW_ATTRIBUTE) === 'source') return
+  const body = getDiagramBody(block)
+  const source = currentSource(block)
+  if (!body || source === undefined) return
+
+  const pre = document.createElement('pre')
+  pre.setAttribute(SOURCE_VIEW_ATTRIBUTE, '')
+  pre.className = SOURCE_VIEW_CLASS
+  pre.textContent = source
+  for (const child of body.children) {
+    if (child instanceof HTMLElement) child.style.display = 'none'
+  }
+  body.appendChild(pre)
+  block.setAttribute(VIEW_ATTRIBUTE, 'source')
+}
+
+const showDiagram = (block: HTMLElement): void => {
+  const body = getDiagramBody(block)
+  body?.querySelector(`[${SOURCE_VIEW_ATTRIBUTE}]`)?.remove()
+  if (body) {
+    for (const child of body.children) {
+      if (child instanceof HTMLElement) child.style.display = ''
+    }
+  }
+  block.removeAttribute(VIEW_ATTRIBUTE)
+}
+
+// Adds a source/rendered toggle to each mermaid block's action bar. The rendered SVG stays
+// mounted (display: none) while the source is shown, so toggling back never re-renders.
+const installMermaidViewToggle = (): (() => void) => {
+  const decorate = (): void => {
+    for (const actions of document.querySelectorAll<HTMLElement>(
+      `${MERMAID_ACTIONS_SELECTOR}:not([${DECORATED_ATTRIBUTE}])`
+    )) {
+      const block = actions.closest(MERMAID_BLOCK_SELECTOR)
+      if (!(block instanceof HTMLElement)) continue
+      // The toggle only works once a rendered diagram has exposed its source; retry next scan.
+      if (!block.querySelector(`svg[${MERMAID_RENDER_ID_ATTRIBUTE}]`)) continue
+
+      actions.setAttribute(DECORATED_ATTRIBUTE, '')
+      const button = document.createElement('button')
+      button.type = 'button'
+      button.className = BUTTON_CLASS
+      button.setAttribute(TOGGLE_ATTRIBUTE, '')
+      button.addEventListener('click', () => {
+        if (block.getAttribute(VIEW_ATTRIBUTE) === 'source') {
+          showDiagram(block)
+        } else {
+          showSource(block)
+        }
+        syncButton(button, block)
+      })
+      actions.prepend(button)
+    }
+
+    // Re-rendered diagrams (retry, streaming) replace the SVG: keep enabled/disabled state and
+    // any visible source view in sync with the latest chart.
+    for (const button of document.querySelectorAll<HTMLButtonElement>(`[${TOGGLE_ATTRIBUTE}]`)) {
+      const block = button.closest(MERMAID_BLOCK_SELECTOR)
+      if (!(block instanceof HTMLElement)) continue
+      syncButton(button, block)
+      const sourceView = getDiagramBody(block)?.querySelector(`[${SOURCE_VIEW_ATTRIBUTE}]`)
+      const source = currentSource(block)
+      if (sourceView && source !== undefined && sourceView.textContent !== source) {
+        sourceView.textContent = source
+      }
+    }
+  }
+
+  const onLanguageChanged = (): void => {
+    for (const button of document.querySelectorAll<HTMLButtonElement>(`[${TOGGLE_ATTRIBUTE}]`)) {
+      const block = button.closest(MERMAID_BLOCK_SELECTOR)
+      if (block instanceof HTMLElement) syncButton(button, block)
+    }
+  }
+
+  decorate()
+  const observer = new MutationObserver(decorate)
+  observer.observe(document.body, { childList: true, subtree: true })
+  i18next.on('languageChanged', onLanguageChanged)
+
+  return () => {
+    observer.disconnect()
+    i18next.off('languageChanged', onLanguageChanged)
+    for (const block of document.querySelectorAll<HTMLElement>(
+      `${MERMAID_BLOCK_SELECTOR}[${VIEW_ATTRIBUTE}="source"]`
+    )) {
+      showDiagram(block)
+    }
+    for (const button of document.querySelectorAll(`[${TOGGLE_ATTRIBUTE}]`)) button.remove()
+    for (const actions of document.querySelectorAll(`[${DECORATED_ATTRIBUTE}]`)) {
+      actions.removeAttribute(DECORATED_ATTRIBUTE)
+    }
+  }
+}
+
+export { installMermaidViewToggle }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -2669,6 +2669,7 @@
     "View raw JSON": "Rohes JSON anzeigen",
     "View release notes on GitHub": "Versionshinweise auf GitHub anzeigen",
     "View source": "Quelle ansehen",
+    "View diagram": "Diagramm ansehen",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "Das Laufzeitprotokoll dieses Geräts anzeigen. Es zeichnet die App-Aktivität auf und hilft bei der Fehlerdiagnose.",
     "View {{name}}": "{{name}} anzeigen",
     "Viewer failed": "Der Viewer ist fehlgeschlagen",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -2991,6 +2991,7 @@
     "View raw JSON": "Ver JSON sin formato",
     "View release notes on GitHub": "Ver notas de la versión en GitHub",
     "View source": "Ver código fuente",
+    "View diagram": "Ver diagrama",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "Consulte el registro del entorno de ejecución de este dispositivo; registra lo que hace la aplicación para poder diagnosticar problemas.",
     "View {{name}}": "Ver {{name}}",
     "Viewer failed": "Error en el visor",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -2991,6 +2991,7 @@
     "View raw JSON": "Afficher le JSON brut",
     "View release notes on GitHub": "Afficher les notes de version sur GitHub",
     "View source": "Voir la source",
+    "View diagram": "Voir le diagramme",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "Consultez le journal d'exécution de cet appareil : il enregistre ce que fait l'application afin que les problèmes puissent être diagnostiqués.",
     "View {{name}}": "Voir {{name}}",
     "Viewer failed": "Échec de la visionneuse",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -2868,6 +2868,7 @@
     "View raw JSON": "生の JSON を表示する",
     "View release notes on GitHub": "GitHub でリリースノートを表示する",
     "View source": "ソースを見る",
+    "View diagram": "図を表示",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "このデバイスのランタイムログを表示します。問題を診断できるように、アプリの動作が記録されます。",
     "View {{name}}": "{{name}} を表示する",
     "Viewer failed": "ビューアが失敗しました",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -2879,6 +2879,7 @@
     "View raw JSON": "원본 JSON 보기",
     "View release notes on GitHub": "GitHub에서 출시 노트 보기",
     "View source": "소스 보기",
+    "View diagram": "다이어그램 보기",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "이 기기의 런타임 로그를 확인하세요. 문제를 진단할 수 있도록 앱이 수행하는 작업을 기록합니다.",
     "View {{name}}": "{{name}} 보기",
     "View {{name}} details": "{{name}} 세부정보 보기",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -3015,6 +3015,7 @@
     "View raw JSON": "Просмотр сырого JSON",
     "View release notes on GitHub": "Просмотр заметок о выпуске на GitHub",
     "View source": "Просмотр источника",
+    "View diagram": "Показать диаграмму",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "Просмотр журнала выполнения этого устройства — он фиксирует, что делает приложение, чтобы можно было диагностировать проблемы.",
     "View {{name}}": "Просмотр {{name}}",
     "View {{name}} details": "Открыть сведения: {{name}}",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -2955,6 +2955,7 @@
     "View raw JSON": "查看原始 JSON",
     "View release notes on GitHub": "在 GitHub 上查看发布说明",
     "View source": "查看源码",
+    "View diagram": "查看图表",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "查看这台设备的运行日志 —— 它记录了应用正在做什么，便于排查问题。",
     "View {{name}}": "查看 {{name}}",
     "Viewer failed": "查看器失败",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -2952,6 +2952,7 @@
     "View raw JSON": "查看原始 JSON",
     "View release notes on GitHub": "在 GitHub 上檢視發布說明",
     "View source": "查看原始碼",
+    "View diagram": "查看圖表",
     "View this device's runtime log — it records what the app is doing so problems can be diagnosed.": "檢視這台裝置的執行記錄檔 —— 它記錄了應用程式正在做什麼，便於排查問題。",
     "View {{name}}": "檢視 {{name}}",
     "Viewer failed": "檢視器失敗",


### PR DESCRIPTION
## What

Adds a source/rendered toggle button to the mermaid block's top-right action bar (alongside download / copy / fullscreen). Clicking it swaps the rendered diagram for the fence's source in a scrollable `<pre>`; clicking again restores the diagram. The SVG stays mounted (`display: none`) while the source is shown, so toggling back costs no re-render.

Related: pairs nicely with #2142 — when both land, the height change from toggling is animated instead of jumping.

## How

Streamdown keeps the mermaid source only in React props — nothing in the DOM carries it. Two pieces:

1. **Source capture** (`mermaid-runtime.ts`, the app's single mermaid import site): wraps the upstream plugin so every `render(id, source)` call records the source in a small bounded registry (`mermaid-source-registry.ts`, 100-entry LRU) and stamps the render id onto the SVG root as `data-mermaid-render-id`. Sources are remembered even when rendering fails.

2. **Toggle installer** (`mermaid-view-toggle.ts`, wired into `installStreamdown`, same pattern as the existing `installCodeLanguageBadges`): a MutationObserver decorates each `mermaid-block-actions` bar inside `.agent-markdown-root` once the rendered SVG has exposed its source. The button mirrors streamdown's own action-button styling, reflects state via icon (code/eye), `aria-pressed`, and `title`/`aria-label`.
   - A re-rendered diagram (retry, streaming) refreshes a visible source view to the latest chart.
   - The button is disabled while an error panel replaces the diagram (the error surface already shows the source).
   - Labels reuse the existing `View source` key and add `View diagram`, translated for all eight locales and updated live on `languageChanged`.
   - Uninstall restores any visible source view and removes the injected buttons.

## Testing

- `mermaid-runtime.test.ts` (5): plugin identity passthrough, source recording + SVG stamping, source retained on render failure, registry LRU eviction and recency refresh.
- `mermaid-view-toggle.test.ts` (7): injection only after a sourced diagram exists, toggle round-trip, source refresh on re-render, disabled state on error panel, live translation on language change (en/de/zh-Hans), uninstall cleanup.
- i18n guard suite (`resources.test.ts`): 804 passed — placeholder parity and per-locale coverage for the new key.
- Full `vitest run`: 26,455 passed; the 46 failures (`kernel-executor`, `package-cache-sandbox`, `network-enforcement`, `literature-review kernel`) reproduce identically on an untouched `main` checkout — environment issues (system python3 is a broken Xcode CLT shim on this machine, sandbox network policy), unrelated to this change.
- `npm run typecheck` and ESLint clean.