### PR TITLE
fix(pdf-context): preserve session and reading source identity

### DIFF
--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.architecture.test.ts
@@ -517,6 +517,7 @@ const sendIntentKeys = [
   'referencedArtifacts',
   'pdfContext',
   'pdfReadingPosition',
+  'pdfReadingPositionSource',
   'pendingPdfContextAttachmentIds',
   'pendingPdfContextVersions',
   'parts',

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -1,3 +1,6 @@
+import type { ArtifactReference } from '../../../../shared/artifacts'
+import { SessionPdfContextOwner } from '../../../../main/session-persistence/pdf-context-owner'
+import { inspectPdfPageCount } from '../../../../main/uploads/attachment-media'
 import type {
   AcpPermissionRequest,
   AcpRuntimeEvent,
@@ -66,6 +69,11 @@ import {
   recoverContextOverflowWorkspaceSession,
   resumeInterruptedWorkspaceSession
 } from './workspace-runtime-session-lifecycle-owner'
+
+vi.mock('../../../../main/uploads/attachment-media', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../../../../main/uploads/attachment-media')>()),
+  inspectPdfPageCount: vi.fn()
+}))
 
 // Runtime boundary tests deliberately feed incomplete provider/IPC events through defensive guards.
 const createEvent = (overrides: Partial<AcpRuntimeEvent>): AcpRuntimeEvent =>
@@ -3076,7 +3084,120 @@ describe('workspace agent message sending', () => {
     })
   })
 
-  it('does not assign the current PDF page to a newly linked document', async () => {
+  it.each(
+    (['single-page', 'unavailable', 'unreadable', 'retained'] as const).flatMap((candidate) =>
+      (['new', 'existing'] as const).map((sessionKind) => ({ candidate, sessionKind }))
+    )
+  )(
+    'keeps a draft reading page with its original PDF in a $sessionKind Session when that candidate is $candidate',
+    async ({ candidate, sessionKind }) => {
+      if (sessionKind === 'existing') {
+        useSessionStore.getState().appendUserMessage({
+          sessionId: 'transport-session-1',
+          content: 'Earlier message',
+          cwd: '/workspace/project',
+          projectId: 'project-1'
+        })
+        useSessionStore.getState().finishRun('transport-session-1')
+      }
+      const sources = ['a', 'b'].map((id) => ({
+        sourceKind: 'artifact-version' as const,
+        sourceFileId: `artifact-${id}`,
+        sourceVersionId: `version-${id}`
+      }))
+      const bindings = sources.map((source) => ({
+        version: 1 as const,
+        bindingId: `binding-${source.sourceVersionId}`,
+        ...source,
+        sourceSessionId: 'source-session',
+        name: `${source.sourceVersionId}.pdf`,
+        mimeType: 'application/pdf' as const,
+        sizeBytes: 42,
+        checksum: source.sourceVersionId,
+        linkedAt: 1
+      }))
+      vi.mocked(inspectPdfPageCount).mockImplementation(async (path) => {
+        if (String(path).includes('version-a')) {
+          if (candidate === 'unreadable') throw new Error('Cannot read PDF')
+          return candidate === 'single-page' ? 1 : 14
+        }
+        return 14
+      })
+      const owner = new SessionPdfContextOwner({
+        sources: {
+          resolveVersion: async ({ sourceVersionId }) => {
+            if (sourceVersionId === 'version-a' && candidate === 'unavailable') return undefined
+            const binding = bindings.find((binding) => binding.sourceVersionId === sourceVersionId)!
+            return {
+              ...binding,
+              filename: binding.name,
+              contentType: binding.mimeType,
+              path: sourceVersionId
+            }
+          }
+        },
+        sessions: {
+          readSessionRuntimeContext: vi.fn(),
+          patchSessionRuntimeContext: vi.fn()
+        }
+      })
+      const filterPdfContextCandidates = vi.fn(owner.filterCandidates.bind(owner))
+      const eligible = await owner.filterCandidates({ projectId: 'project-1', sources })
+      expect(eligible.sources).toEqual(candidate === 'retained' ? sources : [sources[1]])
+      const linkedContext = {
+        version: 1 as const,
+        bindings: bindings.filter((binding) =>
+          eligible.sources.some((source) => source.sourceVersionId === binding.sourceVersionId)
+        )
+      }
+      vi.stubGlobal('window', {
+        api: {
+          sessions: {
+            filterPdfContextCandidates,
+            linkPdfContext: vi
+              .fn()
+              .mockResolvedValue({ version: 1, revision: 1, pdfContext: linkedContext }),
+            saveSession: vi.fn(async (session: PersistedChatSession) => session)
+          }
+        }
+      })
+      const runtime = {
+        state: createSnapshot(sessionKind === 'existing' ? ['transport-session-1'] : []),
+        createSession: vi
+          .fn()
+          .mockResolvedValue({ sessionId: 'transport-session-1', cwd: '/workspace/project' }),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn(),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+      }
+      await sendWorkspaceMessage(runtime, {
+        sessionId: sessionKind === 'existing' ? 'transport-session-1' : undefined,
+        text: 'Explain the page I am reading',
+        cwd: '/workspace/project',
+        projectId: 'project-1',
+        pendingPdfContextVersions: sources,
+        pdfReadingPositionSource: sources[0],
+        pdfReadingPosition: { pageNumber: 1, pageCount: candidate === 'single-page' ? 1 : 14 }
+      })
+      await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
+      const message = useSessionStore.getState().sessions[0].messages.at(-1)
+      if (candidate === 'retained') {
+        expect(message?.pdfContext).toMatchObject({
+          activeBindingId: bindings[0].bindingId,
+          readingPosition: { pageNumber: 1, pageCount: 14 }
+        })
+      } else {
+        expect({
+          snapshot: message?.pdfContext?.readingPosition,
+          promptPositions: runtime.sendPrompt.mock.calls[0]?.[4]?.map(
+            (file: ArtifactReference) => file.pdfReadingPosition
+          )
+        }).toEqual({ snapshot: undefined, promptPositions: [undefined] })
+      }
+    }
+  )
+
+  it('keeps the current PDF page on its existing document when linking another', async () => {
     const firstBinding: SessionPdfContext['bindings'][number] = {
       version: 1,
       bindingId: 'binding-1',
@@ -3166,150 +3287,151 @@ describe('workspace agent message sending', () => {
     const message = useSessionStore.getState().sessions[0].messages.at(-1)
     expect(message?.pdfContext).toEqual({
       ...linkedContext,
-      activeBindingId: secondBinding.bindingId
+      activeBindingId: firstBinding.bindingId,
+      readingPosition: { pageNumber: 7, pageCount: 14 }
     })
-    expect(message?.pdfContext).not.toHaveProperty('readingPosition')
+    expect(
+      runtime.sendPrompt.mock.calls[0]?.[4]?.find(
+        (file: ArtifactReference) => file.versionId === secondBinding.sourceVersionId
+      )
+    ).not.toHaveProperty('pdfReadingPosition')
   })
 
-  it('links staged and immutable PDFs atomically without losing the current page', async () => {
-    useSessionStore.getState().appendUserMessage({
-      sessionId: 'transport-session-1',
-      content: 'Existing prompt',
-      cwd: '/workspace/project',
-      projectId: 'project-1'
-    })
-    useSessionStore.getState().finishRun('transport-session-1')
-    const stagedPdf = createAttachment({
-      id: 'pdf-upload-1',
-      name: 'staged-paper.pdf',
-      originalName: 'staged-paper.pdf',
-      path: '/uploads/.pending/staged-paper.pdf',
-      mimeType: 'application/pdf'
-    })
-    const finalizedPdf = createAttachment({
-      ...stagedPdf,
-      sessionId: 'transport-session-1',
-      path: 'upload-version:project-1/transport-session-1/pdf-version-1',
-      versionId: 'pdf-version-1',
-      versionNumber: 1,
-      checksum: 'a'.repeat(64)
-    })
-    const stagedBinding: SessionPdfContext['bindings'][number] = {
-      version: 1,
-      bindingId: 'binding-upload',
-      sourceKind: 'upload-version',
-      sourceFileId: stagedPdf.id,
-      sourceVersionId: finalizedPdf.versionId!,
-      sourceSessionId: 'transport-session-1',
-      name: stagedPdf.name,
-      mimeType: 'application/pdf',
-      sizeBytes: stagedPdf.size,
-      checksum: 'a'.repeat(64),
-      linkedAt: 1
-    }
-    const immutableBinding: SessionPdfContext['bindings'][number] = {
-      ...stagedBinding,
-      bindingId: 'binding-artifact',
-      sourceKind: 'artifact-version',
-      sourceFileId: 'artifact-2',
-      sourceVersionId: 'artifact-version-2',
-      sourceSessionId: 'source-session-2',
-      name: 'library-paper.pdf',
-      checksum: 'b'.repeat(64),
-      linkedAt: 2
-    }
-    const linkedContext: SessionPdfContext = {
-      version: 1,
-      bindings: [stagedBinding, immutableBinding]
-    }
-    const linkPdfContext = vi.fn().mockImplementation(async ({ sources }) => ({
-      version: 1,
-      revision: sources.length,
-      pdfContext: sources.length === 1 ? { version: 1, bindings: [stagedBinding] } : linkedContext
-    }))
-    vi.stubGlobal('window', {
-      api: {
-        uploads: { finalizeSession: vi.fn().mockResolvedValue([finalizedPdf]) },
-        sessions: {
-          linkPdfContext,
-          saveSession: vi.fn(async (session: PersistedChatSession) => session),
-          filterPdfContextCandidates: vi.fn().mockResolvedValue({
-            sources: [
-              {
-                sourceKind: 'artifact-version',
-                sourceFileId: 'artifact-2',
-                sourceVersionId: 'artifact-version-2'
-              }
-            ],
-            pendingAttachmentIds: [stagedPdf.id]
-          })
-        }
-      }
-    })
-    const runtime = {
-      state: createSnapshot(['transport-session-1']),
-      createSession: vi.fn(),
-      resumeSession: vi.fn(),
-      resetSessionContext: vi.fn(),
-      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
-    }
-    const readingPosition = { pageNumber: 5, pageCount: 14 }
-
-    await sendWorkspaceMessage(runtime, {
-      sessionId: 'transport-session-1',
-      text: 'Compare these papers',
-      attachments: [stagedPdf],
-      pendingPdfContextAttachmentIds: [stagedPdf.id],
-      pendingPdfContextVersions: [
-        {
-          sourceKind: 'artifact-version',
-          sourceFileId: 'artifact-2',
-          sourceVersionId: 'artifact-version-2'
-        }
-      ],
-      pdfReadingPosition: readingPosition,
-      cwd: '/workspace/project',
-      projectId: 'project-1'
-    })
-
-    await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
-    expect(linkPdfContext).toHaveBeenCalledOnce()
-    expect(linkPdfContext).toHaveBeenCalledWith({
-      projectId: 'project-1',
-      sessionId: 'transport-session-1',
-      expectedRevision: 0,
-      sources: [
-        {
-          sourceKind: 'upload-version',
-          sourceFileId: 'pdf-upload-1',
-          sourceVersionId: 'pdf-version-1'
-        },
-        {
-          sourceKind: 'artifact-version',
-          sourceFileId: 'artifact-2',
-          sourceVersionId: 'artifact-version-2'
-        }
-      ],
-      excludeSinglePage: true
-    })
-    expect(useSessionStore.getState().sessions[0].messages.at(-1)?.pdfContext).toEqual({
-      ...linkedContext,
-      activeBindingId: stagedBinding.bindingId,
-      readingPosition
-    })
-    expect(runtime.sendPrompt.mock.calls[0]?.[4]).toEqual([
-      expect.objectContaining({
-        source: 'upload',
-        sourceFileId: 'pdf-upload-1',
-        versionId: 'pdf-version-1'
-      }),
-      expect.objectContaining({
-        source: 'artifact',
-        sourceFileId: 'artifact-2',
-        versionId: 'artifact-version-2'
+  it.each(['staged', 'immutable', 'excluded-staged', 'excluded-immutable'] as const)(
+    'preserves source identity in mixed PDF sends (%s)',
+    async (viewed) => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'transport-session-1',
+        content: 'Existing prompt',
+        cwd: '/workspace/project',
+        projectId: 'project-1'
       })
-    ])
-  })
+      useSessionStore.getState().finishRun('transport-session-1')
+      const stagedPdf = createAttachment({
+        id: 'pdf-upload-1',
+        name: 'staged-paper.pdf',
+        originalName: 'staged-paper.pdf',
+        path: '/uploads/.pending/staged-paper.pdf',
+        mimeType: 'application/pdf'
+      })
+      const finalizedPdf = createAttachment({
+        ...stagedPdf,
+        sessionId: 'transport-session-1',
+        path: 'upload-version:project-1/transport-session-1/pdf-version-1',
+        versionId: 'pdf-version-1',
+        versionNumber: 1,
+        checksum: 'a'.repeat(64)
+      })
+      const stagedBinding: SessionPdfContext['bindings'][number] = {
+        version: 1,
+        bindingId: 'binding-upload',
+        sourceKind: 'upload-version',
+        sourceFileId: stagedPdf.id,
+        sourceVersionId: finalizedPdf.versionId!,
+        sourceSessionId: 'transport-session-1',
+        name: stagedPdf.name,
+        mimeType: 'application/pdf',
+        sizeBytes: stagedPdf.size,
+        checksum: 'a'.repeat(64),
+        linkedAt: 1
+      }
+      const immutableBinding: SessionPdfContext['bindings'][number] = {
+        ...stagedBinding,
+        bindingId: 'binding-artifact',
+        sourceKind: 'artifact-version',
+        sourceFileId: 'artifact-2',
+        sourceVersionId: 'artifact-version-2',
+        sourceSessionId: 'source-session-2',
+        name: 'library-paper.pdf',
+        checksum: 'b'.repeat(64),
+        linkedAt: 2
+      }
+      const linkedContext: SessionPdfContext = {
+        version: 1,
+        bindings: [stagedBinding, immutableBinding].filter((binding) =>
+          viewed === 'excluded-staged'
+            ? binding !== stagedBinding
+            : viewed === 'excluded-immutable'
+              ? binding !== immutableBinding
+              : true
+        )
+      }
+      const eligibleSources = linkedContext.bindings.map(
+        ({ sourceKind, sourceFileId, sourceVersionId }) => ({
+          sourceKind,
+          sourceFileId,
+          sourceVersionId
+        })
+      )
+      const linkPdfContext = vi
+        .fn()
+        .mockResolvedValue({ version: 1, revision: 1, pdfContext: linkedContext })
+      vi.stubGlobal('window', {
+        api: {
+          uploads: { finalizeSession: vi.fn().mockResolvedValue([finalizedPdf]) },
+          sessions: {
+            linkPdfContext,
+            saveSession: vi.fn(async (session: PersistedChatSession) => session),
+            filterPdfContextCandidates: vi.fn().mockResolvedValue({
+              sources: eligibleSources.filter(
+                ({ sourceKind }) => sourceKind === 'artifact-version'
+              ),
+              pendingAttachmentIds: viewed === 'excluded-staged' ? [] : [stagedPdf.id]
+            })
+          }
+        }
+      })
+      const runtime = {
+        state: createSnapshot(['transport-session-1']),
+        createSession: vi.fn(),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn(),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+      }
+      const readingPosition = { pageNumber: 5, pageCount: 14 }
+
+      await sendWorkspaceMessage(runtime, {
+        sessionId: 'transport-session-1',
+        text: 'Compare these papers',
+        attachments: [stagedPdf],
+        pendingPdfContextAttachmentIds: [stagedPdf.id],
+        pendingPdfContextVersions: [
+          {
+            sourceKind: 'artifact-version',
+            sourceFileId: 'artifact-2',
+            sourceVersionId: 'artifact-version-2'
+          }
+        ],
+        pdfReadingPosition: readingPosition,
+        pdfReadingPositionSource: viewed.endsWith('staged')
+          ? { attachmentId: stagedPdf.id }
+          : immutableBinding,
+        cwd: '/workspace/project',
+        projectId: 'project-1'
+      })
+
+      await vi.waitFor(() => expect(runtime.sendPrompt).toHaveBeenCalledOnce())
+      expect(linkPdfContext).toHaveBeenCalledOnce()
+      expect(linkPdfContext).toHaveBeenCalledWith({
+        projectId: 'project-1',
+        sessionId: 'transport-session-1',
+        expectedRevision: 0,
+        sources: eligibleSources,
+        excludeSinglePage: true
+      })
+      const activeBinding = viewed === 'immutable' ? immutableBinding : linkedContext.bindings[0]
+      expect(useSessionStore.getState().sessions[0].messages.at(-1)?.pdfContext).toEqual({
+        ...linkedContext,
+        activeBindingId: activeBinding.bindingId,
+        ...(!viewed.startsWith('excluded') ? { readingPosition } : {})
+      })
+      expect(
+        runtime.sendPrompt.mock.calls[0]?.[4]
+          ?.filter((file: ArtifactReference) => file.pdfReadingPosition)
+          .map((file: ArtifactReference) => file.versionId)
+      ).toEqual(viewed.startsWith('excluded') ? [] : [activeBinding.sourceVersionId])
+    }
+  )
 
   it('limits eligible follow-up PDFs to the remaining Reading capacity', async () => {
     useSessionStore.getState().appendUserMessage({
@@ -3406,6 +3528,11 @@ describe('workspace agent message sending', () => {
         }
       ],
       pdfContext: existingContext,
+      pdfReadingPosition: { pageNumber: 2, pageCount: 14 },
+      pdfReadingPositionSource: {
+        sourceKind: 'artifact-version',
+        sourceVersionId: 'artifact-version-4'
+      },
       cwd: '/workspace/project',
       projectId: 'project-1'
     })
@@ -3422,6 +3549,14 @@ describe('workspace agent message sending', () => {
         ]
       })
     )
+    expect(useSessionStore.getState().sessions[0].messages.at(-1)?.pdfContext).not.toHaveProperty(
+      'readingPosition'
+    )
+    expect(
+      runtime.sendPrompt.mock.calls[0]?.[4]?.some(
+        (file: ArtifactReference) => file.pdfReadingPosition
+      )
+    ).toBe(false)
   })
 
   it('keeps an ineligible follow-up PDF as an ordinary attachment', async () => {
@@ -4647,6 +4782,7 @@ describe('workspace agent message sending', () => {
           }
         ],
         pdfReadingPosition: readingPosition,
+        pdfReadingPositionSource: { attachmentId: stagedPdf.id },
         cwd: '/workspace/project',
         projectId: 'project-1'
       },

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -1,7 +1,10 @@
 import type { AcpMessageImage, AcpRuntimeEvent } from '../../../../shared/acp'
 import type { FileReference } from '../../../../shared/artifacts'
 import * as annotationProtocol from '../../../../shared/annotations'
-import { withPdfContext as withPdf } from '../../../../shared/session-pdf-context'
+import {
+  type PdfReadingPositionSource,
+  withPdfContext as withPdf
+} from '../../../../shared/session-pdf-context'
 import {
   collectSessionReferences,
   isSessionSizeLimitError,
@@ -73,6 +76,7 @@ type SendWorkspaceMessageIntent = {
   referencedArtifacts?: FileReference[]
   pdfContext?: MessagePdfContextSnapshot
   pdfReadingPosition?: PdfReadingPosition
+  pdfReadingPositionSource?: PdfReadingPositionSource
   pendingPdfContextAttachmentIds?: string[]
   pendingPdfContextVersions?: SessionPdfContextSource[]
   parts?: MessagePart[]
@@ -309,12 +313,32 @@ type PendingPromptRequest = SendWorkspaceMessageCommand & {
   contextReset?: boolean
 }
 
+const readingSourceForSend = (
+  request: Pick<SendWorkspaceMessageIntent, 'pdfReadingPositionSource' | 'pdfContext'>,
+  attachments: UploadedAttachment[]
+): SessionPdfContextSource | undefined => {
+  const identity = request.pdfReadingPositionSource
+  if (!identity) {
+    return request.pdfContext?.bindings.find(
+      (binding) =>
+        binding.bindingId ===
+        (request.pdfContext?.activeBindingId ?? request.pdfContext?.bindings[0]?.bindingId)
+    )
+  }
+  if (!('attachmentId' in identity)) return identity
+  const attachment = attachments.find(({ id }) => id === identity.attachmentId)
+  return attachment?.versionId
+    ? { sourceKind: 'upload-version', sourceVersionId: attachment.versionId }
+    : undefined
+}
+
 const linkPdfContextForSend = async ({
   sessionId,
   messageId,
   projectId,
   sources,
   pdfReadingPosition,
+  readingSource,
   excludeSinglePage = false,
   persistSessionBeforeLink = false,
   materializedRuntimeRevision
@@ -324,6 +348,7 @@ const linkPdfContextForSend = async ({
   projectId: string | undefined
   sources: SessionPdfContextSource[]
   pdfReadingPosition?: PdfReadingPosition
+  readingSource?: SessionPdfContextSource
   excludeSinglePage?: boolean
   persistSessionBeforeLink?: boolean
   materializedRuntimeRevision?: number
@@ -331,7 +356,6 @@ const linkPdfContextForSend = async ({
   if (!projectId) throw new Error('The PDF Project is unavailable for Session context.')
   let source = useSessionStore.getState().sessions.find((candidate) => candidate.id === sessionId)
   if (!source) throw new Error(`Session not found: ${sessionId}`)
-  const previousBindings = source.runtimeContext?.pdfContext?.bindings ?? []
   let expectedRevision = materializedRuntimeRevision ?? source.runtimeContext?.revision ?? 0
 
   // A new Agent Session is bound in memory before its first durable save. Materialize that Session
@@ -349,21 +373,24 @@ const linkPdfContextForSend = async ({
     ...(excludeSinglePage ? { excludeSinglePage: true } : {})
   })
   const pdfContext = runtimeContext.pdfContext
-  const activeBinding = sources
-    .map(({ sourceKind, sourceVersionId }) =>
-      pdfContext?.bindings.find(
+  const readingBinding = readingSource
+    ? pdfContext?.bindings.find(
         (binding) =>
-          binding.sourceKind === sourceKind && binding.sourceVersionId === sourceVersionId
+          binding.sourceKind === readingSource.sourceKind &&
+          binding.sourceVersionId === readingSource.sourceVersionId
       )
-    )
-    .find((binding) => binding !== undefined)
-  const activeBindingWasAlreadyLinked = activeBinding
-    ? previousBindings.some(({ bindingId }) => bindingId === activeBinding.bindingId)
-    : false
-  const canApplyReadingPosition =
-    activeBinding !== undefined &&
-    pdfReadingPosition !== undefined &&
-    (previousBindings.length === 0 || activeBindingWasAlreadyLinked)
+    : undefined
+  const activeBinding =
+    readingBinding ??
+    sources
+      .map(({ sourceKind, sourceVersionId }) =>
+        pdfContext?.bindings.find(
+          (binding) =>
+            binding.sourceKind === sourceKind && binding.sourceVersionId === sourceVersionId
+        )
+      )
+      .find((binding) => binding !== undefined)
+  const canApplyReadingPosition = readingBinding !== undefined && pdfReadingPosition !== undefined
   const messagePdfContext: MessagePdfContextSnapshot | undefined = pdfContext
     ? {
         ...pdfContext,
@@ -606,6 +633,7 @@ const startPendingPrompt = (
           projectId: request.projectId,
           sources: pdfContextSources,
           pdfReadingPosition: request.pdfReadingPosition,
+          readingSource: readingSourceForSend(request, attachments),
           excludeSinglePage: true,
           persistSessionBeforeLink: !sessionMaterialized,
           materializedRuntimeRevision
@@ -673,13 +701,18 @@ const sendWorkspaceMessage = async (
   const replayPrompt = replaySession?.pendingContextReplayMessageId
     ? replaySession.messages.find((item) => item.id === replaySession.pendingContextReplayMessageId)
     : undefined
+  const initialReadingSource = readingSourceForSend(input, [])
+  const initialReadingBinding = input.pdfContext?.bindings.find(
+    (binding) =>
+      binding.sourceKind === initialReadingSource?.sourceKind &&
+      binding.sourceVersionId === initialReadingSource.sourceVersionId
+  )
   let pdfContext = replayPrompt
     ? replayPrompt.pdfContext
-    : input.pdfContext && input.pdfReadingPosition
+    : input.pdfContext && input.pdfReadingPosition && initialReadingBinding
       ? {
           ...input.pdfContext,
-          activeBindingId:
-            input.pdfContext.activeBindingId ?? input.pdfContext.bindings[0]?.bindingId,
+          activeBindingId: initialReadingBinding.bindingId,
           readingPosition: input.pdfReadingPosition
         }
       : input.pdfContext
@@ -770,7 +803,8 @@ const sendWorkspaceMessage = async (
                   sourceVersionId
                 })
               ),
-              pdfReadingPosition: pdfContext.readingPosition
+              pdfReadingPosition: pdfContext.readingPosition,
+              pdfReadingPositionSource: readingSourceForSend({ pdfContext }, [])
             }
           : {}),
         pending: pendingPrompt,
@@ -962,6 +996,7 @@ const sendWorkspaceMessage = async (
           projectId,
           sources: pdfContextSources,
           pdfReadingPosition: input.pdfReadingPosition,
+          readingSource: readingSourceForSend(input, promptAttachments),
           excludeSinglePage: true
         })
       }

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.test.ts
@@ -476,6 +476,101 @@ describe('workspace composer controller', () => {
     })
   })
 
+  it.each(['empty session', 'linked session', 'another project', 'return to origin'] as const)(
+    'does not replay queued Reading into a later %s',
+    async (destination) => {
+      const sourceA = {
+        sourceKind: 'upload-version' as const,
+        sourceFileId: 'upload-a',
+        sourceVersionId: 'version-a'
+      }
+      const sourceB = {
+        sourceKind: 'upload-version' as const,
+        sourceFileId: 'upload-b',
+        sourceVersionId: 'version-b'
+      }
+      const bindingB = {
+        version: 1 as const,
+        bindingId: 'binding-b',
+        ...sourceB,
+        sourceFileId: 'upload-b',
+        sourceSessionId: 'source-session',
+        name: 'paper-b.pdf',
+        mimeType: 'application/pdf' as const,
+        sizeBytes: 42,
+        checksum: 'b'.repeat(64),
+        linkedAt: 1
+      }
+      const firstLink = deferred<{ version: 1; revision: number }>()
+      const linkPdfContext = vi
+        .fn()
+        .mockImplementationOnce(() => firstLink.promise)
+        .mockResolvedValueOnce({
+          version: 1,
+          revision: 1,
+          pdfContext: { version: 1, bindings: [bindingB] }
+        })
+      window.api = {
+        sessions: { linkPdfContext, unlinkPdfContext: vi.fn().mockResolvedValue({ revision: 1 }) }
+      } as unknown as Window['api']
+      const hook = renderController(uploads(), undefined, [], {
+        id: 'session-a',
+        projectId: 'project',
+        runtimeContext: { revision: 0 }
+      })
+      mounted.push(hook)
+
+      let linkA!: Promise<void>
+      act(() => {
+        linkA = hook.result.current.actions.linkReadingContext(sourceA)
+      })
+      act(() =>
+        hook.selectSession({
+          id: 'session-b',
+          projectId: 'project',
+          runtimeContext: { revision: 0 }
+        })
+      )
+      let linkB!: Promise<void>
+      act(() => {
+        linkB = hook.result.current.actions.linkReadingContext(sourceB)
+      })
+
+      hook.selectSession({
+        id: 'session-c',
+        projectId: destination === 'another project' ? 'project-c' : 'project',
+        runtimeContext: {
+          revision: 0,
+          ...(destination === 'linked session'
+            ? {
+                pdfContext: {
+                  version: 1 as const,
+                  bindings: [{ ...bindingB, bindingId: 'binding-c', sourceVersionId: 'version-c' }]
+                }
+              }
+            : {})
+        }
+      })
+
+      if (destination === 'return to origin') {
+        hook.selectSession({
+          id: 'session-b',
+          projectId: 'project',
+          runtimeContext: { revision: 0 }
+        })
+      }
+      await act(async () => {
+        firstLink.resolve({ version: 1, revision: 1 })
+        await Promise.all([linkA, linkB])
+      })
+
+      expect({
+        links: linkPdfContext.mock.calls.slice(1),
+        unlinks: vi.mocked(window.api.sessions.unlinkPdfContext).mock.calls
+      }).toEqual({ links: [], unlinks: [] })
+    }
+  )
+
   it('undoes and redoes Reading changes while coalescing rapid async mutations', async () => {
     const source = {
       sourceKind: 'upload-version' as const,
@@ -951,6 +1046,58 @@ describe('workspace composer controller', () => {
     expect(uploadApi.abortTransfer).toHaveBeenCalledWith({ transferId: expect.any(String) })
   })
 
+  it('captures the viewed single-page PDF before send-time candidate filtering', () => {
+    const preview = usePreviewWorkbenchStore.getState()
+    preview.activateProject('project')
+    const selections: PendingPdfContextSelection[] = [1, 2].map((id) => ({
+      kind: 'version',
+      sourceKind: 'literature-attachment-version',
+      sourceVersionId: `version-${id}`,
+      previewItemId: `literature:version-${id}`
+    }))
+    for (const id of [1, 2])
+      preview.upsertItem({
+        id: `literature:version-${id}`,
+        projectId: 'project',
+        sessionId: 'literature-library',
+        type: 'file',
+        source: 'literature',
+        title: `paper-${id}.pdf`,
+        name: `paper-${id}.pdf`,
+        format: 'pdf',
+        path: `literature-attachment-version:version-${id}`,
+        mimeType: 'application/pdf',
+        size: 100
+      })
+    preview.setPendingPdfContext('project', createPendingPdfContext(selections))
+    // Workspace hydration must not remove the file identities backing this Reading draft.
+    preview.activateProject('project', { items: [], panelState: 'collapsed' })
+    const hook = renderController(uploads(), undefined, [], null)
+    mounted.push(hook)
+    act(() => {
+      hook.result.current.actions.openReadingContext(
+        'version:literature-attachment-version:version-1'
+      )
+      usePreviewWorkbenchStore
+        .getState()
+        .setPdfReadingPosition('version:literature-attachment-version:version-1', {
+          pageNumber: 1,
+          pageCount: 1
+        })
+    })
+    expect(hook.result.current.lifecycle.captureSend()).toMatchObject({
+      pendingPdfContextVersions: [
+        { sourceKind: 'literature-attachment-version', sourceVersionId: 'version-1' },
+        { sourceKind: 'literature-attachment-version', sourceVersionId: 'version-2' }
+      ],
+      pdfReadingPosition: { pageNumber: 1, pageCount: 1 },
+      pdfReadingPositionSource: {
+        sourceKind: 'literature-attachment-version',
+        sourceVersionId: 'version-1'
+      }
+    })
+  })
+
   it('previews and removes individual PDFs from a three-document draft and sends the remaining sources', () => {
     const preview = usePreviewWorkbenchStore.getState()
     preview.activateProject('project')
@@ -1079,7 +1226,8 @@ describe('workspace composer controller', () => {
 
     expect(hook.result.current.lifecycle.captureSend()).toMatchObject({
       pendingPdfContextAttachmentIds: ['upload-pdf-1'],
-      pdfReadingPosition: { pageNumber: 7, pageCount: 14 }
+      pdfReadingPosition: { pageNumber: 7, pageCount: 14 },
+      pdfReadingPositionSource: { attachmentId: 'upload-pdf-1' }
     })
   })
 

--- a/src/renderer/src/pages/workspace/workspace-composer-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-composer-controller.ts
@@ -1,3 +1,4 @@
+import type { PdfReadingPositionSource } from '../../../../shared/session-pdf-context'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 
 import type { UploadedAttachment } from '../../../../shared/uploads'
@@ -86,6 +87,7 @@ export type ComposerSendSnapshot = {
   automaticReadingEnabled?: boolean
   pdfContext?: MessagePdfContextSnapshot
   pdfReadingPosition?: PdfReadingPosition
+  pdfReadingPositionSource?: PdfReadingPositionSource
   pendingPdfContextAttachmentIds?: string[]
   pendingPdfContextVersions?: Array<{
     sourceKind: SessionPdfContextSource['sourceKind']
@@ -466,12 +468,14 @@ const useWorkspaceComposerController = ({
     | undefined
   >(undefined)
   const readingMutationPromiseRef = useRef<Promise<void> | undefined>(undefined)
-  const readingMutationPromiseSessionIdRef = useRef<string | undefined>(undefined)
+  const readingMutationPromiseRuntimeRef =
+    useRef<typeof readingMutationRuntimeRef.current>(undefined)
   useLayoutEffect(() => {
     const current = readingMutationRuntimeRef.current
     if (
       activeSession &&
       (current?.sessionId !== activeSession.id ||
+        current?.projectId !== activeSession.projectId ||
         (!readingMutationPromiseRef.current &&
           (activeSession.runtimeContext?.revision ?? 0) >= current.runtimeContext.revision))
     ) {
@@ -490,16 +494,23 @@ const useWorkspaceComposerController = ({
   const reconcileReadingContextSources = useCallback(
     (requestedSources: SessionPdfContextSource[]): Promise<void> => {
       if (!activeSession) return Promise.resolve()
+      const operationRuntime = readingMutationRuntimeRef.current
+      if (!operationRuntime) return Promise.resolve()
       const uniqueSources = [
         ...new Map(requestedSources.map((source) => [pdfContextSourceKey(source), source])).values()
       ].slice(0, MAX_SESSION_PDF_CONTEXTS)
       readingContextSourcesRef.current = uniqueSources
       if (readingMutationPromiseRef.current) {
         const pending = readingMutationPromiseRef.current
-        if (readingMutationPromiseSessionIdRef.current === activeSession.id) return pending
+        if (readingMutationPromiseRuntimeRef.current === operationRuntime) return pending
         return pending
           .catch(() => undefined)
-          .then(() => restoreReadingContextSourcesRef.current(uniqueSources))
+          .then(() => {
+            // Leaving the originating Project/Session invalidates this queued intent, even
+            // if the user returns before the preceding IPC finishes.
+            if (readingMutationRuntimeRef.current !== operationRuntime) return
+            return restoreReadingContextSourcesRef.current(readingContextSourcesRef.current)
+          })
       }
       const currentSources = (
         readingMutationRuntimeRef.current?.runtimeContext.pdfContext?.bindings ?? []
@@ -516,7 +527,7 @@ const useWorkspaceComposerController = ({
       setIsPdfContextPending(true)
       const run = (async (): Promise<void> => {
         try {
-          while (readingMutationRuntimeRef.current?.sessionId === operationSessionId) {
+          while (readingMutationRuntimeRef.current === operationRuntime) {
             const runtime = readingMutationRuntimeRef.current.runtimeContext
             const target = readingContextSourcesRef.current
             const targetKeys = new Set(target.map(pdfContextSourceKey))
@@ -532,7 +543,7 @@ const useWorkspaceComposerController = ({
                 expectedRevision: runtime.revision,
                 bindingId: removed.bindingId
               })
-              if (readingMutationRuntimeRef.current?.sessionId !== operationSessionId) return
+              if (readingMutationRuntimeRef.current !== operationRuntime) return
               readingMutationRuntimeRef.current.runtimeContext = nextRuntime
               usePreviewWorkbenchStore.getState().clearPdfReadingPosition(removed.bindingId)
               continue
@@ -547,13 +558,14 @@ const useWorkspaceComposerController = ({
                 expectedRevision: runtime.revision,
                 sources: added
               })
-              if (readingMutationRuntimeRef.current?.sessionId !== operationSessionId) return
+              if (readingMutationRuntimeRef.current !== operationRuntime) return
               readingMutationRuntimeRef.current.runtimeContext = nextRuntime
               continue
             }
             break
           }
         } catch (error) {
+          if (readingMutationRuntimeRef.current !== operationRuntime) throw error
           const currentBindings =
             readingMutationRuntimeRef.current?.runtimeContext.pdfContext?.bindings ?? []
           readingContextSourcesRef.current = currentBindings.map(
@@ -571,12 +583,12 @@ const useWorkspaceComposerController = ({
       const tracked = run.finally(() => {
         if (readingMutationPromiseRef.current !== tracked) return
         readingMutationPromiseRef.current = undefined
-        readingMutationPromiseSessionIdRef.current = undefined
+        readingMutationPromiseRuntimeRef.current = undefined
         setPdfContextPendingBindingId(undefined)
         setIsPdfContextPending(false)
       })
       readingMutationPromiseRef.current = tracked
-      readingMutationPromiseSessionIdRef.current = operationSessionId
+      readingMutationPromiseRuntimeRef.current = operationRuntime
       return tracked
     },
     [activeSession, onSessionSizeLimit, setError]
@@ -603,7 +615,7 @@ const useWorkspaceComposerController = ({
         return
       const transaction =
         !readingMutationPromiseRef.current ||
-        readingMutationPromiseSessionIdRef.current !== activeSession.id
+        readingMutationPromiseRuntimeRef.current !== readingMutationRuntimeRef.current
           ? beginReadingContextUndo()
           : undefined
       try {
@@ -670,7 +682,7 @@ const useWorkspaceComposerController = ({
       if (!durableBinding || !activeSession) return
       const transaction =
         !readingMutationPromiseRef.current ||
-        readingMutationPromiseSessionIdRef.current !== activeSession.id
+        readingMutationPromiseRuntimeRef.current !== readingMutationRuntimeRef.current
           ? beginReadingContextUndo()
           : undefined
       void reconcileReadingContextSources(
@@ -1051,12 +1063,23 @@ const useWorkspaceComposerController = ({
               }
             }
           : {}),
-        // Finalized uploads precede immutable versions at first-send linking. Do not
-        // apply a version's viewport to an upload in a mixed draft.
-        ...(includeReadingContext &&
-        pdfReadingPosition &&
-        !(activePendingReading?.kind === 'version' && pendingPdfContextAttachmentIds.length > 0)
-          ? { pdfReadingPosition }
+        ...(includeReadingContext && pdfReadingPosition
+          ? {
+              pdfReadingPosition,
+              pdfReadingPositionSource: activeReadingBinding
+                ? {
+                    sourceKind: activeReadingBinding.sourceKind,
+                    sourceVersionId: activeReadingBinding.sourceVersionId
+                  }
+                : activePendingReading?.kind === 'staged-upload'
+                  ? { attachmentId: activePendingReading.attachmentId }
+                  : activePendingReading
+                    ? {
+                        sourceKind: activePendingReading.sourceKind,
+                        sourceVersionId: activePendingReading.sourceVersionId
+                      }
+                    : undefined
+            }
           : {}),
         ...(pendingPdfContextAttachmentIds.length > 0 ? { pendingPdfContextAttachmentIds } : {}),
         ...(pendingPdfContextVersions.length > 0 ? { pendingPdfContextVersions } : {})

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.test.ts
@@ -249,7 +249,12 @@ describe('workspace conversation controller', () => {
       version: 1,
       doc: { nodes: [] },
       annotations: [annotation],
-      attachments: []
+      attachments: [],
+      pdfReadingPosition: { pageNumber: 2, pageCount: 14 },
+      pdfReadingPositionSource: {
+        sourceKind: 'artifact-version' as const,
+        sourceVersionId: 'version-1'
+      }
     }))
     const hook = renderController(input)
     mounted.push(hook)
@@ -259,7 +264,12 @@ describe('workspace conversation controller', () => {
     await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
 
     expect(input.runtime.sendMessage).toHaveBeenCalledWith(
-      expect.objectContaining({ text: '', annotations: [annotation] })
+      expect.objectContaining({
+        text: '',
+        annotations: [annotation],
+        pdfReadingPosition: { pageNumber: 2, pageCount: 14 },
+        pdfReadingPositionSource: { sourceKind: 'artifact-version', sourceVersionId: 'version-1' }
+      })
     )
     expect(hook.result.current.optimisticMessage).toMatchObject({
       content: '',

--- a/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-controller.ts
@@ -516,6 +516,7 @@ const useWorkspaceConversationController = (
             parts: docToMessageParts(snapshot.doc),
             pdfContext: snapshot.pdfContext,
             pdfReadingPosition: snapshot.pdfReadingPosition,
+            pdfReadingPositionSource: snapshot.pdfReadingPositionSource,
             pendingPdfContextAttachmentIds: snapshot.pendingPdfContextAttachmentIds,
             pendingPdfContextVersions: snapshot.pendingPdfContextVersions,
             cwd: activeSession?.cwd,

--- a/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-controller.test.ts
@@ -570,6 +570,8 @@ describe('workspace message queue controller', () => {
     const hook = renderController(input)
     mounted.push(hook)
     const queued = admission('queued with new Reading PDFs')
+    queued.snapshot.pdfReadingPosition = { pageNumber: 2, pageCount: 14 }
+    queued.snapshot.pdfReadingPositionSource = { attachmentId: 'upload-1' }
     queued.snapshot.pendingPdfContextAttachmentIds = ['upload-1']
     queued.snapshot.pendingPdfContextVersions = [
       {
@@ -586,6 +588,8 @@ describe('workspace message queue controller', () => {
     await vi.waitFor(() => expect(input.runtime.sendMessage).toHaveBeenCalledOnce())
     expect(input.runtime.sendMessage).toHaveBeenCalledWith(
       expect.objectContaining({
+        pdfReadingPosition: { pageNumber: 2, pageCount: 14 },
+        pdfReadingPositionSource: { attachmentId: 'upload-1' },
         pendingPdfContextAttachmentIds: ['upload-1'],
         pendingPdfContextVersions: [
           {

--- a/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
+++ b/src/renderer/src/pages/workspace/workspace-message-queue-drain.ts
@@ -123,6 +123,7 @@ const dispatchQueuedSession = (
             parts: item.snapshot ? docToMessageParts(item.snapshot.doc) : undefined,
             pdfContext: item.snapshot?.pdfContext,
             pdfReadingPosition: item.snapshot?.pdfReadingPosition,
+            pdfReadingPositionSource: item.snapshot?.pdfReadingPositionSource,
             pendingPdfContextAttachmentIds: item.snapshot?.pendingPdfContextAttachmentIds,
             pendingPdfContextVersions: item.snapshot?.pendingPdfContextVersions,
             cwd: item.cwd,

--- a/src/shared/session-pdf-context.ts
+++ b/src/shared/session-pdf-context.ts
@@ -4,9 +4,13 @@ import { createLiteratureAttachmentVersionReference } from './literature'
 import type {
   MessagePdfContextSnapshot,
   PdfReadingPosition,
-  SessionPdfBinding
+  SessionPdfBinding,
+  SessionPdfContextSource
 } from './session-persistence'
 import { createUploadVersionReference } from './uploads'
+
+// Transient send identity; staged uploads resolve to immutable versions before linking.
+export type PdfReadingPositionSource = SessionPdfContextSource | { attachmentId: string }
 
 export const sessionPdfBindingToFileReference = (
   projectId: string,


### PR DESCRIPTION
## Problem

A Reading request queued behind another Session's IPC could run against a later selected Session, unlinking its existing PDFs before adding the queued sources. Separately, removing the viewed PDF during candidate filtering could attach its page number and page count to another document in both the saved message and agent prompt.

## Proposed change

- Bind queued reconciliation to its originating Project/Session scope. Leaving that scope cancels unstarted work, including when returning before the preceding IPC settles. Keep rapid same-session changes coalesced.
- Carry transient reading-source identity through composer snapshots, immediate sends, queued sends, and branch preparation. Resolve staged attachment IDs to immutable versions and apply the position only to a matching returned binding after filtering/finalization/capacity trimming.

## Scope and non-goals

No database/schema migration, persisted format change, new lifecycle enum, global queue, or new UI controls. Future durable associations and message positions are corrected; existing historical records are not rewritten because their intended source cannot reliably be reconstructed. Cancelling unstarted work means a user who leaves the originating Session must initiate it again after returning.

## Acceptance criteria and validation

All listed checks ran after the final relevant edits. No local complete suite was run, as requested by the maintainer.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Cross-session/project cancellation, return-to-origin, same-session coalescing, immediate/queued field forwarding | `npm run test:module -- workspace_page` | 30 files / 851 tests passed |
| New/existing Session sends, single-page/unavailable/unreadable filtering, mixed staged/immutable selection, excluded sources, capacity trimming, branch/runtime contracts | `npm run test:module -- workspace_runtime` | 11 files / 500 tests passed |
| Main candidate owner, prompt preparation, history replay | `npm test -- src/main/session-persistence/pdf-context-owner.test.ts src/main/acp/prompt-content-owner.test.ts src/renderer/src/lib/acp/history-preamble.test.ts` | 3 files / 72 tests passed |
| Four provider acceptance paths and linked-PDF routing | `npm test -- src/main/acp/runtime.test.ts -t 'provider prompt acceptance\|linked-PDF\|first provider Session'` | 6 passed |
| Process contracts and style | `npm run typecheck`; `npm run lint` | passed |
| Existing PDF UI journey | `npm run build:e2e`; `npm run test:e2e -- e2e/workspace-files.spec.ts -g 'links a multi-page PDF upload'` | build and 1 Electron test passed; screenshot captured |

The regressions use real controller actions and `sendWorkspaceMessage`; candidate eligibility uses the real `SessionPdfContextOwner.filterCandidates` with controlled file resolution/page inspection. No production test seam was added. Repeated original-code runs failed with the reported IPC mutations and incorrect snapshot/prompt positions. Final A/B verification with unchanged test inputs: original implementation 10 failures / 2 controls passed; fixed implementation all 12 passed.

## Review focus

Identity must survive candidate reordering/removal, staged finalization, and queue dispatch without being inferred from the surviving first candidate. The private source resolver remains inside the runtime owner. Claude Code, OpenCode, Codex Responses and Codex Bridge consume the unchanged common prompt-reference boundary; no subscription, terminalization, or provider protocol code changes.

The affected-test explain command requests full CI fallback for paths outside the curated module map. Local coverage therefore combines the owner modules and explicit consumer contracts above; exact-head PR CI remains authoritative for full and platform lanes. CodeGraph's available index belongs to the base checkout, so final new-symbol/consumer relationships were checked from worktree source and architecture tests. No new platform-dependent paths or persisted formats were introduced. Historical repair and live provider-network execution are outside this PR.
