### PR TITLE
fix(provenance): preserve selection and evidence completeness

### DIFF
--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act } from 'react'
+import { act, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -39,6 +39,12 @@ vi.mock('@/components/ReviewerCard', () => ({
   }
 }))
 
+vi.mock('./previews/PreviewFileContent', () => ({
+  PreviewFileContent: ({ item }: { item: PreviewFileItem }) => (
+    <div data-testid="preview-version">{item.selectedVersionId}</div>
+  )
+}))
+
 vi.mock('./SessionNotebookDialog', () => ({
   NotebookDialogCell: ({ run }: { run: { runId: string } }) => (
     <div data-testid="notebook-run">{run.runId}</div>
@@ -68,6 +74,8 @@ vi.mock('./WorkspaceActivityGroup', () => ({
 }))
 
 import { ArtifactProvenancePanel } from './ArtifactProvenancePanel'
+import { PreviewFileSurface } from './PreviewFileSurface'
+import { buildBoundedExecutionSnapshot } from '../../../../main/artifacts/provenance-execution-evidence'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -1928,6 +1936,18 @@ describe('ArtifactProvenancePanel', () => {
       2,
       expect.objectContaining({ suggestedName: 'sin-v1-r.ipynb' })
     )
+    for (const [index, kernel] of ['python', 'r'].entries()) {
+      const notebook = JSON.parse(new TextDecoder().decode(saveBlobFile.mock.calls[index]![0].data))
+      expect(notebook.metadata.open_science).toMatchObject({
+        kernel_filter: kernel,
+        snapshot_scope: { retained_run_count: 2, kernels: ['python', 'r'] }
+      })
+      expect(notebook.cells[0].cell_type).toBe('markdown')
+      expect(notebook.cells[0].source.join('')).toContain(`only ${kernel} runs`)
+      const code = notebook.cells.filter((cell: { cell_type: string }) => cell.cell_type === 'code')
+      expect(code).toHaveLength(1)
+      expect(code[0].source.join('')).toContain(kernel === 'python' ? 'np.sin(0)' : 'plot(sin(0))')
+    }
   })
 
   it('discloses bounded execution evidence instead of presenting it as complete', async () => {
@@ -1979,5 +1999,298 @@ describe('ArtifactProvenancePanel', () => {
 
     expect(container.textContent).toContain('save cancelled')
     expect(container.querySelector('[data-testid="notebook-run"]')).not.toBeNull()
+  })
+})
+
+describe('Provenance selection and evidence completeness', () => {
+  it('follows an external version selection after accepting a panel navigation', async () => {
+    const renderPanel = (selectedItem: PreviewFileItem): boolean => {
+      root.render(
+        <ArtifactProvenancePanel
+          item={selectedItem}
+          projectId="project-1"
+          onClose={vi.fn()}
+          onVersionChange={renderPanel}
+        />
+      )
+      return true
+    }
+    await act(async () => renderPanel(item))
+    const next = (): HTMLButtonElement =>
+      container.querySelector<HTMLButtonElement>('[aria-label="Next Artifact version"]')!
+    expect(next().disabled).toBe(false)
+    await act(async () => next().click())
+    await flush()
+    expect(getVersionProvenance).toHaveBeenLastCalledWith(
+      expect.objectContaining({ versionId: 'version-2' })
+    )
+    expect(next().disabled).toBe(true)
+
+    await act(async () => renderPanel({ ...item }))
+    await flush()
+    expect
+      .soft(getVersionProvenance)
+      .toHaveBeenLastCalledWith(expect.objectContaining({ versionId: 'version-1' }))
+    expect
+      .soft(window.api.artifacts.getLineage)
+      .toHaveBeenLastCalledWith(expect.objectContaining({ versionId: 'version-1' }))
+    expect(next().disabled).toBe(false)
+  })
+
+  it('keeps the mounted provenance pane aligned with the owning preview selection', async () => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe(): void {
+          /* jsdom does not measure layout. */
+        }
+        unobserve(): void {
+          /* jsdom does not measure layout. */
+        }
+        disconnect(): void {
+          /* jsdom does not measure layout. */
+        }
+      }
+    )
+    const Owner = (): React.JSX.Element => {
+      const [selected, setSelected] = useState(item)
+      return (
+        <>
+          <button onClick={() => setSelected({ ...item })}>Select original file version</button>
+          <PreviewFileSurface
+            item={selected}
+            onItemChange={setSelected}
+            onClose={vi.fn()}
+            provenanceEntry="leading"
+          />
+        </>
+      )
+    }
+    try {
+      await act(async () => root.render(<Owner />))
+      await flush()
+      const open = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Open Provenance for sin.png"]'
+      )!
+      expect(open).not.toBeNull()
+      await act(async () => open.click())
+      await flush()
+      const pane = container.querySelector('[data-testid="preview-provenance-pane"]')!
+      expect(pane).not.toBeNull()
+      const next = (): HTMLButtonElement =>
+        pane.querySelector<HTMLButtonElement>('[aria-label="Next Artifact version"]')!
+      await act(async () => next().click())
+      await flush()
+      expect(container.querySelector('[data-testid="preview-version"]')?.textContent).toBe(
+        'version-2'
+      )
+      expect(next().disabled).toBe(true)
+      await clickTab('Select original file version')
+      await flush()
+      expect(container.querySelector('[data-testid="preview-version"]')?.textContent).toBe(
+        'version-1'
+      )
+      expect(container.querySelector('[data-testid="preview-provenance-pane"]')).toBe(pane)
+      expect(next().disabled).toBe(false)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('reads a pending message snapshot again after file metadata changes and the tab reopens', async () => {
+    getVersionMessages.mockResolvedValueOnce({
+      messages: { state: 'unavailable', reason: 'message-snapshot-pending' }
+    })
+    await clickTab('Messages')
+    await flush()
+    expect(getVersionMessages).toHaveBeenCalledTimes(1)
+    expect(container.textContent).toContain('message-snapshot-pending')
+    await clickTab('Code')
+    await act(async () =>
+      root.render(
+        <ArtifactProvenancePanel
+          item={{ ...item, mtimeMs: 2, versionNumber: 1 }}
+          projectId="project-1"
+          onClose={vi.fn()}
+        />
+      )
+    )
+    await clickTab('Messages')
+    await flush()
+    expect.soft(getVersionMessages).toHaveBeenCalledTimes(2)
+    expect.soft(container.textContent).toContain('The plot is ready.')
+
+    // Remounting proves the same version's available response can be read and displayed.
+    await act(async () =>
+      root.render(
+        <ArtifactProvenancePanel
+          key="reopened"
+          item={item}
+          projectId="project-1"
+          onClose={vi.fn()}
+          initialTab="messages"
+        />
+      )
+    )
+    await flush()
+    expect(container.textContent).toContain('The plot is ready.')
+  })
+
+  it('rechecks pending messages explicitly without polling and retains a ready snapshot on refresh', async () => {
+    const pending = { messages: { state: 'unavailable', reason: 'message-snapshot-pending' } }
+    getVersionMessages.mockResolvedValueOnce(pending).mockResolvedValueOnce(pending)
+    await clickTab('Messages')
+    await flush()
+    const recheck = (): HTMLButtonElement | undefined =>
+      [...container.querySelectorAll('button')].find(
+        (button) => button.textContent === 'Recheck message snapshot'
+      )
+    expect(recheck()).toBeDefined()
+    await act(async () => recheck()!.click())
+    await flush()
+    expect(getVersionMessages).toHaveBeenCalledTimes(2)
+    expect(recheck()).toBeDefined()
+    await flush()
+    expect(getVersionMessages).toHaveBeenCalledTimes(2)
+    await act(async () => recheck()!.click())
+    await flush()
+    expect(getVersionMessages).toHaveBeenCalledTimes(3)
+    expect(container.textContent).toContain('The plot is ready.')
+    expect(recheck()).toBeUndefined()
+    await clickTab('Code')
+    await act(async () =>
+      root.render(
+        <ArtifactProvenancePanel
+          item={{ ...item, mtimeMs: 3 }}
+          projectId="project-1"
+          onClose={vi.fn()}
+        />
+      )
+    )
+    await clickTab('Messages')
+    await flush()
+    expect(getVersionMessages).toHaveBeenCalledTimes(3)
+    expect(container.textContent).toContain('The plot is ready.')
+  })
+
+  it('rechecks pending messages when file metadata changes while Messages stays open', async () => {
+    getVersionMessages.mockResolvedValueOnce({
+      messages: { state: 'unavailable', reason: 'message-snapshot-pending' }
+    })
+    await clickTab('Messages')
+    await flush()
+    await act(async () =>
+      root.render(
+        <ArtifactProvenancePanel
+          item={{ ...item, mtimeMs: 3 }}
+          projectId="project-1"
+          onClose={vi.fn()}
+        />
+      )
+    )
+    await flush()
+    expect(getVersionMessages).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('The plot is ready.')
+  })
+
+  it('preserves known execution omissions in the downloaded notebook', async () => {
+    const truncation = {
+      reason: 'payload-limit',
+      omittedLeadingRunCount: 3,
+      omittedOutputCount: 17,
+      omittedInputCount: 2
+    }
+    getVersionExecution.mockResolvedValue({ execution: { ...provenance().execution!, truncation } })
+    await clickTab('Execution Log')
+    await flush()
+    expect(container.textContent).toContain('omitted 3 earlier runs, 17 outputs, and 2 inputs')
+    await clickTab('Download notebook')
+    expect(saveBlobFile).toHaveBeenCalledOnce()
+    const notebook = JSON.parse(new TextDecoder().decode(saveBlobFile.mock.calls[0]![0].data))
+    expect.soft(notebook.metadata.open_science.truncation).toEqual(truncation)
+    expect(notebook.cells[0]).toMatchObject({ cell_type: 'markdown' })
+    expect(notebook.cells[0].source.join('')).toContain(
+      'omitted 3 earlier runs, 17 outputs, and 2 inputs'
+    )
+  })
+
+  const capturedTable = (): NonNullable<ArtifactVersionProvenance['execution']> => {
+    const base = provenance().execution!
+    const snapshot = buildBoundedExecutionSnapshot(
+      {
+        schemaVersion: 2,
+        rootFrameId: base.rootFrameId,
+        agentFrameId: base.agentFrameId,
+        messageBranchId: base.messageBranchId,
+        terminalPromptMessageId: base.terminalPromptMessageId,
+        producerRunId: base.producerRunId,
+        producerRunIndex: base.producerRunIndex,
+        createdAt: base.createdAt
+      },
+      [
+        {
+          runIndex: 0,
+          run: {
+            runId: base.producerRunId,
+            cellId: 'cell-1',
+            source: 'agent',
+            kernelKind: 'python',
+            script: 'samples',
+            status: 'completed',
+            startedAt: 1,
+            endedAt: 2,
+            text: { stdout: '', stderr: '', traceback: '', plain: [] },
+            outputs: [
+              {
+                type: 'json',
+                data: Array.from({ length: 1000 }, (_, i) => ({
+                  sample: `S-${i}`,
+                  concentration: 3.2
+                }))
+              }
+            ],
+            artifacts: [],
+            workingFiles: []
+          }
+        }
+      ]
+    )
+    expect(snapshot.truncation).toBeUndefined()
+    expect(snapshot.runs[0]!.outputs[0]).toMatchObject({
+      type: 'table',
+      columns: ['sample', 'concentration'],
+      rowCount: 1000
+    })
+    expect(snapshot.inputFiles).toEqual([])
+    expect(snapshot.helperModules ?? []).toEqual([])
+    return { ...snapshot, inputFiles: [], helperModules: [] }
+  }
+
+  it('exports captured table columns and original row count along with preview rows', async () => {
+    const execution = capturedTable()
+    getVersionExecution.mockResolvedValue({ execution })
+    await clickTab('Execution Log')
+    await clickTab('Download notebook')
+    expect(saveBlobFile).toHaveBeenCalledOnce()
+    const notebook = JSON.parse(new TextDecoder().decode(saveBlobFile.mock.calls[0]![0].data))
+    const data = notebook.cells.find((cell: { cell_type: string }) => cell.cell_type === 'code')
+      .outputs[0].data
+    expect.soft(data['application/json']).toMatchObject({
+      columns: ['sample', 'concentration'],
+      rowCount: 1000,
+      previewRows: expect.any(Array)
+    })
+    expect(data['text/plain'].join('')).toContain('concentration')
+    expect(data['text/plain'].join('')).toContain('first 100 of 1000 rows')
+    expect(data['application/json'].previewRows).toHaveLength(100)
+    expect(data['application/json'].previewRows[0]).toEqual(['S-0', 3.2])
+  })
+
+  it('discloses the displayed and original row counts for a sampled execution table', async () => {
+    getVersionExecution.mockResolvedValue({ execution: capturedTable() })
+    await clickTab('Execution Log')
+    await flush()
+    expect(container.querySelector('[data-testid="notebook-run"]')).not.toBeNull()
+    expect(container.textContent).toMatch(/100[\s\S]*1[,]?000/)
   })
 })

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -251,7 +251,24 @@ const toNotebookOutputs = (value: unknown): Array<Record<string, unknown>> => {
     if (type === 'table') {
       outputs.push({
         output_type: 'display_data',
-        data: { 'application/json': output.previewRows ?? [], 'text/plain': ['[Table preview]'] },
+        data: {
+          'application/json': {
+            columns: output.columns,
+            rowCount: output.rowCount,
+            previewRows: output.previewRows
+          },
+          'text/plain': [
+            `Table preview: showing first ${Array.isArray(output.previewRows) ? output.previewRows.length : 0} of ${output.rowCount} rows.\n`,
+            ...(Array.isArray(output.columns) ? [output.columns.join('\t') + '\n'] : []),
+            ...(Array.isArray(output.previewRows)
+              ? output.previewRows.map((row) =>
+                  Array.isArray(row)
+                    ? row.map((cell) => JSON.stringify(cell)).join('\t') + '\n'
+                    : ''
+                )
+              : [])
+          ]
+        },
         metadata: {}
       })
       continue
@@ -263,7 +280,7 @@ const toNotebookOutputs = (value: unknown): Array<Record<string, unknown>> => {
 }
 
 const buildExecutionNotebook = (
-  runs: unknown[],
+  execution: NonNullable<ArtifactVersionProvenance['execution']>,
   kernel: 'python' | 'r',
   metadata: {
     artifactId: string
@@ -271,41 +288,73 @@ const buildExecutionNotebook = (
     producerRunId?: string
     runtimeVersion?: string
   }
-): Record<string, unknown> => ({
-  cells: runs.flatMap((candidate) => {
-    const run = asRecord(candidate)
-    if (!run || asString(run.kernelKind) !== kernel) return []
-    const script = asString(run.script)
-    if (script === undefined) return []
-    return [
-      {
-        cell_type: 'code',
-        execution_count: typeof run.executionCount === 'number' ? run.executionCount : null,
-        metadata: { open_science_run_id: asString(run.runId) },
-        outputs: toNotebookOutputs(run.outputs),
-        source: toSourceLines(script)
+): Record<string, unknown> => {
+  const kernels = [...new Set(execution.runs.map((run) => run.kernelKind))]
+  const notices: string[] = []
+  if (execution.truncation) {
+    const { omittedLeadingRunCount, omittedOutputCount, omittedInputCount } = execution.truncation
+    notices.push(
+      `Execution evidence was bounded for storage: omitted ${omittedLeadingRunCount} earlier runs, ${omittedOutputCount} outputs, and ${omittedInputCount} inputs. Missing earlier code may define values used by retained cells.`
+    )
+  }
+  if (kernels.length > 1) {
+    notices.push(
+      `This notebook contains only ${kernel} runs from a snapshot containing ${kernels.join(', ')} kernels. Omission counts describe the original snapshot, not this kernel alone.`
+    )
+  }
+  return {
+    cells: [
+      ...(notices.length
+        ? [{ cell_type: 'markdown', metadata: {}, source: toSourceLines(notices.join('\n\n')) }]
+        : []),
+      ...execution.runs.flatMap((candidate) => {
+        const run = asRecord(candidate)
+        if (!run || asString(run.kernelKind) !== kernel) return []
+        const script = asString(run.script)
+        if (script === undefined) return []
+        return [
+          {
+            cell_type: 'code',
+            execution_count: typeof run.executionCount === 'number' ? run.executionCount : null,
+            metadata: { open_science_run_id: asString(run.runId) },
+            outputs: toNotebookOutputs(run.outputs),
+            source: toSourceLines(script)
+          }
+        ]
+      })
+    ],
+    metadata: {
+      kernelspec:
+        kernel === 'python'
+          ? { display_name: 'Python 3', language: 'python', name: 'python3' }
+          : { display_name: 'R', language: 'R', name: 'ir' },
+      language_info: {
+        name: kernel,
+        ...(metadata.runtimeVersion ? { version: metadata.runtimeVersion } : {})
+      },
+      open_science: {
+        artifact_id: metadata.artifactId,
+        artifact_version_id: metadata.versionId,
+        producer_run_id: metadata.producerRunId,
+        provenance_snapshot: true,
+        ...(execution.truncation ? { truncation: execution.truncation } : {}),
+        snapshot_scope: {
+          created_at: execution.createdAt,
+          root_frame_id: execution.rootFrameId,
+          agent_frame_id: execution.agentFrameId,
+          message_branch_id: execution.messageBranchId,
+          terminal_prompt_message_id: execution.terminalPromptMessageId,
+          producer_run_index: execution.producerRunIndex,
+          retained_run_count: execution.runs.length,
+          kernels
+        },
+        kernel_filter: kernel
       }
-    ]
-  }),
-  metadata: {
-    kernelspec:
-      kernel === 'python'
-        ? { display_name: 'Python 3', language: 'python', name: 'python3' }
-        : { display_name: 'R', language: 'R', name: 'ir' },
-    language_info: {
-      name: kernel,
-      ...(metadata.runtimeVersion ? { version: metadata.runtimeVersion } : {})
     },
-    open_science: {
-      artifact_id: metadata.artifactId,
-      artifact_version_id: metadata.versionId,
-      producer_run_id: metadata.producerRunId,
-      provenance_snapshot: true
-    }
-  },
-  nbformat: 4,
-  nbformat_minor: 5
-})
+    nbformat: 4,
+    nbformat_minor: 5
+  }
+}
 
 type AvailableProvenanceMessages = Extract<
   ArtifactVersionProvenance['messages'],
@@ -526,7 +575,7 @@ const ArtifactProvenancePanel = ({
     versionId: string
   }>()
   const requestedVersionId =
-    selectedVersion && selectedVersion.artifactId === item.artifactId
+    !onVersionChange && selectedVersion && selectedVersion.artifactId === item.artifactId
       ? selectedVersion.versionId
       : item.selectedVersionId
   const lineageRequestKey = `${lineageKey}:${requestedVersionId ?? ''}`
@@ -811,6 +860,32 @@ const ArtifactProvenancePanel = ({
     ? deferredSectionResults[deferredSectionKey]
     : undefined
   const deferredSectionState = deferredSectionResult?.state
+  const retryDeferredSection = (): void => {
+    setDeferredSectionResults((current) => {
+      if (!deferredSectionKey || !current[deferredSectionKey]) return current
+      const next = { ...current }
+      delete next[deferredSectionKey]
+      return next
+    })
+  }
+  // Pending is a successful read of temporary unavailability, not an immutable snapshot.
+  // Recheck on tab navigation or file refresh; a ready snapshot keeps its version cache.
+  useEffect(() => {
+    const key = `${provenanceKey}:messages:0`
+    setDeferredSectionResults((current) => {
+      const result = current[key]
+      if (
+        result?.state !== 'loaded' ||
+        !('messages' in result.section) ||
+        result.section.messages?.state !== 'unavailable' ||
+        result.section.messages.reason !== 'message-snapshot-pending'
+      )
+        return current
+      const next = { ...current }
+      delete next[key]
+      return next
+    })
+  }, [activeTab, item.mtimeMs, item.versionNumber, provenanceKey])
   const provenance = useMemo(
     () =>
       coreProvenance && deferredSectionResult?.state === 'loaded'
@@ -887,6 +962,8 @@ const ArtifactProvenancePanel = ({
   }, [
     activeTab,
     deferredSectionState,
+    item.mtimeMs,
+    item.versionNumber,
     item.artifactId,
     item.sessionId,
     hasLoadedProvenance,
@@ -1032,18 +1109,24 @@ const ArtifactProvenancePanel = ({
       ? onVersionChange(nextItem)
       : usePreviewWorkbenchStore.getState().upsertItem(nextItem)
     if (!committed) return
-    setSelectedVersion({ artifactId: item.artifactId, versionId })
+    if (!onVersionChange) setSelectedVersion({ artifactId: item.artifactId, versionId })
   }
 
   const downloadExecutionNotebook = async (): Promise<void> => {
-    if (executionKernels.length === 0 || !item.artifactId || !selectedVersionId) return
+    if (
+      executionKernels.length === 0 ||
+      !item.artifactId ||
+      !selectedVersionId ||
+      !provenance?.execution
+    )
+      return
     setExportingNotebook(true)
     setNotebookExportFailure(undefined)
     try {
       const baseName = item.name.replace(/\.[^.]+$/u, '') || 'artifact'
       const versionNumber = selectedVersionDescriptor?.versionNumber ?? 1
       for (const kernel of executionKernels) {
-        const notebook = buildExecutionNotebook(rawExecutionRuns, kernel, {
+        const notebook = buildExecutionNotebook(provenance.execution, kernel, {
           artifactId: item.artifactId,
           versionId: selectedVersionId,
           producerRunId: asString(producer?.producer_run_id),
@@ -1333,14 +1416,7 @@ const ArtifactProvenancePanel = ({
             failure={deferredSectionResult}
             diagnostics={diagnosticsFor(deferredSectionResult, activeTab)}
             onRetry={
-              deferredSectionResult.kind === 'integrity-failed'
-                ? undefined
-                : () =>
-                    setDeferredSectionResults((current) => {
-                      const next = { ...current }
-                      if (deferredSectionKey) delete next[deferredSectionKey]
-                      return next
-                    })
+              deferredSectionResult.kind === 'integrity-failed' ? undefined : retryDeferredSection
             }
           />
         ) : null}
@@ -1601,8 +1677,20 @@ const ArtifactProvenancePanel = ({
                 <p className="px-4 py-2 text-xs text-danger-000">{notebookExportError}</p>
               ) : null}
               <div className="divide-y divide-border-300/50">
-                {executionRuns.map(({ run, index }) => (
-                  <NotebookDialogCell key={run.runId} run={run} index={index} />
+                {executionRuns.map(({ run, index }, runOffset) => (
+                  <div key={run.runId}>
+                    {rawExecutionRuns[runOffset]?.outputs.map((output, outputIndex) =>
+                      output.type === 'table' ? (
+                        <p key={outputIndex} className="px-4 py-2 text-xs text-text-200">
+                          {t('Table preview: showing first {{shown}} of {{total}} rows.', {
+                            shown: output.previewRows.length,
+                            total: output.rowCount
+                          })}
+                        </p>
+                      ) : null
+                    )}
+                    <NotebookDialogCell run={run} index={index} />
+                  </div>
                 ))}
               </div>
             </div>
@@ -1621,16 +1709,23 @@ const ArtifactProvenancePanel = ({
               sessionId={item.sessionId}
             />
           ) : (
-            <p className="p-5 text-sm text-text-300">
-              {provenance.messages.reason === 'message-snapshot-unsupported'
-                ? t(
-                    'This message snapshot was created by a newer version of Open Science. Update the app to view it.'
-                  )
-                : t(
-                    'The immutable message snapshot is not available for this version ({{reason}}).',
-                    { reason: provenance.messages.reason }
-                  )}
-            </p>
+            <div className="space-y-3 p-5 text-sm text-text-300">
+              <p>
+                {provenance.messages.reason === 'message-snapshot-unsupported'
+                  ? t(
+                      'This message snapshot was created by a newer version of Open Science. Update the app to view it.'
+                    )
+                  : t(
+                      'The immutable message snapshot is not available for this version ({{reason}}).',
+                      { reason: provenance.messages.reason }
+                    )}
+              </p>
+              {provenance.messages.reason === 'message-snapshot-pending' ? (
+                <Button type="button" size="sm" variant="outline" onClick={retryDeferredSection}>
+                  {t('Recheck message snapshot')}
+                </Button>
+              ) : null}
+            </div>
           )
         ) : null}
         {provenance && activeTab === 'environment' ? (

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4784,6 +4784,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "Die Vorschau von UTF-16-CSV-Dateien wird nicht unterstützt. Speichern Sie eine Kopie als UTF-8, um sie in der Vorschau anzuzeigen.",
     "The preview limit was reached before a complete header could be read.": "Das Vorschaulimit wurde erreicht, bevor die Kopfzeile vollständig gelesen werden konnte.",
     "The file exceeds the preview limit. Only complete records are shown.": "Die Datei überschreitet das Vorschaulimit. Es werden nur vollständige Datensätze angezeigt.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "Das Trennzeichen konnte nicht zuverlässig erkannt werden. In dieser Vorschau werden Kommas verwendet."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Das Trennzeichen konnte nicht zuverlässig erkannt werden. In dieser Vorschau werden Kommas verwendet.",
+    "Recheck message snapshot": "Nachrichten-Snapshot erneut prüfen",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "Tabellenvorschau: Die ersten {{shown}} von {{total}} Zeilen werden angezeigt."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4946,6 +4946,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "La vista previa de CSV en UTF-16 no es compatible. Guarde una copia en UTF-8 para previsualizarla.",
     "The preview limit was reached before a complete header could be read.": "Se alcanzó el límite de la vista previa antes de poder leer una cabecera completa.",
     "The file exceeds the preview limit. Only complete records are shown.": "El archivo supera el límite de la vista previa. Solo se muestran registros completos.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "No se pudo detectar el delimitador de forma fiable. Se utilizan comas en esta vista previa."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "No se pudo detectar el delimitador de forma fiable. Se utilizan comas en esta vista previa.",
+    "Recheck message snapshot": "Volver a comprobar la instantánea de mensajes",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "Vista previa de la tabla: se muestran las primeras {{shown}} de {{total}} filas."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4946,6 +4946,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "L’aperçu CSV en UTF-16 n’est pas pris en charge. Enregistrez une copie en UTF-8 pour la prévisualiser.",
     "The preview limit was reached before a complete header could be read.": "La limite de l’aperçu a été atteinte avant de pouvoir lire un en-tête complet.",
     "The file exceeds the preview limit. Only complete records are shown.": "Le fichier dépasse la limite de l’aperçu. Seuls les enregistrements complets sont affichés.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "Le séparateur n’a pas pu être détecté de manière fiable. Des virgules sont utilisées dans cet aperçu."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Le séparateur n’a pas pu être détecté de manière fiable. Des virgules sont utilisées dans cet aperçu.",
+    "Recheck message snapshot": "Revérifier l’instantané des messages",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "Aperçu du tableau : affichage des {{shown}} premières lignes sur {{total}}."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4630,6 +4630,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "UTF-16 の CSV プレビューには対応していません。プレビューするには、UTF-8 でコピーを保存してください。",
     "The preview limit was reached before a complete header could be read.": "ヘッダー全体を読み込む前にプレビューの上限に達しました。",
     "The file exceeds the preview limit. Only complete records are shown.": "ファイルがプレビューの上限を超えています。完全なレコードのみ表示しています。",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "区切り文字を確実に検出できませんでした。このプレビューではカンマを使用しています。"
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "区切り文字を確実に検出できませんでした。このプレビューではカンマを使用しています。",
+    "Recheck message snapshot": "メッセージスナップショットを再確認",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "テーブルプレビュー：全 {{total}} 行のうち先頭 {{shown}} 行を表示。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4628,6 +4628,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "UTF-16 CSV 미리보기는 지원되지 않습니다. 미리 보려면 UTF-8로 사본을 저장하세요.",
     "The preview limit was reached before a complete header could be read.": "전체 헤더를 읽기 전에 미리보기 한도에 도달했습니다.",
     "The file exceeds the preview limit. Only complete records are shown.": "파일이 미리보기 한도를 초과합니다. 완전한 레코드만 표시됩니다.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "구분자를 정확히 감지하지 못했습니다. 이 미리보기에서는 쉼표를 사용합니다."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "구분자를 정확히 감지하지 못했습니다. 이 미리보기에서는 쉼표를 사용합니다.",
+    "Recheck message snapshot": "메시지 스냅샷 다시 확인",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "표 미리보기: 전체 {{total}}행 중 처음 {{shown}}행 표시."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5079,6 +5079,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "Предпросмотр CSV в UTF-16 не поддерживается. Сохраните копию в UTF-8 для предпросмотра.",
     "The preview limit was reached before a complete header could be read.": "Предел предпросмотра достигнут до завершения чтения заголовка.",
     "The file exceeds the preview limit. Only complete records are shown.": "Файл превышает предел предпросмотра. Показаны только полные записи.",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "Не удалось надёжно определить разделитель. В этом предпросмотре используются запятые."
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "Не удалось надёжно определить разделитель. В этом предпросмотре используются запятые.",
+    "Recheck message snapshot": "Проверить снимок сообщений ещё раз",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "Предпросмотр таблицы: показаны первые {{shown}} из {{total}} строк."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4630,6 +4630,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "暂不支持预览 UTF-16 编码的 CSV。请另存一份 UTF-8 编码的副本以进行预览。",
     "The preview limit was reached before a complete header could be read.": "尚未读取完整表头，已达到预览上限。",
     "The file exceeds the preview limit. Only complete records are shown.": "文件超出预览上限，仅显示完整记录。",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "无法可靠识别分隔符。本次预览使用逗号作为分隔符。"
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "无法可靠识别分隔符。本次预览使用逗号作为分隔符。",
+    "Recheck message snapshot": "重新检查消息快照",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "表格预览：展示前 {{shown}} 行，共 {{total}} 行。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4630,6 +4630,8 @@
     "UTF-16 CSV preview is not supported. Save a copy as UTF-8 to preview it.": "暫不支援預覽 UTF-16 編碼的 CSV。請另存一份 UTF-8 編碼的副本以進行預覽。",
     "The preview limit was reached before a complete header could be read.": "尚未讀取完整表頭，已達到預覽上限。",
     "The file exceeds the preview limit. Only complete records are shown.": "檔案超出預覽上限，僅顯示完整記錄。",
-    "The delimiter could not be detected reliably. Commas are used in this preview.": "無法可靠識別分隔符號。本次預覽使用逗號作為分隔符號。"
+    "The delimiter could not be detected reliably. Commas are used in this preview.": "無法可靠識別分隔符號。本次預覽使用逗號作為分隔符號。",
+    "Recheck message snapshot": "重新檢查訊息快照",
+    "Table preview: showing first {{shown}} of {{total}} rows.": "表格預覽：顯示前 {{shown}} 列，共 {{total}} 列。"
   }
 }


### PR DESCRIPTION
## Problem

An open provenance panel can stay on a previously selected version after the owning preview returns to another version. Pending message snapshots also remain cached after they become available. Execution notebook downloads lose known omission counts, and sampled table exports lose their column names and original row count.

## Proposed change

- Follow the owner's version selection when `onVersionChange` controls the panel; retain standalone navigation and rejected-switch guards.
- Recheck only pending message results on tab navigation or file metadata refresh, with an explicit pending-only recheck action. Ready snapshots retain their cache; no polling is introduced.
- Preserve execution truncation in `metadata.open_science`, disclose omitted evidence in an opening Markdown cell, and identify the original snapshot scope and kernel filter for notebook exports.
- Export tables as `{ columns, rowCount, previewRows }` with a header-bearing text representation, and show captured versus original row counts beside the execution cell. Translate the two new UI strings in all eight locales.

## Scope and non-goals

No database migration, persisted provenance schema change, new public state enum, capture-budget change, or new dependency. Persistence changes only affect notebook files explicitly downloaded by the user. Existing retained snapshots can be re-exported; already downloaded files are not rewritten and missing historical evidence is not reconstructed.

**Export compatibility:** table `application/json` changes from a positional array to an object preserving columns and range. Custom downstream scripts consuming the old array need to adapt. The notebook remains an nbformat/MIME projection. Multi-kernel omission counts describe the original snapshot, not invented per-kernel counts.

## Acceptance criteria and validation

Before implementation, the six initial regression cases failed twice against unchanged production code, while 48 existing cases passed. The expanded suite was then checked twice against the base panel: the same nine behavior assertions failed (56 cases: 47 passed, 9 failed). The fixed panel suite passes all 56 cases. Tests exercise actual parent/child React components, real bounded snapshot capture, and the bytes passed to `saveBlobFile`; no production test seam was added.

Checks below ran after the last material source edit:

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| Selection, dirty guards, pending recovery, export bytes, preview freshness, table capture, locale coverage | `npm test -- src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx src/renderer/src/pages/workspace/preview-file-item.test.ts src/main/artifacts/provenance-helper-evidence.test.ts src/renderer/src/i18n/resources.test.ts` | 1,042 passed |
| Provenance owner, IPC/preload contracts, publication/session and preview consumers | `artifact_provenance` project-owned plan with `--maxWorkers 4` (command below) | 28 files / 1,796 passed |
| Renderer and imported contract types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Formatting and whitespace | Prettier check of changed files; `git diff --check` | Passed |
| Real browser UI and download | ego-browser with real panel, Notebook cell and message components; fixture-backed APIs | Row-range disclosure, pending recheck to ready, download omission/table metadata and 420px width verified; screenshots retained locally |

The first module run was restricted by sandbox socket permissions (`listen EPERM`); the same module passed outside that sandbox. After resolving actual locale-tail conflicts with main, the final focused set, typecheck and lint passed again. One concurrent module run had a 30-second timeout in an unchanged ACP oversized-tool permission test; its targeted group passed, and the complete same module plan then passed with four workers, without changing code or timeouts:

```sh
node --input-type=module <<'JS'
import { createModuleTestPlan, executeModuleTestPlan } from './scripts/ci/module-test-impact.mjs'
process.exitCode = executeModuleTestPlan(createModuleTestPlan('artifact_provenance'), { testArguments: ['--maxWorkers', '4'] })
JS
```

No full local suite was run, as requested by the maintainer.

`npm run test:affected:explain -- --base a0f70274 --head 03f5ebe8a7f2f8e17e81e8b326685a36061eada0` selects the full fallback because the panel lacks a registered module owner. Required PR CI remains authoritative for that complete plan and platform lanes; the ownership manifest is unchanged.

## Review focus

Controlled versus standalone selection, pending-only invalidation without polling, and exported table compatibility/omission scope. No Electron or complete Agent-generation timing window was exercised locally; browser rendering used fixtures. Independent Codex review on `03f5ebe8a7f2f8e17e81e8b326685a36061eada0` reports **mergeable, no actionable findings**. Required full/platform CI is still running; static checks, CI Integrity and Linux Notebook isolation have passed.
