### PR TITLE
fix(tiff-preview): preserve sample meaning and recover page navigation

### DIFF
--- a/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx
@@ -1,9 +1,16 @@
 // @vitest-environment jsdom
+import { TiffPageDecodeError } from '../tiff-preview-types'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { decodeTiffFixture, LZW_MULTIPAGE_TIFF, LZW_RGB_TIFF } from '../tiff-test-fixtures'
+import {
+  createUnsupportedFirstPageTiff,
+  createSampleTiff,
+  decodeTiffFixture,
+  LZW_MULTIPAGE_TIFF,
+  LZW_RGB_TIFF
+} from '../tiff-test-fixtures'
 import { decodeTiffPage } from '../tiff-preview'
 import type {
   TiffDecodeWorkerRequest,
@@ -48,6 +55,7 @@ class TestTiffWorker {
         response = {
           type: 'error',
           requestId: request.requestId,
+          ...(error instanceof TiffPageDecodeError ? { pageCount: error.pageCount } : {}),
           message: error instanceof Error ? error.message : String(error)
         }
       }
@@ -255,6 +263,67 @@ describe('TiffPreviewContent', () => {
     expect(Array.from(secondPage.data)).toEqual([0, 0, 255, 255])
   })
 
+  it.each([
+    { samples: [10, 20], label: 'Automatic contrast: 10 – 20' },
+    { samples: [0, 1], label: 'Display range: 0 – 1' }
+  ])('discloses floating intensity mapping: $label', async ({ samples, label }) => {
+    const bytes = createSampleTiff({ samples, components: 1, floating: true })
+    vi.mocked(fetch).mockResolvedValue(new Response(bytes, { status: 200 }))
+    vi.mocked(window.api.previewResources.acquire).mockResolvedValue({
+      id: 'float',
+      url: 'open-science-preview://float/image.tiff',
+      size: bytes.byteLength,
+      mimeType: 'image/tiff',
+      version: 1
+    })
+    root = createRoot(container)
+    await act(async () =>
+      root.render(
+        <TiffPreviewContent
+          {...managedArtifactIdentity}
+          path="/workspace/float.tiff"
+          name="float.tiff"
+        />
+      )
+    )
+    expect(container.textContent).toContain(label)
+    expect(container.querySelector('canvas')).not.toBeNull()
+  })
+
+  it('keeps later pages reachable when the first page uses unsupported compression', async () => {
+    const bytes = createUnsupportedFirstPageTiff()
+    expect(() => decodeTiffPage(bytes, 0)).toThrow('Unsupported TIFF compression: 32773')
+    expect(Array.from(decodeTiffPage(bytes, 1).rgba)).toEqual([0, 0, 255, 255])
+    vi.mocked(fetch).mockImplementation(async () => new Response(bytes.slice(0), { status: 200 }))
+    vi.mocked(window.api.previewResources.acquire).mockResolvedValue({
+      id: 'resource-first-page-error',
+      url: 'open-science-preview://resource-first-page-error/stack.tiff',
+      size: bytes.byteLength,
+      mimeType: 'image/tiff',
+      version: 1
+    })
+    root = createRoot(container)
+    await act(async () => {
+      root.render(
+        <TiffPreviewContent
+          {...managedArtifactIdentity}
+          path="/workspace/stack.tiff"
+          name="stack.tiff"
+        />
+      )
+    })
+    await vi.waitFor(() =>
+      expect(container.textContent).toContain("This TIFF encoding isn't supported for preview")
+    )
+    expect.soft(container.textContent).toContain('Page 1 of 2')
+    expect.soft(window.api.previewResources.release).not.toHaveBeenCalled()
+    const next = container.querySelector<HTMLButtonElement>('[aria-label="Next page"]')
+    expect(next).not.toBeNull()
+    await act(async () => next?.click())
+    await vi.waitFor(() => expect(container.textContent).toContain('Page 2 of 2'))
+    expect(Array.from((putImageData.mock.calls[0][0] as ImageData).data)).toEqual([0, 0, 255, 255])
+  })
+
   it('keeps page controls available after one page fails and returns to a valid page', async () => {
     const bytes = decodeTiffFixture(LZW_MULTIPAGE_TIFF)
     vi.mocked(fetch).mockImplementation(
@@ -273,7 +342,12 @@ describe('TiffPreviewContent', () => {
     })
     workerResponseOverride = (request) =>
       request.pageIndex === 1
-        ? { type: 'error', requestId: request.requestId, message: 'Unsupported TIFF test page' }
+        ? {
+            type: 'error',
+            requestId: request.requestId,
+            message: 'Unsupported TIFF test page',
+            pageCount: 2
+          }
         : undefined
 
     root = createRoot(container)

--- a/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.tsx
@@ -8,7 +8,11 @@ import type { PreviewFileSource } from '@/stores/preview-workbench-store'
 
 import { PreviewErrorCard, PreviewLoadingContent } from '../PreviewFallback'
 import { usePreviewResourceKey } from '../usePreviewResourceGeneration'
-import { DEFAULT_TIFF_PREVIEW_LIMITS, type DecodedTiffPage } from '../tiff-preview-types'
+import {
+  DEFAULT_TIFF_PREVIEW_LIMITS,
+  TiffPageDecodeError,
+  type DecodedTiffPage
+} from '../tiff-preview-types'
 import { createTiffDecodeSession, type TiffDecodeSession } from '../tiff-preview-worker-client'
 import type { PreviewFileRendererProps } from '../preview-types'
 import { useManagedPreviewResource } from '../useManagedPreviewResource'
@@ -151,7 +155,6 @@ const TiffPreviewContent = ({
   const resourceEnabled =
     resourceAdmission.resourceKey === resourceKey ? resourceAdmission.enabled : true
   const sessionCacheRef = useRef<CachedTiffSession | null>(null)
-  const lastDecodedPageRef = useRef<{ resourceKey: string; pageCount: number } | null>(null)
   const resourceState = useManagedPreviewResource(
     {
       projectId,
@@ -184,7 +187,6 @@ const TiffPreviewContent = ({
   )
 
   useEffect(() => {
-    lastDecodedPageRef.current = null
     return () => {
       sessionCacheRef.current?.session.dispose()
       sessionCacheRef.current = null
@@ -197,7 +199,6 @@ const TiffPreviewContent = ({
     const resource = resourceState.resource
     const controller = new AbortController()
     const dataKey = `${resourceKey}:${resource.id}:${resource.version}`
-    let decodeStarted = false
 
     void Promise.resolve()
       .then(async () => {
@@ -227,12 +228,10 @@ const TiffPreviewContent = ({
           session = createTiffDecodeSession(data)
           sessionCacheRef.current = { resourceKey: dataKey, session }
         }
-        decodeStarted = true
         return session.decodePage(pageIndex, controller.signal)
       })
       .then((page) => {
         if (!controller.signal.aborted) {
-          lastDecodedPageRef.current = { resourceKey, pageCount: page.pageCount }
           setResult({ requestKey, status: 'ready', page })
         }
       })
@@ -241,14 +240,13 @@ const TiffPreviewContent = ({
         sessionCacheRef.current?.session.dispose()
         sessionCacheRef.current = null
         const normalizedError = error instanceof Error ? error : new Error(String(error))
-        const lastDecodedPage = lastDecodedPageRef.current
-        if (decodeStarted && lastDecodedPage?.resourceKey === resourceKey) {
+        if (normalizedError instanceof TiffPageDecodeError) {
           setResult({
             scope: 'page',
             requestKey,
             status: 'error',
             error: normalizedError,
-            pageCount: lastDecodedPage.pageCount
+            pageCount: normalizedError.pageCount
           })
           return
         }
@@ -334,6 +332,15 @@ const TiffPreviewContent = ({
 
   return (
     <div className="relative size-full overflow-hidden p-4">
+      {result.page.displayRange ? (
+        <div className="absolute left-4 top-4 z-10 rounded-md bg-background/90 px-2 py-1 text-xs text-muted-foreground">
+          {result.page.autoContrast ? t('Automatic contrast') : t('Display range')}
+          {': '}
+          {result.page.displayRange.minimum}
+          {' – '}
+          {result.page.displayRange.maximum}
+        </div>
+      ) : null}
       <ZoomablePreview>
         <TiffCanvas page={result.page} name={name} onError={handleDrawError} />
       </ZoomablePreview>

--- a/src/renderer/src/pages/workspace/previews/tiff-preview-types.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview-types.ts
@@ -3,6 +3,10 @@ type DecodedTiffPage = {
   height: number
   pageIndex: number
   pageCount: number
+  displayRange?: { minimum: number; maximum: number }
+  sampleFormat?: number
+  bitsPerSample?: number
+  autoContrast?: boolean
   rgba: Uint8ClampedArray
 }
 
@@ -28,3 +32,12 @@ const TIFF_THUMBNAIL_MAX_DIMENSION = 512
 
 export { DEFAULT_TIFF_PREVIEW_LIMITS, TIFF_THUMBNAIL_LIMITS, TIFF_THUMBNAIL_MAX_DIMENSION }
 export type { DecodedTiffPage, TiffPreviewLimits }
+
+export class TiffPageDecodeError extends Error {
+  constructor(
+    message: string,
+    readonly pageCount: number
+  ) {
+    super(message)
+  }
+}

--- a/src/renderer/src/pages/workspace/previews/tiff-preview-worker-client.test.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview-worker-client.test.ts
@@ -45,3 +45,44 @@ describe('TIFF decode worker session', () => {
     expect(worker.terminate).toHaveBeenCalledOnce()
   })
 })
+
+it('transports a real Worker page error and decodes the next page in the same session', async () => {
+  const { createUnsupportedFirstPageTiff } = await import('./tiff-test-fixtures')
+  type Request = import('./tiff-preview-worker-protocol').TiffDecodeWorkerRequest
+  type Response = import('./tiff-preview-worker-protocol').TiffDecodeWorkerResponse
+  let handleRequest: (event: MessageEvent<Request>) => void
+  const listeners = new Set<EventListener>()
+  vi.stubGlobal('self', {
+    addEventListener: (_type: string, listener: typeof handleRequest) => {
+      handleRequest = listener
+    },
+    postMessage: (response: Response) => {
+      for (const listener of listeners) listener({ data: response } as MessageEvent<Response>)
+    }
+  })
+  await import('./tiff-preview-worker')
+  const session = createTiffDecodeSession(createUnsupportedFirstPageTiff(), {
+    createWorker: () => ({
+      addEventListener: (type: string, listener: EventListener) => {
+        if (type === 'message') listeners.add(listener)
+      },
+      removeEventListener: (_type: string, listener: EventListener) => {
+        listeners.delete(listener)
+      },
+      postMessage: (request) =>
+        queueMicrotask(() => handleRequest({ data: request } as MessageEvent<Request>)),
+      terminate: () => {}
+    })
+  })
+  try {
+    await expect(session.decodePage(0)).rejects.toMatchObject({
+      message: 'Unsupported TIFF compression: 32773',
+      pageCount: 2
+    })
+    const page = await session.decodePage(1)
+    expect(Array.from(page.rgba)).toEqual([0, 0, 255, 255])
+  } finally {
+    session.dispose()
+    vi.unstubAllGlobals()
+  }
+})

--- a/src/renderer/src/pages/workspace/previews/tiff-preview-worker-client.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview-worker-client.ts
@@ -1,3 +1,4 @@
+import { TiffPageDecodeError } from './tiff-preview-types'
 import type { DecodedTiffPage, TiffPreviewLimits } from './tiff-preview-types'
 import type {
   TiffDecodeWorkerRequest,
@@ -82,7 +83,12 @@ const createTiffDecodeSession = (
     decode.settled = true
 
     if (response.type === 'decoded') decode.resolve(response.page)
-    else decode.reject(new Error(response.message))
+    else
+      decode.reject(
+        response.pageCount === undefined
+          ? new Error(response.message)
+          : new TiffPageDecodeError(response.message, response.pageCount)
+      )
   }
 
   const onError = (): void => failSession(new Error('TIFF decoder worker failed'))

--- a/src/renderer/src/pages/workspace/previews/tiff-preview-worker-protocol.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview-worker-protocol.ts
@@ -11,6 +11,6 @@ type TiffDecodeWorkerRequest = {
 
 type TiffDecodeWorkerResponse =
   | { type: 'decoded'; requestId: number; page: DecodedTiffPage }
-  | { type: 'error'; requestId: number; message: string }
+  | { type: 'error'; requestId: number; message: string; pageCount?: number }
 
 export type { TiffDecodeWorkerRequest, TiffDecodeWorkerResponse }

--- a/src/renderer/src/pages/workspace/previews/tiff-preview-worker.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview-worker.ts
@@ -1,3 +1,4 @@
+import { TiffPageDecodeError } from './tiff-preview-types'
 import { decodeTiffPage, resizeDecodedTiffPage } from './tiff-preview'
 import type {
   TiffDecodeWorkerRequest,
@@ -27,6 +28,7 @@ self.addEventListener('message', (event: MessageEvent<TiffDecodeWorkerRequest>) 
     const response: TiffDecodeWorkerResponse = {
       type: 'error',
       requestId: request.requestId,
+      ...(error instanceof TiffPageDecodeError ? { pageCount: error.pageCount } : {}),
       message: error instanceof Error ? error.message : String(error)
     }
     self.postMessage(response)

--- a/src/renderer/src/pages/workspace/previews/tiff-preview.test.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   createWhiteIsZeroGrayscaleAlphaTiff,
+  createSampleTiff,
   DEFLATE_RGB_TIFF,
   decodeTiffFixture,
   LZW_GRAYSCALE_16_TIFF,
@@ -258,5 +259,118 @@ describe('TIFF preview decoding', () => {
     new DataView(bigTiff).setUint16(2, 43, true)
 
     expect(() => decodeTiffPage(bigTiff, 0)).toThrow('Invalid TIFF header')
+  })
+})
+
+describe('TIFF sample interpretation', () => {
+  it.each([
+    { samples: [200, 0], components: 2, photometric: 1, expected: [200, 200, 200, 255] },
+    { samples: [255, 0, 0, 0], components: 4, photometric: 2, expected: [255, 0, 0, 255] }
+  ])('keeps unspecified extra samples opaque: $components components', (input) => {
+    const page = decodeTiffPage(createSampleTiff({ ...input, extraSample: 0 }), 0)
+    expect(Array.from(page.rgba)).toEqual(input.expected)
+  })
+
+  it.each([1, 2])('preserves declared integer alpha, ExtraSamples=%s', (extraSample) => {
+    const page = decodeTiffPage(
+      createSampleTiff({
+        samples: [extraSample === 1 ? 64 : 128, 128],
+        extraSample
+      }),
+      0
+    )
+    expect(Array.from(page.rgba)).toEqual([128, 128, 128, 128])
+  })
+
+  it.each([0, 0.5])(
+    'rejects associated Float32 alpha %s before returning corrupted pixels',
+    (alpha) => {
+      const straight = decodeTiffPage(createSampleTiff({ samples: [0.5, 0.5], floating: true }), 0)
+      expect(Array.from(straight.rgba)).toEqual([128, 128, 128, 128])
+      expect(() =>
+        decodeTiffPage(
+          createSampleTiff({
+            samples: [0.5 * alpha, alpha],
+            floating: true,
+            extraSample: 1
+          }),
+          0
+        )
+      ).toThrow('Unsupported TIFF floating-point associated alpha layout')
+    }
+  )
+
+  it('keeps an undeclared extra channel opaque', () => {
+    const data = renameClassicTiffTag(createSampleTiff({ samples: [200, 0] }), 338, 65000)
+    expect(Array.from(decodeTiffPage(data, 0).rgba)).toEqual([200, 200, 200, 255])
+  })
+
+  it('ignores unspecified extra data in WhiteIsZero images', () => {
+    const page = decodeTiffPage(
+      createSampleTiff({
+        samples: [55, 0],
+        photometric: 0,
+        extraSample: 0
+      }),
+      0
+    )
+    expect(Array.from(page.rgba)).toEqual([200, 200, 200, 255])
+  })
+
+  it('rejects unknown extra-sample meanings', () => {
+    expect(() =>
+      decodeTiffPage(
+        createSampleTiff({
+          samples: [200, 0],
+          extraSample: 3
+        }),
+        0
+      )
+    ).toThrow('Unsupported TIFF extra sample layout')
+  })
+
+  it('renders zero integer associated alpha as transparent', () => {
+    const page = decodeTiffPage(createSampleTiff({ samples: [0, 0], extraSample: 1 }), 0)
+    expect(Array.from(page.rgba)).toEqual([0, 0, 0, 0])
+  })
+
+  it('keeps Float32 extra data opaque without changing intensity mapping', () => {
+    const page = decodeTiffPage(
+      createSampleTiff({
+        samples: [10, 1000, 20, 2000],
+        floating: true,
+        extraSample: 0
+      }),
+      0
+    )
+    expect(Array.from(page.rgba)).toEqual([0, 0, 0, 255, 255, 255, 255, 255])
+    expect(page.displayRange).toEqual({ minimum: 10, maximum: 20 })
+  })
+
+  it('discloses the intensity range when different Float32 pages look identical', () => {
+    const low = decodeTiffPage(
+      createSampleTiff({
+        samples: [10, 20],
+        components: 1,
+        floating: true,
+        extraSample: 0
+      }),
+      0
+    )
+    const high = decodeTiffPage(
+      createSampleTiff({
+        samples: [100, 200],
+        components: 1,
+        floating: true,
+        extraSample: 0
+      }),
+      0
+    )
+    expect(Array.from(low.rgba)).toEqual([0, 0, 0, 255, 255, 255, 255, 255])
+    expect(Array.from(high.rgba)).toEqual(Array.from(low.rgba))
+    expect(low).toMatchObject({ sampleFormat: 3, bitsPerSample: 32, autoContrast: true })
+    expect(resizeDecodedTiffPage(low, 1).displayRange).toEqual({ minimum: 10, maximum: 20 })
+    expect(low).toHaveProperty('displayRange', { minimum: 10, maximum: 20 })
+    expect(high).toHaveProperty('displayRange', { minimum: 100, maximum: 200 })
   })
 })

--- a/src/renderer/src/pages/workspace/previews/tiff-preview.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-preview.ts
@@ -2,6 +2,7 @@ import { decode, type TiffIfd } from 'tiff'
 
 import {
   DEFAULT_TIFF_PREVIEW_LIMITS,
+  TiffPageDecodeError,
   type DecodedTiffPage,
   type TiffPreviewLimits
 } from './tiff-preview-types'
@@ -10,7 +11,7 @@ import { assertTiffCompressionSafe, inspectTiffStructure } from './tiff-preview-
 const MAX_TIFF_DIMENSION = 16_384
 const TIFF_DECOMPRESSOR_SCRATCH_BYTES = 64 * 1024 * 1024
 
-type SampleRange = { minimum: number; maximum: number }
+type SampleRange = { minimum: number; maximum: number; autoContrast?: boolean }
 
 const sampleToByte = (value: number, range: SampleRange): number => {
   if (!Number.isFinite(value)) return 0
@@ -57,10 +58,10 @@ const getSampleRange = (ifd: TiffIfd, componentIndices: number[]): SampleRange =
 
   if (observedMinimum >= 0 && observedMaximum <= 1) return { minimum: 0, maximum: 1 }
   if (observedMaximum > observedMinimum) {
-    return { minimum: observedMinimum, maximum: observedMaximum }
+    return { minimum: observedMinimum, maximum: observedMaximum, autoContrast: true }
   }
-  if (observedMaximum > 0) return { minimum: 0, maximum: observedMaximum }
-  if (observedMinimum < 0) return { minimum: observedMinimum, maximum: 0 }
+  if (observedMaximum > 0) return { minimum: 0, maximum: observedMaximum, autoContrast: true }
+  if (observedMinimum < 0) return { minimum: observedMinimum, maximum: 0, autoContrast: true }
   return { minimum: 0, maximum: 1 }
 }
 
@@ -81,6 +82,17 @@ const assertSupportedColorLayout = (ifd: TiffIfd): void => {
   // precision before returning the decoded data. Reject this layout instead of rendering it wrong.
   if (ifd.type === 0 && ifd.sampleFormat === 3) {
     throw new Error('Unsupported TIFF floating-point WhiteIsZero layout')
+  }
+  if (ifd.sampleFormat === 3 && ifd.associatedAlpha) {
+    throw new Error('Unsupported TIFF floating-point associated alpha layout')
+  }
+  const extraSamples = ifd.extraSamples ?? []
+  const baseComponents = ifd.type === 2 ? 3 : 1
+  if (
+    extraSamples.length > ifd.components - baseComponents ||
+    extraSamples.some((value) => value !== 0 && value !== 1 && value !== 2)
+  ) {
+    throw new Error('Unsupported TIFF extra sample layout')
   }
   const grayscale =
     (ifd.type === 0 || ifd.type === 1) && (ifd.components === 1 || ifd.components === 2)
@@ -126,14 +138,9 @@ const assertSafeDecodedLayout = (
   }
 }
 
-const convertToRgba = (ifd: TiffIfd): Uint8ClampedArray => {
+const convertToRgba = (ifd: TiffIfd, range: SampleRange): Uint8ClampedArray => {
   const rgba = new Uint8ClampedArray(ifd.size * 4)
-  const hasAlpha = ifd.components === 2 || ifd.components === 4
-  const colorComponentCount = ifd.components - (hasAlpha ? 1 : 0)
-  const range = getSampleRange(
-    ifd,
-    Array.from({ length: colorComponentCount }, (_, index) => index)
-  )
+  const hasAlpha = ifd.extraSamples?.[0] === 1 || ifd.extraSamples?.[0] === 2
   const alphaRange = hasAlpha ? getSampleRange(ifd, [ifd.components - 1]) : range
 
   if ((ifd.type === 0 || ifd.type === 1) && (ifd.components === 1 || ifd.components === 2)) {
@@ -146,7 +153,7 @@ const convertToRgba = (ifd: TiffIfd): Uint8ClampedArray => {
       rgba[target + 2] = value
       // tiff@7.1.3 applies WhiteIsZero inversion to the entire sample array, including
       // ExtraSamples. Photometric inversion does not apply to alpha, so undo it here.
-      if (ifd.components === 2) {
+      if (hasAlpha) {
         const alphaSample =
           ifd.type === 0 ? ifd.maxSampleValue - ifd.data[source + 1] : ifd.data[source + 1]
         rgba[target + 3] = sampleToByte(alphaSample, alphaRange)
@@ -185,7 +192,7 @@ const convertToRgba = (ifd: TiffIfd): Uint8ClampedArray => {
     rgba[target] = sampleToByte(ifd.data[source], range)
     rgba[target + 1] = sampleToByte(ifd.data[source + 1], range)
     rgba[target + 2] = sampleToByte(ifd.data[source + 2], range)
-    rgba[target + 3] = ifd.components === 4 ? sampleToByte(ifd.data[source + 3], alphaRange) : 255
+    rgba[target + 3] = hasAlpha ? sampleToByte(ifd.data[source + 3], alphaRange) : 255
   }
 
   return rgba
@@ -201,22 +208,43 @@ const decodeTiffPage = (
   }
 
   const { pageCount } = inspectTiffStructure(data)
-  const [metadata] = decode(data, { pages: [pageIndex], ignoreImageData: true })
+  try {
+    const [metadata] = decode(data, { pages: [pageIndex], ignoreImageData: true })
 
-  if (!metadata) throw new RangeError(`TIFF page ${pageIndex + 1} is unavailable`)
-  assertSafeDecodedLayout(metadata, data.byteLength, limits)
-  assertTiffCompressionSafe(data, metadata)
+    if (!metadata) throw new RangeError(`TIFF page ${pageIndex + 1} is unavailable`)
+    assertSafeDecodedLayout(metadata, data.byteLength, limits)
+    assertTiffCompressionSafe(data, metadata)
 
-  const [ifd] = decode(data, { pages: [pageIndex] })
+    const [ifd] = decode(data, { pages: [pageIndex] })
 
-  if (!ifd) throw new RangeError(`TIFF page ${pageIndex + 1} is unavailable`)
+    if (!ifd) throw new RangeError(`TIFF page ${pageIndex + 1} is unavailable`)
 
-  return {
-    width: ifd.width,
-    height: ifd.height,
-    pageIndex,
-    pageCount,
-    rgba: convertToRgba(ifd)
+    const range = getSampleRange(ifd, ifd.type === 2 ? [0, 1, 2] : [0])
+    return {
+      width: ifd.width,
+      height: ifd.height,
+      pageIndex,
+      pageCount,
+      ...(ifd.sampleFormat === 3
+        ? {
+            displayRange: { minimum: range.minimum, maximum: range.maximum },
+            sampleFormat: ifd.sampleFormat,
+            bitsPerSample: ifd.bitsPerSample,
+            autoContrast: range.autoContrast === true
+          }
+        : {}),
+      rgba: convertToRgba(ifd, range)
+    }
+  } catch (error) {
+    // Only known unsupported layouts and per-page safety limits are navigable failures.
+    // Read, structure, corrupt-strip and unexpected decoder failures remain resource errors.
+    if (
+      error instanceof Error &&
+      (error.message.startsWith('Unsupported ') || error.message.startsWith('TIFF page '))
+    ) {
+      throw new TiffPageDecodeError(error.message, pageCount)
+    }
+    throw error
   }
 }
 

--- a/src/renderer/src/pages/workspace/previews/tiff-test-fixtures.ts
+++ b/src/renderer/src/pages/workspace/previews/tiff-test-fixtures.ts
@@ -74,3 +74,76 @@ export {
   LZW_RGB_TIFF,
   PALETTE_TIFF
 }
+
+// Small real, uncompressed TIFFs for sample interpretation regression tests.
+export const createSampleTiff = ({
+  samples,
+  components = 2,
+  photometric = 1,
+  floating = false,
+  extraSample = 2
+}: {
+  samples: number[]
+  components?: number
+  photometric?: number
+  floating?: boolean
+  extraSample?: number
+}): ArrayBuffer => {
+  const pixelOffset = 192
+  const sampleBytes = floating ? 4 : 1
+  const data = new ArrayBuffer(pixelOffset + samples.length * sampleBytes)
+  const view = new DataView(data)
+  view.setUint16(0, 0x4949, true)
+  view.setUint16(2, 42, true)
+  view.setUint32(4, 8, true)
+  const repeatedShort = (value: number, offset: number): number => {
+    if (components === 1) return value
+    if (components === 2) return value | (value << 16)
+    for (let index = 0; index < components; index += 1) {
+      view.setUint16(offset + index * 2, value, true)
+    }
+    return offset
+  }
+  const entries = [
+    [256, 4, 1, samples.length / components],
+    [257, 4, 1, 1],
+    [258, 3, components, repeatedShort(floating ? 32 : 8, 160)],
+    [259, 3, 1, 1],
+    [262, 3, 1, photometric],
+    [273, 4, 1, pixelOffset],
+    [277, 3, 1, components],
+    [278, 4, 1, 1],
+    [279, 4, 1, samples.length * sampleBytes],
+    [284, 3, 1, 1],
+    ...(components === 2 || components === 4 ? [[338, 3, 1, extraSample]] : []),
+    [339, 3, components, repeatedShort(floating ? 3 : 1, 176)]
+  ]
+  view.setUint16(8, entries.length, true)
+  entries.forEach(([tag, type, count, value], index) => {
+    const offset = 10 + index * 12
+    view.setUint16(offset, tag, true)
+    view.setUint16(offset + 2, type, true)
+    view.setUint32(offset + 4, count, true)
+    view.setUint32(offset + 8, value, true)
+  })
+  samples.forEach((value, index) => {
+    if (floating) view.setFloat32(pixelOffset + index * sampleBytes, value, true)
+    else view.setUint8(pixelOffset + index, value)
+  })
+  return data
+}
+
+export const createUnsupportedFirstPageTiff = (): ArrayBuffer => {
+  const data = decodeTiffFixture(LZW_MULTIPAGE_TIFF)
+  const view = new DataView(data)
+  const ifdOffset = view.getUint32(4, true)
+  for (let index = 0; index < view.getUint16(ifdOffset, true); index += 1) {
+    const offset = ifdOffset + 2 + index * 12
+    const tag = view.getUint16(offset, true)
+    if (tag === 259) view.setUint16(offset + 8, 32773, true)
+    if (tag === 279) view.setUint32(offset + 8, 4, true)
+  }
+  // Valid PackBits literal run: three bytes encoding one red RGB pixel.
+  new Uint8Array(data, 8, 4).set([2, 255, 0, 0])
+  return data
+}

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -101,6 +101,8 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Automatic contrast": "Automatischer Kontrast",
+    "Display range": "Anzeigebereich",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Ihr Entwurf bleibt erhalten. Laden Sie die aktuellen Details neu und führen Sie sie vor dem Speichern mit Ihrem Entwurf zusammen.",
     "Project: {{name}}": "Projekt: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Für diese Plattform ist kein Installationsprogramm verfügbar. Laden Sie es manuell herunter, um andere Installationsmöglichkeiten zu prüfen.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -102,6 +102,8 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Automatic contrast": "Contraste automático",
+    "Display range": "Rango de visualización",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Se conserva su borrador. Vuelva a cargar los detalles actuales y combínelos con su borrador antes de guardar.",
     "Project: {{name}}": "Proyecto: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "No hay un instalador disponible para esta plataforma. Descargue manualmente para consultar otras opciones de instalación.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -102,6 +102,8 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Automatic contrast": "Contraste automatique",
+    "Display range": "Plage d’affichage",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Votre brouillon est conservé. Rechargez les détails actuels, puis fusionnez-les avec votre brouillon avant de sauvegarder.",
     "Project: {{name}}": "Projet : {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Aucun programme d’installation n’est disponible pour cette plateforme. Consultez le téléchargement manuel pour découvrir d’autres options d’installation.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Automatic contrast": "自動コントラスト",
+    "Display range": "表示範囲",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "下書きは保持されています。現在の説明を再読み込みし、下書きに統合してから保存してください。",
     "Project: {{name}}": "プロジェクト：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "このプラットフォーム用のインストーラーはありません。手動ダウンロードのページで他のインストール方法を確認してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Automatic contrast": "자동 대비",
+    "Display range": "표시 범위",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "초안이 보존됩니다. 현재 설명을 다시 불러온 후 초안에 병합하고 저장하세요.",
     "Project: {{name}}": "프로젝트: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "이 플랫폼에서 사용할 수 있는 설치 프로그램이 없습니다. 수동 다운로드 페이지에서 다른 설치 방법을 확인하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -103,6 +103,8 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Automatic contrast": "Автоматическая контрастность",
+    "Display range": "Диапазон отображения",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Черновик сохранён. Загрузите актуальное описание и объедините его с черновиком перед сохранением.",
     "Project: {{name}}": "Проект: {{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "Установщик для этой платформы недоступен. Перейдите к ручной загрузке, чтобы узнать о других вариантах установки.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Automatic contrast": "自动对比度",
+    "Display range": "显示范围",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "草稿已保留。请重新加载当前说明，将其合并到草稿后再保存。",
     "Project: {{name}}": "项目：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "此平台暂无可用的安装包。请前往手动下载页面查看其他安装选项。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Automatic contrast": "自動對比度",
+    "Display range": "顯示範圍",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "草稿已保留。請重新載入目前說明，將其合併至草稿後再儲存。",
     "Project: {{name}}": "專案：{{name}}",
     "An installer is not available for this platform. Download manually to check other installation options.": "此平台暫無可用的安裝套件。請前往手動下載頁面查看其他安裝選項。",


### PR DESCRIPTION
## Problem

TIFF previews interpret unspecified extra samples as alpha, making valid grayscale/RGB pixels disappear. The installed decoder also corrupts floating-point associated alpha before RGBA conversion. An unsupported first page hides all subsequent pages, and per-page floating-point contrast stretching provides no intensity scale.

## Proposed change

- Identify alpha only from supported ExtraSamples declarations; keep other extra data opaque, reject unknown meanings, and retain WhiteIsZero alpha correction.
- Reject floating-point associated alpha before decoding, including zero alpha, through the existing unsupported-encoding surface. Integer alpha remains supported.
- Carry validated page counts on known page errors through the existing Worker/session contract. Preserve first-page error navigation while read, structure and unexpected decoder failures remain resource errors.
- Return transient floating display range/sample metadata and show a translated automatic-contrast or display-range label in the interactive preview.

## Scope and non-goals

No persistence, database, original-file modification, historical migration, new lifecycle enum, dependency patch or separate document manager. Existing floating associated-alpha files now receive an explicit unsupported message instead of distorted pixels. No cross-page normalization controls or image editor. Thumbnail conversion benefits from corrected sample interpretation; thumbnail navigation remains unchanged.

## Acceptance criteria and validation

All listed local checks ran after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Pixels, opacity, floating rejection, mapping metadata and limits | `npm test -- src/renderer/src/pages/workspace/previews/tiff-preview.test.ts src/renderer/src/pages/workspace/previews/tiff-preview-preflight.test.ts` | Pass |
| Actual Worker message handler, session errors and thumbnail scheduling | `npm test -- src/renderer/src/pages/workspace/previews/tiff-preview-worker-client.test.ts src/renderer/src/pages/workspace/previews/tiff-thumbnail-scheduler.test.ts` | Pass |
| First-page recovery, range labels and artifact thumbnail consumers | `npm test -- src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx src/renderer/src/pages/workspace/artifact-preview-tiff.test.tsx` | Pass |
| Eight locale catalogs | `npm test -- src/renderer/src/i18n/resources.test.ts` | Pass |
| Renderer types and repository lint | `npm run typecheck:web`; `npm run lint` | Pass |

The seven test files ran together: **857 tests passed**. Generated real TIFFs pass through structural preflight and the installed decoder. Original conversion/Worker/session/renderer implementations were restored temporarily: **12 regressions failed consistently on two runs**, with opacity, absent rejection, missing scale or missing navigation assertions. Restoring the fix passes. No production test seam was introduced; the existing Worker transport is reused, with an additional test invoking the actual Worker message listener.

Browser verification mounted the real renderer, CSS, resource hook and browser Worker in a local verification harness: an unsupported first page retains Page 1 of 2 controls; clicking Next displays Page 2 of 2 with `[0,0,255,255]` canvas pixels. The float view displays `Automatic contrast: 10 – 20`. Screenshots were reviewed locally.

`npm run test:affected:explain -- --base origin/main --head HEAD` selects full verification because TIFF renderer ownership is not mapped. Per maintainer instruction the full local suite was not run; PR CI is the full-suite authority. Shared Worker and thumbnail consumers are included above. Main/preload and persistence are unchanged, so no local migration or native-platform suite was added. Packaged Electron and cross-platform certification remain CI coverage, not claimed by the local browser harness. CodeGraph supplied existing consumer relationships but warned its index belongs to the main checkout; the worktree diff and behavioral tests were used for final verification.

## Review focus

Check the boundary between known page failures and global corruption, ExtraSamples interpretation, and whether the conservative floating associated-alpha rejection is appropriate. Display ranges describe intensity mapping, not measurement units or alpha scaling.
