### PR TITLE
fix(previews): clarify scientific preview scope and failures

### DIFF
--- a/src/renderer/src/pages/workspace/artifact-preview.test.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.test.tsx
@@ -128,3 +128,18 @@ describe('artifact preview rendering', () => {
     expect(html).not.toContain('NWK')
   })
 })
+
+it('SC03: bounds multi-sequence FASTA thumbnails to 48 cells', () => {
+  const content =
+    '>long\n' +
+    'A'.repeat(4000) +
+    '\n' +
+    Array.from({ length: 5 }, (_, i) => `>short${i}\nA`).join('\n')
+  const html = renderToStaticMarkup(
+    <ArtifactPreview
+      artifact={createArtifact({ name: 'sequences.fasta' })}
+      preview={createPreview(content)}
+    />
+  )
+  expect((html.match(/<rect/g) ?? []).length).toBeLessThanOrEqual(48)
+})

--- a/src/renderer/src/pages/workspace/artifact-preview.tsx
+++ b/src/renderer/src/pages/workspace/artifact-preview.tsx
@@ -179,7 +179,7 @@ const getFastaRows = (content: string): string[] => {
 
   if (currentSequence) rows.push(currentSequence)
 
-  if (rows.length > 1) return rows.slice(0, 6)
+  if (rows.length > 1) return rows.slice(0, 6).map((row) => row.slice(0, 8))
 
   return rows[0]?.match(/.{1,8}/g)?.slice(0, 6) ?? []
 }

--- a/src/renderer/src/pages/workspace/preview-support.ts
+++ b/src/renderer/src/pages/workspace/preview-support.ts
@@ -67,6 +67,27 @@ export const PREVIEW_CODE_LANGUAGES: Record<string, string> = {
   tsx: 'tsx'
 }
 
+type MoleculeFormat = 'smiles' | 'mol' | 'sdf' | 'rxn'
+
+const MOLECULE_EXTENSIONS: Record<string, MoleculeFormat> = {
+  smi: 'smiles',
+  smiles: 'smiles',
+  mol: 'mol',
+  sdf: 'sdf',
+  rxn: 'rxn'
+}
+const MOLECULE_MIME_TYPES: Record<string, MoleculeFormat> = {
+  'chemical/x-daylight-smiles': 'smiles',
+  'chemical/x-mdl-molfile': 'mol',
+  'chemical/x-mdl-sdfile': 'sdf',
+  'chemical/x-mdl-rxnfile': 'rxn'
+}
+
+// Explicit extensions win; extensionless/unknown names use the same MIME fallback as routing.
+export const getMoleculeFormat = (extension: string, mimeType = ''): MoleculeFormat | undefined =>
+  MOLECULE_EXTENSIONS[extension.toLowerCase()] ??
+  MOLECULE_MIME_TYPES[mimeType.toLowerCase().split(';')[0].trim()]
+
 // Keeps MIME fallback narrow so unknown binary formats still land in the unsupported state.
 const getPreviewFormatForMimeType = (mimeType: string): PreviewFileFormat => {
   const normalizedMimeType = mimeType.toLowerCase().split(';')[0]?.trim() ?? ''
@@ -89,14 +110,7 @@ const getPreviewFormatForMimeType = (mimeType: string): PreviewFileFormat => {
   ) {
     return 'pdb'
   }
-  if (
-    normalizedMimeType === 'chemical/x-mdl-molfile' ||
-    normalizedMimeType === 'chemical/x-mdl-sdfile' ||
-    normalizedMimeType === 'chemical/x-mdl-rxnfile' ||
-    normalizedMimeType === 'chemical/x-daylight-smiles'
-  ) {
-    return 'molecule'
-  }
+  if (getMoleculeFormat('', normalizedMimeType)) return 'molecule'
   if (normalizedMimeType === 'application/pdf') return 'pdf'
   // Office MIME fallback covers extensionless uploads while preserving explicit format routing.
   if (

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -36,12 +36,13 @@ const createViewer = vi.fn(() => ({
   clear: clearViewer
 }))
 
-vi.mock('3dmol', () => ({
-  createViewer,
-  SurfaceType: {
-    VDW: 'VDW'
-  }
-}))
+vi.mock('3dmol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('3dmol')>()
+  addModel.mockImplementation((content: string, _format: string, options: object) => ({
+    selectedAtoms: () => actual.Parsers.pdb(content, options)[0] ?? []
+  }))
+  return { createViewer, SurfaceType: { VDW: 'VDW' } }
+})
 
 vi.mock('@/components/streamdown/code-highlighter-runtime', () => ({
   code: {
@@ -1067,7 +1068,8 @@ describe('PreviewFileContent', () => {
   })
 
   describe('PDB previews', () => {
-    beforeEach(() => {
+    beforeEach(async () => {
+      await import('3dmol')
       restorePdbLayoutMocks = installPdbLayoutMocks()
     })
 
@@ -1117,6 +1119,9 @@ describe('PreviewFileContent', () => {
       expect(container.textContent).toContain('Scroll to zoom')
       expect(createViewer).toHaveBeenCalledTimes(1)
       expect(addModel).toHaveBeenCalledWith(pdbContent, 'pdb', {
+        multimodel: false,
+        keepH: false,
+        altLoc: 'A',
         assignBonds: true,
         noComputeSecondaryStructure: false
       })

--- a/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.test.tsx
@@ -89,7 +89,7 @@ describe('MoleculePreviewRenderer', () => {
 
   it('renders SMILES through OpenChemLib with the available canvas size', async () => {
     const toSVG = vi.fn(() => '<svg data-testid="molecule-svg"></svg>')
-    mocks.fromSmiles.mockReturnValue({ toSVG })
+    mocks.fromSmiles.mockReturnValue({ toSVG, getAllAtoms: () => 3 })
     mocks.state.current = readyState('CCO')
 
     await render(item('ethanol.smi'))

--- a/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/MoleculePreview.tsx
@@ -4,7 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import { cn } from '@/lib/utils'
 
-import { getFileExtension } from '../../preview-support'
+import { getFileExtension, getMoleculeFormat } from '../../preview-support'
 import { PreviewErrorCard, PreviewLoadingContent } from '../PreviewFallback'
 import type { PreviewFileRendererProps } from '../preview-types'
 import { usePreviewFileContent } from '../usePreviewFileContent'
@@ -13,18 +13,13 @@ import { buildReactionMarkup } from './reaction-markup'
 
 type OclModule = typeof import('openchemlib')
 
-// SMILES sources parse via fromSmiles; molfile/SDF via fromMolfile (which reads the first record).
-const SMILES_EXTENSIONS = new Set(['smi', 'smiles'])
-// MDL reaction files render as a laid-out row of component depictions instead of one molecule.
-const REACTION_EXTENSIONS = new Set(['rxn'])
-
 const MoleculePreviewCanvas = ({
   content,
-  extension,
+  format,
   name
 }: {
   content: string
-  extension: string
+  format: ReturnType<typeof getMoleculeFormat>
   name: string
 }): React.JSX.Element => {
   const { t } = useTranslation()
@@ -43,7 +38,7 @@ const MoleculePreviewCanvas = ({
     if (container.clientWidth <= 0 || container.clientHeight <= 0) return
 
     try {
-      if (REACTION_EXTENSIONS.has(extension)) {
+      if (format === 'rxn') {
         // Each reaction component is bounded by the tile height so the row fits and scrolls if wide.
         const componentHeight = Math.max(80, Math.min(container.clientHeight - 24, 260))
         container.innerHTML = buildReactionMarkup(ocl, content, svgId, {
@@ -51,9 +46,16 @@ const MoleculePreviewCanvas = ({
           height: componentHeight
         })
       } else {
-        const molecule = SMILES_EXTENSIONS.has(extension)
-          ? ocl.Molecule.fromSmiles(content)
-          : ocl.Molecule.fromMolfile(content)
+        const molecule =
+          format === 'smiles'
+            ? ocl.Molecule.fromSmiles(
+                content
+                  .split(/\r?\n/)
+                  .find((line) => line.trim())
+                  ?.trim() ?? ''
+              )
+            : ocl.Molecule.fromMolfile(content)
+        if (molecule.getAllAtoms() === 0) throw new Error(t('No atoms found'))
         container.innerHTML = molecule.toSVG(container.clientWidth, container.clientHeight, svgId, {
           autoCrop: true,
           autoCropMargin: 16
@@ -65,7 +67,7 @@ const MoleculePreviewCanvas = ({
       container.replaceChildren()
       setError(renderError instanceof Error ? renderError.message : t('Could not render structure'))
     }
-  }, [content, extension, svgId, t])
+  }, [content, format, svgId, t])
 
   useEffect(() => {
     let canceled = false
@@ -129,6 +131,7 @@ const MoleculePreviewCanvas = ({
 export const MoleculePreviewRenderer = ({ item }: PreviewFileRendererProps): React.JSX.Element => {
   const { t } = useTranslation()
   const state = usePreviewFileContent(item)
+  const [showSource, setShowSource] = useState(false)
 
   if (state.status === 'loading') return <PreviewLoadingContent />
 
@@ -147,11 +150,29 @@ export const MoleculePreviewRenderer = ({ item }: PreviewFileRendererProps): Rea
     return <SourcePreviewContent content={state.preview.content} pagination={state.pagination} />
   }
 
+  const format = getMoleculeFormat(getFileExtension(item.name), item.mimeType)
   return (
-    <MoleculePreviewCanvas
-      content={state.preview.content}
-      extension={getFileExtension(item.name)}
-      name={item.name}
-    />
+    <div className="flex size-full flex-col overflow-hidden">
+      <div className="flex shrink-0 items-center justify-between gap-2 border-b border-border-300 px-3 py-2 text-[12px] text-text-300">
+        <span>
+          {!showSource && format !== 'rxn' ? t('Only the first record is previewed.') : null}
+        </span>
+        <button
+          type="button"
+          className="rounded px-2 py-1 hover:bg-bg-200"
+          aria-pressed={showSource}
+          onClick={() => setShowSource(!showSource)}
+        >
+          {showSource ? t('Preview') : t('Source')}
+        </button>
+      </div>
+      <div className="min-h-0 flex-1">
+        {showSource ? (
+          <SourcePreviewContent content={state.preview.content} pagination={state.pagination} />
+        ) : (
+          <MoleculePreviewCanvas content={state.preview.content} format={format} name={item.name} />
+        )}
+      </div>
+    </div>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/renderers/PdbPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdbPreview.tsx
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { GLViewer } from '3dmol'
 
+import { ErrorNotice } from '@/components/error-notice'
+
 import { cn } from '@/lib/utils'
 
 import { PreviewErrorCard, PreviewLoadingContent } from '../PreviewFallback'
@@ -59,10 +61,6 @@ const PDB_STYLE_SPECS = {
   line: { line: { colorscheme: 'Jmol' } }
 }
 
-const countPdbAtoms = (content: string): number =>
-  content.split(/\r?\n/).filter((line) => line.startsWith('ATOM') || line.startsWith('HETATM'))
-    .length
-
 const hasCartoonBackbone = (content: string): boolean => {
   const polymerResidues = new Set<string>()
 
@@ -93,7 +91,8 @@ const applyPdbStyle = (
   threeDmol: ThreeDmolModule,
   style: PdbStyle,
   shouldZoom: boolean,
-  shouldRenderSurface?: () => boolean
+  shouldRenderSurface: () => boolean,
+  onSurfaceState: (state: 'pending' | 'error' | undefined) => void
 ): void => {
   viewer.removeAllSurfaces()
 
@@ -105,21 +104,24 @@ const applyPdbStyle = (
         stick: { colorscheme: 'Jmol', opacity: 0.12, radius: 0.025 }
       }
     )
-    const surface = viewer.addSurface(
-      threeDmol.SurfaceType.VDW,
-      { opacity: 0.72, colorscheme: 'Jmol' },
-      {}
-    )
-
-    if (surface && typeof (surface as PromiseLike<unknown>).then === 'function') {
-      void (surface as PromiseLike<unknown>).then(
-        () => {
-          if (!shouldRenderSurface || shouldRenderSurface()) viewer.render()
-        },
-        (error) => {
-          console.error('Failed to render PDB surface', error)
-        }
+    onSurfaceState('pending')
+    const failed = (error: unknown): void => {
+      console.error('Failed to render PDB surface', error)
+      if (shouldRenderSurface()) onSurfaceState('error')
+    }
+    try {
+      const surface = viewer.addSurface(
+        threeDmol.SurfaceType.VDW,
+        { opacity: 0.72, colorscheme: 'Jmol' },
+        {}
       )
+      void Promise.resolve(surface).then(() => {
+        if (!shouldRenderSurface()) return
+        onSurfaceState(undefined)
+        viewer.render()
+      }, failed)
+    } catch (error) {
+      failed(error)
     }
   } else {
     viewer.setStyle({}, PDB_STYLE_SPECS[style])
@@ -148,8 +150,17 @@ const PdbPreviewViewer = ({
   const cartoonUnavailableDescriptionId = useId()
   const [selectedStyle, setSelectedStyle] = useState<PdbStyle | undefined>(undefined)
   const [viewerError, setViewerError] = useState<string | undefined>(undefined)
-  const atomCount = useMemo(() => countPdbAtoms(content), [content])
-  const supportsCartoon = useMemo(() => hasCartoonBackbone(content), [content])
+  const [atomCount, setAtomCount] = useState<number | undefined>(undefined)
+  const modelCount = useMemo(
+    () => Math.max(1, (content.match(/^MODEL\s/gm) ?? []).length),
+    [content]
+  )
+  const [surfaceState, setSurfaceState] = useState<'pending' | 'error' | undefined>(undefined)
+  const renderGenerationRef = useRef(0)
+  const supportsCartoon = useMemo(
+    () => hasCartoonBackbone(content.split(/^ENDMDL.*$/m)[0]),
+    [content]
+  )
   const defaultStyle: PdbStyle = supportsCartoon ? 'cartoon' : 'stick'
   const style =
     selectedStyle && (supportsCartoon || selectedStyle !== 'cartoon') ? selectedStyle : defaultStyle
@@ -167,13 +178,21 @@ const PdbPreviewViewer = ({
       return false
     }
 
+    const generation = ++renderGenerationRef.current
     viewerState.viewer.resize()
     applyPdbStyle(
       viewerState.viewer,
       viewerState.threeDmol,
       styleRef.current,
       shouldZoom,
-      () => viewerStateRef.current?.viewer === viewerState.viewer && styleRef.current === 'surface'
+      () =>
+        viewerStateRef.current?.viewer === viewerState.viewer &&
+        styleRef.current === 'surface' &&
+        generation === renderGenerationRef.current,
+      (state) => {
+        setSurfaceState(state)
+        if (state === 'error') setSelectedStyle('stick')
+      }
     )
     pendingRenderRef.current = false
     if (shouldZoom) pendingZoomRef.current = false
@@ -194,6 +213,8 @@ const PdbPreviewViewer = ({
     if (!viewerElement) return
 
     setViewerError(undefined)
+    setAtomCount(undefined)
+    setSurfaceState(undefined)
     pendingRenderRef.current = true
     pendingZoomRef.current = true
     viewerElement.replaceChildren()
@@ -203,10 +224,14 @@ const PdbPreviewViewer = ({
         if (canceled) return
 
         const viewer = threeDmol.createViewer(viewerElement, { backgroundColor: 'white' })
-        viewer.addModel(content, 'pdb', {
+        const model = viewer.addModel(content, 'pdb', {
+          multimodel: false,
+          keepH: false,
+          altLoc: 'A',
           assignBonds: true,
           noComputeSecondaryStructure: false
         })
+        setAtomCount(model.selectedAtoms({}).length)
         viewerStateRef.current = { viewer, threeDmol }
         renderCurrentStyle(true)
       })
@@ -261,7 +286,7 @@ const PdbPreviewViewer = ({
           </span>
         </div>
         <div className="shrink-0 text-[12px] text-text-300">
-          {t('{{count}} atoms', { count: atomCount })}
+          {atomCount !== undefined ? t('{{count}} atoms', { count: atomCount }) : null}
         </div>
       </div>
       <div className="flex shrink-0 items-center gap-2 border-b border-border-300 bg-bg-000 px-3 py-2">
@@ -292,7 +317,8 @@ const PdbPreviewViewer = ({
                     'cursor-not-allowed opacity-45 hover:bg-transparent hover:text-text-300'
                 )}
                 onClick={() => {
-                  if (isDisabled) return
+                  if (isDisabled || option.id === style) return
+                  setSurfaceState(undefined)
                   setSelectedStyle(option.id)
                 }}
               >
@@ -302,6 +328,25 @@ const PdbPreviewViewer = ({
           })}
         </div>
       </div>
+      <div className="shrink-0 px-3 py-2 text-[11px] text-text-300">
+        {t('Previewing model 1 of {{total}}.', { total: modelCount })}{' '}
+        {t(
+          'Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.'
+        )}
+      </div>
+      {surfaceState === 'pending' ? (
+        <div role="status" className="px-3 py-2 text-[12px]">
+          {t('Generating surface…')}
+        </div>
+      ) : null}
+      {surfaceState === 'error' ? (
+        <ErrorNotice
+          role="alert"
+          tone="amber"
+          title={t('Surface could not be generated. Showing sticks.')}
+          primaryButton={{ label: t('Retry'), onClick: () => setSelectedStyle('surface') }}
+        />
+      ) : null}
       <div className="relative min-h-0 flex-1 overflow-hidden bg-bg-000">
         {viewerError ? (
           <div className="absolute inset-0 flex items-center justify-center px-6 text-center text-[12px] text-danger-000">

--- a/src/renderer/src/pages/workspace/previews/renderers/scientific-preview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/scientific-preview.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { Molecule, Reaction } from 'openchemlib'
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+import { getPreviewFormatForFile } from '../../preview-support'
+
+const mocks = vi.hoisted(() => ({
+  state: undefined as unknown,
+  addSurface: vi.fn(),
+  atoms: [] as unknown[]
+}))
+vi.mock('../usePreviewFileContent', () => ({ usePreviewFileContent: () => mocks.state }))
+vi.mock('3dmol', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('3dmol')>()
+  return {
+    SurfaceType: { VDW: 1 },
+    createViewer: () => ({
+      addModel: (content: string, _format: string, options: object) => {
+        mocks.atoms = actual.Parsers.pdb(content, options)[0] ?? []
+        return { selectedAtoms: () => mocks.atoms }
+      },
+      resize: vi.fn(),
+      setStyle: vi.fn(),
+      removeAllSurfaces: vi.fn(),
+      addSurface: mocks.addSurface,
+      zoomTo: vi.fn(),
+      render: vi.fn(),
+      clear: vi.fn()
+    })
+  }
+})
+import { MoleculePreviewRenderer } from './MoleculePreview'
+import { PdbPreviewRenderer } from './PdbPreview'
+
+const file = (name: string, mimeType?: string): PreviewFileItem => ({
+  id: name,
+  sessionId: 's',
+  title: name,
+  type: 'file',
+  path: `/workspace/${name}`,
+  name,
+  mimeType,
+  format: getPreviewFormatForFile({ name, mimeType })
+})
+const ready = (content: string, truncated = false): void => {
+  mocks.state = {
+    status: 'ready',
+    preview: { content, encoding: 'utf8', truncated },
+    pagination: { pageNumber: 1, hasPrevious: false, hasNext: false }
+  }
+}
+beforeEach(() => {
+  vi.spyOn(HTMLElement.prototype, 'clientWidth', 'get').mockReturnValue(640)
+  vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockReturnValue(400)
+  mocks.atoms = []
+  mocks.addSurface.mockReset().mockResolvedValue(undefined)
+})
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+const structure = (): Element | null =>
+  document.querySelector('[aria-label^="Structure preview"] svg')
+
+it.each(['smi', 'sdf'])(
+  'SC01: labels the first record and exposes complete %s source',
+  async (ext) => {
+    const content =
+      ext === 'smi'
+        ? 'CCO ethanol\nc1ccccc1 benzene'
+        : ['CCO', 'c1ccccc1']
+            .map((s) => Molecule.fromSmiles(s).toMolfile() + '\n> <NAME>\nrecord-name\n\n$$$$\n')
+            .join('')
+    const parsed = ext === 'smi' ? Molecule.fromSmiles(content) : Molecule.fromMolfile(content)
+    expect(parsed.getMolecularFormula().formula).toBe('C2H6O')
+    ready(content)
+    render(<MoleculePreviewRenderer item={file(`records.${ext}`)} />)
+    await waitFor(() => expect(structure()).not.toBeNull())
+    expect(screen.getByText('Only the first record is previewed.')).toBeTruthy()
+    fireEvent.click(screen.getByRole('button', { name: 'Source' }))
+    expect(document.querySelector('code')?.textContent).toContain(
+      ext === 'smi' ? 'benzene' : 'record-name'
+    )
+  }
+)
+it.each(['smi', 'sdf'])('keeps truncated %s in source view', (ext) => {
+  ready('partial record', true)
+  render(<MoleculePreviewRenderer item={file(`large.${ext}`)} />)
+  expect(document.querySelector('code')?.textContent).toContain('partial record')
+  expect(structure()).toBeNull()
+})
+it('SC05: uses SMILES MIME for an extensionless structure', async () => {
+  ready('CCO')
+  const item = file('structure', 'chemical/x-daylight-smiles')
+  expect(item.format).toBe('molecule')
+  render(<MoleculePreviewRenderer item={item} />)
+  await waitFor(() => expect(structure()?.querySelectorAll('circle')).toHaveLength(3))
+})
+it('SC05: rejects a parsed zero-atom molfile', async () => {
+  expect(Molecule.fromMolfile('CCO').getAllAtoms()).toBe(0)
+  ready('CCO')
+  render(<MoleculePreviewRenderer item={file('invalid.mol')} />)
+  await waitFor(() => expect(screen.getByText(/No atoms found/)).toBeTruthy())
+  expect(structure()).toBeNull()
+})
+it('SC05: uses RXN MIME for an extensionless reaction', async () => {
+  const reaction = Reaction.create()
+  reaction.addReactant(Molecule.fromSmiles('CCO'))
+  reaction.addProduct(Molecule.fromSmiles('CC=O'))
+  ready(reaction.toRxn())
+  render(<MoleculePreviewRenderer item={file('reaction', 'chemical/x-mdl-rxnfile')} />)
+  await waitFor(() =>
+    expect(document.querySelectorAll('[aria-label^="Structure preview"] svg')).toHaveLength(2)
+  )
+})
+const atom = (serial: number, element = 'C', alt = ' '): string =>
+  `HETATM${String(serial).padStart(5)}  ${element.padEnd(3)}${alt}LIG A   1       ${serial.toFixed(3).padStart(5)}   0.000   0.000  1.00 20.00          ${element.padStart(2)}  `
+it.each([
+  [
+    'two models',
+    `MODEL        1\n${atom(1)}\n${atom(2)}\nENDMDL\nMODEL        2\n${atom(3)}\nENDMDL`,
+    2
+  ],
+  ['hydrogen', `${atom(1)}\n${atom(2, 'H')}`, 1],
+  ['alternate locations', `${atom(1, 'C', 'A')}\n${atom(2, 'C', 'B')}`, 1],
+  ['unfiltered control', `${atom(1)}\n${atom(2)}`, 2]
+])('SC02: reports parsed atoms for %s', async (_label, content, count) => {
+  ready(content)
+  render(<PdbPreviewRenderer item={file('structure.pdb')} />)
+  await waitFor(() => expect(mocks.atoms).toHaveLength(count))
+  expect(screen.getByText(`${count} atoms`)).toBeTruthy()
+  if (_label !== 'unfiltered control') expect(screen.getByText(/Hydrogens are hidden/)).toBeTruthy()
+  if (content.includes('MODEL')) expect(screen.getByText(/Previewing model 1 of 2\./)).toBeTruthy()
+})
+it('SC04: reports pending and failed surface generation and allows another attempt', async () => {
+  let reject!: (reason: Error) => void
+  mocks.addSurface.mockImplementationOnce(
+    () =>
+      new Promise((_resolve, rejectPromise) => {
+        reject = rejectPromise
+      })
+  )
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  ready(atom(1))
+  render(<PdbPreviewRenderer item={file('structure.pdb')} />)
+  await waitFor(() => expect(mocks.atoms).toHaveLength(1))
+  fireEvent.click(screen.getByRole('button', { name: 'Surface' }))
+  await waitFor(() => expect(mocks.addSurface).toHaveBeenCalledOnce())
+  expect(screen.getByRole('status').textContent).toContain('Generating surface')
+  fireEvent.click(screen.getByRole('button', { name: 'Surface' }))
+  expect(screen.getByRole('status').textContent).toContain('Generating surface')
+  await act(async () => reject(new Error('surface failure')))
+  expect(screen.getByRole('alert').textContent).toContain('Surface could not be generated')
+  expect(screen.getByRole('button', { name: 'Stick' }).getAttribute('aria-pressed')).toBe('true')
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+  await waitFor(() => expect(mocks.addSurface).toHaveBeenCalledTimes(2))
+})
+
+it('ignores a stale surface failure after switching styles', async () => {
+  let reject!: (reason: Error) => void
+  mocks.addSurface.mockImplementationOnce(
+    () =>
+      new Promise((_resolve, rejectPromise) => {
+        reject = rejectPromise
+      })
+  )
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  ready(atom(1))
+  render(<PdbPreviewRenderer item={file('structure.pdb')} />)
+  await waitFor(() => expect(mocks.atoms).toHaveLength(1))
+  fireEvent.click(screen.getByRole('button', { name: 'Surface' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Sphere' }))
+  await act(async () => reject(new Error('stale surface')))
+  expect(screen.queryByRole('alert')).toBeNull()
+  expect(screen.queryByRole('status')).toBeNull()
+  expect(screen.getByRole('button', { name: 'Sphere' }).getAttribute('aria-pressed')).toBe('true')
+})
+it('keeps an explicit SMILES extension ahead of conflicting MIME metadata', async () => {
+  ready('CCO')
+  render(<MoleculePreviewRenderer item={file('structure.smi', 'chemical/x-mdl-molfile')} />)
+  await waitFor(() => expect(structure()?.querySelectorAll('circle')).toHaveLength(3))
+})

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4810,6 +4810,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "Andere Vergleiche werden ausgeführt. Warten Sie, bis sie abgeschlossen sind, und versuchen Sie es erneut.",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "Der Versionsspeicher ist nicht verfügbar. Prüfen Sie, ob der Speicherort erreichbar ist, und versuchen Sie es erneut.",
     "This comparison could not be completed. Return to the version preview to check the file.": "Dieser Vergleich konnte nicht abgeschlossen werden. Kehren Sie zur Versionsvorschau zurück, um die Datei zu prüfen.",
-    "View version": "Version anzeigen"
+    "View version": "Version anzeigen",
+    "Only the first record is previewed.": "Nur der erste Datensatz wird in der Vorschau angezeigt.",
+    "No atoms found": "Keine Atome gefunden",
+    "Previewing model 1 of {{total}}.": "Vorschau von Modell 1 von {{total}}.",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Wasserstoffatome sind ausgeblendet; alternative Positionen verwenden ein Leerzeichen oder A. Die Atomzahl bezieht sich auf das angezeigte Modell.",
+    "Generating surface…": "Oberfläche wird erzeugt…",
+    "Surface could not be generated. Showing sticks.": "Die Oberfläche konnte nicht erzeugt werden. Stäbchen werden angezeigt."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4972,6 +4972,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "Hay otras comparaciones en curso. Espere a que terminen y vuelva a intentarlo.",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "El almacenamiento de versiones no está disponible. Compruebe que la ubicación sea accesible y vuelva a intentarlo.",
     "This comparison could not be completed. Return to the version preview to check the file.": "No se pudo completar la comparación. Vuelva a la vista previa de la versión para comprobar el archivo.",
-    "View version": "Ver versión"
+    "View version": "Ver versión",
+    "Only the first record is previewed.": "Solo se muestra una vista previa del primer registro.",
+    "No atoms found": "No se encontraron átomos",
+    "Previewing model 1 of {{total}}.": "Vista previa del modelo 1 de {{total}}.",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Los hidrógenos están ocultos; las posiciones alternativas usan un espacio o A. El número de átomos corresponde al modelo mostrado.",
+    "Generating surface…": "Generando superficie…",
+    "Surface could not be generated. Showing sticks.": "No se pudo generar la superficie. Se muestra en forma de varillas."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4972,6 +4972,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "D’autres comparaisons sont en cours. Attendez leur fin, puis réessayez.",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "Le stockage des versions est indisponible. Vérifiez que son emplacement est accessible, puis réessayez.",
     "This comparison could not be completed. Return to the version preview to check the file.": "Cette comparaison n’a pas pu aboutir. Revenez à l’aperçu de la version pour vérifier le fichier.",
-    "View version": "Voir la version"
+    "View version": "Voir la version",
+    "Only the first record is previewed.": "Seul le premier enregistrement est affiché en aperçu.",
+    "No atoms found": "Aucun atome trouvé",
+    "Previewing model 1 of {{total}}.": "Aperçu du modèle 1 sur {{total}}.",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Les hydrogènes sont masqués ; les positions alternatives utilisent un espace ou A. Le nombre d’atomes correspond au modèle affiché.",
+    "Generating surface…": "Génération de la surface…",
+    "Surface could not be generated. Showing sticks.": "Impossible de générer la surface. Affichage en bâtonnets."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4656,6 +4656,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "他の比較を実行中です。完了してから再試行してください。",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "バージョンの保存先を利用できません。保存先にアクセスできることを確認してから再試行してください。",
     "This comparison could not be completed. Return to the version preview to check the file.": "比較を完了できませんでした。バージョンのプレビューに戻ってファイルを確認してください。",
-    "View version": "バージョンを表示"
+    "View version": "バージョンを表示",
+    "Only the first record is previewed.": "最初のレコードのみプレビューしています。",
+    "No atoms found": "原子が見つかりません",
+    "Previewing model 1 of {{total}}.": "{{total}} 個中のモデル 1 をプレビューしています。",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "水素原子は非表示です。代替位置は空白または A を使用します。原子数は表示中のモデルのものです。",
+    "Generating surface…": "表面を生成中…",
+    "Surface could not be generated. Showing sticks.": "表面を生成できませんでした。スティック表示に戻しました。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4654,6 +4654,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "다른 비교가 실행 중입니다. 완료될 때까지 기다린 후 다시 시도하세요.",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "버전 저장소를 사용할 수 없습니다. 저장 위치에 접근할 수 있는지 확인한 후 다시 시도하세요.",
     "This comparison could not be completed. Return to the version preview to check the file.": "비교를 완료하지 못했습니다. 버전 미리보기로 돌아가 파일을 확인하세요.",
-    "View version": "버전 보기"
+    "View version": "버전 보기",
+    "Only the first record is previewed.": "첫 번째 레코드만 미리 봅니다.",
+    "No atoms found": "원자를 찾을 수 없습니다",
+    "Previewing model 1 of {{total}}.": "모델 {{total}}개 중 1번을 미리 봅니다.",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "수소 원자는 숨깁니다. 대체 위치는 공백 또는 A를 사용합니다. 원자 수는 표시된 모델 기준입니다.",
+    "Generating surface…": "표면 생성 중…",
+    "Surface could not be generated. Showing sticks.": "표면을 생성하지 못했습니다. 막대 형태로 표시합니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5105,6 +5105,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "Выполняются другие сравнения. Дождитесь их завершения и повторите попытку.",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "Хранилище версий недоступно. Проверьте доступность места хранения и повторите попытку.",
     "This comparison could not be completed. Return to the version preview to check the file.": "Не удалось завершить сравнение. Вернитесь к предпросмотру версии, чтобы проверить файл.",
-    "View version": "Открыть версию"
+    "View version": "Открыть версию",
+    "Only the first record is previewed.": "В предпросмотре показана только первая запись.",
+    "No atoms found": "Атомы не найдены",
+    "Previewing model 1 of {{total}}.": "Предпросмотр модели 1 из {{total}}.",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "Атомы водорода скрыты; для альтернативных положений используются пробел или A. Число атомов относится к отображаемой модели.",
+    "Generating surface…": "Создание поверхности…",
+    "Surface could not be generated. Showing sticks.": "Не удалось создать поверхность. Показана стержневая модель."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4656,6 +4656,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "其他比较正在进行。请等待完成后重试。",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "版本存储不可用。请确认存储位置可以访问后重试。",
     "This comparison could not be completed. Return to the version preview to check the file.": "无法完成此次比较。请返回版本预览检查文件。",
-    "View version": "查看版本"
+    "View version": "查看版本",
+    "Only the first record is previewed.": "仅预览首条记录。",
+    "No atoms found": "未找到原子",
+    "Previewing model 1 of {{total}}.": "正在预览第 1 个模型，共 {{total}} 个。",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "隐藏氢原子；替代位置使用空白或 A。原子数指当前显示的模型。",
+    "Generating surface…": "正在生成表面…",
+    "Surface could not be generated. Showing sticks.": "无法生成表面。已显示为棍状。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4656,6 +4656,12 @@
     "Other comparisons are running. Wait for them to finish, then retry.": "其他比較正在進行。請等待完成後重試。",
     "Version storage is unavailable. Check that the storage location is accessible, then retry.": "版本儲存空間無法使用。請確認儲存位置可以存取後重試。",
     "This comparison could not be completed. Return to the version preview to check the file.": "無法完成此次比較。請返回版本預覽檢查檔案。",
-    "View version": "查看版本"
+    "View version": "查看版本",
+    "Only the first record is previewed.": "僅預覽首筆記錄。",
+    "No atoms found": "找不到原子",
+    "Previewing model 1 of {{total}}.": "正在預覽第 1 個模型，共 {{total}} 個。",
+    "Hydrogens are hidden; alternate locations use blank or A. Atom count refers to the displayed model.": "隱藏氫原子；替代位置使用空白或 A。原子數指目前顯示的模型。",
+    "Generating surface…": "正在產生表面…",
+    "Surface could not be generated. Showing sticks.": "無法產生表面。已顯示為棍狀。"
   }
 }


### PR DESCRIPTION
## Problem

Scientific previews can imply that a single structure represents a complete multi-record file. PDB atom counts include records that 3Dmol does not display, surface failures are invisible, extensionless SMILES/RXN files use the wrong parser, and a small multi-sequence FASTA thumbnail can create 24,000 SVG rectangles.

## Proposed change

- SC01: label first-record molecule previews, parse only the first non-empty SMILES line, and expose full source including SDF records/properties.
- SC02: count atoms from the parsed model and disclose the first-model scope and hydrogen/alternate-location defaults.
- SC03: cap FASTA thumbnails at six rows by eight columns (48 rectangles).
- SC04: show surface progress, restore sticks on failure, offer retry, and ignore stale completions.
- SC05: share extension/MIME molecule-format resolution and reject zero-atom structures.
- Translate the added UI copy in all eight locales.

## Scope and non-goals

- Historical compatibility: no migration or legacy data adapter is required; input files remain unchanged.
- Added state: component-local `showSource`, parsed atom count, surface `pending`/`error`/idle state, and a render-generation guard. The molecule format union describes existing formats; no persisted or protocol enum is extended.
- Persistence: no database, storage format, IPC, or backend changes.
- No multi-record navigation, conformer animation, SDF property editor, new dependency, or new production test seam.

## Acceptance criteria and validation

The original implementation failed ten targeted regression cases for the reported reasons before changes. The branch was rebased onto `origin/main` at `3cc81113` at the maintainer’s request. All checks below ran after the final rebase and translation-conflict resolution (head `153b23f5`). All upstream strings, including source-navigation and version-comparison copy, and the six scientific-preview strings per locale were retained.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| SC01, SC02, SC04, SC05; truncated-source and normal-model controls | `npx vitest run src/renderer/src/pages/workspace/previews/renderers/scientific-preview.test.tsx` | Pass; real OpenChemLib and installed 3Dmol parser |
| Existing molecule/reaction behavior | `MoleculePreview.test.tsx`, `reaction-markup.test.ts` in the same renderer directory | Pass |
| Renderer dispatch and complete preview consumer | `previews/PreviewFileContent.test.tsx`, `previews/preview-registry.test.tsx`, `preview-support.test.ts` | Pass |
| SC03 and thumbnail consumers | `artifact-preview.test.tsx`, `artifact-preview.interaction.test.tsx`, `artifact-preview-tiff.test.tsx` | Pass |
| All locale keys and translation contracts | `npx vitest run src/renderer/src/i18n/resources.test.ts` | Pass |
| Renderer types | `npm run typecheck:web` | Pass |
| Repository lint | `npm run lint` | Pass |

The ten explicitly selected test files passed 965 tests together. The upstream SourcePreview/JsonPreview consumer suites passed another 18 tests (983 total across 12 files). Renderer typecheck and repository lint also passed after the rebase. `npm run test:affected:explain -- --base origin/main --head HEAD` reports unknown ownership for the preview files and falls back to full. Per maintainer instruction, local validation uses the explicit owner/consumer checks above rather than rerunning the full suite; PR CI remains authoritative for complete and platform coverage. No ownership manifest or CI routing was changed.

Browser verification used production components, fixture file reads, real OpenChemLib SVG output, and real 3Dmol WebGL in ego-browser. Verified 48 FASTA rectangles, three displayed non-hydrogen atoms in a two-model PDB, both SDF records/properties in Source, visible surface failure, and successful real surface generation after Retry. Surface rejection was controlled fault injection, not a claim of reproducing a hardware/driver failure. Screenshots were captured for the maintainer. This is component-level browser evidence, not a full Electron end-to-end run.

## Review focus

Confirm that the displayed scope is unambiguous, source access preserves all records/properties, and stale surface work cannot overwrite the current style. Independent PR review and selected exact-head CI checks remain required. No OS path-handling, persistence, or backend interfaces changed; cross-platform CI is the remaining platform authority.
