### PR TITLE
fix(updater): handle multipart download response errors

### DIFF
--- a/patches/electron-updater+6.8.9.patch
+++ b/patches/electron-updater+6.8.9.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/electron-updater/out/differentialDownloader/multipleRangeDownloader.js b/node_modules/electron-updater/out/differentialDownloader/multipleRangeDownloader.js
+index 56adc38fe..79fd6e85b 100644
+--- a/node_modules/electron-updater/out/differentialDownloader/multipleRangeDownloader.js
++++ b/node_modules/electron-updater/out/differentialDownloader/multipleRangeDownloader.js
+@@ -74,6 +74,7 @@ function doExecuteTasks(differentialDownloader, options, out, resolve, reject) {
+     const requestOptions = differentialDownloader.createRequestOptions();
+     requestOptions.headers.Range = ranges.substring(0, ranges.length - 2);
+     const request = differentialDownloader.httpExecutor.createRequest(requestOptions, response => {
++        response.on("error", reject);
+         if (!checkIsRangesSupported(response, reject)) {
+             return;
+         }

--- a/src/main/update/multipart-response.test.ts
+++ b/src/main/update/multipart-response.test.ts
@@ -1,0 +1,63 @@
+import { createRequire } from 'node:module'
+import { EventEmitter } from 'node:events'
+import { PassThrough } from 'node:stream'
+
+import { expect, it, vi } from 'vitest'
+
+// Exercise the installed dependency, including our patch-package fix. The strategy's FakeUpdater
+// cannot reproduce an error emitted by Electron's response stream outside downloadUpdate's promise.
+const require = createRequire(import.meta.url)
+const {
+  executeTasksUsingMultipleRangeRequests
+} = require('electron-updater/out/differentialDownloader/multipleRangeDownloader')
+
+it('rejects a multipart download when its response resets instead of throwing a main-process exception', async () => {
+  const response = Object.assign(new PassThrough(), {
+    statusCode: 206,
+    headers: { 'content-type': 'multipart/byteranges; boundary=regression' }
+  })
+  const output = new PassThrough()
+  const request = Object.assign(new EventEmitter(), { end: vi.fn() })
+  let rejectDownload!: (error: Error) => void
+  const download = new Promise<void>((_resolve, reject) => {
+    rejectDownload = reject
+  })
+  const error = new Error('net::ERR_CONNECTION_RESET')
+  // Attach the assertion before delivering the asynchronous transport event.
+  const rejected = expect(download).rejects.toBe(error)
+  const downloader = {
+    createRequestOptions: () => ({ headers: {} }),
+    httpExecutor: {
+      createRequest: (_options: unknown, onResponse: (value: typeof response) => void) => {
+        request.end.mockImplementation(() => onResponse(response))
+        return request
+      },
+      addErrorAndTimeoutHandlers: (req: typeof request, reject: (error: Error) => void) =>
+        req.on('error', reject)
+    },
+    options: {}
+  }
+
+  try {
+    executeTasksUsingMultipleRangeRequests(
+      downloader,
+      [
+        { kind: 1, start: 0, end: 4 },
+        { kind: 1, start: 8, end: 12 }
+      ],
+      output,
+      -1,
+      rejectDownload
+    )(0)
+    // This event arrives after the response callback, just as SimpleURLLoaderWrapper emits it.
+    // Without the patch it throws this exact error and leaves the download promise pending.
+    expect(() => response.emit('error', error)).not.toThrow()
+    await rejected
+  } finally {
+    // Settle the assertion even on the red run, without letting a hung promise mask the real failure.
+    rejectDownload(error)
+    await rejected
+    response.destroy()
+    output.destroy()
+  }
+})


### PR DESCRIPTION
## Problem

A connection reset after a multipart differential-update response starts can escape as an uncaught
main-process exception (`net::ERR_CONNECTION_RESET` at `SimpleURLLoaderWrapper`) instead of settling
the download. Electron displays its fatal JavaScript error dialog and the normal full-download
fallback cannot run.

## Proposed change

Backport the one-line response error listener from
[electron-builder #10021](https://github.com/electron-userland/electron-builder/pull/10021) to the
locked electron-updater 6.8.9 using the existing patch-package postinstall mechanism. Add a regression
at the installed dependency's existing multipart boundary; it asserts that the response error does
not throw and that the download rejects with the original error.

## Scope and non-goals

Keep differential downloads, the existing full-download fallback, and existing error/retry UI.
No global exception swallowing, dependency upgrade, new test seam in production, fields, enums,
architecture, domain model, persisted format, migration, or historical-data compatibility changes.
Existing caches remain unchanged. No renderer/layout changes. Previously installed releases still
contain their old updater code until upgraded.

## Acceptance criteria and validation

Checks below ran after the last material edit. No complete local npm test run, per maintainer request.

| Behavior | Check | Result |
| --- | --- | --- |
| A multipart response reset rejects instead of escaping | `vitest run src/main/update/multipart-response.test.ts` | Stable red before fix: `Error: net::ERR_CONNECTION_RESET` thrown; green after fix |
| Actual Chromium transport failure | Local Electron 39.8.10 loopback server sends a partial multipart response then resets TCP | 3/3 uncaught before, 3/3 caught download rejection after; exact reported stack reproduced |
| Full updater recovery | Real `NsisUpdater.checkForUpdates()` and `downloadUpdate()` against the loopback fixture | Reset differential response falls back to one full request; downloaded bytes verified |
| Persistent outage | Same real updater fixture, also resetting the full response | Normal error event and rejected download; no uncaught exception |
| Existing update owner and consumers | Targeted Vitest: 9 main/update suites, shared/update, renderer update-store, UpdateDialog render/lifecycle and UpdateCapsule render | 14 files / 232 tests passed |
| Formatting and lint | `npm run lint`; `git diff --check` | Passed |
| Main types | `npm run typecheck:node` | Environment-blocked: shared generated Prisma client predates origin/main's contentBlob/literature models; CI must validate with freshly generated client |

<details>
<summary>Exact 232-test invocation from the worktree root</summary>

```powershell
node ../../node_modules/vitest/vitest.mjs run src/main/update/electron-updater-strategy.test.ts src/main/update/create-strategy.test.ts src/main/update/downloader.test.ts src/main/update/ipc.test.ts src/main/update/manifest.test.ts src/main/update/scheduler.test.ts src/main/update/service.test.ts src/main/update/service.save-dialog.test.ts src/main/update/strategy.test.ts src/shared/update.test.ts src/renderer/src/stores/update-store.test.ts src/renderer/src/components/UpdateDialog.render.test.tsx src/renderer/src/components/UpdateDialog.lifecycle.test.tsx src/renderer/src/components/UpdateCapsule.render.test.tsx --maxWorkers=4
```

</details>

Local dependency isolation: origin/main's lockfile differs from the main checkout. No Junction,
dependency download, or shared node_modules modification was made. The regression was first run
against the unpatched parent install, then run unchanged against an isolated copy after applying the
actual patch with `patch-package --error-on-fail`. Source and verification-copy SHA256 matched.
The other targeted suites used the existing parent Vitest binary directly, since npm pretest assumes
a local generated Prisma directory. The committed regression tests the installed patched dependency
in normal CI. Diagnostic fixtures and the temporary package copy are local-only.

Windows Electron runtime was exercised. The portable regression has no OS-specific paths or APIs;
macOS/Linux native execution and packaged installer execution were not performed locally. No
installer was started. PR CI remains authoritative for the clean dependency/typecheck and platform
lanes; skipped lanes are not evidence.

## Review focus

Confirm patch-package applies the pinned patch during CI/release installation, the regression
actually rejects through the response listener, and the existing fallback/retry boundaries remain
unchanged. Upstream repair is intentionally limited to the multipart response error listener.

## CI follow-up for b2c02a93b

Full portable tests (all three Ubuntu shards), module coverage, static checks including Node/Web
typechecking, Windows core, macOS build/E2E, Windows E2E shard 2, CodeQL and AI review passed.
CI's freshly generated Prisma client resolves the local typecheck environment limitation above.
Independent Standards and Spec reviews found no actionable issue; Spec review separately reproduced
the red/green regression and checked the fallback chain.

Windows E2E shard 1 initially failed fail-on-flaky: the existing message-revision persistence test
timed out while gracefully closing Electron for a restart (10 seconds), then passed its automatic
retry. It does not execute differential update downloads. Only that failed job and its dependent
gate were rerun in Actions run 34093846581, attempt 2. That rerun passed, including Windows E2E
shard 1 and the final PR Gate. All required checks for b2c02a93b are green; no test threshold or
gate was relaxed.
