### PR TITLE
fix(preview): preserve JSON source and bound text rendering

### DIFF
--- a/src/renderer/src/pages/workspace/HighlightedCodeLines.tsx
+++ b/src/renderer/src/pages/workspace/HighlightedCodeLines.tsx
@@ -10,6 +10,7 @@ const MAX_HIGHLIGHT_BYTES = 256 * 1024
 type HighlightedCodeLinesProps = {
   code: string
   language?: string
+  startingLineNumber?: number
   highlightLine?: number
   rowClassName?: string
   rowStyle?: React.CSSProperties
@@ -36,6 +37,7 @@ const HighlightedCodeLines = ({
   code,
   language,
   highlightLine,
+  startingLineNumber = 1,
   rowClassName,
   rowStyle,
   lineNumberClassName,
@@ -87,7 +89,7 @@ const HighlightedCodeLines = ({
       : undefined
   const lineNumberStyle = rowStyle
     ? undefined
-    : { minWidth: `${String(lines.length).length + 2}ch` }
+    : { minWidth: `${String(startingLineNumber + lines.length - 1).length + 2}ch` }
 
   return (
     <>
@@ -95,7 +97,10 @@ const HighlightedCodeLines = ({
         return (
           <div
             key={`${index}-${line}`}
-            className={cn(rowClassName, highlightLine === index + 1 && 'bg-danger-900')}
+            className={cn(
+              rowClassName,
+              highlightLine === startingLineNumber + index && 'bg-danger-900'
+            )}
             style={rowStyle}
           >
             <span
@@ -104,7 +109,7 @@ const HighlightedCodeLines = ({
               style={lineNumberStyle}
               aria-hidden="true"
             >
-              {index + 1}
+              {startingLineNumber + index}
             </span>
             <span className={cn('whitespace-pre-wrap break-words text-text-000', contentClassName)}>
               {tokens?.[index]?.map((token, tokenIndex) => (

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -582,7 +582,7 @@ describe('PreviewFileContent', () => {
     consoleError.mockRestore()
   })
 
-  it('formats valid JSON previews with indentation', async () => {
+  it('preserves the original JSON source', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
       content: '{"name":"sample","values":[1,true]}',
       encoding: 'utf8',
@@ -598,8 +598,8 @@ describe('PreviewFileContent', () => {
       fileId: 'file-1',
       maxBytes: 1024 * 1024
     })
-    expect(container.querySelector('pre')?.textContent).toContain('"name": "sample"')
-    expect(container.querySelector('pre')?.textContent).toContain('"values": [')
+    expect(container.querySelector('pre')?.textContent).toContain('"name":"sample"')
+    expect(container.querySelector('pre')?.textContent).toContain('"values":[')
   })
 
   it('renders line numbers next to text previews', async () => {
@@ -734,6 +734,12 @@ describe('PreviewFileContent', () => {
 
     await renderFile(createFileItem({ format: 'code', name: 'large.py' }))
 
+    expect(container.querySelectorAll('[data-testid="source-line-number"]')).toHaveLength(2000)
+    for (let page = 0; page < 6; page += 1) {
+      await act(async () => {
+        container.querySelector<HTMLButtonElement>('[aria-label="Next preview page"]')?.click()
+      })
+    }
     expect(container.textContent).toContain('import pandas as pd # 13999')
     expect(highlightSpy).not.toHaveBeenCalled()
     expect(container.querySelector('[data-testid="source-code-token"]')).toBeNull()
@@ -863,7 +869,7 @@ describe('PreviewFileContent', () => {
     consoleError.mockRestore()
   })
 
-  it('renders line numbers next to formatted JSON previews', async () => {
+  it('renders line numbers next to original JSON previews', async () => {
     vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
       content: '{"name":"sample","values":[1,true]}',
       encoding: 'utf8',
@@ -874,7 +880,7 @@ describe('PreviewFileContent', () => {
     await renderFile(createFileItem({ format: 'json', name: 'data.json' }))
 
     expect(container.querySelector('[data-testid="source-line-number"]')?.textContent).toBe('1')
-    expect(container.textContent).toContain('"name": "sample"')
+    expect(container.textContent).toContain('"name":"sample"')
   })
 
   it('uses paged source instead of parsing truncated JSON', async () => {

--- a/src/renderer/src/pages/workspace/previews/renderers/JsonPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/JsonPreview.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+import { JsonPreviewBody } from './JsonPreview'
+
+const item: PreviewFileItem = {
+  id: 'json-file',
+  sessionId: 'session-1',
+  type: 'file',
+  title: 'data.json',
+  name: 'data.json',
+  path: '/workspace/data.json',
+  format: 'json'
+}
+
+const renderJson = (content: string, truncated = false): HTMLElement =>
+  render(
+    <JsonPreviewBody
+      item={item}
+      state={{
+        status: 'ready',
+        preview: { content, encoding: 'utf8', size: content.length, truncated },
+        pagination: {
+          pageNumber: 1,
+          hasPrevious: false,
+          hasNext: truncated,
+          previousPage: () => undefined,
+          nextPage: () => undefined
+        }
+      }}
+    />
+  ).container
+
+// Read only visible source cells, excluding the non-selectable line-number gutter.
+const sourceText = (container: HTMLElement): string =>
+  [...container.querySelectorAll('[data-testid="source-line-number"]')]
+    .map((number) => number.nextElementSibling?.textContent ?? '')
+    .join('\n')
+
+afterEach(cleanup)
+
+describe('JSON source fidelity', () => {
+  it.each([
+    ['unsafe integer', '{"id":9007199254740993}', '9007199254740993'],
+    ['overflowing exponent', '{"value":1e400}', '1e400'],
+    ['duplicate property', '{"sample":"first","sample":"second"}', '"first"']
+  ])('preserves the original %s in the visible source', (_name, content, value) => {
+    expect(sourceText(renderJson(content))).toContain(value)
+  })
+
+  it('does not diagnose valid deeply nested JSON as a syntax error', () => {
+    const content = '['.repeat(10_000) + '0' + ']'.repeat(10_000)
+    expect(() => JSON.parse(content)).not.toThrow()
+    const container = renderJson(content)
+    expect(sourceText(container)).toBe(content)
+    expect(container.textContent).not.toContain('Invalid JSON')
+  })
+
+  it('retains syntax diagnostics and the source of invalid JSON', () => {
+    const content = '{"sample":}'
+    const container = renderJson(content)
+    expect(container.textContent).toContain('Invalid JSON')
+    expect(sourceText(container)).toBe(content)
+  })
+
+  it('preserves safe values and arrays', () => {
+    const content = '{"id":42,"values":[1,2,3]}'
+    expect(JSON.parse(sourceText(renderJson(content)))).toEqual(JSON.parse(content))
+  })
+
+  it('leaves incomplete pages unparsed', () => {
+    const content = '{"id":9007199254740993'
+    const container = renderJson(content, true)
+    expect(sourceText(container)).toBe(content)
+    expect(container.textContent).not.toContain('Invalid JSON')
+  })
+})

--- a/src/renderer/src/pages/workspace/previews/renderers/JsonPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/JsonPreview.tsx
@@ -5,22 +5,6 @@ import type { PreviewFileRendererProps } from '../preview-types'
 import type { PreviewFileContentLoadState } from '../usePreviewFileContent'
 import { SourcePreviewContent } from './SourcePreview'
 
-// `unknownErrorText` is passed in because this runs outside React and can't call the t() hook; the
-// caller supplies the localized wording for a thrown value that isn't an Error.
-const formatJsonPreview = (
-  content: string,
-  unknownErrorText: string
-): { formatted: string; error?: string } => {
-  try {
-    return { formatted: JSON.stringify(JSON.parse(content), null, 2) }
-  } catch (error) {
-    return {
-      formatted: content,
-      error: error instanceof Error ? error.message : unknownErrorText
-    }
-  }
-}
-
 // Presentation half of the JSON preview, split from the reading half so the Plan-aware JSON
 // renderer can back both its raw view and its fallback path with one loaded preview.
 export const JsonPreviewBody = ({
@@ -46,13 +30,25 @@ export const JsonPreviewBody = ({
     return <SourcePreviewContent content={state.preview.content} pagination={state.pagination} />
   }
 
-  const { formatted, error } = formatJsonPreview(state.preview.content, t('Invalid JSON'))
+  let errorContent: React.JSX.Element | undefined
+  try {
+    // Validate syntax only: parsing must never replace the source shown to the user.
+    JSON.parse(state.preview.content)
+  } catch (error) {
+    errorContent = (
+      <div className="shrink-0 border-b border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-danger-000">
+        {error instanceof SyntaxError
+          ? t('Invalid JSON: {{error}}', { error: error.message || t('Invalid JSON') })
+          : t('JSON validation unavailable')}
+      </div>
+    )
+  }
 
-  const errorContent = error ? (
-    <div className="shrink-0 border-b border-border-300 bg-bg-000 px-3 py-2 text-[12px] text-danger-000">
-      {t('Invalid JSON: {{error}}', { error })}
-    </div>
-  ) : undefined
-
-  return <SourcePreviewContent content={formatted} topContent={errorContent} />
+  return (
+    <SourcePreviewContent
+      content={state.preview.content}
+      pagination={state.pagination}
+      topContent={errorContent}
+    />
+  )
 }

--- a/src/renderer/src/pages/workspace/previews/renderers/SourcePreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/SourcePreview.test.tsx
@@ -1,0 +1,210 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, renderHook, waitFor } from '@testing-library/react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { usePreviewFileContent } from '../usePreviewFileContent'
+import { SourcePreviewContent } from './SourcePreview'
+import { NotebookCodeBlock } from '../../notebook-code'
+
+const PaginatedSource = ({
+  maxBytes,
+  fileId = 'file-1'
+}: {
+  maxBytes: number
+  fileId?: string
+}): React.JSX.Element => {
+  const state = usePreviewFileContent({
+    projectId: 'project-1',
+    managedFileId: fileId,
+    path: '/managed/source.txt',
+    source: 'artifact',
+    maxBytes
+  })
+  return state.status === 'ready' ? (
+    <SourcePreviewContent content={state.preview.content} pagination={state.pagination} />
+  ) : (
+    <div>{state.status}</div>
+  )
+}
+
+const installFile = (content: string): void => {
+  const bytes = new TextEncoder().encode(content)
+  window.api = {
+    previewResources: {
+      acquire: vi.fn().mockResolvedValue({
+        id: 'resource-1',
+        url: 'https://preview.test/resource-1',
+        size: bytes.length,
+        mimeType: 'text/plain',
+        version: 1
+      }),
+      release: vi.fn().mockResolvedValue(undefined)
+    }
+  } as unknown as Window['api']
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_input, init) => {
+      const range = new Headers(init?.headers).get('range')?.match(/^bytes=(\d+)-(\d+)$/u)
+      if (!range) throw new Error('Expected a byte Range request.')
+      const begin = Number(range[1])
+      const end = Math.min(Number(range[2]) + 1, bytes.length)
+      return new Response(bytes.slice(begin, end), {
+        status: 206,
+        headers: { 'Content-Range': `bytes ${begin}-${end - 1}/${bytes.length}` }
+      })
+    })
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
+
+describe('Source preview display bounds and locations', () => {
+  it('bounds rendered rows for dense newlines and offers continued viewing', () => {
+    const html = renderToStaticMarkup(<SourcePreviewContent content={'\n'.repeat(65_536)} />)
+    const rows = html.match(/data-testid="source-line-number"/g)?.length ?? 0
+    // A generous display ceiling, independent of the eventual page-size tuning.
+    expect(rows).toBeLessThanOrEqual(10_000)
+    expect(html).toContain('Next preview page')
+  })
+
+  it('preserves notebook line numbering and the highlighted error line', () => {
+    const { container } = render(<NotebookCodeBlock code={'first\nsecond'} highlightLine={2} />)
+    const numbers = [...container.querySelectorAll('[data-testid="source-line-number"]')]
+    expect(numbers.map((number) => number.textContent)).toEqual(['1', '2'])
+    expect(numbers[0].parentElement?.className).not.toContain('bg-danger-900')
+    expect(numbers[1].parentElement?.className).toContain('bg-danger-900')
+  })
+
+  it('renders one row for equally sized text without newlines', () => {
+    const html = renderToStaticMarkup(<SourcePreviewContent content={'x'.repeat(65_536)} />)
+    expect(html.match(/data-testid="source-line-number"/g)).toHaveLength(1)
+  })
+
+  it('keeps file line numbers across byte pages without changing the pinned resource', async () => {
+    const content = 'alpha\nbeta\ngamma'
+    installFile(content)
+    const { container } = render(<PaginatedSource maxBytes={8} />)
+    const displayed: Array<{ text: string; numbers: number[]; expected: number[] }> = []
+    let offset = 0
+    for (let page = 0; page < 10; page += 1) {
+      await waitFor(() => expect(container.querySelector('code')).not.toBeNull())
+      const cells = [...container.querySelectorAll('[data-testid="source-line-number"]')]
+      const lines = cells.map((cell) =>
+        (cell.nextElementSibling?.textContent ?? '').replace(/\u00a0/g, '')
+      )
+      const text = lines.join('\n')
+      const startingLine = content.slice(0, offset).split('\n').length
+      displayed.push({
+        text,
+        numbers: cells.map((cell) => Number(cell.textContent)),
+        expected: lines.map((_line, index) => startingLine + index)
+      })
+      offset += text.length
+      const next = container.querySelector<HTMLButtonElement>('[aria-label="Next preview page"]')
+      if (!next || next.disabled) break
+      fireEvent.click(next)
+    }
+    expect(displayed.map((page) => page.text).join('')).toBe(content)
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+    expect(displayed.map((page) => page.numbers)).toEqual(displayed.map((page) => page.expected))
+  })
+
+  it('discloses a continued line when a long line exceeds the byte budget', async () => {
+    installFile('abcdefghijklmnop')
+    const { container, getByRole } = render(<PaginatedSource maxBytes={8} />)
+    await waitFor(() => expect(container.querySelector('code')).not.toBeNull())
+    fireEvent.click(getByRole('button', { name: 'Next preview page' }))
+    await waitFor(() => expect(container.querySelector('code')?.textContent).toContain('ijklmnop'))
+    expect(container.textContent).toMatch(/continued|continuation|fragment/i)
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+  })
+
+  it('visits every display slice in both directions and resets for replacement content', () => {
+    const lines = Array.from({ length: 4001 }, (_, index) => `row-${index + 1}`)
+    const { container, getByRole, rerender } = render(
+      <SourcePreviewContent content={lines.join('\n')} />
+    )
+    const visible = (): string[] =>
+      [...container.querySelectorAll('[data-testid="source-line-number"]')].map(
+        (cell) => cell.nextElementSibling?.textContent ?? ''
+      )
+    const collected = [...visible()]
+    expect(collected).toHaveLength(2000)
+    fireEvent.click(getByRole('button', { name: 'Next preview page' }))
+    collected.push(...visible())
+    expect(container.querySelector('[data-testid="source-line-number"]')?.textContent).toBe('2001')
+    fireEvent.click(getByRole('button', { name: 'Next preview page' }))
+    collected.push(...visible())
+    expect(collected).toEqual(lines)
+    expect((getByRole('button', { name: 'Next preview page' }) as HTMLButtonElement).disabled).toBe(
+      true
+    )
+    fireEvent.click(getByRole('button', { name: 'Previous preview page' }))
+    expect(visible()[0]).toBe('row-2001')
+    fireEvent.click(getByRole('button', { name: 'Previous preview page' }))
+    expect(visible()[0]).toBe('row-1')
+    fireEvent.click(getByRole('button', { name: 'Next preview page' }))
+    rerender(<SourcePreviewContent content="replacement" />)
+    expect(visible()).toEqual(['replacement'])
+    expect(container.querySelector('button')).toBeNull()
+  })
+
+  it('returns to the last display slice of a previous byte page and resets on file switches', async () => {
+    installFile('a\n'.repeat(3000) + 'b\n'.repeat(1000))
+    const { container, getByRole, rerender } = render(<PaginatedSource maxBytes={6000} />)
+    const firstNumber = (): string | null | undefined =>
+      container.querySelector('[data-testid="source-line-number"]')?.textContent
+    await waitFor(() => expect(firstNumber()).toBe('1'))
+    fireEvent.click(getByRole('button', { name: 'Next preview page' }))
+    expect(firstNumber()).toBe('2001')
+    fireEvent.click(getByRole('button', { name: 'Next preview page' }))
+    await waitFor(() => expect(firstNumber()).toBe('3001'))
+    fireEvent.click(getByRole('button', { name: 'Previous preview page' }))
+    await waitFor(() => expect(firstNumber()).toBe('2001'))
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+    rerender(<PaginatedSource maxBytes={6000} fileId="file-2" />)
+    await waitFor(() => expect(firstNumber()).toBe('1'))
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(2)
+  })
+
+  it.each([1, 2, 5, 8])(
+    'preserves UTF-8, CRLF, empty lines and locations with a %i-byte budget',
+    async (maxBytes) => {
+      const content = 'α\r\n\r\n猫\nlast\n'
+      installFile(content)
+      const { result } = renderHook(() =>
+        usePreviewFileContent({
+          projectId: 'project-1',
+          managedFileId: 'file-1',
+          source: 'artifact',
+          path: '/managed/source.txt',
+          maxBytes
+        })
+      )
+      let consumed = ''
+      for (let page = 0; page < 30; page += 1) {
+        await waitFor(() => expect(result.current.status).toBe('ready'))
+        const state = result.current
+        if (state.status !== 'ready') throw new Error('Expected a ready page')
+        expect(state.preview.content).not.toContain('�')
+        expect(state.preview.content.endsWith('\r')).toBe(false)
+        expect(state.pagination.startingLineNumber).toBe(consumed.split('\n').length)
+        expect(state.pagination.startsMidLine).toBe(consumed.length > 0 && !consumed.endsWith('\n'))
+        expect(state.pagination.byteStart).toBe(new TextEncoder().encode(consumed).length)
+        consumed += state.preview.content
+        expect(state.pagination.byteEnd).toBe(new TextEncoder().encode(consumed).length)
+        expect(state.pagination.endsMidLine).toBe(
+          state.preview.truncated && !consumed.endsWith('\n')
+        )
+        if (!state.pagination.hasNext) break
+        act(() => state.pagination.nextPage())
+      }
+      expect(consumed).toBe(content)
+      expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(1)
+    }
+  )
+})

--- a/src/renderer/src/pages/workspace/previews/renderers/SourcePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/SourcePreview.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react'
+import { useMemo, useState, type ReactNode } from 'react'
 import { ChevronLeft, ChevronRight } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -14,6 +14,8 @@ type SourcePreviewContentProps = {
   language?: string
 }
 
+const PREVIEW_SOURCE_MAX_LINES = 2000
+
 // Shared source renderer for text-like previews so line numbers stay aligned across formats.
 export const SourcePreviewContent = ({
   content,
@@ -23,22 +25,60 @@ export const SourcePreviewContent = ({
   language
 }: SourcePreviewContentProps): React.JSX.Element => {
   const { t } = useTranslation()
-  const lineNumberWidth = `${Math.max(String(content.replace(/\0/g, '').split(/\r?\n/).length).length, 2) + 1}ch`
+  const lines = useMemo(() => content.replace(/\0/g, '').split(/\r?\n/), [content])
+  const lastSlice = Math.floor((lines.length - 1) / PREVIEW_SOURCE_MAX_LINES)
+  const pageKey = pagination?.pageKey ?? pagination?.pageNumber
+  const initialSlice = pagination?.showLastLines ? lastSlice : 0
+  const [position, setPosition] = useState({ content, pageKey, slice: initialSlice })
+  const active =
+    position.content === content && position.pageKey === pageKey
+      ? position
+      : { content, pageKey, slice: initialSlice }
+  if (active !== position) setPosition(active)
+  const slice = Math.min(active.slice, lastSlice)
+  const firstIndex = slice * PREVIEW_SOURCE_MAX_LINES
+  const visibleLines = lines.slice(firstIndex, firstIndex + PREVIEW_SOURCE_MAX_LINES)
+  const startingLineNumber = (pagination?.startingLineNumber ?? 1) + firstIndex
+  const endingLineNumber = startingLineNumber + visibleLines.length - 1
+  const lineNumberWidth = `${Math.max(String(endingLineNumber).length, 2) + 1}ch`
+  const hasPrevious = slice > 0 || Boolean(pagination?.hasPrevious)
+  const hasNext = slice < lastSlice || Boolean(pagination?.hasNext)
+  const partialContext = lastSlice > 0 || Boolean(pagination?.hasPrevious || pagination?.hasNext)
+  const previous = (): void => {
+    if (slice > 0) setPosition({ ...active, slice: slice - 1 })
+    else pagination?.previousPage()
+  }
+  const next = (): void => {
+    if (slice < lastSlice) setPosition({ ...active, slice: slice + 1 })
+    else pagination?.nextPage()
+  }
 
   return (
     <div className="flex size-full flex-col overflow-hidden bg-bg-10">
       {topContent}
-      {pagination && (pagination.hasPrevious || pagination.hasNext) ? (
+      {hasPrevious || hasNext ? (
         <div className="flex shrink-0 items-center justify-between border-b border-border-300 bg-bg-000 px-3 py-1.5 text-[12px] text-text-300">
-          <span>{t('Page {{page}}', { page: pagination.pageNumber })}</span>
+          <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1">
+            <span>
+              {t('Lines {{start}}–{{end}}', { start: startingLineNumber, end: endingLineNumber })}
+            </span>
+            {pagination?.byteStart !== undefined && pagination.byteEnd !== undefined ? (
+              <span>
+                {t('Loaded bytes {{start}}–{{end}}', {
+                  start: pagination.byteStart + 1,
+                  end: pagination.byteEnd
+                })}
+              </span>
+            ) : null}
+          </div>
           <div className="flex items-center gap-1">
             <button
               type="button"
               className="rounded p-1 hover:bg-bg-200 disabled:opacity-40"
               aria-label={t('Previous preview page')}
               title={t('Previous page')}
-              disabled={!pagination.hasPrevious}
-              onClick={pagination.previousPage}
+              disabled={!hasPrevious}
+              onClick={previous}
             >
               <ChevronLeft className="size-3.5" aria-hidden />
             </button>
@@ -47,25 +87,44 @@ export const SourcePreviewContent = ({
               className="rounded p-1 hover:bg-bg-200 disabled:opacity-40"
               aria-label={t('Next preview page')}
               title={t('Next page')}
-              disabled={!pagination.hasNext}
-              onClick={pagination.nextPage}
+              disabled={!hasNext}
+              onClick={next}
             >
               <ChevronRight className="size-3.5" aria-hidden />
             </button>
           </div>
         </div>
       ) : null}
-      <pre className="m-0 min-h-0 flex-1 overflow-auto bg-bg-000 p-0 font-mono text-[12px] leading-5 text-text-000">
+      {slice === 0 && pagination?.startsMidLine ? (
+        <div className="shrink-0 border-b border-border-300 px-3 py-1 text-[12px] text-text-300">
+          {t('First line is continued from the previous page')}
+        </div>
+      ) : null}
+      {partialContext && language ? (
+        <div className="shrink-0 px-3 py-1 text-[12px] text-text-300">
+          {t('Partial source context; syntax highlighting is unavailable')}
+        </div>
+      ) : null}
+      <pre
+        key={`${pageKey}-${slice}`}
+        className="m-0 min-h-0 flex-1 overflow-auto bg-bg-000 p-0 font-mono text-[12px] leading-5 text-text-000"
+      >
         <code className="block min-w-full py-3">
           <HighlightedCodeLines
-            code={content}
-            language={language}
+            code={visibleLines.join('\n')}
+            startingLineNumber={startingLineNumber}
+            language={partialContext ? undefined : language}
             rowClassName="grid min-w-full gap-3 px-3 hover:bg-bg-200/70"
             rowStyle={{ gridTemplateColumns: `${lineNumberWidth} minmax(0, 1fr)` }}
             contentClassName={cn('text-[12px] leading-5', lineClassName)}
           />
         </code>
       </pre>
+      {slice === lastSlice && pagination?.endsMidLine ? (
+        <div className="shrink-0 border-t border-border-300 px-3 py-1 text-[12px] text-text-300">
+          {t('Last line continues on the next page')}
+        </div>
+      ) : null}
     </div>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
@@ -15,6 +15,13 @@ const PUBLICATION_RETRY_LIMIT = 4
 
 type PreviewPagination = {
   pageNumber: number
+  pageKey?: string
+  startingLineNumber?: number
+  startsMidLine?: boolean
+  endsMidLine?: boolean
+  byteStart?: number
+  byteEnd?: number
+  showLastLines?: boolean
   hasPrevious: boolean
   hasNext: boolean
   previousPage: () => void
@@ -130,6 +137,14 @@ const readManagedPreviewPage = async (
         contentBytesRead += 1
       }
     }
+    // Keep CRLF together, using the same bounded lookahead as UTF-8 completion.
+    if (
+      request.encoding === 'utf8' &&
+      bytes[contentBytesRead - 1] === 13 &&
+      bytes[contentBytesRead] === 10
+    ) {
+      contentBytesRead += 1
+    }
     const contentBytes = bytes.subarray(0, contentBytesRead)
     const nextOffset = request.offset + contentBytesRead
 
@@ -180,18 +195,21 @@ export const usePreviewFileContent = ({
     maxBytes,
     path
   ])
-  // Keep byte offsets, not prior page contents, so only the active page remains in memory.
-  const [pageState, setPageState] = useState<{ fileKey: string; offsets: number[]; index: number }>(
-    {
-      fileKey,
-      offsets: [0],
-      index: 0
-    }
-  )
+  // Retain locations, not previous page contents, for the pinned resource sequence.
+  const firstPage = { offset: 0, startingLineNumber: 1, startsMidLine: false }
+  const [pageState, setPageState] = useState<{
+    fileKey: string
+    pages: (typeof firstPage)[]
+    index: number
+    showLastLines: boolean
+  }>({ fileKey, pages: [firstPage], index: 0, showLastLines: false })
   const activePageState =
-    pageState.fileKey === fileKey ? pageState : { fileKey, offsets: [0], index: 0 }
+    pageState.fileKey === fileKey
+      ? pageState
+      : { fileKey, pages: [firstPage], index: 0, showLastLines: false }
   if (pageState.fileKey !== fileKey) setPageState(activePageState)
-  const offset = activePageState.offsets[activePageState.index] ?? 0
+  const page = activePageState.pages[activePageState.index] ?? firstPage
+  const offset = page.offset
   const requestKey = `${fileKey}:${offset}`
   const [state, setState] = useState<PreviewFileContentInternalState>({
     status: 'loading',
@@ -271,7 +289,7 @@ export const usePreviewFileContent = ({
   const previousPage = (): void => {
     setPageState((current) => {
       const active = current.fileKey === fileKey ? current : activePageState
-      return { ...active, index: Math.max(0, active.index - 1) }
+      return { ...active, index: Math.max(0, active.index - 1), showLastLines: true }
     })
   }
   const nextPage = (): void => {
@@ -280,9 +298,15 @@ export const usePreviewFileContent = ({
     setPageState((current) => {
       const active = current.fileKey === fileKey ? current : activePageState
       // Discard forward history when navigation continues from an earlier page.
-      const nextOffsets = active.offsets.slice(0, active.index + 1)
-      nextOffsets.push(state.preview.nextOffset as number)
-      return { fileKey, offsets: nextOffsets, index: active.index + 1 }
+      const pages = active.pages.slice(0, active.index + 1)
+      pages.push({
+        offset: state.preview.nextOffset as number,
+        startingLineNumber:
+          page.startingLineNumber +
+          (encoding === 'utf8' ? (state.preview.content.match(/\n/g)?.length ?? 0) : 0),
+        startsMidLine: encoding === 'utf8' && !state.preview.content.endsWith('\n')
+      })
+      return { fileKey, pages, index: active.index + 1, showLastLines: false }
     })
   }
 
@@ -290,6 +314,14 @@ export const usePreviewFileContent = ({
     ...state,
     pagination: {
       pageNumber: activePageState.index + 1,
+      pageKey: requestKey,
+      startingLineNumber: page.startingLineNumber,
+      startsMidLine: page.startsMidLine,
+      endsMidLine:
+        encoding === 'utf8' && state.preview.truncated && !state.preview.content.endsWith('\n'),
+      byteStart: offset,
+      byteEnd: state.preview.nextOffset ?? state.preview.size,
+      showLastLines: activePageState.showLastLines,
       hasPrevious: activePageState.index > 0,
       hasNext: state.preview.nextOffset !== undefined,
       previousPage,

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4779,6 +4779,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "Die Vorschau von UTF-16-CSV-Dateien wird nicht unterstützt. Speichern Sie eine Kopie als UTF-8, um sie in der Vorschau anzuzeigen.",
     "The preview limit was reached before a complete header could be read.": "Das Vorschaulimit wurde erreicht, bevor die Kopfzeile vollständig gelesen werden konnte.",
     "The file exceeds the preview limit. Only complete records are shown.": "Die Datei überschreitet das Vorschaulimit. Es werden nur vollständige Datensätze angezeigt.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "Das Trennzeichen konnte nicht zuverlässig erkannt werden. In dieser Vorschau werden Kommas verwendet."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Das Trennzeichen konnte nicht zuverlässig erkannt werden. In dieser Vorschau werden Kommas verwendet.",
+    "JSON validation unavailable": "JSON-Validierung nicht verfügbar",
+    "Lines {{start}}–{{end}}": "Zeilen {{start}}–{{end}}",
+    "Loaded bytes {{start}}–{{end}}": "Geladene Bytes {{start}}–{{end}}",
+    "First line is continued from the previous page": "Die erste Zeile wird von der vorherigen Seite fortgesetzt",
+    "Last line continues on the next page": "Die letzte Zeile wird auf der nächsten Seite fortgesetzt",
+    "Partial source context; syntax highlighting is unavailable": "Unvollständiger Quelltextkontext; Syntaxhervorhebung nicht verfügbar"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4941,6 +4941,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "La vista previa de CSV en UTF-16 no es compatible. Guarde una copia en UTF-8 para previsualizarla.",
     "The preview limit was reached before a complete header could be read.": "Se alcanzó el límite de la vista previa antes de poder leer una cabecera completa.",
     "The file exceeds the preview limit. Only complete records are shown.": "El archivo supera el límite de la vista previa. Solo se muestran registros completos.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "No se pudo detectar el delimitador de forma fiable. Se utilizan comas en esta vista previa."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "No se pudo detectar el delimitador de forma fiable. Se utilizan comas en esta vista previa.",
+    "JSON validation unavailable": "Validación de JSON no disponible",
+    "Lines {{start}}–{{end}}": "Líneas {{start}}–{{end}}",
+    "Loaded bytes {{start}}–{{end}}": "Bytes cargados {{start}}–{{end}}",
+    "First line is continued from the previous page": "La primera línea continúa desde la página anterior",
+    "Last line continues on the next page": "La última línea continúa en la página siguiente",
+    "Partial source context; syntax highlighting is unavailable": "Contexto de código fuente parcial; resaltado de sintaxis no disponible"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4941,6 +4941,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "L’aperçu CSV en UTF-16 n’est pas pris en charge. Enregistrez une copie en UTF-8 pour la prévisualiser.",
     "The preview limit was reached before a complete header could be read.": "La limite de l’aperçu a été atteinte avant de pouvoir lire un en-tête complet.",
     "The file exceeds the preview limit. Only complete records are shown.": "Le fichier dépasse la limite de l’aperçu. Seuls les enregistrements complets sont affichés.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "Le séparateur n’a pas pu être détecté de manière fiable. Des virgules sont utilisées dans cet aperçu."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Le séparateur n’a pas pu être détecté de manière fiable. Des virgules sont utilisées dans cet aperçu.",
+    "JSON validation unavailable": "Validation JSON indisponible",
+    "Lines {{start}}–{{end}}": "Lignes {{start}}–{{end}}",
+    "Loaded bytes {{start}}–{{end}}": "Octets chargés {{start}}–{{end}}",
+    "First line is continued from the previous page": "La première ligne est la suite de la page précédente",
+    "Last line continues on the next page": "La dernière ligne continue sur la page suivante",
+    "Partial source context; syntax highlighting is unavailable": "Contexte du code source incomplet ; coloration syntaxique indisponible"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4625,6 +4625,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "UTF-16 の CSV プレビューには対応していません。プレビューするには、UTF-8 でコピーを保存してください。",
     "The preview limit was reached before a complete header could be read.": "ヘッダー全体を読み込む前にプレビューの上限に達しました。",
     "The file exceeds the preview limit. Only complete records are shown.": "ファイルがプレビューの上限を超えています。完全なレコードのみ表示しています。",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "区切り文字を確実に検出できませんでした。このプレビューではカンマを使用しています。"
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "区切り文字を確実に検出できませんでした。このプレビューではカンマを使用しています。",
+    "JSON validation unavailable": "JSON の検証を利用できません",
+    "Lines {{start}}–{{end}}": "{{start}}～{{end}}行",
+    "Loaded bytes {{start}}–{{end}}": "読み込み済みのバイト範囲：{{start}}～{{end}}",
+    "First line is continued from the previous page": "最初の行は前のページからの続きです",
+    "Last line continues on the next page": "最後の行は次のページに続きます",
+    "Partial source context; syntax highlighting is unavailable": "ソースの前後関係が不完全なため、構文の強調表示は利用できません"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4623,6 +4623,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "UTF-16 CSV 미리보기는 지원되지 않습니다. 미리 보려면 UTF-8로 사본을 저장하세요.",
     "The preview limit was reached before a complete header could be read.": "전체 헤더를 읽기 전에 미리보기 한도에 도달했습니다.",
     "The file exceeds the preview limit. Only complete records are shown.": "파일이 미리보기 한도를 초과합니다. 완전한 레코드만 표시됩니다.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "구분자를 정확히 감지하지 못했습니다. 이 미리보기에서는 쉼표를 사용합니다."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "구분자를 정확히 감지하지 못했습니다. 이 미리보기에서는 쉼표를 사용합니다.",
+    "JSON validation unavailable": "JSON 검증을 사용할 수 없습니다",
+    "Lines {{start}}–{{end}}": "{{start}}–{{end}}행",
+    "Loaded bytes {{start}}–{{end}}": "불러온 바이트 {{start}}–{{end}}",
+    "First line is continued from the previous page": "첫 번째 행은 이전 페이지에서 이어집니다",
+    "Last line continues on the next page": "마지막 행은 다음 페이지로 이어집니다",
+    "Partial source context; syntax highlighting is unavailable": "소스 컨텍스트이 일부만 있어 구문 강조를 사용할 수 없습니다"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5074,6 +5074,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "Предпросмотр CSV в UTF-16 не поддерживается. Сохраните копию в UTF-8 для предпросмотра.",
     "The preview limit was reached before a complete header could be read.": "Предел предпросмотра достигнут до завершения чтения заголовка.",
     "The file exceeds the preview limit. Only complete records are shown.": "Файл превышает предел предпросмотра. Показаны только полные записи.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "Не удалось надёжно определить разделитель. В этом предпросмотре используются запятые."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Не удалось надёжно определить разделитель. В этом предпросмотре используются запятые.",
+    "JSON validation unavailable": "Проверка JSON недоступна",
+    "Lines {{start}}–{{end}}": "Строки {{start}}–{{end}}",
+    "Loaded bytes {{start}}–{{end}}": "Загруженные байты {{start}}–{{end}}",
+    "First line is continued from the previous page": "Первая строка продолжается с предыдущей страницы",
+    "Last line continues on the next page": "Последняя строка продолжается на следующей странице",
+    "Partial source context; syntax highlighting is unavailable": "Неполный контекст исходного кода; подсветка синтаксиса недоступна"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4625,6 +4625,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "暂不支持预览 UTF-16 编码的 CSV。请另存一份 UTF-8 编码的副本以进行预览。",
     "The preview limit was reached before a complete header could be read.": "尚未读取完整表头，已达到预览上限。",
     "The file exceeds the preview limit. Only complete records are shown.": "文件超出预览上限，仅显示完整记录。",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "无法可靠识别分隔符。本次预览使用逗号作为分隔符。"
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "无法可靠识别分隔符。本次预览使用逗号作为分隔符。",
+    "JSON validation unavailable": "无法验证 JSON",
+    "Lines {{start}}–{{end}}": "第 {{start}}–{{end}} 行",
+    "Loaded bytes {{start}}–{{end}}": "已读取字节 {{start}}–{{end}}",
+    "First line is continued from the previous page": "首行接续上一页的内容",
+    "Last line continues on the next page": "末行将在下一页继续",
+    "Partial source context; syntax highlighting is unavailable": "源码上下文不完整，无法进行语法高亮"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4625,6 +4625,12 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "暫不支援預覽 UTF-16 編碼的 CSV。請另存一份 UTF-8 編碼的副本以進行預覽。",
     "The preview limit was reached before a complete header could be read.": "尚未讀取完整表頭，已達到預覽上限。",
     "The file exceeds the preview limit. Only complete records are shown.": "檔案超出預覽上限，僅顯示完整記錄。",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "無法可靠識別分隔符號。本次預覽使用逗號作為分隔符號。"
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "無法可靠識別分隔符號。本次預覽使用逗號作為分隔符號。",
+    "JSON validation unavailable": "無法驗證 JSON",
+    "Lines {{start}}–{{end}}": "第 {{start}}–{{end}} 行",
+    "Loaded bytes {{start}}–{{end}}": "已讀取位元組 {{start}}–{{end}}",
+    "First line is continued from the previous page": "首行接續上一頁的內容",
+    "Last line continues on the next page": "末行將在下一頁繼續",
+    "Partial source context; syntax highlighting is unavailable": "原始碼上下文不完整，無法進行語法醒目提示"
   }
 }


### PR DESCRIPTION
## Problem

Complete JSON previews silently changed unsafe integers, overflowing exponents, and duplicate properties through parse/stringify. Valid deeply nested JSON could be mislabeled as invalid. Dense newlines created unbounded source rows, and byte pages reset file line numbers without disclosing continued lines.

## Proposed change

Display JSON source unchanged while retaining syntax diagnostics. Limit source display to 2,000 rows per slice and use the existing previous/next controls across slices and byte pages. Carry original line numbers and continuation metadata through the existing pinned-resource history; show loaded byte ranges and continuation notices. Keep CRLF together within the existing bounded lookahead. Partial source context uses plain text. Add copy in all eight renderer locales.

## Scope and non-goals

Renderer-only location/navigation metadata; no persisted fields, schema migration, historical-version conversion, new status enum, dependency, or editor. Existing immutable managed-resource leases remain unchanged. JSON keeps its original whitespace. Text annotation lookup still operates on the visible content; cross-page annotation discovery is not added.

## Acceptance criteria and validation

Seven regression assertions failed twice against unchanged production code, with four controls passing. Failures matched the reported visible values, row count, line numbering, and diagnostic. Those same assertions now pass without a production test seam.

Checks ran after the final material implementation change:

| Behavior | Check | Result |
| --- | --- | --- |
| JSON fidelity, source bounds, navigation, renderer consumers, UTF-8/CRLF, pinned-resource contracts | `npx vitest run src/renderer/src/pages/workspace/previews src/renderer/src/pages/workspace/NotebookPreview.gate.render.test.tsx src/renderer/src/pages/workspace/NotebookPreview.follow-scroll.test.tsx src/main/managed-preview-resources.test.ts src/main/managed-preview-protocol.test.ts src/main/managed-preview-ipc.test.ts src/main/managed-file-preview.test.ts --maxWorkers=4` | 579 passed, 43 files |
| Locale keys, placeholders and language conventions | `npx vitest run src/renderer/src/i18n/resources.test.ts` | 804 passed |
| Renderer interfaces | `npm run typecheck:web` | Passed |
| Lint and formatting | `npm run lint`; Prettier check of changed files | Passed |
| Visible UI | ego-browser with real preview components and project CSS, at 1280px and 780px widths | Original JSON retained; 2,000 rows after paging; second byte page shows lines 2–3 and continuation notice; screenshots inspected |

Source consumers include text, code, Markdown/HTML source, FASTA and scientific source fallbacks. Notebook numbering/error highlighting is explicitly covered. Managed resource tests protect the retained acquisition/release contract. No main/preload implementation or platform path handling changed, so local node typecheck and platform-specific E2E were not added.

The affected-test explain command reports a full fallback because `HighlightedCodeLines.tsx` has no registered Module owner. The maintainer explicitly requested module-scoped local validation; no complete local suite was run. PR CI remains authoritative for full and platform checks. Browser evidence uses an isolated component fixture, not the full Electron shell; no peak-memory, latency, clipboard, or crash claim is made.

## Review focus

Check forward/backward display-slice transitions, original line metadata at byte boundaries, and the deliberate removal of JSON pretty-printing. The 2,000-row limit is a conservative display bound rather than a benchmark-derived optimum.
