### PR TITLE
fix(preview): preserve drafts across restores and layout changes

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -200,6 +200,7 @@
           "src/renderer/src/pages/workspace/WorkspacePage.image-staging.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.pending-switch.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx",
+          "src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx",
           "src/renderer/src/pages/workspace/WorkspacePage.specialist-barrier.test.tsx",
           "src/renderer/src/pages/workspace/ComposerMessageQueue.interaction.test.tsx",

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -51,6 +51,43 @@ afterEach(async () => {
 })
 
 describe('preview state repository (integration)', () => {
+  it.each([false, true])(
+    'round-trips 100 files and the active first file (Subagents: %s)',
+    async (withSubagents) => {
+      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-limit-'))
+      const client = createProjectDbClient(storageRoot)
+      disconnect = () => client.$disconnect()
+      await migrateApplicationDatabase(client)
+      await client.project.create({ data: { id: 'project-a', name: 'Project A' } })
+      const repository = new PreviewStateRepository(() => Promise.resolve(client))
+      const items = Array.from({ length: 100 }, (_, index) => ({
+        ...createState().items[0]!,
+        id: `file-${index}`
+      }))
+      const subagents = withSubagents
+        ? {
+            id: 'tool:session-1:subagents',
+            sessionId: 'session-1',
+            title: 'Subagents',
+            type: 'tool' as const,
+            toolKind: 'subagents' as const,
+            selectedAgentFrameId: 'child-1'
+          }
+        : undefined
+      await expect(
+        repository.save('project-a', createState({ items, activeItemId: 'file-0', subagents }), 0)
+      ).resolves.toMatchObject({ status: 'saved' })
+      const row = await client.projectPreviewState.findUniqueOrThrow({
+        where: { projectId: 'project-a' }
+      })
+      expect(JSON.parse(row.items)).toHaveLength(withSubagents ? 101 : 100)
+      const loaded = await repository.get('project-a')
+      expect.soft(loaded?.state.items).toHaveLength(100)
+      expect.soft(loaded?.state.activeItemId).toBe('file-0')
+      expect(loaded?.state.subagents).toEqual(subagents)
+    }
+  )
+
   it('treats a late save after Project deletion as a no-op without touching another Project', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-preview-'))
 

--- a/src/main/projects/preview-repository.test.ts
+++ b/src/main/projects/preview-repository.test.ts
@@ -1,7 +1,7 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 // Item-path encode/decode falls back to resolveDataRoot(), which reads electron's app.getPath.
 vi.mock('electron', () => ({
@@ -9,6 +9,7 @@ vi.mock('electron', () => ({
 }))
 
 import type { PersistedPreviewState } from '../../shared/preview-state'
+import { initDataRoot } from '../storage-root'
 import { PreviewStateRepository, type PreviewStateClient } from './preview-repository'
 import { createProjectDbClient, migrateApplicationDatabase } from './prisma-client'
 
@@ -40,7 +41,13 @@ const createState = (overrides: Partial<PersistedPreviewState> = {}): PersistedP
   ...overrides
 })
 
+beforeEach(() => {
+  // Match application startup: path encoding must not probe legacy home directories for every tab.
+  initDataRoot(DATA_ROOT)
+})
+
 afterEach(async () => {
+  initDataRoot(undefined)
   await disconnect?.()
   disconnect = undefined
 

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx
@@ -1073,7 +1073,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
   })
 
-  it('restores the authoritative snapshot and advances after a save conflict', async () => {
+  it('rebases the rejected local change and advances after a save conflict', async () => {
     await act(async () => {
       root.render(<PersistenceHarness projectId="project-a" />)
       await flushPreviewPersistence()
@@ -1108,17 +1108,20 @@ describe('usePreviewPersistence per-project save/restore', () => {
     })
     await flushPreviewPersistence()
 
-    expect(save).toHaveBeenCalledTimes(1)
+    expect(save).toHaveBeenCalledTimes(2)
     expect(usePreviewWorkbenchStore.getState()).toMatchObject({
-      activeItemId: serverItem.id,
-      items: [expect.objectContaining({ id: serverItem.id })]
+      activeItemId: createStoredFileItem().id,
+      items: [
+        expect.objectContaining({ id: serverItem.id }),
+        expect.objectContaining({ id: createStoredFileItem().id })
+      ]
     })
 
     save.mockResolvedValueOnce({ status: 'saved', revision: 11 })
     act(() => usePreviewWorkbenchStore.getState().collapsePanel())
     await flushPreviewPersistence()
 
-    expect(save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedRevision: 10 }))
+    expect(save).toHaveBeenLastCalledWith(expect.objectContaining({ expectedRevision: 11 }))
   })
 
   it('rebases a user change queued after the conflicting snapshot', async () => {
@@ -1183,6 +1186,7 @@ describe('usePreviewPersistence per-project save/restore', () => {
         activeItemId: queuedItem.id,
         items: [
           expect.objectContaining({ id: serverItem.id }),
+          expect.objectContaining({ id: submittedItem.id }),
           expect.objectContaining({ id: queuedItem.id })
         ]
       })

--- a/src/renderer/src/lib/preview-persistence/preview-persistence.ts
+++ b/src/renderer/src/lib/preview-persistence/preview-persistence.ts
@@ -154,7 +154,7 @@ const indexAuthoritativeArtifactIds = (sessions: ChatSession[]): ReadonlyMap<str
 }
 
 // Applies only the changes made after `base` to the authoritative state. This preserves remote tabs
-// while retaining user actions that happened after the conflicting save had already started.
+// while retaining local actions since the last accepted snapshot, including the rejected write.
 const rebasePreviewState = (
   base: PersistedPreviewState,
   local: PersistedPreviewState,
@@ -249,7 +249,10 @@ const createPreviewSaveScheduler = (
       try {
         while (queue.pendingState) {
           const nextState = queue.pendingState
-          const nextBaseState = queue.pendingBaseState
+          const nextBaseState =
+            queue.pendingBaseState ??
+            acceptedStates.get(projectId) ??
+            createEmptyPersistedPreviewState()
           queue.pendingState = undefined
           queue.pendingBaseState = undefined
           queue.inFlightState = nextState
@@ -263,8 +266,8 @@ const createPreviewSaveScheduler = (
             if (result.status === 'conflict') {
               const authoritativeState =
                 result.snapshot?.state ?? createEmptyPersistedPreviewState()
-              const localState = queue.pendingState ?? (nextBaseState ? nextState : undefined)
-              const localBaseState = queue.pendingState ? nextState : nextBaseState
+              const localState = queue.pendingState ?? nextState
+              const localBaseState = nextBaseState
               const revision = result.snapshot?.revision ?? 0
               revisions.set(projectId, revision)
               acceptedStates.set(projectId, authoritativeState)
@@ -484,6 +487,15 @@ const toRestoredSlice = (
 
 const suppressedConflictRestoreSaves = new Set<string>()
 
+const applyPreviewRestore = (projectId: string, apply: () => boolean): boolean => {
+  suppressedConflictRestoreSaves.add(projectId)
+  try {
+    return apply()
+  } finally {
+    suppressedConflictRestoreSaves.delete(projectId)
+  }
+}
+
 const restorePreviewConflict = (projectId: string, snapshot: PreviewStateSnapshot | null): void => {
   const store = usePreviewWorkbenchStore.getState()
   // The next activation will merge a fresh durable snapshot into the cached runtime-owned tabs.
@@ -492,15 +504,12 @@ const restorePreviewConflict = (projectId: string, snapshot: PreviewStateSnapsho
   const projectSessions = useSessionStore
     .getState()
     .sessions.filter((session) => session.projectId === projectId)
-  suppressedConflictRestoreSaves.add(projectId)
-  try {
-    store.activateProject(
-      projectId,
-      snapshot ? toRestoredSlice(snapshot.state, projectSessions) : { items: [] }
-    )
-  } finally {
-    suppressedConflictRestoreSaves.delete(projectId)
-  }
+  store.activateProject(
+    projectId,
+    snapshot ? toRestoredSlice(snapshot.state, projectSessions) : { items: [] },
+    false,
+    (apply) => applyPreviewRestore(projectId, apply)
+  )
 }
 
 // WorkspacePage can unmount while an IPC save is still in flight. Keep one renderer-lifetime scheduler
@@ -573,7 +582,9 @@ export const usePreviewPersistence = (
         .getState()
         .activateProject(
           activeProjectId,
-          snapshot ? toRestoredSlice(snapshot.state, projectSessions) : undefined
+          snapshot ? toRestoredSlice(snapshot.state, projectSessions) : undefined,
+          false,
+          (apply) => !cancelled && applyPreviewRestore(activeProjectId, apply)
         )
     }
 

--- a/src/renderer/src/pages/workspace/MobilePreviewSheet.tsx
+++ b/src/renderer/src/pages/workspace/MobilePreviewSheet.tsx
@@ -108,7 +108,7 @@ const MobilePreviewSheet = ({
         <div
           ref={setContentRef}
           tabIndex={-1}
-          role={isMobile ? 'dialog' : undefined}
+          role={modalOpen ? 'dialog' : undefined}
           aria-modal={modalOpen || undefined}
           aria-label={isMobile ? t('Preview') : undefined}
           aria-description={

--- a/src/renderer/src/pages/workspace/MobilePreviewSheet.tsx
+++ b/src/renderer/src/pages/workspace/MobilePreviewSheet.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useRef } from 'react'
+import { FocusScope } from '@radix-ui/react-focus-scope'
 import { X } from 'lucide-react'
-import * as Dialog from '@/components/ui/dialog'
+import { useChildLayerDismissalGuard } from '@/components/ui/use-child-layer-dismissal-guard'
 import { useTranslation } from 'react-i18next'
 
 import { PreviewPanelSurface } from './PreviewPanel'
@@ -7,6 +9,7 @@ import type { RestoredPlanResponder } from './session-plan/SessionPlanSurfaces'
 import type { PreviewInteractionPort } from './previews/preview-types'
 
 type MobilePreviewSheetProps = PreviewInteractionPort & {
+  isMobile?: boolean
   open: boolean
   onClose: () => void
   restoredPlanResponder?: RestoredPlanResponder
@@ -16,6 +19,7 @@ type MobilePreviewSheetProps = PreviewInteractionPort & {
 // Mobile workbench presentation: generated files, code, and notebooks keep the desktop tab model,
 // but rise from the bottom so the conversation remains the primary screen.
 const MobilePreviewSheet = ({
+  isMobile = true,
   open,
   onClose,
   restoredPlanResponder,
@@ -23,42 +27,135 @@ const MobilePreviewSheet = ({
   ...annotationPort
 }: MobilePreviewSheetProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const surfaceRef = useRef<HTMLDivElement>(null)
+  const modalOpen = isMobile && open
+  const { setContentRef, onInteractOutside } = useChildLayerDismissalGuard(surfaceRef)
+
+  useEffect(() => {
+    if (!modalOpen) return
+    const surface = surfaceRef.current
+    if (!surface) return
+    const previousFocus = document.activeElement
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    // The sheet stays inline to preserve the editor. Isolate siblings along its ancestor path,
+    // rather than making the app root (which now contains the sheet) inert.
+    const isolated: { element: HTMLElement; inert: boolean; hidden: string | null }[] = []
+    for (
+      let child: HTMLElement = surface;
+      child.parentElement && child.parentElement !== document.body;
+      child = child.parentElement
+    ) {
+      for (const sibling of child.parentElement.children) {
+        if (
+          sibling === child ||
+          !(sibling instanceof HTMLElement) ||
+          sibling.hasAttribute('data-preview-sheet-overlay')
+        )
+          continue
+        isolated.push({
+          element: sibling,
+          inert: sibling.inert,
+          hidden: sibling.getAttribute('aria-hidden')
+        })
+        sibling.setAttribute('inert', '')
+        sibling.setAttribute('aria-hidden', 'true')
+      }
+    }
+    if (!surface.contains(previousFocus)) surface.focus()
+    return () => {
+      for (const { element, inert, hidden } of isolated) {
+        if (inert) element.setAttribute('inert', '')
+        else element.removeAttribute('inert')
+        if (hidden === null) element.removeAttribute('aria-hidden')
+        else element.setAttribute('aria-hidden', hidden)
+      }
+      document.body.style.overflow = previousOverflow
+      if (
+        previousFocus instanceof HTMLElement &&
+        previousFocus.isConnected &&
+        surface.hidden &&
+        (surface.contains(document.activeElement) || document.activeElement === document.body) &&
+        !previousFocus.closest('[inert], [hidden]')
+      )
+        previousFocus.focus()
+    }
+  }, [modalOpen])
 
   return (
-    <Dialog.Root open={open} onOpenChange={(next) => (next ? undefined : onClose())}>
-      <Dialog.Portal>
-        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/45 data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 motion-reduce:data-[state=closed]:animate-none motion-reduce:data-[state=open]:animate-none" />
-        <Dialog.Content
-          data-testid="mobile-preview-sheet"
-          className="fixed inset-x-0 bottom-0 z-[60] flex h-[min(82dvh,760px)] flex-col overflow-hidden rounded-t-2xl border border-b-0 border-border-200 bg-bg-10 pb-[env(safe-area-inset-bottom)] text-text-000 shadow-dialog outline-none data-[state=closed]:animate-out data-[state=open]:animate-in data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom motion-reduce:data-[state=closed]:animate-none motion-reduce:data-[state=open]:animate-none"
+    <>
+      {modalOpen ? (
+        <div
+          data-preview-sheet-overlay
+          aria-hidden="true"
+          className="fixed inset-0 z-50 bg-black/45"
+          onPointerDown={(event) => {
+            onInteractOutside({
+              detail: { originalEvent: event.nativeEvent },
+              preventDefault: () => event.preventDefault()
+            })
+            if (!event.defaultPrevented) onClose()
+          }}
+        />
+      ) : null}
+      <FocusScope
+        asChild
+        loop={modalOpen}
+        trapped={modalOpen}
+        onMountAutoFocus={(event) => event.preventDefault()}
+        onUnmountAutoFocus={(event) => event.preventDefault()}
+      >
+        <div
+          ref={setContentRef}
+          tabIndex={-1}
+          role={isMobile ? 'dialog' : undefined}
+          aria-modal={modalOpen || undefined}
+          aria-label={isMobile ? t('Preview') : undefined}
+          aria-description={
+            isMobile ? t('Open files, generated artifacts, code, and notebooks.') : undefined
+          }
+          hidden={isMobile && !open}
+          data-testid={isMobile && open ? 'mobile-preview-sheet' : undefined}
+          onKeyDown={(event) => {
+            if (modalOpen && event.key === 'Escape' && !event.defaultPrevented) {
+              event.preventDefault()
+              event.stopPropagation()
+              onClose()
+            }
+          }}
+          className={
+            isMobile
+              ? 'fixed inset-x-0 bottom-0 z-[60] h-[min(82dvh,760px)] overflow-hidden rounded-t-2xl border border-b-0 border-border-200 bg-bg-10 pb-[env(safe-area-inset-bottom)] text-text-000 shadow-dialog outline-none'
+              : 'h-full min-h-0 outline-none'
+          }
         >
-          <div className="flex shrink-0 items-center gap-3 border-b border-border-200 px-4 py-2.5">
-            <div className="h-1 w-10 rounded-full bg-border-300 md:hidden" aria-hidden="true" />
-            <Dialog.Title className="min-w-0 flex-1 text-sm font-semibold">
-              {t('Preview')}
-            </Dialog.Title>
-            <Dialog.Description className="sr-only">
-              {t('Open files, generated artifacts, code, and notebooks.')}
-            </Dialog.Description>
-            <Dialog.Close asChild>
+          <div className="flex h-full min-h-0 flex-col">
+            <div
+              hidden={!isMobile}
+              className="shrink-0 items-center gap-3 border-b border-border-200 px-4 py-2.5"
+              style={isMobile ? { display: 'flex' } : undefined}
+            >
+              <div className="h-1 w-10 rounded-full bg-border-300 md:hidden" aria-hidden="true" />
+              <h2 className="min-w-0 flex-1 text-sm font-semibold">{t('Preview')}</h2>
               <button
                 type="button"
                 className="grid size-8 shrink-0 place-items-center rounded-lg text-text-300 hover:bg-bg-200 hover:text-text-000"
                 aria-label={t('Close preview')}
+                onClick={onClose}
               >
                 <X className="size-4" aria-hidden="true" />
               </button>
-            </Dialog.Close>
+            </div>
+            <PreviewPanelSurface
+              className="min-h-0 flex-1"
+              restoredPlanResponder={restoredPlanResponder}
+              {...annotationPort}
+              onPdfContextError={onPdfContextError}
+            />
           </div>
-          <PreviewPanelSurface
-            className="min-h-0 flex-1"
-            restoredPlanResponder={restoredPlanResponder}
-            {...annotationPort}
-            onPdfContextError={onPdfContextError}
-          />
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        </div>
+      </FocusScope>
+    </>
   )
 }
 

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1758,8 +1758,8 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
           onConfirm={() => {
             const action = pendingLeaveAction
             setPendingLeaveAction(undefined)
-            discardEdit()
-            if (action) previewLeaveGuards.runApproved(leaveGuardScope, action)
+            // A deferred restore may have become obsolete while the confirmation was open.
+            if (!action || previewLeaveGuards.runApproved(leaveGuardScope, action)) discardEdit()
           }}
         />
       </ActionMenuProvider>

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -40,6 +40,8 @@ import { usePdfContextAction } from './use-pdf-context-action'
 import { requestComposerFocus } from './composer-focus-events'
 
 type PreviewPanelProps = PreviewInteractionPort & {
+  children?: React.ReactNode
+  isMobile?: boolean
   panelRef: React.Ref<PanelImperativeHandle>
   defaultSize: string
   minSize: string
@@ -937,6 +939,8 @@ const PreviewPanelSurface = ({
 
 // Desktop right-side workbench: a tab strip over every previewed file, plus active content.
 const PreviewPanel = ({
+  children,
+  isMobile = false,
   panelRef,
   defaultSize,
   minSize,
@@ -952,7 +956,7 @@ const PreviewPanel = ({
     _panelId: string | number | undefined,
     previousPanelSize: PanelSize | undefined
   ): void => {
-    onResize(panelSize, previousPanelSize)
+    if (!isMobile) onResize(panelSize, previousPanelSize)
   }
 
   return (
@@ -961,18 +965,22 @@ const PreviewPanel = ({
       // The parent drives expand/collapse in response to store open requests and header toggles.
       panelRef={panelRef}
       defaultSize={defaultSize}
-      minSize={minSize}
+      minSize={isMobile ? '0%' : minSize}
+      maxSize={isMobile ? '0%' : undefined}
+      disabled={isMobile}
       collapsible
       collapsedSize="0%"
       onResize={handleResize}
     >
-      <PreviewPanelSurface
-        restoredPlanResponder={restoredPlanResponder}
-        onPdfContextError={onPdfContextError}
-        onLinkReadingContext={onLinkReadingContext}
-        onUnlinkReadingContext={onUnlinkReadingContext}
-        {...annotationPort}
-      />
+      {children ?? (
+        <PreviewPanelSurface
+          restoredPlanResponder={restoredPlanResponder}
+          onPdfContextError={onPdfContextError}
+          onLinkReadingContext={onLinkReadingContext}
+          onUnlinkReadingContext={onUnlinkReadingContext}
+          {...annotationPort}
+        />
+      )}
     </ResizablePanel>
   )
 }

--- a/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.preview-panel-resize.test.tsx
@@ -241,11 +241,13 @@ vi.mock('./FilePreviewDialog', () => ({
 
 vi.mock('./PreviewPanel', () => ({
   PreviewPanel: ({
+    children,
     panelRef,
     defaultSize,
     minSize,
     onResize
   }: {
+    children?: React.ReactNode
     panelRef: React.Ref<PanelImperativeHandle>
     defaultSize: string
     minSize: string
@@ -264,7 +266,7 @@ vi.mock('./PreviewPanel', () => ({
       workspacePageHarness.previewPanelRef.current = workspacePageHarness.previewPanelHandle
     }
 
-    return <div data-testid="preview-panel" />
+    return <div data-testid="preview-panel">{children}</div>
   }
 }))
 
@@ -869,7 +871,7 @@ describe('WorkspacePage preview panel resize sync', () => {
     workspacePageHarness.isMobile = true
     await renderPage()
 
-    expect(container.querySelector('[data-testid="preview-panel"]')).toBeNull()
+    expect(container.querySelector('[data-testid="preview-panel"]')).not.toBeNull()
     expect(
       container.querySelector('[data-testid="mobile-preview-sheet"]')?.getAttribute('data-open')
     ).toBe('false')

--- a/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
@@ -376,6 +376,18 @@ describe('preview draft lifecycle', () => {
     expect(confirmation()).toBeNull()
   })
 
+  it('allows the workspace navigation shortcut when the mobile preview is closed', async () => {
+    viewport.mobile = true
+    usePreviewWorkbenchStore.getState().syncPanelState('collapsed')
+    await act(async () => root.render(<ResponsivePreview />))
+    await act(async () =>
+      window.dispatchEvent(new KeyboardEvent('keydown', { key: 'b', ctrlKey: true, bubbles: true }))
+    )
+    expect(
+      document.querySelector('[role="dialog"][aria-label="Workspace navigation"]')
+    ).not.toBeNull()
+  })
+
   it('isolates the mobile background, guards Escape, and preserves a nested confirmation across resizing', async () => {
     await act(async () =>
       root.render(

--- a/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
@@ -323,6 +323,25 @@ describe('preview draft lifecycle', () => {
     }
   )
 
+  it('applies an approved restore after unrelated composer state changes', async () => {
+    await act(async () => root.render(<PreviewPanelSurface />))
+    await startEditing()
+    await act(async () =>
+      usePreviewWorkbenchStore.getState().activateProject(projectId, { items: [] })
+    )
+    expect(confirmation()).not.toBeNull()
+    await act(async () =>
+      usePreviewWorkbenchStore.getState().setDraftStagedUploadIds(['new-attachment'])
+    )
+    await act(async () =>
+      confirmation()!.querySelector<HTMLButtonElement>('button:last-of-type')!.click()
+    )
+    expect(editor()).toBeNull()
+    expect(usePreviewWorkbenchStore.getState().items).toEqual([])
+    expect(usePreviewWorkbenchStore.getState().draftStagedUploadIds).toEqual(['new-attachment'])
+    expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+  })
+
   it('does not discard a draft for an obsolete restore after a newer tab action', async () => {
     await act(async () => root.render(<PreviewPanelSurface />))
     await startEditing()

--- a/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
@@ -1,0 +1,459 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  createInitialPreviewWorkbenchState,
+  usePreviewWorkbenchStore,
+  type PreviewFileItem
+} from '@/stores/preview-workbench-store'
+import { previewLeaveGuards } from '@/stores/preview-leave-guard'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { createInitialSessionState, useSessionStore } from '@/stores/session-store'
+import {
+  flushPreviewPersistence,
+  toPersistedPreviewState,
+  usePreviewPersistence
+} from '@/lib/preview-persistence/preview-persistence'
+import type { SavePreviewStateResult } from '../../../../shared/preview-state'
+
+const viewport = vi.hoisted(() => ({ mobile: false }))
+vi.mock('@/hooks/useMediaQuery', () => ({ useMediaQuery: () => viewport.mobile }))
+// jsdom supplies no panel geometry; keep the real workspace/preview/editor lifecycle beneath it.
+vi.mock('@/components/ui/resizable', () => ({
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizableHandle: () => <div />
+}))
+// Read-only rendering is irrelevant to editing: the real editor loads its baseline through inspect.
+vi.mock('./previews/PreviewFileContent', () => ({ PreviewFileContent: () => <div /> }))
+
+import { PreviewPanelSurface } from './PreviewPanel'
+import { WorkspacePanelLayout } from './workspace-panel-layout'
+
+let root: Root
+let container: HTMLDivElement
+let projectId: string
+let nextProject = 0
+const draft = '# Unsaved work\n'
+const file: PreviewFileItem = {
+  id: 'upload:readme',
+  type: 'file',
+  source: 'upload',
+  managedFileId: 'readme',
+  selectedVersionId: 'v1',
+  sessionId: 'session-1',
+  title: 'README.md',
+  name: 'README.md',
+  path: 'upload-version:project/session-1/readme/v1',
+  format: 'markdown'
+}
+
+const editor = (): HTMLTextAreaElement | null => document.body.querySelector('textarea')
+const confirmation = (): HTMLElement | null =>
+  document.body.querySelector('[data-testid="discard-preview-changes-confirmation"]')
+
+const startEditing = async (): Promise<void> => {
+  const button = document.body.querySelector<HTMLButtonElement>('[aria-label="Edit README.md"]')
+  expect(button).not.toBeNull()
+  await act(async () => button!.click())
+  expect(editor()?.value).toBe('# Current\n')
+  await act(async () => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+      editor(),
+      draft
+    )
+    editor()!.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  expect(editor()?.value).toBe(draft)
+}
+
+const PersistentPreview = (): React.JSX.Element => {
+  usePreviewPersistence(projectId, true)
+  return <PreviewPanelSurface />
+}
+
+const ResponsivePreview = (): React.JSX.Element => {
+  const store = usePreviewWorkbenchStore()
+  return (
+    <WorkspacePanelLayout
+      hasPreviewItems={store.items.length > 0}
+      preview={{
+        state: store.panelState,
+        openRequestVersion: store.openRequestVersion,
+        toggle: store.togglePanel,
+        syncState: store.syncPanelState
+      }}
+      renderDesktopSidebar={() => null}
+      renderMobileSidebar={() => null}
+      renderConversation={() => <div />}
+    />
+  )
+}
+
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  viewport.mobile = false
+  projectId = `draft-lifecycle-${++nextProject}`
+  previewLeaveGuards.clear()
+  usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
+  useSessionStore.setState(createInitialSessionState())
+  useNavigationStore.setState({ activeProjectId: projectId })
+  usePreviewWorkbenchStore.getState().activateProject(projectId)
+  usePreviewWorkbenchStore.getState().upsertAndActivateItem({ ...file, projectId })
+  const state = toPersistedPreviewState(usePreviewWorkbenchStore.getState())
+  window.api = {
+    preview: {
+      load: vi.fn().mockResolvedValue({ state, revision: 1 }),
+      save: vi.fn().mockResolvedValue({ status: 'saved', revision: 2 })
+    },
+    artifacts: { getLineage: vi.fn().mockResolvedValue(undefined) },
+    managedFileVersions: {
+      inspect: vi.fn().mockResolvedValue({
+        ok: true,
+        value: {
+          source: 'upload',
+          projectId,
+          fileId: 'readme',
+          sessionId: 'session-1',
+          displayName: 'README.md',
+          headVersionId: 'v1',
+          selectedVersionId: 'v1',
+          versions: [
+            {
+              id: 'v1',
+              source: 'upload',
+              fileId: 'readme',
+              versionNumber: 1,
+              displayName: 'README.md',
+              originKind: 'user_upload',
+              basedOnVersionId: null,
+              contentType: 'text/markdown',
+              sizeBytes: 10,
+              checksum: '1',
+              createdAt: '2026-09-07T00:00:00.000Z'
+            }
+          ],
+          canEdit: true,
+          canDiff: true,
+          text: '# Current\n',
+          textFormat: { hasUtf8Bom: false, newline: 'lf', hasTrailingNewline: true }
+        }
+      }),
+      saveTextEdit: vi.fn().mockResolvedValue({
+        ok: false,
+        error: { code: 'VERSION_CONFLICT', message: 'test save conflict' }
+      })
+    }
+  } as unknown as Window['api']
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  await flushPreviewPersistence()
+  container.remove()
+  previewLeaveGuards.clear()
+  vi.unstubAllGlobals()
+})
+
+describe('preview draft lifecycle', () => {
+  it('protects dirty text when the active tab is closed normally', async () => {
+    await act(async () => root.render(<PreviewPanelSurface />))
+    await startEditing()
+    await act(async () => {
+      expect(usePreviewWorkbenchStore.getState().removeItem(file.id)).toBe(false)
+    })
+    expect(confirmation()).not.toBeNull()
+    expect.soft(editor()?.value).toBe(draft)
+    expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+  })
+
+  it('retains dirty text when a same-project restore removes the active file', async () => {
+    await act(async () => root.render(<PreviewPanelSurface />))
+    await startEditing()
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().activateProject(projectId, { items: [] })
+    })
+    expect.soft(editor()?.value).toBe(draft)
+    expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+  })
+
+  it('retains dirty text when a background tab save conflicts with a remote close', async () => {
+    await act(async () => root.render(<PersistentPreview />))
+    await act(async () => flushPreviewPersistence())
+    await startEditing()
+    let resolveSave!: (result: SavePreviewStateResult) => void
+    const save = vi.mocked(window.api.preview.save)
+    save.mockClear()
+    save.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertItem({
+        ...file,
+        id: 'upload:background',
+        managedFileId: 'background',
+        title: 'other.md',
+        name: 'other.md',
+        projectId
+      })
+    })
+    expect(save).toHaveBeenCalledTimes(1)
+    expect(editor()?.value).toBe(draft)
+    await act(async () => {
+      resolveSave({
+        status: 'conflict',
+        snapshot: { revision: 3, state: { version: 1, panelState: 'open', items: [] } }
+      })
+      await flushPreviewPersistence()
+    })
+    expect.soft(editor()?.value).toBe(draft)
+    expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+  })
+
+  it('retains the newly opened tab from a conflicting save alongside remote tabs', async () => {
+    await act(async () => root.render(<PersistentPreview />))
+    await act(async () => flushPreviewPersistence())
+    const baseline = toPersistedPreviewState(usePreviewWorkbenchStore.getState())
+    let resolveSave!: (result: SavePreviewStateResult) => void
+    vi.mocked(window.api.preview.save).mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveSave = resolve
+        })
+    )
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertItem({
+        ...file,
+        id: 'local-file',
+        managedFileId: 'local-file',
+        projectId
+      })
+    })
+    await act(async () => {
+      resolveSave({
+        status: 'conflict',
+        snapshot: {
+          revision: 3,
+          state: {
+            ...baseline,
+            items: [...baseline.items, { ...baseline.items[0]!, id: 'remote-file' }]
+          }
+        }
+      })
+      await flushPreviewPersistence()
+    })
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual(
+      expect.arrayContaining([file.id, 'local-file', 'remote-file'])
+    )
+  })
+
+  it.each(['remove', 'selection', 'version', 'collapse'] as const)(
+    'confirms a restore that changes the active file through %s',
+    async (change) => {
+      await act(async () => root.render(<PreviewPanelSurface />))
+      await startEditing()
+      const restoredFile = { ...file, projectId }
+      const other = { ...restoredFile, id: 'other', managedFileId: 'other' }
+      await act(async () => {
+        usePreviewWorkbenchStore.getState().activateProject(projectId, {
+          items:
+            change === 'remove'
+              ? [other]
+              : [{ ...restoredFile, selectedVersionId: change === 'version' ? 'v2' : 'v1' }, other],
+          activeItemId: change === 'selection' || change === 'remove' ? other.id : file.id,
+          panelState: change === 'collapse' ? 'collapsed' : 'open'
+        })
+      })
+      expect(editor()?.value).toBe(draft)
+      expect(confirmation()).not.toBeNull()
+      expect(usePreviewWorkbenchStore.getState().items.some((item) => item.id === 'other')).toBe(
+        true
+      )
+      await act(async () =>
+        confirmation()!.querySelector<HTMLButtonElement>('button:last-of-type')!.click()
+      )
+      expect(editor()).toBeNull()
+      const store = usePreviewWorkbenchStore.getState()
+      if (change === 'remove') expect(store.items.map((item) => item.id)).toEqual(['other'])
+      if (change === 'selection') expect(store.activeItemId).toBe('other')
+      if (change === 'version')
+        expect(store.items.find((item) => item.id === file.id)).toMatchObject({
+          selectedVersionId: 'v2'
+        })
+      if (change === 'collapse') expect(store.panelState).toBe('collapsed')
+    }
+  )
+
+  it.each(['Cancel', 'Discard changes'])(
+    'does not write a delayed restore back when choosing %s',
+    async (label) => {
+      await act(async () => root.render(<PersistentPreview />))
+      await act(async () => flushPreviewPersistence())
+      await startEditing()
+      const save = vi.mocked(window.api.preview.save)
+      save.mockClear()
+      save.mockResolvedValueOnce({
+        status: 'conflict',
+        snapshot: { revision: 3, state: { version: 1, panelState: 'open', items: [] } }
+      })
+      await act(async () => {
+        usePreviewWorkbenchStore.getState().upsertItem({ ...file, id: 'background', projectId })
+        await flushPreviewPersistence()
+      })
+      expect(confirmation()).not.toBeNull()
+      const calls = save.mock.calls.length
+      await act(async () => {
+        Array.from(confirmation()!.querySelectorAll('button'))
+          .find((button) => button.textContent === label)!
+          .click()
+        await flushPreviewPersistence()
+      })
+      expect(save).toHaveBeenCalledTimes(calls)
+      expect(label === 'Cancel' ? editor()?.value : editor()).toBe(
+        label === 'Cancel' ? draft : null
+      )
+    }
+  )
+
+  it('does not discard a draft for an obsolete restore after a newer tab action', async () => {
+    await act(async () => root.render(<PreviewPanelSurface />))
+    await startEditing()
+    await act(async () =>
+      usePreviewWorkbenchStore.getState().activateProject(projectId, { items: [] })
+    )
+    await act(async () =>
+      usePreviewWorkbenchStore.getState().upsertItem({ ...file, id: 'later', projectId })
+    )
+    await act(async () =>
+      confirmation()!.querySelector<HTMLButtonElement>('button:last-of-type')!.click()
+    )
+    expect(editor()?.value).toBe(draft)
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toContain('later')
+  })
+
+  it('rebases the same local action across successive conflicts without resurrecting a remote close', async () => {
+    await act(async () => root.render(<PersistentPreview />))
+    await act(async () => flushPreviewPersistence())
+    const baseline = toPersistedPreviewState(usePreviewWorkbenchStore.getState())
+    const save = vi.mocked(window.api.preview.save)
+    save.mockClear()
+    for (const revision of [3, 4])
+      save.mockResolvedValueOnce({
+        status: 'conflict',
+        snapshot: {
+          revision,
+          state: {
+            ...baseline,
+            activeItemId: undefined,
+            items: [{ ...baseline.items[0]!, id: `remote-${revision}` }]
+          }
+        }
+      })
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertItem({ ...file, id: 'local', projectId })
+      await flushPreviewPersistence()
+    })
+    expect(save.mock.calls.map(([request]) => request.expectedRevision)).toEqual([1, 3, 4])
+    expect(usePreviewWorkbenchStore.getState().items.map((item) => item.id)).toEqual([
+      'remote-4',
+      'local'
+    ])
+  })
+
+  it('keeps the draft across a render within the same layout', async () => {
+    await act(async () => root.render(<ResponsivePreview />))
+    await startEditing()
+    await act(async () => root.render(<ResponsivePreview />))
+    expect.soft(editor()?.value).toBe(draft)
+    expect(confirmation()).toBeNull()
+  })
+
+  it('isolates the mobile background, guards Escape, and preserves a nested confirmation across resizing', async () => {
+    await act(async () =>
+      root.render(
+        <>
+          <button data-testid="background">Background</button>
+          <ResponsivePreview />
+        </>
+      )
+    )
+    await startEditing()
+    viewport.mobile = true
+    await act(async () =>
+      root.render(
+        <>
+          <button data-testid="background">Background</button>
+          <ResponsivePreview />
+        </>
+      )
+    )
+    expect(container.querySelector('[data-testid="background"]')!.hasAttribute('inert')).toBe(true)
+    await act(async () =>
+      editor()!.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true }))
+    )
+    expect(confirmation()).not.toBeNull()
+    expect(editor()?.value).toBe(draft)
+    viewport.mobile = false
+    await act(async () =>
+      root.render(
+        <>
+          <button data-testid="background">Background</button>
+          <ResponsivePreview />
+        </>
+      )
+    )
+    expect(container.querySelector('[data-testid="background"]')!.hasAttribute('inert')).toBe(false)
+    viewport.mobile = true
+    await act(async () =>
+      root.render(
+        <>
+          <button data-testid="background">Background</button>
+          <ResponsivePreview />
+        </>
+      )
+    )
+    expect(confirmation()!.closest('[inert]')).toBeNull()
+    await act(async () =>
+      confirmation()!.querySelector<HTMLButtonElement>('button:first-of-type')!.click()
+    )
+    expect(editor()?.value).toBe(draft)
+    expect(confirmation()).toBeNull()
+  })
+
+  it.each([false, true])(
+    'keeps editing across a viewport breakpoint (starts mobile: %s)',
+    async (mobile) => {
+      viewport.mobile = mobile
+      await act(async () => root.render(<ResponsivePreview />))
+      await startEditing()
+      viewport.mobile = !mobile
+      await act(async () => root.render(<ResponsivePreview />))
+      expect(document.body.querySelector('[data-testid="mobile-preview-sheet"]') !== null).toBe(
+        !mobile
+      )
+      expect.soft(editor()?.value).toBe(draft)
+      expect(confirmation()).toBeNull()
+      expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+      await act(async () =>
+        document.body.querySelector<HTMLButtonElement>('[aria-label="Save changes"]')!.click()
+      )
+      expect(window.api.managedFileVersions.saveTextEdit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: draft,
+          basedOnVersionId: 'v1',
+          expectedHeadVersionId: 'v1',
+          projectId,
+          fileId: 'readme'
+        })
+      )
+    }
+  )
+})

--- a/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
+++ b/src/renderer/src/pages/workspace/workspace-panel-layout.tsx
@@ -43,6 +43,7 @@ type ResizablePanelState = 'open' | 'collapsed'
 type PanelAnimationDirection = 'opening' | 'closing'
 
 type AnimatedResizablePanelOptions = {
+  enabled?: boolean
   panelState: ResizablePanelState
   defaultOpenSize: number
   minOpenSize: number
@@ -61,6 +62,7 @@ type AnimatedResizablePanel = {
 
 // Owns the imperative animation lifecycle shared by the two workspace side panels.
 const useAnimatedResizablePanel = ({
+  enabled = true,
   panelState,
   defaultOpenSize,
   minOpenSize,
@@ -195,6 +197,12 @@ const useAnimatedResizablePanel = ({
 
   // Synchronize restored state on first layout without introducing an entrance animation.
   useLayoutEffect(() => {
+    if (!enabled) {
+      animationRef.current?.stop()
+      if (animationFrameRef.current !== null) window.cancelAnimationFrame(animationFrameRef.current)
+      animationDirectionRef.current = null
+      return
+    }
     const shouldAnimate = hasSyncedInitialSizeRef.current
     hasSyncedInitialSizeRef.current = true
 
@@ -206,7 +214,7 @@ const useAnimatedResizablePanel = ({
     animatePanelSize(Math.max(lastOpenSizeRef.current, minOpenSize), 'opening', {
       animate: shouldAnimate
     })
-  }, [animatePanelSize, minOpenSize, panelState, requestVersion])
+  }, [animatePanelSize, enabled, minOpenSize, panelState, requestVersion])
 
   useEffect(
     () => () => {
@@ -316,6 +324,7 @@ const useWorkspacePanelLayout = (
     previewPort.state === 'collapsed' ? PANEL_COLLAPSED_SIZE_CSS : PREVIEW_PANEL_DEFAULT_SIZE_CSS
   )
   const preview = useAnimatedResizablePanel({
+    enabled: !isMobile,
     panelState: previewPort.state,
     defaultOpenSize: PREVIEW_PANEL_DEFAULT_SIZE,
     minOpenSize: PREVIEW_PANEL_MIN_OPEN_SIZE,
@@ -630,32 +639,31 @@ const WorkspacePanelLayout = ({
                   preview.state === 'collapsed' ? 'pointer-events-none opacity-0' : 'opacity-100'
                 }`}
               />
-
-              <PreviewPanel
-                panelRef={preview.panelRef}
-                defaultSize={preview.defaultSize}
-                minSize={preview.minSize}
-                onResize={preview.onResize}
-                restoredPlanResponder={restoredPlanResponder}
-                {...previewAnnotations}
-                onPdfContextError={onPdfContextError}
-              />
             </>
           ) : null}
+          <PreviewPanel
+            isMobile={isMobile}
+            panelRef={preview.panelRef}
+            defaultSize={preview.defaultSize}
+            minSize={preview.minSize}
+            onResize={preview.onResize}
+            restoredPlanResponder={restoredPlanResponder}
+            {...previewAnnotations}
+            onPdfContextError={onPdfContextError}
+          >
+            <MobilePreviewSheet
+              isMobile={isMobile}
+              open={isPreviewPresentationActive && preview.state === 'open'}
+              onClose={preview.collapse}
+              restoredPlanResponder={restoredPlanResponder}
+              {...previewAnnotations}
+              onPdfContextError={onPdfContextError}
+            />
+          </PreviewPanel>
         </ResizablePanelGroup>
         {!isMobile && hasPreviewItems ? preview.toggleButton : null}
         {!isMobile && sidebar.state === 'collapsed' ? sidebar.toggleButton : null}
       </div>
-
-      {isMobile ? (
-        <MobilePreviewSheet
-          open={isPreviewPresentationActive && preview.state === 'open'}
-          onClose={preview.collapse}
-          restoredPlanResponder={restoredPlanResponder}
-          {...previewAnnotations}
-          onPdfContextError={onPdfContextError}
-        />
-      ) : null}
     </>
   )
 }

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -167,7 +167,8 @@ type PreviewWorkbenchStore = PreviewWorkbenchStoreData & {
   activateProject: (
     projectId: string,
     restored?: RestoredPreviewSlice,
-    skipGuard?: boolean
+    skipGuard?: boolean,
+    applyRestore?: (apply: () => boolean) => boolean
   ) => boolean
   reconcileFinalizedUploads: (uploads: UploadedAttachment[]) => void
   setPendingPdfContext: (projectId: string, selection: PendingPdfContext | undefined) => void
@@ -450,70 +451,113 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
   // Switches the visible preview slice to a project's own tabs, stashing the outgoing project's slice
   // so returning to it restores its tabs. `restored` replaces the durable subset with authoritative
   // persistence while retaining runtime-owned tool tabs.
-  activateProject: (projectId, restored, skipGuard = false) => {
-    const activate = (): true => {
-      set((state) => {
-        if (state.activeProjectId === projectId) {
-          if (!restored) return state
+  activateProject: (projectId, restored, skipGuard = false, applyRestore = (apply) => apply()) => {
+    const initial = get()
+    // Deferred restore callbacks must not overwrite a later tab action or another restore.
+    let expected = initial
+    const activate = (): boolean => {
+      if (restored && get() !== expected) return false
+      return applyRestore(() => {
+        set((state) => {
+          if (state.activeProjectId === projectId) {
+            if (!restored) return state
 
-          const targetSlice = mergeRestoredPreviewSlice(
-            state,
-            restored,
-            projectId,
-            state.pendingPdfContextByProject[projectId]
-          )
-          const expandedToolItemId = targetSlice.items.some(
-            (item) => item.id === state.expandedToolItemId && !isDurablePreviewItem(item)
-          )
-            ? state.expandedToolItemId
-            : null
-
-          return {
-            ...targetSlice,
-            expandedToolItemId,
-            fileDialogItem: state.fileDialogItem
-          }
-        }
-
-        const byProject = { ...state.byProject }
-
-        if (state.activeProjectId) {
-          byProject[state.activeProjectId] = {
-            items: state.items,
-            activeItemId: state.activeItemId,
-            panelState: state.panelState,
-            openRequestVersion: state.openRequestVersion
-          }
-        }
-
-        const cachedSlice = byProject[projectId]
-        const targetSlice = restored
-          ? mergeRestoredPreviewSlice(
-              cachedSlice ?? createEmptyPreviewSlice(),
+            const targetSlice = mergeRestoredPreviewSlice(
+              state,
               restored,
               projectId,
               state.pendingPdfContextByProject[projectId]
             )
-          : (cachedSlice ?? createEmptyPreviewSlice())
+            const expandedToolItemId = targetSlice.items.some(
+              (item) => item.id === state.expandedToolItemId && !isDurablePreviewItem(item)
+            )
+              ? state.expandedToolItemId
+              : null
 
-        // The active slice lives at top level, never duplicated in the stash.
-        delete byProject[projectId]
+            return {
+              ...targetSlice,
+              expandedToolItemId,
+              fileDialogItem: state.fileDialogItem
+            }
+          }
 
-        // The expanded files surface is tied to the outgoing project's workbench layout.
-        return {
-          ...targetSlice,
-          panelState: targetSlice.items.length > 0 ? targetSlice.panelState : 'collapsed',
-          activeProjectId: projectId,
-          byProject,
-          expandedToolItemId: null,
-          fileDialogItem:
-            state.fileDialogItem?.projectId === projectId ? state.fileDialogItem : undefined
-        }
+          const byProject = { ...state.byProject }
+
+          if (state.activeProjectId) {
+            byProject[state.activeProjectId] = {
+              items: state.items,
+              activeItemId: state.activeItemId,
+              panelState: state.panelState,
+              openRequestVersion: state.openRequestVersion
+            }
+          }
+
+          const cachedSlice = byProject[projectId]
+          const targetSlice = restored
+            ? mergeRestoredPreviewSlice(
+                cachedSlice ?? createEmptyPreviewSlice(),
+                restored,
+                projectId,
+                state.pendingPdfContextByProject[projectId]
+              )
+            : (cachedSlice ?? createEmptyPreviewSlice())
+
+          // The active slice lives at top level, never duplicated in the stash.
+          delete byProject[projectId]
+
+          // The expanded files surface is tied to the outgoing project's workbench layout.
+          return {
+            ...targetSlice,
+            panelState: targetSlice.items.length > 0 ? targetSlice.panelState : 'collapsed',
+            activeProjectId: projectId,
+            byProject,
+            expandedToolItemId: null,
+            fileDialogItem:
+              state.fileDialogItem?.projectId === projectId ? state.fileDialogItem : undefined
+          }
+        })
+        return true
       })
-      return true
     }
-    return get().activeProjectId !== projectId && !skipGuard
-      ? previewLeaveGuards.request(activeWorkbenchGuardScope(get()), activate)
+    if (!skipGuard && initial.activeProjectId === projectId && restored) {
+      const target = mergeRestoredPreviewSlice(
+        initial,
+        restored,
+        projectId,
+        initial.pendingPdfContextByProject[projectId]
+      )
+      const currentFile = initial.items.find(
+        (item) => item.id === initial.activeItemId && item.type === 'file'
+      )
+      const nextFile = target.items.find((item) => item.id === initial.activeItemId)
+      const leavesFile =
+        currentFile?.type === 'file' &&
+        (target.activeItemId !== initial.activeItemId ||
+          target.panelState !== initial.panelState ||
+          nextFile?.type !== 'file' ||
+          nextFile.source !== currentFile.source ||
+          nextFile.managedFileId !== currentFile.managedFileId ||
+          nextFile.artifactId !== currentFile.artifactId ||
+          nextFile.selectedVersionId !== currentFile.selectedVersionId ||
+          (!currentFile.managedFileId && nextFile.path !== currentFile.path))
+      if (leavesFile && !previewLeaveGuards.request(activeWorkbenchGuardScope(initial), activate)) {
+        // Merge remote changes outside the dirty file without replacing its editor or selection.
+        applyRestore(() => {
+          set({
+            ...target,
+            items: [...target.items.filter((item) => item.id !== currentFile.id), currentFile],
+            activeItemId: initial.activeItemId,
+            panelState: initial.panelState
+          })
+          return true
+        })
+        expected = get()
+        return false
+      }
+      if (leavesFile) return true
+    }
+    return initial.activeProjectId !== projectId && !skipGuard
+      ? previewLeaveGuards.request(activeWorkbenchGuardScope(initial), activate)
       : activate()
   },
 

--- a/src/renderer/src/stores/preview-workbench-store.ts
+++ b/src/renderer/src/stores/preview-workbench-store.ts
@@ -456,7 +456,17 @@ export const usePreviewWorkbenchStore = create<PreviewWorkbenchStore>((set, get)
     // Deferred restore callbacks must not overwrite a later tab action or another restore.
     let expected = initial
     const activate = (): boolean => {
-      if (restored && get() !== expected) return false
+      const current = get()
+      if (
+        restored &&
+        (current.activeProjectId !== expected.activeProjectId ||
+          current.items !== expected.items ||
+          current.activeItemId !== expected.activeItemId ||
+          current.panelState !== expected.panelState ||
+          current.openRequestVersion !== expected.openRequestVersion ||
+          current.byProject[projectId] !== expected.byProject[projectId])
+      )
+        return false
       return applyRestore(() => {
         set((state) => {
           if (state.activeProjectId === projectId) {

--- a/src/shared/preview-state.ts
+++ b/src/shared/preview-state.ts
@@ -174,13 +174,12 @@ const sanitizeSubagentsPreviewItem = (
 export const normalizePersistedPreviewState = (value: unknown): PersistedPreviewState => {
   if (!isRecord(value)) return createEmptyPersistedPreviewState()
 
-  const serializedItems = Array.isArray(value.items)
-    ? value.items.slice(-MAX_PERSISTED_PREVIEW_ITEMS)
-    : []
+  const serializedItems = Array.isArray(value.items) ? value.items : []
   const items = serializedItems.length
     ? serializedItems
         .map(sanitizePreviewFileItem)
         .filter((item): item is PersistedPreviewFileItem => !!item)
+        .slice(-MAX_PERSISTED_PREVIEW_ITEMS)
     : []
   const subagents =
     sanitizeSubagentsPreviewItem(value.subagents) ??


### PR DESCRIPTION
## Problem

A concurrent preview-state save could close or replace an actively edited file without the unsaved-changes confirmation. Crossing the desktop/mobile breakpoint also remounted the editor and lost its draft. At the supported capacity, restoring 100 file tabs plus a Subagents tab returned only 99 files and could clear the active selection.

## Proposed change

- Guard same-project restores that remove/switch/collapse the active file or change its editing identity. Merge other tabs while a dirty editor stays mounted. Skip obsolete deferred restores, and suppress restore-triggered saves when the deferred mutation actually executes.
- Rebase changes from the last accepted snapshot, retaining actions in the rejected save as well as later queued actions, while respecting remote closes of unchanged tabs.
- Keep one preview surface at a stable tree position across responsive layouts. The mobile presentation owns focus containment, background isolation, Escape/backdrop dismissal and scroll locking; desktop resizing stays disabled while that presentation is mobile.
- Apply the 100-file cap after separating valid file and Subagents entries.

## Scope and non-goals

No new database columns, tables, persisted fields, format version, or business-state enum. Existing mixed `items` JSON remains readable without migration. Drafts remain editor-owned in memory; there is no automatic file-content save or crash-recovery draft database. Previously lost drafts and tabs already omitted by later writes cannot be reconstructed.

## Acceptance criteria and validation

Regressions were added before production changes. Two consecutive runs on the original code each had the same six failing cases and three passing controls. Failures were missing real editor text, a lost locally opened tab, and a real SQLite round trip returning 99 files/clearing `file-0`; no production test seam was added.

Independent review also identified that a closed mobile sheet still exposed `role="dialog"`, blocking workspace shortcuts. A real workspace-navigation shortcut regression failed twice before restricting that role to the open sheet, then passed.

A second review found that whole-store identity made unrelated composer updates cancel deferred confirmations. An actual-editor regression failed twice before narrowing freshness checks to the relevant project/preview slice, then passed alongside the existing newer-tab-action protection. No mutation counter or new state field was added.

The following checks passed after the last material source/test edit (counts overlap):

| Behavior / consumer boundary | Project-owned check | Result |
| --- | --- | --- |
| Workspace layout, composition and new lifecycle regressions | `npm run test:module -- workspace_page` | 31 files, 869 tests passed |
| Real editor, mobile annotations/Subagents, panel and transient file-dialog consumers | `npm test -- src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx src/renderer/src/pages/workspace/MobilePreviewSheet.annotation.test.tsx src/renderer/src/pages/workspace/SubagentReleaseSurfaces.render.test.tsx src/renderer/src/pages/workspace/PreviewPanel.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx src/renderer/src/pages/workspace/FilePreviewDialog.versioning.test.tsx` | 259 tests passed |
| Restore guard, save suppression/repeated conflicts, navigation/shortcut/event consumers | `npm test -- src/renderer/src/stores/navigation-store.test.ts src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts src/renderer/src/lib/acp/workspace-events.test.ts src/renderer/src/lib/preview-persistence/preview-persistence.test.tsx src/renderer/src/stores/preview-workbench-store.test.ts src/renderer/src/stores/preview-leave-guard.test.ts` | 227 tests passed |
| SQLite round trip, shared normalization, Electron/Web API contracts, translations and module manifest | `npm test -- src/main/projects/preview-repository.test.ts src/main/projects/ipc.test.ts src/shared/preview-state.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/renderer-surface-matrix.test.ts src/preload/index.test.ts src/renderer/web/api-installer.test.ts scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts src/renderer/src/i18n/resources.test.ts` | 1009 tests passed |
| Both runtime type boundaries and style | `npm run typecheck:web`; `npm run typecheck:node`; `npm run lint`; `git diff --check` | Passed |

Repeated SQLite capacity checks exposed missing test startup initialization: uncached data-root resolution probed legacy home directories for every tab and sometimes exceeded 15 seconds. The suite now uses the existing application `initDataRoot` boundary; real SQLite and path encoding/decoding remain intact. With that initialization, two runs against the original normalizer still failed specifically with 99 files and missing `file-0` (the no-Subagents control passed); the fixed combined contract suite passed all 1009 tests without increasing timeouts.

Real Chromium verification used the actual layout, resizable panels, editor and persistence hook with controlled external API responses. A 1280 → 640 → 1280 CSS viewport transition retained the same textarea DOM element, text and focus; background inertness/scroll locking toggled with the mobile sheet. Mobile dirty-close confirmation and conflict cancellation retained the draft. Canceling the injected conflict left the tab-save count at two and the file-content save count at zero. Screenshots were captured and delivered in the task.

The exact base-to-head `test:affected:explain` currently selects full CI because the module manifest changes (only a regression test registration). Local verification intentionally remains module/contract-scoped as requested by the maintainer. The shared normalization is exercised through both the real repository and Electron/Web contracts. No schema/path algorithm changed, so there is no new migration or OS-specific implementation to validate locally; required CI remains authoritative for the full/platform lanes.

Limits: no two independent clients were launched; conflict responses were controlled. Native Electron window resizing/device rotation were not claimed from CSS viewport testing. CodeGraph reported a worktree mismatch, so changed relationships were checked in the current diff and through the real component/contract tests rather than trusting its other-worktree source.

## Review focus

Please review deferred confirmation freshness and suppression, rejected-write rebase semantics, and the stable mobile surface's focus/overlay behavior. Independent review and required CI are the final verification authority.


Review clarification: the `acceptedStates` snapshot map is pre-existing, not added by this PR. At base `52152ed4c254a6563b6592b971a1ebfa93408599`, `preview-persistence.ts:218` already declares it, line 239 reads it for save deduplication, and lines 270, 295 and 358 write conflict, successful-save and adopted snapshots. This PR changes none of those allocation/write paths; it additionally reads the existing accepted snapshot as the rejected write's rebase baseline. Cache lifetime/eviction is unchanged and outside this fix's scope. Please assess regressions against that base rather than treating this unchanged map as a new cache.
