### PR TITLE
feat(cli): add connector management commands

### DIFF
--- a/cli/connector-management.test.ts
+++ b/cli/connector-management.test.ts
@@ -1,0 +1,61 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Issue #2287 entry-point reproductions. Operation-specific contracts follow design review;
+// these checks establish only that the requested CLI surface is missing.
+describe('Connector CLI entry point', () => {
+  it.each([
+    ['list'],
+    ['show', 'context7'],
+    ['enable', 'context7'],
+    ['disable', 'context7'],
+    ['add'],
+    ['update', 'context7'],
+    ['remove', 'context7'],
+    ['test', 'context7']
+  ])('recognizes connector %s before operation validation', (...args) => {
+    const configRoot = mkdtempSync(join(tmpdir(), 'connector-cli-repro-'))
+    try {
+      const result = spawnSync(
+        process.execPath,
+        [
+          resolve('packages/open-science/cli.mjs'),
+          'connector',
+          ...args,
+          '--config-root',
+          configRoot,
+          '--json'
+        ],
+        { encoding: 'utf8', timeout: 10_000 }
+      )
+      expect(result.error).toBeUndefined()
+      expect(result.signal).toBeNull()
+      const error = result.stderr.trim() ? JSON.parse(result.stderr).error : undefined
+      expect(error?.message ?? '').not.toMatch(/^Unknown command: connector\b/)
+    } finally {
+      rmSync(configRoot, { recursive: true, force: true })
+    }
+  })
+})
+
+it('accepts real piped credential JSON without echoing its secret', () => {
+  const script = `
+    import { parseCliArgs, runTaskCommand } from './packages/open-science/cli.mjs';
+    await runTaskCommand(parseCliArgs(['credential', 'add', '--json']), {
+      connect: async () => ({ createCredential: async (input) => {
+        if (input.secret !== 'private-token') throw new Error('input was not read');
+        return { createdCredential: { id: 'saved' } };
+      } })
+    });`
+  const result = spawnSync(process.execPath, ['--input-type=module', '-e', script], {
+    input: JSON.stringify({ kind: 'token', displayName: 'Example', secret: 'private-token' }),
+    encoding: 'utf8',
+    timeout: 10_000
+  })
+  expect(result.status, result.stderr).toBe(0)
+  expect(JSON.parse(result.stdout)).toEqual({ createdCredential: { id: 'saved' } })
+  expect(result.stdout + result.stderr).not.toContain('private-token')
+})

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -527,3 +527,67 @@ not match SQLite, or when a rollback target already exists.
 
 The initial CLI does not expose file or directory attachments, per-run model selection, or per-run
 agent-backend selection. These require stable public runtime contracts before they can be added.
+
+## Connector management
+
+Connector commands use the running backend and the same saved Settings as the desktop and web UI.
+Use `--config-root` to select the intended instance. Custom MCP and credential mutations require a
+local authenticated connection; run the CLI on the server itself, including through SSH.
+
+```sh
+open-science connector list --json
+open-science connector show context7 --json
+open-science connector enable context7
+open-science connector disable context7
+open-science connector add --json < connector.json
+open-science connector update context7 --json < connector-update.json
+open-science connector remove context7
+open-science connector test context7 --json
+```
+
+`add` reads an object with `name`, `displayName`, `transport`, and `command` (stdio) or `url`
+(`streamable_http` or `sse`). Optional fields include `args`, `description`, `envCredentialIds`,
+`headerCredentialIds`, and `oauthCredentialId`. Names and IDs remain stable on update. `update`
+requires `transport`; omitted credential bindings retain their saved values. Use an empty binding
+object to clear environment/header bindings. Only custom MCP Connectors can be added, edited, or removed.
+
+```json
+{
+  "name": "context7",
+  "displayName": "Context7",
+  "transport": "streamable_http",
+  "url": "https://mcp.example.test/mcp"
+}
+```
+
+`list` and `show` expose safe Settings views, not raw credential material. `enabled` is a selection
+preference, not proof of connectivity or a global revocation of Specialist access. `availability`,
+`checking`, credential-presence fields, and `skillProjectionStatus` retain their Settings meanings.
+Changes reuse existing agent refresh behavior. Start a new session if its tool list remains unchanged;
+these commands do not force-reset active conversations.
+
+`test` opens a separate MCP connection, discovers tools, and closes it. It does not enable a disabled
+Connector or execute business tools. Its result is `{ success, toolCount?, message }`; failure exits
+nonzero. Discovery is bounded to ten seconds. Bundled Connector live diagnostics are unsupported.
+OAuth refresh may update existing encrypted token state; testing does not perform first-time browser login.
+
+### Credentials
+
+```sh
+open-science credential list --json
+open-science credential add --json < credential.json
+open-science credential update <credential-id> --json < credential-update.json
+```
+
+Credential writes read JSON exclusively from stdin. Do not put secrets in command arguments or shell
+history. Protect any input file and remove it when no longer needed. A token input has the shape
+`{ "displayName": "Service token", "kind": "token", "secret": "..." }`; `api_key` is also supported.
+The returned `createdCredential.id` can be bound in `envCredentialIds` or `headerCredentialIds`.
+Updates accept `displayName` and/or `secret`. Existing OAuth registration can be created with `kind:
+"oauth"`, `resourceUri`, remote `transport`, and an `oauth` registration object, then authenticated
+through Settings. First-time browserless OAuth login is outside these commands.
+
+Secrets use the existing OS-protected store. A headless machine without a usable system credential
+vault cannot save secrets; there is no plaintext fallback. Existing unreadable credentials need re-entry.
+These commands do not migrate historical configuration or store diagnostic history. Older backends that
+lack the endpoints return an endpoint error; the CLI never falls back to editing Settings files directly.

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -8,6 +8,7 @@ import { chmod, lstat, mkdir, readFile, readlink, rename, rm, stat } from 'node:
 import { dirname, join, resolve } from 'node:path'
 import { Readable } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
+import { text as readStreamText } from 'node:stream/consumers'
 import { spawn } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 
@@ -34,6 +35,10 @@ Commands:
   url         Print the authenticated web URL
   update      Check, download, and apply an application update
   codex login [--force]
+  connector list | show <id> | enable <id> | disable <id>
+  connector add | update <id>      Read configuration JSON from stdin
+  connector remove <id> | test <id>
+  credential list | add | update <id>  Read credential JSON from stdin for writes
   project list
   project create <name> [--description <text>] [--agent-context <text> | --agent-context-file <path>]
   project update <id-or-name> [--name <name>] [--description <text>] [--agent-context <text> | --agent-context-file <path> | --clear-agent-context]
@@ -138,11 +143,41 @@ const VALUE_OPTIONS = {
   '--output': 'output'
 }
 
-const TASK_COMMANDS = new Set(['project', 'run', 'session', 'settings', 'plan', 'artifacts'])
-const GROUP_COMMANDS = new Set(['codex', 'project', 'session', 'settings', 'plan', 'artifacts'])
+const TASK_COMMANDS = new Set([
+  'project',
+  'run',
+  'session',
+  'settings',
+  'plan',
+  'artifacts',
+  'connector',
+  'credential'
+])
+const GROUP_COMMANDS = new Set([
+  'codex',
+  'project',
+  'session',
+  'settings',
+  'plan',
+  'artifacts',
+  'connector',
+  'credential'
+])
 // Project create, update, and session-defaults intentionally remain unbounded because their
 // positional Project names may contain multiple unquoted words.
 const POSITIONAL_LIMITS = new Map([
+  ['connector list', 0],
+  ['connector show', 1],
+  ['connector enable', 1],
+  ['connector disable', 1],
+  ['connector add', 0],
+  ['connector update', 1],
+  ['connector remove', 1],
+  ['connector test', 1],
+  ['credential list', 0],
+  ['credential add', 0],
+  ['credential update', 1],
+
   ['start', 0],
   ['stop', 0],
   ['status', 0],
@@ -894,7 +929,7 @@ const TASK_DEPS = {
   connect: (options) => connectToOpenScience(options),
   readFile: (path) => readFile(path, 'utf8'),
   readBinaryFile: (path) => readFile(path),
-  readStdin: () => readFile(0, 'utf8'),
+  readStdin: () => readStreamText(process.stdin),
   writeDownload,
   log: (...args) => console.log(...args),
   warn: (...args) => console.warn(...args),
@@ -1377,6 +1412,58 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
   const deps = { ...TASK_DEPS, ...dependencies }
   const { command, subcommand, positionals = [], options } = parsed
   const client = await deps.connect({ configRoot: options.configRoot })
+
+  if (command === 'connector' || command === 'credential') {
+    const id = positionals[0]
+    const actions =
+      command === 'connector'
+        ? ['list', 'show', 'enable', 'disable', 'add', 'update', 'remove', 'test']
+        : ['list', 'add', 'update']
+    if (!actions.includes(subcommand))
+      throw new CliUsageError(`Unknown command: ${command} ${subcommand ?? ''}`)
+    if (!['list', 'add'].includes(subcommand) && !id) throw new CliUsageError('An ID is required.')
+    let input
+    if (subcommand === 'add' || subcommand === 'update') {
+      if (deps.stdinIsTTY)
+        throw new CliUsageError('Pipe a JSON configuration object through stdin.')
+      try {
+        input = JSON.parse(await deps.readStdin())
+      } catch {
+        throw new CliUsageError('Stdin must contain a valid JSON configuration object.')
+      }
+      if (!input || typeof input !== 'object' || Array.isArray(input)) {
+        throw new CliUsageError('Stdin must contain a JSON configuration object.')
+      }
+    }
+    let result
+    if (command === 'credential') {
+      if (subcommand === 'list') result = await client.listCredentials()
+      else if (subcommand === 'add') result = await client.createCredential(input)
+      else result = await client.updateCredential(id, input)
+    } else {
+      if (subcommand === 'list') result = await client.listConnectors()
+      else if (subcommand === 'show') result = await client.getConnector(id)
+      else if (subcommand === 'enable' || subcommand === 'disable')
+        result = await client.setConnectorEnabled(id, subcommand === 'enable')
+      else if (subcommand === 'add') result = await client.addConnector(input)
+      else if (subcommand === 'update') result = await client.updateConnector(id, input)
+      else if (subcommand === 'remove') result = await client.removeConnector(id)
+      else result = await client.testConnector(id)
+    }
+    // Preserve every safe status/configuration field in both output formats.
+    deps.log(JSON.stringify(result, null, options.json ? undefined : 2))
+    if (
+      !options.json &&
+      command === 'connector' &&
+      ['add', 'update', 'remove', 'enable', 'disable'].includes(subcommand)
+    ) {
+      deps.log(
+        'Connector settings saved. Existing session refresh follows the configured agent framework; start a new session if its tool list is unchanged.'
+      )
+    }
+    if (subcommand === 'test' && result?.success === false) deps.setExitCode(1)
+    return
+  }
 
   if (command === 'project' && subcommand === 'list') {
     outputValue(await client.listProjects(), options, deps)

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -51,11 +51,21 @@ afterEach(async () => {
 })
 
 describe('OpenScienceClient', () => {
-  it('pins the SDK method inventory without exposing management capabilities', () => {
+  it('pins the SDK method inventory including Connector management', () => {
     expect(Object.getOwnPropertyNames(OpenScienceClient.prototype).sort()).toEqual(
       [
         'constructor',
         'health',
+        'listConnectors',
+        'getConnector',
+        'setConnectorEnabled',
+        'addConnector',
+        'updateConnector',
+        'removeConnector',
+        'testConnector',
+        'listCredentials',
+        'createCredential',
+        'updateCredential',
         'listProjects',
         'createProject',
         'updateProject',

--- a/packages/open-science/connector-types.test.ts
+++ b/packages/open-science/connector-types.test.ts
@@ -1,0 +1,42 @@
+import { resolve } from 'node:path'
+import ts from 'typescript'
+import { expect, it } from 'vitest'
+
+it('publishes the complete safe Connector and credential contracts', () => {
+  const path = resolve('packages/open-science/connector-contract.fixture.ts')
+  const source = `
+    import type { OpenScienceClient } from './index'
+    import type * as Shared from '../../src/shared/settings'
+    type Equal<A, B> = (<T>() => T extends A ? 1 : 2) extends (<T>() => T extends B ? 1 : 2) ? true : false
+    type Assert<T extends true> = T
+    type List = Assert<Equal<Awaited<ReturnType<OpenScienceClient['listConnectors']>>, Shared.ConnectorsSnapshot>>
+    type Detail = Assert<Equal<Awaited<ReturnType<OpenScienceClient['getConnector']>>, Shared.ConnectorDetailView | Shared.CustomServerView>>
+    type Add = Assert<Equal<Parameters<OpenScienceClient['addConnector']>[0], Shared.AddCustomServerRequest>>
+    type Update = Assert<Equal<Parameters<OpenScienceClient['updateConnector']>[1], Omit<Shared.UpdateCustomServerRequest, 'id'>>>
+    type Credentials = Assert<Equal<Awaited<ReturnType<OpenScienceClient['listCredentials']>>, Shared.DeviceCredentialsSnapshot>>
+    type Create = Assert<Equal<Parameters<OpenScienceClient['createCredential']>[0], Shared.CreateDeviceCredentialRequest>>
+    type Created = Assert<Equal<Awaited<ReturnType<OpenScienceClient['createCredential']>>, Shared.CreateDeviceCredentialResult>>
+  `
+  const options: ts.CompilerOptions = {
+    noEmit: true,
+    strict: true,
+    skipLibCheck: true,
+    target: ts.ScriptTarget.ES2022,
+    module: ts.ModuleKind.ESNext,
+    moduleResolution: ts.ModuleResolutionKind.Bundler,
+    types: []
+  }
+  const host = ts.createCompilerHost(options)
+  const originalGetSourceFile = host.getSourceFile.bind(host)
+  host.getSourceFile = (fileName, languageVersion, onError, shouldCreateNewSourceFile) =>
+    fileName === path
+      ? ts.createSourceFile(path, source, languageVersion)
+      : originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
+  const program = ts.createProgram([path], options, host)
+  const diagnostics = ts
+    .getPreEmitDiagnostics(program)
+    .filter((diagnostic) => diagnostic.file?.fileName === path)
+  expect(
+    diagnostics.map((diagnostic) => ts.flattenDiagnosticMessageText(diagnostic.messageText, '\n'))
+  ).toEqual([])
+}, 15_000)

--- a/packages/open-science/connector-types.test.ts
+++ b/packages/open-science/connector-types.test.ts
@@ -1,9 +1,9 @@
-import { resolve } from 'node:path'
+import { resolve, sep } from 'node:path'
 import ts from 'typescript'
 import { expect, it } from 'vitest'
 
 it('publishes the complete safe Connector and credential contracts', () => {
-  const path = resolve('packages/open-science/connector-contract.fixture.ts')
+  const path = resolve('packages/open-science/connector-contract.fixture.ts').split(sep).join('/')
   const source = `
     import type { OpenScienceClient } from './index'
     import type * as Shared from '../../src/shared/settings'
@@ -33,6 +33,7 @@ it('publishes the complete safe Connector and credential contracts', () => {
       ? ts.createSourceFile(path, source, languageVersion)
       : originalGetSourceFile(fileName, languageVersion, onError, shouldCreateNewSourceFile)
   const program = ts.createProgram([path], options, host)
+  expect(program.getSourceFile(path)).toBeDefined()
   const diagnostics = ts
     .getPreEmitDiagnostics(program)
     .filter((diagnostic) => diagnostic.file?.fileName === path)

--- a/packages/open-science/connector.test.ts
+++ b/packages/open-science/connector.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it, vi } from 'vitest'
+import { OpenScienceClient } from './index.mjs'
+import { parseCliArgs, runTaskCommand } from './cli.mjs'
+
+const cases = [
+  ['listConnectors', [], '/api/v1/connectors', 'GET'],
+  ['getConnector', ['a/b'], '/api/v1/connectors/a%2Fb', 'GET'],
+  ['setConnectorEnabled', ['a', false], '/api/v1/connectors/a/enabled', 'PUT'],
+  [
+    'addConnector',
+    [{ name: 'a', transport: 'stdio', command: 'node' }],
+    '/api/v1/connectors',
+    'POST'
+  ],
+  ['updateConnector', ['a', { transport: 'stdio', args: [] }], '/api/v1/connectors/a', 'PATCH'],
+  ['removeConnector', ['a'], '/api/v1/connectors/a', 'DELETE'],
+  ['testConnector', ['a'], '/api/v1/connectors/a/test', 'POST'],
+  ['listCredentials', [], '/api/v1/credentials', 'GET'],
+  [
+    'createCredential',
+    [{ kind: 'token', displayName: 'Token', secret: 'secret' }],
+    '/api/v1/credentials',
+    'POST'
+  ],
+  ['updateCredential', ['a', { secret: 'new-secret' }], '/api/v1/credentials/a', 'PATCH']
+] as const
+
+describe('Connector public client', () => {
+  it.each(cases)('%s uses authenticated HTTP', async (method, args, path, verb) => {
+    const fetch = vi.fn(async () => new Response(JSON.stringify({ data: { saved: true } })))
+    const client = new OpenScienceClient({
+      baseUrl: 'http://localhost:44100',
+      token: 'test-token',
+      fetch
+    })
+    await expect(client[method](...args)).resolves.toEqual({ saved: true })
+    expect(fetch).toHaveBeenCalledWith(
+      `http://localhost:44100${path}`,
+      expect.objectContaining({
+        method: verb,
+        headers: expect.objectContaining({ authorization: 'Bearer test-token' })
+      })
+    )
+  })
+})
+
+describe('Connector CLI behavior', () => {
+  it.each([
+    ['list', [], 'listConnectors', []],
+    ['show', ['a'], 'getConnector', ['a']],
+    ['enable', ['a'], 'setConnectorEnabled', ['a', true]],
+    ['disable', ['a'], 'setConnectorEnabled', ['a', false]],
+    ['remove', ['a'], 'removeConnector', ['a']],
+    ['test', ['a'], 'testConnector', ['a']]
+  ])('%s dispatches and emits a single JSON result', async (action, ids, method, expected) => {
+    const operation = vi.fn(async () => ({ id: 'a', enabled: false }))
+    const log = vi.fn()
+    await runTaskCommand(parseCliArgs(['connector', action, ...ids, '--json']), {
+      connect: async () => ({ [method]: operation }),
+      log
+    })
+    expect(operation).toHaveBeenCalledWith(...expected)
+    expect(log.mock.calls).toEqual([[JSON.stringify({ id: 'a', enabled: false })]])
+  })
+
+  it('reads credentials from stdin without echoing them', async () => {
+    const createCredential = vi.fn(async () => ({ createdCredential: { id: 'c' } }))
+    const log = vi.fn()
+    await runTaskCommand(parseCliArgs(['credential', 'add', '--json']), {
+      connect: async () => ({ createCredential }),
+      stdinIsTTY: false,
+      readStdin: async () =>
+        JSON.stringify({ kind: 'token', displayName: 'Token', secret: 'secret' }),
+      log
+    })
+    expect(createCredential).toHaveBeenCalledWith({
+      kind: 'token',
+      displayName: 'Token',
+      secret: 'secret'
+    })
+    expect(JSON.stringify(log.mock.calls)).not.toContain('secret')
+  })
+})

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,3 +1,85 @@
+export type ConnectorTransport = 'stdio' | 'streamable_http' | 'sse'
+export type ConnectorConfiguration = {
+  transport: ConnectorTransport
+  displayName?: string
+  description?: string
+  command?: string
+  args?: string[]
+  url?: string
+  envCredentialIds?: Record<string, string>
+  headerCredentialIds?: Record<string, string>
+  oauthCredentialId?: string
+}
+export type ConnectorView = {
+  id: string
+  name: string
+  displayName: string
+  description?: string
+  enabled: boolean
+  transport?: ConnectorTransport
+  command?: string
+  args?: string[]
+  url?: string
+  availability?: 'unavailable' | 'unauthenticated' | 'credential_unavailable'
+  checking?: boolean
+  hasEnv?: boolean
+  environmentNames?: string[]
+  hasHeaders?: boolean
+  headerNames?: string[]
+  oauthCredentialId?: string
+  oauth?: {
+    hasTokens: boolean
+    hasClientSecret?: boolean
+    sharedCredential?: boolean
+    clientMetadataUrl?: string
+    authorizationServerUrl?: string
+    clientId?: string
+    redirectUri?: string
+    scopes?: string[]
+  }
+}
+export type ConnectorsSnapshot = {
+  connectors: ConnectorView[]
+  customServers: ConnectorView[]
+  ncbi: { contactEmail?: string; hasApiKey: boolean }
+  openAlex?: { hasApiKey: boolean }
+  skillProjectionStatus?: 'degraded'
+  reservedCustomServerIds?: string[]
+}
+export type ConnectorTestResult = { success: boolean; toolCount?: number; message: string }
+export type CredentialInput =
+  | { kind: 'api_key' | 'token'; displayName: string; secret: string }
+  | {
+      kind: 'oauth'
+      displayName: string
+      resourceUri: string
+      transport: 'streamable_http' | 'sse'
+      oauth: {
+        clientMetadataUrl?: string
+        authorizationServerUrl?: string
+        clientId?: string
+        redirectUri?: string
+        scopes?: string[]
+        clientSecret?: string
+      }
+    }
+export type CredentialView = {
+  id: string
+  displayName: string
+  kind: 'api_key' | 'token' | 'oauth'
+  status: 'stored' | 'connected' | 'disconnected'
+  needsSecret: boolean
+  consumerCount: number
+  consumerNames: string[]
+  createdAt: number
+  updatedAt: number
+  resourceUri?: string
+  transport?: 'streamable_http' | 'sse'
+  hasClientSecret?: boolean
+  needsClientSecret?: boolean
+}
+export type CredentialsSnapshot = { credentials: CredentialView[] }
+
 export type PermissionProfile = 'ask' | 'auto' | 'full'
 export type DelegationPolicy = 'allow' | 'deny'
 export type TurnIntent = 'plan-first'
@@ -260,6 +342,34 @@ export class OpenScienceClient {
     requestTimeoutMs?: number
   })
   health(options?: RequestOptions): Promise<unknown>
+  listConnectors(options?: RequestOptions): Promise<ConnectorsSnapshot>
+  getConnector(id: string, options?: RequestOptions): Promise<ConnectorView>
+  setConnectorEnabled(
+    id: string,
+    enabled: boolean,
+    options?: RequestOptions
+  ): Promise<ConnectorsSnapshot>
+  addConnector(
+    request: ConnectorConfiguration & { name: string; displayName: string; id?: string },
+    options?: RequestOptions
+  ): Promise<ConnectorsSnapshot>
+  updateConnector(
+    id: string,
+    request: ConnectorConfiguration,
+    options?: RequestOptions
+  ): Promise<ConnectorsSnapshot>
+  removeConnector(id: string, options?: RequestOptions): Promise<ConnectorsSnapshot>
+  testConnector(id: string, options?: RequestOptions): Promise<ConnectorTestResult>
+  listCredentials(options?: RequestOptions): Promise<CredentialsSnapshot>
+  createCredential(
+    request: CredentialInput,
+    options?: RequestOptions
+  ): Promise<{ createdCredential: CredentialView; credentials?: CredentialView[] }>
+  updateCredential(
+    id: string,
+    request: { displayName?: string; secret?: string },
+    options?: RequestOptions
+  ): Promise<CredentialsSnapshot>
   listProjects(options?: RequestOptions): Promise<Project[]>
   createProject(
     request: {

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,84 +1,199 @@
-export type ConnectorTransport = 'stdio' | 'streamable_http' | 'sse'
-export type ConnectorConfiguration = {
-  transport: ConnectorTransport
-  displayName?: string
-  description?: string
-  command?: string
-  args?: string[]
-  url?: string
-  envCredentialIds?: Record<string, string>
-  headerCredentialIds?: Record<string, string>
-  oauthCredentialId?: string
+// Keep these standalone published types aligned with the safe Settings contracts.
+// connector-types.test.ts verifies complete request and response equivalence.
+export type ToolPermission = 'allow' | 'ask' | 'block'
+
+export type ConnectorToolView = {
+  id: string // "<connector>/<method>"
+  method: string
+  description: string
+  permission: ToolPermission
 }
+
+export type ConnectorGroup = 'featured' | 'directory'
+
 export type ConnectorView = {
   id: string
+  // Immutable invocation/export name. Bundled Connectors currently use the same value as id.
   name: string
   displayName: string
+  description: string
+  sources: string[]
+  requiresNcbi: boolean
+  enabled: boolean // !disabledConnectorIds.includes(id)
+  autoAllow: boolean // autoAllowIds.includes(id) — "Skip approvals"
+  group: ConnectorGroup
+}
+
+export type ConnectorDetailView = ConnectorView & {
+  useWhen: string
+  termsUrl?: string
+  tools: ConnectorToolView[]
+}
+
+export type NcbiCredentialsView = { contactEmail?: string; hasApiKey: boolean }
+
+export type OpenAlexCredentialView = { hasApiKey: boolean }
+
+export type CustomServerTransport = 'stdio' | 'streamable_http' | 'sse'
+
+export type CustomServerView = {
+  id: string
+  // Immutable agent-facing name used by host.mcp, Specialists, and generated MCP skills.
+  name: string
+  // User-facing label; spaces, punctuation, and duplicates are allowed.
+  displayName: string
   description?: string
+  transport: CustomServerTransport
   enabled: boolean
-  transport?: ConnectorTransport
+  // Physical availability is independent of Main's enabled toggle. An invalid persisted server may
+  // remain visible to a Specialist but can never be selected or dispatched.
+  availability?: 'unavailable' | 'unauthenticated' | 'credential_unavailable'
+  // Background discovery is transient and does not make the Connector unavailable by itself.
+  checking?: boolean
+  // Display-only config summary. Environment/header names are safe to show; values stay write-only.
   command?: string
   args?: string[]
   url?: string
-  availability?: 'unavailable' | 'unauthenticated' | 'credential_unavailable'
-  checking?: boolean
-  hasEnv?: boolean
-  environmentNames?: string[]
   hasHeaders?: boolean
   headerNames?: string[]
+  hasEnv?: boolean
+  environmentNames?: string[]
+  // Opaque device credential reference used to preselect a shared OAuth credential in Configure.
   oauthCredentialId?: string
   oauth?: {
-    hasTokens: boolean
-    hasClientSecret?: boolean
-    sharedCredential?: boolean
     clientMetadataUrl?: string
     authorizationServerUrl?: string
+    scopes?: string[]
     clientId?: string
     redirectUri?: string
-    scopes?: string[]
+    hasTokens: boolean
+    // Optional for compatibility with snapshots from an older main process during development.
+    hasClientSecret?: boolean
+    sharedCredential?: boolean
   }
 }
+
 export type ConnectorsSnapshot = {
   connectors: ConnectorView[]
-  customServers: ConnectorView[]
-  ncbi: { contactEmail?: string; hasApiKey: boolean }
-  openAlex?: { hasApiKey: boolean }
+  customServers: CustomServerView[]
+  // Derived Agent Skill documents can fail independently after durable Connector settings save.
   skillProjectionStatus?: 'degraded'
+  // Local IDs reserved until interrupted custom Connector deletion cleanup completes.
   reservedCustomServerIds?: string[]
+  ncbi: NcbiCredentialsView
+  // Optional only for compatibility with an older main process during local development.
+  openAlex?: OpenAlexCredentialView
 }
-export type ConnectorTestResult = { success: boolean; toolCount?: number; message: string }
-export type CredentialInput =
-  | { kind: 'api_key' | 'token'; displayName: string; secret: string }
-  | {
-      kind: 'oauth'
-      displayName: string
-      resourceUri: string
-      transport: 'streamable_http' | 'sse'
-      oauth: {
-        clientMetadataUrl?: string
-        authorizationServerUrl?: string
-        clientId?: string
-        redirectUri?: string
-        scopes?: string[]
-        clientSecret?: string
-      }
-    }
-export type CredentialView = {
+
+export type DeviceCredentialKind = 'api_key' | 'token' | 'oauth'
+
+export type DeviceOAuthTransport = Extract<CustomServerTransport, 'streamable_http' | 'sse'>
+
+export type DeviceOAuthRegistration = {
+  clientMetadataUrl?: string
+  authorizationServerUrl?: string
+  scopes?: string[]
+  clientId?: string
+  redirectUri?: string
+}
+
+export type DeviceCredentialView = {
   id: string
   displayName: string
-  kind: 'api_key' | 'token' | 'oauth'
+  kind: DeviceCredentialKind
   status: 'stored' | 'connected' | 'disconnected'
   needsSecret: boolean
+  resourceUri?: string
+  transport?: DeviceOAuthTransport
+  oauth?: DeviceOAuthRegistration
+  hasClientSecret?: boolean
+  // Derived separately from unreadable OAuth login state; never persisted.
+  needsClientSecret?: boolean
   consumerCount: number
   consumerNames: string[]
   createdAt: number
   updatedAt: number
-  resourceUri?: string
-  transport?: 'streamable_http' | 'sse'
-  hasClientSecret?: boolean
-  needsClientSecret?: boolean
 }
-export type CredentialsSnapshot = { credentials: CredentialView[] }
+
+export type DeviceCredentialsSnapshot = { credentials: DeviceCredentialView[] }
+
+export type CreateDeviceCredentialResult = {
+  // Missing when creation committed but the full consumer projection could not be read.
+  credentials?: DeviceCredentialView[]
+  createdCredential: DeviceCredentialView
+}
+
+export type CreateDeviceCredentialRequest =
+  | { displayName: string; kind: 'api_key' | 'token'; secret: string }
+  | {
+      displayName: string
+      kind: 'oauth'
+      resourceUri: string
+      transport: DeviceOAuthTransport
+      oauth: DeviceOAuthRegistration & {
+        clientSecret?: string
+      }
+    }
+
+export type UpdateDeviceCredentialRequest = {
+  id: string
+  displayName?: string
+  secret?: string
+}
+
+export type AddCustomServerRequest = {
+  // Optional immutable local ID. Omission lets main infer one from `name` and fall back to a UUID.
+  id?: string
+  name: string
+  displayName: string
+  description?: string
+  transport: CustomServerTransport
+  command?: string
+  args?: string[]
+  envCredentialIds?: Record<string, string>
+  url?: string
+  headerCredentialIds?: Record<string, string>
+  oauthCredentialId?: string
+  // Non-secret registration requirements checked against a selected shared OAuth credential.
+  // They are validation input only and are not persisted on the Connector.
+  oauthRequirements?: DeviceOAuthRegistration
+  // Request-only marker from an imported template. Main validates the selected shared credential;
+  // the marker is never persisted on the Connector.
+  requiresOAuthClientSecret?: boolean
+}
+
+export type UpdateCustomServerRequest = {
+  id: string
+  displayName?: string
+  description?: string
+  transport: CustomServerTransport
+  command?: string
+  // Omitted keeps saved args while staying on stdio; [] explicitly clears them.
+  args?: string[]
+  env?: Record<string, string>
+  envCredentialIds?: Record<string, string>
+  url?: string
+  headers?: Record<string, string>
+  headerCredentialIds?: Record<string, string>
+  // Omitted retains the current shared OAuth binding; a value selects or replaces it.
+  oauthCredentialId?: string
+  oauth?: {
+    clientMetadataUrl?: string
+    authorizationServerUrl?: string
+    scopes?: string[]
+    clientId?: string
+    redirectUri?: string
+    // Omitted keeps the stored secret; null explicitly removes it.
+    clientSecret?: string | null
+  } | null
+}
+
+export type ConnectorTransport = CustomServerTransport
+export type ConnectorConfiguration = Omit<UpdateCustomServerRequest, 'id'>
+export type ConnectorTestResult = { success: boolean; toolCount?: number; message: string }
+export type CredentialInput = CreateDeviceCredentialRequest
+export type CredentialView = DeviceCredentialView
+export type CredentialsSnapshot = DeviceCredentialsSnapshot
 
 export type PermissionProfile = 'ask' | 'auto' | 'full'
 export type DelegationPolicy = 'allow' | 'deny'
@@ -343,14 +458,17 @@ export class OpenScienceClient {
   })
   health(options?: RequestOptions): Promise<unknown>
   listConnectors(options?: RequestOptions): Promise<ConnectorsSnapshot>
-  getConnector(id: string, options?: RequestOptions): Promise<ConnectorView>
+  getConnector(
+    id: string,
+    options?: RequestOptions
+  ): Promise<ConnectorDetailView | CustomServerView>
   setConnectorEnabled(
     id: string,
     enabled: boolean,
     options?: RequestOptions
   ): Promise<ConnectorsSnapshot>
   addConnector(
-    request: ConnectorConfiguration & { name: string; displayName: string; id?: string },
+    request: AddCustomServerRequest,
     options?: RequestOptions
   ): Promise<ConnectorsSnapshot>
   updateConnector(
@@ -364,7 +482,7 @@ export class OpenScienceClient {
   createCredential(
     request: CredentialInput,
     options?: RequestOptions
-  ): Promise<{ createdCredential: CredentialView; credentials?: CredentialView[] }>
+  ): Promise<CreateDeviceCredentialResult>
   updateCredential(
     id: string,
     request: { displayName?: string; secret?: string },

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -179,6 +179,67 @@ export class OpenScienceClient {
     )
   }
 
+  listConnectors(options) {
+    return this.request(`/api/v1/connectors`, { ...options, method: 'GET' })
+  }
+
+  getConnector(id, options) {
+    return this.request(`/api/v1/connectors/${encodeURIComponent(id)}`, {
+      ...options,
+      method: 'GET'
+    })
+  }
+
+  setConnectorEnabled(id, enabled, options) {
+    return this.request(`/api/v1/connectors/${encodeURIComponent(id)}/enabled`, {
+      ...options,
+      method: 'PUT',
+      body: { enabled }
+    })
+  }
+
+  addConnector(request, options) {
+    return this.request(`/api/v1/connectors`, { ...options, method: 'POST', body: request })
+  }
+
+  updateConnector(id, request, options) {
+    return this.request(`/api/v1/connectors/${encodeURIComponent(id)}`, {
+      ...options,
+      method: 'PATCH',
+      body: request
+    })
+  }
+
+  removeConnector(id, options) {
+    return this.request(`/api/v1/connectors/${encodeURIComponent(id)}`, {
+      ...options,
+      method: 'DELETE'
+    })
+  }
+
+  testConnector(id, options) {
+    return this.request(`/api/v1/connectors/${encodeURIComponent(id)}/test`, {
+      ...options,
+      method: 'POST'
+    })
+  }
+
+  listCredentials(options) {
+    return this.request(`/api/v1/credentials`, { ...options, method: 'GET' })
+  }
+
+  createCredential(request, options) {
+    return this.request(`/api/v1/credentials`, { ...options, method: 'POST', body: request })
+  }
+
+  updateCredential(id, request, options) {
+    return this.request(`/api/v1/credentials/${encodeURIComponent(id)}`, {
+      ...options,
+      method: 'PATCH',
+      body: request
+    })
+  }
+
   listProjects(options) {
     return this.request('/api/v1/projects', options)
   }

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -289,10 +289,22 @@ describe('application command composition', () => {
     expect(composition.task.commandNames()).not.toContain('reviewer:abort-fix-loop')
   })
 
-  it('exposes only the twenty-one Task commands and no transport-wide capability', async () => {
+  it('exposes only the explicit Task commands and no transport-wide capability', async () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
+      'settings:list-connectors',
+      'settings:get-connector-detail',
+      'settings:set-connector-enabled',
+      'settings:set-custom-server-enabled',
+      'settings:add-custom-server',
+      'settings:update-custom-server',
+      'settings:remove-custom-server',
+      'settings:test-custom-server',
+      'settings:list-device-credentials',
+      'settings:create-device-credential',
+      'settings:update-device-credential',
+
       'projects:list',
       'projects:create',
       'projects:update',
@@ -565,4 +577,20 @@ describe('application command composition', () => {
     ])
     expect(listProjects).toHaveBeenCalledTimes(2)
   })
+})
+
+it('routes Task Connector reads to the existing Settings owner without adding Web diagnostics', async () => {
+  const snapshot = { connectors: [], customServers: [], ncbi: { hasApiKey: false } }
+  const listConnectors = vi.fn(async () => snapshot)
+  const composition = createApplicationCommandComposition({
+    ...dependencies(),
+    settingsCore: { service: { listConnectors } } as never
+  })
+  await expect(composition.task.invoke('settings:list-connectors', invocation())).resolves.toEqual(
+    snapshot
+  )
+  expect(listConnectors).toHaveBeenCalledOnce()
+  expect(composition.localWeb.commandNames()).not.toContain('settings:test-custom-server')
+  expect(composition.remoteWeb.commandNames()).not.toContain('settings:test-custom-server')
+  composition.dispose()
 })

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -142,6 +142,7 @@ const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
 ])
 
 const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
+  'settings:test-custom-server',
   'projects:update-session-defaults',
   'reviewer:abort',
   'settings:set-agent-routing',
@@ -152,6 +153,18 @@ const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
 ])
 
 const TASK_COMMAND_NAMES = Object.freeze([
+  'settings:list-connectors',
+  'settings:get-connector-detail',
+  'settings:set-connector-enabled',
+  'settings:set-custom-server-enabled',
+  'settings:add-custom-server',
+  'settings:update-custom-server',
+  'settings:remove-custom-server',
+  'settings:test-custom-server',
+  'settings:list-device-credentials',
+  'settings:create-device-credential',
+  'settings:update-device-credential',
+
   'projects:list',
   'projects:create',
   'projects:update',

--- a/src/main/settings/integration-application-commands.test.ts
+++ b/src/main/settings/integration-application-commands.test.ts
@@ -46,6 +46,7 @@ const expectedSkillChannels = [
 ] as const
 
 const expectedConnectorChannels = [
+  'settings:test-custom-server',
   'settings:list-device-credentials',
   'settings:create-device-credential',
   'settings:update-device-credential',
@@ -151,7 +152,7 @@ const createDependencies = (): Readonly<{
 }
 
 describe('Settings integration application commands', () => {
-  it('defines the exact 36-command Skill, Connector, and approval inventory', () => {
+  it('defines the exact 37-command Skill, Connector, and approval inventory', () => {
     const groups = [
       settingsSkillApplicationCommandGroup,
       settingsConnectorApplicationCommandGroup,
@@ -185,12 +186,12 @@ describe('Settings integration application commands', () => {
     expect(settingsApprovalApplicationCommandGroup.commands.map((command) => command.name)).toEqual(
       expectedApprovalChannels
     )
-    expect(groups.reduce((count, group) => count + group.commands.length, 0)).toBe(36)
+    expect(groups.reduce((count, group) => count + group.commands.length, 0)).toBe(37)
     expect(router.dispatcher.commandNames()).toEqual([...expectedChannels].sort())
     expect(settingsChannels).toEqual(
       expect.arrayContaining([
         ...expectedSkillChannels,
-        ...expectedConnectorChannels,
+        ...expectedConnectorChannels.filter((channel) => channel !== 'settings:test-custom-server'),
         ...expectedApprovalChannels
       ])
     )
@@ -594,6 +595,13 @@ describe('Settings integration application commands', () => {
         )
       )
     ).rejects.toThrow('Channel only available from the local app: settings:retry-custom-server')
+
+    await expect(
+      router.dispatcher.invoke(
+        settingsIntegrationApplicationCommands.testCustomServer,
+        invocation([{ id: 'server-1' }] as const, createTaskCallerContext({ location: 'remote' }))
+      )
+    ).rejects.toThrow('Channel only available from the local app: settings:test-custom-server')
 
     await expect(
       router.dispatcher.invoke(

--- a/src/main/settings/integration-application-commands.ts
+++ b/src/main/settings/integration-application-commands.ts
@@ -53,6 +53,7 @@ type ConnectorIntegrationWorkflows = Pick<
   | 'disconnectCustomServer'
   | 'retryConnectorProjection'
   | 'retryCustomServer'
+  | 'testCustomServer'
 >
 
 type OwnerArgs<Owner, Method extends keyof Owner> = Owner[Method] extends (
@@ -74,6 +75,11 @@ const requireLocalCaller = (context: CallerContext, channel: string): void => {
 }
 
 const settingsIntegrationApplicationCommands = Object.freeze({
+  testCustomServer: defineApplicationCommand<
+    'settings:test-custom-server',
+    OwnerArgs<ConnectorIntegrationWorkflows, 'testCustomServer'>,
+    OwnerResult<ConnectorIntegrationWorkflows, 'testCustomServer'>
+  >('settings:test-custom-server'),
   listDeviceCredentials: defineApplicationCommand<
     'settings:list-device-credentials',
     OwnerArgs<ConnectorIntegrationWorkflows, 'listDeviceCredentials'>,
@@ -271,6 +277,7 @@ const settingsSkillApplicationCommandGroup = defineApplicationCommandGroup('sett
 const settingsConnectorApplicationCommandGroup = defineApplicationCommandGroup(
   'settings-connectors',
   [
+    settingsIntegrationApplicationCommands.testCustomServer,
     settingsIntegrationApplicationCommands.listDeviceCredentials,
     settingsIntegrationApplicationCommands.createDeviceCredential,
     settingsIntegrationApplicationCommands.updateDeviceCredential,
@@ -340,6 +347,10 @@ const registerIntegrationSettingsApplicationCommands = (
         dependencies.skills.importSkillZipBatch(args[0])
     })
     scope.registerGroup(settingsConnectorApplicationCommandGroup, {
+      'settings:test-custom-server': ({ args, callerContext, callerLease }) => {
+        requireLocalCaller(callerContext, 'settings:test-custom-server')
+        return dependencies.connectors.testCustomServer(args[0], callerLease.signal)
+      },
       'settings:list-device-credentials': ({ callerContext }) => {
         requireLocalCaller(callerContext, 'settings:list-device-credentials')
         return dependencies.connectors.listDeviceCredentials()

--- a/src/main/settings/workflows/connectors-diagnostic.test.ts
+++ b/src/main/settings/workflows/connectors-diagnostic.test.ts
@@ -1,0 +1,154 @@
+import { createServer } from 'node:http'
+import { randomUUID } from 'node:crypto'
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { SSEServerTransport } from '@modelcontextprotocol/sdk/server/sse.js'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  ConnectorSettingsWorkflows,
+  type ConnectorSettingsWorkflowStore,
+  type ConnectorSettingsWorkflowEffects
+} from './connectors'
+
+const serverScript = `
+const readline = require('node:readline');
+readline.createInterface({ input: process.stdin }).on('line', line => {
+  const request = JSON.parse(line);
+  if (!('id' in request)) return;
+  let result;
+  if (request.method === 'initialize') result = { protocolVersion: '2024-11-05', capabilities: { tools: {} }, serverInfo: { name: 'fixture', version: '1' } };
+  else if (request.method === 'tools/list') result = { tools: [{ name: 'example', inputSchema: { type: 'object' } }] };
+  else process.exit(42);
+  process.stdout.write(JSON.stringify({ jsonrpc: '2.0', id: request.id, result }) + '\\n');
+});`
+
+const makeWorkflow = (
+  command: string,
+  args: string[]
+): {
+  workflow: ConnectorSettingsWorkflows
+  getConnectors: () => Promise<{ customMcpServers: Array<{ enabled: boolean }> }>
+} => {
+  const getConnectors = vi.fn(async () => ({
+    customMcpServers: [
+      {
+        id: 'fixture',
+        name: 'fixture',
+        displayName: 'Fixture',
+        transport: 'stdio',
+        command,
+        args,
+        enabled: false
+      }
+    ]
+  }))
+  const workflow = new ConnectorSettingsWorkflows(
+    {
+      getConnectors,
+      saveCustomServerOAuthState: vi.fn()
+    } as unknown as ConnectorSettingsWorkflowStore,
+    {} as ConnectorSettingsWorkflowEffects
+  )
+  return { workflow, getConnectors }
+}
+
+describe('Connector diagnostics', () => {
+  it('discovers real stdio tools without enabling the disabled Connector', async () => {
+    const { workflow, getConnectors } = makeWorkflow(process.execPath, ['-e', serverScript])
+    await expect(workflow.testCustomServer({ id: 'fixture' })).resolves.toMatchObject({
+      success: true,
+      toolCount: 1
+    })
+    expect((await getConnectors()).customMcpServers[0].enabled).toBe(false)
+  })
+
+  it('reports an exited server as a diagnostic failure', async () => {
+    const { workflow } = makeWorkflow(process.execPath, ['-e', 'process.exit(1)'])
+    await expect(workflow.testCustomServer({ id: 'fixture' })).resolves.toMatchObject({
+      success: false
+    })
+  })
+
+  it('does not pretend a missing or bundled Connector was tested', async () => {
+    const { workflow } = makeWorkflow(process.execPath, [])
+    await expect(workflow.testCustomServer({ id: 'unknown' })).resolves.toMatchObject({
+      success: false
+    })
+  })
+})
+
+it('honors cancellation before starting a probe', async () => {
+  const { workflow } = makeWorkflow(process.execPath, ['-e', 'setInterval(() => {}, 1000)'])
+  const controller = new AbortController()
+  const pending = workflow.testCustomServer({ id: 'fixture' }, controller.signal)
+  controller.abort()
+  await expect(pending).resolves.toMatchObject({ success: false })
+})
+
+it.each(['streamable_http', 'sse'] as const)(
+  'discovers tools through real %s transport',
+  async (transportKind) => {
+    const mcp = new McpServer({ name: 'diagnostic-fixture', version: '1' })
+    const call = vi.fn(async () => ({ content: [] }))
+    mcp.registerTool('example', { inputSchema: {} }, call)
+    let transport: StreamableHTTPServerTransport | SSEServerTransport
+    const server = createServer(async (request, response) => {
+      try {
+        if (transportKind === 'streamable_http') {
+          await (transport as StreamableHTTPServerTransport).handleRequest(request, response)
+        } else if (request.method === 'GET') {
+          transport = new SSEServerTransport('/messages', response)
+          await mcp.connect(transport)
+        } else {
+          await (transport as SSEServerTransport).handlePostMessage(request, response)
+        }
+      } catch {
+        response.writeHead(500).end()
+      }
+    })
+    if (transportKind === 'streamable_http') {
+      transport = new StreamableHTTPServerTransport({ sessionIdGenerator: () => randomUUID() })
+      await mcp.connect(transport)
+    }
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const address = server.address() as { port: number }
+    const workflow = new ConnectorSettingsWorkflows(
+      {
+        getConnectors: async () => ({
+          customMcpServers: [
+            {
+              id: 'remote',
+              name: 'remote',
+              displayName: 'Remote',
+              enabled: false,
+              transport: transportKind,
+              url: `http://127.0.0.1:${address.port}/mcp`
+            }
+          ]
+        }),
+        saveCustomServerOAuthState: vi.fn()
+      } as unknown as ConnectorSettingsWorkflowStore,
+      {} as ConnectorSettingsWorkflowEffects
+    )
+    try {
+      expect(await workflow.testCustomServer({ id: 'remote' })).toMatchObject({
+        success: true,
+        toolCount: 1
+      })
+      expect(call).not.toHaveBeenCalled()
+    } finally {
+      await mcp.close()
+      server.closeAllConnections()
+      await new Promise<void>((resolve) => server.close(() => resolve()))
+    }
+  },
+  15_000
+)
+
+it('bounds a stalled stdio server by the diagnostic timeout', async () => {
+  const { workflow } = makeWorkflow(process.execPath, ['-e', 'setInterval(() => {}, 1000)'])
+  await expect(workflow.testCustomServer({ id: 'fixture' })).resolves.toEqual({
+    success: false,
+    message: 'MCP connection timed out.'
+  })
+}, 15_000)

--- a/src/main/settings/workflows/connectors.ts
+++ b/src/main/settings/workflows/connectors.ts
@@ -1,3 +1,10 @@
+import { McpClientManager } from '../../connectors/mcp-client-manager'
+import {
+  classifyCustomMcpFailure,
+  hasUsableCustomMcpCredentials,
+  isCustomMcpServerRouteSafe,
+  toCustomMcpConfig
+} from '../../connectors/custom-mcp-bootstrap'
 import type {
   AuthenticateCustomServerRequest,
   CreateDeviceCredentialRequest,
@@ -22,6 +29,7 @@ import type { SettingsService } from '../service'
 type ConnectorSettingsWorkflowStore = Pick<
   SettingsService,
   | 'getConnectors'
+  | 'saveCustomServerOAuthState'
   | 'listConnectors'
   | 'listDeviceCredentials'
   | 'deviceCredentialConsumerIds'
@@ -70,6 +78,56 @@ class ConnectorSettingsWorkflows {
     private readonly settings: ConnectorSettingsWorkflowStore,
     private readonly effects: ConnectorSettingsWorkflowEffects
   ) {}
+
+  async testCustomServer(
+    request: { id: string },
+    callerSignal?: AbortSignal
+  ): Promise<{ success: boolean; toolCount?: number; message: string }> {
+    const servers = (await this.settings.getConnectors())?.customMcpServers ?? []
+    const server = servers.find((item) => item.id === request.id)
+    if (!server)
+      return {
+        success: false,
+        message:
+          'Diagnostics require an existing custom MCP Connector. Bundled Connector live tests are not supported.'
+      }
+    if (!isCustomMcpServerRouteSafe(server, servers))
+      return { success: false, message: 'Connector configuration is invalid.' }
+    if (!hasUsableCustomMcpCredentials(server))
+      return {
+        success: false,
+        message:
+          'Connector credentials are unavailable. Re-enter them using secure credential storage.'
+      }
+    // A probe must not reset or populate the shared runtime client cache.
+    const manager = new McpClientManager({
+      saveOAuthState: (id, state, fingerprint, secretRef) =>
+        this.settings.saveCustomServerOAuthState(id, state, fingerprint, secretRef)
+    })
+    const timeout = AbortSignal.timeout(10_000)
+    const signal = callerSignal ? AbortSignal.any([callerSignal, timeout]) : timeout
+    try {
+      const tools = await manager.listTools(toCustomMcpConfig(server), signal)
+      return {
+        success: true,
+        toolCount: tools.length,
+        message: 'MCP connection and tool discovery succeeded. Business tools were not executed.'
+      }
+    } catch (error) {
+      return {
+        success: false,
+        message: callerSignal?.aborted
+          ? 'MCP diagnostic cancelled.'
+          : signal.aborted
+            ? 'MCP connection timed out.'
+            : classifyCustomMcpFailure(error) === 'unauthenticated'
+              ? 'MCP authentication failed. Authenticate the existing credential before retrying.'
+              : 'MCP connection or tool discovery failed. Check the command, endpoint, and credentials.'
+      }
+    } finally {
+      await manager.closeAll()
+    }
+  }
 
   async setConnectorEnabled(
     request: SetConnectorEnabledRequest

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1,3 +1,5 @@
+// @ts-expect-error The published ESM entry uses a sibling index.d.ts.
+import { OpenScienceClient } from '../../../packages/open-science/index.mjs'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { request as httpRequest, type IncomingMessage, ServerResponse } from 'node:http'
 import { connect } from 'node:net'
@@ -35,7 +37,7 @@ import {
   type ExternalWebAccessAuthorization,
   type RunningWebServer
 } from './http-server'
-import { TaskApiError } from './task-api'
+import { HeadlessTaskApi, TaskApiError } from './task-api'
 import { ManagedPreviewResources } from '../managed-preview-resources'
 import { createManagedPreviewOwnerRegistry } from '../managed-preview-ipc'
 import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
@@ -4488,5 +4490,63 @@ describe('Web preview reconnect owner contract', () => {
     } finally {
       for (const socket of sockets) socket.close()
     }
+  })
+})
+
+describe('Connector Task HTTP routes', () => {
+  it('routes authenticated SDK reads and writes to the same Settings snapshot', async () => {
+    const snapshot = {
+      connectors: [],
+      customServers: [
+        {
+          id: 'sample',
+          name: 'sample',
+          displayName: 'Sample',
+          transport: 'stdio',
+          command: 'node',
+          enabled: false
+        }
+      ],
+      ncbi: { hasApiKey: false }
+    }
+    const invoke = vi.fn(async (channel: string, invocation: { args: readonly unknown[] }) => {
+      if (channel === 'settings:set-custom-server-enabled')
+        snapshot.customServers[0].enabled = (invocation.args[0] as { enabled: boolean }).enabled
+      return snapshot
+    })
+    const tasks = new HeadlessTaskApi({
+      commands: { commandNames: () => [], invoke },
+      agent: {} as never
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      tasks,
+      rpc: { channels: () => [], invoke: vi.fn() },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: 'test',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+    const baseUrl = `http://127.0.0.1:${server.port}`
+    expect((await fetch(`${baseUrl}/api/v1/connectors`)).status).toBe(401)
+    const client = new OpenScienceClient({ baseUrl, token: 'test-token' })
+    expect((await client.listConnectors()).customServers[0].enabled).toBe(false)
+    await client.setConnectorEnabled('sample', true)
+    expect((await client.getConnector('sample')).enabled).toBe(true)
+    expect(invoke).toHaveBeenCalledWith(
+      'settings:set-custom-server-enabled',
+      expect.objectContaining({
+        args: [{ id: 'sample', enabled: true }],
+        callerContext: expect.objectContaining({ surface: 'task', location: 'local' })
+      })
+    )
+    await tasks.dispose()
   })
 })

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -156,6 +156,16 @@ type WebServerOptions = {
         | 'updateProjectSessionDefaults'
         | 'getSessionConfiguration'
         | 'updateSessionConfiguration'
+        | 'listConnectors'
+        | 'getConnector'
+        | 'setConnectorEnabled'
+        | 'addConnector'
+        | 'updateConnector'
+        | 'removeConnector'
+        | 'testConnector'
+        | 'listCredentials'
+        | 'createCredential'
+        | 'updateCredential'
         | 'getAgentRouting'
         | 'updateAgentRouting'
       >
@@ -977,6 +987,70 @@ const handleTaskApiRequest = async (
   tasks.runWithCallerContext(callerContext, async () => {
     try {
       await waitUntilTasksReady?.()
+      const connectorMatch = url.pathname.match(
+        /^\/api\/v1\/connectors(?:\/([^/]+)(?:\/(enabled|test))?)?$/
+      )
+      const credentialMatch = url.pathname.match(/^\/api\/v1\/credentials(?:\/([^/]+))?$/)
+      if (connectorMatch || credentialMatch) {
+        const match = connectorMatch ?? credentialMatch!
+        const id = match[1] ? decodeURIComponent(match[1]) : undefined
+        const action = match[2]
+        let body: unknown
+        if (['POST', 'PATCH', 'PUT'].includes(request.method ?? '') && action !== 'test') {
+          body = await readJsonBody(
+            request,
+            response,
+            requestBodyBudgetRegistry,
+            requestBodyClientId
+          )
+          if (!body || typeof body !== 'object' || Array.isArray(body)) {
+            throw new TaskApiError('invalid_request', 'Configuration must be a JSON object.')
+          }
+        }
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        let operation: (() => Promise<unknown>) | undefined
+        if (connectorMatch) {
+          if (!id && request.method === 'GET' && tasks.listConnectors)
+            operation = () => tasks.listConnectors!()
+          else if (!id && request.method === 'POST' && tasks.addConnector)
+            operation = () =>
+              tasks.addConnector!(body as Parameters<HeadlessTaskApi['addConnector']>[0])
+          else if (id && !action && request.method === 'GET' && tasks.getConnector)
+            operation = () => tasks.getConnector!(id)
+          else if (id && !action && request.method === 'PATCH' && tasks.updateConnector)
+            operation = () =>
+              tasks.updateConnector!(id, body as Parameters<HeadlessTaskApi['updateConnector']>[1])
+          else if (id && !action && request.method === 'DELETE' && tasks.removeConnector)
+            operation = () => tasks.removeConnector!(id)
+          else if (
+            id &&
+            action === 'enabled' &&
+            request.method === 'PUT' &&
+            tasks.setConnectorEnabled
+          )
+            operation = () => tasks.setConnectorEnabled!(id, (body as { enabled: boolean }).enabled)
+          else if (id && action === 'test' && request.method === 'POST' && tasks.testConnector)
+            operation = () => tasks.testConnector!(id)
+        } else {
+          if (!id && request.method === 'GET' && tasks.listCredentials)
+            operation = () => tasks.listCredentials!()
+          else if (!id && request.method === 'POST' && tasks.createCredential)
+            operation = () =>
+              tasks.createCredential!(body as Parameters<HeadlessTaskApi['createCredential']>[0])
+          else if (id && request.method === 'PATCH' && tasks.updateCredential)
+            operation = () =>
+              tasks.updateCredential!(
+                id,
+                body as Parameters<HeadlessTaskApi['updateCredential']>[1]
+              )
+        }
+        if (operation) {
+          const data = await operation()
+          assertExternalAuthorizationCurrent(externalAuthorization)
+          json(response, 200, { data })
+          return true
+        }
+      }
       if (url.pathname === '/api/v1/projects' && request.method === 'GET') {
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, { data: await tasks.listProjects() })

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -1548,3 +1548,66 @@ describe('HeadlessTaskApi adapter', () => {
     await api.runWithCallerContext(context, () => api.cancelRun(run.id))
   })
 })
+
+describe('Connector management through Task API', () => {
+  const snapshot = {
+    connectors: [{ id: 'bundled', enabled: true }],
+    customServers: [{ id: 'custom', enabled: false, transport: 'stdio', command: 'node' }],
+    ncbi: { hasApiKey: false }
+  }
+  it('shares Connector reads and mutations with Settings command owners', async () => {
+    const invoke = vi.fn(async () => snapshot)
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+    expect(await api.listConnectors()).toEqual(snapshot)
+    expect(await api.getConnector('custom')).toEqual(snapshot.customServers[0])
+    await api.setConnectorEnabled('custom', true)
+    expect(invoke).toHaveBeenCalledWith('settings:set-custom-server-enabled', taskCallerContext(), [
+      { id: 'custom', enabled: true }
+    ])
+    await api.setConnectorEnabled('bundled', false)
+    expect(invoke).toHaveBeenCalledWith('settings:set-connector-enabled', taskCallerContext(), [
+      { id: 'bundled', enabled: false }
+    ])
+    await api.updateConnector('custom', { transport: 'stdio', args: [] })
+    expect(invoke).toHaveBeenCalledWith('settings:update-custom-server', taskCallerContext(), [
+      { id: 'custom', transport: 'stdio', args: [] }
+    ])
+    await api.removeConnector('custom')
+    expect(invoke).toHaveBeenCalledWith('settings:remove-custom-server', taskCallerContext(), [
+      { id: 'custom' }
+    ])
+  })
+
+  it('rejects remote mutation before accessing configuration', async () => {
+    const invoke = vi.fn(async () => snapshot)
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+    await expect(
+      api.runWithCallerContext(createTaskCallerContext({ location: 'remote' }), () =>
+        api.updateConnector('custom', { transport: 'stdio' })
+      )
+    ).rejects.toThrow('local')
+    expect(invoke).not.toHaveBeenCalled()
+  })
+
+  it('does not forward secret-bearing failure messages', async () => {
+    const invoke = vi.fn(async () => {
+      throw new Error('bad secret=do-not-print')
+    })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+    await expect(
+      api.createCredential({ kind: 'token', displayName: 'A', secret: 'do-not-print' })
+    ).rejects.toThrow('Credential operation failed')
+  })
+})
+
+it('preserves the safe saved-but-refresh-failed outcome for credential updates', async () => {
+  const message =
+    'Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.'
+  const api = new HeadlessTaskApi({
+    commands: commandsFrom(async () => {
+      throw new Error(message)
+    }),
+    agent: createAgent()
+  })
+  await expect(api.updateCredential('credential', { secret: 'private' })).rejects.toThrow(message)
+})

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -10,7 +10,18 @@ import type { Project } from '../../shared/projects'
 import type { ReviewRunResult, ReviewWithChecks } from '../../shared/reviewer'
 import type { ActivePlanProjection, PlanResponseCommand } from '../../shared/session-plan/contract'
 import type { PersistedArtifact, PersistedChatSession } from '../../shared/session-persistence'
-import type { SettingsSnapshot } from '../../shared/settings'
+import type {
+  AddCustomServerRequest,
+  UpdateCustomServerRequest,
+  ConnectorsSnapshot,
+  ConnectorDetailView,
+  CustomServerView,
+  CreateDeviceCredentialRequest,
+  UpdateDeviceCredentialRequest,
+  DeviceCredentialsSnapshot,
+  CreateDeviceCredentialResult,
+  SettingsSnapshot
+} from '../../shared/settings'
 import type {
   AcquiredTaskArtifact,
   CreateTaskProjectRequest,
@@ -254,6 +265,98 @@ class HeadlessTaskApi {
     request: UpdateProjectSessionDefaultsRequest
   ): Promise<TaskProjectSessionDefaults> {
     return this.runner.updateProjectSessionDefaults(projectId, request)
+  }
+
+  async listConnectors(): Promise<ConnectorsSnapshot> {
+    return this.invoke('settings:list-connectors') as Promise<ConnectorsSnapshot>
+  }
+
+  async getConnector(id: string): Promise<ConnectorDetailView | CustomServerView> {
+    const snapshot = await this.listConnectors()
+    const custom = snapshot.customServers.find((item) => item.id === id)
+    if (custom) return custom
+    if (!snapshot.connectors.some((item) => item.id === id)) {
+      throw new TaskRunnerError('invalid_request', 'Unknown Connector ID.')
+    }
+    return this.invoke('settings:get-connector-detail', id) as Promise<ConnectorDetailView>
+  }
+
+  async setConnectorEnabled(id: string, enabled: boolean): Promise<ConnectorsSnapshot> {
+    this.requireLocalConnectorCaller()
+    if (typeof enabled !== 'boolean')
+      throw new TaskRunnerError('invalid_request', 'enabled must be a boolean.')
+    const snapshot = await this.listConnectors()
+    const custom = snapshot.customServers.some((item) => item.id === id)
+    if (!custom && !snapshot.connectors.some((item) => item.id === id)) {
+      throw new TaskRunnerError('invalid_request', 'Unknown Connector ID.')
+    }
+    return this.connectorOperation(
+      custom ? 'settings:set-custom-server-enabled' : 'settings:set-connector-enabled',
+      { id, enabled }
+    )
+  }
+
+  addConnector(request: AddCustomServerRequest): Promise<ConnectorsSnapshot> {
+    return this.connectorOperation('settings:add-custom-server', request)
+  }
+
+  updateConnector(
+    id: string,
+    request: Omit<UpdateCustomServerRequest, 'id'>
+  ): Promise<ConnectorsSnapshot> {
+    return this.connectorOperation('settings:update-custom-server', { ...request, id })
+  }
+
+  removeConnector(id: string): Promise<ConnectorsSnapshot> {
+    return this.connectorOperation('settings:remove-custom-server', { id })
+  }
+
+  testConnector(id: string): Promise<{ success: boolean; toolCount?: number; message: string }> {
+    return this.connectorOperation('settings:test-custom-server', { id })
+  }
+
+  listCredentials(): Promise<DeviceCredentialsSnapshot> {
+    return this.connectorOperation('settings:list-device-credentials')
+  }
+
+  createCredential(request: CreateDeviceCredentialRequest): Promise<CreateDeviceCredentialResult> {
+    return this.connectorOperation('settings:create-device-credential', request)
+  }
+
+  updateCredential(
+    id: string,
+    request: Omit<UpdateDeviceCredentialRequest, 'id'>
+  ): Promise<DeviceCredentialsSnapshot> {
+    return this.connectorOperation('settings:update-device-credential', { ...request, id })
+  }
+
+  private requireLocalConnectorCaller(): void {
+    if (this.currentCallerContext().location !== 'local') {
+      throw new TaskRunnerError(
+        'invalid_request',
+        'Connector and credential changes require a local connection.'
+      )
+    }
+  }
+
+  private async connectorOperation<Result>(channel: string, request?: unknown): Promise<Result> {
+    this.requireLocalConnectorCaller()
+    try {
+      return (await this.invoke(channel, ...(request === undefined ? [] : [request]))) as Result
+    } catch (error) {
+      // Provider errors can contain submitted credentials. Never forward their raw messages.
+      const message =
+        error instanceof Error &&
+        [
+          'Secure credential storage is unavailable. Unlock the system keychain and retry.',
+          'Credential changes were saved, but Connectors could not refresh. Retry from Settings > Connectors.'
+        ].includes(error.message)
+          ? error.message
+          : channel.includes('credential')
+            ? 'Credential operation failed. Check the input and system credential storage.'
+            : 'Connector operation failed. Check the ID, configuration, and credential bindings.'
+      throw new TaskRunnerError('invalid_configuration', message)
+    }
   }
 
   async getAgentRouting(): Promise<TaskAgentRouting> {


### PR DESCRIPTION
## Problem

Terminal and headless operators cannot inspect or maintain Connectors through the CLI. The public SDK has no Connector entry point. Closes #2287.

## Proposed change

Add `connector list/show/enable/disable/add/update/remove/test` and `credential list/add/update`, with JSON output. CLI writes read JSON from stdin; secrets stay in the existing OS-protected credential store and safe Settings projections. The SDK and authenticated Task HTTP routes invoke existing Settings command owners and their mutation/reload workflow. Explicit Task command inventories include the new capabilities; desktop/web capability inventories remain unchanged.

Custom MCP tests use a separate connection for bounded discovery over stdio, Streamable HTTP, or SSE. They never execute business tools, enable a Connector, or reset the shared active client. Cancellation and cleanup use the existing MCP manager. Errors return safe diagnostic categories. Real pipe coverage also fixes the existing stdin reader by using Node's stream consumer.

## Scope and non-goals

- No new database tables, persisted fields, status enums, credential format, history migration, or UI layout.
- Mutations write existing Settings/credential records. OAuth diagnostics can refresh existing encrypted token state. Existing unreadable credentials require re-entry; no plaintext fallback or historical-data rewrite.
- Custom Connector and credential operations require a local caller. This does not expand remote command execution or approval authority.
- `enabled` remains a Main selection preference, not a global Specialist-access revocation or health guarantee.
- No bundled-provider live health checks, first-time browserless OAuth flow, offline Settings writer, diagnostic history, or background monitoring.
- Existing agent refresh/retirement and subscription behavior is reused for Claude Code, OpenCode, Codex Responses, and Codex Bridge. No session/branch replay changes.

## Acceptance criteria and validation

Red/green evidence (local artifacts retained, not committed):

- Real CLI subprocesses: eight Connector commands failed twice with `Unknown command: connector` before implementation; now pass.
- SDK/CLI contract tests: missing methods/dispatch failed twice; now pass.
- Real HTTP: missing route returned `Task API endpoint not found` twice with the route implementation absent; restored route passes authenticated read/write integration.
- Diagnostic owner: missing method failed twice; now passes real stdio, Streamable HTTP, SSE, stalled-server timeout, cancellation, and disabled-state preservation.
- Actual piped credential JSON failed twice in the old stdin reader; the standard stream reader passes without echoing the secret.
- A saved-but-refresh-failed credential outcome was masked as an unsaved operation twice; the safe, explicit saved outcome is now retained.
- Composition tests detected the missing Task/native inventory wiring twice; explicit inventory and real Settings-owner dispatch now pass.

Independent review identified incomplete SDK declarations. A compiler-based contract test failed twice on the reviewed declarations; complete safe Connector/detail/credential and input types now pass exact contract equivalence. No runtime or persisted fields changed in this follow-up.

Final local Test Impact Set after the last material edit: **725 tests passed across 22 files**, zero failures/skips. No complete local `npm test` was run, per maintainer instruction.

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| CLI parsing, real stdin, SDK request/authentication/output and complete public types | `cli/connector-management.test.ts`; `packages/open-science/{connector,connector-types,client,cli}.test.ts` | Passed |
| HTTP authentication, Task dispatch, shared Settings snapshot | `src/main/web-service/{task-api,http-server}.test.ts` | Passed |
| Allowlisted capabilities and local-only diagnostic command | `src/main/application-command-composition.test.ts`; `src/main/settings/integration-application-commands.test.ts` | Passed |
| Settings writes, credential protection, mutation refresh | `src/main/settings/{workflows,connector-settings,device-credentials}.test.ts` | Passed |
| Real diagnostics, transport lifecycle, runtime projection | `src/main/settings/workflows/connectors-diagnostic.test.ts`; `src/main/connectors/{mcp-client-manager,runtime-settings-projection}.test.ts`; `src/main/connector-reload.test.ts` | Passed |
| Framework connection/retirement/resume consumers | `src/main/acp/{runtime-coordinator,connection-transition-owner,provider-session-creator,handler-workflows,session-resume-policy}.test.ts` | Passed |
| Import-cycle architecture | `src/main/runtime-import-cycle.architecture.test.ts` | Passed |
| Types / lint | `npm run typecheck:node` (includes Sandbox), `npm run typecheck:web`, `npm run lint`, `git diff --check` | Passed |

Each test group above was executed with the repository's installed `vitest run` and explicit file paths. Exact-head impact explain requests the full CI fallback because CLI.md overlaps CLI SDK and documentation ownership (the pre-commit plan also found an unowned new test). Do not change classifier ownership merely to bypass that fallback. PR Gate remains the final portable/platform verification authority.

Uncovered locally: native Windows/Linux vault behavior and real third-party OAuth/provider credentials. Cross-platform CI is required; no live provider calls or real user configuration were used. No screenshot applies because no page changed.

## Review focus

Check Task capability narrowing, credential-safe projections/errors, stdin handling, diagnostic teardown/token persistence, and reuse of Settings mutation effects. Independent PR review and exact-head CI are required before merge.
