### PR TITLE
fix(office-preview): preserve worksheet visibility and session errors

### DIFF
--- a/patches/@file-viewer+renderer-spreadsheet+2.2.3.patch
+++ b/patches/@file-viewer+renderer-spreadsheet+2.2.3.patch
@@ -213,7 +213,7 @@ index 3378e4a7..55292dc1 100644
          cached.loadingWindows.clear();
          virtualState = cached;
          errorMessage = '';
-@@ -1418,7 +1506,7 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+@@ -1418,26 +1506,49 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
      };
      controller.onWorkerEvent('sheets', ({ sheets: list }) => {
          sheets = list;
@@ -222,7 +222,9 @@ index 3378e4a7..55292dc1 100644
          if (firstSheet) {
              sheetIndex = firstSheet.id;
              renderChrome();
-@@ -1428,16 +1516,39 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+             startSheetSession();
+             scrollActiveSheetIntoView();
+             return;
          }
          sheetInitializing = false;
          loadingState = false;

--- a/patches/@file-viewer+renderer-spreadsheet+2.2.3.patch
+++ b/patches/@file-viewer+renderer-spreadsheet+2.2.3.patch
@@ -1,5 +1,5 @@
 diff --git a/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet.js b/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet.js
-index 3378e4a..d779036 100644
+index 3378e4a7..55292dc1 100644
 --- a/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet.js
 +++ b/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet.js
 @@ -4,6 +4,8 @@ import { buildRows, clampWindowStart, collectWindowStarts, createEmptyVirtualSta
@@ -39,6 +39,18 @@ index 3378e4a..d779036 100644
      let scrollDirection = 1;
      let lastScrollY = 0;
      let sheetSessionId = 0;
+@@ -636,9 +652,9 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+     const getActiveSheet = () => sheets.find(sheet => sheet.id === sheetIndex);
+     const getSheetTabs = () => {
+         const visible = sheets.filter(sheet => !sheet.hidden);
+-        return visible.length ? visible : sheets;
++        return visible;
+     };
+-    const getActiveSheetId = () => { var _a; return sheetIndex !== null && sheetIndex !== void 0 ? sheetIndex : (_a = sheets[0]) === null || _a === void 0 ? void 0 : _a.id; };
++    const getActiveSheetId = () => { var _a; return sheetIndex !== null && sheetIndex !== void 0 ? sheetIndex : (_a = sheets.find(sheet => !sheet.hidden)) === null || _a === void 0 ? void 0 : _a.id; };
+     const getHostHeight = () => tableHost.clientHeight || 0;
+     const showBlockingLoading = () => !errorMessage && !hasInitialWindow && (loadingState || sheetInitializing);
+     const showStreamingLoading = () => !showBlockingLoading() &&
 @@ -905,7 +921,7 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
              endRow,
              direction: scrollDirection,
@@ -201,8 +213,28 @@ index 3378e4a..d779036 100644
          cached.loadingWindows.clear();
          virtualState = cached;
          errorMessage = '';
-@@ -1431,13 +1519,28 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+@@ -1418,7 +1506,7 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+     };
+     controller.onWorkerEvent('sheets', ({ sheets: list }) => {
+         sheets = list;
+-        const firstSheet = list.find((sheet) => !sheet.hidden) || list[0];
++        const firstSheet = list.find((sheet) => !sheet.hidden);
+         if (firstSheet) {
+             sheetIndex = firstSheet.id;
+             renderChrome();
+@@ -1428,16 +1516,39 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+         }
+         sheetInitializing = false;
+         loadingState = false;
++        const empty = documentRef.createElement('p');
++        empty.className = 'spreadsheet-empty';
++        empty.setAttribute('role', 'status');
++        empty.textContent = t(list.length ? 'state.empty.message' : 'state.empty.title');
++        tableHost.replaceChildren(empty);
          renderChrome();
++        setHidden(toolbar, true);
++        hasNotifiedFirstPaint = true;
++        context?.onProgressiveRender?.();
      });
      controller.onWorkerEvent('parseSheet', ({ sessionId, sheet, sheetData: ws }) => {
 +        const startRow = ws.meta?.startRow;
@@ -230,7 +262,7 @@ index 3378e4a..d779036 100644
              return;
          }
          sheetInitializing = false;
-@@ -1458,6 +1561,8 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+@@ -1458,6 +1569,8 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
          renderChrome();
      });
      controller.onWorkerError((event) => {
@@ -239,3 +271,30 @@ index 3378e4a..d779036 100644
          sheetInitializing = false;
          loadingState = false;
          errorMessage = event.message || t('spreadsheet.error.workerFailed');
+@@ -1469,7 +1582,7 @@ const renderFileViewerSpreadsheet = async (buffer, target, type, context) => {
+     });
+     (_k = context === null || context === void 0 ? void 0 : context.registerThumbnailAdapter) === null || _k === void 0 ? void 0 : _k.call(context, {
+         beforeCapture: async ({ signal }) => {
+-            while (!hasInitialWindow && !errorMessage && !disposed) {
++            while (!hasNotifiedFirstPaint && !errorMessage && !disposed) {
+                 if (signal === null || signal === void 0 ? void 0 : signal.aborted) {
+                     throw signal.reason;
+                 }
+diff --git a/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet/worker/sheetjs/parser.js b/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet/worker/sheetjs/parser.js
+index 25966063..5d904cb1 100644
+--- a/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet/worker/sheetjs/parser.js
++++ b/node_modules/@file-viewer/renderer-spreadsheet/dist/spreadsheet/worker/sheetjs/parser.js
+@@ -73,12 +73,9 @@ const parseSheets = (context) => {
+         const ref = worksheet === null || worksheet === void 0 ? void 0 : worksheet['!ref'];
+         const drawingBounds = getDrawingBounds(worksheet);
+         const chartBounds = getChartBounds(context.charts[name]);
+-        if (!ref && !drawingBounds.rowCount && !drawingBounds.colCount && !chartBounds.rowCount && !chartBounds.colCount) {
+-            return result;
+-        }
+         const range = ref ? utils.decode_range(ref) : utils.decode_range('A1');
+         result.push({
+-            id: result.length,
++            id: sourceIndex,
+             name,
+             hidden: !!((_a = workbookSheets[sourceIndex]) === null || _a === void 0 ? void 0 : _a.Hidden),
+             rowCount: Math.max(range.e.r + 1, drawingBounds.rowCount, chartBounds.rowCount),

--- a/src/renderer/src/office-preview/office-preview-controller.test.ts
+++ b/src/renderer/src/office-preview/office-preview-controller.test.ts
@@ -50,6 +50,38 @@ describe('connectOfficePreviewRuntime', () => {
     expect(disposeRender).toHaveBeenCalledOnce()
   })
 
+  it('hides failed runtime content and ignores reports from a disconnected session', async () => {
+    let startListener: ((start: never) => void) | undefined
+    let emit: RunOfficePreviewOptions['reportState'] | undefined
+    const reportState = vi.fn()
+    const container = document.createElement('div')
+    const disconnect = connectOfficePreviewRuntime({
+      container,
+      bridge: {
+        onStart: (listener) => {
+          startListener = listener
+          return vi.fn<() => void>()
+        },
+        reportState
+      },
+      runPreview: async (options) => {
+        emit = options.reportState
+        return vi.fn<() => void>()
+      }
+    })
+    startListener?.({ sessionId: 'session-1' } as never)
+    await vi.waitFor(() => expect(emit).toBeTypeOf('function'))
+    emit?.({ sessionId: 'session-1', phase: 'ready' })
+    expect(container.dataset.officePreviewReady).toBe('true')
+    emit?.({ sessionId: 'session-1', phase: 'error', error: 'RENDER_FAILED' })
+    expect(container.dataset.officePreviewReady).toBe('false')
+    await disconnect()
+    const count = reportState.mock.calls.length
+    emit?.({ sessionId: 'session-1', phase: 'ready' })
+    expect(reportState).toHaveBeenCalledTimes(count)
+    expect(container.dataset.officePreviewReady).toBe('false')
+  })
+
   it('reports the stable error code returned by the isolated runtime', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined)
     let startListener: ((start: never) => void) | undefined
@@ -57,7 +89,7 @@ describe('connectOfficePreviewRuntime', () => {
     const bridge = {
       onStart: vi.fn((listener) => {
         startListener = listener
-        return vi.fn()
+        return vi.fn<() => void>()
       }),
       reportState
     }
@@ -104,7 +136,7 @@ describe('connectOfficePreviewRuntime', () => {
     const bridge = {
       onStart: vi.fn((listener) => {
         startListener = listener
-        return vi.fn()
+        return vi.fn<() => void>()
       }),
       reportState
     }
@@ -129,7 +161,7 @@ describe('connectOfficePreviewRuntime', () => {
       })
       expect(container.dataset.officePreviewReady).toBe('false')
       options.reportState({ sessionId: start.sessionId, phase: 'ready' })
-      return vi.fn()
+      return vi.fn<() => void>()
     })
 
     connectOfficePreviewRuntime({ bridge, container, runPreview })

--- a/src/renderer/src/office-preview/office-preview-controller.ts
+++ b/src/renderer/src/office-preview/office-preview-controller.ts
@@ -41,6 +41,8 @@ const connectOfficePreviewRuntime = (
           container: options.container,
           fetchFile: fetch,
           reportState: (state) => {
+            if (disconnected || currentGeneration !== generation) return
+            if (state.phase === 'error') options.container.dataset.officePreviewReady = 'false'
             if (state.phase === 'ready') options.container.dataset.officePreviewReady = 'true'
             options.bridge.reportState(state)
           }

--- a/src/renderer/src/office-preview/office-preview-runtime.test.ts
+++ b/src/renderer/src/office-preview/office-preview-runtime.test.ts
@@ -21,6 +21,38 @@ describe('runOfficePreview', () => {
     mocks.render.mockResolvedValue(vi.fn())
   })
 
+  it('does not report ready when a session error races the renderer return', async () => {
+    const failure = new Error('Worker stopped after first paint')
+    const dispose = vi.fn()
+    mocks.render.mockImplementation(async (options) => {
+      options.onError(failure)
+      return dispose
+    })
+    const reportState = vi.fn()
+    await expect(
+      runOfficePreview({
+        start: {
+          sessionId: 'session-race',
+          extension: 'xlsx',
+          name: 'book.xlsx',
+          attempt: 0,
+          resource: {
+            id: 'resource',
+            url: 'https://preview.test/book.xlsx',
+            size: 3,
+            mimeType: 'application/octet-stream',
+            version: 1
+          }
+        },
+        container: document.createElement('div'),
+        fetchFile: vi.fn().mockResolvedValue(new Response(new Uint8Array([1, 2, 3]))),
+        reportState
+      })
+    ).rejects.toThrow(failure.message)
+    expect(dispose).toHaveBeenCalledOnce()
+    expect(reportState.mock.calls.some(([state]) => state.phase === 'ready')).toBe(false)
+  })
+
   it('reads, validates, and renders inside the isolated runtime', async () => {
     const bytes = new Uint8Array([1, 2, 3])
     const disposeRender = vi.fn()

--- a/src/renderer/src/office-preview/office-preview-runtime.ts
+++ b/src/renderer/src/office-preview/office-preview-runtime.ts
@@ -77,6 +77,8 @@ const runOfficePreview = async (
   const { start, container, fetchFile, reportState } = options
   const controller = new AbortController()
   let disposeRender: OfficePreviewRuntimeCleanup | undefined
+  let ready = false
+  let sessionError: Error | undefined
 
   try {
     reportState({ sessionId: start.sessionId, phase: 'reading' })
@@ -132,6 +134,13 @@ const runOfficePreview = async (
         name: start.name,
         container,
         signal: controller.signal,
+        onError: (error) => {
+          if (controller.signal.aborted) return
+          sessionError = error
+          controller.abort(error)
+          if (ready)
+            reportState({ sessionId: start.sessionId, phase: 'error', error: 'RENDER_FAILED' })
+        },
         onStatus: (status) =>
           reportState({
             sessionId: start.sessionId,
@@ -150,6 +159,11 @@ const runOfficePreview = async (
       }
       throw asRuntimeError(error, 'RENDER_FAILED', 'Office preview rendering failed')
     }
+    if (sessionError) {
+      await disposeRender?.()
+      throw asRuntimeError(sessionError, 'RENDER_FAILED', 'Office preview rendering failed')
+    }
+    ready = true
     reportState({ sessionId: start.sessionId, phase: 'ready' })
   } catch (error) {
     controller.abort(error)

--- a/src/renderer/src/office-preview/office-preview-runtime.ts
+++ b/src/renderer/src/office-preview/office-preview-runtime.ts
@@ -1,3 +1,4 @@
+import { initI18n } from '../i18n'
 import type {
   OfficePreviewErrorCode,
   OfficePreviewRuntimeStart,
@@ -81,6 +82,7 @@ const runOfficePreview = async (
   let sessionError: Error | undefined
 
   try {
+    initI18n(start.locale ?? 'en')
     reportState({ sessionId: start.sessionId, phase: 'reading' })
     let bytes: Uint8Array
     try {

--- a/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
+++ b/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
@@ -7,6 +7,7 @@ import {
   createSpreadsheetParserContext,
   handleSpreadsheetWorkerRequest
 } from '@file-viewer/renderer-spreadsheet/worker/sheetjs'
+import { initI18n } from '../../../i18n'
 import { runOfficePreview } from '../../../office-preview/office-preview-runtime'
 import { validateOfficePackage } from './office-package'
 import { renderOfficeFile } from './office-renderers'
@@ -146,7 +147,7 @@ describe('Office behavior through real parsers and adapters', () => {
     'OF01: a blank visible %s sheet completes first paint',
     async (extension) => {
       const outcome = await renderWorkbook(workbookBytes(extension), extension)
-      await vi.waitFor(() => expect(outcome.state).toBe('ready'), { timeout: 500 })
+      await vi.waitFor(() => expect(outcome.state).toBe('ready'), { timeout: 2_000 })
       expect(
         Array.from(container.querySelectorAll('.sheet-tab'), (tab) => tab.textContent)
       ).toEqual(['Visible'])
@@ -160,8 +161,8 @@ describe('Office behavior through real parsers and adapters', () => {
   ] as const)(
     'OF02: %s visible data=%s never selects hidden content',
     async (extension, visibleData) => {
-      await renderWorkbook(workbookBytes(extension, visibleData, true), extension)
-      await vi.waitFor(() => expect(harness.instances.length).toBeGreaterThan(0))
+      const outcome = await renderWorkbook(workbookBytes(extension, visibleData, true), extension)
+      await vi.waitFor(() => expect(outcome.state).toBe('ready'))
       expect(JSON.stringify(harness.instances.flatMap((table) => table.getRows()))).not.toContain(
         'HIDDEN_DATA'
       )
@@ -170,6 +171,28 @@ describe('Office behavior through real parsers and adapters', () => {
       ).toEqual(['Visible'])
     }
   )
+
+  it('keeps visible worksheet tabs displayed and switches to another worksheet', async () => {
+    const workbook = utils.book_new()
+    utils.book_append_sheet(workbook, utils.aoa_to_sheet([['FIRST_DATA']]), 'First')
+    utils.book_append_sheet(workbook, utils.aoa_to_sheet([['SECOND_DATA']]), 'Second')
+    const outcome = await renderWorkbook(
+      new Uint8Array(write(workbook, { type: 'array', bookType: 'xlsx' })),
+      'xlsx'
+    )
+    await vi.waitFor(() => expect(outcome.state).toBe('ready'))
+    const toolbar = container.querySelector<HTMLElement>('.toolbar')!
+    expect(getComputedStyle(toolbar).display).not.toBe('none')
+    const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>('.sheet-tab'))
+    expect(tabs.map((tab) => tab.textContent)).toEqual(['First', 'Second'])
+    tabs[1].click()
+    await vi.waitFor(() =>
+      expect(JSON.stringify(harness.instances.flatMap((table) => table.getRows()))).toContain(
+        'SECOND_DATA'
+      )
+    )
+    expect(getComputedStyle(toolbar).display).not.toBe('none')
+  })
 
   it.each([1, 2] as const)(
     'completes an all-hidden workbook without exposing Hidden=%s',
@@ -213,6 +236,45 @@ describe('Office behavior through real parsers and adapters', () => {
     ])
     expect(context.workbook?.Workbook?.Sheets?.map((sheet) => sheet.Hidden)).toEqual([0, 1])
   })
+
+  it.each([
+    ['zh-Hans', '此工作簿没有可见的工作表。'],
+    [undefined, 'This workbook has no visible worksheets.']
+  ] as const)(
+    'applies startup locale %s before rendering the empty state',
+    async (locale, expected) => {
+      initI18n(locale ? 'en' : 'de')
+      const workbook = utils.book_new()
+      utils.book_append_sheet(workbook, utils.aoa_to_sheet([]), 'Private')
+      utils.book_set_sheet_visibility(workbook, 'Private', 1)
+      const bytes = new Uint8Array(write(workbook, { type: 'array', bookType: 'xlsx' }))
+      const start = {
+        sessionId: 'locale-session',
+        extension: 'xlsx' as const,
+        name: 'hidden.xlsx',
+        attempt: 0,
+        locale,
+        resource: {
+          id: 'locale-resource',
+          url: 'https://preview.test/hidden.xlsx',
+          size: bytes.byteLength,
+          mimeType: 'application/octet-stream',
+          version: 1
+        }
+      }
+      try {
+        cleanup = await runOfficePreview({
+          start,
+          container,
+          fetchFile: vi.fn().mockResolvedValue(new Response(new Uint8Array(bytes).buffer)),
+          reportState: vi.fn()
+        })
+        expect(container.querySelector('[role="status"]')?.textContent).toBe(expected)
+      } finally {
+        initI18n('en')
+      }
+    }
+  )
 
   it('OF03: reports a terminal Worker failure after ready', async () => {
     const bytes = workbookBytes('xlsx', true)

--- a/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
+++ b/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
@@ -172,6 +172,35 @@ describe('Office behavior through real parsers and adapters', () => {
     }
   )
 
+  it('waits for the first visible sheet window before completing first paint', async () => {
+    const postMessage = ParserWorker.prototype.postMessage
+    let releaseWindow: (() => void) | undefined
+    vi.spyOn(ParserWorker.prototype, 'postMessage').mockImplementation(function (
+      this: ParserWorker,
+      message
+    ) {
+      if (message.type === 'parseSheet') {
+        releaseWindow = () => postMessage.call(this, message)
+      } else {
+        postMessage.call(this, message)
+      }
+    })
+    const outcome = await renderWorkbook(workbookBytes('xlsx', true), 'xlsx')
+    await vi.waitFor(() => expect(releaseWindow).toBeDefined())
+    // Let any readiness callbacks from the sheets event settle while the data window is held.
+    await new Promise((resolve) => window.setTimeout(resolve, 50))
+    expect(outcome.state).toBe('pending')
+    expect(container.querySelector('.spreadsheet-empty')).toBeNull()
+    expect(getComputedStyle(container.querySelector<HTMLElement>('.toolbar')!).display).not.toBe(
+      'none'
+    )
+    releaseWindow!()
+    await vi.waitFor(() => expect(outcome.state).toBe('ready'))
+    expect(JSON.stringify(harness.instances.flatMap((table) => table.getRows()))).toContain(
+      'VISIBLE_DATA'
+    )
+  })
+
   it('keeps visible worksheet tabs displayed and switches to another worksheet', async () => {
     const workbook = utils.book_new()
     utils.book_append_sheet(workbook, utils.aoa_to_sheet([['FIRST_DATA']]), 'First')

--- a/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
+++ b/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
@@ -1,0 +1,318 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { utils, write } from 'styled-exceljs'
+import { zipSync, strToU8, unzipSync, strFromU8 } from 'fflate'
+import { renderAsync } from 'docx-preview'
+import {
+  createSpreadsheetParserContext,
+  handleSpreadsheetWorkerRequest
+} from '@file-viewer/renderer-spreadsheet/worker/sheetjs'
+import { runOfficePreview } from '../../../office-preview/office-preview-runtime'
+import { validateOfficePackage } from './office-package'
+import { renderOfficeFile } from './office-renderers'
+
+vi.mock('@file-viewer/renderer-spreadsheet/worker/sheetjs/sheet.worker?worker&url', () => ({
+  default: 'local-sheet-worker.js'
+}))
+
+// Execute the installed parser using its real Worker protocol; only thread transport is simulated.
+class ParserWorker extends EventTarget {
+  static instances: ParserWorker[] = []
+  context = createSpreadsheetParserContext()
+  terminated = false
+  responses: unknown[] = []
+  constructor() {
+    super()
+    ParserWorker.instances.push(this)
+  }
+  postMessage(message: Parameters<typeof handleSpreadsheetWorkerRequest>[1]): void {
+    window.setTimeout(() => {
+      void Promise.resolve(handleSpreadsheetWorkerRequest(this.context, message)).then(
+        (responses) => {
+          if (this.terminated) return
+          this.responses.push(...responses)
+          for (const data of responses) this.dispatchEvent(new MessageEvent('message', { data }))
+        }
+      )
+    }, 0)
+  }
+  terminate(): void {
+    this.terminated = true
+  }
+}
+
+const workbookBytes = (
+  extension: 'xlsx' | 'xls',
+  visibleData = false,
+  hidden = false
+): Uint8Array => {
+  const workbook = utils.book_new()
+  utils.book_append_sheet(
+    workbook,
+    utils.aoa_to_sheet(visibleData ? [['VISIBLE_DATA']] : []),
+    'Visible'
+  )
+  if (hidden) {
+    utils.book_append_sheet(workbook, utils.aoa_to_sheet([['HIDDEN_DATA']]), 'Hidden')
+    utils.book_set_sheet_visibility(workbook, 'Hidden', 1)
+  }
+  return new Uint8Array(write(workbook, { type: 'array', bookType: extension }))
+}
+
+const bookmarkDocx = (): Uint8Array =>
+  zipSync(
+    {
+      '[Content_Types].xml': strToU8(
+        '<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types"><Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/><Override PartName="/word/document.xml" ContentType="application/vnd.openxmlformats-officedocument.wordprocessingml.document.main+xml"/></Types>'
+      ),
+      '_rels/.rels': strToU8(
+        '<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships"><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="word/document.xml"/></Relationships>'
+      ),
+      'word/document.xml': strToU8(
+        '<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:p><w:hyperlink w:anchor="section1"><w:r><w:t>Jump to section</w:t></w:r></w:hyperlink></w:p><w:p><w:bookmarkStart w:id="1" w:name="section1"/><w:r><w:t>Section one</w:t></w:r><w:bookmarkEnd w:id="1"/></w:p><w:sectPr/></w:body></w:document>'
+      )
+    },
+    { level: 0 }
+  )
+
+describe('Office behavior through real parsers and adapters', () => {
+  let container: HTMLDivElement
+  let controller: AbortController
+  let cleanup: (() => void | Promise<void>) | undefined
+  const harness = { instances: [] as Array<{ getRows: () => Array<Record<string, unknown>> }> }
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.append(container)
+    controller = new AbortController()
+    cleanup = undefined
+    harness.instances = []
+    ParserWorker.instances = []
+    vi.stubGlobal('Worker', ParserWorker)
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      window.setTimeout(() => callback(0), 0)
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => window.clearTimeout(id))
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(null)
+    vi.stubGlobal('__openScienceTestTableHarness', harness)
+    Object.defineProperty(HTMLElement.prototype, 'scrollIntoView', {
+      configurable: true,
+      value: vi.fn()
+    })
+  })
+  afterEach(async () => {
+    controller.abort()
+    await cleanup?.()
+    ParserWorker.instances.forEach((worker) => worker.terminate())
+    container.remove()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  const renderWorkbook = async (
+    bytes: Uint8Array,
+    extension: 'xlsx' | 'xls'
+  ): Promise<{ state: 'pending' | 'ready' | 'error' }> => {
+    await validateOfficePackage(bytes, extension, controller.signal)
+    const outcome = { state: 'pending' as 'pending' | 'ready' | 'error' }
+    const completion = renderOfficeFile({
+      bytes,
+      extension,
+      name: `book.${extension}`,
+      container,
+      signal: controller.signal
+    })
+      .then((dispose) => {
+        cleanup = dispose
+        outcome.state = 'ready'
+      })
+      .catch(() => {
+        outcome.state = 'error'
+      })
+    // Always release a pending first-paint wait, including when an assertion fails.
+    cleanup = async () => {
+      controller.abort()
+      await completion
+    }
+    await vi.waitFor(() =>
+      expect(ParserWorker.instances[0]?.responses).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'sheets' })])
+      )
+    )
+    return outcome
+  }
+
+  it.each(['xlsx', 'xls'] as const)(
+    'OF01: a blank visible %s sheet completes first paint',
+    async (extension) => {
+      const outcome = await renderWorkbook(workbookBytes(extension), extension)
+      await vi.waitFor(() => expect(outcome.state).toBe('ready'), { timeout: 500 })
+      expect(
+        Array.from(container.querySelectorAll('.sheet-tab'), (tab) => tab.textContent)
+      ).toEqual(['Visible'])
+    }
+  )
+
+  it.each([
+    ['xlsx', false],
+    ['xlsx', true],
+    ['xls', false]
+  ] as const)(
+    'OF02: %s visible data=%s never selects hidden content',
+    async (extension, visibleData) => {
+      await renderWorkbook(workbookBytes(extension, visibleData, true), extension)
+      await vi.waitFor(() => expect(harness.instances.length).toBeGreaterThan(0))
+      expect(JSON.stringify(harness.instances.flatMap((table) => table.getRows()))).not.toContain(
+        'HIDDEN_DATA'
+      )
+      expect(
+        Array.from(container.querySelectorAll('.sheet-tab'), (tab) => tab.textContent)
+      ).toEqual(['Visible'])
+    }
+  )
+
+  it.each([1, 2] as const)(
+    'completes an all-hidden workbook without exposing Hidden=%s',
+    async (hidden) => {
+      const workbook = utils.book_new()
+      utils.book_append_sheet(workbook, utils.aoa_to_sheet([['HIDDEN_DATA']]), 'Private')
+      utils.book_set_sheet_visibility(workbook, 'Private', hidden)
+      const bytes = new Uint8Array(write(workbook, { type: 'array', bookType: 'xlsx' }))
+      const outcome = await renderWorkbook(bytes, 'xlsx')
+      await vi.waitFor(() => expect(outcome.state).toBe('ready'))
+      expect(container.querySelectorAll('.sheet-tab')).toHaveLength(0)
+      expect(container.querySelector('[role="status"]')?.textContent).toBe(
+        'This workbook has no visible worksheets.'
+      )
+      expect(JSON.stringify(harness.instances.flatMap((table) => table.getRows()))).not.toContain(
+        'HIDDEN_DATA'
+      )
+    }
+  )
+
+  it('completes a successfully parsed package with zero worksheets', async () => {
+    const entries = unzipSync(workbookBytes('xlsx'))
+    entries['xl/workbook.xml'] = strToU8(
+      strFromU8(entries['xl/workbook.xml']).replace(/<sheets>.*?<\/sheets>/s, '<sheets/>')
+    )
+    const outcome = await renderWorkbook(zipSync(entries, { level: 0 }), 'xlsx')
+    await vi.waitFor(() => expect(outcome.state).toBe('ready'))
+    expect(container.querySelector('[role="status"]')?.textContent).toBe(
+      'This workbook has no worksheets.'
+    )
+    expect(container.querySelectorAll('.sheet-tab')).toHaveLength(0)
+  })
+
+  it('preserves original sheet identity and hidden flags across blank sheets', async () => {
+    await renderWorkbook(workbookBytes('xlsx', false, true), 'xlsx')
+    const context = ParserWorker.instances[0].context
+    expect(context.workbook?.SheetNames).toEqual(['Visible', 'Hidden'])
+    expect(context.sheets).toEqual([
+      expect.objectContaining({ id: 0, name: 'Visible', hidden: false }),
+      expect.objectContaining({ id: 1, name: 'Hidden', hidden: true })
+    ])
+    expect(context.workbook?.Workbook?.Sheets?.map((sheet) => sheet.Hidden)).toEqual([0, 1])
+  })
+
+  it('OF03: reports a terminal Worker failure after ready', async () => {
+    const bytes = workbookBytes('xlsx', true)
+    const reportState = vi.fn()
+    cleanup = await runOfficePreview({
+      start: {
+        sessionId: 'session-1',
+        extension: 'xlsx',
+        name: 'book.xlsx',
+        attempt: 0,
+        resource: {
+          id: 'resource-1',
+          url: 'https://preview.test/book.xlsx',
+          size: bytes.byteLength,
+          mimeType: 'application/octet-stream',
+          version: 1
+        }
+      },
+      container,
+      fetchFile: vi.fn().mockResolvedValue(new Response(new Uint8Array(bytes).buffer)),
+      reportState
+    })
+    expect(reportState).toHaveBeenLastCalledWith({ sessionId: 'session-1', phase: 'ready' })
+    ParserWorker.instances[0].dispatchEvent(
+      new ErrorEvent('error', { message: 'Worker cannot continue' })
+    )
+    await vi.waitFor(() =>
+      expect(reportState).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          sessionId: 'session-1',
+          phase: 'error',
+          error: 'RENDER_FAILED'
+        })
+      )
+    )
+    await vi.waitFor(() => expect(ParserWorker.instances[0].terminated).toBe(true))
+    expect(container.childNodes).toHaveLength(0)
+    const reports = reportState.mock.calls.length
+    ParserWorker.instances[0].dispatchEvent(
+      new ErrorEvent('error', { message: 'duplicate failure' })
+    )
+    await cleanup?.()
+    expect(reportState).toHaveBeenCalledTimes(reports)
+  })
+
+  it('never resolves a DOCX bookmark outside its own preview', async () => {
+    const entries = unzipSync(bookmarkDocx())
+    entries['word/document.xml'] = strToU8(
+      strFromU8(entries['word/document.xml']).replace('w:anchor="section1"', 'w:anchor="outside"')
+    )
+    const outside = document.createElement('div')
+    outside.id = 'outside'
+    document.body.append(outside)
+    try {
+      cleanup = await renderOfficeFile({
+        bytes: zipSync(entries, { level: 0 }),
+        extension: 'docx',
+        name: 'outside.docx',
+        container,
+        signal: controller.signal
+      })
+      const scroll = vi.spyOn(outside, 'scrollIntoView')
+      container.querySelector<HTMLAnchorElement>('a')!.click()
+      expect(scroll).not.toHaveBeenCalled()
+      expect(container.querySelector('a')?.getAttribute('href')).toBeNull()
+    } finally {
+      outside.remove()
+    }
+  })
+
+  it('OF04: activates a real DOCX bookmark inside the preview', async () => {
+    const bytes = bookmarkDocx()
+    await validateOfficePackage(bytes, 'docx', controller.signal)
+    const direct = document.createElement('div')
+    await renderAsync(bytes, direct, direct, { useBase64URL: true })
+    expect(direct.querySelector('a')?.getAttribute('href')).toBe('#section1')
+    cleanup = await renderOfficeFile({
+      bytes,
+      extension: 'docx',
+      name: 'bookmarks.docx',
+      container,
+      signal: controller.signal
+    })
+    const target = container.querySelector<HTMLElement>('[id="section1"]')!
+    expect(target).not.toBeNull()
+    const scroll = vi.spyOn(target, 'scrollIntoView')
+    container.querySelector<HTMLAnchorElement>('a')!.click()
+    expect(scroll).toHaveBeenCalledOnce()
+    const link = container.querySelector<HTMLAnchorElement>('a')!
+    expect(link.getAttribute('href')).toBeNull()
+    expect(link.tabIndex).toBe(0)
+    link.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, cancelable: true })
+    )
+    expect(scroll).toHaveBeenCalledTimes(2)
+    expect(document.activeElement).toBe(target)
+    expect(target.getAttribute('tabindex')).toBe('-1')
+    await cleanup?.()
+    expect(target.hasAttribute('tabindex')).toBe(false)
+    link.click()
+    expect(scroll).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/office-renderers.test.ts
+++ b/src/renderer/src/pages/workspace/previews/office-renderers.test.ts
@@ -563,6 +563,10 @@ describe('renderOfficeFile', () => {
           onProgressiveRender: expect.any(Function),
           options: {
             locale: 'en-US',
+            messages: {
+              'state.empty.title': 'This workbook has no worksheets.',
+              'state.empty.message': 'This workbook has no visible worksheets.'
+            },
             spreadsheet: {
               worker: true,
               workerUrl: new URL('local-sheet-worker.js', document.baseURI).href

--- a/src/renderer/src/pages/workspace/previews/office-renderers.ts
+++ b/src/renderer/src/pages/workspace/previews/office-renderers.ts
@@ -1,3 +1,5 @@
+import { i18next } from '../../../i18n'
+
 import type { OfficeFileExtension } from './office-package'
 
 export type OfficeRenderCleanup = () => void | Promise<void>
@@ -12,6 +14,7 @@ type RenderOfficeFileOptions = {
   container: HTMLDivElement
   signal: AbortSignal
   onStatus?: (status: OfficeRenderStatus) => void
+  onError?: (error: Error) => void
 }
 
 type TargetedOfficeRenderSession = {
@@ -24,7 +27,7 @@ type TargetedOfficeRenderSession = {
 
 type RenderTargetedOfficeFileOptions = Omit<
   RenderOfficeFileOptions,
-  'extension' | 'name' | 'onStatus'
+  'extension' | 'name' | 'onStatus' | 'onError'
 > & {
   extension: 'docx' | 'pptx'
   targetPages: number[]
@@ -353,13 +356,52 @@ const installPptxFit = (
   }
 }
 
-// Keeps rendered hyperlinks visible as document text without allowing preview navigation or pings.
-const neutralizeDocxLinks = (container: HTMLElement): void => {
+// Keep bookmark activation local; never restore href navigation, external URLs, or pings.
+const installDocxLinks = (container: HTMLElement): OfficeRenderCleanup => {
+  const listeners: Array<() => void> = []
+  const targets = new Map(
+    Array.from(container.querySelectorAll<HTMLElement>('[id]'), (node) => [node.id, node])
+  )
   container.querySelectorAll<HTMLAnchorElement>('a').forEach((link) => {
+    const href = link.getAttribute('href')
     for (const attribute of ['href', 'target', 'rel', 'download', 'ping', 'referrerpolicy']) {
       link.removeAttribute(attribute)
     }
+    if (!href?.startsWith('#')) return
+    let id = href.slice(1)
+    if (!targets.has(id)) {
+      try {
+        id = decodeURIComponent(id)
+      } catch {
+        return
+      }
+    }
+    const target = targets.get(id)
+    if (!target) return
+    link.setAttribute('role', 'link')
+    link.tabIndex = 0
+    const activate = (event: Event): void => {
+      event.preventDefault()
+      if (!container.contains(target)) return
+      target.scrollIntoView({ block: 'start' })
+      // Chromium drops focus if tabindex is removed immediately after focusing a bookmark.
+      if (!target.hasAttribute('tabindex')) {
+        target.tabIndex = -1
+        listeners.push(() => target.removeAttribute('tabindex'))
+      }
+      target.focus({ preventScroll: true })
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Enter') activate(event)
+    }
+    link.addEventListener('click', activate)
+    link.addEventListener('keydown', onKeyDown)
+    listeners.push(() => {
+      link.removeEventListener('click', activate)
+      link.removeEventListener('keydown', onKeyDown)
+    })
   })
+  return () => listeners.forEach((remove) => remove())
 }
 
 const SPREADSHEET_WORKER_STARTUP_TIMEOUT_MS = 5_000
@@ -372,6 +414,11 @@ const RENDERING_STATUS: OfficeRenderStatus = {
   phase: 'rendering'
 }
 const SPREADSHEET_STATUS_STYLE = `
+${SPREADSHEET_STATUS_SCOPE} .spreadsheet-empty {
+  padding: 2rem;
+  text-align: center;
+  color: var(--text-100);
+}
 ${SPREADSHEET_STATUS_SCOPE} .excel-wrapper .loading {
   display: none !important;
 }
@@ -579,7 +626,8 @@ export const renderOfficeFile = async ({
   name,
   container,
   signal,
-  onStatus
+  onStatus,
+  onError
 }: RenderOfficeFileOptions): Promise<OfficeRenderCleanup> => {
   if (extension === 'docx') {
     // Keep active-content features disabled and inline media so detached Blob URLs cannot leak.
@@ -599,12 +647,13 @@ export const renderOfficeFile = async ({
       clearContainer(container)
       throw error
     }
-    neutralizeDocxLinks(container)
+    const disposeLinks = installDocxLinks(container)
     const wrapper = container.querySelector<HTMLElement>('.docx-wrapper')
     const disposeFit = wrapper ? installDocxFit(container, wrapper) : undefined
     const blobUrls = collectBlobUrls(container)
 
     return () => {
+      disposeLinks()
       disposeFit?.()
       blobUrls.forEach((url) => URL.revokeObjectURL(url))
       clearContainer(container)
@@ -627,6 +676,9 @@ export const renderOfficeFile = async ({
       throw new Error('Spreadsheet preview error observer is unavailable')
     }
 
+    let disposed = false
+    let sessionReady = false
+    let fatalError: Error | undefined
     let firstPaintSettled = false
     let resolveFirstPaint: () => void = () => undefined
     let rejectFirstPaint: (error: Error) => void = () => undefined
@@ -639,16 +691,23 @@ export const renderOfficeFile = async ({
     // Upstream does not call onProgressiveRender for parse errors, so observe its error node early.
     const errorObserver = new MutationObserverCtor(() => {
       const error = getSpreadsheetParseError(container)
-      if (!error || firstPaintSettled) return
-
-      firstPaintSettled = true
+      if (!error || fatalError || disposed || signal.aborted) return
+      fatalError = error
       errorObserver.disconnect()
-      rejectFirstPaint(error)
+      if (!firstPaintSettled) {
+        firstPaintSettled = true
+        rejectFirstPaint(error)
+      }
+      if (sessionReady) {
+        void dispose().catch((cleanupError) =>
+          console.error('Failed to dispose spreadsheet preview', cleanupError)
+        )
+        onError?.(error)
+      }
     })
     const markFirstPaint = (): void => {
       if (firstPaintSettled) return
       firstPaintSettled = true
-      errorObserver.disconnect()
       onStatus?.(RENDERING_STATUS)
       resolveFirstPaint()
     }
@@ -674,6 +733,14 @@ export const renderOfficeFile = async ({
             onProgressiveRender: markFirstPaint,
             options: {
               locale: 'en-US',
+              messages: {
+                'state.empty.title': i18next.isInitialized
+                  ? i18next.t('This workbook has no worksheets.')
+                  : 'This workbook has no worksheets.',
+                'state.empty.message': i18next.isInitialized
+                  ? i18next.t('This workbook has no visible worksheets.')
+                  : 'This workbook has no visible worksheets.'
+              },
               spreadsheet: {
                 worker: true,
                 workerUrl
@@ -692,11 +759,11 @@ export const renderOfficeFile = async ({
       throw error
     }
 
-    let disposed = false
     // Cleanup is idempotent because timeout, abort, file replacement, and unmount can race.
     const dispose = async (): Promise<void> => {
       if (disposed) return
       disposed = true
+      errorObserver.disconnect()
       try {
         if ('unmount' in instance) await instance.unmount()
         else if ('$destroy' in instance) await instance.$destroy()
@@ -752,6 +819,11 @@ export const renderOfficeFile = async ({
       if (signal.aborted) onAbort()
     })
 
+    if (fatalError) {
+      await dispose()
+      throw fatalError
+    }
+    sessionReady = true
     return dispose
   }
 
@@ -961,7 +1033,7 @@ export const renderTargetedOfficeFile = async ({
     if (page) wrapper.appendChild(page)
   }
   container.appendChild(wrapper)
-  neutralizeDocxLinks(container)
+  const disposeLinks = installDocxLinks(container)
   const disposeFit = pages.size > 0 ? installDocxFit(container, wrapper) : undefined
   const blobUrls = collectBlobUrls(container)
   let disposed = false
@@ -980,6 +1052,7 @@ export const renderTargetedOfficeFile = async ({
     dispose: () => {
       if (disposed) return
       disposed = true
+      disposeLinks()
       disposeFit?.()
       blobUrls.forEach((url) => URL.revokeObjectURL(url))
       clearContainer(container)

--- a/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx
@@ -298,6 +298,43 @@ describe('OfficePreviewRenderer', () => {
     }
   })
 
+  it('updates the isolated preview when the host language changes after attachment', async () => {
+    await renderPreview()
+    const frame = container.querySelector<HTMLIFrameElement>('[data-office-preview-frame]')!
+    const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage')
+    await act(async () => {
+      frame.dispatchEvent(new Event('load'))
+      await flushMicrotasks()
+    })
+    await act(async () => {
+      emitState({ sessionId: 'office-session-1', phase: 'ready' })
+      await flushMicrotasks()
+    })
+    expect(attachFrame).toHaveBeenCalledOnce()
+    postMessage.mockClear()
+    try {
+      await act(async () => {
+        await i18next.changeLanguage('zh-Hans')
+        await flushMicrotasks()
+      })
+      // The installed hook returns a new i18n wrapper when its language changes.
+      expect(open).toHaveBeenCalledOnce()
+      expect(attachFrame).toHaveBeenCalledTimes(2)
+      expect(container.querySelector('[data-office-preview-frame]')).toBe(frame)
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'start',
+          start: expect.objectContaining({ locale: 'zh-Hans' })
+        }),
+        OFFICE_PREVIEW_RUNTIME_ORIGIN
+      )
+    } finally {
+      await act(async () => {
+        await i18next.changeLanguage('en')
+      })
+    }
+  })
+
   it('attaches on iframe load before relaying start and runtime state', async () => {
     await renderPreview()
     const frame = container.querySelector<HTMLIFrameElement>('[data-office-preview-frame]')

--- a/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.test.tsx
@@ -272,6 +272,32 @@ describe('OfficePreviewRenderer', () => {
     expect(latestOpenContextMenu).toHaveBeenCalledWith({ x: 17, y: 29 }, frame)
   })
 
+  it('passes the current host language when starting the isolated iframe', async () => {
+    await act(async () => {
+      await i18next.changeLanguage('zh-Hans')
+    })
+    try {
+      await renderPreview()
+      const frame = container.querySelector<HTMLIFrameElement>('[data-office-preview-frame]')!
+      const postMessage = vi.spyOn(frame.contentWindow!, 'postMessage')
+      await act(async () => {
+        frame.dispatchEvent(new Event('load'))
+        await flushMicrotasks()
+      })
+      expect(postMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: 'start',
+          start: expect.objectContaining({ locale: 'zh-Hans' })
+        }),
+        OFFICE_PREVIEW_RUNTIME_ORIGIN
+      )
+    } finally {
+      await act(async () => {
+        await i18next.changeLanguage('en')
+      })
+    }
+  })
+
   it('attaches on iframe load before relaying start and runtime state', async () => {
     await renderPreview()
     const frame = container.querySelector<HTMLIFrameElement>('[data-office-preview-frame]')

--- a/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/OfficePreview.tsx
@@ -3,6 +3,7 @@ import { FileWarning } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import type { PreviewFileItem, PreviewFileSource } from '@/stores/preview-workbench-store'
+import { resolveLocaleFromTags } from '../../../../../../shared/locale'
 import type {
   OfficePreviewErrorCode,
   OfficePreviewHostMessage,
@@ -166,7 +167,7 @@ const RemoteOfficePreviewContent = ({
   item: PreviewFileItem
   source: OfficePreviewSource
 }): React.JSX.Element => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const hostId = useId()
   const frameRef = useRef<HTMLIFrameElement | null>(null)
   const { openContextMenu } = usePreviewActions()
@@ -353,7 +354,10 @@ const RemoteOfficePreviewContent = ({
           channel: OFFICE_PREVIEW_FRAME_MESSAGE_CHANNEL,
           version: OFFICE_PREVIEW_FRAME_MESSAGE_VERSION,
           type: 'start',
-          start: result.start
+          start: {
+            ...result.start,
+            locale: resolveLocaleFromTags([i18n.resolvedLanguage ?? i18n.language])
+          }
         }
         frameRef.current?.contentWindow?.postMessage(message, OFFICE_PREVIEW_RUNTIME_ORIGIN)
       })
@@ -370,7 +374,7 @@ const RemoteOfficePreviewContent = ({
       active = false
       window.removeEventListener('message', handleMessage)
     }
-  }, [frame, frameLoadGeneration])
+  }, [frame, frameLoadGeneration, i18n])
 
   const visibleState: OfficeHostState =
     ownsLease && !hasSourceIdentity ? { kind: 'error', error: 'FILE_READ_FAILED' } : state

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4816,6 +4816,8 @@
     "Previewing model 1 of {{total}}.": "Vorschau von Modell 1 von {{total}}.",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Wasserstoffatome sind ausgeblendet; alternative Positionen verwenden ein Leerzeichen oder A. Die Atomzahl bezieht sich auf das angezeigte Modell.",
     "Generating surface…": "Oberfläche wird erzeugt…",
-    "Surface could not be generated. Showing sticks.": "Die Oberfläche konnte nicht erzeugt werden. Stäbchen werden angezeigt."
+    "Surface could not be generated. Showing sticks.": "Die Oberfläche konnte nicht erzeugt werden. Stäbchen werden angezeigt.",
+    "This workbook has no worksheets.": "Diese Arbeitsmappe enthält keine Arbeitsblätter.",
+    "This workbook has no visible worksheets.": "Diese Arbeitsmappe enthält keine sichtbaren Arbeitsblätter."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4978,6 +4978,8 @@
     "Previewing model 1 of {{total}}.": "Vista previa del modelo 1 de {{total}}.",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Los hidrógenos están ocultos; las posiciones alternativas usan un espacio o A. El número de átomos corresponde al modelo mostrado.",
     "Generating surface…": "Generando superficie…",
-    "Surface could not be generated. Showing sticks.": "No se pudo generar la superficie. Se muestra en forma de varillas."
+    "Surface could not be generated. Showing sticks.": "No se pudo generar la superficie. Se muestra en forma de varillas.",
+    "This workbook has no worksheets.": "Este libro no contiene hojas de cálculo.",
+    "This workbook has no visible worksheets.": "Este libro no contiene hojas de cálculo visibles."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4978,6 +4978,8 @@
     "Previewing model 1 of {{total}}.": "Aperçu du modèle 1 sur {{total}}.",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Les hydrogènes sont masqués ; les positions alternatives utilisent un espace ou A. Le nombre d’atomes correspond au modèle affiché.",
     "Generating surface…": "Génération de la surface…",
-    "Surface could not be generated. Showing sticks.": "Impossible de générer la surface. Affichage en bâtonnets."
+    "Surface could not be generated. Showing sticks.": "Impossible de générer la surface. Affichage en bâtonnets.",
+    "This workbook has no worksheets.": "Ce classeur ne contient aucune feuille de calcul.",
+    "This workbook has no visible worksheets.": "Ce classeur ne contient aucune feuille de calcul visible."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4662,6 +4662,8 @@
     "Previewing model 1 of {{total}}.": "{{total}} 個中のモデル 1 をプレビューしています。",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "水素原子は非表示です。代替位置は空白または A を使用します。原子数は表示中のモデルのものです。",
     "Generating surface…": "表面を生成中…",
-    "Surface could not be generated. Showing sticks.": "表面を生成できませんでした。スティック表示に戻しました。"
+    "Surface could not be generated. Showing sticks.": "表面を生成できませんでした。スティック表示に戻しました。",
+    "This workbook has no worksheets.": "このブックにはワークシートがありません。",
+    "This workbook has no visible worksheets.": "このブックには表示されているワークシートがありません。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4660,6 +4660,8 @@
     "Previewing model 1 of {{total}}.": "모델 {{total}}개 중 1번을 미리 봅니다.",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "수소 원자는 숨깁니다. 대체 위치는 공백 또는 A를 사용합니다. 원자 수는 표시된 모델 기준입니다.",
     "Generating surface…": "표면 생성 중…",
-    "Surface could not be generated. Showing sticks.": "표면을 생성하지 못했습니다. 막대 형태로 표시합니다."
+    "Surface could not be generated. Showing sticks.": "표면을 생성하지 못했습니다. 막대 형태로 표시합니다.",
+    "This workbook has no worksheets.": "이 통합 문서에는 워크시트가 없습니다.",
+    "This workbook has no visible worksheets.": "이 통합 문서에는 표시된 워크시트가 없습니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5111,6 +5111,8 @@
     "Previewing model 1 of {{total}}.": "Предпросмотр модели 1 из {{total}}.",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Атомы водорода скрыты; для альтернативных положений используются пробел или A. Число атомов относится к отображаемой модели.",
     "Generating surface…": "Создание поверхности…",
-    "Surface could not be generated. Showing sticks.": "Не удалось создать поверхность. Показана стержневая модель."
+    "Surface could not be generated. Showing sticks.": "Не удалось создать поверхность. Показана стержневая модель.",
+    "This workbook has no worksheets.": "В этой книге нет листов.",
+    "This workbook has no visible worksheets.": "В этой книге нет видимых листов."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4662,6 +4662,8 @@
     "Previewing model 1 of {{total}}.": "正在预览第 1 个模型，共 {{total}} 个。",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "隐藏氢原子；替代位置使用空白或 A。原子数指当前显示的模型。",
     "Generating surface…": "正在生成表面…",
-    "Surface could not be generated. Showing sticks.": "无法生成表面。已显示为棍状。"
+    "Surface could not be generated. Showing sticks.": "无法生成表面。已显示为棍状。",
+    "This workbook has no worksheets.": "此工作簿没有工作表。",
+    "This workbook has no visible worksheets.": "此工作簿没有可见的工作表。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4662,6 +4662,8 @@
     "Previewing model 1 of {{total}}.": "正在預覽第 1 個模型，共 {{total}} 個。",
     "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "隱藏氫原子；替代位置使用空白或 A。原子數指目前顯示的模型。",
     "Generating surface…": "正在產生表面…",
-    "Surface could not be generated. Showing sticks.": "無法產生表面。已顯示為棍狀。"
+    "Surface could not be generated. Showing sticks.": "無法產生表面。已顯示為棍狀。",
+    "This workbook has no worksheets.": "此活頁簿沒有工作表。",
+    "This workbook has no visible worksheets.": "此活頁簿沒有可見的工作表。"
   }
 }

--- a/src/shared/office-preview.test.ts
+++ b/src/shared/office-preview.test.ts
@@ -71,6 +71,14 @@ describe('Office preview frame messages', () => {
       name: 'report.docx',
       attempt: 0
     }
+    const message = { channel: 'open-science-office-preview', version: 1, type: 'start', start }
+    expect(isOfficePreviewHostMessage({ ...message, start: { ...start, locale: 'zh-Hans' } })).toBe(
+      true
+    )
+    expect(
+      isOfficePreviewHostMessage({ ...message, start: { ...start, locale: 'unsupported' } })
+    ).toBe(false)
+    expect(isOfficePreviewHostMessage({ ...message, start: { ...start, locale: 42 } })).toBe(false)
     expect(
       isOfficePreviewHostMessage({
         channel: 'open-science-office-preview',

--- a/src/shared/office-preview.ts
+++ b/src/shared/office-preview.ts
@@ -1,3 +1,5 @@
+import { isLocale, type Locale } from './locale'
+
 export const OFFICE_PREVIEW_MAX_FILE_BYTES = 40 * 1024 * 1024
 export const OFFICE_PREVIEW_PROCESS_MEMORY_LIMIT_BYTES = 1_536 * 1024 * 1024
 export const OFFICE_PREVIEW_PROCESS_MEMORY_POLL_MS = 1_000
@@ -94,6 +96,7 @@ export type OfficePreviewRuntimeStart = {
   extension: OfficePreviewRequestedExtension
   name: string
   attempt: number
+  locale?: Locale
 }
 
 export type OfficePreviewPhase =
@@ -185,6 +188,7 @@ const isOfficePreviewRuntimeStart = (value: unknown): value is OfficePreviewRunt
     typeof start.extension === 'string' &&
     OFFICE_PREVIEW_EXTENSIONS.has(start.extension as OfficePreviewRequestedExtension) &&
     isNonEmptyString(start.name) &&
+    (start.locale === undefined || isLocale(start.locale)) &&
     Number.isSafeInteger(start.attempt) &&
     (start.attempt ?? -1) >= 0 &&
     typeof resource === 'object' &&


### PR DESCRIPTION
## Problem

A normal blank XLSX worksheet is discarded, leaving first paint pending or causing a hidden worksheet to be shown instead. Spreadsheet errors after first paint never reach the existing retry card. DOCX internal bookmark links lose activation in the adapter.

## Proposed change

- Preserve blank worksheets and source identity in the existing spreadsheet patch. Select only visible sheets; zero/no-visible worksheets render an explicit empty state and complete readiness.
- Keep the spreadsheet error channel until disposal. Reuse `error` / `RENDER_FAILED`, cleanup and retry; reject stale runtime reports.
- Activate DOCX bookmarks only within the preview container, supporting pointer/Enter and retaining keyboard focus. External navigation remains disabled.

## Scope and non-goals

No persistence, migrations, historical-data compatibility layer, or new state enum. The transient runtime-start message gains an optional validated `locale`; omitted values default to English. The host supplies its active locale and the isolated runtime initializes translation before rendering. One optional callback is added to the local renderer options. Both Hidden=1 and Hidden=2 stay hidden. XLS controls pass, without generalizing to every XLS variant. PPTX partial-error recovery and local row-window retries are out of scope.

## Acceptance criteria and validation

Before fixes, two consecutive runs of the real-parser regression suite yielded exactly four report-matching failures and three passing controls. Tests use generated XLSX/XLS/DOCX packages, real package validation and installed parsing/rendering code; only Worker transport and the existing canvas observation fixture are substituted in jsdom. No production test seam was added.

Final checks ran after the last material edit:

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| Blank/hidden/zero-sheet XLSX; legacy controls; post-ready failure; DOCX activation and containment | `office-behavior-regressions.test.ts` | Pass |
| Adapter startup/abort/cleanup and bounded caches | `office-renderers.test.ts`, `spreadsheet-cache-policy.test.ts`, `office-package.test.ts` | Pass |
| Session errors, stale events, IPC/host retry contracts | renderer `office-preview/`, main `office-preview/`, shared `office-preview.test.ts`, `office-preview-lease.test.ts`, `OfficePreview.test.tsx`, `locale.test.ts` | Pass |
| Host and targeted-reviewer consumers | `PreviewFileContent.test.tsx`, `PreviewFallback.test.tsx`, `PreviewToolContent.reviewer.integration.test.tsx` | Pass |
| New empty-state copy in all eight translated locales | `npx vitest run src/renderer/src/i18n/resources.test.ts` | 804 pass |
| Renderer/shared-contract types and lint | `npm run typecheck:node`; `npm run typecheck:web`; `npm run lint`; Prettier check | Pass |
| Reproducible dependency patch | Apply patch to clean vendor and compare to tested files | Pass |

The explicit Office/consumer slice above is 18 test files / 229 passing tests. No complete local `npm test` run; full/platform validation is delegated to PR CI as requested. The shared startup contract changed, so both process typechecks and host/runtime contract tests are included. No main-process logic changed, but its supervisor/protocol contracts are included because they consume runtime error states. Notebook/ACP execution paths are not modified.

Built Chromium integration checks use the actual bundled Worker and canvas renderer: blank and blank+hidden workbooks reach ready, no-visible sheets show empty copy, controlled Worker error reaches the existing retry card and Retry restores ready, and pointer/Enter bookmark activation retains target focus without URL navigation. This is a focused harness using real runtime and fallback components, not a full Electron screenshot or an OS-level Worker crash. The real-browser check caught and fixed Chromium losing focus when tabindex was removed immediately. A separate Chinese all-hidden-workbook capture confirms runtime initialization without any harness-side translation initialization. Locale regressions failed before the follow-up fix and pass after it.

## Review focus

Review blank-sheet metadata/visibility, first-paint versus session error races and disposal, and bookmark containment/focus cleanup. CodeGraph supplied baseline relationships; its index belongs to the main checkout, so final worktree relationships were verified against source and the listed tests. Independent PR review and exact-head CI remain the final authority.

The initial review correctly identified isolated-runtime translation initialization; the optional startup locale addresses it. Its toolbar finding does not reproduce: visible-sheet startup returns before the empty-branch toolbar hide. An added regression checks computed toolbar visibility and switches to a second visible sheet through the actual renderer.

The second review raised premature first paint on visible workbooks. A controlled first-window transport hold confirms the renderer remains pending, keeps the toolbar visible, and never inserts empty copy until the actual data window arrives. This passes without a production-code change. The patch now includes the previously omitted `return` context, so the no-visible-sheet branch is directly reviewable. After resolving translation-only conflicts with main and this test addition, the combined Office/consumer/i18n run passes 19 files / 1,033 tests; web types, lint and patch reproducibility were rechecked.

The third review assumed `useTranslation().i18n` has stable identity across language changes. The installed react-i18next implementation returns a new language-specific wrapper. A ready-host regression changes the actual i18next language, verifies the same iframe receives a new start locale, and confirms reattachment without reopening the host session. It passes without changing production code. This guards the observed dependency behavior rather than assuming older library semantics.
