### PR TITLE
fix(artifacts): reject incomplete script reconstructions

### DIFF
--- a/src/main/acp/artifact-code-reconstruction-runner.test.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.test.ts
@@ -186,6 +186,50 @@ describe('ArtifactCodeReconstructionRunner cleanup', () => {
     )
   })
 
+  it.each(['claude-code', 'opencode', 'codex', 'codebuddy'] as const)(
+    'accepts only normal completion for %s while preserving usage and releasing the runner',
+    async (frameworkId) => {
+      temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-completion-'))
+      const usage = { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }
+      const inference = vi.spyOn(RestrictedInferenceRunner.prototype, 'run').mockResolvedValue({
+        text: 'print("partial")',
+        frameworkId,
+        model: 'model-a',
+        stopReason: 'max_turn_requests',
+        usage
+      })
+      const recordUsage = vi.fn(async () => undefined)
+      const runner = new ArtifactCodeReconstructionRunner({
+        appVersion: '0.11.0',
+        configRoot: temporaryRoot,
+        captureTarget: vi.fn(),
+        resolveTarget: vi.fn(),
+        recordUsage
+      })
+      const selected = { ...target, frameworkId }
+      const context = { projectId: 'project-1', sessionId: 'session-1' }
+      await expect(runner.run('evidence', selected, context)).rejects.toThrow(
+        'did not finish normally'
+      )
+      expect(recordUsage).toHaveBeenCalledExactlyOnceWith(
+        expect.objectContaining({ frameworkId, usage })
+      )
+      inference.mockResolvedValue({
+        text: 'print("complete")',
+        frameworkId,
+        model: 'model-a',
+        stopReason: 'end_turn',
+        usage
+      })
+      await expect(runner.run('evidence', selected, context)).resolves.toEqual({
+        text: 'print("complete")',
+        frameworkId,
+        model: 'model-a'
+      })
+      expect(recordUsage).toHaveBeenCalledTimes(2)
+    }
+  )
+
   it('records provider usage attached to an ordinary reconstruction error', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-reconstruction-error-usage-'))
     const usage = { inputTokens: 7, cacheTokens: 1, outputTokens: 2, turnCount: 1 }

--- a/src/main/acp/artifact-code-reconstruction-runner.ts
+++ b/src/main/acp/artifact-code-reconstruction-runner.ts
@@ -116,6 +116,23 @@ export class ArtifactCodeReconstructionRunner {
         result.model,
         result.usage
       )
+      // Usage is already recorded even when a partial response cannot be committed as a script.
+      if (result.stopReason !== 'end_turn') {
+        switch (result.stopReason) {
+          case 'cancelled':
+            throw new Error('Code reconstruction was cancelled. Try generating the script again.')
+          case 'refusal':
+            throw new Error('The selected model refused code reconstruction. Try another model.')
+          case 'max_tokens':
+            throw new Error(
+              'Code reconstruction reached the model output limit. Try another model.'
+            )
+          default:
+            throw new Error(
+              'Code reconstruction did not finish normally. Try generating the script again.'
+            )
+        }
+      }
       return {
         text: result.text,
         frameworkId: result.frameworkId,

--- a/src/main/artifacts/code-reconstruction.test.ts
+++ b/src/main/artifacts/code-reconstruction.test.ts
@@ -234,64 +234,125 @@ const makeHarness = (value = provenance(), frameworkId: 'codex' | 'codebuddy' = 
 afterEach(() => vi.restoreAllMocks())
 
 describe('ArtifactCodeReconstructionService', () => {
-  it('refuses replay when an earlier failed cell may have mutated kernel state', async () => {
+  it.each([undefined, true])(
+    'refuses replay when an earlier failed cell may have mutated kernel state (dispatched: %s)',
+    async (kernelDispatched) => {
+      const value = provenance()
+      const helperSource = 'def offset(value):\n    return value + 2'
+      const helper = {
+        helperId: 'offset-helper',
+        skillIdentity: 'skill:offset-helper',
+        packageOrigin: 'built-in',
+        interfaceRevision: '1',
+        registeredGeneration: 'generation-1',
+        exports: ['offset'],
+        source: helperSource,
+        sourceDigest: digest(helperSource)
+      }
+      const first = value.execution!.runs[0]!
+      const producer = value.execution!.runs[1]!
+      first.script = 'baseline = 0'
+      first.kernelEpochId = producer.kernelEpochId = 'epoch-1'
+      producer.runIndex = 3
+      producer.script = 'print(offset(baseline))'
+      producer.helperModuleKeys = [notebookHelperEvidenceKey(helper)]
+      value.execution!.producerRunIndex = 3
+      if ('run_index' in value.evidence.producer) value.evidence.producer.run_index = 3
+      const failed = {
+        ...first,
+        runId: 'failed-run',
+        runIndex: 2,
+        status: 'failed' as const,
+        ...(kernelDispatched === undefined ? {} : { kernelDispatched }),
+        script: 'baseline = 40\nraise ValueError("after mutation")',
+        outputs: [{ type: 'error' as const, name: 'ValueError', message: 'after mutation' }]
+      }
+      value.execution!.runs = [first, failed, producer]
+      value.execution!.helperModules = [helper]
+      value.execution!.helperEvidenceStatus = { state: 'complete' }
+      const original = await execFileAsync('python3', [
+        '-c',
+        [
+          helperSource,
+          first.script,
+          'try:',
+          ...failed.script.split('\n').map((line) => `    ${line}`),
+          'except ValueError:',
+          '    pass',
+          producer.script
+        ].join('\n')
+      ])
+      expect(original.stdout.trim()).toBe('42')
+      const harness = makeHarness(value)
+      const generated = await harness.service.generate(request)
+      // On the broken implementation, demonstrate the semantic mismatch before the guard assertion.
+      if (generated.state === 'cached') {
+        const replay = await execFileAsync('python3', ['-c', generated.value.code])
+        expect.soft(replay.stdout.trim()).toBe(original.stdout.trim())
+        expect(generated.value).toMatchObject({ origin: 'app-replay', sourceTruncated: false })
+      }
+      expect(generated).toEqual({ state: 'unavailable', reason: 'supporting-code-incomplete' })
+      await expect(harness.service.get(request)).resolves.toEqual(generated)
+      expect(harness.run).not.toHaveBeenCalled()
+      expect(harness.writeCodeReconstructionCache).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['app-replay', 'llm'] as const)(
+    'allows %s after an explicitly non-dispatched failure and caches the result',
+    async (origin) => {
+      const value = provenance()
+      const first = value.execution!.runs[0]!
+      const producer = value.execution!.runs[1]!
+      Object.assign(first, {
+        status: 'failed',
+        kernelDispatched: false,
+        script: 'raise RuntimeError("must not replay")'
+      })
+      first.kernelEpochId = producer.kernelEpochId = 'epoch-1'
+      producer.script = 'print(2)'
+      if (origin === 'app-replay') {
+        const source = 'def offset(value):\n    return value + 2'
+        const helper = {
+          helperId: 'offset-helper',
+          skillIdentity: 'skill:offset-helper',
+          packageOrigin: 'built-in',
+          interfaceRevision: '1',
+          registeredGeneration: 'generation-1',
+          exports: ['offset'],
+          source,
+          sourceDigest: digest(source)
+        }
+        value.execution!.helperModules = [helper]
+        value.execution!.helperEvidenceStatus = { state: 'complete' }
+        producer.helperModuleKeys = [notebookHelperEvidenceKey(helper)]
+        producer.script = 'print(offset(0))'
+      }
+      const harness = makeHarness(value)
+      harness.run.mockResolvedValue({ text: 'print(2)', frameworkId: 'codex', model: 'model-a' })
+      await expect(harness.service.get(request)).resolves.toMatchObject({ state: 'ready', origin })
+      const generated = await harness.service.generate(request)
+      expect(generated).toMatchObject({ state: 'cached', value: { origin } })
+      if (generated.state !== 'cached') throw new Error('expected cached reconstruction')
+      expect(generated.value.code).not.toContain('must not replay')
+      if (origin === 'app-replay') {
+        expect(harness.run).not.toHaveBeenCalled()
+        const replay = await execFileAsync('python3', ['-c', generated.value.code])
+        expect(replay.stdout.trim()).toBe('2')
+      }
+      await expect(harness.service.get(request)).resolves.toEqual(generated)
+    }
+  )
+
+  it('does not accept an undispatched failed producer as evidence of an artifact computation', async () => {
     const value = provenance()
-    const helperSource = 'def offset(value):\n    return value + 2'
-    const helper = {
-      helperId: 'offset-helper',
-      skillIdentity: 'skill:offset-helper',
-      packageOrigin: 'built-in',
-      interfaceRevision: '1',
-      registeredGeneration: 'generation-1',
-      exports: ['offset'],
-      source: helperSource,
-      sourceDigest: digest(helperSource)
-    }
-    const first = value.execution!.runs[0]!
-    const producer = value.execution!.runs[1]!
-    first.script = 'baseline = 0'
-    first.kernelEpochId = producer.kernelEpochId = 'epoch-1'
-    producer.runIndex = 3
-    producer.script = 'print(offset(baseline))'
-    producer.helperModuleKeys = [notebookHelperEvidenceKey(helper)]
-    value.execution!.producerRunIndex = 3
-    if ('run_index' in value.evidence.producer) value.evidence.producer.run_index = 3
-    const failed = {
-      ...first,
-      runId: 'failed-run',
-      runIndex: 2,
-      status: 'failed' as const,
-      script: 'baseline = 40\nraise ValueError("after mutation")',
-      outputs: [{ type: 'error' as const, name: 'ValueError', message: 'after mutation' }]
-    }
-    value.execution!.runs = [first, failed, producer]
-    value.execution!.helperModules = [helper]
-    value.execution!.helperEvidenceStatus = { state: 'complete' }
-    const original = await execFileAsync('python3', [
-      '-c',
-      [
-        helperSource,
-        first.script,
-        'try:',
-        ...failed.script.split('\n').map((line) => `    ${line}`),
-        'except ValueError:',
-        '    pass',
-        producer.script
-      ].join('\n')
-    ])
-    expect(original.stdout.trim()).toBe('42')
+    Object.assign(value.execution!.runs[1]!, { status: 'failed', kernelDispatched: false })
     const harness = makeHarness(value)
-    const generated = await harness.service.generate(request)
-    // On the broken implementation, demonstrate the semantic mismatch before the guard assertion.
-    if (generated.state === 'cached') {
-      const replay = await execFileAsync('python3', ['-c', generated.value.code])
-      expect.soft(replay.stdout.trim()).toBe(original.stdout.trim())
-      expect(generated.value).toMatchObject({ origin: 'app-replay', sourceTruncated: false })
-    }
-    expect(generated).toEqual({ state: 'unavailable', reason: 'supporting-code-incomplete' })
-    await expect(harness.service.get(request)).resolves.toEqual(generated)
+    await expect(harness.service.generate(request)).resolves.toEqual({
+      state: 'unavailable',
+      reason: 'supporting-code-incomplete'
+    })
     expect(harness.run).not.toHaveBeenCalled()
-    expect(harness.writeCodeReconstructionCache).not.toHaveBeenCalled()
   })
 
   it.each(['max_tokens', 'cancelled', 'refusal'] as const)(
@@ -496,6 +557,7 @@ describe('ArtifactCodeReconstructionService', () => {
       const producer = value.execution!.runs[1]!
       first.status = status
       first.kernelKind = producer.kernelKind = kernelKind
+      if ('kernel_kind' in value.evidence.producer) value.evidence.producer.kernel_kind = kernelKind
       // Legacy evidence has no epoch IDs, so isolation cannot be established.
       const harness = makeHarness(value)
       const code = 'print("cached")'

--- a/src/main/artifacts/code-reconstruction.test.ts
+++ b/src/main/artifacts/code-reconstruction.test.ts
@@ -2,14 +2,20 @@ import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { promisify } from 'node:util'
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import {
+  ArtifactCodeReconstructionRunner,
+  type ArtifactCodeReconstructionRunResult
+} from '../acp/artifact-code-reconstruction-runner'
+import { RestrictedInferenceRunner } from '../acp/restricted-inference-runner'
 import type { ExplicitAgentBackendTarget } from '../settings/backend-resolver'
 import { notebookHelperEvidenceKey } from '../notebook/helper-evidence'
 import type { ArtifactVersionReconstructionProvenance } from './provenance-read-model'
 import {
   ArtifactCodeReconstructionService,
   CONTEXT_MAX_BYTES,
+  PROMPT_VERSION,
   normalizeResponse
 } from './code-reconstruction'
 
@@ -183,15 +189,20 @@ const makeHarness = (value = provenance(), frameworkId: 'codex' | 'codebuddy' = 
       cache = serialized
     }
   )
-  const run = vi.fn(async (prompt: string, target: ExplicitAgentBackendTarget) => {
-    void prompt
-    void target
-    return {
-      text: '```python\nimport pandas as pd\ndf = pd.read_csv("groups.csv")\nplot(df)\n```',
-      frameworkId,
-      model: 'model-a'
+  const run = vi.fn(
+    async (
+      prompt: string,
+      target: ExplicitAgentBackendTarget
+    ): Promise<ArtifactCodeReconstructionRunResult> => {
+      void prompt
+      void target
+      return {
+        text: '```python\nimport pandas as pd\ndf = pd.read_csv("groups.csv")\nplot(df)\n```',
+        frameworkId,
+        model: 'model-a'
+      }
     }
-  })
+  )
   const captureTarget = vi.fn(async () => ({
     frameworkId,
     providerId: 'provider-a',
@@ -220,7 +231,160 @@ const makeHarness = (value = provenance(), frameworkId: 'codex' | 'codebuddy' = 
   }
 }
 
+afterEach(() => vi.restoreAllMocks())
+
 describe('ArtifactCodeReconstructionService', () => {
+  it('refuses replay when an earlier failed cell may have mutated kernel state', async () => {
+    const value = provenance()
+    const helperSource = 'def offset(value):\n    return value + 2'
+    const helper = {
+      helperId: 'offset-helper',
+      skillIdentity: 'skill:offset-helper',
+      packageOrigin: 'built-in',
+      interfaceRevision: '1',
+      registeredGeneration: 'generation-1',
+      exports: ['offset'],
+      source: helperSource,
+      sourceDigest: digest(helperSource)
+    }
+    const first = value.execution!.runs[0]!
+    const producer = value.execution!.runs[1]!
+    first.script = 'baseline = 0'
+    first.kernelEpochId = producer.kernelEpochId = 'epoch-1'
+    producer.runIndex = 3
+    producer.script = 'print(offset(baseline))'
+    producer.helperModuleKeys = [notebookHelperEvidenceKey(helper)]
+    value.execution!.producerRunIndex = 3
+    if ('run_index' in value.evidence.producer) value.evidence.producer.run_index = 3
+    const failed = {
+      ...first,
+      runId: 'failed-run',
+      runIndex: 2,
+      status: 'failed' as const,
+      script: 'baseline = 40\nraise ValueError("after mutation")',
+      outputs: [{ type: 'error' as const, name: 'ValueError', message: 'after mutation' }]
+    }
+    value.execution!.runs = [first, failed, producer]
+    value.execution!.helperModules = [helper]
+    value.execution!.helperEvidenceStatus = { state: 'complete' }
+    const original = await execFileAsync('python3', [
+      '-c',
+      [
+        helperSource,
+        first.script,
+        'try:',
+        ...failed.script.split('\n').map((line) => `    ${line}`),
+        'except ValueError:',
+        '    pass',
+        producer.script
+      ].join('\n')
+    ])
+    expect(original.stdout.trim()).toBe('42')
+    const harness = makeHarness(value)
+    const generated = await harness.service.generate(request)
+    // On the broken implementation, demonstrate the semantic mismatch before the guard assertion.
+    if (generated.state === 'cached') {
+      const replay = await execFileAsync('python3', ['-c', generated.value.code])
+      expect.soft(replay.stdout.trim()).toBe(original.stdout.trim())
+      expect(generated.value).toMatchObject({ origin: 'app-replay', sourceTruncated: false })
+    }
+    expect(generated).toEqual({ state: 'unavailable', reason: 'supporting-code-incomplete' })
+    await expect(harness.service.get(request)).resolves.toEqual(generated)
+    expect(harness.run).not.toHaveBeenCalled()
+    expect(harness.writeCodeReconstructionCache).not.toHaveBeenCalled()
+  })
+
+  it.each(['max_tokens', 'cancelled', 'refusal'] as const)(
+    'does not cache a reconstruction terminated by %s and allows retry without losing usage',
+    async (stopReason) => {
+      const usage = { inputTokens: 13, cacheTokens: 3, outputTokens: 5, turnCount: 1 }
+      const inference = vi.spyOn(RestrictedInferenceRunner.prototype, 'run').mockResolvedValue({
+        text: 'print("unfinished',
+        frameworkId: 'codex',
+        model: 'model-a',
+        stopReason,
+        usage
+      })
+      const recordUsage = vi.fn(async () => undefined)
+      const harness = makeHarness()
+      const runner = new ArtifactCodeReconstructionRunner({
+        appVersion: '0.11.0',
+        configRoot: '/unused-mocked-inference',
+        captureTarget: harness.captureTarget,
+        resolveTarget: vi.fn(),
+        recordUsage
+      })
+      harness.run.mockImplementation((prompt, target) =>
+        runner.run(prompt, target, {
+          projectId: request.projectId,
+          sessionId: request.appSessionId
+        })
+      )
+      const result = await harness.service.generate(request).then(
+        (value) => value,
+        (error: unknown) => error
+      )
+      // Verify that the existing cache read path exposes the same incorrect success on baseline.
+      if (!(result instanceof Error)) {
+        await expect(harness.service.get(request)).resolves.toEqual(result)
+        expect(inference).toHaveBeenCalledOnce()
+      }
+      expect(result).toBeInstanceOf(Error)
+      expect(harness.writeCodeReconstructionCache).not.toHaveBeenCalled()
+      expect(recordUsage).toHaveBeenCalledExactlyOnceWith(expect.objectContaining({ usage }))
+      await expect(harness.service.get(request)).resolves.toMatchObject({
+        state: 'ready',
+        origin: 'llm'
+      })
+      inference.mockResolvedValue({
+        text: 'print("complete")',
+        frameworkId: 'codex',
+        model: 'model-a',
+        stopReason: 'end_turn',
+        usage
+      })
+      await expect(harness.service.generate(request)).resolves.toMatchObject({
+        state: 'cached',
+        value: { code: 'print("complete")' }
+      })
+      expect(inference).toHaveBeenCalledTimes(2)
+      expect(recordUsage).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it('budgets the actual escaped prompt including its evidence envelope', async () => {
+    const value = provenance()
+    const earlier = value.execution!.runs[0]!
+    const producer = value.execution!.runs[1]!
+    producer.runIndex = 31
+    value.execution!.producerRunIndex = 31
+    if ('run_index' in value.evidence.producer) value.evidence.producer.run_index = 31
+    value.execution!.runs = [
+      ...Array.from({ length: 30 }, (_, index) => ({
+        ...earlier,
+        runId: `history-${index}`,
+        runIndex: index + 1,
+        script: `# ${'<'.repeat(15_000)}`,
+        outputs: []
+      })),
+      producer
+    ]
+    const harness = makeHarness(value)
+    const generated = await harness.service.generate(request)
+    const prompt = harness.run.mock.calls[0]![0]
+    const envelope = prompt.match(
+      /<artifact_execution_evidence>\n([\s\S]*)\n<\/artifact_execution_evidence>/u
+    )![1]!
+    expect(envelope).not.toContain('<')
+    expect(envelope).toContain('\\u003c')
+    expect(Buffer.byteLength(prompt, 'utf8')).toBeLessThanOrEqual(CONTEXT_MAX_BYTES)
+    const context = JSON.parse(envelope)
+    expect(context.execution.runs[0].runId).toBe(producer.runId)
+    expect(context.omissions.omittedRuns).toBe(31 - context.execution.runs.length)
+    expect(context.omissions.reasons).toContain('context-byte-limit')
+    expect(generated).toMatchObject({ state: 'cached', value: { sourceTruncated: true } })
+  })
+
   it('checks only durable evidence and cache until generation is explicitly requested', async () => {
     const harness = makeHarness()
 
@@ -275,38 +439,133 @@ describe('ArtifactCodeReconstructionService', () => {
     expect(harness.run).toHaveBeenCalledOnce()
   })
 
-  it('reads legacy model-generated cache entries without mislabeling their origin', async () => {
-    const harness = makeHarness()
-    const code = 'print("legacy")'
-    harness.seedCache(
-      JSON.stringify({
-        schemaVersion: 1,
-        artifactVersionId: 'version-1',
-        sourceExecutionChecksum: 'b'.repeat(64),
-        contextChecksum: 'context-checksum',
-        promptVersion: 'artifact-code-reconstruction-v2',
-        frameworkId: 'codex',
-        model: 'legacy-model',
-        language: 'python',
-        generatedAt: '2026-08-06T00:30:00.000Z',
-        sourceTruncated: false,
-        codeChecksum: digest(code),
-        code
+  it.each([
+    { schemaVersion: 1, origin: undefined },
+    { schemaVersion: 2, origin: 'llm' },
+    { schemaVersion: 2, origin: 'app-replay' }
+  ])(
+    'invalidates old $origin schema $schemaVersion caches without generating on read',
+    async (identity) => {
+      const harness = makeHarness()
+      const code = 'print("legacy")'
+      harness.seedCache(
+        JSON.stringify({
+          ...identity,
+          artifactVersionId: 'version-1',
+          sourceExecutionChecksum: 'b'.repeat(64),
+          contextChecksum: 'context-checksum',
+          promptVersion: 'artifact-code-reconstruction-v2',
+          frameworkId: 'codex',
+          model: 'legacy-model',
+          language: 'python',
+          generatedAt: '2026-08-06T00:30:00.000Z',
+          sourceTruncated: false,
+          codeChecksum: digest(code),
+          code
+        })
+      )
+      await expect(harness.service.get(request)).resolves.toMatchObject({
+        state: 'ready',
+        origin: 'llm'
       })
-    )
+      expect(harness.run).not.toHaveBeenCalled()
+      expect(harness.writeCodeReconstructionCache).not.toHaveBeenCalled()
+      const generated = await harness.service.generate(request)
+      expect(generated).toMatchObject({
+        state: 'cached',
+        value: { origin: 'llm', model: 'model-a' }
+      })
+      expect(JSON.parse(harness.writeCodeReconstructionCache.mock.calls[0]![1])).toMatchObject({
+        promptVersion: PROMPT_VERSION
+      })
+      await expect(harness.service.get(request)).resolves.toEqual(generated)
+      expect(harness.run).toHaveBeenCalledOnce()
+    }
+  )
 
-    await expect(harness.service.get(request)).resolves.toEqual({
+  it.each([
+    { status: 'failed', kernelKind: 'python' },
+    { status: 'timeout', kernelKind: 'python' },
+    { status: 'interrupted', kernelKind: 'r' },
+    { status: 'cancelled', kernelKind: 'repl' }
+  ] as const)(
+    'rejects $status $kernelKind history before reading even a current cache',
+    async ({ status, kernelKind }) => {
+      const value = provenance()
+      const first = value.execution!.runs[0]!
+      const producer = value.execution!.runs[1]!
+      first.status = status
+      first.kernelKind = producer.kernelKind = kernelKind
+      // Legacy evidence has no epoch IDs, so isolation cannot be established.
+      const harness = makeHarness(value)
+      const code = 'print("cached")'
+      harness.seedCache(
+        JSON.stringify({
+          schemaVersion: 2,
+          origin: 'llm',
+          artifactVersionId: 'version-1',
+          sourceExecutionChecksum: 'b'.repeat(64),
+          promptVersion: PROMPT_VERSION,
+          language: 'python',
+          frameworkId: 'codex',
+          model: 'model-a',
+          generatedAt: '2026-08-06T00:30:00.000Z',
+          codeChecksum: digest(code),
+          code
+        })
+      )
+      const expected = { state: 'unavailable', reason: 'supporting-code-incomplete' }
+      await expect(harness.service.get(request)).resolves.toEqual(expected)
+      await expect(harness.service.generate(request)).resolves.toEqual(expected)
+      expect(harness.readCodeReconstructionCache).not.toHaveBeenCalled()
+      expect(harness.run).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each(['different-epoch', 'later-run', 'other-kernel', 'stateless-shell'] as const)(
+    'does not block reconstruction for failed history outside retained kernel state: %s',
+    async (scope) => {
+      const value = provenance()
+      const first = value.execution!.runs[0]!
+      const producer = value.execution!.runs[1]!
+      first.status = 'failed'
+      first.kernelEpochId = producer.kernelEpochId = 'epoch-1'
+      if (scope === 'different-epoch') first.kernelEpochId = 'epoch-0'
+      if (scope === 'later-run') first.runIndex = producer.runIndex + 1
+      if (scope === 'other-kernel') first.kernelKind = 'r'
+      if (scope === 'stateless-shell') first.kernelKind = producer.kernelKind = 'bash'
+      const harness = makeHarness(value)
+      await expect(harness.service.get(request)).resolves.toMatchObject({ state: 'ready' })
+    }
+  )
+
+  it('accounts for removed producer outputs after escaping and refuses oversized required evidence', async () => {
+    const value = provenance()
+    value.execution!.runs[1]!.outputs = Array.from({ length: 20 }, () => ({
+      type: 'text',
+      text: '<'.repeat(4_000)
+    }))
+    const harness = makeHarness(value)
+    await expect(harness.service.generate(request)).resolves.toMatchObject({
       state: 'cached',
-      value: {
-        origin: 'llm',
-        code,
-        language: 'python',
-        generatedAt: '2026-08-06T00:30:00.000Z',
-        frameworkId: 'codex',
-        model: 'legacy-model',
-        sourceTruncated: false
-      }
+      value: { sourceTruncated: true }
     })
+    const prompt = harness.run.mock.calls[0]![0]
+    expect(Buffer.byteLength(prompt)).toBeLessThanOrEqual(CONTEXT_MAX_BYTES)
+    const context = JSON.parse(
+      prompt.match(
+        /<artifact_execution_evidence>\n([\s\S]*)\n<\/artifact_execution_evidence>/u
+      )![1]!
+    )
+    expect(context.execution.runs).toHaveLength(1)
+    expect(context.omissions).toMatchObject({ omittedRuns: 1, omittedOutputs: 21 })
+    value.execution!.runs[1]!.script = `# ${'<'.repeat(60_000)}`
+    const tooLarge = makeHarness(value)
+    await expect(tooLarge.service.generate(request)).rejects.toThrow(
+      'too large to reconstruct safely'
+    )
+    expect(tooLarge.run).not.toHaveBeenCalled()
+    expect(tooLarge.writeCodeReconstructionCache).not.toHaveBeenCalled()
   })
 
   it('keeps the inert evidence envelope under the byte limit and puts the producer first', async () => {

--- a/src/main/artifacts/code-reconstruction.ts
+++ b/src/main/artifacts/code-reconstruction.ts
@@ -23,7 +23,8 @@ const CONTEXT_MAX_BYTES = 256 * 1024
 const PRODUCER_SCRIPT_MAX_BYTES = 160 * 1024
 const OUTPUT_MAX_BYTES = 4 * 1024
 const RESPONSE_MAX_BYTES = 1024 * 1024
-const PROMPT_VERSION = 'artifact-code-reconstruction-v2'
+// Older caches did not validate completion or preserve failed-cell state.
+const PROMPT_VERSION = 'artifact-code-reconstruction-v3'
 
 type CodeReconstructionRepository = Pick<
   import('./provenance-repository').ArtifactProvenanceRepository,
@@ -213,6 +214,22 @@ const sourceState = (
   )
   if (!producerRun?.script.trim()) {
     return { state: 'unavailable', reason: 'producer-script-missing' }
+  }
+  // Failed/interrupted cells can mutate a persistent kernel before stopping. Apply this before
+  // cache lookup and both reconstruction paths; missing epoch IDs cannot prove isolation.
+  if (
+    producerRun.kernelKind !== 'bash' &&
+    provenance.execution.runs.some(
+      (run) =>
+        run.runIndex <= producerRun.runIndex &&
+        run.kernelKind === producerRun.kernelKind &&
+        (!producerRun.kernelEpochId ||
+          !run.kernelEpochId ||
+          run.kernelEpochId === producerRun.kernelEpochId) &&
+        run.status !== 'completed'
+    )
+  ) {
+    return { state: 'unavailable', reason: 'supporting-code-incomplete' }
   }
   const hasHelperKeys = provenance.execution.runs.some(
     (run) => (run.helperModuleKeys?.length ?? 0) > 0
@@ -440,32 +457,44 @@ const buildContext = (
     }
   }
 
+  const omitRun = (run: ReconstructionRun): void => {
+    context.omissions.omittedRuns += 1
+    context.omissions.omittedOutputs += run.outputs.length
+    context.omissions.omittedBytes += byteLength(escapePromptEvidence(JSON.stringify(run)))
+    if (!context.omissions.reasons.includes('context-byte-limit')) {
+      context.omissions.reasons.push('context-byte-limit')
+    }
+  }
   for (const run of earlierRuns) {
     const projected = projectRun(run, PRODUCER_SCRIPT_MAX_BYTES)
     context.execution.runs.push(projected)
-    if (byteLength(JSON.stringify(context)) > CONTEXT_MAX_BYTES) {
+    if (byteLength(buildPrompt(JSON.stringify(context))) > CONTEXT_MAX_BYTES) {
       context.execution.runs.pop()
-      context.omissions.omittedRuns += 1
-      context.omissions.omittedOutputs += run.outputs.length
-      context.omissions.omittedBytes += byteLength(JSON.stringify(projected))
-      if (!context.omissions.reasons.includes('context-byte-limit')) {
-        context.omissions.reasons.push('context-byte-limit')
-      }
+      omitRun(projected)
     }
   }
 
   let serialized = JSON.stringify(context)
-  if (byteLength(serialized) > CONTEXT_MAX_BYTES) {
-    const producerWithoutOutputs = { ...producer, outputs: [] }
+  // Omission metadata also consumes space; discard the oldest retained history until it fits.
+  while (
+    byteLength(buildPrompt(serialized)) > CONTEXT_MAX_BYTES &&
+    context.execution.runs.length > 1
+  ) {
+    omitRun(context.execution.runs.pop()!)
+    serialized = JSON.stringify(context)
+  }
+  if (byteLength(buildPrompt(serialized)) > CONTEXT_MAX_BYTES && producer.outputs.length > 0) {
     context.omissions.omittedOutputs += producer.outputs.length
-    context.omissions.omittedBytes += byteLength(JSON.stringify(producer.outputs))
+    context.omissions.omittedBytes += byteLength(
+      escapePromptEvidence(JSON.stringify(producer.outputs))
+    )
     if (!context.omissions.reasons.includes('context-byte-limit')) {
       context.omissions.reasons.push('context-byte-limit')
     }
-    context.execution.runs = [producerWithoutOutputs]
+    producer.outputs = []
     serialized = JSON.stringify(context)
   }
-  if (byteLength(serialized) > CONTEXT_MAX_BYTES) {
+  if (byteLength(buildPrompt(serialized)) > CONTEXT_MAX_BYTES) {
     throw new Error('The producer script is too large to reconstruct safely.')
   }
   return {

--- a/src/main/artifacts/code-reconstruction.ts
+++ b/src/main/artifacts/code-reconstruction.ts
@@ -216,7 +216,8 @@ const sourceState = (
     return { state: 'unavailable', reason: 'producer-script-missing' }
   }
   // Failed/interrupted cells can mutate a persistent kernel before stopping. Apply this before
-  // cache lookup and both reconstruction paths; missing epoch IDs cannot prove isolation.
+  // cache lookup and both reconstruction paths. Only explicit non-dispatch makes earlier failures
+  // safe to omit; missing dispatch evidence or epoch IDs cannot prove isolation.
   if (
     producerRun.kernelKind !== 'bash' &&
     provenance.execution.runs.some(
@@ -226,7 +227,8 @@ const sourceState = (
         (!producerRun.kernelEpochId ||
           !run.kernelEpochId ||
           run.kernelEpochId === producerRun.kernelEpochId) &&
-        run.status !== 'completed'
+        run.status !== 'completed' &&
+        (run.runId === producerRun.runId || run.kernelDispatched !== false)
     )
   ) {
     return { state: 'unavailable', reason: 'supporting-code-incomplete' }

--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -147,6 +147,9 @@ const sanitizeRun = (
     runtimeSegmentId: run.runtimeSegmentId ?? '',
     promptMessageId: run.promptMessageId ?? '',
     ...(run.kernelEpochId ? { kernelEpochId: run.kernelEpochId } : {}),
+    ...(typeof run.kernelDispatched === 'boolean'
+      ? { kernelDispatched: run.kernelDispatched }
+      : {}),
     kernelKind: run.kernelKind,
     ...(run.environment ? { environmentName: run.environment } : {}),
     script,

--- a/src/main/artifacts/provenance-execution-snapshot-decoder.ts
+++ b/src/main/artifacts/provenance-execution-snapshot-decoder.ts
@@ -119,6 +119,7 @@ const executionRunValue = (value: unknown): boolean => {
     typeof run.runtimeSegmentId === 'string' &&
     typeof run.promptMessageId === 'string' &&
     (run.kernelEpochId === undefined || typeof run.kernelEpochId === 'string') &&
+    (run.kernelDispatched === undefined || typeof run.kernelDispatched === 'boolean') &&
     (run.kernelKind === 'python' ||
       run.kernelKind === 'r' ||
       run.kernelKind === 'repl' ||

--- a/src/main/artifacts/provenance-helper-evidence.test.ts
+++ b/src/main/artifacts/provenance-helper-evidence.test.ts
@@ -66,6 +66,21 @@ const snapshot = (runs: NotebookRunRecord[]): PersistedArtifactExecutionSnapshot
   )
 
 describe('Artifact helper execution evidence', () => {
+  it('preserves explicit non-dispatch evidence through immutable snapshot serialization', () => {
+    const failed = {
+      ...run('failed-run', 'seed = 40', []),
+      status: 'failed' as const,
+      kernelDispatched: false
+    }
+    const legacy = run('legacy-run', 'seed = 0', [])
+    delete legacy.kernelDispatched
+    const value = snapshot([failed, run('producer', 'print(2)', []), legacy])
+    const decoded = parseArtifactExecutionSnapshot(JSON.stringify(value))
+    expect(decoded.runs[0]).toHaveProperty('kernelDispatched', false)
+    expect(decoded.runs[1]).toHaveProperty('kernelDispatched', true)
+    expect(decoded.runs[2]).not.toHaveProperty('kernelDispatched')
+  })
+
   it('freezes and deterministically deduplicates sticky helper generations', () => {
     const first = helper('helper-a')
     const value = snapshot([

--- a/src/main/artifacts/provenance-snapshot-decoder.test.ts
+++ b/src/main/artifacts/provenance-snapshot-decoder.test.ts
@@ -90,6 +90,30 @@ describe('Artifact persistence decoders', () => {
     })
   })
 
+  it.each([false, true, undefined])(
+    'preserves optional dispatch evidence %s in Execution v2',
+    (kernelDispatched) => {
+      const value = executionSnapshot(2)
+      const runs = value.runs as Record<string, unknown>[]
+      Object.assign(runs[0]!, { kernelDispatched })
+      const decoded = decodeArtifactExecutionSnapshot(JSON.stringify(value))
+      expect(decoded.status).toBe('valid')
+      if (decoded.status !== 'valid') throw new Error('expected valid execution evidence')
+      if (kernelDispatched === undefined)
+        expect(decoded.value.runs[0]).not.toHaveProperty('kernelDispatched')
+      else expect(decoded.value.runs[0]).toHaveProperty('kernelDispatched', kernelDispatched)
+    }
+  )
+
+  it.each(['false', 0, null])(
+    'rejects malformed dispatch evidence %s instead of treating it as safe',
+    (kernelDispatched) => {
+      const value = executionSnapshot(2)
+      Object.assign((value.runs as Record<string, unknown>[])[0]!, { kernelDispatched })
+      expect(decodeArtifactExecutionSnapshot(JSON.stringify(value))).toEqual({ status: 'corrupt' })
+    }
+  )
+
   it('classifies Review scope v2 as valid, v1 as legacy, and future versions as unsupported', () => {
     expect(decodeReviewScopeSnapshot('{"schemaVersion":2,"blocks":[]}').status).toBe('valid')
     expect(decodeReviewScopeSnapshot('{"schemaVersion":1,"blocks":[]}').status).toBe('legacy')

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -1210,6 +1210,50 @@ describe('ArtifactProvenancePanel', () => {
     expect(container.textContent).toContain('Corrective Retrieval Augmented Generation')
   })
 
+  it('explains incomplete kernel state without hiding the reason or offering a download', async () => {
+    act(() => root.unmount())
+    getCodeReconstruction.mockResolvedValue({
+      state: 'unavailable',
+      reason: 'supporting-code-incomplete'
+    })
+    root = createRoot(container)
+    await act(async () =>
+      root.render(<ArtifactProvenancePanel item={item} projectId="project-1" onClose={vi.fn()} />)
+    )
+    await flush()
+    const reason = [...container.querySelectorAll('p')].find((p) =>
+      p.textContent?.includes('Failed or interrupted cells')
+    )
+    expect(reason?.textContent).toContain('may have changed kernel state before stopping')
+    expect(reason?.className).not.toContain('truncate')
+    const generate = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Generate script'
+    )
+    expect(generate?.disabled).toBe(true)
+    expect(container.textContent).not.toContain('Download script')
+    expect(generateCodeReconstruction).not.toHaveBeenCalled()
+  })
+
+  it('retains generation after an incomplete model response and offers download only after retry succeeds', async () => {
+    generateCodeReconstruction.mockRejectedValueOnce(
+      new Error('Code reconstruction reached the model output limit. Try another model.')
+    )
+    const generate = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Generate script'
+    )
+    await act(async () => generate?.click())
+    await flush()
+    expect(container.querySelector('[role="alert"]')?.textContent).toContain('model output limit')
+    expect(container.textContent).not.toContain('Download script')
+    const retry = [...container.querySelectorAll('button')].find(
+      (button) => button.textContent === 'Generate script'
+    )
+    await act(async () => retry?.click())
+    await flush()
+    expect(generateCodeReconstruction).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('Download script')
+  })
+
   it('checks the reconstruction cache on Code open without calling the model', async () => {
     expect(getCodeReconstruction).toHaveBeenCalledOnce()
     expect(getCodeReconstruction).toHaveBeenCalledWith({

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -179,7 +179,9 @@ const codeReconstructionUnavailableLabel = (
     case 'helper-evidence-incomplete':
       return t('Helper source evidence is incomplete for this version.')
     case 'supporting-code-incomplete':
-      return t('Supporting code evidence is incomplete for this version.')
+      return t(
+        'Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.'
+      )
   }
 }
 
@@ -1441,7 +1443,7 @@ const ArtifactProvenancePanel = ({
                   {codeReconstructionResult.message}
                 </p>
               ) : codeReconstructionState?.state === 'unavailable' ? (
-                <p className="min-w-0 flex-1 truncate text-sm text-text-200">
+                <p className="min-w-0 flex-1 text-sm text-text-200">
                   {codeReconstructionUnavailableLabel(codeReconstructionState.reason, t)}
                 </p>
               ) : codeReconstructionResult?.status === 'generating' ? (

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -466,6 +466,8 @@ export type ProvenanceNotebookRun = {
   runtimeSegmentId: string
   promptMessageId: string
   kernelEpochId?: string
+  // Missing in older snapshots; only explicit false proves the script never reached the kernel.
+  kernelDispatched?: boolean
   kernelKind: NotebookKernelKind
   environmentName?: string
   script: string

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4036,7 +4036,7 @@
     "Saved names: {{names}}.": "Gespeicherte Namen: {{names}}.",
     "Failed to restore scratch auto-detection.": "Die automatische Erkennung des Scratch-Verzeichnisses konnte nicht wiederhergestellt werden.",
     "Helper source evidence is incomplete for this version.": "Die Nachweise zum Quellcode der Hilfsprogramme sind für diese Version unvollständig.",
-    "Supporting code evidence is incomplete for this version.": "Die Nachweise zum unterstützenden Code sind für diese Version unvollständig.",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "Der unterstützende Code ist unvollständig. Fehlgeschlagene oder unterbrochene Zellen haben möglicherweise vor dem Abbruch den Kernel-Zustand verändert.",
     "Reconstructed directly from the immutable Execution Log · see <logLink>Execution Log</logLink> for the raw record": "Direkt aus dem unveränderlichen Ausführungsprotokoll rekonstruiert · den Rohdatensatz finden Sie im <logLink>Ausführungsprotokoll</logLink>",
     "Reconstructing directly from recorded helper and execution evidence.": "Direkte Rekonstruktion aus den aufgezeichneten Hilfsprogramm- und Ausführungsnachweisen.",
     "This script can be reconstructed directly from the immutable Execution Log.": "Dieses Skript kann direkt aus dem unveränderlichen Ausführungsprotokoll rekonstruiert werden.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1403,7 +1403,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "Se genera a partir del nombre cuando es posible. Edítelo ahora o déjelo en blanco para generarlo automáticamente; no podrá cambiarse después de la creación.",
     "Generating reconstructed script": "Generando script reconstruido",
     "Helper source evidence is incomplete for this version.": "La evidencia del código fuente del helper está incompleta para esta versión.",
-    "Supporting code evidence is incomplete for this version.": "La evidencia del código complementario está incompleta para esta versión.",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "El código de apoyo está incompleto. Las celdas fallidas o interrumpidas pueden haber cambiado el estado del kernel antes de detenerse.",
     "Generating script…": "Generando script…",
     "Generating…": "Generando…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "Reciba una notificación de escritorio cuando una tarea finalice, falle o espere su aprobación mientras esté fuera de la aplicación.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1401,7 +1401,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "Généré à partir du nom lorsque cela est possible. Modifiez-le maintenant ou laissez-le vide pour le générer automatiquement ; il ne peut pas être modifié après la création.",
     "Generating reconstructed script": "Génération d'un script reconstruit",
     "Helper source evidence is incomplete for this version.": "Les preuves du code source des helpers sont incomplètes pour cette version.",
-    "Supporting code evidence is incomplete for this version.": "Les preuves du code complémentaire sont incomplètes pour cette version.",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "Le code auxiliaire est incomplet. Les cellules en échec ou interrompues peuvent avoir modifié l’état du noyau avant de s’arrêter.",
     "Generating script…": "Génération du script…",
     "Generating…": "Générer…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "Recevez une notification sur le bureau lorsqu'une tâche se termine, échoue ou attend votre approbation lorsque vous êtes absent de l'application.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1341,7 +1341,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "可能な場合は名前から生成されます。今すぐ編集するか、空白のままにすると自動的に生成されます。作成後は変更できません。",
     "Generating reconstructed script": "再構築されたスクリプトの生成",
     "Helper source evidence is incomplete for this version.": "このバージョンのヘルパーソースの証拠は不完全です。",
-    "Supporting code evidence is incomplete for this version.": "このバージョンの補助コードの証拠は不完全です。",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "補助コードが不完全です。失敗または中断したセルは、停止前にカーネルの状態を変更した可能性があります。",
     "Generating script…": "スクリプトを生成中…",
     "Generating…": "生成中…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "アプリを離れている間にタスクが完了、失敗、または承認待ちになったときに、デスクトップ通知を受け取ります。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1360,7 +1360,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "가능한 경우 이름에서 생성됩니다. 지금 편집하거나 자동으로 생성되도록 비워 두세요. 생성 후에는 변경할 수 없습니다.",
     "Generating reconstructed script": "재구성된 스크립트 생성",
     "Helper source evidence is incomplete for this version.": "이 버전의 헬퍼 소스 근거가 불완전합니다.",
-    "Supporting code evidence is incomplete for this version.": "이 버전의 지원 코드 근거가 불완전합니다.",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "보조 코드가 불완전합니다. 실패하거나 중단된 셀이 멈추기 전에 커널 상태를 변경했을 수 있습니다.",
     "Generating script…": "스크립트 생성 중…",
     "Generating…": "생성 중…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "앱을 사용하지 않는 동안 작업이 완료되거나 실패하거나 승인을 기다리는 경우 데스크톱 알림을 받습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1402,7 +1402,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "Создано из имени, если возможно. Редактируйте его сейчас или оставьте пустым, чтобы сгенерировать автоматически; после создания изменить нельзя.",
     "Generating reconstructed script": "Создание восстановленного скрипта",
     "Helper source evidence is incomplete for this version.": "Данные об исходном коде вспомогательных модулей для этой версии неполны.",
-    "Supporting code evidence is incomplete for this version.": "Данные о вспомогательном коде для этой версии неполны.",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "Вспомогательный код неполон. Ячейки с ошибкой или прерванным выполнением могли изменить состояние ядра до остановки.",
     "Generating script…": "Создание скрипта…",
     "Generating…": "Создание…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "Получать уведомления, когда задача завершена, завершилась с ошибкой или ожидает разрешения, пока приложение неактивно.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1427,7 +1427,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "可根据名称自动生成。现在可以编辑，或留空以自动生成；创建后不可更改。",
     "Generating reconstructed script": "正在生成重建脚本",
     "Helper source evidence is incomplete for this version.": "此版本的 Helper 源代码证据不完整。",
-    "Supporting code evidence is incomplete for this version.": "此版本的支持代码证据不完整。",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "辅助代码不完整。失败或中断的单元格可能在停止前已改变内核状态。",
     "Generating script…": "正在生成脚本…",
     "Generating…": "正在生成…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "当你不在应用中时，任务完成、失败或等待批准时会收到桌面通知。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1426,7 +1426,7 @@
     "Generated from the name when possible. Edit it now or leave it blank to generate automatically; it cannot be changed after creation.": "可根據名稱自動產生。現在可以編輯，或留空以自動產生；建立後不可變更。",
     "Generating reconstructed script": "正在產生重建腳本",
     "Helper source evidence is incomplete for this version.": "此版本的 Helper 原始碼證據不完整。",
-    "Supporting code evidence is incomplete for this version.": "此版本的支援程式碼證據不完整。",
+    "Supporting code is incomplete. Failed or interrupted cells may have changed kernel state before stopping.": "輔助程式碼不完整。失敗或中斷的儲存格可能在停止前已改變核心狀態。",
     "Generating script…": "正在產生腳本…",
     "Generating…": "正在產生…",
     "Get a desktop notification when a task finishes, fails, or waits for your approval while you're away from the app.": "當你不在應用程式中時，任務完成、失敗或等待核准時會收到桌面通知。",


### PR DESCRIPTION
## Problem

A failed notebook cell can mutate kernel state before raising. Dropping that cell from reconstruction silently changes the result even when the generated script exits successfully. Separately, interrupted model responses were reusable success caches, and evidence escaping could expand a nominally bounded context past its byte limit.

## Proposed change

- Refuse reconstruction before cache lookup when the producer's persistent-kernel execution prefix contains incomplete runs that were dispatched or whose dispatch is unknown. Preserve the existing Notebook `kernelDispatched` boolean in immutable evidence so explicitly non-dispatched earlier failures remain reconstructable. Preserve epoch isolation and helper/source checks; use the existing `supporting-code-incomplete` reason for both replay and model reconstruction.
- Accept only normal model completion in the dedicated runner, preserving reported usage exactly once and allowing another explicit generation attempt after failure.
- Bound the actual escaped user prompt, including instructions and envelope, to 256 KiB. Account for removed history/outputs and reject required evidence that still cannot fit.
- Explain incomplete kernel state in the existing provenance panel, allowing the text to wrap in narrow panels; update all eight translations.

## Scope and non-goals

Persisted-format change: add optional `kernelDispatched?: boolean` to each immutable execution-snapshot run, copying the existing Notebook-owned value. Execution schema version remains 2: omitted values stay unknown, explicit false permits skipping an earlier incomplete run, and malformed values are rejected. No historical backfill, new enum, database schema, migration, or architecture change. Stateless shell execution remains outside the persistent-kernel eligibility rule. No automatic reexecution, model requests, dependency analysis, or state snapshots.

Historical compatibility: old snapshots still decode without the optional flag and remain conservative for incomplete runs; original snapshots are not rewritten. Advance the existing `promptVersion` so previous reconstruction caches are ignored lazily. Original artifacts and immutable evidence remain intact; no bulk deletion occurs. Regeneration requires an explicit user action and may incur model usage, including for previously valid model-generated scripts. Existing caches lack completion evidence, so reliably separating good and interrupted historical model outputs is not possible.

## Acceptance criteria and validation

Before changing production, the five regression cases failed identically in two runs, with 28 existing checks passing: real Python executions returned 42 versus 2, three non-completion reasons produced cached success, and the actual prompt was 1,535,271 bytes against a 262,144-byte limit. No Jupyter or real model service was used. Tests and UI fixtures use isolated evidence.

| Behavior | Command / project-owned checks | Result |
| --- | --- | --- |
| Replay state, completion caching, escaped budget, UI and translations | `npm test -- src/main/artifacts/code-reconstruction.test.ts src/main/acp/artifact-code-reconstruction-runner.test.ts src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx src/renderer/src/i18n/resources.test.ts` | 898 passed |
| Provenance owner, IPC/preload and representative UI consumers | `npm run test:module -- artifact_provenance` | 1,806 passed |
| Backend selection, restricted profiles and provider bridges | `npm run test:module -- settings_backend_resolution` | 783 passed, 4 skipped |
| Stop/usage transport contracts | `npm test -- src/main/acp/restricted-inference-runner.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/acp/claude-turn-adapter.test.ts src/main/acp/opencode-turn-adapter.test.ts src/main/acp/codex-turn-adapter.test.ts src/main/acp/codebuddy-turn-adapter.test.ts` | 79 passed |
| Additional completion/usage checks for all four framework IDs | `npm test -- src/main/acp/artifact-code-reconstruction-runner.test.ts` | 17 passed |
| Main, sandbox and renderer types | `npm run typecheck`; final `npm run typecheck:node` | Passed |
| Repository lint and patch hygiene | `npm run lint`; `git diff --check` | Passed |

All production checks ran after the final production edit; the added runner cases, Node typecheck and lint were rerun after the last test-only edit. Browser verification used the real panel and styles with isolated API fixtures, in Chinese and at a narrow English viewport; generation errors preserve the generation button and unavailable evidence disables it. Screenshots are retained locally, outside the commit.

The normalized stop contract is shared by Claude Code, OpenCode, Codex and CodeBuddy. Existing Codex bridge tool-less scope, forced Responses compatibility, subscription rejection and shutdown/cleanup checks remain covered; no subscription or protocol lifecycle changes are introduced. No real provider request or cross-platform packaging was performed locally.

`npm run test:affected -- --base origin/main --head HEAD --explain` reports full fallback because the runner has no registered module owner. The maintainer explicitly requested module-scoped local runs and full PR CI, so the fallback remains intact for CI; no ownership manifest changes were made to weaken selection. Initial local HTTP tests hit sandbox `listen EPERM`; the same module commands passed when allowed to bind loopback. Full portable and cross-platform verification remains delegated to exact-head PR CI.

## Review focus

- Eligibility must run before cached results can bypass it; unknown dispatch/epochs remain conservative, while explicit non-dispatch, proven different epochs and later runs do not block. A failed producer is still unavailable.
- Non-completion must not become successful cache content or drop/double-count reported usage.
- Escaping remains intact and omission metadata itself consumes budget.
- Historical cache invalidation is intentional; original scientific data is untouched.

The independent review's pre-dispatch finding is addressed with the maintainer-approved additive field. Before this follow-up fix, public-boundary regressions reproduced lost dispatch evidence, refusal of both reconstruction paths and acceptance of malformed flag values (49 passed, 6 expected failures). After the fix, the final focused snapshot/reconstruction/decoder suite has 57 passing tests, including legacy missing flags, explicit true/false, failed producers and real Python replay. After the production follow-up, `npm run test:module -- artifact_provenance` passed 1,808 tests and `npm run typecheck` passed Node/Sandbox/Web. The final 57-test focused suite, `npm run typecheck:node`, `npm run lint` and `git diff --check` also passed after the last test-only edit. The prior-head CI passed all other required/platform lanes; Ubuntu shard 1 hit its 15-minute job limit without an assertion report, which caused the aggregate failure. Final-head CI at `b7c7743b0ae1d2ed4b6c25c17f04153797b8ccc5` passed all three full portable test shards, coverage aggregation, static checks, Linux Notebook isolation, Windows core and both E2E shards, macOS build/E2E, CI integrity and CodeQL. Independent review of this same head returned **mergeable**, with no actionable findings. The earlier timeout did not recur.
