### PR TITLE
fix(versions): bound diff context and explain comparison failures

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -1105,3 +1105,19 @@ alert region excludes the diagnostic payload so opening it does not announce the
 - CSL examples use a focusable preview button and a non-modal Popover: hover/focus discovers, click/tap pins, Escape/outside interaction dismisses, and internal scrolling preserves the panel. Show the complete style title, lazy-load and deduplicate per style, retain cached examples, and offer Retry after failure. The formatter's plain-text contract and content-addressed style identities stay unchanged.
 - Root canvas, body, and application root share the current theme background so exposed scrolling regions remain continuous; document canvases retain their own surface.
 - Use tabular digits for comparable numeric columns and changing counts/durations. Right-align numeric columns and reserve a minimum duration width where appropriate; retain existing formats and units.
+
+## File version comparisons
+
+Version comparisons retain the first and last three lines of each unchanged run and show explicit
+omitted line ranges. Omitted rows contain range metadata, never synthetic source text. All changed
+lines remain subject to the existing Worker time, memory, concurrency and output limits; exceeding
+the output budget is an explicit failure, never a successful truncated result. Markdown with omitted
+sections is shown as source excerpts because the missing text may contain fences or reference definitions.
+Complete files remain available through version previews and per-version downloads; this surface does
+not expand omitted ranges in place.
+
+Comparison failures use compact `ErrorNotice` with controlled translated explanations. Concurrency,
+timeout and temporarily unavailable storage offer a direct manual retry through fresh inspection;
+capacity failures explain the limit and return to version preview. Raw internal errors are not displayed.
+Visible CR/LF/CRLF labels and trailing-newline/BOM summaries clarify format changes without changing raw
+segments. BOM flags and omitted ranges are transient comparison metadata, not persisted version fields.

--- a/src/main/managed-file-versions/diff-task.test.ts
+++ b/src/main/managed-file-versions/diff-task.test.ts
@@ -1,11 +1,85 @@
 import { createRequire } from 'node:module'
+import {
+  inspectManagedTextEditEligibility,
+  type ManagedFileVersionDiffRow,
+  type ManagedFileVersionDiffLine
+} from '../../shared/managed-file-versions'
 
 import { describe, expect, it } from 'vitest'
 
 import { ManagedFileVersionError } from './service'
 import { ManagedTextDiffTaskRunner, resolveDiffModulePath } from './diff-task'
 
+const textLine = (line: ManagedFileVersionDiffRow | undefined): ManagedFileVersionDiffLine => {
+  if (!line || line.kind === 'omitted')
+    throw new Error('Expected a source line, not an omitted range')
+  return line
+}
+
 describe('ManagedTextDiffTaskRunner', () => {
+  it.each([6, 7, 50])(
+    'accounts for every source line when compacting %i unchanged lines',
+    async (count) => {
+      const before = Array.from({ length: count }, (_, index) => `value-${index}\n`)
+      const after = [...before]
+      if (count === 50) {
+        after[0] = 'changed-first\n'
+        after[24] = 'changed-middle\n'
+        after[26] = 'changed-nearby\n'
+        after[49] = 'changed-last\n'
+      }
+      const rows = await new ManagedTextDiffTaskRunner().run({
+        requestId: `context-${count}`,
+        before: before.join(''),
+        after: after.join('')
+      })
+      for (const [side, original] of [
+        ['old', before],
+        ['new', after]
+      ] as const) {
+        const reconstructed = rows
+          .flatMap((row) => {
+            if (row.kind === 'omitted') {
+              const start = (side === 'old' ? row.oldLineNumber : row.newLineNumber) - 1
+              return original.slice(start, start + row.count)
+            }
+            if (row.kind === (side === 'old' ? 'added' : 'removed')) return []
+            return row.segments.map((segment) => segment.text)
+          })
+          .join('')
+        expect(reconstructed).toBe(original.join(''))
+      }
+      const omissions = rows.filter((row) => row.kind === 'omitted')
+      expect(omissions.length).toBe(count === 6 ? 0 : count === 7 ? 1 : 2)
+      if (count === 7)
+        expect(omissions).toEqual([
+          { kind: 'omitted', oldLineNumber: 4, newLineNumber: 4, count: 1 }
+        ])
+      if (count === 50) expect(rows.filter((row) => row.kind === 'added')).toHaveLength(4)
+      expect(Buffer.byteLength(JSON.stringify(rows))).toBeLessThanOrEqual(500 * 1024)
+    }
+  )
+
+  it.each([100, 5000])(
+    'reviews a one-character edit in %i repeated lines within the existing budget',
+    async (count) => {
+      const before = 'value=12345\n'.repeat(count)
+      expect(Buffer.byteLength(before)).toBe(count * 12)
+      expect(inspectManagedTextEditEligibility('data.txt', Buffer.from(before)).editable).toBe(true)
+      const lines = await new ManagedTextDiffTaskRunner().run({
+        requestId: `sparse-edit-${count}`,
+        before,
+        after: before.replace('12345', '12346')
+      })
+      expect(lines.filter((line) => line.kind === 'added' || line.kind === 'removed')).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: 'removed' }),
+          expect.objectContaining({ kind: 'added', newLineNumber: 1 })
+        ])
+      )
+    }
+  )
+
   it('returns line numbers and intra-line segments for a replacement', async () => {
     const runner = new ManagedTextDiffTaskRunner()
 
@@ -30,10 +104,18 @@ describe('ManagedTextDiffTaskRunner', () => {
         segments: [{ kind: 'context', text: 'keep\n' }]
       }
     ])
-    expect(lines[0]?.segments.map((segment) => segment.text).join('')).toBe('alpha beta\n')
-    expect(lines[1]?.segments.map((segment) => segment.text).join('')).toBe('alpha gamma\n')
-    expect(lines[0]?.segments.some((segment) => segment.kind === 'removed')).toBe(true)
-    expect(lines[1]?.segments.some((segment) => segment.kind === 'added')).toBe(true)
+    expect(
+      textLine(lines[0])
+        .segments.map((segment) => segment.text)
+        .join('')
+    ).toBe('alpha beta\n')
+    expect(
+      textLine(lines[1])
+        .segments.map((segment) => segment.text)
+        .join('')
+    ).toBe('alpha gamma\n')
+    expect(textLine(lines[0]).segments.some((segment) => segment.kind === 'removed')).toBe(true)
+    expect(textLine(lines[1]).segments.some((segment) => segment.kind === 'added')).toBe(true)
   })
 
   it('preserves a shared CRLF on an unchanged context line', async () => {
@@ -230,8 +312,16 @@ describe('ManagedTextDiffTaskRunner', () => {
       after: `alpha${character}new`
     })
 
-    expect(lines[0]?.segments.map((segment) => segment.text).join('')).toBe(`alpha${character}old`)
-    expect(lines[1]?.segments.map((segment) => segment.text).join('')).toBe(`alpha${character}new`)
+    expect(
+      textLine(lines[0])
+        .segments.map((segment) => segment.text)
+        .join('')
+    ).toBe(`alpha${character}old`)
+    expect(
+      textLine(lines[1])
+        .segments.map((segment) => segment.text)
+        .join('')
+    ).toBe(`alpha${character}new`)
   })
 
   it('reconstructs both complete sources from a mixed-ending diff DTO', async () => {
@@ -245,7 +335,7 @@ describe('ManagedTextDiffTaskRunner', () => {
     const reconstruct = (excludedKind: 'added' | 'removed'): string =>
       lines
         .filter((line) => line.kind !== excludedKind)
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .map((segment) => segment.text)
         .join('')
 
@@ -352,9 +442,11 @@ describe('ManagedTextDiffTaskRunner', () => {
         kind: line.kind,
         oldLineNumber: line.oldLineNumber,
         newLineNumber: line.newLineNumber,
-        text: line.segments.map((segment) => segment.text).join(''),
-        changed: line.segments
-          .filter((segment) => segment.kind === line.kind)
+        text: textLine(line)
+          .segments.map((segment) => segment.text)
+          .join(''),
+        changed: textLine(line)
+          .segments.filter((segment) => segment.kind === line.kind)
           .map((segment) => segment.text)
           .join('')
       }))
@@ -409,9 +501,11 @@ describe('ManagedTextDiffTaskRunner', () => {
     })
     const summary = lines.map((line) => ({
       kind: line.kind,
-      text: line.segments.map((segment) => segment.text).join(''),
-      changed: line.segments
-        .filter((segment) => segment.kind === line.kind)
+      text: textLine(line)
+        .segments.map((segment) => segment.text)
+        .join(''),
+      changed: textLine(line)
+        .segments.filter((segment) => segment.kind === line.kind)
         .map((segment) => segment.text)
         .join('')
     }))
@@ -437,7 +531,7 @@ describe('ManagedTextDiffTaskRunner', () => {
   })
 
   it.each([199, 200])(
-    'preserves %i unchanged blank lines around a paragraph replacement',
+    'accounts for %i unchanged blank lines around a paragraph replacement',
     async (blankLineCount) => {
       const blankLines = '\n'.repeat(blankLineCount)
       const lines = await new ManagedTextDiffTaskRunner().run({
@@ -446,25 +540,30 @@ describe('ManagedTextDiffTaskRunner', () => {
         after: `Paragraph new.\n${blankLines}`
       })
 
-      expect(lines.filter((line) => line.kind === 'context')).toHaveLength(blankLineCount)
+      expect(lines.filter((line) => line.kind === 'context')).toHaveLength(6)
+      expect(lines.filter((line) => line.kind === 'omitted')).toEqual([
+        { kind: 'omitted', oldLineNumber: 5, newLineNumber: 5, count: blankLineCount - 6 }
+      ])
       expect(
         lines
           .filter((line) => line.kind === 'context')
           .every(
             (line) =>
-              line.segments.length === 1 &&
-              line.segments[0].kind === 'context' &&
-              line.segments[0].text === '\n'
+              textLine(line).segments.length === 1 &&
+              textLine(line).segments[0].kind === 'context' &&
+              textLine(line).segments[0].text === '\n'
           )
       ).toBe(true)
       expect(
         lines
-          .filter((line) => line.kind !== 'context')
+          .filter((line) => line.kind === 'added' || line.kind === 'removed')
           .map((line) => ({
             kind: line.kind,
-            text: line.segments.map((segment) => segment.text).join(''),
-            changed: line.segments
-              .filter((segment) => segment.kind === line.kind)
+            text: textLine(line)
+              .segments.map((segment) => segment.text)
+              .join(''),
+            changed: textLine(line)
+              .segments.filter((segment) => segment.kind === line.kind)
               .map((segment) => segment.text)
               .join('')
           }))
@@ -490,11 +589,11 @@ describe('ManagedTextDiffTaskRunner', () => {
     ])
     expect(
       lines
-        .filter((line) => line.kind !== 'context')
+        .filter((line) => line.kind === 'added' || line.kind === 'removed')
         .map((line) => ({
           kind: line.kind,
-          changed: line.segments
-            .filter((segment) => segment.kind === line.kind)
+          changed: textLine(line)
+            .segments.filter((segment) => segment.kind === line.kind)
             .map((segment) => segment.text)
             .join('')
         }))
@@ -514,9 +613,11 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines.map((line) => ({
         kind: line.kind,
-        text: line.segments.map((segment) => segment.text).join(''),
-        changed: line.segments
-          .filter((segment) => segment.kind === line.kind)
+        text: textLine(line)
+          .segments.map((segment) => segment.text)
+          .join(''),
+        changed: textLine(line)
+          .segments.filter((segment) => segment.kind === line.kind)
           .map((segment) => segment.text)
           .join('')
       }))
@@ -539,9 +640,11 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines.map((line) => ({
         kind: line.kind,
-        text: line.segments.map((segment) => segment.text).join(''),
-        changed: line.segments
-          .filter((segment) => segment.kind === line.kind)
+        text: textLine(line)
+          .segments.map((segment) => segment.text)
+          .join(''),
+        changed: textLine(line)
+          .segments.filter((segment) => segment.kind === line.kind)
           .map((segment) => segment.text)
           .join('')
       }))
@@ -574,7 +677,9 @@ describe('ManagedTextDiffTaskRunner', () => {
       after: fixture.after
     })
 
-    expect(lines.slice(0, 2).map((line) => line.segments.map((segment) => segment.text))).toEqual([
+    expect(
+      lines.slice(0, 2).map((line) => textLine(line).segments.map((segment) => segment.text))
+    ).toEqual([
       ['Heading ', 'old', '.\n'],
       ['Heading ', 'new', '.\n']
     ])
@@ -594,9 +699,11 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines.map((line) => ({
         kind: line.kind,
-        text: line.segments.map((segment) => segment.text).join(''),
-        changed: line.segments
-          .filter((segment) => segment.kind === line.kind)
+        text: textLine(line)
+          .segments.map((segment) => segment.text)
+          .join(''),
+        changed: textLine(line)
+          .segments.filter((segment) => segment.kind === line.kind)
           .map((segment) => segment.text)
           .join('')
       }))
@@ -619,9 +726,11 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines.slice(2, 4).map((line) => ({
         kind: line.kind,
-        text: line.segments.map((segment) => segment.text).join(''),
-        changed: line.segments
-          .filter((segment) => segment.kind === line.kind)
+        text: textLine(line)
+          .segments.map((segment) => segment.text)
+          .join(''),
+        changed: textLine(line)
+          .segments.filter((segment) => segment.kind === line.kind)
           .map((segment) => segment.text)
           .join('')
       }))
@@ -643,14 +752,14 @@ describe('ManagedTextDiffTaskRunner', () => {
     })
 
     expect(
-      lines[0]?.segments
-        .filter((segment) => segment.kind === 'context')
+      textLine(lines[0])
+        .segments.filter((segment) => segment.kind === 'context')
         .map((segment) => segment.text)
         .join('')
     ).toContain(fixture.common)
     expect(
-      lines[1]?.segments
-        .filter((segment) => segment.kind === 'context')
+      textLine(lines[1])
+        .segments.filter((segment) => segment.kind === 'context')
         .map((segment) => segment.text)
         .join('')
     ).toContain(fixture.common)
@@ -681,27 +790,27 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines
         .filter((line) => line.kind !== 'added')
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .map((segment) => segment.text)
         .join('')
     ).toBe(fixture.before)
     expect(
       lines
         .filter((line) => line.kind !== 'removed')
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .map((segment) => segment.text)
         .join('')
     ).toBe(fixture.after)
     expect(
       lines
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .filter((segment) => segment.kind === 'removed')
         .map((segment) => segment.text)
         .join('')
     ).toBe(fixture.removed)
     expect(
       lines
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .filter((segment) => segment.kind === 'added')
         .map((segment) => segment.text)
         .join('')
@@ -720,21 +829,21 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines
         .filter((line) => line.kind !== 'added')
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .map((segment) => segment.text)
         .join('')
     ).toBe(before)
     expect(
       lines
         .filter((line) => line.kind !== 'removed')
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .map((segment) => segment.text)
         .join('')
     ).toBe(after)
     expect(
       lines
         .filter((line) => line.kind === 'removed')
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .filter((segment) => segment.kind === 'context')
         .map((segment) => segment.text)
         .join('')
@@ -742,7 +851,7 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(
       lines
         .filter((line) => line.kind === 'added')
-        .flatMap((line) => line.segments)
+        .flatMap((line) => textLine(line).segments)
         .filter((segment) => segment.kind === 'context')
         .map((segment) => segment.text)
         .join('')
@@ -759,13 +868,13 @@ describe('ManagedTextDiffTaskRunner', () => {
     })
     const beforeContext = lines
       .filter((line) => line.kind !== 'added')
-      .flatMap((line) => line.segments)
+      .flatMap((line) => textLine(line).segments)
       .filter((segment) => segment.kind === 'context')
       .map((segment) => segment.text)
       .join('')
     const afterContext = lines
       .filter((line) => line.kind !== 'removed')
-      .flatMap((line) => line.segments)
+      .flatMap((line) => textLine(line).segments)
       .filter((segment) => segment.kind === 'context')
       .map((segment) => segment.text)
       .join('')
@@ -790,20 +899,20 @@ describe('ManagedTextDiffTaskRunner', () => {
       expect(
         lines
           .filter((line) => line.kind !== excludedKind)
-          .flatMap((line) => line.segments)
+          .flatMap((line) => textLine(line).segments)
           .map((segment) => segment.text)
           .join('')
       ).toBe(expected)
     }
     const beforeContext = lines
       .filter((line) => line.kind !== 'added')
-      .flatMap((line) => line.segments)
+      .flatMap((line) => textLine(line).segments)
       .filter((segment) => segment.kind === 'context')
       .map((segment) => segment.text)
       .join('')
     const afterContext = lines
       .filter((line) => line.kind !== 'removed')
-      .flatMap((line) => line.segments)
+      .flatMap((line) => textLine(line).segments)
       .filter((segment) => segment.kind === 'context')
       .map((segment) => segment.text)
       .join('')
@@ -918,12 +1027,12 @@ describe('ManagedTextDiffTaskRunner', () => {
     expect(terminated).toBe(true)
   })
 
-  it('rejects a complete diff beyond the line limit instead of returning a truncation', async () => {
+  it('rejects changed content beyond the output budget instead of returning a truncation', async () => {
     const runner = new ManagedTextDiffTaskRunner()
-    const before = Array.from({ length: 20_001 }, (_, index) => `old-${index}`).join('\n')
+    const before = Array.from({ length: 10_000 }, (_, index) => `old-${index}`).join('\n')
 
     await expect(
-      runner.run({ requestId: 'diff-output-limit', before, after: before })
+      runner.run({ requestId: 'diff-output-limit', before: '', after: before })
     ).rejects.toEqual(
       expect.objectContaining<Partial<ManagedFileVersionError>>({
         code: 'DIFF_OUTPUT_LIMIT_EXCEEDED'

--- a/src/main/managed-file-versions/diff-task.ts
+++ b/src/main/managed-file-versions/diff-task.ts
@@ -4,7 +4,7 @@ import { Worker } from 'node:worker_threads'
 import {
   MANAGED_DIFF_MAX_OUTPUT_BYTES,
   MANAGED_DIFF_MAX_OUTPUT_LINES,
-  type ManagedFileVersionDiffLine
+  type ManagedFileVersionDiffRow
 } from '../../shared/managed-file-versions'
 import { createLogger } from '../logger'
 import { ManagedFileVersionError } from './error'
@@ -431,7 +431,7 @@ if (!changes) {
   return
 }
 let outputBytes = 2
-const pushLine = (line) => {
+const pushOutput = (line) => {
   const nextBytes = Buffer.byteLength(JSON.stringify(line), 'utf8') + (lines.length === 0 ? 0 : 1)
   if (lines.length + 1 > workerData.maxOutputLines || outputBytes + nextBytes > workerData.maxOutputBytes) {
     parentPort.postMessage({ error: 'DIFF_OUTPUT_LIMIT_EXCEEDED' })
@@ -439,6 +439,26 @@ const pushLine = (line) => {
   }
   lines.push(line)
   outputBytes += nextBytes
+  return true
+}
+// Retain each unchanged run's first/last three lines, including file boundaries.
+// Buffer at most six rows; omitted source text never enters the serialized output budget.
+let context = []
+let omitted
+const flushContext = () => {
+  const rows = omitted ? [...context.slice(0, 3), omitted, ...context.slice(3)] : context
+  context = []
+  omitted = undefined
+  return rows.every(pushOutput)
+}
+const pushLine = (line) => {
+  if (line.kind !== 'context') return flushContext() && pushOutput(line)
+  context.push(line)
+  if (context.length > 6) {
+    const skipped = context.splice(3, 1)[0]
+    if (omitted) omitted.count += 1
+    else omitted = { kind: 'omitted', oldLineNumber: skipped.oldLineNumber, newLineNumber: skipped.newLineNumber, count: 1 }
+  }
   return true
 }
 const pushAlignedLine = (aligned) => {
@@ -563,7 +583,7 @@ for (const change of changes) {
     lineGroup.push({ kind, line })
   }
 }
-if (!flushLineGroup()) return
+if (!flushLineGroup() || !flushContext()) return
 parentPort.postMessage(lines)
 }
 run()
@@ -577,7 +597,7 @@ class ManagedTextDiffTaskRunner {
 
   constructor(private readonly options: DiffTaskRunnerOptions = {}) {}
 
-  run(task: DiffTask): Promise<ManagedFileVersionDiffLine[]> {
+  run(task: DiffTask): Promise<ManagedFileVersionDiffRow[]> {
     if (this.active.has(task.requestId)) {
       return Promise.reject(
         new ManagedFileVersionError('INVALID_REQUEST', 'Diff request id is already active.')
@@ -627,7 +647,7 @@ class ManagedTextDiffTaskRunner {
           )
           return
         }
-        const lines = value as ManagedFileVersionDiffLine[]
+        const lines = value as ManagedFileVersionDiffRow[]
         if (
           lines.length > MANAGED_DIFF_MAX_OUTPUT_LINES ||
           Buffer.byteLength(JSON.stringify(lines), 'utf8') > MANAGED_DIFF_MAX_OUTPUT_BYTES

--- a/src/main/managed-file-versions/ipc.test.ts
+++ b/src/main/managed-file-versions/ipc.test.ts
@@ -45,6 +45,8 @@ const cancelDiffRequest: ManagedFileVersionCancelDiffRequest = { requestId: 'dif
 const diffResult: ManagedFileVersionDiffResult = {
   baseVersionId: 'version-1',
   selectedVersionId: 'version-2',
+  baseFormat: { hasUtf8Bom: true },
+  selectedFormat: { hasUtf8Bom: false },
   lines: [
     {
       kind: 'removed',
@@ -55,7 +57,8 @@ const diffResult: ManagedFileVersionDiffResult = {
       kind: 'added',
       newLineNumber: 1,
       segments: [{ kind: 'added', text: 'after' }]
-    }
+    },
+    { kind: 'omitted', oldLineNumber: 2, newLineNumber: 2, count: 20 }
   ]
 }
 const inspectResult: ManagedFileVersionInspectResult = {

--- a/src/main/managed-file-versions/service.integration.test.ts
+++ b/src/main/managed-file-versions/service.integration.test.ts
@@ -57,11 +57,14 @@ describe('ManagedFileVersionService (SQLite + filesystem)', () => {
     outsideRoot = undefined
   })
 
-  const createFixture = async (source: 'artifact' | 'upload'): Promise<SourceFixture> => {
+  const createFixture = async (
+    source: 'artifact' | 'upload',
+    content?: [Buffer, Buffer]
+  ): Promise<SourceFixture> => {
     const fileId = `${source}-file-1`
     const versionIds: [string, string] = [`${source}-v1`, `${source}-v2`]
-    const first = Buffer.from('\ufefffirst\r\nline\r\n')
-    const second = Buffer.from('second\n')
+    const first = content?.[0] ?? Buffer.from('\ufefffirst\r\nline\r\n')
+    const second = content?.[1] ?? Buffer.from('second\n')
     const storageKeys = versionIds.map(
       (versionId) => `${source}s/project-1/session-1/${fileId}/versions/${versionId}/content`
     )
@@ -152,6 +155,49 @@ describe('ManagedFileVersionService (SQLite + filesystem)', () => {
     })
     return { source, fileId, versionIds }
   }
+
+  it.each([
+    ['artifact', true],
+    ['upload', true],
+    ['artifact', false],
+    ['upload', false]
+  ] as const)(
+    'reports a BOM-only change for %s versions (base BOM: %s)',
+    async (source, baseBom) => {
+      const fixture = await createFixture(source, [
+        Buffer.from(`${baseBom ? '\ufeff' : ''}print(1)\n`),
+        Buffer.from(`${baseBom ? '' : '\ufeff'}print(1)\n`)
+      ])
+      const service = new ManagedFileVersionService({
+        storageRoot,
+        getClient: () => Promise.resolve(client)
+      })
+      const identity = { source, projectId: 'project-1', fileId: fixture.fileId }
+      const base = await service.inspect({ ...identity, versionId: fixture.versionIds[0] })
+      const selected = await service.inspect({ ...identity, versionId: fixture.versionIds[1] })
+      expect(base.textFormat?.hasUtf8Bom).toBe(baseBom)
+      expect(selected.textFormat?.hasUtf8Bom).toBe(!baseBom)
+      expect(base.text).toBe(selected.text)
+      expect(selected.canDiff).toBe(true)
+      const result = await service.diffText({
+        ...identity,
+        versionId: fixture.versionIds[1],
+        requestId: `${source}-bom-only`
+      })
+      expect(result.lines).toEqual([
+        {
+          kind: 'context',
+          oldLineNumber: 1,
+          newLineNumber: 1,
+          segments: [{ kind: 'context', text: 'print(1)\n' }]
+        }
+      ])
+      expect(result).toMatchObject({
+        baseFormat: { hasUtf8Bom: baseBom },
+        selectedFormat: { hasUtf8Bom: !baseBom }
+      })
+    }
+  )
 
   it.each(['artifact', 'upload'] as const)(
     'bounds the initial %s history response for a frequently edited file',

--- a/src/main/managed-file-versions/service.ts
+++ b/src/main/managed-file-versions/service.ts
@@ -603,9 +603,19 @@ class ManagedFileVersionService {
       const after = await this.readTextForDiff(selected)
       assertNotCancelled()
       active.workerStarted = true
-      const lines = await this.diffTaskRunner.run({ requestId, before, after })
+      const lines = await this.diffTaskRunner.run({
+        requestId,
+        before: before.text,
+        after: after.text
+      })
       assertNotCancelled()
-      return { baseVersionId: ownedBaseVersionId, selectedVersionId: selected.version.id, lines }
+      return {
+        baseVersionId: ownedBaseVersionId,
+        selectedVersionId: selected.version.id,
+        lines,
+        baseFormat: { hasUtf8Bom: before.format.hasUtf8Bom },
+        selectedFormat: { hasUtf8Bom: after.format.hasUtf8Bom }
+      }
     } finally {
       if (this.activeDiffs.get(requestId) === active) {
         this.activeDiffs.delete(requestId)
@@ -1403,7 +1413,9 @@ class ManagedFileVersionService {
     }
   }
 
-  private async readTextForDiff(resolved: ResolvedManagedFileVersion): Promise<string> {
+  private async readTextForDiff(
+    resolved: ResolvedManagedFileVersion
+  ): Promise<Extract<ReturnType<typeof inspectManagedTextEditEligibility>, { editable: true }>> {
     if (resolved.version.sizeBytes > BigInt(MANAGED_DIFF_MAX_INPUT_BYTES)) {
       operationError('DIFF_INPUT_LIMIT_EXCEEDED', 'Managed file exceeds the diff input limit.')
     }
@@ -1414,7 +1426,7 @@ class ManagedFileVersionService {
       }
       operationError(eligibility.reason, 'Managed file is not eligible for text diff.')
     }
-    return (eligibility as Extract<typeof eligibility, { editable: true }>).text
+    return eligibility as Extract<typeof eligibility, { editable: true }>
   }
 
   private async verifyResolvedVersion(resolved: ResolvedManagedFileVersion): Promise<void> {

--- a/src/renderer/src/pages/workspace/ManagedVersionDiffContent.test.tsx
+++ b/src/renderer/src/pages/workspace/ManagedVersionDiffContent.test.tsx
@@ -56,6 +56,28 @@ describe('ManagedVersionDiffContent', () => {
     }
   )
 
+  it.each([true, false])(
+    'keeps a bare trailing carriage return distinct from a newline (added: %s)',
+    async (added) => {
+      const lines = await new ManagedTextDiffTaskRunner().run({
+        requestId: `bare-carriage-return-${added}`,
+        before: added ? 'line' : 'line\r',
+        after: added ? 'line\r' : 'line'
+      })
+      await act(async () =>
+        root.render(
+          <ManagedVersionDiffContent
+            result={{ baseVersionId: 'v1', selectedVersionId: 'v2', lines }}
+            format="text"
+            name="script.py"
+          />
+        )
+      )
+      expect(container.textContent).toContain('Carriage return (CR)')
+      expect(container.textContent).not.toMatch(/Newline at end of file/u)
+    }
+  )
+
   it.each([true, false])('explains a trailing newline change (added: %s)', async (added) => {
     const lines = await new ManagedTextDiffTaskRunner().run({
       requestId: `ending-${added}`,

--- a/src/renderer/src/pages/workspace/ManagedVersionDiffContent.test.tsx
+++ b/src/renderer/src/pages/workspace/ManagedVersionDiffContent.test.tsx
@@ -24,6 +24,90 @@ describe('ManagedVersionDiffContent', () => {
     container.remove()
   })
 
+  it.each([
+    ['text', 'script.py'],
+    ['text', 'notes.txt'],
+    ['markdown', 'README.md']
+  ] as const)(
+    'names a removed carriage return in %s %s while preserving raw content',
+    async (format, name) => {
+      const lines = await new ManagedTextDiffTaskRunner().run({
+        requestId: 'visible-carriage-return',
+        before: 'line\r\n',
+        after: 'line\n'
+      })
+      await act(async () => {
+        root.render(
+          <ManagedVersionDiffContent
+            result={{ baseVersionId: 'v1', selectedVersionId: 'v2', lines }}
+            format={format}
+            name={name}
+          />
+        )
+      })
+      const removed = container.querySelector('del[data-managed-diff="removed"]')
+      expect(removed?.querySelector('[data-managed-diff-content]')?.textContent).toBe('\r')
+      const explanation = [
+        container.textContent,
+        removed?.getAttribute('aria-label'),
+        removed?.getAttribute('title')
+      ].join(' ')
+      expect(explanation).toMatch(/carriage return|\bCR\b|CRLF/iu)
+    }
+  )
+
+  it.each([true, false])('explains a trailing newline change (added: %s)', async (added) => {
+    const lines = await new ManagedTextDiffTaskRunner().run({
+      requestId: `ending-${added}`,
+      before: added ? 'line' : 'line\n',
+      after: added ? 'line\n' : 'line'
+    })
+    await act(async () =>
+      root.render(
+        <ManagedVersionDiffContent
+          result={{ baseVersionId: 'v1', selectedVersionId: 'v2', lines }}
+          format="markdown"
+          name="notes.md"
+        />
+      )
+    )
+    expect(container.textContent).toContain(
+      added ? 'Newline at end of file added' : 'Newline at end of file removed'
+    )
+  })
+
+  it('displays omitted ranges and a BOM-only change without inventing source content', async () => {
+    const lines = await new ManagedTextDiffTaskRunner().run({
+      requestId: 'omitted-bom',
+      before: 'same\n'.repeat(50),
+      after: 'same\n'.repeat(50)
+    })
+    await act(async () =>
+      root.render(
+        <ManagedVersionDiffContent
+          result={{
+            baseVersionId: 'v1',
+            selectedVersionId: 'v2',
+            baseFormat: { hasUtf8Bom: true },
+            selectedFormat: { hasUtf8Bom: false },
+            lines
+          }}
+          format="markdown"
+          name="notes.md"
+        />
+      )
+    )
+    expect(container.textContent).toContain('UTF-8 BOM removed')
+    expect(container.textContent).toContain('No text changes.')
+    expect(container.querySelector('[data-diff-kind="omitted"]')?.textContent).toContain(
+      '44 (base 4–47, selected 4–47)'
+    )
+    expect(
+      container.querySelector('[data-diff-kind="omitted"] [data-managed-diff-content]')
+    ).toBeNull()
+    expect(container.querySelector('.managed-version-diff-markdown')).toBeNull()
+  })
+
   it('renders Markdown structure and semantic inline changes without visible line numbers', async () => {
     const result: ManagedFileVersionDiffResult = {
       baseVersionId: 'v1',

--- a/src/renderer/src/pages/workspace/ManagedVersionDiffContent.tsx
+++ b/src/renderer/src/pages/workspace/ManagedVersionDiffContent.tsx
@@ -3,7 +3,10 @@ import { useTranslation } from 'react-i18next'
 
 import { AgentMarkdown, type AgentMarkdownExtension } from '@/components/streamdown/AgentMarkdown'
 import type { PreviewFileFormat } from '@/stores/preview-workbench-store'
-import type { ManagedFileVersionDiffResult } from '../../../../shared/managed-file-versions'
+import type {
+  ManagedFileVersionDiffResult,
+  ManagedFileVersionDiffSegment
+} from '../../../../shared/managed-file-versions'
 
 import { getFileExtension } from './preview-support'
 import {
@@ -23,7 +26,7 @@ const markdownChangeStyles =
   '[&_[data-managed-diff=added]]:bg-diff-added-highlight [&_[data-managed-diff=added]]:font-medium [&_[data-managed-diff=added]]:text-text-000 [&_[data-managed-diff=added]]:no-underline [&_[data-managed-diff=removed]]:bg-diff-removed-highlight [&_[data-managed-diff=removed]]:text-text-000 [&_[data-managed-diff=removed]]:line-through'
 
 type ManagedDiffTagProps = Record<string, unknown> & { children?: ReactNode }
-type DiffSegment = ManagedFileVersionDiffResult['lines'][number]['segments'][number]
+type DiffSegment = ManagedFileVersionDiffSegment
 type MarkdownDiffBlock = Extract<DiffRenderBlock, { kind: 'markdown' }>
 
 const ManagedDiffAdded = ({ children }: ManagedDiffTagProps): React.JSX.Element => {
@@ -48,6 +51,28 @@ const ManagedDiffRemoved = ({ children }: ManagedDiffTagProps): React.JSX.Elemen
   )
 }
 
+const ControlCharacterLabel = ({ text }: { text: string }): React.JSX.Element | null => {
+  const { t } = useTranslation()
+  if (!/^[\r\n]+$/u.test(text)) return null
+  const label =
+    text === '\r'
+      ? t('Carriage return (CR)')
+      : text === '\n'
+        ? t('Line feed (LF)')
+        : text === '\r\n'
+          ? t('Line ending (CRLF)')
+          : t('Line ending characters')
+  return (
+    <span
+      data-diff-format-label=""
+      className="mx-1 select-none rounded border px-1 font-sans text-xs no-underline"
+      style={{ textDecoration: 'none' }}
+    >
+      {label}
+    </span>
+  )
+}
+
 const DiffSegments = ({ segments }: { segments: DiffSegment[] }): React.JSX.Element => {
   const { t } = useTranslation()
   return (
@@ -61,6 +86,7 @@ const DiffSegments = ({ segments }: { segments: DiffSegment[] }): React.JSX.Elem
             className="bg-diff-added-highlight font-medium text-text-000 no-underline"
           >
             <span className="sr-only">{t('Added:')} </span>
+            <ControlCharacterLabel text={segment.text} />
             <span data-managed-diff-content="">{segment.text}</span>
           </ins>
         ) : segment.kind === 'removed' ? (
@@ -71,6 +97,7 @@ const DiffSegments = ({ segments }: { segments: DiffSegment[] }): React.JSX.Elem
             className="bg-diff-removed-highlight text-text-000 line-through"
           >
             <span className="sr-only">{t('Removed:')} </span>
+            <ControlCharacterLabel text={segment.text} />
             <span data-managed-diff-content="">{segment.text}</span>
           </del>
         ) : (
@@ -136,13 +163,70 @@ const ManagedVersionDiffContent = memo(
       [markdownChangeTags, presentationKind, result]
     )
 
+    const lastBefore = result.lines.findLast(
+      (line) => line.kind === 'context' || line.kind === 'removed'
+    )
+    const lastAfter = result.lines.findLast(
+      (line) => line.kind === 'context' || line.kind === 'added'
+    )
+    const endsWithNewline = (line: typeof lastBefore): boolean =>
+      line !== undefined &&
+      line.kind !== 'omitted' &&
+      /[\r\n]$/u.test(line.segments.map((segment) => segment.text).join(''))
+    const trailingNewlineChanged = endsWithNewline(lastBefore) !== endsWithNewline(lastAfter)
+
     return (
       <div
         className="min-h-full bg-bg-000 py-2 font-mono text-xs text-text-000"
         role="region"
         aria-label={t('File version differences')}
       >
+        {trailingNewlineChanged ? (
+          <p className="mx-4 mb-2 select-none font-sans text-sm" data-diff-format-summary="">
+            {endsWithNewline(lastAfter)
+              ? t('Newline at end of file added')
+              : t('Newline at end of file removed')}
+          </p>
+        ) : null}
+        {result.baseFormat &&
+        result.selectedFormat &&
+        result.baseFormat.hasUtf8Bom !== result.selectedFormat.hasUtf8Bom ? (
+          <p className="mx-4 mb-2 select-none font-sans text-sm" data-diff-format-summary="">
+            {result.selectedFormat.hasUtf8Bom ? t('UTF-8 BOM added') : t('UTF-8 BOM removed')}
+          </p>
+        ) : null}
+        {!result.lines.some((line) => line.kind === 'added' || line.kind === 'removed') ? (
+          <p className="mx-4 mb-2 select-none font-sans text-sm">{t('No text changes.')}</p>
+        ) : null}
+        {result.lines.some((line) => line.kind === 'omitted') ? (
+          <p className="mx-4 mb-2 select-none font-sans text-xs text-text-100">
+            {t(
+              'Unchanged sections are omitted. Use the version preview or download to read the complete files.'
+            )}
+          </p>
+        ) : null}
         {blocks.map((block) => {
+          if (block.kind === 'omitted') {
+            const lineCount = block.count
+            return (
+              <div
+                key={`omitted:${block.startIndex}`}
+                data-diff-kind="omitted"
+                className="my-2 select-none border-y px-4 py-2 font-sans text-text-100"
+              >
+                {t(
+                  'Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})',
+                  {
+                    lineCount,
+                    oldStart: block.oldLineNumber,
+                    oldEnd: block.oldLineNumber + lineCount - 1,
+                    newStart: block.newLineNumber,
+                    newEnd: block.newLineNumber + lineCount - 1
+                  }
+                )}
+              </div>
+            )
+          }
           if (block.kind === 'markdown') {
             if (block.changeKind === 'context' || block.changeKind === 'mixed') {
               return (

--- a/src/renderer/src/pages/workspace/ManagedVersionDiffContent.tsx
+++ b/src/renderer/src/pages/workspace/ManagedVersionDiffContent.tsx
@@ -172,7 +172,7 @@ const ManagedVersionDiffContent = memo(
     const endsWithNewline = (line: typeof lastBefore): boolean =>
       line !== undefined &&
       line.kind !== 'omitted' &&
-      /[\r\n]$/u.test(line.segments.map((segment) => segment.text).join(''))
+      /\n$/u.test(line.segments.map((segment) => segment.text).join(''))
     const trailingNewlineChanged = endsWithNewline(lastBefore) !== endsWithNewline(lastAfter)
 
     return (

--- a/src/renderer/src/pages/workspace/ManagedVersionDiffError.test.tsx
+++ b/src/renderer/src/pages/workspace/ManagedVersionDiffError.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ManagedVersionDiffError } from './ManagedVersionDiffError'
+
+afterEach(cleanup)
+
+it.each([
+  ['DIFF_INPUT_LIMIT_EXCEEDED', '2 MiB', false],
+  ['DIFF_OUTPUT_LIMIT_EXCEEDED', 'display limit', false],
+  ['DIFF_TIMEOUT', 'time limit', true],
+  ['DIFF_CONCURRENCY_LIMIT', 'Other comparisons', true],
+  ['STORAGE_UNAVAILABLE', 'storage location', true]
+] as const)(
+  'explains %s and offers the appropriate recovery action',
+  (code, explanation, retryable) => {
+    const onRetry = vi.fn()
+    const onView = vi.fn()
+    render(<ManagedVersionDiffError error={{ code }} onRetry={onRetry} onView={onView} />)
+    expect(screen.getByRole('alert').textContent).toContain(explanation)
+    const retry = screen.queryByRole('button', { name: 'Retry' })
+    expect(Boolean(retry)).toBe(retryable)
+    if (retry) {
+      fireEvent.click(retry)
+      expect(onRetry).toHaveBeenCalledTimes(1)
+    }
+    fireEvent.click(screen.getByRole('button', { name: 'View version' }))
+    expect(onView).toHaveBeenCalledTimes(1)
+  }
+)

--- a/src/renderer/src/pages/workspace/ManagedVersionDiffError.tsx
+++ b/src/renderer/src/pages/workspace/ManagedVersionDiffError.tsx
@@ -1,0 +1,58 @@
+import { useTranslation } from 'react-i18next'
+import { ErrorNotice } from '@/components/error-notice'
+import type { ManagedFileVersionErrorCode } from '../../../../shared/managed-file-versions'
+
+type Props = {
+  error: { code?: ManagedFileVersionErrorCode }
+  onRetry: () => void
+  onView: () => void
+}
+
+export const ManagedVersionDiffError = ({ error, onRetry, onView }: Props): React.JSX.Element => {
+  const { t } = useTranslation()
+  const description = (() => {
+    switch (error.code) {
+      case 'DIFF_INPUT_LIMIT_EXCEEDED':
+        return t(
+          'A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.'
+        )
+      case 'DIFF_OUTPUT_LIMIT_EXCEEDED':
+        return t(
+          'The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.'
+        )
+      case 'DIFF_TIMEOUT':
+        return t(
+          'Comparison took too long. You can retry, but complex changes may reach the time limit again.'
+        )
+      case 'DIFF_CONCURRENCY_LIMIT':
+        return t('Other comparisons are running. Wait for them to finish, then retry.')
+      case 'STORAGE_UNAVAILABLE':
+        return t(
+          'Version storage is unavailable. Check that the storage location is accessible, then retry.'
+        )
+      default:
+        return t(
+          'This comparison could not be completed. Return to the version preview to check the file.'
+        )
+    }
+  })()
+  const retryable =
+    !error.code ||
+    ['DIFF_TIMEOUT', 'DIFF_CONCURRENCY_LIMIT', 'STORAGE_UNAVAILABLE'].includes(error.code)
+  return (
+    <div className="p-4">
+      <ErrorNotice
+        role="alert"
+        tone="amber"
+        title={t('Diff could not be loaded.')}
+        description={description}
+        primaryButton={
+          retryable
+            ? { label: t('Retry'), onClick: onRetry }
+            : { label: t('View version'), onClick: onView }
+        }
+        secondaryButton={retryable ? { label: t('View version'), onClick: onView } : undefined}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -80,6 +80,7 @@ import { PreviewFileContent } from './previews/PreviewFileContent'
 import type { PreviewDownloadVersionContext } from './previews/preview-runtime-context'
 import type { PreviewInteractionPort } from './previews/preview-types'
 import { ArtifactProvenancePanel } from './ArtifactProvenancePanel'
+import { ManagedVersionDiffError } from './ManagedVersionDiffError'
 import { ManagedVersionDiffContent } from './ManagedVersionDiffContent'
 import { PreviewActionMenuAdapterProvider } from './preview-actions/preview-action-adapter'
 import { usePreviewActions } from './preview-actions/preview-action-hooks'
@@ -1669,10 +1670,14 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                         format={resolvedPreviewItem.format}
                         name={resolvedPreviewItem.name}
                       />
+                    ) : managedWorkflow.diffError ? (
+                      <ManagedVersionDiffError
+                        error={managedWorkflow.diffError}
+                        onRetry={managedWorkflow.refreshInspect}
+                        onView={managedWorkflow.stopDiff}
+                      />
                     ) : (
-                      <div className="p-4 text-sm text-text-100">
-                        {managedWorkflow.diffError ?? t('Comparing versions...')}
-                      </div>
+                      <div className="p-4 text-sm text-text-100">{t('Comparing versions...')}</div>
                     )
                   ) : renderContent ? (
                     <PreviewFileContent

--- a/src/renderer/src/pages/workspace/managed-version-diff-presentation.test.ts
+++ b/src/renderer/src/pages/workspace/managed-version-diff-presentation.test.ts
@@ -2,7 +2,10 @@ import { marked } from 'marked'
 import { describe, expect, it, vi } from 'vitest'
 
 import { ManagedTextDiffTaskRunner } from '../../../../main/managed-file-versions/diff-task'
-import type { ManagedFileVersionDiffResult } from '../../../../shared/managed-file-versions'
+import type {
+  ManagedFileVersionDiffResult,
+  ManagedFileVersionDiffSegment
+} from '../../../../shared/managed-file-versions'
 import {
   toDiffPresentationBlocks,
   type DiffRenderBlock,
@@ -49,7 +52,7 @@ const expectPresentation = (actual: DiffRenderBlock[], expected: object[]): void
 }
 
 const expectSourceReconstruction = (
-  segments: ManagedFileVersionDiffResult['lines'][number]['segments'],
+  segments: ManagedFileVersionDiffSegment[],
   before: string,
   after: string
 ): void => {
@@ -1266,7 +1269,9 @@ describe('managed version diff presentation', () => {
     ].join('\n')
 
     const blocks = await diffMarkdown(before, after, 'rendered-real-world-shortened-paragraph')
-    const mixedBlocks = blocks.filter((block) => block.changeKind === 'mixed')
+    const mixedBlocks = blocks.filter(
+      (block) => block.kind !== 'omitted' && block.changeKind === 'mixed'
+    )
 
     expect(mixedBlocks.length).toBeGreaterThan(0)
     expect(mixedBlocks.every((block) => block.kind === 'markdown')).toBe(true)

--- a/src/renderer/src/pages/workspace/managed-version-diff-presentation.ts
+++ b/src/renderer/src/pages/workspace/managed-version-diff-presentation.ts
@@ -2,9 +2,14 @@ import { diffArrays } from 'diff'
 import { marked } from 'marked'
 import { html, parseFragment, type DefaultTreeAdapterTypes } from 'parse5'
 
-import type { ManagedFileVersionDiffResult } from '../../../../shared/managed-file-versions'
+import type {
+  ManagedFileVersionDiffResult,
+  ManagedFileVersionDiffLine,
+  ManagedFileVersionDiffOmission
+} from '../../../../shared/managed-file-versions'
 
-type DiffLine = ManagedFileVersionDiffResult['lines'][number]
+type DiffLine = ManagedFileVersionDiffLine
+type TextDiffResult = { lines: DiffLine[] }
 type DiffSegment = DiffLine['segments'][number]
 type DiffPresentationKind = 'markdown' | 'prose' | 'structured'
 type MarkdownChangeTags = { added: string; removed: string }
@@ -63,6 +68,7 @@ type MarkdownRenderBlockBase = {
 }
 
 type DiffRenderBlock =
+  | (ManagedFileVersionDiffOmission & { startIndex: number })
   | {
       kind: 'text'
       changeKind: 'context' | 'mixed' | 'added' | 'removed'
@@ -419,7 +425,7 @@ const conservativeMarkdownContainerRanges = (entries: IndexedDiffLine[]): DiffRa
 const markdownContainerRanges = (
   before: IndexedDiffLine[],
   after: IndexedDiffLine[],
-  lines: ManagedFileVersionDiffResult['lines'],
+  lines: DiffLine[],
   useStructureSkeleton: boolean
 ): DiffRange[] | undefined => {
   if (![...before, ...after].some(({ line }) => MARKDOWN_FENCE_MARKER.test(diffLineText(line)))) {
@@ -1428,11 +1434,7 @@ const isRenderableStandaloneTableRow = (line: DiffLine): boolean => {
 const indentationWidth = (indentation: string): number =>
   Array.from(indentation).reduce((width, character) => width + (character === '\t' ? 4 : 1), 0)
 
-const hasListAncestor = (
-  lines: ManagedFileVersionDiffResult['lines'],
-  index: number,
-  indentation: string
-): boolean => {
+const hasListAncestor = (lines: DiffLine[], index: number, indentation: string): boolean => {
   const currentIndentation = indentationWidth(indentation)
   if (currentIndentation < 4) return true
   for (let previousIndex = index - 1; previousIndex >= 0; previousIndex -= 1) {
@@ -1458,10 +1460,7 @@ const mergeOverlappingDiffRanges = (ranges: DiffRange[]): DiffRange[] => {
   return merged
 }
 
-const mergeMarkdownRanges = (
-  ranges: DiffRange[],
-  lines: ManagedFileVersionDiffResult['lines']
-): DiffRange[] => {
+const mergeMarkdownRanges = (ranges: DiffRange[], lines: DiffLine[]): DiffRange[] => {
   const merged: DiffRange[] = []
   for (const range of mergeOverlappingDiffRanges(ranges)) {
     const previous = merged.at(-1)
@@ -1685,7 +1684,7 @@ const toStandaloneMarkdownChange = (
 }
 
 const inlineMarkdownPairs = (
-  lines: ManagedFileVersionDiffResult['lines'],
+  lines: DiffLine[],
   tags: MarkdownChangeTags
 ): {
   pairs: Map<number, InlineMarkdownChange>
@@ -1742,10 +1741,9 @@ const inlineMarkdownPairs = (
   return { pairs, indexes, stableHtmlIndexes, stableMarkdownIndexes, forcedRawRanges }
 }
 
-const markdownSourceContent = (lines: ManagedFileVersionDiffResult['lines']): string =>
-  markdownSource(lines).content
+const markdownSourceContent = (lines: DiffLine[]): string => markdownSource(lines).content
 
-const markdownContent = (lines: ManagedFileVersionDiffResult['lines']): string =>
+const markdownContent = (lines: DiffLine[]): string =>
   markdownSourceContent(lines).replace(/(?:\r\n|\n)$/u, '')
 
 const isMarkdownParagraphLine = (line: DiffLine): boolean => {
@@ -1763,7 +1761,7 @@ const isMarkdownParagraphLine = (line: DiffLine): boolean => {
 }
 
 const nonInlineParagraphRanges = (
-  lines: ManagedFileVersionDiffResult['lines'],
+  lines: DiffLine[],
   inlinePairs: ReadonlyMap<number, InlineMarkdownChange>
 ): DiffRange[] => {
   const ranges: DiffRange[] = []
@@ -1793,7 +1791,7 @@ const nonInlineParagraphRanges = (
 }
 
 const toTextRenderBlocks = (
-  result: ManagedFileVersionDiffResult,
+  result: TextDiffResult,
   presentationKind: Exclude<DiffPresentationKind, 'markdown'>,
   mergeStructuredReplacements = false
 ): DiffRenderBlock[] => {
@@ -1848,7 +1846,7 @@ const toTextRenderBlocks = (
 }
 
 const toRawMarkdownRenderBlocks = (
-  result: ManagedFileVersionDiffResult,
+  result: TextDiffResult,
   markdownRanges: DiffRange[] = []
 ): DiffRenderBlock[] => {
   const blocks: DiffRenderBlock[] = []
@@ -1959,7 +1957,7 @@ const toRawMarkdownRenderBlocks = (
   return blocks
 }
 
-const requiresRawMarkdownDiff = (result: ManagedFileVersionDiffResult): boolean => {
+const requiresRawMarkdownDiff = (result: TextDiffResult): boolean => {
   const before = markdownSourceContent(result.lines.filter((line) => line.kind !== 'added'))
   const after = markdownSourceContent(result.lines.filter((line) => line.kind !== 'removed'))
   return [before, after].some(
@@ -1970,7 +1968,7 @@ const requiresRawMarkdownDiff = (result: ManagedFileVersionDiffResult): boolean 
 }
 
 const isInlineSemanticRange = (
-  lines: ManagedFileVersionDiffResult['lines'],
+  lines: DiffLine[],
   range: DiffRange,
   inlineChangeIndexes: ReadonlySet<number>,
   stableHtmlIndexes: ReadonlySet<number>,
@@ -2013,7 +2011,7 @@ const isInlineSemanticRange = (
 }
 
 const toMarkdownRenderBlocks = (
-  result: ManagedFileVersionDiffResult,
+  result: TextDiffResult,
   tags: MarkdownChangeTags
 ): DiffRenderBlock[] => {
   const before = result.lines
@@ -2224,8 +2222,30 @@ const toDiffPresentationBlocks = (
   presentationKind: DiffPresentationKind,
   markdownChangeTags: MarkdownChangeTags = DEFAULT_MARKDOWN_CHANGE_TAGS
 ): DiffRenderBlock[] => {
-  if (presentationKind === 'markdown') return toMarkdownRenderBlocks(result, markdownChangeTags)
-  return toTextRenderBlocks(result, presentationKind, presentationKind === 'structured')
+  const hasOmissions = result.lines.some((line) => line.kind === 'omitted')
+  const blocks: DiffRenderBlock[] = []
+  let pending: DiffLine[] = []
+  let start = 0
+  const flush = (): void => {
+    const chunk = { lines: pending }
+    // Omitted Markdown may start inside a fence/table or omit reference definitions.
+    // Keep these disjoint excerpts as source, and preserve invisible changed characters.
+    const rendered =
+      presentationKind === 'markdown' && !hasOmissions
+        ? toMarkdownRenderBlocks(chunk, markdownChangeTags)
+        : toTextRenderBlocks(chunk, presentationKind === 'prose' ? 'prose' : 'structured', true)
+    blocks.push(...rendered.map((block) => ({ ...block, startIndex: block.startIndex + start })))
+    pending = []
+  }
+  result.lines.forEach((line, index) => {
+    if (line.kind === 'omitted') {
+      flush()
+      blocks.push({ ...line, startIndex: index })
+      start = index + 1
+    } else pending.push(line)
+  })
+  flush()
+  return blocks
 }
 
 export { toDiffPresentationBlocks }

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx
@@ -574,3 +574,51 @@ it.each(['success', 'error', 'reject'] as const)(
     expect(workflow.diffResult).toEqual(result)
   }
 )
+
+it.each([
+  'DIFF_INPUT_LIMIT_EXCEEDED',
+  'DIFF_OUTPUT_LIMIT_EXCEEDED',
+  'DIFF_TIMEOUT',
+  'DIFF_CONCURRENCY_LIMIT',
+  'STORAGE_UNAVAILABLE'
+] as const)('retains the actionable diff failure %s', async (code) => {
+  inspect.mockResolvedValue({ ok: true, value: snapshot('upload', 2) })
+  window.api.managedFileVersions.diffText = vi.fn().mockResolvedValue({
+    ok: false,
+    error: { code, message: 'Internal diagnostic must not become display copy' }
+  })
+  window.api.managedFileVersions.cancelDiff = vi.fn().mockResolvedValue({
+    ok: true,
+    value: { cancelled: true }
+  })
+  await render(itemFor('upload'))
+  await act(async () => workflow.startDiff())
+  expect(window.api.managedFileVersions.diffText).toHaveBeenCalledTimes(1)
+  expect(workflow.diffResult).toBeUndefined()
+  expect(workflow.diffError).toMatchObject({ code })
+})
+
+it('retries a failed comparison through a fresh inspection and clears its error', async () => {
+  inspect.mockResolvedValue({ ok: true, value: snapshot('upload', 2) })
+  const value = { baseVersionId: 'v1', selectedVersionId: 'v2', lines: [] }
+  window.api.managedFileVersions.diffText = vi
+    .fn()
+    .mockResolvedValueOnce({
+      ok: false,
+      error: { code: 'DIFF_CONCURRENCY_LIMIT', message: 'busy' }
+    })
+    .mockResolvedValueOnce({ ok: true, value })
+  window.api.managedFileVersions.cancelDiff = vi
+    .fn()
+    .mockResolvedValue({ ok: true, value: { cancelled: true } })
+  await render(itemFor('upload'))
+  await act(async () => workflow.startDiff())
+  expect(workflow.diffError).toMatchObject({ code: 'DIFF_CONCURRENCY_LIMIT' })
+  await act(async () => workflow.refreshInspect())
+  expect(inspect).toHaveBeenCalledTimes(2)
+  expect(workflow.diffError).toBeUndefined()
+  expect(workflow.diffResult).toEqual(value)
+  const calls = vi.mocked(window.api.managedFileVersions.diffText).mock.calls
+  expect(calls).toHaveLength(2)
+  expect(calls[0][0].requestId).not.toBe(calls[1][0].requestId)
+})

--- a/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
+++ b/src/renderer/src/pages/workspace/useManagedVersionWorkflow.ts
@@ -16,6 +16,7 @@ import { useSessionStore } from '@/stores/session-store'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import type {
   ManagedFileIdentity,
+  ManagedFileVersionErrorCode,
   ManagedFileVersionDiffResult,
   ManagedFileVersionInspectResult
 } from '../../../../shared/managed-file-versions'
@@ -30,7 +31,7 @@ type ManagedVersionWorkflow = {
   navigationInspect: ManagedFileVersionInspectResult | undefined
   controlsInspect: ManagedFileVersionInspectResult | undefined
   diffResult: ManagedFileVersionDiffResult | undefined
-  diffError: string | undefined
+  diffError: { code?: ManagedFileVersionErrorCode } | undefined
   showTextTools: boolean
   isSelectedSourceText: boolean
   downloadVersionContext: PreviewDownloadVersionContext | undefined
@@ -80,7 +81,7 @@ const useManagedVersionWorkflow = ({
   const [diff, setDiff] = useState<{
     key?: string
     result?: ManagedFileVersionDiffResult
-    error?: string
+    error?: { code?: ManagedFileVersionErrorCode }
   }>({})
   const activeDiffRequestId = useRef<string | undefined>(undefined)
   const source = item.source ?? 'artifact'
@@ -275,11 +276,11 @@ const useManagedVersionWorkflow = ({
         activeDiffRequestId.current = undefined
         if (result.ok) setDiff({ key: requestKey, result: result.value })
         else if (result.error.code !== 'DIFF_CANCELLED')
-          setDiff({ key: requestKey, error: t('Diff could not be loaded.') })
+          setDiff({ key: requestKey, error: { code: result.error.code } })
       })
       .catch(() => {
         if (activeDiffRequestId.current === requestId && refresh === refreshGeneration.current)
-          setDiff({ key: requestKey, error: t('Diff could not be loaded.') })
+          setDiff({ key: requestKey, error: {} })
       })
     return () => {
       if (activeDiffRequestId.current !== requestId) return

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4790,6 +4790,24 @@
     "Loaded bytes {{start}}–{{end}}": "Geladene Bytes {{start}}–{{end}}",
     "First line is continued from the previous page": "Die erste Zeile wird von der vorherigen Seite fortgesetzt",
     "Last line continues on the next page": "Die letzte Zeile wird auf der nächsten Seite fortgesetzt",
-    "Partial source context; syntax highlighting is unavailable": "Unvollständiger Quelltextkontext; Syntaxhervorhebung nicht verfügbar"
+    "Partial source context; syntax highlighting is unavailable": "Unvollständiger Quelltextkontext; Syntaxhervorhebung nicht verfügbar",
+    "Carriage return (CR)": "Wagenrücklauf (CR)",
+    "Line feed (LF)": "Zeilenvorschub (LF)",
+    "Line ending (CRLF)": "Zeilenende (CRLF)",
+    "Line ending characters": "Zeilenendezeichen",
+    "UTF-8 BOM added": "UTF-8-BOM hinzugefügt",
+    "UTF-8 BOM removed": "UTF-8-BOM entfernt",
+    "No text changes.": "Keine Textänderungen.",
+    "Newline at end of file added": "Zeilenumbruch am Dateiende hinzugefügt",
+    "Newline at end of file removed": "Zeilenumbruch am Dateiende entfernt",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "Unveränderte Abschnitte sind ausgelassen. Verwenden Sie die Versionsvorschau oder den Download, um die vollständigen Dateien zu lesen.",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "Ausgelassene unveränderte Zeilen: {{lineCount}} (Basis {{oldStart}}–{{oldEnd}}, Auswahl {{newStart}}–{{newEnd}})",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "Eine Version überschreitet die Eingabegrenze von 2 MiB. Öffnen Sie die Vorschau oder laden Sie jede Version herunter, um die vollständigen Dateien zu vergleichen.",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "Die Änderungen überschreiten auch ohne unveränderte Abschnitte die Anzeigegrenze. Öffnen Sie die Vorschau oder laden Sie jede Version herunter, um die vollständigen Dateien zu vergleichen.",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "Der Vergleich hat zu lange gedauert. Sie können es erneut versuchen, aber komplexe Änderungen können das Zeitlimit erneut erreichen.",
+    "Other comparisons are running. Wait for them to finish, then retry.": "Andere Vergleiche werden ausgeführt. Warten Sie, bis sie abgeschlossen sind, und versuchen Sie es erneut.",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "Der Versionsspeicher ist nicht verfügbar. Prüfen Sie, ob der Speicherort erreichbar ist, und versuchen Sie es erneut.",
+    "This comparison could not be completed. Return to the version preview to check the file.": "Dieser Vergleich konnte nicht abgeschlossen werden. Kehren Sie zur Versionsvorschau zurück, um die Datei zu prüfen.",
+    "View version": "Version anzeigen"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4952,6 +4952,24 @@
     "Loaded bytes {{start}}–{{end}}": "Bytes cargados {{start}}–{{end}}",
     "First line is continued from the previous page": "La primera línea continúa desde la página anterior",
     "Last line continues on the next page": "La última línea continúa en la página siguiente",
-    "Partial source context; syntax highlighting is unavailable": "Contexto de código fuente parcial; resaltado de sintaxis no disponible"
+    "Partial source context; syntax highlighting is unavailable": "Contexto de código fuente parcial; resaltado de sintaxis no disponible",
+    "Carriage return (CR)": "Retorno de carro (CR)",
+    "Line feed (LF)": "Salto de línea (LF)",
+    "Line ending (CRLF)": "Final de línea (CRLF)",
+    "Line ending characters": "Caracteres de final de línea",
+    "UTF-8 BOM added": "BOM UTF-8 añadido",
+    "UTF-8 BOM removed": "BOM UTF-8 eliminado",
+    "No text changes.": "No hay cambios en el texto.",
+    "Newline at end of file added": "Salto de línea al final del archivo añadido",
+    "Newline at end of file removed": "Salto de línea al final del archivo eliminado",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "Se omiten las secciones sin cambios. Use la vista previa de la versión o descargue los archivos para leerlos completos.",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "Líneas sin cambios omitidas: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, seleccionada {{newStart}}–{{newEnd}})",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "Una versión supera el límite de entrada de 2 MiB. Abra la vista previa o descargue cada versión para comparar los archivos completos.",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "Los cambios superan el límite de visualización, incluso omitiendo las secciones sin cambios. Abra la vista previa o descargue cada versión para comparar los archivos completos.",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "La comparación tardó demasiado. Puede reintentar, pero los cambios complejos pueden volver a alcanzar el límite de tiempo.",
+    "Other comparisons are running. Wait for them to finish, then retry.": "Hay otras comparaciones en curso. Espere a que terminen y vuelva a intentarlo.",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "El almacenamiento de versiones no está disponible. Compruebe que la ubicación sea accesible y vuelva a intentarlo.",
+    "This comparison could not be completed. Return to the version preview to check the file.": "No se pudo completar la comparación. Vuelva a la vista previa de la versión para comprobar el archivo.",
+    "View version": "Ver versión"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4952,6 +4952,24 @@
     "Loaded bytes {{start}}–{{end}}": "Octets chargés {{start}}–{{end}}",
     "First line is continued from the previous page": "La première ligne est la suite de la page précédente",
     "Last line continues on the next page": "La dernière ligne continue sur la page suivante",
-    "Partial source context; syntax highlighting is unavailable": "Contexte du code source incomplet ; coloration syntaxique indisponible"
+    "Partial source context; syntax highlighting is unavailable": "Contexte du code source incomplet ; coloration syntaxique indisponible",
+    "Carriage return (CR)": "Retour chariot (CR)",
+    "Line feed (LF)": "Saut de ligne (LF)",
+    "Line ending (CRLF)": "Fin de ligne (CRLF)",
+    "Line ending characters": "Caractères de fin de ligne",
+    "UTF-8 BOM added": "BOM UTF-8 ajouté",
+    "UTF-8 BOM removed": "BOM UTF-8 supprimé",
+    "No text changes.": "Aucune modification du texte.",
+    "Newline at end of file added": "Saut de ligne ajouté en fin de fichier",
+    "Newline at end of file removed": "Saut de ligne supprimé en fin de fichier",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "Les sections inchangées sont omises. Utilisez l’aperçu des versions ou téléchargez les fichiers pour les lire en entier.",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "Lignes inchangées omises : {{lineCount}} (base {{oldStart}}–{{oldEnd}}, sélection {{newStart}}–{{newEnd}})",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "Une version dépasse la limite d’entrée de 2 Mio. Ouvrez l’aperçu ou téléchargez chaque version pour comparer les fichiers complets.",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "Les modifications dépassent la limite d’affichage, même en omettant les sections inchangées. Ouvrez l’aperçu ou téléchargez chaque version pour comparer les fichiers complets.",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "La comparaison a pris trop de temps. Vous pouvez réessayer, mais des modifications complexes peuvent à nouveau atteindre la limite de temps.",
+    "Other comparisons are running. Wait for them to finish, then retry.": "D’autres comparaisons sont en cours. Attendez leur fin, puis réessayez.",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "Le stockage des versions est indisponible. Vérifiez que son emplacement est accessible, puis réessayez.",
+    "This comparison could not be completed. Return to the version preview to check the file.": "Cette comparaison n’a pas pu aboutir. Revenez à l’aperçu de la version pour vérifier le fichier.",
+    "View version": "Voir la version"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4636,6 +4636,24 @@
     "Loaded bytes {{start}}–{{end}}": "読み込み済みのバイト範囲：{{start}}～{{end}}",
     "First line is continued from the previous page": "最初の行は前のページからの続きです",
     "Last line continues on the next page": "最後の行は次のページに続きます",
-    "Partial source context; syntax highlighting is unavailable": "ソースの前後関係が不完全なため、構文の強調表示は利用できません"
+    "Partial source context; syntax highlighting is unavailable": "ソースの前後関係が不完全なため、構文の強調表示は利用できません",
+    "Carriage return (CR)": "復帰文字（CR）",
+    "Line feed (LF)": "改行文字（LF）",
+    "Line ending (CRLF)": "行末文字（CRLF）",
+    "Line ending characters": "行末文字",
+    "UTF-8 BOM added": "UTF-8 BOM を追加",
+    "UTF-8 BOM removed": "UTF-8 BOM を削除",
+    "No text changes.": "本文に変更はありません。",
+    "Newline at end of file added": "ファイル末尾の改行を追加",
+    "Newline at end of file removed": "ファイル末尾の改行を削除",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "変更のない部分は省略されています。全文を読むには、バージョンをプレビューするかダウンロードしてください。",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "省略された未変更行数：{{lineCount}}（比較元 {{oldStart}}–{{oldEnd}}、選択中 {{newStart}}–{{newEnd}}）",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "バージョンが比較入力の上限 2 MiB を超えています。各バージョンをプレビューまたはダウンロードして、ファイル全体を比較してください。",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "変更のない部分を省略しても、差分が表示上限を超えています。各バージョンをプレビューまたはダウンロードして、ファイル全体を比較してください。",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "比較に時間がかかりすぎました。再試行できますが、複雑な変更では再び制限時間に達する場合があります。",
+    "Other comparisons are running. Wait for them to finish, then retry.": "他の比較を実行中です。完了してから再試行してください。",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "バージョンの保存先を利用できません。保存先にアクセスできることを確認してから再試行してください。",
+    "This comparison could not be completed. Return to the version preview to check the file.": "比較を完了できませんでした。バージョンのプレビューに戻ってファイルを確認してください。",
+    "View version": "バージョンを表示"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4634,6 +4634,24 @@
     "Loaded bytes {{start}}–{{end}}": "불러온 바이트 {{start}}–{{end}}",
     "First line is continued from the previous page": "첫 번째 행은 이전 페이지에서 이어집니다",
     "Last line continues on the next page": "마지막 행은 다음 페이지로 이어집니다",
-    "Partial source context; syntax highlighting is unavailable": "소스 컨텍스트이 일부만 있어 구문 강조를 사용할 수 없습니다"
+    "Partial source context; syntax highlighting is unavailable": "소스 컨텍스트이 일부만 있어 구문 강조를 사용할 수 없습니다",
+    "Carriage return (CR)": "캐리지 리턴(CR)",
+    "Line feed (LF)": "줄 바꿈(LF)",
+    "Line ending (CRLF)": "줄 끝 문자(CRLF)",
+    "Line ending characters": "줄 끝 문자",
+    "UTF-8 BOM added": "UTF-8 BOM 추가됨",
+    "UTF-8 BOM removed": "UTF-8 BOM 제거됨",
+    "No text changes.": "텍스트 변경 사항이 없습니다.",
+    "Newline at end of file added": "파일 끝 줄 바꿈 추가됨",
+    "Newline at end of file removed": "파일 끝 줄 바꿈 제거됨",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "변경되지 않은 부분은 생략됩니다. 전체 파일을 읽으려면 버전 미리보기를 사용하거나 다운로드하세요.",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "생략된 변경 없는 줄 수: {{lineCount}} (기준 {{oldStart}}–{{oldEnd}}, 선택 {{newStart}}–{{newEnd}})",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "버전이 비교 입력 한도인 2 MiB를 초과합니다. 전체 파일을 비교하려면 각 버전의 미리보기를 사용하거나 다운로드하세요.",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "변경되지 않은 부분을 생략해도 변경 사항이 비교 표시 한도를 초과합니다. 전체 파일을 비교하려면 각 버전의 미리보기를 사용하거나 다운로드하세요.",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "비교 시간이 너무 오래 걸렸습니다. 다시 시도할 수 있지만 복잡한 변경 사항은 다시 시간 한도에 도달할 수 있습니다.",
+    "Other comparisons are running. Wait for them to finish, then retry.": "다른 비교가 실행 중입니다. 완료될 때까지 기다린 후 다시 시도하세요.",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "버전 저장소를 사용할 수 없습니다. 저장 위치에 접근할 수 있는지 확인한 후 다시 시도하세요.",
+    "This comparison could not be completed. Return to the version preview to check the file.": "비교를 완료하지 못했습니다. 버전 미리보기로 돌아가 파일을 확인하세요.",
+    "View version": "버전 보기"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5085,6 +5085,24 @@
     "Loaded bytes {{start}}–{{end}}": "Загруженные байты {{start}}–{{end}}",
     "First line is continued from the previous page": "Первая строка продолжается с предыдущей страницы",
     "Last line continues on the next page": "Последняя строка продолжается на следующей странице",
-    "Partial source context; syntax highlighting is unavailable": "Неполный контекст исходного кода; подсветка синтаксиса недоступна"
+    "Partial source context; syntax highlighting is unavailable": "Неполный контекст исходного кода; подсветка синтаксиса недоступна",
+    "Carriage return (CR)": "Возврат каретки (CR)",
+    "Line feed (LF)": "Перевод строки (LF)",
+    "Line ending (CRLF)": "Окончание строки (CRLF)",
+    "Line ending characters": "Символы окончания строки",
+    "UTF-8 BOM added": "Добавлен BOM UTF-8",
+    "UTF-8 BOM removed": "Удалён BOM UTF-8",
+    "No text changes.": "Текст не изменён.",
+    "Newline at end of file added": "Добавлен перевод строки в конце файла",
+    "Newline at end of file removed": "Удалён перевод строки в конце файла",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "Неизменённые разделы пропущены. Для чтения файлов целиком откройте предпросмотр версии или скачайте их.",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "Пропущено неизменённых строк: {{lineCount}} (базовая версия {{oldStart}}–{{oldEnd}}, выбранная {{newStart}}–{{newEnd}})",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "Одна из версий превышает лимит входных данных сравнения в 2 МиБ. Откройте предпросмотр или скачайте каждую версию для сравнения файлов целиком.",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "Изменения превышают лимит отображения даже после пропуска неизменённых разделов. Откройте предпросмотр или скачайте каждую версию для сравнения файлов целиком.",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "Сравнение заняло слишком много времени. Можно повторить попытку, но сложные изменения могут снова привести к превышению времени.",
+    "Other comparisons are running. Wait for them to finish, then retry.": "Выполняются другие сравнения. Дождитесь их завершения и повторите попытку.",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "Хранилище версий недоступно. Проверьте доступность места хранения и повторите попытку.",
+    "This comparison could not be completed. Return to the version preview to check the file.": "Не удалось завершить сравнение. Вернитесь к предпросмотру версии, чтобы проверить файл.",
+    "View version": "Открыть версию"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4636,6 +4636,24 @@
     "Loaded bytes {{start}}–{{end}}": "已读取字节 {{start}}–{{end}}",
     "First line is continued from the previous page": "首行接续上一页的内容",
     "Last line continues on the next page": "末行将在下一页继续",
-    "Partial source context; syntax highlighting is unavailable": "源码上下文不完整，无法进行语法高亮"
+    "Partial source context; syntax highlighting is unavailable": "源码上下文不完整，无法进行语法高亮",
+    "Carriage return (CR)": "回车符（CR）",
+    "Line feed (LF)": "换行符（LF）",
+    "Line ending (CRLF)": "行结束符（CRLF）",
+    "Line ending characters": "行结束字符",
+    "UTF-8 BOM added": "已添加 UTF-8 BOM",
+    "UTF-8 BOM removed": "已移除 UTF-8 BOM",
+    "No text changes.": "正文没有变化。",
+    "Newline at end of file added": "已添加文件末尾换行",
+    "Newline at end of file removed": "已移除文件末尾换行",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "已省略未变化的部分。可通过版本预览或下载查看完整文件。",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "已省略的未变化行数：{{lineCount}}（基准 {{oldStart}}–{{oldEnd}}，所选 {{newStart}}–{{newEnd}}）",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "某个版本超过了 2 MiB 的比较输入限制。请预览或下载各版本以比较完整文件。",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "即使省略未变化的部分，差异仍超过比较显示限制。请预览或下载各版本以比较完整文件。",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "比较耗时过长。可以重试，但复杂修改可能再次达到时限。",
+    "Other comparisons are running. Wait for them to finish, then retry.": "其他比较正在进行。请等待完成后重试。",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "版本存储不可用。请确认存储位置可以访问后重试。",
+    "This comparison could not be completed. Return to the version preview to check the file.": "无法完成此次比较。请返回版本预览检查文件。",
+    "View version": "查看版本"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4636,6 +4636,24 @@
     "Loaded bytes {{start}}–{{end}}": "已讀取位元組 {{start}}–{{end}}",
     "First line is continued from the previous page": "首行接續上一頁的內容",
     "Last line continues on the next page": "末行將在下一頁繼續",
-    "Partial source context; syntax highlighting is unavailable": "原始碼上下文不完整，無法進行語法醒目提示"
+    "Partial source context; syntax highlighting is unavailable": "原始碼上下文不完整，無法進行語法醒目提示",
+    "Carriage return (CR)": "歸位字元（CR）",
+    "Line feed (LF)": "換行字元（LF）",
+    "Line ending (CRLF)": "行尾字元（CRLF）",
+    "Line ending characters": "行尾字元",
+    "UTF-8 BOM added": "已新增 UTF-8 BOM",
+    "UTF-8 BOM removed": "已移除 UTF-8 BOM",
+    "No text changes.": "正文沒有變更。",
+    "Newline at end of file added": "已新增檔案末尾換行",
+    "Newline at end of file removed": "已移除檔案末尾換行",
+    "Unchanged sections are omitted. Use the version preview or download to read the complete files.": "已省略未變更的部分。可透過版本預覽或下載查看完整檔案。",
+    "Unchanged lines omitted: {{lineCount}} (base {{oldStart}}–{{oldEnd}}, selected {{newStart}}–{{newEnd}})": "已省略的未變更行數：{{lineCount}}（基準 {{oldStart}}–{{oldEnd}}，所選 {{newStart}}–{{newEnd}}）",
+    "A version exceeds the 2 MiB comparison input limit. Preview or download each version to compare the complete files.": "某個版本超過了 2 MiB 的比較輸入限制。請預覽或下載各版本以比較完整檔案。",
+    "The changes exceed the comparison display limit, even with unchanged sections omitted. Preview or download each version to compare the complete files.": "即使省略未變更的部分，差異仍超過比較顯示限制。請預覽或下載各版本以比較完整檔案。",
+    "Comparison took too long. You can retry, but complex changes may reach the time limit again.": "比較耗時過長。可以重試，但複雜修改可能再次達到時限。",
+    "Other comparisons are running. Wait for them to finish, then retry.": "其他比較正在進行。請等待完成後重試。",
+    "Version storage is unavailable. Check that the storage location is accessible, then retry.": "版本儲存空間無法使用。請確認儲存位置可以存取後重試。",
+    "This comparison could not be completed. Return to the version preview to check the file.": "無法完成此次比較。請返回版本預覽檢查檔案。",
+    "View version": "查看版本"
   }
 }

--- a/src/shared/managed-file-versions.ts
+++ b/src/shared/managed-file-versions.ts
@@ -131,10 +131,21 @@ type ManagedFileVersionDiffLine = {
   segments: ManagedFileVersionDiffSegment[]
 }
 
+type ManagedFileVersionDiffOmission = {
+  kind: 'omitted'
+  oldLineNumber: number
+  newLineNumber: number
+  count: number
+}
+
+type ManagedFileVersionDiffRow = ManagedFileVersionDiffLine | ManagedFileVersionDiffOmission
+
 type ManagedFileVersionDiffResult = {
   baseVersionId: string
   selectedVersionId: string
-  lines: ManagedFileVersionDiffLine[]
+  lines: ManagedFileVersionDiffRow[]
+  baseFormat?: Pick<ManagedTextFormat, 'hasUtf8Bom'>
+  selectedFormat?: Pick<ManagedTextFormat, 'hasUtf8Bom'>
 }
 
 type ManagedFileVersionSaveTextEditRequest = ManagedFileIdentity & {
@@ -271,6 +282,8 @@ export {
   type ManagedFileVersionDiffRequest,
   type ManagedFileVersionCancelDiffRequest,
   type ManagedFileVersionDiffLine,
+  type ManagedFileVersionDiffRow,
+  type ManagedFileVersionDiffOmission,
   type ManagedFileVersionDiffResult,
   type ManagedFileVersionDiffSegment,
   type ManagedFileVersionInspectRequest,


### PR DESCRIPTION
## Problem

A one-character edit in a 60 KB, 5,000-line file exceeded the comparison output budget because every unchanged line was serialized. Failed comparisons also discarded their error codes, invisible line-ending changes lacked readable labels, and BOM-only changes were absent from the comparison result.

## Proposed change

- Retain the first/last three lines of each unchanged run inside the Worker, with explicit omitted line ranges. Count omission metadata against the existing output budget and continue failing atomically when changed content exceeds it.
- Preserve structured failure codes and use compact ErrorNotice with translated explanations, manual retry for transient failures/timeouts, and a return-to-preview action.
- Label changed CR/LF/CRLF segments and trailing-newline changes without replacing raw content. Return detected BOM flags and show additions/removals.
- Render Markdown containing omissions as source excerpts so missing fences or reference definitions cannot produce misleading rendered content.

## Scope and non-goals

The response row union adds `omitted` with old/new starts and a count; the response also carries BOM metadata. These are transient transport fields: no database/schema migration, persistent state, version-byte rewrites, new error codes, or historical-data conversion. Existing version bytes supply format information on demand. No in-place expansion, pagination, cache, automatic retry loop, or mixed-version client protocol is introduced. Worker memory, timeout, concurrency and output limits remain unchanged. Complete versions remain available through existing preview/download controls.

## Acceptance criteria and validation

Reproduced before production edits: two consecutive runs produced nine expected failures and one passing small-file control. The same reported cases pass after the fix. Tests use the real Worker, workflow hook, React component, and migrated temporary SQLite/filesystem service; no production test seam was added.

Rebased onto the latest main at maintainer request; the only conflicts were concurrent additions to the eight locale catalogs. Both sets of additions were retained. The prior review failure was a checkout error for the unavailable merge ref while the PR conflicted; the rebased PR is mergeable and all selected CI checks now pass.

Final local behavior-to-check mapping, repeated on rebased commit `e4d8fd53` after the last material edit (1,477 passed, both runtime typechecks and lint passed):

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| Sparse changes, omitted-range reconstruction, retained output failure and Worker controls | `src/main/managed-file-versions/diff-task.test.ts` | 52 passed |
| Artifact/Upload BOM additions/removals, verified reads and version lifecycle | `src/main/managed-file-versions/service.integration.test.ts`, `version-file-operator.test.ts` | 135 passed |
| Response forwarding, cancellation, concurrency and surface exposure | `src/main/managed-file-versions/ipc.test.ts`, `src/preload/index.test.ts`, `src/shared/renderer-surface-inventory.test.ts` | 105 passed |
| Error identity, retry freshness and obsolete-response rejection | `useManagedVersionWorkflow.test.tsx` | 44 passed |
| Omission/format rendering and error recovery controls | `ManagedVersionDiffContent.test.tsx`, `ManagedVersionDiffContent.fallback.test.tsx`, `ManagedVersionDiffError.test.tsx`, `managed-version-diff-presentation.test.ts` | 185 passed |
| Preview integration and version freshness | `PreviewFileSurface.test.tsx`, `PreviewFileSurface.freshness.test.tsx` | 152 passed |
| All eight translated locales | `src/renderer/src/i18n/resources.test.ts` | 804 passed |
| Runtime contracts and source quality | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint` | passed |

The 1,477 tests above were run together with:

```sh
node node_modules/vitest/vitest.mjs run src/main/managed-file-versions \
  src/renderer/src/pages/workspace/useManagedVersionWorkflow.test.tsx \
  src/renderer/src/pages/workspace/ManagedVersionDiffContent.test.tsx \
  src/renderer/src/pages/workspace/ManagedVersionDiffContent.fallback.test.tsx \
  src/renderer/src/pages/workspace/managed-version-diff-presentation.test.ts \
  src/renderer/src/pages/workspace/ManagedVersionDiffError.test.tsx \
  src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx \
  src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx \
  src/renderer/src/i18n/resources.test.ts src/preload/index.test.ts \
  src/shared/renderer-surface-inventory.test.ts --maxWorkers=3
```

Browser verification used the actual components with Worker-generated local fixtures: omitted ranges and CR/BOM labels were visible; retry dispatched; selecting the raw CR returned CR unchanged. Screenshots were provided locally to the maintainer. This was a component test page, not a complete Electron session or screen-reader test.

`npm run test:affected:explain -- --base origin/main --head HEAD` requests a full suite because the managed-version test owner is not registered in the module manifest. Per maintainer instruction, the full local suite was not run; full/platform PR CI remains authoritative. CodeGraph reported the parent-worktree index, so final consumers were checked through current imports, typechecks and the tests above, not assumed from a stale graph. No path or persisted-format semantics changed; additional OS/Electron verification is left to CI.

CI on `e4d8fd53`: 24 successful checks and 3 intentionally skipped checks, including all portable shards, coverage aggregation, Windows core/E2E, macOS build/E2E, Linux Notebook isolation, static checks, and CodeQL. The first Ubuntu shard attempt had two Prisma P2028 fixture-migration timeouts (5-second transaction budget, about 5.9 seconds elapsed). Both affected test files passed a focused 114-test run; rerunning only that shard and its dependent coverage aggregation passed. No production timeout, migration, or test requirement was changed.

## Review focus

Confirm omitted ranges account for every unchanged line without hiding a changed row; disjoint Markdown is not rendered as a continuous document; retries retain request-generation guards; format labels never replace raw segments. The first independent review identified bare trailing CR being misclassified as a newline. Two regression cases reproduced that failure before changing the predicate to match the existing LF/CRLF eligibility rule. Both now pass. The independent review of `e4d8fd53` returned `mergeable` with no actionable findings.
