### PR TITLE
fix(pdf-preview): correct search ranges and navigation

### DIFF
--- a/src/renderer/src/pages/workspace/previews/renderers/PdfOutlineSidebar.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfOutlineSidebar.tsx
@@ -270,24 +270,34 @@ const PdfOutlineTree = ({
   const { t } = useTranslation()
   const parents = useMemo(() => collectParents(items), [items])
   const activeId = useMemo(() => activeOutlineId(items, currentPage), [currentPage, items])
-  const [expanded, setExpanded] = useState<ReadonlySet<string>>(
-    () => new Set(items.filter((item) => item.children.length > 0).map((item) => item.id))
-  )
-  const [focusedId, setFocusedId] = useState<string | undefined>(activeId ?? items[0]?.id)
-  const itemRefs = useRef(new Map<string, HTMLButtonElement>())
-  const visibleExpanded = useMemo(() => {
-    const next = new Set(expanded)
+  const expandActiveParents = (current: ReadonlySet<string>): ReadonlySet<string> => {
+    const next = new Set(current)
     let parentId = activeId ? parents.get(activeId) : undefined
     while (parentId) {
       next.add(parentId)
       parentId = parents.get(parentId)
     }
     return next
-  }, [activeId, expanded, parents])
-  const visible = useMemo(() => flattenVisible(items, visibleExpanded), [items, visibleExpanded])
-  const effectiveFocusedId = visible.some(({ item }) => item.id === focusedId)
-    ? focusedId
-    : (activeId ?? visible[0]?.item.id)
+  }
+  const [expanded, setExpanded] = useState<ReadonlySet<string>>(() =>
+    expandActiveParents(
+      new Set(items.filter((item) => item.children.length > 0).map((item) => item.id))
+    )
+  )
+  const [expandedActiveId, setExpandedActiveId] = useState(activeId)
+  // Expand once per active section, then respect the user's collapse until it changes.
+  if (expandedActiveId !== activeId) {
+    setExpandedActiveId(activeId)
+    setExpanded(expandActiveParents(expanded))
+  }
+  const [focusedId, setFocusedId] = useState<string | undefined>(activeId ?? items[0]?.id)
+  const itemRefs = useRef(new Map<string, HTMLButtonElement>())
+  const visible = useMemo(() => flattenVisible(items, expanded), [items, expanded])
+  let effectiveFocusedId = focusedId
+  while (effectiveFocusedId && !visible.some(({ item }) => item.id === effectiveFocusedId)) {
+    effectiveFocusedId = parents.get(effectiveFocusedId)
+  }
+  effectiveFocusedId ??= visible[0]?.item.id
   const toggle = (id: string, force?: boolean): void => {
     setExpanded((current) => {
       const next = new Set(current)
@@ -311,7 +321,7 @@ const PdfOutlineTree = ({
     <ul role="tree" aria-label={t('Outline')} className="space-y-0.5">
       {visible.map(({ item, level, parentId }, index) => {
         const hasChildren = item.children.length > 0
-        const isExpanded = hasChildren && visibleExpanded.has(item.id)
+        const isExpanded = hasChildren && expanded.has(item.id)
         const isActive = item.id === activeId
         return (
           <li key={item.id} role="none">

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, Component, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -9,6 +9,7 @@ import {
 } from '../../../../../../shared/web-event-connection'
 import { createManagedPdfLoadingTask } from '../managed-pdf-document'
 import { PdfPreviewContent, PdfPreviewRenderer } from './PdfPreview'
+import { PdfOutlineSidebar } from './PdfOutlineSidebar'
 import { requestAnnotationReveal } from '../../annotations/annotation-reveal'
 
 vi.mock('../managed-pdf-document', () => ({ createManagedPdfLoadingTask: vi.fn() }))
@@ -128,6 +129,15 @@ describe('PdfPreviewContent', () => {
     document.body.appendChild(container)
     root = createRoot(container)
     Element.prototype.scrollIntoView = vi.fn()
+    // jsdom implements DOM ranges but has no layout engine.
+    vi.stubGlobal(
+      'Range',
+      class extends Range {
+        getBoundingClientRect(): DOMRect {
+          return new DOMRect()
+        }
+      }
+    )
     window.api = {
       previewResources: {
         acquire: vi.fn().mockResolvedValue({
@@ -713,6 +723,330 @@ describe('PdfPreviewContent', () => {
     await vi.waitFor(() => expect(input.parentElement?.textContent).toContain('1/1'))
     await vi.waitFor(() => expect(highlights.set).toHaveBeenCalledWith('pdf-search-results', {}))
     expect(constructedHighlights.some((ranges) => ranges.length > 0)).toBe(true)
+  })
+
+  const openSearch = async (query: string): Promise<HTMLInputElement> => {
+    const scroll = container.querySelector<HTMLElement>('[role="region"]')!
+    await act(async () =>
+      scroll.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'f',
+          metaKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    )
+    const input = container.querySelector<HTMLInputElement>('[aria-label="Search document"]')!
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, query)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    await act(async () => vi.advanceTimersByTimeAsync(180))
+    return input
+  }
+
+  it.each([
+    { text: ['İA'], query: 'a', expected: ['A'] },
+    { text: ['İA', 'B'], query: 'ab', expected: ['AB'] },
+    { text: ['AA'], query: 'a', expected: ['A', 'A'] },
+    { text: ['A', 'B'], query: 'ab', expected: ['AB'] },
+    { text: ['İ'], query: 'i', expected: ['İ'] },
+    { text: ['İΟΣ'], query: 'ος', expected: ['ΟΣ'] },
+    { text: ['😀İA'], query: 'a', expected: ['A'] },
+    { text: ['I\u0307A'], query: 'a', expected: ['A'], locale: 'tr' },
+    { text: ['I\u0301A'], query: 'a', expected: ['A'], locale: 'lt' }
+  ])(
+    'highlights original DOM characters for $text searching $query',
+    async ({ text, query, expected, locale = 'en' }) => {
+      vi.useFakeTimers()
+      const lower = String.prototype.toLocaleLowerCase
+      vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function (this: string) {
+        return lower.call(this, locale)
+      })
+      const highlights = new Map<string, Set<Range>>()
+      vi.stubGlobal('CSS', { highlights })
+      vi.stubGlobal(
+        'Highlight',
+        class extends Set<Range> {
+          constructor(...ranges: Range[]) {
+            super(ranges)
+          }
+        }
+      )
+      const errors: Error[] = []
+      class SearchBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+        state = { failed: false }
+        static getDerivedStateFromError(): { failed: boolean } {
+          return { failed: true }
+        }
+        componentDidCatch(error: Error): void {
+          errors.push(error)
+        }
+        render(): ReactNode {
+          return this.state.failed ? null : this.props.children
+        }
+      }
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      getPage.mockResolvedValue({
+        getViewport: () => ({ width: 600, height: 800 }),
+        getTextContent: async () => ({ items: text.map((str) => ({ str })), styles: {} }),
+        render: () => ({ promise: Promise.resolve(), cancel: vi.fn() }),
+        cleanup: vi.fn()
+      })
+      await act(async () =>
+        root.render(
+          <SearchBoundary>
+            <PdfPreviewContent path="/workspace/unicode.pdf" name="unicode.pdf" />
+          </SearchBoundary>
+        )
+      )
+      expect(container.querySelector('[data-pdf-text-layer]')?.textContent).toBe(text.join(''))
+      const input = await openSearch(query)
+      expect(errors.map((error) => error.name)).toEqual([])
+      expect(input.parentElement?.textContent).toContain(`1/${expected.length}`)
+      expect(
+        Array.from(highlights.get('pdf-search-results') ?? [], (range) => range.toString())
+      ).toEqual(expected)
+    }
+  )
+
+  it.each(['first', 'next'])('reveals the %s match inside a tall PDF page', async (target) => {
+    vi.useFakeTimers()
+    const highlights = new Map<string, Set<Range>>()
+    vi.stubGlobal('CSS', { highlights })
+    vi.stubGlobal(
+      'Highlight',
+      class extends Set<Range> {
+        constructor(...ranges: Range[]) {
+          super(ranges)
+        }
+      }
+    )
+    getPage.mockResolvedValue({
+      getViewport: () => ({ width: 600, height: 1800 }),
+      getTextContent: async () => ({
+        items: [{ str: target === 'next' ? 'needle needle' : 'needle' }],
+        styles: {}
+      }),
+      render: () => ({ promise: Promise.resolve(), cancel: vi.fn() }),
+      cleanup: vi.fn()
+    })
+    await act(async () =>
+      root.render(<PdfPreviewContent path="/workspace/tall.pdf" name="tall.pdf" />)
+    )
+    const scroll = container.querySelector<HTMLElement>('[role="region"]')!
+    vi.spyOn(scroll, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 800, 600))
+    vi.spyOn(scroll, 'clientHeight', 'get').mockReturnValue(600)
+    vi.spyOn(scroll, 'clientWidth', 'get').mockReturnValue(800)
+    vi.stubGlobal(
+      'Range',
+      class extends Range {
+        getBoundingClientRect(): DOMRect {
+          const top = target === 'first' || this.startOffset > 0 ? 1800 : 100
+          return new DOMRect(40, top - scroll.scrollTop, 60, 20)
+        }
+        getClientRects(): DOMRectList {
+          return [this.getBoundingClientRect()] as unknown as DOMRectList
+        }
+      }
+    )
+    const input = await openSearch('needle')
+    expect(input.parentElement?.textContent).toContain(target === 'next' ? '1/2' : '1/1')
+    if (target === 'next') {
+      expect(scroll.scrollTop).toBe(0)
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Next match"]')!.click()
+      )
+      expect(input.parentElement?.textContent).toContain('2/2')
+    }
+    const current = Array.from(highlights.get('pdf-search-current') ?? [])[0]
+    expect(current?.toString()).toBe('needle')
+    const bounds = current.getBoundingClientRect()
+    expect(bounds.top).toBeGreaterThanOrEqual(0)
+    expect(bounds.bottom).toBeLessThanOrEqual(600)
+  })
+
+  it.each(['ready', 'query cleared', 'document replaced'])(
+    'finishes a deferred match reveal only while its request is current: %s',
+    async (outcome) => {
+      vi.useFakeTimers()
+      let intersectionCallback: IntersectionObserverCallback | undefined
+      const observed: Element[] = []
+      vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+          observe = (element: Element): void => {
+            observed.push(element)
+          }
+          unobserve = vi.fn()
+          disconnect = vi.fn()
+          constructor(callback: IntersectionObserverCallback) {
+            intersectionCallback = callback
+          }
+        }
+      )
+      getPage.mockImplementation(async () => ({
+        getViewport: () => ({ width: 600, height: 1800 }),
+        getTextContent: async () => ({ items: [{ str: 'needle needle' }], styles: {} }),
+        render: () => ({ promise: Promise.resolve(), cancel: vi.fn() }),
+        cleanup: vi.fn()
+      }))
+      await act(async () =>
+        root.render(<PdfPreviewContent path="/workspace/deferred.pdf" name="deferred.pdf" />)
+      )
+      const scroll = container.querySelector<HTMLElement>('[role="region"]')!
+      vi.spyOn(scroll, 'getBoundingClientRect').mockReturnValue(new DOMRect(0, 0, 800, 600))
+      vi.spyOn(scroll, 'clientHeight', 'get').mockReturnValue(600)
+      vi.spyOn(scroll, 'clientWidth', 'get').mockReturnValue(800)
+      vi.stubGlobal(
+        'Range',
+        class extends Range {
+          getBoundingClientRect(): DOMRect {
+            return new DOMRect(40, 1800 - scroll.scrollTop, 60, 20)
+          }
+        }
+      )
+      const input = await openSearch('needle')
+      expect(input.parentElement?.textContent).toContain('1/2')
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Next match"]')!.click()
+      )
+      expect(input.parentElement?.textContent).toContain('2/2')
+      expect(container.querySelector('[data-pdf-text-layer]')).toBeNull()
+      expect(Element.prototype.scrollIntoView).toHaveBeenCalledWith({
+        block: 'start',
+        behavior: 'auto'
+      })
+      expect(scroll.scrollTop).toBe(0)
+      if (outcome === 'query cleared') {
+        await act(async () => {
+          Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set?.call(input, '')
+          input.dispatchEvent(new Event('input', { bubbles: true }))
+        })
+      } else if (outcome === 'document replaced') {
+        await act(async () =>
+          root.render(
+            <PdfPreviewContent path="/workspace/replacement.pdf" name="replacement.pdf" />
+          )
+        )
+      }
+      await act(async () => {
+        intersectionCallback?.(
+          [{ isIntersecting: true, target: observed.at(-1) } as IntersectionObserverEntry],
+          {} as IntersectionObserver
+        )
+      })
+      expect(container.querySelector('[data-pdf-text-layer]')?.textContent).toBe('needle needle')
+      expect(scroll.scrollTop).toBe(outcome === 'ready' ? 1510 : 0)
+      // A later text-layer render must not pull the reader back to a completed result.
+      scroll.scrollTop = 400
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Zoom in"]')!.click()
+      )
+      expect(scroll.scrollTop).toBe(400)
+    }
+  )
+
+  it.each(['mouse', 'keyboard'])(
+    'allows collapsing the active section parent using $0',
+    async (method) => {
+      vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+          observe = vi.fn()
+          unobserve = vi.fn()
+          disconnect = vi.fn()
+        }
+      )
+      vi.mocked(createManagedPdfLoadingTask).mockReturnValue({
+        promise: Promise.resolve({
+          numPages: 2,
+          getPage,
+          destroy: destroyDocument,
+          getOutline: async () => [
+            { title: 'Chapter', dest: [0], items: [{ title: 'Section', dest: [1], items: [] }] }
+          ]
+        }),
+        destroy: vi.fn().mockResolvedValue(undefined)
+      } as never)
+      await act(async () =>
+        root.render(<PdfPreviewContent path="/workspace/outline-collapse.pdf" name="outline.pdf" />)
+      )
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Show navigation"]')!.click()
+      )
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[title="Section"]')!.click()
+      )
+      expect(container.querySelector('[title="Section"]')?.getAttribute('aria-selected')).toBe(
+        'true'
+      )
+      const parent = container.querySelector<HTMLButtonElement>('[title="Chapter"]')!
+      await act(async () => {
+        if (method === 'mouse')
+          container.querySelector<HTMLButtonElement>('[aria-label="Collapse"]')!.click()
+        else parent.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+      })
+      expect(parent.getAttribute('aria-expanded')).toBe('false')
+      expect(container.querySelector('[title="Section"]')).toBeNull()
+      expect(container.querySelector('[role="treeitem"][tabindex="0"]')).toBe(parent)
+      await act(async () => parent.click())
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[aria-label="Expand"]')!.click()
+      )
+      await act(async () =>
+        container.querySelector<HTMLButtonElement>('[title="Section"]')!.click()
+      )
+      expect(parent.getAttribute('aria-expanded')).toBe('true')
+    }
+  )
+
+  it('reopens active ancestors only when the section changes or the outline is first shown', async () => {
+    const items = [
+      {
+        id: 'chapter',
+        title: 'Chapter',
+        pageNumber: 1,
+        children: [
+          {
+            id: 'section',
+            title: 'Section',
+            pageNumber: 2,
+            children: [{ id: 'subsection', title: 'Subsection', pageNumber: 3, children: [] }]
+          }
+        ]
+      }
+    ]
+    const renderOutline = async (currentPage: number): Promise<void> => {
+      await act(async () =>
+        root.render(
+          <PdfOutlineSidebar
+            document={{ getPage } as never}
+            items={items}
+            pageCount={4}
+            currentPage={currentPage}
+            width={240}
+            onWidthChange={vi.fn()}
+            onClose={vi.fn()}
+            onNavigate={vi.fn()}
+          />
+        )
+      )
+    }
+    await renderOutline(3)
+    expect(container.querySelector('[title="Subsection"]')).not.toBeNull()
+    const chapter = container.querySelector<HTMLButtonElement>('[title="Chapter"]')!
+    await act(async () =>
+      chapter.dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true }))
+    )
+    await renderOutline(4)
+    expect(chapter.getAttribute('aria-expanded')).toBe('false')
+    expect(container.querySelector('[title="Subsection"]')).toBeNull()
+    expect(container.querySelector('[role="treeitem"][tabindex="0"]')).toBe(chapter)
+    await renderOutline(2)
+    expect(chapter.getAttribute('aria-expanded')).toBe('true')
+    expect(container.querySelector('[title="Section"]')?.getAttribute('aria-selected')).toBe('true')
   })
 
   it('stops a stale full-document search before parsing the remaining pages', async () => {

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -746,70 +746,74 @@ describe('PdfPreviewContent', () => {
     return input
   }
 
-  it.each([
-    { text: ['İA'], query: 'a', expected: ['A'] },
-    { text: ['İA', 'B'], query: 'ab', expected: ['AB'] },
-    { text: ['AA'], query: 'a', expected: ['A', 'A'] },
-    { text: ['A', 'B'], query: 'ab', expected: ['AB'] },
-    { text: ['İ'], query: 'i', expected: ['İ'] },
-    { text: ['İΟΣ'], query: 'ος', expected: ['ΟΣ'] },
-    { text: ['😀İA'], query: 'a', expected: ['A'] },
-    { text: ['I\u0307A'], query: 'a', expected: ['A'], locale: 'tr' },
-    { text: ['I\u0301A'], query: 'a', expected: ['A'], locale: 'lt' }
-  ])(
-    'highlights original DOM characters for $text searching $query',
-    async ({ text, query, expected, locale = 'en' }) => {
-      vi.useFakeTimers()
-      const lower = String.prototype.toLocaleLowerCase
-      vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function (this: string) {
-        return lower.call(this, locale)
-      })
-      const highlights = new Map<string, Set<Range>>()
-      vi.stubGlobal('CSS', { highlights })
-      vi.stubGlobal(
-        'Highlight',
-        class extends Set<Range> {
-          constructor(...ranges: Range[]) {
-            super(ranges)
+  describe.each([true, false])('Intl.Segmenter available: %s', (available) => {
+    it.each([
+      { text: ['İA'], query: 'a', expected: ['A'] },
+      { text: ['İA', 'B'], query: 'ab', expected: ['AB'] },
+      { text: ['AA'], query: 'a', expected: ['A', 'A'] },
+      { text: ['A', 'B'], query: 'ab', expected: ['AB'] },
+      { text: ['İ'], query: 'i', expected: ['İ'] },
+      { text: ['İΟΣ'], query: 'ος', expected: ['ΟΣ'] },
+      { text: ['😀İA'], query: 'a', expected: ['A'] },
+      { text: ['I\u0307A'], query: 'a', expected: ['A'], locale: 'tr' },
+      { text: ['I\u0301A'], query: 'a', expected: ['A'], locale: 'lt' }
+    ])(
+      'highlights original DOM characters for $text searching $query',
+      async ({ text, query, expected, locale = 'en' }) => {
+        vi.useFakeTimers()
+        if (!available)
+          vi.stubGlobal('Intl', Object.create(Intl, { Segmenter: { value: undefined } }))
+        const lower = String.prototype.toLocaleLowerCase
+        vi.spyOn(String.prototype, 'toLocaleLowerCase').mockImplementation(function (this: string) {
+          return lower.call(this, locale)
+        })
+        const highlights = new Map<string, Set<Range>>()
+        vi.stubGlobal('CSS', { highlights })
+        vi.stubGlobal(
+          'Highlight',
+          class extends Set<Range> {
+            constructor(...ranges: Range[]) {
+              super(ranges)
+            }
+          }
+        )
+        const errors: Error[] = []
+        class SearchBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+          state = { failed: false }
+          static getDerivedStateFromError(): { failed: boolean } {
+            return { failed: true }
+          }
+          componentDidCatch(error: Error): void {
+            errors.push(error)
+          }
+          render(): ReactNode {
+            return this.state.failed ? null : this.props.children
           }
         }
-      )
-      const errors: Error[] = []
-      class SearchBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
-        state = { failed: false }
-        static getDerivedStateFromError(): { failed: boolean } {
-          return { failed: true }
-        }
-        componentDidCatch(error: Error): void {
-          errors.push(error)
-        }
-        render(): ReactNode {
-          return this.state.failed ? null : this.props.children
-        }
-      }
-      vi.spyOn(console, 'error').mockImplementation(() => undefined)
-      getPage.mockResolvedValue({
-        getViewport: () => ({ width: 600, height: 800 }),
-        getTextContent: async () => ({ items: text.map((str) => ({ str })), styles: {} }),
-        render: () => ({ promise: Promise.resolve(), cancel: vi.fn() }),
-        cleanup: vi.fn()
-      })
-      await act(async () =>
-        root.render(
-          <SearchBoundary>
-            <PdfPreviewContent path="/workspace/unicode.pdf" name="unicode.pdf" />
-          </SearchBoundary>
+        vi.spyOn(console, 'error').mockImplementation(() => undefined)
+        getPage.mockResolvedValue({
+          getViewport: () => ({ width: 600, height: 800 }),
+          getTextContent: async () => ({ items: text.map((str) => ({ str })), styles: {} }),
+          render: () => ({ promise: Promise.resolve(), cancel: vi.fn() }),
+          cleanup: vi.fn()
+        })
+        await act(async () =>
+          root.render(
+            <SearchBoundary>
+              <PdfPreviewContent path="/workspace/unicode.pdf" name="unicode.pdf" />
+            </SearchBoundary>
+          )
         )
-      )
-      expect(container.querySelector('[data-pdf-text-layer]')?.textContent).toBe(text.join(''))
-      const input = await openSearch(query)
-      expect(errors.map((error) => error.name)).toEqual([])
-      expect(input.parentElement?.textContent).toContain(`1/${expected.length}`)
-      expect(
-        Array.from(highlights.get('pdf-search-results') ?? [], (range) => range.toString())
-      ).toEqual(expected)
-    }
-  )
+        expect(container.querySelector('[data-pdf-text-layer]')?.textContent).toBe(text.join(''))
+        const input = await openSearch(query)
+        expect(errors.map((error) => error.name)).toEqual([])
+        expect(input.parentElement?.textContent).toContain(`1/${expected.length}`)
+        expect(
+          Array.from(highlights.get('pdf-search-results') ?? [], (range) => range.toString())
+        ).toEqual(expected)
+      }
+    )
+  })
 
   it.each(['first', 'next'])('reveals the %s match inside a tall PDF page', async (target) => {
     vi.useFakeTimers()

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -157,18 +157,34 @@ const textRangesForQuery = (root: HTMLElement, query: string): Range[] => {
   const normalizedText = text.toLocaleLowerCase()
   const normalizedQuery = query.toLocaleLowerCase()
   if (!normalizedQuery) return []
+  // Keep whole-string casing (for example, Greek final sigma), but map length-changing
+  // graphemes back to their original DOM character, including locale-specific combining marks.
+  const originalStarts: number[] = []
+  const originalEnds: number[] = []
+  for (const { segment, index } of new Intl.Segmenter(undefined, {
+    granularity: 'grapheme'
+  }).segment(text)) {
+    const length = segment.toLocaleLowerCase().length
+    for (let offset = 0; offset < length; offset += 1) {
+      originalStarts.push(index + (length === segment.length ? offset : 0))
+      originalEnds.push(index + (length === segment.length ? offset + 1 : segment.length))
+    }
+  }
   const ranges: Range[] = []
   let index = 0
   while ((index = normalizedText.indexOf(normalizedQuery, index)) >= 0) {
     const end = index + normalizedQuery.length
-    const startNodeIndex = starts.findLastIndex((start) => start <= index)
-    const endNodeIndex = starts.findLastIndex((start) => start < end)
+    const originalStart = originalStarts[index]
+    const originalEnd = originalEnds[end - 1]
+    // Inserted word/line gaps have no DOM node: anchor their endpoints to adjacent text.
+    const startNodeIndex = starts.findIndex((start, i) => start + nodes[i].length > originalStart)
+    const endNodeIndex = starts.findLastIndex((start) => start < originalEnd)
     const startNode = nodes[startNodeIndex]
     const endNode = nodes[endNodeIndex]
     if (startNode && endNode) {
       const range = new Range()
-      range.setStart(startNode, index - starts[startNodeIndex])
-      range.setEnd(endNode, end - starts[endNodeIndex])
+      range.setStart(startNode, Math.max(0, originalStart - starts[startNodeIndex]))
+      range.setEnd(endNode, Math.min(endNode.length, originalEnd - starts[endNodeIndex]))
       ranges.push(range)
     }
     index = Math.max(end, index + 1)
@@ -180,13 +196,13 @@ const updatePdfSearchHighlights = (
   scroll: HTMLElement | null,
   query: string,
   selected?: PdfSearchMatch
-): void => {
+): Range | undefined => {
   const registry = (globalThis as unknown as { CSS?: { highlights?: HighlightRegistry } }).CSS
     ?.highlights
   const HighlightClass = (globalThis as unknown as { Highlight?: HighlightConstructor }).Highlight
   registry?.delete('pdf-search-results')
   registry?.delete('pdf-search-current')
-  if (!registry || !HighlightClass || !scroll || !query) return
+  if (!scroll || !query) return
   const allRanges: Range[] = []
   let selectedRange: Range | undefined
   for (const page of scroll.querySelectorAll<HTMLElement>('[data-page-number]')) {
@@ -198,8 +214,33 @@ const updatePdfSearchHighlights = (
       selectedRange = pageRanges[selected.occurrence]
     }
   }
-  if (allRanges.length > 0) registry.set('pdf-search-results', new HighlightClass(...allRanges))
-  if (selectedRange) registry.set('pdf-search-current', new HighlightClass(selectedRange))
+  if (registry && HighlightClass) {
+    if (allRanges.length > 0) registry.set('pdf-search-results', new HighlightClass(...allRanges))
+    if (selectedRange) registry.set('pdf-search-current', new HighlightClass(selectedRange))
+  }
+  return selectedRange
+}
+
+const revealPdfSearchRange = (scroll: HTMLElement, range: Range | undefined): boolean => {
+  const bounds = range?.getBoundingClientRect()
+  if (!bounds || bounds.width <= 0 || bounds.height <= 0) return false
+  const viewport = scroll.getBoundingClientRect()
+  const left = viewport.left + scroll.clientLeft
+  const top = viewport.top + scroll.clientTop
+  const right = left + scroll.clientWidth
+  const bottom = top + scroll.clientHeight
+  // Center offscreen matches away from the floating controls; leave visible matches still.
+  // An oversized match reveals its beginning.
+  if (bounds.top < top || bounds.bottom > bottom) {
+    scroll.scrollTop += bounds.top - top - Math.max(0, (scroll.clientHeight - bounds.height) / 2)
+  }
+  if (bounds.left < left || bounds.right > right) {
+    scroll.scrollLeft +=
+      bounds.left < left || bounds.width > scroll.clientWidth
+        ? bounds.left - left
+        : bounds.right - right
+  }
+  return true
 }
 
 const isPdfPageRef = (value: unknown): value is { num: number; gen: number } =>
@@ -1159,6 +1200,15 @@ export const PdfPreviewContent = ({
   const [selectedSearchIndex, setSelectedSearchIndex] = useState(0)
   const [textLayerEpoch, setTextLayerEpoch] = useState(0)
   const searchTextCacheRef = useRef(new Map<number, Promise<string>>())
+  const pendingSearchRevealRef = useRef<
+    | {
+        document: PdfDocument
+        requestKey: string
+        query: string
+        match: PdfSearchMatch
+      }
+    | undefined
+  >(undefined)
   const [outlineState, setOutlineState] = useState<
     Readonly<{ requestKey: string; items: readonly PdfOutlineItem[] }> | undefined
   >()
@@ -1401,6 +1451,23 @@ export const PdfPreviewContent = ({
     currentPageRef.current = pageNumber
     setCurrentPage(pageNumber)
   }, [])
+  const revealSearchMatch = useCallback(
+    (match: PdfSearchMatch): void => {
+      const scroll = scrollRef.current
+      if (!scroll || !document) return
+      const range = updatePdfSearchHighlights(scroll, searchQuery, match)
+      pendingSearchRevealRef.current = undefined
+      if (revealPdfSearchRange(scroll, range)) return
+      pendingSearchRevealRef.current = {
+        document,
+        requestKey: resourceRequestKey,
+        query: searchQuery,
+        match
+      }
+      scrollToPage(match.pageNumber)
+    },
+    [document, resourceRequestKey, searchQuery, scrollToPage]
+  )
   const navigateToPage = scrollToPage
   useEffect(
     () =>
@@ -1466,7 +1533,7 @@ export const PdfPreviewContent = ({
             if (!revealedFirstMatch && matches[0]) {
               revealedFirstMatch = true
               setSelectedSearchIndex(0)
-              scrollToPage(matches[0].pageNumber)
+              revealSearchMatch({ pageNumber: matches[0].pageNumber, occurrence: 0 })
             }
           }
         }
@@ -1475,23 +1542,42 @@ export const PdfPreviewContent = ({
         setSearchResultCount(matchCount)
         if (!revealedFirstMatch && matches[0]) {
           setSelectedSearchIndex(0)
-          scrollToPage(matches[0].pageNumber)
+          revealSearchMatch({ pageNumber: matches[0].pageNumber, occurrence: 0 })
         }
       })()
     }, 180)
     return () => {
       canceled = true
       clearTimeout(timer)
+      pendingSearchRevealRef.current = undefined
     }
-  }, [document, searchQuery, scrollToPage])
+  }, [document, searchQuery, revealSearchMatch])
 
   useEffect(() => {
-    updatePdfSearchHighlights(
-      scrollRef.current,
-      searchQuery,
-      resolvePdfSearchMatch(searchResults, selectedSearchIndex)
-    )
-  }, [searchQuery, searchResults, selectedSearchIndex, textLayerEpoch])
+    const scroll = scrollRef.current
+    const selected = resolvePdfSearchMatch(searchResults, selectedSearchIndex)
+    const range = updatePdfSearchHighlights(scroll, searchQuery, selected)
+    const pending = pendingSearchRevealRef.current
+    if (!pending) return
+    if (
+      pending.document !== document ||
+      pending.requestKey !== resourceRequestKey ||
+      pending.query !== searchQuery ||
+      pending.match.pageNumber !== selected?.pageNumber ||
+      pending.match.occurrence !== selected.occurrence
+    ) {
+      pendingSearchRevealRef.current = undefined
+      return
+    }
+    if (scroll && revealPdfSearchRange(scroll, range)) pendingSearchRevealRef.current = undefined
+  }, [
+    document,
+    resourceRequestKey,
+    searchQuery,
+    searchResults,
+    selectedSearchIndex,
+    textLayerEpoch
+  ])
 
   useLayoutEffect(() => {
     const anchor = viewportAnchorRef.current
@@ -1623,7 +1709,7 @@ export const PdfPreviewContent = ({
     const nextMatch = resolvePdfSearchMatch(searchResults, nextIndex)
     if (!nextMatch) return
     setSelectedSearchIndex(nextIndex)
-    scrollToPage(nextMatch.pageNumber)
+    revealSearchMatch(nextMatch)
   }
   const closeSearch = (): void => {
     setSearchOpen(false)

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -157,13 +157,13 @@ const textRangesForQuery = (root: HTMLElement, query: string): Range[] => {
   const normalizedText = text.toLocaleLowerCase()
   const normalizedQuery = query.toLocaleLowerCase()
   if (!normalizedQuery) return []
-  // Keep whole-string casing (for example, Greek final sigma), but map length-changing
-  // graphemes back to their original DOM character, including locale-specific combining marks.
+  // Keep whole-string casing (for example, Greek final sigma). Length-changing lowercase
+  // mappings need a base character and its combining marks together (Turkish/Lithuanian I).
+  // Unicode mark runs suffice here; full grapheme segmentation would require Intl.Segmenter
+  // in older Web browsers without improving these UTF-16 mappings.
   const originalStarts: number[] = []
   const originalEnds: number[] = []
-  for (const { segment, index } of new Intl.Segmenter(undefined, {
-    granularity: 'grapheme'
-  }).segment(text)) {
+  for (const { 0: segment, index } of text.matchAll(/\P{M}\p{M}*|\p{M}+/gu)) {
     const length = segment.toLocaleLowerCase().length
     for (let offset = 0; offset < length; offset += 1) {
       originalStarts.push(index + (length === segment.length ? offset : 0))


### PR DESCRIPTION
## Problem

Searching text such as `İA` for `a` uses lowercased string offsets against the original DOM text, throwing `IndexSizeError`. Search navigation selects the correct occurrence but scrolls only to the page start, leaving matches on tall pages offscreen. Outline auto-expansion also overrides attempts to collapse the active section's parent.

## Proposed change

- Map normalized search offsets back to original DOM UTF-16 boundaries, including length-changing base/combining-mark sequences and matches across spans. Preserve whole-string casing for context-sensitive text.
- Reuse the selected match Range to reveal offscreen results within the PDF scroller. Visible results stay still; unrendered pages receive a deferred reveal guarded by document, resource request, query and occurrence identity.
- Expand the active section's ancestors only on initial presentation or an actual section change; preserve manual collapse and a visible keyboard tab stop.

## Scope and non-goals

Three renderer files only. No new dependency, public interface, search-result model, enum, IPC, persistent field or historical-data migration. Added state is limited to temporary offset arrays, one pending reveal ref and the last automatically expanded section identity. Existing PDFs require no conversion.

## Acceptance criteria and validation

All listed checks ran after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Original Unicode DOM ranges, ASCII/cross-span controls, tall-page result visibility, delayed reveal/cancellation and outline mouse/keyboard collapse | `npm test -- src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx` (included in the combined run below) | Passed |
| PDF search counts, thumbnails, PDF.js/resource adapter, preview registry consumers, region evidence and reading reveal | Combined targeted run of `PdfPreview.test.tsx`, `PdfThumbnail.test.tsx`, `pdf-search-matches.test.ts`, `preview-registry.test.tsx`, `managed-pdf-document.test.ts`, `pdfjs.test.ts`, `pdf-region-evidence.test.ts`, and `pdf-reading-reveal.test.ts` | 8 files / 102 tests passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Lint and whitespace | `npm run lint`; `git diff --check` | Passed |

Before changing production code, repeated component runs produced six failures matching the reports: two `IndexSizeError` cases, two selected ranges below the viewport, and mouse/keyboard collapse remaining `aria-expanded=true`; the ASCII control passed. After review identified a missing-Intl.Segmenter regression, nine additional cases first failed with TypeError. Replacing unnecessary grapheme segmentation with Unicode base/mark grouping makes both supported and missing-Segmenter environments pass. Tests mount the existing public reader without adding a production test seam. jsdom geometry is supplied at the browser API boundary.

Manual Chromium verification uses real PDF.js, production reader/CSS and generated valid PDFs, including a ToUnicode mapping yielding `İA`. Searching `a` selects only `A` without an uncaught exception; same-page next-result navigation makes `2/2` visible; the active section's parent collapses by mouse and keyboard. Screenshots are retained as local review artifacts.

The module classifier reports these PDF files as an unknown module owner and recommends full fallback. At the maintainer's explicit request, no complete local test suite was run: the focused PDF owner/adapter/consumer checks above were selected from the call paths instead. Required PR CI remains authoritative. No main/preload, persistence or platform-specific path changes are present, so local Node/platform lanes were not added. Real browser checks are manual and are not claimed as a committed automated E2E suite.

## Review focus

Normalized-to-original offset mapping, deferred reveal cancellation on query/document changes, and preserving manual outline state while maintaining keyboard access.
