### PR TITLE
fix(dialogs): keep long content and actions reachable

### DIFF
--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -76,6 +76,29 @@ const findButtonByName = async (pattern: RegExp): Promise<HTMLButtonElement> => 
 }
 
 describe('CloseConfirmModal', () => {
+  it('keeps a long running-task list separate from the close actions', async () => {
+    render()
+    act(() =>
+      emit({
+        requestId: 'many-tasks',
+        variant: 'quit',
+        sessions: Array.from({ length: 35 }, (_, index) => ({
+          sessionId: `scroll-session-${index}`,
+          projectId: `scroll-project-${index}`,
+          kind: 'agent'
+        }))
+      })
+    )
+    const dialog = document.querySelector('[role="alertdialog"]')!
+    const viewport = dialog.querySelector('[data-slot="scroll-area-viewport"]')!
+    expect(viewport.querySelectorAll('li')).toHaveLength(35)
+    expect(viewport.textContent).toContain('scroll-session-34')
+    const cancel = await findButtonByName(/^Cancel$/)
+    expect(viewport.contains(cancel)).toBe(false)
+    act(() => cancel.click())
+    expect(sendResponse).toHaveBeenCalledWith({ requestId: 'many-tasks', choice: 'cancel' })
+  })
+
   it('retains a covered close request until its presentation becomes active', async () => {
     act(() => root.render(<CloseConfirmModal active={false} />))
     act(() => {

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   dialogBodyClassName,
   dialogCancelButtonClassName,
@@ -108,68 +109,73 @@ export const CloseConfirmModal = ({
       <AlertDialog.Portal>
         <AlertDialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
         <AlertDialog.Content
-          className={dialogPanelClassName('z-[60] w-[min(420px,calc(100vw-2rem))] p-0')}
+          className={dialogPanelClassName(
+            'z-[60] flex max-h-[calc(100svh-2rem)] flex-col w-[min(420px,calc(100vw-2rem))] p-0'
+          )}
         >
-          <div className={dialogHeaderClassName}>
+          <div className={cn(dialogHeaderClassName, 'shrink-0')}>
             <AlertDialog.Title className={dialogTitleClassName}>{title}</AlertDialog.Title>
           </div>
 
-          <div className={dialogBodyClassName}>
-            <AlertDialog.Description className={dialogDescriptionClassName}>
-              {description}
-            </AlertDialog.Description>
-            {hasSessions ? (
-              <ul className="mt-3 space-y-1 text-xs">
-                {dialogRequest.sessions.map((session) => {
-                  const row = resolveActiveSessionDisplay(session)
-                  // Clicking a row cancels the close and jumps to that session so the user can check on
-                  // it. Only navigable when we resolved its project (openSession needs the project id).
-                  const openThisSession = (): void => {
-                    if (!row.projectId) return
-                    useNavigationStore
-                      .getState()
-                      .openSession(row.projectId, session.sessionId, 'user', () => reply('cancel'))
-                  }
-                  return (
-                    // title lives on the li, not the button: a disabled button dispatches no hover
-                    // events, so a button-level tooltip would be dead exactly on truncated unresolved rows.
-                    <li
-                      key={`${session.kind}:${session.sessionId}`}
-                      title={t('{{project}} — {{title}}', {
-                        project: row.project,
-                        title: row.title
-                      })}
-                    >
-                      <button
-                        type="button"
-                        onClick={openThisSession}
-                        disabled={!row.projectId}
-                        className="block w-full truncate rounded-lg border border-border bg-muted/40 p-2 text-left text-foreground enabled:cursor-pointer enabled:hover:bg-muted disabled:cursor-default"
-                      >
-                        {t('{{project}} — {{title}}', {
-                          project: truncateLabel(row.project),
-                          title: truncateLabel(row.title)
+          <ScrollArea className="grid min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:h-auto [&>[data-slot=scroll-area-viewport]]:min-h-0">
+            <div className={dialogBodyClassName}>
+              <AlertDialog.Description className={dialogDescriptionClassName}>
+                {description}
+              </AlertDialog.Description>
+              {hasSessions ? (
+                <ul className="mt-3 space-y-1 text-xs">
+                  {dialogRequest.sessions.map((session) => {
+                    const row = resolveActiveSessionDisplay(session)
+                    // Clicking a row cancels the close and jumps to that session so the user can check on
+                    // it. Only navigable when we resolved its project (openSession needs the project id).
+                    const openThisSession = (): void => {
+                      if (!row.projectId) return
+                      useNavigationStore
+                        .getState()
+                        .openSession(row.projectId, session.sessionId, 'user', () =>
+                          reply('cancel')
+                        )
+                    }
+                    return (
+                      // title lives on the li, not the button: a disabled button dispatches no hover
+                      // events, so a button-level tooltip would be dead exactly on truncated unresolved rows.
+                      <li
+                        key={`${session.kind}:${session.sessionId}`}
+                        title={t('{{project}} — {{title}}', {
+                          project: row.project,
+                          title: row.title
                         })}
-                      </button>
-                    </li>
-                  )
-                })}
-              </ul>
-            ) : null}
-            {!isQuitVariant && !isPersistenceFailure ? (
-              <label className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
-                <input
-                  type="checkbox"
-                  checked={remember}
-                  onChange={(event) => setRemember(event.target.checked)}
-                  className="size-4 shrink-0 accent-primary"
-                />
-                <span>{t("Don't ask again")}</span>
-              </label>
-            ) : null}
-          </div>
-
-          <div className={dialogFooterClassName}>
+                      >
+                        <button
+                          type="button"
+                          onClick={openThisSession}
+                          disabled={!row.projectId}
+                          className="block w-full truncate rounded-lg border border-border bg-muted/40 p-2 text-left text-foreground enabled:cursor-pointer enabled:hover:bg-muted disabled:cursor-default"
+                        >
+                          {t('{{project}} — {{title}}', {
+                            project: truncateLabel(row.project),
+                            title: truncateLabel(row.title)
+                          })}
+                        </button>
+                      </li>
+                    )
+                  })}
+                </ul>
+              ) : null}
+              {!isQuitVariant && !isPersistenceFailure ? (
+                <label className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
+                  <input
+                    type="checkbox"
+                    checked={remember}
+                    onChange={(event) => setRemember(event.target.checked)}
+                    className="size-4 shrink-0 accent-primary"
+                  />
+                  <span>{t("Don't ask again")}</span>
+                </label>
+              ) : null}
+            </div>
+          </ScrollArea>
+          <div className={cn(dialogFooterClassName, 'shrink-0 flex-wrap')}>
             {isPersistenceFailure ? (
               <>
                 <AlertDialog.Cancel asChild>

--- a/src/renderer/src/components/UpdateDialog.lifecycle.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.lifecycle.test.tsx
@@ -8,7 +8,8 @@ import { useUpdateStore } from '@/stores/update-store'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
-vi.mock('radix-ui', () => ({
+vi.mock('radix-ui', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('radix-ui')>()),
   Dialog: {
     Root: ({ open, children }: PropsWithChildren<{ open?: boolean }>) => (
       <div data-testid="dialog-root" data-open={String(open)}>

--- a/src/renderer/src/components/UpdateDialog.render.test.tsx
+++ b/src/renderer/src/components/UpdateDialog.render.test.tsx
@@ -30,6 +30,24 @@ afterEach(() => {
 })
 
 describe('UpdateDialog', () => {
+  it('keeps long release notes in one scrolling body and cancellation outside it', () => {
+    const notes = Array.from({ length: 35 }, (_, index) => `Release note ${index + 1}`).join('\n')
+    useUpdateStore.setState({
+      isDialogOpen: true,
+      status: { state: 'available', current: '0.26.0', latest: '0.26.1', notes }
+    })
+    act(() => root.render(<UpdateDialog />))
+    const dialog = document.querySelector('[role="dialog"]')!
+    const viewport = dialog.querySelector('[data-slot="scroll-area-viewport"]')!
+    expect(viewport.textContent).toContain('Release note 35')
+    const cancel = Array.from(dialog.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Cancel'
+    )!
+    expect(viewport.contains(cancel)).toBe(false)
+    act(() => cancel.click())
+    expect(useUpdateStore.getState().isDialogOpen).toBe(false)
+  })
+
   it('U04: offers manual download instead of an inert button when the installer artifact is missing', () => {
     useUpdateStore.setState({
       isDialogOpen: true,

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -6,6 +6,7 @@ import { DownloadProgressLine } from '@/components/DownloadProgressLine'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { AgentMarkdown } from '@/components/streamdown/AgentMarkdown'
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   dialogBodyClassName,
   dialogCancelButtonClassName,
@@ -73,9 +74,11 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
           <Dialog.Overlay className={cn(dialogOverlayClassName, 'z-[60]')} />
           <Dialog.Content
             onInteractOutside={(event) => event.preventDefault()}
-            className={dialogPanelClassName('z-[60] w-[min(560px,calc(100vw-2rem))] p-0')}
+            className={dialogPanelClassName(
+              'z-[60] flex max-h-[calc(100svh-2rem)] flex-col w-[min(560px,calc(100vw-2rem))] p-0'
+            )}
           >
-            <div className={dialogHeaderClassName}>
+            <div className={cn(dialogHeaderClassName, 'shrink-0')}>
               <div>
                 <Dialog.Title className={dialogTitleClassName}>
                   {t('Update available')}
@@ -103,102 +106,107 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
               </Dialog.Close>
             </div>
 
-            <div className={dialogBodyClassName}>
-              {releaseNotes ? (
-                <div>
-                  <p className="mb-1 text-xs font-medium text-muted-foreground">
-                    {t("What's new")}
-                  </p>
-                  {isEnglishFallback ? (
-                    <p className="mb-2 text-xs text-muted-foreground">
-                      {t('Localized release notes are unavailable; showing English.')}
+            <ScrollArea className="grid min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:h-auto [&>[data-slot=scroll-area-viewport]]:min-h-0">
+              <div className={dialogBodyClassName}>
+                {releaseNotes ? (
+                  <div>
+                    <p className="mb-1 text-xs font-medium text-muted-foreground">
+                      {t("What's new")}
                     </p>
-                  ) : null}
-                  <div className="max-h-96 overflow-auto rounded-lg bg-muted px-3 py-2">
-                    <AgentMarkdown content={releaseNotes} />
+                    {isEnglishFallback ? (
+                      <p className="mb-2 text-xs text-muted-foreground">
+                        {t('Localized release notes are unavailable; showing English.')}
+                      </p>
+                    ) : null}
+                    <div className="rounded-lg bg-muted px-3 py-2">
+                      <AgentMarkdown content={releaseNotes} />
+                    </div>
+                    <ExternalTextLink href={releaseUrl} className="mt-2 text-xs">
+                      {t('View full release notes on GitHub')}
+                    </ExternalTextLink>
                   </div>
-                  <ExternalTextLink href={releaseUrl} className="mt-2 text-xs">
-                    {t('View full release notes on GitHub')}
-                  </ExternalTextLink>
-                </div>
-              ) : (
-                <div className="rounded-lg border border-border bg-muted/50 px-3 py-3 text-xs text-muted-foreground">
-                  {t("Release notes aren't available in-app for this version.")}{' '}
-                  <ExternalTextLink href={releaseUrl} className="text-xs">
-                    {t('View release notes on GitHub')}
-                  </ExternalTextLink>
-                </div>
-              )}
+                ) : (
+                  <div className="rounded-lg border border-border bg-muted/50 px-3 py-3 text-xs text-muted-foreground">
+                    {t("Release notes aren't available in-app for this version.")}{' '}
+                    <ExternalTextLink href={releaseUrl} className="text-xs">
+                      {t('View release notes on GitHub')}
+                    </ExternalTextLink>
+                  </div>
+                )}
 
-              {isDownloading ? (
-                <div className="mt-4">
-                  <DownloadProgressLine
-                    progress={
-                      dialogStatus.downloadProgress ?? {
-                        phase: 'downloading',
-                        transferred: dialogStatus.downloadedBytes ?? 0,
-                        total: dialogStatus.totalBytes,
-                        percent: dialogStatus.progress ?? 0,
-                        bytesPerSecond: 0,
-                        attempt: 0
+                {isDownloading ? (
+                  <div className="mt-4">
+                    <DownloadProgressLine
+                      progress={
+                        dialogStatus.downloadProgress ?? {
+                          phase: 'downloading',
+                          transferred: dialogStatus.downloadedBytes ?? 0,
+                          total: dialogStatus.totalBytes,
+                          percent: dialogStatus.progress ?? 0,
+                          bytesPerSecond: 0,
+                          attempt: 0
+                        }
                       }
-                    }
-                  />
-                </div>
-              ) : null}
+                    />
+                  </div>
+                ) : null}
 
-              {isApplying ? (
-                <div className="mt-4 rounded-lg border border-border bg-muted/50 px-3 py-3 text-xs text-muted-foreground">
-                  {t(
-                    "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically."
-                  )}
-                </div>
-              ) : null}
+                {isApplying ? (
+                  <div className="mt-4 rounded-lg border border-border bg-muted/50 px-3 py-3 text-xs text-muted-foreground">
+                    {t(
+                      "Open Science is stopping background tasks and will close to finish installing. The update may take a moment; please don't reopen the app during this step. The updated app will reopen automatically."
+                    )}
+                  </div>
+                ) : null}
 
-              {dialogStatus.error ? (
-                <div className="mt-3" role="alert">
-                  <p className="text-xs text-destructive">
-                    {dialogStatus.error === UPDATE_BACKGROUND_PROCESS_ERROR
-                      ? t('Could not stop background processes before updating. Please try again.')
-                      : dialogStatus.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
+                {dialogStatus.error ? (
+                  <div className="mt-3" role="alert">
+                    <p className="text-xs text-destructive">
+                      {dialogStatus.error === UPDATE_BACKGROUND_PROCESS_ERROR
                         ? t(
-                            'Could not fully stop background processes before updating. Please try again.'
+                            'Could not stop background processes before updating. Please try again.'
                           )
-                        : dialogStatus.error === UPDATE_SETTINGS_INSTALL_ERROR
+                        : dialogStatus.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
                           ? t(
-                              'An Agent Runtime is still installing. Wait for it to finish before restarting to update.'
+                              'Could not fully stop background processes before updating. Please try again.'
                             )
-                          : (dialogStatus.error ?? t('Update failed'))}
-                  </p>
-                  {isBackgroundProcessError ? (
-                    <p className="mt-2 text-xs text-muted-foreground">
-                      <Trans
-                        i18nKey="Cancel this update, then use Reveal in Settings → General → Diagnostics to locate the log file. Quit and reopen Open Science, then try the update again. If the problem returns, review the log for local file paths and give it to a developer or <issueLink>open a GitHub issue</issueLink>."
-                        components={{
-                          issueLink: (
-                            <ExternalTextLink href={APP.links.githubIssues}>{''}</ExternalTextLink>
-                          )
-                        }}
-                      />
+                          : dialogStatus.error === UPDATE_SETTINGS_INSTALL_ERROR
+                            ? t(
+                                'An Agent Runtime is still installing. Wait for it to finish before restarting to update.'
+                              )
+                            : (dialogStatus.error ?? t('Update failed'))}
                     </p>
-                  ) : null}
-                  {/* Fallback when the in-app update fails (e.g. a blocked/failed in-place install): let the
+                    {isBackgroundProcessError ? (
+                      <p className="mt-2 text-xs text-muted-foreground">
+                        <Trans
+                          i18nKey="Cancel this update, then use Reveal in Settings → General → Diagnostics to locate the log file. Quit and reopen Open Science, then try the update again. If the problem returns, review the log for local file paths and give it to a developer or <issueLink>open a GitHub issue</issueLink>."
+                          components={{
+                            issueLink: (
+                              <ExternalTextLink href={APP.links.githubIssues}>
+                                {''}
+                              </ExternalTextLink>
+                            )
+                          }}
+                        />
+                      </p>
+                    ) : null}
+                    {/* Fallback when the in-app update fails (e.g. a blocked/failed in-place install): let the
                     user grab the installer by hand, mirroring the macOS manual-reinstall path. */}
-                  <ExternalTextLink href={APP.update.downloadPage} className="mt-1 text-xs">
-                    {t('Download manually')}
-                  </ExternalTextLink>
-                </div>
-              ) : null}
-              {isInstallerUnavailable ? (
-                <p className="mt-3 text-xs text-muted-foreground">
-                  {t(
-                    'An installer is not available for this platform. Download manually to check other installation options.'
-                  )}
-                </p>
-              ) : null}
-            </div>
-
-            <div className={dialogFooterClassName}>
+                    <ExternalTextLink href={APP.update.downloadPage} className="mt-1 text-xs">
+                      {t('Download manually')}
+                    </ExternalTextLink>
+                  </div>
+                ) : null}
+                {isInstallerUnavailable ? (
+                  <p className="mt-3 text-xs text-muted-foreground">
+                    {t(
+                      'An installer is not available for this platform. Download manually to check other installation options.'
+                    )}
+                  </p>
+                ) : null}
+              </div>
+            </ScrollArea>
+            <div className={cn(dialogFooterClassName, 'shrink-0 flex-wrap')}>
               <button
                 type="button"
                 onClick={() => closeDialog()}

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -1478,6 +1478,46 @@ describe('LiteratureLibraryPage', () => {
     )
   })
 
+  it('keeps every Reading project selectable and creation outside the scrolling list', async () => {
+    const entry = createLibraryItemWithPdf()
+    const template = useProjectStore.getState().projects[0]
+    useProjectStore.setState({
+      projects: Array.from({ length: 35 }, (_, index) => ({
+        ...template,
+        id: `project-${index + 1}`,
+        name: `Reading project ${index + 1}`
+      }))
+    })
+    search.mockImplementation((request: { scope: string }) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [entry] } : { entries: [] })
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Preview paper.pdf' }))
+    fireEvent.click(
+      within(screen.getByTestId('literature-pdf-preview')).getByRole('button', {
+        name: 'Read with agent',
+        hidden: true
+      })
+    )
+    const dialog = await screen.findByRole('dialog', { name: 'Read with agent' })
+    const viewport = dialog.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')!
+    const lastProject = within(dialog).getByRole('button', { name: 'Reading project 35' })
+    expect(viewport.contains(lastProject)).toBe(true)
+    expect(viewport.contains(within(dialog).getByRole('button', { name: 'New project' }))).toBe(
+      false
+    )
+    expect(within(viewport).getAllByRole('button')).toHaveLength(35)
+    fireEvent.click(lastProject)
+    await waitFor(() =>
+      expect(startPdfReadingConversation).toHaveBeenCalledWith(
+        'project-35',
+        expect.objectContaining({ source: 'literature' }),
+        { sourceKind: 'literature-attachment-version', sourceVersionId: 'version-1' }
+      )
+    )
+  })
+
   it('reviews a batch of references and opens a three-PDF Reading draft without silently including missing PDFs', async () => {
     const entries = [1, 2, 3, 4].map((id) => {
       const entry = createLibraryItemWithPdf()

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -56,6 +56,7 @@ import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { ActionToast } from '@/components/ActionToast'
 import { LiteratureErrorNotice } from './LiteratureErrorNotice'
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   dialogBodyClassName,
   dialogCancelButtonClassName,
@@ -5329,8 +5330,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       >
         <Dialog.Portal>
           <Dialog.Overlay className={dialogOverlayClassName} />
-          <Dialog.Content className={dialogPanelClassName('w-[min(440px,calc(100vw-2rem))] p-0')}>
-            <div className={dialogHeaderClassName}>
+          <Dialog.Content
+            className={dialogPanelClassName(
+              'flex max-h-[calc(100svh-2rem)] w-[min(440px,calc(100vw-2rem))] flex-col p-0'
+            )}
+          >
+            <div className={cn(dialogHeaderClassName, 'shrink-0')}>
               <div>
                 <Dialog.Title className={dialogTitleClassName}>{t('Read with agent')}</Dialog.Title>
                 <Dialog.Description className={dialogDescriptionClassName}>
@@ -5349,87 +5354,89 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                 </Button>
               </Dialog.Close>
             </div>
-            <div className={dialogBodyClassName}>
-              {readingProjectError ? (
-                <div className="mb-3">
-                  <p role="alert" className="text-sm text-danger-000">
-                    {readingProjectError}
-                  </p>
-                  {readingSelectionEntries ? (
-                    <Button
-                      className="mt-2"
-                      variant="outline"
-                      size="sm"
-                      disabled={Boolean(startingReadingProjectId)}
-                      onClick={() => {
-                        setPendingLiteratureReading(undefined)
-                        setReadingProjectError(undefined)
-                        setBatchReading({ entries: readingSelectionEntries })
-                      }}
-                    >
-                      {t('Back')}
-                    </Button>
-                  ) : null}
-                </div>
-              ) : null}
-              {projectsLoaded ? (
-                activeProjects.length > 0 ? (
-                  <div className="grid gap-2">
-                    {activeProjects.map((project) => (
+            <ScrollArea className="grid min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:h-auto [&>[data-slot=scroll-area-viewport]]:min-h-0">
+              <div className={dialogBodyClassName}>
+                {readingProjectError ? (
+                  <div className="mb-3">
+                    <p role="alert" className="text-sm text-danger-000">
+                      {readingProjectError}
+                    </p>
+                    {readingSelectionEntries ? (
                       <Button
-                        key={project.id}
-                        type="button"
+                        className="mt-2"
                         variant="outline"
-                        className="justify-start"
+                        size="sm"
                         disabled={Boolean(startingReadingProjectId)}
-                        onClick={() => void startReadingInProject(project.id)}
+                        onClick={() => {
+                          setPendingLiteratureReading(undefined)
+                          setReadingProjectError(undefined)
+                          setBatchReading({ entries: readingSelectionEntries })
+                        }}
                       >
-                        {startingReadingProjectId === project.id ? (
-                          <LoaderCircle
-                            className="size-4 animate-spin motion-reduce:animate-none"
-                            aria-hidden="true"
-                          />
-                        ) : (
-                          <FolderOpen className="size-4" aria-hidden="true" />
-                        )}
-                        <span className="truncate">{project.name}</span>
+                        {t('Back')}
                       </Button>
-                    ))}
+                    ) : null}
                   </div>
-                ) : (
-                  <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed border-border-300/80 bg-bg-100 p-4">
-                    <FolderPlus className="size-5 text-muted-foreground" aria-hidden="true" />
-                    <div>
-                      <h3 className="text-sm font-medium">{t('No projects yet')}</h3>
-                      <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
-                        {pendingLiteratureReading && pendingLiteratureReading.length > 1
-                          ? t(
-                              'Create a project to keep these papers and their Reading session together.'
-                            )
-                          : t(
-                              'Create a project to keep this paper and its Reading session together.'
-                            )}
-                      </p>
+                ) : null}
+                {projectsLoaded ? (
+                  activeProjects.length > 0 ? (
+                    <div className="grid gap-2">
+                      {activeProjects.map((project) => (
+                        <Button
+                          key={project.id}
+                          type="button"
+                          variant="outline"
+                          className="min-w-0 justify-start"
+                          disabled={Boolean(startingReadingProjectId)}
+                          onClick={() => void startReadingInProject(project.id)}
+                        >
+                          {startingReadingProjectId === project.id ? (
+                            <LoaderCircle
+                              className="size-4 animate-spin motion-reduce:animate-none"
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            <FolderOpen className="size-4" aria-hidden="true" />
+                          )}
+                          <span className="truncate">{project.name}</span>
+                        </Button>
+                      ))}
                     </div>
-                    <Button
-                      type="button"
-                      disabled={Boolean(startingReadingProjectId)}
-                      onClick={readingProjectFormDialog.openCreateDialog}
-                    >
-                      <FolderPlus className="size-4" aria-hidden="true" />
-                      {t('Create project')}
-                    </Button>
-                  </div>
-                )
-              ) : (
-                <p role="status" className="text-sm text-muted-foreground">
-                  {t('Loading…')}
-                </p>
-              )}
-            </div>
+                  ) : (
+                    <div className="flex flex-col items-start gap-3 rounded-lg border border-dashed border-border-300/80 bg-bg-100 p-4">
+                      <FolderPlus className="size-5 text-muted-foreground" aria-hidden="true" />
+                      <div>
+                        <h3 className="text-sm font-medium">{t('No projects yet')}</h3>
+                        <p className="mt-1 text-sm leading-relaxed text-muted-foreground">
+                          {pendingLiteratureReading && pendingLiteratureReading.length > 1
+                            ? t(
+                                'Create a project to keep these papers and their Reading session together.'
+                              )
+                            : t(
+                                'Create a project to keep this paper and its Reading session together.'
+                              )}
+                        </p>
+                      </div>
+                      <Button
+                        type="button"
+                        disabled={Boolean(startingReadingProjectId)}
+                        onClick={readingProjectFormDialog.openCreateDialog}
+                      >
+                        <FolderPlus className="size-4" aria-hidden="true" />
+                        {t('Create project')}
+                      </Button>
+                    </div>
+                  )
+                ) : (
+                  <p role="status" className="text-sm text-muted-foreground">
+                    {t('Loading…')}
+                  </p>
+                )}
+              </div>
+            </ScrollArea>
             {projectsLoaded && activeProjects.length > 0 ? (
               <div
-                className={`${dialogFooterClassName} flex-wrap items-center [&_button]:max-w-full [&_button]:whitespace-normal [&_button]:h-auto [&_button]:min-h-8 [&_button]:py-1`}
+                className={`${dialogFooterClassName} shrink-0 flex-wrap items-center [&_button]:max-w-full [&_button]:whitespace-normal [&_button]:h-auto [&_button]:min-h-8 [&_button]:py-1`}
               >
                 <Button
                   type="button"

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
@@ -47,6 +47,21 @@ afterEach(() => {
 })
 
 describe('ComputeApprovalDialog', () => {
+  it('keeps the complete expanded command separate from the approval actions', async () => {
+    const commandFull = Array.from(
+      { length: 120 },
+      (_, i) => `python analysis.py --sample ${i}`
+    ).join('; ')
+    useComputeStore.setState({ pendingApprovals: [{ ...request, commandFull }] })
+    act(() => root.render(<ComputeApprovalDialog />))
+    act(() => findButton('Show full command')!.click())
+    const viewport = document.querySelector('[data-slot="scroll-area-viewport"]')!
+    expect(viewport.textContent).toContain(commandFull)
+    expect(viewport.contains(findButton('Deny')!)).toBe(false)
+    await act(async () => findButton('Deny')!.click())
+    expect(useComputeStore.getState().respondApproval).toHaveBeenCalledWith(request.id, 'deny')
+  })
+
   it('renders nothing without a pending approval', () => {
     act(() => root.render(<ComputeApprovalDialog />))
 

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
@@ -47,6 +47,32 @@ afterEach(() => {
 })
 
 describe('ComputeApprovalDialog', () => {
+  it('starts the next queued approval at the top after scrolling a long request', async () => {
+    const nextRequest = {
+      ...request,
+      id: 'approval-2',
+      commandPreview: 'Inspect the next request',
+      commandFull: 'Inspect the next request'
+    }
+    useComputeStore.setState({
+      pendingApprovals: [
+        { ...request, commandFull: 'python analysis.py; '.repeat(120) },
+        nextRequest
+      ],
+      respondApproval: vi.fn(async () => {
+        useComputeStore.setState({ pendingApprovals: [nextRequest] })
+      })
+    })
+    act(() => root.render(<ComputeApprovalDialog />))
+    act(() => findButton('Show full command')!.click())
+    const viewport = document.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')!
+    viewport.scrollTop = 500
+    await act(async () => findButton('Deny')!.click())
+    const nextViewport = document.querySelector<HTMLElement>('[data-slot="scroll-area-viewport"]')!
+    expect(nextViewport.textContent).toContain(nextRequest.commandPreview)
+    expect(nextViewport.scrollTop).toBe(0)
+  })
+
   it('keeps the complete expanded command separate from the approval actions', async () => {
     const commandFull = Array.from(
       { length: 120 },

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
@@ -131,7 +131,10 @@ export function ComputeApprovalDialog({
             </div>
           </div>
 
-          <ScrollArea className="grid min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:h-auto [&>[data-slot=scroll-area-viewport]]:min-h-0">
+          <ScrollArea
+            key={dialogRequest.id}
+            className="grid min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:h-auto [&>[data-slot=scroll-area-viewport]]:min-h-0"
+          >
             <div className={dialogBodyClassName}>
               <div className="space-y-1.5 rounded-lg border border-border bg-muted/40 p-3 text-xs">
                 <div className="flex gap-2">

--- a/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
+++ b/src/renderer/src/pages/settings/ComputeApprovalDialog.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 
 import type { ComputeApprovalDecision } from '../../../../shared/compute'
 import { Button } from '@/components/ui/button'
+import { ScrollArea } from '@/components/ui/scroll-area'
 import {
   dialogBodyClassName,
   dialogDescriptionClassName,
@@ -115,10 +116,10 @@ export function ComputeApprovalDialog({
           onInteractOutside={(event) => event.preventDefault()}
           onEscapeKeyDown={(event) => event.preventDefault()}
           className={dialogPanelClassName(
-            'z-[60] w-[min(480px,calc(100vw-2rem))] overscroll-contain p-0'
+            'z-[60] flex max-h-[calc(100svh-2rem)] w-[min(480px,calc(100vw-2rem))] flex-col overscroll-contain p-0'
           )}
         >
-          <div className={cn(dialogHeaderClassName, 'items-start justify-start')}>
+          <div className={cn(dialogHeaderClassName, 'shrink-0 items-start justify-start')}>
             <ShieldAlert className="mt-0.5 size-5 shrink-0 text-amber-500" aria-hidden="true" />
             <div className="min-w-0">
               <Dialog.Title className={dialogTitleClassName}>{title}</Dialog.Title>
@@ -130,137 +131,142 @@ export function ComputeApprovalDialog({
             </div>
           </div>
 
-          <div className={dialogBodyClassName}>
-            <div className="space-y-1.5 rounded-lg border border-border bg-muted/40 p-3 text-xs">
-              <div className="flex gap-2">
-                <span className="w-16 shrink-0 text-muted-foreground">{t('Host')}</span>
-                <span className="min-w-0 truncate font-medium text-foreground">
-                  {dialogRequest.providerName}
-                </span>
-              </div>
-              <div className="flex gap-2">
-                <span className="w-16 shrink-0 text-muted-foreground">{t('Intent')}</span>
-                <span className="min-w-0 break-words text-foreground">{dialogRequest.intent}</span>
-              </div>
-              {hasCommand ? (
+          <ScrollArea className="grid min-h-0 flex-1 [&>[data-slot=scroll-area-viewport]]:h-auto [&>[data-slot=scroll-area-viewport]]:min-h-0">
+            <div className={dialogBodyClassName}>
+              <div className="space-y-1.5 rounded-lg border border-border bg-muted/40 p-3 text-xs">
                 <div className="flex gap-2">
-                  <span className="w-20 shrink-0 text-muted-foreground">{t('Command')}</span>
-                  <div className="min-w-0 flex-1">
-                    <span className="break-all font-mono text-muted-foreground">
-                      {showFull ? dialogRequest.commandFull : dialogRequest.commandPreview}
-                    </span>
-                    {isLongCommand && (
-                      <button
-                        type="button"
-                        onClick={() =>
-                          setExpandedRequestId((id) =>
-                            id === dialogRequest.id ? null : dialogRequest.id
-                          )
-                        }
-                        className="mt-1 flex items-center gap-0.5 text-xs text-primary hover:underline"
-                        aria-expanded={showFull}
-                      >
-                        {showFull ? (
-                          <>
-                            <ChevronUp className="size-3" aria-hidden="true" /> {t('Show less')}
-                          </>
-                        ) : (
-                          <>
-                            <ChevronDown className="size-3" aria-hidden="true" />{' '}
-                            {t('Show full command')}
-                          </>
-                        )}
-                      </button>
-                    )}
-                  </div>
-                </div>
-              ) : (
-                <div className="flex gap-2">
-                  <span className="w-20 shrink-0 text-muted-foreground">{t('Remote path')}</span>
-                  <span className="min-w-0 break-all font-mono text-muted-foreground">
-                    {dialogRequest.remotePath}
+                  <span className="w-16 shrink-0 text-muted-foreground">{t('Host')}</span>
+                  <span className="min-w-0 truncate font-medium text-foreground">
+                    {dialogRequest.providerName}
                   </span>
                 </div>
-              )}
-              {dialogRequest.operation === 'submit_job' && dialogRequest.inputsSummary && (
                 <div className="flex gap-2">
-                  <span className="w-20 shrink-0 text-muted-foreground">{t('Inputs')}</span>
+                  <span className="w-16 shrink-0 text-muted-foreground">{t('Intent')}</span>
                   <span className="min-w-0 break-words text-foreground">
-                    {dialogRequest.inputsSummary}
+                    {dialogRequest.intent}
                   </span>
                 </div>
-              )}
-              {dialogRequest.operation === 'submit_job' && dialogRequest.executionMode && (
-                <div className="flex gap-2">
-                  <span className="w-20 shrink-0 text-muted-foreground">{t('Execution mode')}</span>
-                  <span className="min-w-0 text-foreground">
-                    {dialogRequest.executionMode === 'slurm' ? t('Slurm') : t('Direct SSH')}
-                  </span>
-                </div>
-              )}
-              {dialogRequest.operation === 'submit_job' && dialogRequest.environment && (
-                <div className="flex gap-2">
-                  <span className="w-20 shrink-0 text-muted-foreground">{t('Environment')}</span>
-                  <span className="min-w-0 break-all font-mono text-muted-foreground">
-                    {dialogRequest.environment}
-                  </span>
-                </div>
-              )}
-              {dialogRequest.operation === 'submit_job' && dialogRequest.resources && (
-                <div className="flex gap-2">
-                  <span className="w-20 shrink-0 text-muted-foreground">{t('Resources')}</span>
-                  <span className="min-w-0 break-all font-mono text-muted-foreground">
-                    {dialogRequest.resources}
-                  </span>
-                </div>
-              )}
-              {dialogRequest.operation === 'submit_job' && (
-                <>
+                {hasCommand ? (
                   <div className="flex gap-2">
-                    <span className="w-20 shrink-0 text-muted-foreground">{t('Timeout')}</span>
-                    <span className="min-w-0 text-foreground">
-                      {t('{{count}} seconds', {
-                        count: dialogRequest.timeoutSeconds,
-                        defaultValue_one: '{{count}} second'
-                      })}
+                    <span className="w-20 shrink-0 text-muted-foreground">{t('Command')}</span>
+                    <div className="min-w-0 flex-1">
+                      <span className="break-all font-mono text-muted-foreground">
+                        {showFull ? dialogRequest.commandFull : dialogRequest.commandPreview}
+                      </span>
+                      {isLongCommand && (
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedRequestId((id) =>
+                              id === dialogRequest.id ? null : dialogRequest.id
+                            )
+                          }
+                          className="mt-1 flex items-center gap-0.5 text-xs text-primary hover:underline"
+                          aria-expanded={showFull}
+                        >
+                          {showFull ? (
+                            <>
+                              <ChevronUp className="size-3" aria-hidden="true" /> {t('Show less')}
+                            </>
+                          ) : (
+                            <>
+                              <ChevronDown className="size-3" aria-hidden="true" />{' '}
+                              {t('Show full command')}
+                            </>
+                          )}
+                        </button>
+                      )}
+                    </div>
+                  </div>
+                ) : (
+                  <div className="flex gap-2">
+                    <span className="w-20 shrink-0 text-muted-foreground">{t('Remote path')}</span>
+                    <span className="min-w-0 break-all font-mono text-muted-foreground">
+                      {dialogRequest.remotePath}
                     </span>
                   </div>
+                )}
+                {dialogRequest.operation === 'submit_job' && dialogRequest.inputsSummary && (
+                  <div className="flex gap-2">
+                    <span className="w-20 shrink-0 text-muted-foreground">{t('Inputs')}</span>
+                    <span className="min-w-0 break-words text-foreground">
+                      {dialogRequest.inputsSummary}
+                    </span>
+                  </div>
+                )}
+                {dialogRequest.operation === 'submit_job' && dialogRequest.executionMode && (
                   <div className="flex gap-2">
                     <span className="w-20 shrink-0 text-muted-foreground">
-                      {t('Remote workdir')}
+                      {t('Execution mode')}
                     </span>
-                    <span className="min-w-0 break-all font-mono text-muted-foreground">
-                      {dialogRequest.remoteWorkdir}
+                    <span className="min-w-0 text-foreground">
+                      {dialogRequest.executionMode === 'slurm' ? t('Slurm') : t('Direct SSH')}
                     </span>
                   </div>
-                </>
-              )}
+                )}
+                {dialogRequest.operation === 'submit_job' && dialogRequest.environment && (
+                  <div className="flex gap-2">
+                    <span className="w-20 shrink-0 text-muted-foreground">{t('Environment')}</span>
+                    <span className="min-w-0 break-all font-mono text-muted-foreground">
+                      {dialogRequest.environment}
+                    </span>
+                  </div>
+                )}
+                {dialogRequest.operation === 'submit_job' && dialogRequest.resources && (
+                  <div className="flex gap-2">
+                    <span className="w-20 shrink-0 text-muted-foreground">{t('Resources')}</span>
+                    <span className="min-w-0 break-all font-mono text-muted-foreground">
+                      {dialogRequest.resources}
+                    </span>
+                  </div>
+                )}
+                {dialogRequest.operation === 'submit_job' && (
+                  <>
+                    <div className="flex gap-2">
+                      <span className="w-20 shrink-0 text-muted-foreground">{t('Timeout')}</span>
+                      <span className="min-w-0 text-foreground">
+                        {t('{{count}} seconds', {
+                          count: dialogRequest.timeoutSeconds,
+                          defaultValue_one: '{{count}} second'
+                        })}
+                      </span>
+                    </div>
+                    <div className="flex gap-2">
+                      <span className="w-20 shrink-0 text-muted-foreground">
+                        {t('Remote workdir')}
+                      </span>
+                      <span className="min-w-0 break-all font-mono text-muted-foreground">
+                        {dialogRequest.remoteWorkdir}
+                      </span>
+                    </div>
+                  </>
+                )}
+              </div>
+              {dialogRequest.willPersistUnencrypted ? (
+                <div
+                  role="alert"
+                  className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
+                >
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                  <span>
+                    {t(
+                      "Secure storage is unavailable. This job's command, paths, and output may be stored without encryption."
+                    )}
+                  </span>
+                </div>
+              ) : null}
+              {responseErrorRequestId === dialogRequest.id ? (
+                <div
+                  role="alert"
+                  className="mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
+                >
+                  <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
+                  <span>{t('Could not submit this approval. Try again.')}</span>
+                </div>
+              ) : null}
             </div>
-            {dialogRequest.willPersistUnencrypted ? (
-              <div
-                role="alert"
-                className="mt-3 flex items-start gap-2 rounded-lg border border-amber-500/30 bg-amber-500/10 px-3 py-2 text-xs text-amber-700 dark:text-amber-300"
-              >
-                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-                <span>
-                  {t(
-                    "Secure storage is unavailable. This job's command, paths, and output may be stored without encryption."
-                  )}
-                </span>
-              </div>
-            ) : null}
-            {responseErrorRequestId === dialogRequest.id ? (
-              <div
-                role="alert"
-                className="mt-3 flex items-start gap-2 rounded-lg border border-danger-000/30 bg-danger-000/10 px-3 py-2 text-xs text-danger-000"
-              >
-                <AlertTriangle className="mt-0.5 size-3.5 shrink-0" aria-hidden="true" />
-                <span>{t('Could not submit this approval. Try again.')}</span>
-              </div>
-            ) : null}
-          </div>
-
-          <div className={cn(dialogFooterClassName, 'flex-wrap')}>
+          </ScrollArea>
+          <div className={cn(dialogFooterClassName, 'shrink-0 flex-wrap')}>
             <Button type="button" variant="destructive" disabled={responding} onClick={deny}>
               {t('Deny')}
             </Button>


### PR DESCRIPTION
## Problem

Selecting Read with agent from a Literature PDF opens an unbounded project chooser. With 35 projects in a 1100×700 viewport, its bounds extend from about −400px to 1100px, making projects and controls unreachable. The related-dialog audit reproduced the same failure for 35 running tasks in quit confirmation, long release notes in a 500px-high viewport, and an expanded remote command in compute approval.

## Proposed change

Keep these four dialogs within the viewport, with a shrinking ScrollArea body and visible header/footer actions. Use grid sizing inside ScrollArea so its viewport actually shrinks inside a max-height flex panel. Remove the update notes' nested vertical scroller. Preserve existing selection, close, update and permission decisions. Key the compute approval scroll area by its existing request ID so a queued request starts at the top instead of inheriting the previous request’s scroll position.

## Scope and non-goals

- Four renderer surfaces only: Reading project chooser, close confirmation, update confirmation and compute approval.
- No shared Dialog default changes, new dependencies, search/pagination, architecture or API changes.
- No new data fields, enum values, application states, persistence behavior or historical migration.
- Adjacent project/collection destination menus, batch Reading selection, workspace project switching, file browsing and skill-import approval already have bounded scrolling structures; they are not changed for stylistic consistency.

## Acceptance criteria and validation

Final checks ran after the last material edit. The local full test suite was intentionally not run, as requested by the maintainer.

| Behavior | Check | Result |
| --- | --- | --- |
| Reading single/batch entry, 35-project selection and existing Literature flows | `npx vitest run src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx` | 108 passed (22.06s) |
| Long task list, cancellation; long update notes, cancellation and closing lifecycle; expanded command and denial | Focused `CloseConfirmModal.render`, `UpdateDialog.render`, `UpdateDialog.lifecycle`, `ComputeApprovalDialog.render` suites | Passed |
| Consumer and UI contracts | `compute-i18n.render`, `navigation-store`, `i18n/resources`, `ui/dialog.render` suites | Passed |
| Runtime types | `npm run typecheck`; final renderer correction: `npm run typecheck:web` | Passed |
| Source conventions | `npm run lint`; `git diff --check` | Passed |
| Actual browser layout and input | Authenticated isolated Web Reading workflow: 35 projects, wheel to last row, select it and open Reading; native Tab traversal to last row at 700×420. Production-component browser fixtures: 35 running tasks, 35 update notes at 1000×500, 120-command expansion; wheel to end with visible actions and cancel/deny responses. | Passed |

On final head `d0533b42`, the eight owner/consumer suites passed 211 tests (22.19s), and the i18n guard passed 804 tests (11.91s): 1,015 targeted checks passed. The commands include the four dialog owners, update lifecycle, compute i18n, navigation store, shared dialog rendering and i18n resources. No test timeout or production behavior was weakened.

The queued-approval regression was first observed failing with `scrollTop` 500 instead of 0; after keying the scroll area by request ID, all 29 focused compute/i18n/dialog checks passed, followed by the final impact set above. Final renderer typecheck and lint passed after this correction. The earlier full runtime typecheck remains applicable to unchanged main/sandbox code.

Independent Standards and Spec reviews found no remaining actionable issues and confirmed the final behavior-to-check mapping, including the queued-approval correction. Screenshots were captured and inspected for all four surfaces, including the small-viewport keyboard case. Layout screenshots precede the lifecycle-only key correction; the queued reset is covered by the red/green DOM regression, not claimed as additional browser geometry evidence.

## Review focus

Check the ScrollArea grid/viewport sizing and header/footer reachability. New DOM tests protect complete content and action dispatch; browser verification supplies geometry and real input evidence that JSDOM cannot establish.

No Electron-specific protocol, main-process, path, migration or ACP adapter behavior changed, so those contract matrices were excluded from local testing. Quit and compute visual checks used production renderer components with isolated event/store fixtures, not live operating-system quit or remote command execution. Cross-platform packaged layout and wider integration remain CI validation boundaries.
