### PR TITLE
fix(preview): preserve CSV data integrity in bounded previews

### DIFF
--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx
@@ -19,10 +19,21 @@ afterEach(async () => {
 const renderCsv = (
   content: string,
   extension = 'csv',
-  truncated = false
+  truncated = false,
+  bytes?: Uint8Array
 ): ReturnType<typeof render> => {
   const transport = createManagedPreviewTestTransport({
-    read: async () => ({ content, encoding: 'utf8', size: content.length, truncated })
+    read: async (_source, request) => {
+      if (!bytes) return { content, encoding: 'utf8', size: content.length, truncated }
+      const offset = request.offset ?? 0
+      const end = Math.min(bytes.length, offset + (request.maxBytes ?? PREVIEW_TEXT_MAX_BYTES) + 3)
+      return {
+        content: Buffer.from(bytes.subarray(offset, end)).toString('base64'),
+        encoding: 'base64',
+        size: bytes.length,
+        truncated: end < bytes.length
+      }
+    }
   })
   vi.stubGlobal('api', { previewResources: transport })
   vi.stubGlobal('fetch', transport.fetch)
@@ -86,7 +97,7 @@ describe('CSV preview row count', () => {
   it('omits the total when bytes are truncated before the parser row limit', async () => {
     renderCsv('a,b\n1,x\n2,y', 'csv', true)
     await screen.findByRole('table')
-    expect(screen.getByText('Showing 2 rows · 2 columns')).toBeTruthy()
+    expect(screen.getByText('Showing 1 rows · 2 columns')).toBeTruthy()
     expect(screen.queryByText('2 rows · 2 columns', { exact: true })).toBeNull()
     expect(screen.queryByText('2+ rows · 2 columns', { exact: true })).toBeNull()
   })
@@ -135,7 +146,7 @@ describe('CSV preview localization', () => {
     } else {
       expect(screen.getByText('2 行 · 2 列', { exact: true })).toBeTruthy()
     }
-    expect(screen.getByText('显示 2 行 · 2 列')).toBeTruthy()
+    expect(screen.getByText(`显示 ${truncated ? 1 : 2} 行 · 2 列`)).toBeTruthy()
     expect(document.body.textContent).not.toMatch(/rows|columns/)
     expect(document.body.textContent).not.toContain('CSV 解析出现问题')
   })
@@ -147,5 +158,134 @@ describe('CSV preview localization', () => {
     expect(table.textContent).toContain('unterminated')
     expect(document.body.textContent).not.toContain('Quoted field unterminated')
     expect(screen.getByText(/CSV 解析出现问题，预览可能不完整。/)).toBeTruthy()
+  })
+})
+
+describe('CSV preview data integrity', () => {
+  it.each([
+    ['csv', ','],
+    ['tsv', '\t']
+  ])('shows fields beyond the first record in %s files', async (extension, delimiter) => {
+    const { container } = renderCsv(
+      ['a,b', '1,2', '3,4,EXTRA_DATA'].join('\n').replaceAll(',', delimiter),
+      extension
+    )
+    await screen.findByRole('table')
+    expect(container.querySelector('tbody')?.textContent).toContain('EXTRA_DATA')
+    expect(screen.getByRole('columnheader', { name: 'Column 3' })).toBeTruthy()
+    expect(screen.getByText('2 rows · 3 columns', { exact: true })).toBeTruthy()
+  })
+
+  it('counts extra fields beyond the visible column limit', async () => {
+    renderCsv('a,b\n' + Array.from({ length: 26 }, (_, i) => `value${i}`).join(','))
+    await screen.findByRole('table')
+    expect(screen.getByText('1 rows · 26 columns', { exact: true })).toBeTruthy()
+    expect(screen.getByText('2 more columns hidden in this preview')).toBeTruthy()
+    expect(screen.getAllByRole('columnheader')).toHaveLength(25)
+  })
+
+  it('does not present a byte-truncated number as a complete cell', async () => {
+    const prefix = 'text,value\n'
+    const content = prefix + 'x'.repeat(PREVIEW_TEXT_MAX_BYTES - prefix.length - 4) + ',123456\n'
+    const bytes = new TextEncoder().encode(content)
+    expect(
+      new TextDecoder().decode(bytes.subarray(0, PREVIEW_TEXT_MAX_BYTES)).endsWith(',123')
+    ).toBe(true)
+    const { container } = renderCsv('', 'csv', false, bytes)
+    await screen.findByRole('table')
+    expect(container.querySelector('tbody [title="123"]')).toBeNull()
+  })
+
+  it.each(['LE', 'BE'])('does not silently display UTF-16%s BOM data as UTF-8', async (order) => {
+    const content = 'sample\tvalue\nA\t12\n'
+    const bytes = new Uint8Array(2 + content.length * 2)
+    const view = new DataView(bytes.buffer)
+    view.setUint16(0, 0xfeff, order === 'LE')
+    for (let i = 0; i < content.length; i += 1)
+      view.setUint16(2 + i * 2, content.charCodeAt(i), order === 'LE')
+    renderCsv('', 'tsv', false, bytes)
+    await screen.findByText(
+      'UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.'
+    )
+    expect(screen.queryByRole('table')).toBeNull()
+    // Either decode correctly or replace the garbled table with an encoding notice.
+    expect(document.querySelector('table')?.textContent ?? '').not.toContain('\u0000')
+    expect(document.querySelector('table')?.textContent ?? '').not.toContain('\ufffd')
+  })
+
+  it('does not warn about corruption for a complete single-column CSV', async () => {
+    const { container } = renderCsv('value\n1\n2')
+    await screen.findByRole('table')
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(2)
+    expect(screen.queryByText(/CSV parsing encountered a problem/)).toBeNull()
+  })
+})
+
+describe('CSV preview record boundaries', () => {
+  it.each(['\n', '\r\n', '\r'])(
+    'keeps complete quoted records with %j terminators and omits the partial tail',
+    async (newline) => {
+      const complete = ['a,b', `"first${newline}second ""quoted""",123456`].join(newline) + newline
+      const { container } = renderCsv(complete + '"partial' + newline, 'csv', true)
+      await screen.findByRole('table')
+      expect(container.querySelectorAll('tbody tr')).toHaveLength(1)
+      expect(container.querySelector('tbody [title="123456"]')).toBeTruthy()
+      expect(container.querySelector('tbody')?.textContent).toContain('quoted')
+      expect(container.querySelector('tbody')?.textContent).not.toContain('partial')
+      expect(
+        screen.getByText('The file exceeds the preview limit. Only complete records are shown.')
+      ).toBeTruthy()
+      expect(screen.queryByText(/CSV parsing encountered a problem/)).toBeNull()
+    }
+  )
+
+  it('keeps a complete record whose terminator coincides with the read boundary', async () => {
+    const { container } = renderCsv('a,b\n1,123456\n', 'csv', true)
+    await screen.findByRole('table')
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(1)
+    expect(container.querySelector('tbody [title="123456"]')).toBeTruthy()
+  })
+
+  it.each(['a,b', '"header\n'])('does not display a partial header %j', async (content) => {
+    renderCsv(content, 'csv', true)
+    await screen.findByText('The preview limit was reached before a complete header could be read.')
+    expect(screen.queryByRole('table')).toBeNull()
+  })
+
+  it('preserves an intact final number without a record terminator at EOF', async () => {
+    const { container } = renderCsv('a,b\n1,123456')
+    await screen.findByRole('table')
+    expect(container.querySelector('tbody [title="123456"]')).toBeTruthy()
+    expect(
+      screen.queryByText('The file exceeds the preview limit. Only complete records are shown.')
+    ).toBeNull()
+  })
+
+  it('decodes a UTF-8 BOM and non-ASCII cell values', async () => {
+    renderCsv('', 'tsv', false, new TextEncoder().encode('\ufeffsample\tvalue\n样本\t12'))
+    await screen.findByRole('table')
+    expect(screen.getByRole('columnheader', { name: 'sample' })).toBeTruthy()
+    expect(screen.getByText('样本')).toBeTruthy()
+    expect(screen.getByText('12')).toBeTruthy()
+  })
+
+  it('withholds a partial UTF-8 character without leaking replacement text', async () => {
+    const prefix = 'a,b\n'
+    const content = prefix + 'x'.repeat(PREVIEW_TEXT_MAX_BYTES - prefix.length - 1) + '样,2'
+    const { container } = renderCsv('', 'csv', false, new TextEncoder().encode(content))
+    await screen.findByRole('table')
+    expect(container.querySelectorAll('tbody tr')).toHaveLength(0)
+    expect(container.textContent).not.toContain('\ufffd')
+  })
+
+  it('explains delimiter uncertainty separately from malformed quoting', async () => {
+    renderCsv('a,b\n1\n2')
+    await screen.findByRole('table')
+    expect(
+      screen.getByText(
+        'The delimiter could not be detected reliably. Commas are used in this preview.'
+      )
+    ).toBeTruthy()
+    expect(screen.queryByText(/CSV parsing encountered a problem/)).toBeNull()
   })
 })

--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
@@ -1,5 +1,7 @@
-import { parse } from 'papaparse'
+import { parse, type ParseError } from 'papaparse'
 import { useTranslation } from 'react-i18next'
+
+import { ErrorNotice } from '@/components/error-notice'
 
 import { getFileExtension } from '../../preview-support'
 import { PreviewErrorCard, PreviewLoadingContent } from '../PreviewFallback'
@@ -11,24 +13,52 @@ const VISIBLE_COLUMNS = 24
 
 const parseCsvRows = (
   content: string,
-  extension: string
-): { rows: string[][]; errors: string[]; rowTruncated: boolean } => {
-  const parsed = parse<string[]>(content, {
+  extension: string,
+  byteTruncated: boolean
+): {
+  rows: string[][]
+  errors: ParseError[]
+  delimiterUncertain: boolean
+  rowTruncated: boolean
+} => {
+  const rows: string[][] = []
+  const errors: ParseError[] = []
+  let rowTruncated = false
+  parse<string[]>(content, {
     delimiter: extension === 'tsv' ? '\t' : '',
     skipEmptyLines: true,
-    preview: VISIBLE_ROWS + 1
+    step: (result, parser) => {
+      // Papa owns record boundaries, including quoted newlines. At the byte boundary a
+      // record needs a terminator and closed quotes; EOF alone cannot confirm it is complete.
+      if (
+        byteTruncated &&
+        result.meta.cursor >= content.length &&
+        (!content.endsWith(result.meta.linebreak) ||
+          result.errors.some((error) => error.code === 'MissingQuotes'))
+      )
+        return
+      if (rows.length === VISIBLE_ROWS + 1) {
+        rowTruncated = true
+        parser.abort()
+        return
+      }
+      rows.push(result.data)
+      errors.push(...result.errors)
+    }
   })
-
+  const singleColumn = rows.length > 0 && rows.every((row) => row.length === 1)
   return {
-    rows: parsed.data.filter((row): row is string[] => Array.isArray(row)),
-    errors: parsed.errors.map((error) => error.message),
-    rowTruncated: parsed.meta.truncated
+    rows,
+    errors: errors.filter((error) => error.code !== 'UndetectableDelimiter'),
+    delimiterUncertain:
+      !singleColumn && errors.some((error) => error.code === 'UndetectableDelimiter'),
+    rowTruncated
   }
 }
 
 export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JSX.Element => {
   const { t } = useTranslation()
-  const state = usePreviewFileContent(item)
+  const state = usePreviewFileContent({ ...item, encoding: 'base64' })
 
   if (state.status === 'loading') return <PreviewLoadingContent />
 
@@ -42,15 +72,43 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
     )
   }
 
-  const { rows, errors, rowTruncated } = parseCsvRows(
-    state.preview.content,
-    getFileExtension(item.name)
+  // Keep BOM detection local to CSV; other text previews retain their decoding and paging.
+  const bytes = Uint8Array.from(atob(state.preview.content), (character) => character.charCodeAt(0))
+  const utf16 = (bytes[0] === 0xff && bytes[1] === 0xfe) || (bytes[0] === 0xfe && bytes[1] === 0xff)
+  if (utf16) {
+    return (
+      <ErrorNotice
+        role="status"
+        title={t('Preview unavailable')}
+        description={t('UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.')}
+      />
+    )
+  }
+  // A streaming decode withholds a partial UTF-8 character at the read boundary.
+  const content = new TextDecoder().decode(bytes, { stream: state.preview.truncated })
+  const { rows, errors, delimiterUncertain, rowTruncated } = parseCsvRows(
+    content,
+    getFileExtension(item.name),
+    state.preview.truncated
   )
+  if (state.preview.truncated && rows.length === 0) {
+    return (
+      <ErrorNotice
+        role="status"
+        title={t('Preview unavailable')}
+        description={t('The preview limit was reached before a complete header could be read.')}
+      />
+    )
+  }
   // CSV does not reliably identify headers. Preserve the first-row convention and disclose it.
   const headers = rows[0] ?? []
   const dataRows = rows.slice(1, VISIBLE_ROWS + 1)
-  const visibleHeaders = headers.slice(0, VISIBLE_COLUMNS)
-  const hiddenColumnCount = Math.max(headers.length - visibleHeaders.length, 0)
+  const columnCount = Math.max(0, ...rows.map((row) => row.length))
+  const visibleHeaders = Array.from(
+    { length: Math.min(columnCount, VISIBLE_COLUMNS) },
+    (_, index) => headers[index] ?? ''
+  )
+  const hiddenColumnCount = Math.max(columnCount - visibleHeaders.length, 0)
   const totalKnown = !state.preview.truncated && !rowTruncated
 
   return (
@@ -60,7 +118,7 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
           <span>
             {t('{{rows}} rows · {{columns}} columns', {
               rows: dataRows.length,
-              columns: headers.length
+              columns: columnCount
             })}
           </span>
         ) : null}
@@ -77,6 +135,22 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
           </span>
         ) : null}
       </div>
+      {state.preview.truncated ? (
+        <div
+          className="shrink-0 border-b border-border-300 px-3 py-2 text-[12px] text-text-300"
+          role="status"
+        >
+          {t('The file exceeds the preview limit. Only complete records are shown.')}
+        </div>
+      ) : null}
+      {delimiterUncertain && errors.length === 0 ? (
+        <div
+          className="shrink-0 border-b border-border-300 px-3 py-2 text-[12px] text-text-300"
+          role="status"
+        >
+          {t('The delimiter could not be detected reliably. Commas are used in this preview.')}
+        </div>
+      ) : null}
       <div className="min-h-0 flex-1 overflow-auto">
         <table className="min-w-full border-separate border-spacing-0 text-left text-[12px]">
           <thead className="sticky top-0 z-10 bg-bg-200 text-text-000">

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4774,6 +4774,10 @@
     "Automatic correction stopped because the active conversation changed.": "Die automatische Korrektur wurde gestoppt, weil sich die aktive Konversation geändert hat.",
     "Review did not start. Please try again.": "Die Prüfung wurde nicht gestartet. Bitte versuchen Sie es erneut.",
     "Review failed. You can try again.": "Die Prüfung ist fehlgeschlagen. Sie können es erneut versuchen.",
-    "No checkable claims": "Keine überprüfbaren Aussagen"
+    "No checkable claims": "Keine überprüfbaren Aussagen",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "Die Vorschau von UTF-16-CSV-Dateien wird nicht unterstützt. Speichern Sie eine Kopie als UTF-8, um sie in der Vorschau anzuzeigen.",
+    "The preview limit was reached before a complete header could be read.": "Das Vorschaulimit wurde erreicht, bevor die Kopfzeile vollständig gelesen werden konnte.",
+    "The file exceeds the preview limit. Only complete records are shown.": "Die Datei überschreitet das Vorschaulimit. Es werden nur vollständige Datensätze angezeigt.",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Das Trennzeichen konnte nicht zuverlässig erkannt werden. In dieser Vorschau werden Kommas verwendet."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4936,6 +4936,10 @@
     "Automatic correction stopped because the active conversation changed.": "La corrección automática se detuvo porque cambió la conversación activa.",
     "Review did not start. Please try again.": "La revisión no se inició. Vuelva a intentarlo.",
     "Review failed. You can try again.": "La revisión falló. Puede volver a intentarlo.",
-    "No checkable claims": "No hay afirmaciones verificables"
+    "No checkable claims": "No hay afirmaciones verificables",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "La vista previa de CSV en UTF-16 no es compatible. Guarde una copia en UTF-8 para previsualizarla.",
+    "The preview limit was reached before a complete header could be read.": "Se alcanzó el límite de la vista previa antes de poder leer una cabecera completa.",
+    "The file exceeds the preview limit. Only complete records are shown.": "El archivo supera el límite de la vista previa. Solo se muestran registros completos.",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "No se pudo detectar el delimitador de forma fiable. Se utilizan comas en esta vista previa."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4936,6 +4936,10 @@
     "Automatic correction stopped because the active conversation changed.": "La correction automatique a été arrêtée, car la conversation active a changé.",
     "Review did not start. Please try again.": "L’examen n’a pas démarré. Veuillez réessayer.",
     "Review failed. You can try again.": "L’examen a échoué. Vous pouvez réessayer.",
-    "No checkable claims": "Aucune affirmation vérifiable"
+    "No checkable claims": "Aucune affirmation vérifiable",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "L’aperçu CSV en UTF-16 n’est pas pris en charge. Enregistrez une copie en UTF-8 pour la prévisualiser.",
+    "The preview limit was reached before a complete header could be read.": "La limite de l’aperçu a été atteinte avant de pouvoir lire un en-tête complet.",
+    "The file exceeds the preview limit. Only complete records are shown.": "Le fichier dépasse la limite de l’aperçu. Seuls les enregistrements complets sont affichés.",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Le séparateur n’a pas pu être détecté de manière fiable. Des virgules sont utilisées dans cet aperçu."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4620,6 +4620,10 @@
     "Automatic correction stopped because the active conversation changed.": "アクティブな会話が変更されたため、自動修正を停止しました。",
     "Review did not start. Please try again.": "レビューを開始できませんでした。もう一度お試しください。",
     "Review failed. You can try again.": "レビューに失敗しました。再試行できます。",
-    "No checkable claims": "検証可能な主張はありません"
+    "No checkable claims": "検証可能な主張はありません",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "UTF-16 の CSV プレビューには対応していません。プレビューするには、UTF-8 でコピーを保存してください。",
+    "The preview limit was reached before a complete header could be read.": "ヘッダー全体を読み込む前にプレビューの上限に達しました。",
+    "The file exceeds the preview limit. Only complete records are shown.": "ファイルがプレビューの上限を超えています。完全なレコードのみ表示しています。",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "区切り文字を確実に検出できませんでした。このプレビューではカンマを使用しています。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4618,6 +4618,10 @@
     "Automatic correction stopped because the active conversation changed.": "활성 대화가 변경되어 자동 수정을 중지했습니다.",
     "Review did not start. Please try again.": "검토가 시작되지 않았습니다. 다시 시도하세요.",
     "Review failed. You can try again.": "검토에 실패했습니다. 다시 시도할 수 있습니다.",
-    "No checkable claims": "검증할 수 있는 주장이 없습니다"
+    "No checkable claims": "검증할 수 있는 주장이 없습니다",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "UTF-16 CSV 미리보기는 지원되지 않습니다. 미리 보려면 UTF-8로 사본을 저장하세요.",
+    "The preview limit was reached before a complete header could be read.": "전체 헤더를 읽기 전에 미리보기 한도에 도달했습니다.",
+    "The file exceeds the preview limit. Only complete records are shown.": "파일이 미리보기 한도를 초과합니다. 완전한 레코드만 표시됩니다.",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "구분자를 정확히 감지하지 못했습니다. 이 미리보기에서는 쉼표를 사용합니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5069,6 +5069,10 @@
     "Automatic correction stopped because the active conversation changed.": "Автоматическое исправление остановлено, поскольку активный диалог изменился.",
     "Review did not start. Please try again.": "Проверка не началась. Повторите попытку.",
     "Review failed. You can try again.": "Проверка завершилась ошибкой. Можно повторить попытку.",
-    "No checkable claims": "Нет утверждений для проверки"
+    "No checkable claims": "Нет утверждений для проверки",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "Предпросмотр CSV в UTF-16 не поддерживается. Сохраните копию в UTF-8 для предпросмотра.",
+    "The preview limit was reached before a complete header could be read.": "Предел предпросмотра достигнут до завершения чтения заголовка.",
+    "The file exceeds the preview limit. Only complete records are shown.": "Файл превышает предел предпросмотра. Показаны только полные записи.",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Не удалось надёжно определить разделитель. В этом предпросмотре используются запятые."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4620,6 +4620,10 @@
     "Automatic correction stopped because the active conversation changed.": "活动对话已变化，自动修正已停止。",
     "Review did not start. Please try again.": "审查未启动，请重试。",
     "Review failed. You can try again.": "审查失败，可以重试。",
-    "No checkable claims": "没有可检查的主张"
+    "No checkable claims": "没有可检查的主张",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "暂不支持预览 UTF-16 编码的 CSV。请另存一份 UTF-8 编码的副本以进行预览。",
+    "The preview limit was reached before a complete header could be read.": "尚未读取完整表头，已达到预览上限。",
+    "The file exceeds the preview limit. Only complete records are shown.": "文件超出预览上限，仅显示完整记录。",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "无法可靠识别分隔符。本次预览使用逗号作为分隔符。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4620,6 +4620,10 @@
     "Automatic correction stopped because the active conversation changed.": "作用中的對話已變更，自動修正已停止。",
     "Review did not start. Please try again.": "審查未啟動，請重試。",
     "Review failed. You can try again.": "審查失敗，可以重試。",
-    "No checkable claims": "沒有可檢查的主張"
+    "No checkable claims": "沒有可檢查的主張",
+    "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "暫不支援預覽 UTF-16 編碼的 CSV。請另存一份 UTF-8 編碼的副本以進行預覽。",
+    "The preview limit was reached before a complete header could be read.": "尚未讀取完整表頭，已達到預覽上限。",
+    "The file exceeds the preview limit. Only complete records are shown.": "檔案超出預覽上限，僅顯示完整記錄。",
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "無法可靠識別分隔符號。本次預覽使用逗號作為分隔符號。"
   }
 }


### PR DESCRIPTION
## Problem

CSV/TSV previews silently omit fields wider than the first record, can display a byte-truncated number as a complete value, decode UTF-16 BOM files as garbled UTF-8, and report valid single-column CSV as a parsing problem.

## Proposed change

- Derive displayed and hidden column counts from the complete records in the bounded preview, using the existing fallback header labels and 24-column cap.
- Use Papa Parse's step callback and record cursor to omit an unfinished boundary record, including quoted multiline cells. Explain byte truncation and show a notice if no complete header fits.
- Inspect BOM bytes locally through the existing base64 read mode. Give UTF-16 files explicit UTF-8 conversion guidance; keep the shared reading hook unchanged.
- Retain structured parse errors, distinguish delimiter uncertainty, and preserve malformed-quote warnings without warning about valid single-column files.
- Translate the new notices in all eight locales.

## Scope and non-goals

No dependency, shared interface, domain data field, status enum, persistence, migration, or historical-data conversion changes. Source files remain unchanged. UTF-16 pagination and guessing legacy encodings without BOMs are outside scope. The existing 1 MiB, 100-record and 24-column limits remain.

## Acceptance criteria and validation

Seven regression cases failed twice on unmodified production code at the reported public renderer behavior (missing extra cell, wrong column count, ordinary `title="123"`, UTF-16 NUL/replacement characters, and false warning). The existing 13 cases passed. The same regression behavior passes after the fix; additional tests cover multiline/escaped quotes, CRLF/CR, partial headers, exact record boundaries, intact final values and UTF-8 BOMs.

Checks below ran after the final material edit:

| Behavior / impact | Command | Result |
| --- | --- | --- |
| CSV rendering, shared reader consumers, preview boundaries, ErrorNotice and all locale guards | `npm test -- src/renderer/src/pages/workspace/previews src/renderer/src/components/error-notice.test.tsx src/renderer/src/i18n/resources.test.ts` | 37 files, 1199 tests passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |
| Changed-file formatting and whitespace | Prettier check on changed TSX/locales; `git diff --check` | Passed |
| Visible behavior | ego lite with real CsvPreviewRenderer, shared hook, Papa Parse and CSS; byte-range fixtures | Confirmed extra column, omitted partial number with notice, UTF-16 guidance and warning-free single column; screenshot captured |

The focused run includes the shared hook and preview consumers because CSV now uses its existing base64 mode. Main/preload implementations and their contracts are unchanged, so local node/platform suites were excluded. The browser exercise uses a controlled resource transport, not a complete Electron journey.

`npm run test:affected:explain -- --base origin/main --head HEAD` reports a full fallback because the CSV tests have no declared module owner. Per maintainer instruction, no complete local suite was run and ownership/configuration was not broadened for this fix; PR CI remains the authority for the complete and platform checks. Independent PR review and CI are pending.

## Review focus

Record completeness at the byte boundary, preserving malformed-quote diagnostics, bounded column counts, and keeping BOM handling local to CSV. The record callback uses the existing [Papa Parse streaming API](https://www.papaparse.com/docs#config).
