### PR TITLE
fix(markdown): preserve literal source and enable table keyboard actions

### DIFF
--- a/src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.streaming.render.test.tsx
@@ -29,6 +29,21 @@ describe('AgentMarkdown streaming presentation', () => {
     container.remove()
   })
 
+  it('renders fenced alert examples as their original source text', async () => {
+    vi.useRealTimers()
+    const literal = '> [!NOTE]\n> This is literal example source.'
+    await act(async () => {
+      root.render(<PresentedAgentMarkdown content={'```markdown\n' + literal + '\n```'} />)
+    })
+    // Highlighted lines are separate elements, so textContent may omit their visual line breaks.
+    await vi.waitFor(() =>
+      expect(container.querySelector('pre')?.textContent?.replace(/\n/g, '')).toBe(
+        literal.replace(/\n/g, '')
+      )
+    )
+    expect(container.querySelector('pre')?.textContent).not.toContain('<aside')
+  })
+
   it('continues painting while target content grows faster than animation frames', async () => {
     await act(async () => {
       root.render(<AgentMarkdown content="流" isAnimating />)

--- a/src/renderer/src/components/streamdown/code-fence.test.ts
+++ b/src/renderer/src/components/streamdown/code-fence.test.ts
@@ -162,3 +162,12 @@ describe('createMarkdownPluginNeedsScanner', () => {
     expect(incremental('```')).toEqual(getMarkdownPluginNeeds('```'))
   })
 })
+
+it('finds a real chart after code containing a fence info string', () => {
+  const source = '```md\n```js\nconst value = 1\n```\n\n```mermaid\ngraph TD\n A --> B\n```'
+  expect(getMarkdownPluginNeeds(source)).toEqual({ code: true, mermaid: true })
+  const scan = createMarkdownPluginNeedsScanner()
+  for (let end = 1; end <= source.length; end += 1) {
+    expect(scan(source.slice(0, end))).toEqual(getMarkdownPluginNeeds(source.slice(0, end)))
+  }
+})

--- a/src/renderer/src/components/streamdown/code-fence.ts
+++ b/src/renderer/src/components/streamdown/code-fence.ts
@@ -91,7 +91,7 @@ const feedScanFence = (state: PluginNeedsScanState, line: string): boolean => {
   return state.fenceOpen
 }
 
-const scanPluginNeedsLine = (state: PluginNeedsScanState, rawLine: string): void => {
+const scanPluginNeedsLine = (state: PluginNeedsScanState, rawLine: string): boolean => {
   const wasOpen = state.fenceOpen
   let line = rawLine
   let blockquoteDepth = 0
@@ -100,6 +100,20 @@ const scanPluginNeedsLine = (state: PluginNeedsScanState, rawLine: string): void
     if (!prefix) break
     line = line.slice(prefix.length)
     blockquoteDepth += 1
+  }
+
+  // A fenced block cannot outlive its enclosing blockquote or list item. Reprocess the
+  // first outside line as Markdown so a new fence or alert can start there immediately.
+  if (
+    wasOpen &&
+    (blockquoteDepth < state.fenceBlockquoteDepth ||
+      (state.fenceListIndent > 0 &&
+        line.trim() &&
+        (line.match(LEADING_WHITESPACE)?.[0].length ?? 0) < state.fenceListIndent))
+  ) {
+    state.fenceOpen = false
+    state.fenceListIndent = 0
+    return scanPluginNeedsLine(state, rawLine)
   }
 
   if (wasOpen && state.fenceListIndent > 0) {
@@ -128,14 +142,27 @@ const scanPluginNeedsLine = (state: PluginNeedsScanState, rawLine: string): void
   if (!wasOpen && isOpen) {
     state.fenceBlockquoteDepth = blockquoteDepth
     state.fenceListIndent = state.listContentIndents.at(-1) ?? 0
+    state.code = true
+    const language = line.replace(FENCE_LINE, '').trim().split(/\s+/, 1)[0]
+    if (language === 'mermaid') state.mermaid = true
   } else if (wasOpen && !isOpen) {
     state.fenceListIndent = 0
   }
-  if (wasOpen || !isOpen) return
+  return wasOpen || isOpen
+}
 
-  state.code = true
-  const language = line.replace(FENCE_LINE, '').trim().split(/\s+/, 1)[0]
-  if (language === 'mermaid') state.mermaid = true
+// Normalization needs the same container context as plugin detection, while deferred code
+// rendering can keep using the raw-line tracker above.
+const createMarkdownFenceScanner = (): {
+  // Returns whether this line belongs to a code fence, including opening and closing markers.
+  feed: (line: string) => boolean
+  isOpen: () => boolean
+} => {
+  const state = createPluginNeedsScanState()
+  return {
+    feed: (line: string): boolean => scanPluginNeedsLine(state, line),
+    isOpen: () => state.fenceOpen
+  }
 }
 
 const getMarkdownPluginNeeds = (markdown: string): MarkdownPluginNeeds => {
@@ -200,6 +227,7 @@ const createMarkdownPluginNeedsScanner = (): ((markdown: string) => MarkdownPlug
 export {
   FENCE_LINE,
   createCodeFenceTracker,
+  createMarkdownFenceScanner,
   createMarkdownPluginNeedsScanner,
   getMarkdownPluginNeeds
 }

--- a/src/renderer/src/components/streamdown/code-fence.ts
+++ b/src/renderer/src/components/streamdown/code-fence.ts
@@ -11,7 +11,8 @@ type MarkdownPluginNeeds = {
 }
 
 // Tracks one fence's open/close state while lines stream through `feed`. A fence opens on the
-// first marker line and closes on a marker with the same character at equal or greater length.
+// first marker line and closes on a marker with the same character at equal or greater length,
+// followed only by spaces or tabs (and an optional CR from CRLF input).
 const createCodeFenceTracker = (): {
   feed: (line: string) => boolean
   isOpen: () => boolean
@@ -29,7 +30,11 @@ const createCodeFenceTracker = (): {
           open = true
           markerChar = fence[1][0]
           markerLength = fence[1].length
-        } else if (fence[1][0] === markerChar && fence[1].length >= markerLength) {
+        } else if (
+          fence[1][0] === markerChar &&
+          fence[1].length >= markerLength &&
+          /^[ \t]*\r?$/.test(line.slice(fence[0].length))
+        ) {
           open = false
         }
       }
@@ -77,7 +82,8 @@ const feedScanFence = (state: PluginNeedsScanState, line: string): boolean => {
       state.fenceMarkerLength = fence[1].length
     } else if (
       fence[1][0] === state.fenceMarkerChar &&
-      fence[1].length >= state.fenceMarkerLength
+      fence[1].length >= state.fenceMarkerLength &&
+      /^[ \t]*\r?$/.test(line.slice(fence[0].length))
     ) {
       state.fenceOpen = false
     }

--- a/src/renderer/src/components/streamdown/install-streamdown.download.test.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.download.test.ts
@@ -40,7 +40,16 @@ const createMermaidDownload = (
   return { button, diagram }
 }
 
-const clickInlineTableCsvDownload = (): void => {
+const activateButton = (button: HTMLButtonElement, input: 'pointer' | 'click'): void => {
+  if (input === 'pointer') {
+    for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup']) {
+      button.dispatchEvent(new MouseEvent(type, { button: 0, bubbles: true, cancelable: true }))
+    }
+  }
+  button.click()
+}
+
+const createInlineTable = (): HTMLDivElement => {
   const root = document.createElement('div')
   root.className = 'agent-markdown-root'
   root.innerHTML = `
@@ -56,18 +65,22 @@ const clickInlineTableCsvDownload = (): void => {
     </div>
   `
   document.body.appendChild(root)
+  return root
+}
+
+const clickInlineTableCsvDownload = (
+  trigger: 'pointer' | 'click' = 'pointer',
+  item: 'pointer' | 'click' = 'pointer'
+): void => {
+  const root = createInlineTable()
   const downloadButton = root.querySelectorAll<HTMLButtonElement>('.relative > button').item(1)
-  downloadButton.dispatchEvent(
-    new MouseEvent('mousedown', { button: 0, bubbles: true, cancelable: true })
-  )
+  activateButton(downloadButton, trigger)
 
   const csvButton = [
     ...document.querySelectorAll<HTMLButtonElement>('[data-sd-table-format-menu] button')
   ].find((button) => button.textContent === 'CSV')
   if (!csvButton) throw new Error('CSV table format action was not rendered')
-  csvButton.dispatchEvent(
-    new MouseEvent('mousedown', { button: 0, bubbles: true, cancelable: true })
-  )
+  activateButton(csvButton, item)
 }
 
 beforeEach(() => {
@@ -81,6 +94,7 @@ afterEach(() => {
   uninstall = undefined
   document.body.innerHTML = ''
   vi.restoreAllMocks()
+  vi.unstubAllGlobals()
 })
 
 describe('Streamdown blob download bridge', () => {
@@ -235,4 +249,69 @@ describe('Streamdown table download bridge', () => {
     )
     expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
   })
+})
+
+describe('table format semantic activation', () => {
+  it('opens and saves from semantic button clicks', async () => {
+    clickInlineTableCsvDownload('click', 'click')
+    await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+  })
+
+  it('activates a format by click after opening with a pointer', async () => {
+    clickInlineTableCsvDownload('pointer', 'click')
+    await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+  })
+})
+
+it('moves menu focus, dismisses with Escape, and restores the trigger', () => {
+  const root = createInlineTable()
+  const trigger = root.querySelectorAll<HTMLButtonElement>('.relative > button')[1]
+  trigger.focus()
+  trigger.click()
+  const items = [
+    ...document.querySelectorAll<HTMLButtonElement>('[data-sd-table-format-menu] button')
+  ]
+  expect(document.activeElement).toBe(items[0])
+  expect(trigger.getAttribute('aria-expanded')).toBe('true')
+  items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true }))
+  expect(document.activeElement).toBe(items[1])
+  items[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Home', bubbles: true }))
+  expect(document.activeElement).toBe(items[0])
+  items[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+  expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+  expect(document.activeElement).toBe(trigger)
+  expect(trigger.getAttribute('aria-expanded')).toBe('false')
+  expect(saveBlobFile).not.toHaveBeenCalled()
+})
+
+it('copies once for a complete pointer click sequence and restores focus', async () => {
+  const writeText = vi.fn().mockResolvedValue(undefined)
+  vi.stubGlobal('navigator', { ...navigator, clipboard: { writeText } })
+  const root = createInlineTable()
+  const trigger = root.querySelector<HTMLButtonElement>('.relative > button')!
+  activateButton(trigger, 'pointer')
+  const item = document.querySelector<HTMLButtonElement>('[data-sd-table-format-menu] button')!
+  activateButton(item, 'pointer')
+  await vi.waitFor(() => expect(writeText).toHaveBeenCalledOnce())
+  expect(writeText.mock.calls[0][0]).toContain('alpha')
+  expect(document.activeElement).toBe(trigger)
+  expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+})
+
+it('dismisses on outside focus without stealing focus and disposes an open menu', () => {
+  const root = createInlineTable()
+  const trigger = root.querySelector<HTMLButtonElement>('.relative > button')!
+  const outside = document.createElement('button')
+  document.body.appendChild(outside)
+  trigger.click()
+  outside.focus()
+  expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+  expect(document.activeElement).toBe(outside)
+  trigger.click()
+  uninstall?.()
+  expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+  trigger.click()
+  expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
 })

--- a/src/renderer/src/components/streamdown/install-streamdown.table.render.test.tsx
+++ b/src/renderer/src/components/streamdown/install-streamdown.table.render.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { Streamdown } from 'streamdown'
+
+import { installStreamdown } from './install-streamdown'
+
+afterEach(cleanup)
+
+it('owns a real Streamdown table click without opening its native menu or saving twice', async () => {
+  const saveBlobFile = vi.fn().mockResolvedValue({ saved: true })
+  const previousApi = window.api
+  ;(window as unknown as { api: unknown }).api = { saveBlobFile }
+  const uninstall = installStreamdown()
+  try {
+    const { container } = render(
+      <div className="agent-markdown-root">
+        <Streamdown mode="static">{'| Name | Value |\n| --- | --- |\n| alpha | 1 |'}</Streamdown>
+      </div>
+    )
+    const trigger = container.querySelector<HTMLButtonElement>('button[title="Download table"]')!
+    fireEvent.mouseDown(trigger)
+    // The installed Streamdown uses onClick, not onMouseDown, for this trigger.
+    expect(container.querySelector('.relative > .absolute')).toBeNull()
+    fireEvent.mouseUp(trigger)
+    fireEvent.click(trigger)
+    expect(container.querySelector('.relative > .absolute')).toBeNull()
+    const csv = document.querySelector<HTMLButtonElement>('[data-sd-table-format-menu] button')!
+    expect(csv.textContent).toBe('CSV')
+    fireEvent.mouseDown(csv)
+    fireEvent.mouseUp(csv)
+    fireEvent.click(csv)
+    await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    expect(document.querySelector('[data-sd-table-format-menu]')).toBeNull()
+  } finally {
+    uninstall()
+    window.api = previousApi
+  }
+})

--- a/src/renderer/src/components/streamdown/install-streamdown.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.ts
@@ -306,6 +306,7 @@ const FORMAT_OPTIONS: Record<TableAction, Array<{ id: TableFormat; label: string
 }
 
 let activeTableMenu: HTMLElement | null = null
+let activeTableMenuAnchor: HTMLButtonElement | null = null
 
 const findTableSurface = (from: Element): HTMLTableElement | null => {
   const wrapper = from.closest('[data-streamdown="table-wrapper"]')
@@ -378,9 +379,13 @@ const runTableAction = async (
   }
 }
 
-const closeActiveTableMenu = (): void => {
+const closeActiveTableMenu = (restoreFocus = false): void => {
+  const anchor = activeTableMenuAnchor
   activeTableMenu?.remove()
   activeTableMenu = null
+  activeTableMenuAnchor = null
+  anchor?.setAttribute('aria-expanded', 'false')
+  if (restoreFocus && anchor?.isConnected) anchor.focus()
 }
 
 const showInlineFormatMenu = (
@@ -394,15 +399,19 @@ const showInlineFormatMenu = (
   const menu = document.createElement('div')
   menu.setAttribute('data-sd-table-format-menu', 'true')
   menu.className = 'sd-table-format-menu'
+  menu.setAttribute('role', 'menu')
+  anchor.setAttribute('aria-haspopup', 'menu')
+  anchor.setAttribute('aria-expanded', 'true')
 
   for (const option of FORMAT_OPTIONS[action]) {
     const item = document.createElement('button')
     item.type = 'button'
     item.textContent = option.label
-    item.addEventListener('mousedown', (event) => {
+    item.setAttribute('role', 'menuitem')
+    item.addEventListener('click', (event) => {
       event.preventDefault()
       event.stopPropagation()
-      closeActiveTableMenu()
+      closeActiveTableMenu(true)
       void runTableAction(table, action, option.id).catch((error) => {
         console.error('[streamdown-table] action failed:', error)
       })
@@ -423,6 +432,8 @@ const showInlineFormatMenu = (
   menu.style.left = `${Math.round(left)}px`
 
   activeTableMenu = menu
+  activeTableMenuAnchor = anchor
+  menu.querySelector('button')?.focus()
 }
 
 const onFullscreenMenuPointer = (event: Event): void => {
@@ -464,7 +475,7 @@ const onFullscreenMenuPointer = (event: Event): void => {
   })
 }
 
-const onInlineToolbarPointer = (event: Event): void => {
+const onInlineToolbarClick = (event: Event): void => {
   if (!(event instanceof MouseEvent) || event.button !== 0) return
 
   const target = event.target
@@ -486,7 +497,8 @@ const onInlineToolbarPointer = (event: Event): void => {
   event.preventDefault()
   event.stopImmediatePropagation()
 
-  showInlineFormatMenu(button, action, table)
+  if (activeTableMenuAnchor === button) closeActiveTableMenu(true)
+  else showInlineFormatMenu(button, action, table)
 }
 
 const onDismissTableMenu = (event: Event): void => {
@@ -503,23 +515,53 @@ const onDismissTableMenu = (event: Event): void => {
   closeActiveTableMenu()
 }
 
-const onTableMenuEscape = (event: KeyboardEvent): void => {
-  if (event.key === 'Escape') {
-    closeActiveTableMenu()
+const onTableMenuKeyDown = (event: KeyboardEvent): void => {
+  if (!activeTableMenu) return
+  if (event.key === 'Escape' || event.key === 'Tab') {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      event.stopPropagation()
+    }
+    // Let native Tab continue from the trigger in the document's normal tab order.
+    closeActiveTableMenu(true)
+    return
   }
+  const items = [...activeTableMenu.querySelectorAll('button')]
+  const index = items.findIndex((item) => item === document.activeElement)
+  let next: number
+  switch (event.key) {
+    case 'ArrowDown':
+      next = (index + 1) % items.length
+      break
+    case 'ArrowUp':
+      next = (index - 1 + items.length) % items.length
+      break
+    case 'Home':
+      next = 0
+      break
+    case 'End':
+      next = items.length - 1
+      break
+    default:
+      return
+  }
+  event.preventDefault()
+  items[next]?.focus()
 }
 
 const installTableActions = (): (() => void) => {
   document.addEventListener('mousedown', onFullscreenMenuPointer, true)
-  document.addEventListener('mousedown', onInlineToolbarPointer, true)
-  document.addEventListener('mousedown', onDismissTableMenu, true)
-  document.addEventListener('keydown', onTableMenuEscape)
+  document.addEventListener('click', onInlineToolbarClick, true)
+  document.addEventListener('pointerdown', onDismissTableMenu, true)
+  document.addEventListener('focusin', onDismissTableMenu)
+  document.addEventListener('keydown', onTableMenuKeyDown, true)
 
   return () => {
     document.removeEventListener('mousedown', onFullscreenMenuPointer, true)
-    document.removeEventListener('mousedown', onInlineToolbarPointer, true)
-    document.removeEventListener('mousedown', onDismissTableMenu, true)
-    document.removeEventListener('keydown', onTableMenuEscape)
+    document.removeEventListener('click', onInlineToolbarClick, true)
+    document.removeEventListener('pointerdown', onDismissTableMenu, true)
+    document.removeEventListener('focusin', onDismissTableMenu)
+    document.removeEventListener('keydown', onTableMenuKeyDown, true)
     closeActiveTableMenu()
   }
 }

--- a/src/renderer/src/components/streamdown/normalize-agent-markdown.test.ts
+++ b/src/renderer/src/components/streamdown/normalize-agent-markdown.test.ts
@@ -224,3 +224,57 @@ describe('createAgentMarkdownNormalizer', () => {
     expect(incremental(grown)).toBe(normalizeAgentMarkdown(grown))
   })
 })
+
+describe('fenced alert source fidelity', () => {
+  it.each(['```', '````', '~~~', '~~~~'])(
+    'preserves literal alerts in %s fences throughout streaming',
+    (fence) => {
+      const source = `${fence}markdown\n> [!NOTE]\n> This is literal example source.\n\n> [!TIP]\n> Still literal.\n${fence}\n`
+      const normalize = createAgentMarkdownNormalizer()
+      for (let end = 1; end <= source.length; end += 1) {
+        expect(normalize(source.slice(0, end))).toBe(source.slice(0, end))
+      }
+      const outside = '> [!NOTE]\n> Actual alert.'
+      expect(normalize(source + '\n' + outside)).toBe(source + '\n' + normalizeGfmAlerts(outside))
+    }
+  )
+})
+
+it.each(['```', '````', '~~~', '~~~~'])(
+  'preserves fenced alerts during full normalization with %s',
+  (fence) => {
+    const source = `${fence}markdown\n> [!NOTE]\n> This is literal example source.\n${fence}\n`
+    expect(normalizeAgentMarkdown(source)).toBe(source)
+  }
+)
+
+it.each([
+  ['````', '```', '`````'],
+  ['~~~~', '~~~', '~~~~~'],
+  ['```', '~~~', '```']
+])('keeps alerts literal past a non-closing %s fence marker', (opener, inner, closer) => {
+  const code = `${opener}markdown\n${inner}\n> [!NOTE]\n> Literal.\n${closer}\n`
+  const input = '> [!TIP]\n> Before.\n\n' + code + '\n> [!NOTE]\n> After.'
+  const expected =
+    normalizeGfmAlerts('> [!TIP]\n> Before.\n\n') +
+    code +
+    '\n' +
+    normalizeGfmAlerts('> [!NOTE]\n> After.')
+  expect(normalizeAgentMarkdown(input)).toBe(expected)
+  const incremental = createAgentMarkdownNormalizer()
+  for (let end = 1; end <= input.length; end += 1) {
+    expect(incremental(input.slice(0, end))).toBe(normalizeAgentMarkdown(input.slice(0, end)))
+  }
+})
+
+it('preserves CRLF source inside an unclosed Python fence', () => {
+  const input = '```python\r\nexample = """\r\n> [!NOTE]\r\n> Literal.\r\n"""'
+  expect(normalizeAgentMarkdown(input)).toBe(input)
+})
+
+it('leaves ambiguous axis quoting unchanged', () => {
+  for (const labels of ['"Control, untreated, Treatment', 'Control"untreated, Treatment']) {
+    const input = `xychart-beta\n x-axis [${labels}]`
+    expect(normalizeMermaidChart(input)).toBe(input)
+  }
+})

--- a/src/renderer/src/components/streamdown/normalize-agent-markdown.test.ts
+++ b/src/renderer/src/components/streamdown/normalize-agent-markdown.test.ts
@@ -287,3 +287,29 @@ it('keeps a fence info string inside an open code block literal', () => {
     expect(incremental(code.slice(0, end))).toBe(code.slice(0, end))
   }
 })
+
+it.each([
+  '> ```markdown\n> [!NOTE]\n> Literal.\n> ```\n',
+  '> - ```markdown\n>   > [!NOTE]\n>   > Literal.\n>   ```\n'
+])('preserves alert source in a container fence: %s', (code) => {
+  expect(normalizeAgentMarkdown(code)).toBe(code)
+  const incremental = createAgentMarkdownNormalizer()
+  for (let end = 1; end <= code.length; end += 1) {
+    expect(incremental(code.slice(0, end))).toBe(code.slice(0, end))
+  }
+  const alert = '\n> [!TIP]\n> Outside.'
+  expect(incremental(code + alert)).toBe(code + normalizeGfmAlerts(alert))
+})
+
+it.each(['> ```md\n> Literal.\n\n', '- ```md\n  Literal.\n\n'])(
+  'converts alerts after an unclosed fence leaves its container: %s',
+  (code) => {
+    const alert = '> [!NOTE]\n> Outside.'
+    const input = code + alert
+    expect(normalizeAgentMarkdown(input)).toBe(code + normalizeGfmAlerts(alert))
+    const incremental = createAgentMarkdownNormalizer()
+    for (let end = 1; end <= input.length; end += 1) {
+      expect(incremental(input.slice(0, end))).toBe(normalizeAgentMarkdown(input.slice(0, end)))
+    }
+  }
+)

--- a/src/renderer/src/components/streamdown/normalize-agent-markdown.test.ts
+++ b/src/renderer/src/components/streamdown/normalize-agent-markdown.test.ts
@@ -278,3 +278,12 @@ it('leaves ambiguous axis quoting unchanged', () => {
     expect(normalizeMermaidChart(input)).toBe(input)
   }
 })
+
+it('keeps a fence info string inside an open code block literal', () => {
+  const code = '```markdown\n```js\n> [!NOTE]\n> Literal.\n\n> [!TIP]\n> Also literal.\n```\n'
+  expect(normalizeAgentMarkdown(code)).toBe(code)
+  const incremental = createAgentMarkdownNormalizer()
+  for (let end = 1; end <= code.length; end += 1) {
+    expect(incremental(code.slice(0, end))).toBe(code.slice(0, end))
+  }
+})

--- a/src/renderer/src/components/streamdown/normalize-agent-markdown.ts
+++ b/src/renderer/src/components/streamdown/normalize-agent-markdown.ts
@@ -1,16 +1,35 @@
 import { createCodeFenceTracker } from './code-fence'
 
-const quoteAxisListItems = (raw: string): string =>
-  raw
-    .split(',')
+const quoteAxisListItems = (raw: string): string => {
+  const items: string[] = []
+  let start = 0
+  let quote = ''
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index]
+    if (quote) {
+      if (char === '\\') index += 1
+      else if (char === quote) quote = ''
+    } else if (char === '"' || char === "'") {
+      // Embedded quotes in an unquoted label are ambiguous; preserve the source.
+      if (raw.slice(start, index).trim()) return raw
+      quote = char
+    } else if (char === ',') {
+      items.push(raw.slice(start, index))
+      start = index + 1
+    }
+  }
+  if (quote) return raw
+  items.push(raw.slice(start))
+  return items
     .map((item) => item.trim())
     .filter(Boolean)
     .map((item) => {
       if (item.startsWith('"') || item.startsWith("'")) return item
       if (/^-?\d+(\.\d+)?$/.test(item)) return item
-      return `"${item.replace(/^["']|["']$/g, '')}"`
+      return `"${item}"`
     })
     .join(', ')
+}
 
 const normalizeXychartLine = (line: string): string[] => {
   const titleAndXAxis = line.match(/^\s*"([^"]+)"\s+x-axis\s+\[(.+)\]\s*$/i)
@@ -48,7 +67,7 @@ const normalizeMermaidBlocks = (markdown: string): string =>
   )
 
 /** GitHub-style alerts: > [!NOTE] → styled aside (ChatGPT/Cursor/Claude docs style). */
-const normalizeGfmAlerts = (markdown: string): string =>
+const replaceGfmAlerts = (markdown: string): string =>
   markdown.replace(
     /^>\s*\[!([A-Z]+)\]\s*\r?\n((?:>\s?.+\r?\n?)+)/gim,
     (_match, type: string, body: string) => {
@@ -61,6 +80,26 @@ const normalizeGfmAlerts = (markdown: string): string =>
       return `<aside data-agent-alert="${type.toLowerCase()}">\n\n${content}\n\n</aside>\n\n`
     }
   )
+
+// Transform only prose spans. Fence lines and bodies retain their original bytes, including
+// incomplete streaming fences and CRLF line endings.
+const normalizeGfmAlerts = (markdown: string): string => {
+  const tracker = createCodeFenceTracker()
+  let proseStart = 0
+  let output = ''
+  for (const match of markdown.matchAll(/[^\n]*(?:\n|$)/g)) {
+    const line = match[0]
+    if (!line) continue
+    const wasOpen = tracker.isOpen()
+    const isOpen = tracker.feed(line.replace(/\r?\n$/, ''))
+    if (!wasOpen && isOpen) output += replaceGfmAlerts(markdown.slice(proseStart, match.index))
+    if (wasOpen || isOpen) {
+      output += line
+      proseStart = match.index + line.length
+    }
+  }
+  return output + replaceGfmAlerts(markdown.slice(proseStart))
+}
 
 /** Normalize agent markdown before Streamdown parses it. */
 const normalizeAgentMarkdown = (markdown: string): string =>

--- a/src/renderer/src/components/streamdown/normalize-agent-markdown.ts
+++ b/src/renderer/src/components/streamdown/normalize-agent-markdown.ts
@@ -1,4 +1,4 @@
-import { createCodeFenceTracker } from './code-fence'
+import { createMarkdownFenceScanner } from './code-fence'
 
 const quoteAxisListItems = (raw: string): string => {
   const items: string[] = []
@@ -84,17 +84,14 @@ const replaceGfmAlerts = (markdown: string): string =>
 // Transform only prose spans. Fence lines and bodies retain their original bytes, including
 // incomplete streaming fences and CRLF line endings.
 const normalizeGfmAlerts = (markdown: string): string => {
-  const tracker = createCodeFenceTracker()
+  const tracker = createMarkdownFenceScanner()
   let proseStart = 0
   let output = ''
   for (const match of markdown.matchAll(/[^\n]*(?:\n|$)/g)) {
     const line = match[0]
     if (!line) continue
-    const wasOpen = tracker.isOpen()
-    const isOpen = tracker.feed(line.replace(/\r?\n$/, ''))
-    if (!wasOpen && isOpen) output += replaceGfmAlerts(markdown.slice(proseStart, match.index))
-    if (wasOpen || isOpen) {
-      output += line
+    if (tracker.feed(line.replace(/\r?\n$/, ''))) {
+      output += replaceGfmAlerts(markdown.slice(proseStart, match.index)) + line
       proseStart = match.index + line.length
     }
   }
@@ -182,7 +179,7 @@ const widenPastMermaidOpener = (markdown: string, boundary: number): number => {
 // the first line not yet fed to the tracker; only the per-call widening still walks the text.
 const createNormalizationBoundaryFinder = (): ((markdown: string) => number) => {
   let cachedInput: string | null = null
-  let fenceTracker = createCodeFenceTracker()
+  let fenceTracker = createMarkdownFenceScanner()
   let fenceOpenerStart = -1
   let boundary = 0
   // Start of the first line not yet fed to the tracker. The trailing partial line is never fed:
@@ -190,7 +187,7 @@ const createNormalizationBoundaryFinder = (): ((markdown: string) => number) => 
   let scanPosition = 0
 
   const reset = (): void => {
-    fenceTracker = createCodeFenceTracker()
+    fenceTracker = createMarkdownFenceScanner()
     fenceOpenerStart = -1
     boundary = 0
     scanPosition = 0
@@ -205,7 +202,8 @@ const createNormalizationBoundaryFinder = (): ((markdown: string) => number) => 
       const line = markdown.slice(scanPosition, newlineIndex)
 
       const fenceWasOpen = fenceTracker.isOpen()
-      const fenceIsOpen = fenceTracker.feed(line)
+      fenceTracker.feed(line)
+      const fenceIsOpen = fenceTracker.isOpen()
       if (!fenceWasOpen && fenceIsOpen) {
         fenceOpenerStart = scanPosition
       } else if (fenceWasOpen && !fenceIsOpen) {

--- a/src/renderer/src/components/streamdown/normalize-mermaid.parse.test.ts
+++ b/src/renderer/src/components/streamdown/normalize-mermaid.parse.test.ts
@@ -1,0 +1,18 @@
+// @vitest-environment jsdom
+import mermaid from 'mermaid'
+import { expect, it } from 'vitest'
+
+import { normalizeMermaidChart } from './normalize-agent-markdown'
+
+it.each([
+  '"Control, untreated", "Treatment"',
+  '"Control", "Treatment"',
+  '"Control, untreated", Treatment'
+])('keeps axis labels parseable by Mermaid: %s', async (labels) => {
+  const source = `xychart-beta
+ x-axis [${labels}]
+ y-axis "Value" 0 --> 10
+ bar [3, 7]`
+  await expect(mermaid.parse(source)).resolves.toBeTruthy()
+  await expect(mermaid.parse(normalizeMermaidChart(source))).resolves.toBeTruthy()
+})


### PR DESCRIPTION
## Problem

Markdown preprocessing rewrites alert examples inside fenced code into HTML and splits Mermaid axis labels at commas inside quotes. This changes displayed/copied code and makes otherwise valid charts fail parsing. Inline table format controls also respond only to mouse press, leaving keyboard button activation ineffective.

## Proposed change

- Restrict alert rewriting to spans outside code fences using the existing blockquote/list-aware scanner, with closing markers restricted to whitespace-only suffixes and container exits handled before processing the next prose line. Preserve source and line endings during full and incremental normalization.
- Scan axis items across quote boundaries, preserving quoted labels and leaving ambiguous quoting unchanged.
- Use semantic button clicks for inline table actions. Focus the first option on open, support arrow/Home/End navigation, dismiss on Escape/Tab/outside interaction, and restore trigger focus where appropriate.

## Scope and non-goals

Renderer normalization and the existing inline table DOM adapter only. No new dependencies, data fields, business enums, database changes, migrations, persisted state, or historical message conversion. One transient DOM reference owns focus return. The fullscreen table action adapter remains unchanged. This is not a general Markdown parser replacement or a visual redesign.

## Acceptance criteria and validation

Regression-first evidence: the final focused tests were run against the original production files before restoring the fix; 20 tests failed for literal-source rewriting, Mermaid parser rejection, and unavailable semantic menu/focus behavior. Controls passed. The same tests pass after the fix. Additional fence-info-string and blockquoted-code tests were demonstrated failing before their fixes, then passing afterward. Container-exit regressions also ensure an unclosed quote/list fence does not suppress later prose alerts. Tests use existing normalizer exports, real PresentedAgentMarkdown/Streamdown, the installed Mermaid parser, and the public installStreamdown DOM behavior; no production test seam was added.

Final local checks ran after the last material edit:

| Behavior | Command/check | Result |
| --- | --- | --- |
| Normalization, parser, menu side effects/focus/lifecycle and Streamdown contracts | `npx vitest run src/renderer/src/components/streamdown` plus the consumer paths listed below | 22 files, 227 tests passed combined |
| Message presentation, containment, import preview and update-dialog consumers | Same Vitest invocation, adding `src/renderer/src/pages/workspace/session-message-artifact-reference.test.ts` (shared fence-tracker consumer), `src/renderer/src/pages/workspace/SessionMessageMarkdown.test.tsx`, `src/renderer/src/pages/workspace/WorkspaceMessageItem.containment.test.tsx`, `src/renderer/src/pages/settings/SkillImportCandidatePreview.render.test.tsx`, `src/renderer/src/components/UpdateDialog.render.test.tsx` | Included in the 227 passing tests |
| Renderer types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Native keyboard/pointer activation and visual output | ego-browser Chromium, real PresentedAgentMarkdown + Streamdown and project CSS, stubbed save bridge | Enter opens with CSV focused; Enter executes once and restores focus; Space opens; Escape restores focus; Tab advances normally; native mouse executes once; literal code preserved and chart rendered |
| Test-plan explain | `npm run test:affected:explain -- --base origin/main --head HEAD` | Requests full fallback because Streamdown is not a declared module owner |

Per maintainer instruction, the complete suite is deferred to PR CI; the local focused suite is not presented as full verification. Consumer checks cover the renderer's message and non-message Markdown surfaces. Main/preload, database and platform-specific filesystem behavior are unchanged. Browser evidence is component-level Chromium, not a complete Electron journey; the save bridge is stubbed and no real file was written. Screenshot evidence is retained locally with the task.

## Review focus

Fence boundaries and incremental source fidelity; preserving valid quoted axis labels; single activation with correct menu focus and cleanup. `install-streamdown.table.render.test.tsx` mounts the actual installed Streamdown and verifies that mousedown opens no native menu, the adapter captures the native click, and a complete pointer sequence saves once. The installed dependency uses onClick for table triggers; there is no native onMouseDown handler requiring a second suppression path. CI and independent review remain the final verification authority.
