### PR TITLE
fix(preview): keep source actions aligned with current navigation

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -636,6 +636,24 @@ test('previews and opens an Agent HTTPS source link in the isolated preview tab'
   await expect(sourceProgress).toHaveCount(0)
   await expect(sourceSkeleton).toHaveCount(0)
 
+  // Use real Chromium same-document navigations; IPC injection cannot verify this adapter.
+  const sourceDocument = sourceFrame.contentFrame().locator('body')
+  for (const operation of ['anchor', 'push', 'replace', 'back', 'forward']) {
+    const previousUrl = await sourceHeaderUrl.textContent()
+    await sourceDocument.evaluate((_body, action) => {
+      if (action === 'anchor') location.hash = 'methods'
+      else if (action === 'push') history.pushState({}, '', '?section=results')
+      else if (action === 'replace') history.replaceState({}, '', '?section=discussion')
+      else if (action === 'back') history.back()
+      else history.forward()
+    }, operation)
+    await expect.poll(() => sourceDocument.evaluate(() => location.href)).not.toBe(previousUrl)
+    await expect(sourceHeaderUrl).toHaveText(await sourceDocument.evaluate(() => location.href))
+    await expect(sourceSkeleton).toHaveCount(0)
+    await expect(sourceProgress).toHaveCount(0)
+    await expect(sourceFrame).toHaveAttribute('src', 'https://citation.example/paper')
+  }
+
   await page.screenshot({ path: testInfo.outputPath('citation-source-preview.png') })
 
   const replicationLink = page.getByRole('link', { name: 'Chen et al. 2026' })

--- a/src/main/source-preview-load-monitor.test.ts
+++ b/src/main/source-preview-load-monitor.test.ts
@@ -36,6 +36,30 @@ describe('source preview load monitor', () => {
     })
   })
 
+  it.each(['loading', 'loaded', 'failed'] as const)(
+    'preserves %s metadata and identity during in-page navigation',
+    (phase) => {
+      const publish = vi.fn()
+      const monitor = createSourcePreviewLoadMonitor(publish)
+      const frame = { frameTreeNodeId: 7, processId: 11, routingId: 13 }
+      const sourceUrl = 'https://example.com/paper'
+      monitor.registerRoot(frame, sourceUrl)
+      if (phase === 'loaded') monitor.finishNavigation(frame, sourceUrl, 201, 'Created')
+      if (phase === 'failed') monitor.finishNavigation(frame, sourceUrl, 404, 'Not Found')
+      const previous = publish.mock.calls.at(-1)![0]
+      monitor.navigateInPage(frame, `${sourceUrl}#methods`)
+      expect(publish).toHaveBeenLastCalledWith({ ...previous, currentUrl: `${sourceUrl}#methods` })
+      const count = publish.mock.calls.length
+      monitor.navigateInPage(frame, `${sourceUrl}#methods`)
+      monitor.navigateInPage(null, `${sourceUrl}#ignored`)
+      monitor.navigateInPage({ frameTreeNodeId: 8 }, `${sourceUrl}#ignored`)
+      expect(publish).toHaveBeenCalledTimes(count)
+      monitor.releaseSource(sourceUrl)
+      monitor.navigateInPage({ processId: 11, routingId: 13 }, `${sourceUrl}#released`)
+      expect(publish).toHaveBeenCalledTimes(count)
+    }
+  )
+
   it('ignores late lifecycle events after a source is released', () => {
     const publish = vi.fn()
     const monitor = createSourcePreviewLoadMonitor(publish) as ReturnType<

--- a/src/main/source-preview-load-monitor.ts
+++ b/src/main/source-preview-load-monitor.ts
@@ -18,6 +18,7 @@ type SourcePreviewLoadMonitor = {
     currentUrl: string,
     isSameDocument: boolean
   ) => void
+  navigateInPage: (frame: SourcePreviewFrameIdentity | null, currentUrl: string) => void
   finishNavigation: (
     frame: SourcePreviewFrameIdentity | null,
     currentUrl: string,
@@ -37,6 +38,7 @@ type TrackedSourceRoot = {
   currentUrl: string
   navigationId: number
   settled: boolean
+  lastState?: SourcePreviewLoadState
 }
 
 const BLOCKED_ERROR_CODES = new Set([-30, -27, -20])
@@ -58,6 +60,11 @@ const createSourcePreviewLoadMonitor = (
   const roots = new Map<number, TrackedSourceRoot>()
   const rootIdsByRoutingIdentity = new Map<string, number>()
   let nextNavigationId = 0
+
+  const publishState = (root: TrackedSourceRoot, state: SourcePreviewLoadState): void => {
+    root.lastState = state
+    publish(state)
+  }
 
   const getRoutingIdentity = (frame: SourcePreviewFrameIdentity): string | undefined =>
     frame.processId === undefined || frame.routingId === undefined
@@ -109,7 +116,7 @@ const createSourcePreviewLoadMonitor = (
       }
       roots.set(frame.frameTreeNodeId, root)
       rememberRoutingIdentity(frame, frame.frameTreeNodeId)
-      publish({
+      publishState(root, {
         navigationId: root.navigationId,
         sourceUrl,
         currentUrl: sourceUrl,
@@ -136,12 +143,18 @@ const createSourcePreviewLoadMonitor = (
       root.currentUrl = currentUrl
       root.navigationId = ++nextNavigationId
       root.settled = false
-      publish({
+      publishState(root, {
         navigationId: root.navigationId,
         sourceUrl: root.sourceUrl,
         currentUrl,
         phase: 'loading'
       })
+    },
+    navigateInPage: (frame, currentUrl) => {
+      const root = getActiveRoot(frame)
+      if (!root?.lastState || root.lastState.currentUrl === currentUrl) return
+      root.currentUrl = currentUrl
+      publishState(root, { ...root.lastState, currentUrl })
     },
     finishNavigation: (frame, currentUrl, httpStatusCode, httpStatusText) => {
       const root = getActiveRoot(frame)
@@ -149,7 +162,7 @@ const createSourcePreviewLoadMonitor = (
       root.settled = true
 
       if (httpStatusCode >= 400) {
-        publish({
+        publishState(root, {
           navigationId: root.navigationId,
           sourceUrl: root.sourceUrl,
           currentUrl,
@@ -161,7 +174,7 @@ const createSourcePreviewLoadMonitor = (
         return
       }
 
-      publish({
+      publishState(root, {
         navigationId: root.navigationId,
         sourceUrl: root.sourceUrl,
         currentUrl,
@@ -178,7 +191,7 @@ const createSourcePreviewLoadMonitor = (
       if (!root || root.settled) return
       root.settled = true
 
-      publish({
+      publishState(root, {
         navigationId: root.navigationId,
         sourceUrl: root.sourceUrl,
         currentUrl,

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -659,6 +659,59 @@ describe('window navigation policy', () => {
     }
   })
 
+  it('publishes committed in-page source URLs without restarting loading', () => {
+    createMainWindow()
+    const window = lastWindow!
+    const sourceUrl = 'https://citation.example/paper'
+    const frame = {
+      frameTreeNodeId: 2,
+      processId: 7,
+      routingId: 8,
+      name: 'open-science-source-preview',
+      url: 'about:blank',
+      parent: window.mainFrame
+    }
+    window.webContentsHandlers.get('will-frame-navigate')!({
+      url: sourceUrl,
+      isMainFrame: false,
+      frame,
+      preventDefault: vi.fn()
+    })
+    webFrameMainFromIdMock.mockReturnValue(frame)
+    window.webContentsHandlers.get('did-frame-navigate')!({}, sourceUrl, 200, 'OK', false, 7, 8)
+    expect(window.sendMock).toHaveBeenLastCalledWith('source-preview:load-state', {
+      sourceUrl,
+      currentUrl: sourceUrl,
+      navigationId: 1,
+      phase: 'loaded',
+      httpStatusCode: 200,
+      httpStatusText: 'OK'
+    })
+    for (const currentUrl of [
+      `${sourceUrl}#methods`,
+      `${sourceUrl}?section=results`,
+      `${sourceUrl}?section=discussion`,
+      `${sourceUrl}#methods`,
+      sourceUrl
+    ]) {
+      window.webContentsHandlers.get('did-start-navigation')!({
+        url: currentUrl,
+        isSameDocument: true,
+        isMainFrame: false,
+        frame
+      })
+      window.webContentsHandlers.get('did-navigate-in-page')?.({}, currentUrl, false, 7, 8)
+      expect(window.sendMock).toHaveBeenLastCalledWith('source-preview:load-state', {
+        sourceUrl,
+        currentUrl,
+        navigationId: 1,
+        phase: 'loaded',
+        httpStatusCode: 200,
+        httpStatusText: 'OK'
+      })
+    }
+  })
+
   it('reports source root loading and HTTP failures without observing unrelated subframes', () => {
     createMainWindow()
     const window = lastWindow!

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -226,6 +226,15 @@ const createAppWindow = (options: BrowserWindowConstructorOptions): BrowserWindo
     }
   )
   window.webContents.on(
+    'did-navigate-in-page',
+    (_event, url, _isMainFrame, processId, routingId) => {
+      sourcePreviewLoadMonitor.navigateInPage(
+        webFrameMain.fromId(processId, routingId) ?? { processId, routingId },
+        url
+      )
+    }
+  )
+  window.webContents.on(
     'did-frame-navigate',
     (_event, url, httpResponseCode, httpStatusText, _isMainFrame, processId, routingId) => {
       sourcePreviewLoadMonitor.finishNavigation(

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -360,6 +360,87 @@ describe('PreviewPanel', () => {
     expect(iframe?.closest<HTMLElement>('[role="tabpanel"]')?.hidden).toBe(false)
   })
 
+  it.each([
+    ['loaded', '[data-source-preview-header-external]'],
+    ['failed', '[data-source-preview-header-external]'],
+    ['failed', '[data-source-preview-error] button']
+  ] as const)(
+    'opens the displayed source URL after a %s navigation via %s',
+    async (phase, selector) => {
+      const sourceItem = createSourceItem()
+      const currentUrl = 'https://example.com/supplement'
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(sourceItem)
+      await renderPanel()
+      const iframe = container.querySelector('[data-source-preview-frame]')
+      const open = vi.spyOn(window, 'open').mockReturnValue(null)
+      try {
+        await act(async () => {
+          sourcePreviewListener!({
+            sourceUrl: sourceItem.url,
+            currentUrl,
+            navigationId: 2,
+            phase,
+            httpStatusCode: phase === 'failed' ? 404 : 200,
+            httpStatusText: phase === 'failed' ? 'Not Found' : 'OK',
+            ...(phase === 'failed' ? { failure: 'http' } : {})
+          })
+        })
+        expect(container.querySelector('[data-source-preview-header-url]')?.textContent).toBe(
+          currentUrl
+        )
+        const button = [...container.querySelectorAll<HTMLButtonElement>(selector)].find(
+          (candidate) =>
+            candidate.getAttribute('aria-label') === 'Open source in browser' ||
+            candidate.textContent === 'Open source in browser'
+        )
+        expect(button).toBeDefined()
+        await act(async () => button!.click())
+        expect(open).toHaveBeenLastCalledWith(currentUrl, '_blank', 'noreferrer')
+        expect(container.querySelector('[data-source-preview-frame]')).toBe(iframe)
+        expect(iframe?.getAttribute('src')).toBe(sourceItem.url)
+        await act(async () => {
+          container.querySelector<HTMLButtonElement>('[data-source-preview-header-close]')!.click()
+        })
+        expect(releaseSourcePreview).toHaveBeenCalledWith(sourceItem.url)
+      } finally {
+        open.mockRestore()
+      }
+    }
+  )
+
+  it.each(['http://example.com/paper', 'javascript:alert(1)', 'invalid'])(
+    'keeps the HTTPS fallback for an invalid current source URL: %s',
+    async (currentUrl) => {
+      const sourceItem = createSourceItem()
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(sourceItem)
+      await renderPanel()
+      const open = vi.spyOn(window, 'open').mockReturnValue(null)
+      try {
+        await act(async () => {
+          sourcePreviewListener!({
+            sourceUrl: sourceItem.url,
+            currentUrl,
+            navigationId: 1,
+            phase: 'loaded',
+            httpStatusCode: 200,
+            httpStatusText: 'OK'
+          })
+        })
+        expect(container.querySelector('[data-source-preview-header-url]')?.textContent).toBe(
+          sourceItem.url
+        )
+        await act(async () => {
+          container
+            .querySelector<HTMLButtonElement>('[data-source-preview-header-external]')!
+            .click()
+        })
+        expect(open).toHaveBeenCalledWith(sourceItem.url, '_blank', 'noreferrer')
+      } finally {
+        open.mockRestore()
+      }
+    }
+  )
+
   it('does not grant remote source previews permission to open popup windows', async () => {
     usePreviewWorkbenchStore.getState().upsertAndActivateItem(createSourceItem())
 

--- a/src/renderer/src/pages/workspace/previews/SourceWebPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/SourceWebPreview.tsx
@@ -230,7 +230,7 @@ const SourceWebPreviewContent = ({
                 className="text-text-100 hover:text-text-000"
                 data-source-preview-header-external=""
                 aria-label={t('Open source in browser')}
-                onClick={() => window.open(sourceUrl.href, '_blank', 'noreferrer')}
+                onClick={() => window.open(displayedUrl, '_blank', 'noreferrer')}
               >
                 <ExternalLink data-source-preview-header-external-icon="" aria-hidden="true" />
               </Button>
@@ -310,7 +310,7 @@ const SourceWebPreviewContent = ({
                 errorCode={getFailureCode(loadState)}
                 secondaryButton={{
                   label: t('Open source in browser'),
-                  onClick: () => window.open(sourceUrl.href, '_blank', 'noreferrer')
+                  onClick: () => window.open(displayedUrl, '_blank', 'noreferrer')
                 }}
                 primaryButton={{ label: t('Try again'), onClick: retry }}
               />


### PR DESCRIPTION
## Problem

After navigating a source preview from an article to another page, the header showed the destination but both external-open actions still opened the original article. Same-document navigation also left the header at the old URL.

## Proposed change

Use the existing HTTPS-validated display URL for both external actions. Forward Electron's committed `did-navigate-in-page` events to the existing monitor, retaining the published phase, HTTP/error metadata and navigation ID while updating the current URL.

## Scope and non-goals

Original `sourceUrl` remains the subscription, iframe, retry and release identity. One monitor-local memory snapshot is added; there are no IPC schema, enum, persistence, migration or historical-data compatibility changes. No new controls or layout changes.

Late terminal-event/request correlation is deferred: a synthetic event ordering demonstrates a state-machine weakness, but the separate local controlled-server probe failed to bootstrap its host page before exercising rapid navigation. This PR does not claim to reproduce or fix that risk.

## Acceptance criteria and validation

The original code repeatedly failed four new assertions at the reported behavior: three real component button cases opened the original URL and the registered Electron handler test retained the old fragment URL. The existing 140 tests in those files passed. The unchanged regression assertions pass after the fix.

Final checks ran after the last material edit:

- Current-page external actions, invalid-HTTPS fallback, original identity/release, in-page state preservation and response-owner/window contracts -> `npx vitest run src/main/source-preview-load-monitor.test.ts src/main/source-preview-web-request-owner.test.ts src/main/source-preview-embed-policy.test.ts src/main/windows.test.ts src/renderer/src/pages/workspace/PreviewPanel.test.tsx` -> 154 passed across 5 files.
- Actual Chromium anchor, pushState, replaceState, back and forward navigation through the real application, with no loading skeleton or iframe remount -> `npm run build:e2e`, then `npx playwright test e2e/workspace-conversation.spec.ts -g 'previews and opens an Agent HTTPS source'` -> passed; screenshot captured.
- Both affected runtimes -> `npm run typecheck` -> passed.
- Repository lint and changed-file Prettier checks -> passed.

The affected-plan explain command falls back to full because these paths have no declared module coverage. Per maintainer instruction, the complete suite is deferred to PR CI. Local checks cover the monitor owner, Electron adapter, web-request/embed collaborators and renderer consumer; no persisted or platform-path format changed. Cross-platform Electron behavior remains subject to PR CI.

## Review focus

Confirm the immutable source identity is retained, in-page commits preserve state and metadata, HTTPS validation is reused, and the final test-impact mapping covers the changed behavior. Independent review and selected PR CI checks remain required.
