### PR TITLE
fix(artifacts): preserve complete export selections and snapshots

### DIFF
--- a/src/main/data-content-application-commands.test.ts
+++ b/src/main/data-content-application-commands.test.ts
@@ -129,6 +129,7 @@ const createDependencies = () => {
   const projectFiles = {
     getOverview: vi.fn(),
     listArtifactGroups: vi.fn(),
+    readExportFiles: vi.fn(),
     listFiles: vi.fn(),
     repairIndex: vi.fn(),
     resolveFile: vi.fn(),
@@ -320,6 +321,7 @@ describe('Data and content application commands', () => {
         'project-files:get-overview',
         'project-files:list-artifact-groups',
         'project-files:list-files',
+        'project-files:read-export-files',
         'project-files:repair-index',
         'project-files:resolve-file',
         'project-files:search-artifacts',
@@ -481,6 +483,11 @@ describe('Data and content application commands', () => {
         key: 'projectFilesListFiles',
         args: [request('project-files-list')],
         owner: deps.projectFiles.listFiles
+      },
+      {
+        key: 'projectFilesReadExportFiles',
+        args: [request('project-files-export')],
+        owner: deps.projectFiles.readExportFiles
       },
       {
         key: 'projectFilesRepairIndex',

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -256,6 +256,10 @@ const dataContentApplicationCommands = Object.freeze({
     'listArtifactGroups'
   ),
   projectFilesListFiles: projectFilesCommand('project-files:list-files', 'listFiles'),
+  projectFilesReadExportFiles: projectFilesCommand(
+    'project-files:read-export-files',
+    'readExportFiles'
+  ),
   projectFilesRepairIndex: projectFilesCommand('project-files:repair-index', 'repairIndex'),
   projectFilesResolveFile: projectFilesCommand('project-files:resolve-file', 'resolveFile'),
   projectFilesSearchArtifacts: projectFilesCommand(
@@ -439,6 +443,7 @@ const dataContentApplicationCommandGroups = Object.freeze([
     dataContentApplicationCommands.projectFilesGetOverview,
     dataContentApplicationCommands.projectFilesListArtifactGroups,
     dataContentApplicationCommands.projectFilesListFiles,
+    dataContentApplicationCommands.projectFilesReadExportFiles,
     dataContentApplicationCommands.projectFilesRepairIndex,
     dataContentApplicationCommands.projectFilesResolveFile,
     dataContentApplicationCommands.projectFilesSearchArtifacts
@@ -619,6 +624,8 @@ const registerDataContentApplicationCommands = (
       'project-files:list-artifact-groups': ({ args }) =>
         dependencies.projectFiles.listArtifactGroups(args[0]),
       'project-files:list-files': ({ args }) => dependencies.projectFiles.listFiles(args[0]),
+      'project-files:read-export-files': ({ args }) =>
+        dependencies.projectFiles.readExportFiles(args[0]),
       'project-files:repair-index': ({ args }) => dependencies.projectFiles.repairIndex(args[0]),
       'project-files:resolve-file': ({ args }) => dependencies.projectFiles.resolveFile(args[0]),
       'project-files:search-artifacts': ({ args }) =>

--- a/src/main/file-save.test.ts
+++ b/src/main/file-save.test.ts
@@ -2179,6 +2179,57 @@ describe('file save IPC handlers', () => {
     }
   )
 
+  it('suffixes canonically equivalent ZIP names from different sessions', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-case-'))
+    const upperPath = join(root, 'managed-upper.csv')
+    const lowerPath = join(root, 'managed-lower.csv')
+    await writeFile(upperPath, 'upper bytes')
+    await writeFile(lowerPath, 'lower bytes')
+    const destinationPath = join(root, 'Research-artifacts.zip')
+    const resolveSessionArtifactFilePath = vi
+      .fn()
+      .mockResolvedValueOnce(upperPath)
+      .mockResolvedValueOnce(lowerPath)
+    showSaveDialog.mockResolvedValue({ canceled: false, filePath: destinationPath })
+    registerProjectFileSaveHandlers({ resolveSessionArtifactFilePath } as never)
+
+    try {
+      const result = await handlers.get('file:save-project-artifacts')!(
+        { sender: {} },
+        {
+          projectId: 'project-1',
+          suggestedArchiveName: 'Research',
+          files: [
+            {
+              source: 'artifact',
+              sessionId: 'session-1',
+              fileId: 'test-file-id',
+              versionId: 'test-file-id-version',
+              suggestedName: 'é.csv'
+            },
+            {
+              source: 'artifact',
+              sessionId: 'session-2',
+              fileId: 'second-file',
+              versionId: 'second-version',
+              suggestedName: 'e\u0301.csv'
+            }
+          ]
+        }
+      )
+
+      expect(result).toEqual({ saved: true, filePath: destinationPath })
+      const entries = unzipSync(new Uint8Array(await readFile(destinationPath)))
+      expect(Object.keys(entries)).toEqual(['generated/é.csv', 'generated/e\u0301 (2).csv'])
+      expect(Buffer.from(entries['generated/é.csv']!).toString('utf8')).toBe('upper bytes')
+      expect(Buffer.from(entries['generated/e\u0301 (2).csv']!).toString('utf8')).toBe(
+        'lower bytes'
+      )
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('claims zip entry names case-insensitively so case-only twins cannot overlap on disk', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-save-project-case-'))
     const upperPath = join(root, 'managed-upper.csv')

--- a/src/main/file-save.ts
+++ b/src/main/file-save.ts
@@ -338,7 +338,7 @@ const writeProjectArtifactArchive = async (options: {
           takenNames,
           `${categoryDirectory}/${getSafeZipEntryName(file.suggestedName)}`
         )
-        takenNames.add(entryName.toLowerCase())
+        takenNames.add(zipEntryNameKey(entryName))
         const zipEntry = new ZipDeflate(entryName, { level: 6 })
         zip.add(zipEntry)
         entryStarted = true
@@ -412,10 +412,12 @@ const addFilenameCollisionSuffix = (filename: string, suffix: number): string =>
   return `${stem} (${suffix})${extension}`
 }
 
+const zipEntryNameKey = (name: string): string => name.normalize('NFC').toLowerCase()
+
 // Zip entries share one archive-wide namespace; claim the first free name with the same collision
 // suffix scheme used for on-disk batch exports. The suffix applies to the file name part only so
 // category prefixes like 'generated/' survive renaming. Name claims compare case-insensitively
-// because the archive may be extracted onto case-insensitive file systems.
+// and canonically equivalent Unicode spellings because extraction may equate those paths.
 const claimZipEntryName = (takenNames: ReadonlySet<string>, entryName: string): string => {
   const slashIndex = entryName.lastIndexOf('/')
   const directory = slashIndex === -1 ? '' : entryName.slice(0, slashIndex + 1)
@@ -423,7 +425,7 @@ const claimZipEntryName = (takenNames: ReadonlySet<string>, entryName: string): 
   for (let suffix = 1; ; suffix += 1) {
     const candidate =
       suffix === 1 ? entryName : `${directory}${addFilenameCollisionSuffix(fileName, suffix)}`
-    if (!takenNames.has(candidate.toLowerCase())) return candidate
+    if (!takenNames.has(zipEntryNameKey(candidate))) return candidate
   }
 }
 

--- a/src/main/project-files/ipc.test.ts
+++ b/src/main/project-files/ipc.test.ts
@@ -60,6 +60,7 @@ describe('project files IPC handlers', () => {
     }
     const repository = {
       getOverview: vi.fn().mockResolvedValue(overview),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn().mockResolvedValue(filePage),
       resolveFile: vi.fn().mockResolvedValue(resolvedFile),
       listArtifactGroups: vi.fn().mockResolvedValue(groupPage),
@@ -116,6 +117,7 @@ describe('project files IPC handlers', () => {
   it('routes an explicit index repair through the session coordinator', async () => {
     const repository = {
       getOverview: vi.fn(),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
@@ -136,6 +138,7 @@ describe('project files IPC handlers', () => {
     const recoveryFailure = new Error('another Project deletion is incomplete')
     const repository = {
       getOverview: vi.fn(),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
@@ -167,6 +170,7 @@ describe('project files IPC handlers', () => {
           isIndexComplete: true
         }
       }),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(async () => {
         order.push('files')
         return { items: [], totalCount: 0 }
@@ -265,6 +269,7 @@ describe('registerProjectFilesIpcHandlers', () => {
         artifactGroupCount: 0,
         isIndexComplete: true
       }),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
       resolveFile: vi.fn().mockResolvedValue(undefined),
       listArtifactGroups: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }),
@@ -286,6 +291,7 @@ describe('registerProjectFilesIpcHandlers', () => {
 
     expect(handlers.has('project-files:get-overview')).toBe(true)
     expect(handlers.has('project-files:list-files')).toBe(true)
+    expect(handlers.has('project-files:read-export-files')).toBe(true)
     expect(handlers.has('project-files:resolve-file')).toBe(true)
     expect(handlers.has('project-files:list-artifact-groups')).toBe(true)
     expect(handlers.has('project-files:search-artifacts')).toBe(true)
@@ -302,6 +308,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     }
     const injected: ProjectFilesHandlers = {
       getOverview: vi.fn().mockResolvedValue(overview),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
@@ -329,6 +336,7 @@ describe('registerProjectFilesIpcHandlers', () => {
         artifactGroupCount: 0,
         isIndexComplete: true
       }),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
@@ -362,6 +370,7 @@ describe('registerProjectFilesIpcHandlers', () => {
           isIndexComplete: true
         }
       }),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),
@@ -388,6 +397,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     const order: string[] = []
     const localRepository: ProjectFilesQueryRepository = {
       getOverview: vi.fn(),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(async () => {
         order.push('files')
         return { items: [], totalCount: 0 }
@@ -418,10 +428,36 @@ describe('registerProjectFilesIpcHandlers', () => {
     expect(localRepository.listFiles).toHaveBeenCalledWith(filesRequest)
   })
 
+  it('gates export snapshots on project recovery and forwards the exact scope', async () => {
+    registerProjectFilesIpcHandlers(repository, repairBackend, recoveryBackend)
+    const request = { projectId: 'project-1', sessionId: 'session-1' }
+    let resolveRecovery!: () => void
+    vi.mocked(recoveryBackend.waitForProjectOperations).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveRecovery = resolve
+        })
+    )
+    const pending = invoke('project-files:read-export-files', request)
+    expect(repository.readExportFiles).not.toHaveBeenCalled()
+    resolveRecovery()
+    await expect(pending).resolves.toEqual([])
+    expect(repository.readExportFiles).toHaveBeenCalledExactlyOnceWith(request)
+    expect(recoveryBackend.waitForProjectOperations).toHaveBeenCalledWith(['project-1'])
+    vi.mocked(recoveryBackend.waitForProjectOperations).mockRejectedValueOnce(
+      new Error('recovery failed')
+    )
+    await expect(invoke('project-files:read-export-files', request)).rejects.toThrow(
+      'recovery failed'
+    )
+    expect(repository.readExportFiles).toHaveBeenCalledTimes(1)
+  })
+
   it('list-artifact-groups handler waits for deletion recovery before listing groups', async () => {
     const order: string[] = []
     const localRepository: ProjectFilesQueryRepository = {
       getOverview: vi.fn(),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(async () => {
@@ -452,6 +488,7 @@ describe('registerProjectFilesIpcHandlers', () => {
     const order: string[] = []
     const localRepository: ProjectFilesQueryRepository = {
       getOverview: vi.fn(),
+      readExportFiles: vi.fn().mockResolvedValue([]),
       listFiles: vi.fn(),
       resolveFile: vi.fn(),
       listArtifactGroups: vi.fn(),

--- a/src/main/project-files/ipc.ts
+++ b/src/main/project-files/ipc.ts
@@ -5,6 +5,7 @@ import type {
   GetProjectFilesOverviewRequest,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
+  ReadProjectExportFilesRequest,
   ProjectFilesOverview,
   ProjectFilesPage,
   ProjectFileItem,
@@ -16,6 +17,7 @@ import type {
 type ProjectFilesQueryRepository = {
   getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
   listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
+  readExportFiles(request: ReadProjectExportFilesRequest): Promise<ProjectFileItem[]>
   resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined>
   listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
   searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
@@ -33,6 +35,7 @@ type ProjectFilesRecoveryBackend = {
 type ProjectFilesHandlers = {
   getOverview(request: GetProjectFilesOverviewRequest): Promise<ProjectFilesOverview>
   listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage>
+  readExportFiles(request: ReadProjectExportFilesRequest): Promise<ProjectFileItem[]>
   resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined>
   listArtifactGroups(request: ListArtifactGroupsRequest): Promise<ArtifactGroupPage>
   searchArtifacts(request: SearchArtifactsRequest): Promise<SearchArtifactsResult>
@@ -53,6 +56,10 @@ const createProjectFilesHandlers = (
   listFiles: async (request) => {
     await recoveryBackend.waitForProjectOperations([request.projectId])
     return repository.listFiles(request)
+  },
+  readExportFiles: async (request) => {
+    await recoveryBackend.waitForProjectOperations([request.projectId])
+    return repository.readExportFiles(request)
   },
   resolveFile: async (request) => {
     await recoveryBackend.waitForProjectOperations([request.projectId])
@@ -95,6 +102,10 @@ const registerProjectFilesIpcHandlers = (
   )
   ipcMainHandle('project-files:list-files', (_event, request: ListProjectFilesRequest) =>
     handlers.listFiles(request)
+  )
+  ipcMainHandle(
+    'project-files:read-export-files',
+    (_event, request: ReadProjectExportFilesRequest) => handlers.readExportFiles(request)
   )
   ipcMainHandle('project-files:resolve-file', (_event, request: ResolveProjectFileRequest) =>
     handlers.resolveFile(request)

--- a/src/main/project-files/query-owner.ts
+++ b/src/main/project-files/query-owner.ts
@@ -6,6 +6,7 @@ import type {
   HostArtifactCatalogItem,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
+  ReadProjectExportFilesRequest,
   ProjectFileItem,
   ProjectFilesOverview,
   ProjectFilesPage,
@@ -187,6 +188,24 @@ class ProjectFilesQueryOwner {
             })
           : undefined
     }
+  }
+
+  async readExportFiles(request: ReadProjectExportFilesRequest): Promise<ProjectFileItem[]> {
+    requireIdentifier(request.projectId, 'projectId')
+    if (request.sessionId !== undefined) requireIdentifier(request.sessionId, 'sessionId')
+    const client = await this.getClient()
+    if (!this.readIndexComplete(request.projectId)) {
+      throw new Error('Some Project Files could not be indexed yet.')
+    }
+    // A single SQL statement fixes both membership and immutable Version IDs. Never traverse live
+    // pages here: a new current Version can move an unread file behind an earlier page's cursor.
+    const rows = await queryAuthoritativeFiles(client, {
+      projectIds: [request.projectId],
+      ...(request.sessionId === undefined
+        ? {}
+        : { source: 'artifact', sessionId: request.sessionId })
+    })
+    return rows.map((row) => toProjectFileItem(row))
   }
 
   async resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined> {

--- a/src/main/project-files/repository.test.ts
+++ b/src/main/project-files/repository.test.ts
@@ -1,3 +1,5 @@
+import { listAllSessionArtifacts } from '../../renderer/src/pages/workspace/session-artifact-download-data'
+import { listAllProjectFiles } from '../../renderer/src/pages/workspace/project-artifact-download-data'
 import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -74,6 +76,179 @@ describe('ManagedFileIndexRepository', () => {
     await client.$disconnect()
     await rm(storageRoot, { recursive: true, force: true })
   }, WINDOWS_SQLITE_HOOK_TIMEOUT_MS)
+
+  it.each([
+    { source: 'upload', updateDuringRead: false },
+    { source: 'upload', updateDuringRead: true },
+    { source: 'artifact', updateDuringRead: false },
+    { source: 'artifact', updateDuringRead: true }
+  ] as const)(
+    'keeps every $source export member and version when updating during read: $updateDuringRead',
+    async ({ source, updateDuringRead }) => {
+      await client.fileOriginSession.create({
+        data: { projectId: PROJECT_ID, sessionId: SESSION_ID }
+      })
+      const files = Array.from({ length: 101 }, (_, index) => ({
+        id: `export-${source}-${index}`,
+        filename: `file-${index}.txt`,
+        createdAt: new Date(1_710_000_000_000 + index * 1000)
+      }))
+      if (source === 'upload') {
+        await client.uploadFile.createMany({
+          data: files.map((file) => ({
+            id: file.id,
+            projectId: PROJECT_ID,
+            sessionId: SESSION_ID,
+            filename: file.filename,
+            originalFilename: file.filename
+          }))
+        })
+        await client.uploadVersion.createMany({
+          data: files.map((file) => ({
+            id: `${file.id}-v1`,
+            uploadFileId: file.id,
+            versionNumber: 1,
+            state: 'ready',
+            filename: file.filename,
+            originalFilename: file.filename,
+            contentStorageKey: `uploads/${file.id}/v1`,
+            sizeBytes: 1n,
+            checksum: 'a'.repeat(64),
+            createdAt: file.createdAt
+          }))
+        })
+        await client.$transaction(
+          files.map((file) =>
+            client.uploadFile.update({
+              where: { id: file.id },
+              data: { currentVersionId: `${file.id}-v1` }
+            })
+          )
+        )
+      } else {
+        await client.artifactLineage.createMany({
+          data: files.map((file) => ({
+            id: file.id,
+            projectId: PROJECT_ID,
+            sessionId: SESSION_ID,
+            filename: file.filename,
+            normalizedFilename: file.filename
+          }))
+        })
+        await client.artifactVersion.createMany({
+          data: files.map((file) => ({
+            id: `${file.id}-v1`,
+            artifactId: file.id,
+            versionNumber: 1,
+            state: 'finalized',
+            originKind: 'legacy',
+            filename: file.filename,
+            contentStorageKey: `artifacts/${file.id}/v1`,
+            sizeBytes: 1n,
+            checksum: 'a'.repeat(64),
+            createdAt: file.createdAt
+          }))
+        })
+        await client.$transaction(
+          files.map((file) =>
+            client.artifactLineage.update({
+              where: { id: file.id },
+              data: { currentVersionId: `${file.id}-v1` }
+            })
+          )
+        )
+      }
+      const promote = async (): Promise<void> => {
+        const version = {
+          id: `${files[0].id}-v2`,
+          versionNumber: 2,
+          originKind: 'user_edit',
+          basedOnVersionId: `${files[0].id}-v1`,
+          storageTag: 'v00000002',
+          storedFilename: 'v00000002_file-0.txt',
+          filename: files[0].filename,
+          contentStorageKey: `${source}/${files[0].id}/v2`,
+          sizeBytes: 1n,
+          checksum: 'b'.repeat(64),
+          createdAt: new Date(1_710_001_000_000)
+        }
+        if (source === 'upload') {
+          await client.uploadVersion.create({
+            data: {
+              ...version,
+              uploadFileId: files[0].id,
+              state: 'ready',
+              originalFilename: files[0].filename
+            }
+          })
+          await client.uploadFile.update({
+            where: { id: files[0].id },
+            data: { currentVersionId: version.id }
+          })
+        } else {
+          await client.artifactVersion.create({
+            data: { ...version, artifactId: files[0].id, state: 'finalized' }
+          })
+          await client.artifactLineage.update({
+            where: { id: files[0].id },
+            data: { currentVersionId: version.id }
+          })
+        }
+      }
+      // Let SQLite perform the real read, then publish a new head before the caller receives it.
+      // The old paginated collector loses file-0 when it moves ahead of the first page's cursor.
+      const queryRaw = client.$queryRaw.bind(client)
+      let promoted = false
+      const querySpy = vi.spyOn(client, '$queryRaw').mockImplementation((async (
+        query: TemplateStringsArray | Prisma.Sql,
+        ...values: unknown[]
+      ) => {
+        const rows = await queryRaw(query, ...values)
+        const sql = 'strings' in query ? query.strings.join('?') : query.join('?')
+        if (updateDuringRead && !promoted && sql.includes('SELECT file.*')) {
+          promoted = true
+          await promote()
+        }
+        return rows
+      }) as typeof client.$queryRaw)
+      try {
+        const options = {
+          projectId: PROJECT_ID,
+          getOverview: ({ projectId }: { projectId: string }) => repository.getOverview(projectId),
+          repairIndex: async () => {},
+          readExportFiles: (request: { projectId: string; sessionId?: string }) =>
+            repository.readExportFiles(request)
+        }
+        const collected =
+          source === 'upload'
+            ? await listAllProjectFiles(options)
+            : await listAllSessionArtifacts({ ...options, sessionId: SESSION_ID })
+        expect(promoted).toBe(updateDuringRead)
+        expect(collected.map((item) => item.sourceFileId).sort()).toEqual(
+          files.map((file) => file.id).sort()
+        )
+        expect(collected.find((item) => item.sourceFileId === files[0].id)?.sourceVersionId).toBe(
+          `${files[0].id}-v1`
+        )
+        const refreshed = await repository.readExportFiles({ projectId: PROJECT_ID })
+        expect(refreshed).toHaveLength(101)
+        expect(refreshed.find((item) => item.sourceFileId === files[0].id)?.sourceVersionId).toBe(
+          `${files[0].id}-${updateDuringRead ? 'v2' : 'v1'}`
+        )
+        if (source === 'upload') {
+          await expect(
+            repository.readExportFiles({ projectId: PROJECT_ID, sessionId: SESSION_ID })
+          ).resolves.toEqual([])
+        }
+        await expect(repository.readExportFiles({ projectId: 'project-b' })).resolves.toEqual([])
+        await expect(
+          repository.readExportFiles({ projectId: PROJECT_ID, sessionId: 'another-session' })
+        ).resolves.toEqual([])
+      } finally {
+        querySpy.mockRestore()
+      }
+    }
+  )
 
   it('adopts a path-only legacy Artifact into an immutable v1 before indexing it', async () => {
     const artifactPath = join(
@@ -3064,6 +3239,9 @@ describe('ManagedFileIndexRepository', () => {
     await expect(repository.syncSession(session)).resolves.toEqual([])
     expect((await repository.getOverview(PROJECT_ID)).isIndexComplete).toBe(false)
     expect((await repository.getOverview(PROJECT_ID)).totalCount).toBe(0)
+    await expect(repository.readExportFiles({ projectId: PROJECT_ID })).rejects.toThrow(
+      'could not be indexed'
+    )
 
     await writeManagedFile(missingPath, 'ready')
     await repository.syncSession(session)
@@ -3524,6 +3702,12 @@ describe('ManagedFileIndexRepository', () => {
   })
 
   it('rejects an empty session scope instead of returning every project artifact', async () => {
+    await expect(
+      repository.readExportFiles({ projectId: PROJECT_ID, sessionId: '' })
+    ).rejects.toThrow(/sessionId.*required/)
+    await expect(repository.readExportFiles({ projectId: '' })).rejects.toThrow(
+      /projectId.*required/
+    )
     await expect(
       repository.listFiles({
         projectId: PROJECT_ID,

--- a/src/main/project-files/repository.ts
+++ b/src/main/project-files/repository.ts
@@ -5,6 +5,7 @@ import type {
   HostArtifactCatalogItem,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
+  ReadProjectExportFilesRequest,
   ProjectFileItem,
   ProjectFilesOverview,
   ProjectFilesPage,
@@ -97,6 +98,10 @@ class ManagedFileIndexRepository {
 
   async listFiles(request: ListProjectFilesRequest): Promise<ProjectFilesPage> {
     return this.queryOwner.listFiles(request)
+  }
+
+  async readExportFiles(request: ReadProjectExportFilesRequest): Promise<ProjectFileItem[]> {
+    return this.queryOwner.readExportFiles(request)
   }
 
   async resolveFile(request: ResolveProjectFileRequest): Promise<ProjectFileItem | undefined> {

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -444,6 +444,7 @@ describe('preload bridge — public surface inventory', () => {
       'projectFiles.listArtifactGroups',
       'projectFiles.listFiles',
       'projectFiles.onChanged',
+      'projectFiles.readExportFiles',
       'projectFiles.repairIndex',
       'projectFiles.resolveFile',
       'projectFiles.searchArtifacts',

--- a/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.render.test.tsx
+++ b/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.render.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act } from 'react'
+import { i18next } from '../../i18n'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -44,11 +45,11 @@ const files: ProjectFileItem[] = [
 
 let container: HTMLElement
 let root: Root
-let listFiles: ReturnType<typeof vi.fn>
+let readExportFiles: ReturnType<typeof vi.fn>
 let saveProjectArtifacts: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
-  listFiles = vi.fn().mockResolvedValue({ items: files, totalCount: files.length })
+  readExportFiles = vi.fn().mockResolvedValue(files)
   saveProjectArtifacts = vi.fn().mockResolvedValue({
     saved: true,
     filePath: '/downloads/research.zip'
@@ -62,7 +63,7 @@ beforeEach(() => {
         artifactGroupCount: 2,
         isIndexComplete: true
       }),
-      listFiles,
+      readExportFiles,
       repairIndex: vi.fn().mockResolvedValue(undefined)
     },
     saveProjectArtifacts
@@ -98,6 +99,67 @@ const checkboxes = (): HTMLInputElement[] => [
 ]
 
 describe('DownloadProjectArtifactsDialog', () => {
+  it('rebuilds the original checked ZIP selection after a partial export', async () => {
+    saveProjectArtifacts.mockResolvedValueOnce({
+      saved: true,
+      filePath: '/downloads/research.zip',
+      failures: [
+        {
+          source: 'artifact',
+          sessionId: 'session-2',
+          fileId: 'figure',
+          suggestedName: 'figure.csv',
+          message: 'temporarily unreadable'
+        }
+      ]
+    })
+    await renderDialog()
+    act(() => checkboxes()[2].click())
+    await act(async () => {
+      confirmButton()?.click()
+    })
+    await act(async () => {
+      confirmButton()?.click()
+    })
+    expect(saveProjectArtifacts).toHaveBeenCalledTimes(2)
+    expect(saveProjectArtifacts.mock.calls[1][0].files).toEqual(
+      saveProjectArtifacts.mock.calls[0][0].files
+    )
+  })
+
+  it('translates the partial project export summary into the active language', async () => {
+    await i18next.changeLanguage('zh-Hans')
+    try {
+      saveProjectArtifacts.mockResolvedValueOnce({
+        saved: true,
+        filePath: '/downloads/research.zip',
+        failures: [
+          {
+            source: 'artifact',
+            sessionId: 'session-2',
+            fileId: 'figure',
+            suggestedName: 'figure.csv',
+            message: 'temporarily unreadable'
+          }
+        ]
+      })
+      await renderDialog()
+      await act(async () => {
+        confirmButton()?.click()
+      })
+      const expected = i18next.t(
+        'Downloaded {{downloaded}} of {{total}} artifacts. {{failed}} failed.',
+        { downloaded: 2, total: 3, failed: 1 }
+      )
+      expect(expected).not.toContain('Downloaded')
+      expect(document.body.querySelector('[role="alert"]')?.textContent).toBe(expected)
+    } finally {
+      await act(async () => {
+        await i18next.changeLanguage('en')
+      })
+    }
+  })
+
   it('groups every file flat under Generated and Uploads headings without session levels', async () => {
     await renderDialog()
 
@@ -132,7 +194,7 @@ describe('DownloadProjectArtifactsDialog', () => {
   })
 
   it('hides a group heading when that source has no files', async () => {
-    listFiles.mockResolvedValue({ items: [files[0]], totalCount: 1 })
+    readExportFiles.mockResolvedValue([files[0]])
     await renderDialog()
 
     const headings = [
@@ -200,7 +262,7 @@ describe('DownloadProjectArtifactsDialog', () => {
   })
 
   it('exports the immutable Version shown in the Project Files snapshot without a path', async () => {
-    listFiles.mockResolvedValue({ items: [files[0]!], totalCount: 1 })
+    readExportFiles.mockResolvedValue([files[0]!])
     await renderDialog()
 
     await act(async () => {
@@ -223,7 +285,7 @@ describe('DownloadProjectArtifactsDialog', () => {
     })
   })
 
-  it('keeps only failed files selected with an inline summary after a partial export', async () => {
+  it('keeps the complete selection with an inline summary after a partial export', async () => {
     const onClose = vi.fn()
     // A same-name file from another source must not be mistaken for the failed logical file.
     const colliding: ProjectFileItem = {
@@ -231,7 +293,7 @@ describe('DownloadProjectArtifactsDialog', () => {
       name: 'figure.csv',
       path: 'artifact://figure'
     }
-    listFiles.mockResolvedValue({ items: [...files, colliding], totalCount: 4 })
+    readExportFiles.mockResolvedValue([...files, colliding])
     saveProjectArtifacts.mockResolvedValue({
       saved: true,
       filePath: '/downloads/research.zip',
@@ -252,7 +314,7 @@ describe('DownloadProjectArtifactsDialog', () => {
       await Promise.resolve()
     })
 
-    expect(checkboxes().map((checkbox) => checkbox.checked)).toEqual([false, true, false, false])
+    expect(checkboxes().map((checkbox) => checkbox.checked)).toEqual([true, true, true, true])
     expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
       'Downloaded 3 of 4 artifacts. 1 failed.'
     )
@@ -280,7 +342,7 @@ describe('DownloadProjectArtifactsDialog', () => {
       await Promise.resolve()
     })
     expect(document.body.querySelector('[role="alert"]')).not.toBeNull()
-    expect(checkboxes().map((checkbox) => checkbox.checked)).toEqual([true, false, false])
+    expect(checkboxes().map((checkbox) => checkbox.checked)).toEqual([true, true, true])
 
     await act(async () => {
       root.render(<DownloadProjectArtifactsDialog project={undefined} onClose={onClose} />)
@@ -292,7 +354,7 @@ describe('DownloadProjectArtifactsDialog', () => {
       await Promise.resolve()
     })
 
-    expect(listFiles).toHaveBeenCalledTimes(2)
+    expect(readExportFiles).toHaveBeenCalledTimes(2)
     expect(document.body.querySelector('[role="alert"]')).toBeNull()
     expect(document.body.textContent).toContain('3 of 3 selected')
     expect(checkboxes().every((checkbox) => checkbox.checked)).toBe(true)
@@ -335,10 +397,10 @@ describe('DownloadProjectArtifactsDialog', () => {
   })
 
   it('offers Retry when the file snapshot cannot be loaded', async () => {
-    listFiles
+    readExportFiles
       .mockReset()
       .mockRejectedValueOnce(new Error('file index unavailable'))
-      .mockResolvedValueOnce({ items: files, totalCount: files.length })
+      .mockResolvedValueOnce(files)
     await renderDialog()
 
     expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
@@ -354,7 +416,7 @@ describe('DownloadProjectArtifactsDialog', () => {
       await Promise.resolve()
     })
 
-    expect(listFiles).toHaveBeenCalledTimes(2)
+    expect(readExportFiles).toHaveBeenCalledTimes(2)
     expect(document.body.textContent).toContain('report.csv')
     expect(document.body.textContent).toContain('3 of 3 selected')
   })
@@ -374,7 +436,7 @@ describe('DownloadProjectArtifactsDialog', () => {
   })
 
   it('shows an empty state when the project has no files', async () => {
-    listFiles.mockResolvedValue({ items: [], totalCount: 0 })
+    readExportFiles.mockResolvedValue([])
     await renderDialog()
 
     expect(document.body.textContent).toContain('No downloadable artifacts in this project.')

--- a/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.tsx
+++ b/src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.tsx
@@ -38,6 +38,10 @@ type FileGroup = {
   files: ProjectFileItem[]
 }
 
+type DownloadError =
+  | { kind: 'partial'; downloaded: number; total: number; failed: number }
+  | { kind: 'raw'; message: string }
+
 const EMPTY_FILES: ProjectFileItem[] = []
 
 const getFileType = (file: ProjectFileItem): string => {
@@ -50,12 +54,6 @@ const getFileType = (file: ProjectFileItem): string => {
 
 const getErrorMessage = (error: unknown): string =>
   error instanceof Error ? error.message : String(error)
-
-const projectFileKey = (file: Pick<ProjectFileItem, 'source' | 'sourceFileId'>): string =>
-  `${file.source}\u0000${file.sourceFileId}`
-
-const failedFileKey = (file: { source: ProjectFileItem['source']; fileId: string }): string =>
-  `${file.source}\u0000${file.fileId}`
 
 // Generated output is the primary product of a Project, so it leads; Uploads follow. Empty groups
 // are dropped entirely, and rows stay flat inside a group — no per-session nesting.
@@ -74,7 +72,7 @@ const DownloadProjectArtifactsDialog = ({
   const dialogProject = useRetainedDialogValue(project)
   const [settledFileList, setSettledFileList] = useState<SettledFileList>()
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
-  const [downloadError, setDownloadError] = useState<string>()
+  const [downloadError, setDownloadError] = useState<DownloadError>()
   const [isDownloading, setIsDownloading] = useState(false)
   const [retryVersion, setRetryVersion] = useState(0)
   const projectId = project?.id
@@ -90,7 +88,7 @@ const DownloadProjectArtifactsDialog = ({
 
     void listAllProjectFiles({
       getOverview: window.api.projectFiles.getOverview,
-      listFiles: window.api.projectFiles.listFiles,
+      readExportFiles: window.api.projectFiles.readExportFiles,
       repairIndex: window.api.projectFiles.repairIndex,
       projectId
     }).then(
@@ -175,20 +173,18 @@ const DownloadProjectArtifactsDialog = ({
       })
       if (!result.saved) return
       if (result.failures?.length) {
-        const failedKeys = new Set(result.failures.map(failedFileKey))
-        setSelectedIds(
-          new Set(
-            files.filter((file) => failedKeys.has(projectFileKey(file))).map((file) => file.id)
-          )
-        )
-        setDownloadError(
-          `Downloaded ${selectedFiles.length - result.failures.length} of ${selectedFiles.length} artifacts. ${result.failures.length} failed.`
-        )
+        // A retry replaces the whole ZIP, so retain successful files in the selection too.
+        setDownloadError({
+          kind: 'partial',
+          downloaded: selectedFiles.length - result.failures.length,
+          total: selectedFiles.length,
+          failed: result.failures.length
+        })
         return
       }
       onClose()
     } catch (error) {
-      setDownloadError(getErrorMessage(error))
+      setDownloadError({ kind: 'raw', message: getErrorMessage(error) })
     } finally {
       setIsDownloading(false)
       onDownloadingChange?.(false)
@@ -326,7 +322,12 @@ const DownloadProjectArtifactsDialog = ({
             <div className="flex min-w-0 items-center gap-3">
               {status === 'ready' && downloadError ? (
                 <p role="alert" className="truncate text-xs text-danger-000">
-                  {downloadError}
+                  {downloadError.kind === 'partial'
+                    ? t(
+                        'Downloaded {{downloaded}} of {{total}} artifacts. {{failed}} failed.',
+                        downloadError
+                      )
+                    : downloadError.message}
                 </p>
               ) : null}
               <Button

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
@@ -51,11 +51,11 @@ const artifacts: ProjectFileItem[] = [
 
 let container: HTMLElement
 let root: Root
-let listFiles: ReturnType<typeof vi.fn>
+let readExportFiles: ReturnType<typeof vi.fn>
 let saveSessionArtifacts: ReturnType<typeof vi.fn>
 
 beforeEach(() => {
-  listFiles = vi.fn().mockResolvedValue({ items: artifacts, totalCount: artifacts.length })
+  readExportFiles = vi.fn().mockResolvedValue(artifacts)
   saveSessionArtifacts = vi.fn().mockResolvedValue({
     saved: true,
     filePaths: ['/downloads/report.csv']
@@ -69,7 +69,7 @@ beforeEach(() => {
         artifactGroupCount: 1,
         isIndexComplete: true
       }),
-      listFiles,
+      readExportFiles,
       repairIndex: vi.fn().mockResolvedValue(undefined)
     },
     saveSessionArtifacts
@@ -86,6 +86,40 @@ afterEach(() => {
 })
 
 describe('DownloadSessionArtifactsDialog', () => {
+  it('blocks stale version submission while a reopened session refreshes', async () => {
+    const render = async (value: ChatSession | undefined): Promise<void> => {
+      await act(async () => {
+        root.render(<DownloadSessionArtifactsDialog session={value} onClose={vi.fn()} />)
+      })
+    }
+    await render(session)
+    await render(undefined)
+    let resolveList!: (files: ProjectFileItem[]) => void
+    readExportFiles.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveList = resolve
+        })
+    )
+    await render(session)
+    expect(readExportFiles).toHaveBeenCalledTimes(2)
+    const button = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="download-session-artifacts-confirm"]'
+    )!
+    await act(async () => {
+      button.click()
+    })
+    expect(saveSessionArtifacts).not.toHaveBeenCalled()
+    expect(button.disabled).toBe(true)
+    await act(async () => {
+      resolveList([{ ...artifacts[0], sourceVersionId: 'updated-version' }])
+    })
+    await act(async () => {
+      button.click()
+    })
+    expect(saveSessionArtifacts.mock.calls[0][0].files[0].versionId).toBe('updated-version')
+  })
+
   it('selects every Artifact by default and downloads only the checked rows', async () => {
     const onClose = vi.fn()
     await act(async () => {
@@ -160,15 +194,15 @@ describe('DownloadSessionArtifactsDialog', () => {
       await Promise.resolve()
     })
 
-    expect(listFiles).toHaveBeenCalledTimes(1)
+    expect(readExportFiles).toHaveBeenCalledTimes(1)
     expect(document.body.textContent).toContain('1 of 2 selected')
   })
 
   it('offers Retry when the Artifact snapshot cannot be loaded', async () => {
-    listFiles
+    readExportFiles
       .mockReset()
       .mockRejectedValueOnce(new Error('file index unavailable'))
-      .mockResolvedValueOnce({ items: artifacts, totalCount: artifacts.length })
+      .mockResolvedValueOnce(artifacts)
     await act(async () => {
       root.render(<DownloadSessionArtifactsDialog session={session} onClose={vi.fn()} />)
       await Promise.resolve()
@@ -188,7 +222,7 @@ describe('DownloadSessionArtifactsDialog', () => {
       await Promise.resolve()
     })
 
-    expect(listFiles).toHaveBeenCalledTimes(2)
+    expect(readExportFiles).toHaveBeenCalledTimes(2)
     expect(document.body.textContent).toContain('report.csv')
     expect(document.body.textContent).toContain('2 of 2 selected')
   })

--- a/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
+++ b/src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.tsx
@@ -75,7 +75,7 @@ const DownloadSessionArtifactsDialog = ({
 
     void listAllSessionArtifacts({
       getOverview: window.api.projectFiles.getOverview,
-      listFiles: window.api.projectFiles.listFiles,
+      readExportFiles: window.api.projectFiles.readExportFiles,
       repairIndex: window.api.projectFiles.repairIndex,
       projectId,
       sessionId
@@ -105,6 +105,18 @@ const DownloadSessionArtifactsDialog = ({
       isCurrent = false
     }
   }, [projectId, requestKey, sessionId])
+
+  // Keep the retained title for the closing animation, but invalidate the previous selection.
+  const [wasOpen, setWasOpen] = useState(Boolean(session))
+  const isOpen = Boolean(session)
+  if (isOpen !== wasOpen) {
+    setWasOpen(isOpen)
+    if (!isOpen) {
+      setSettledArtifactList(undefined)
+      setSelectedIds(new Set())
+      setDownloadError(undefined)
+    }
+  }
 
   const selectedArtifacts = useMemo(
     () => artifacts.filter((artifact) => selectedIds.has(artifact.id)),

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -316,6 +316,7 @@ describe('ProjectFilesView', () => {
       )
 
     window.api.projectFiles = {
+      readExportFiles: vi.fn(),
       searchArtifacts: vi.fn(),
       getOverview: vi.fn(async (request) => {
         const library = getLibrary()

--- a/src/renderer/src/pages/workspace/project-artifact-download-data.test.ts
+++ b/src/renderer/src/pages/workspace/project-artifact-download-data.test.ts
@@ -17,13 +17,10 @@ const file = (id: string, source: ProjectFileItem['source'] = 'artifact'): Proje
 })
 
 describe('Project Artifact download data', () => {
-  it('loads every page of the flat all-files collection', async () => {
+  it('reads every project export member from one snapshot', async () => {
     const firstPage = Array.from({ length: 100 }, (_, index) => file(`file-${index}`))
     const lastPage = [file('file-100'), file('upload-1', 'upload')]
-    const listFiles = vi
-      .fn()
-      .mockResolvedValueOnce({ items: firstPage, nextCursor: 'page-2', totalCount: 102 })
-      .mockResolvedValueOnce({ items: lastPage, totalCount: 102 })
+    const readExportFiles = vi.fn().mockResolvedValue([...firstPage, ...lastPage])
     const getOverview = vi.fn().mockResolvedValue({
       totalCount: 102,
       uploadCount: 1,
@@ -34,20 +31,10 @@ describe('Project Artifact download data', () => {
     const repairIndex = vi.fn()
 
     await expect(
-      listAllProjectFiles({ getOverview, listFiles, repairIndex, projectId: 'project-1' })
+      listAllProjectFiles({ getOverview, readExportFiles, repairIndex, projectId: 'project-1' })
     ).resolves.toEqual([...firstPage, ...lastPage])
     expect(repairIndex).not.toHaveBeenCalled()
-    expect(listFiles).toHaveBeenNthCalledWith(1, {
-      projectId: 'project-1',
-      collection: { kind: 'all' },
-      limit: 100
-    })
-    expect(listFiles).toHaveBeenNthCalledWith(2, {
-      projectId: 'project-1',
-      collection: { kind: 'all' },
-      cursor: 'page-2',
-      limit: 100
-    })
+    expect(readExportFiles).toHaveBeenCalledExactlyOnceWith({ projectId: 'project-1' })
   })
 
   it('repairs an incomplete Project Files index before listing', async () => {
@@ -68,10 +55,10 @@ describe('Project Artifact download data', () => {
         isIndexComplete: true
       })
     const repairIndex = vi.fn().mockResolvedValue(undefined)
-    const listFiles = vi.fn().mockResolvedValue({ items: [file('file-1')], totalCount: 1 })
+    const readExportFiles = vi.fn().mockResolvedValue([file('file-1')])
 
     await expect(
-      listAllProjectFiles({ getOverview, listFiles, repairIndex, projectId: 'project-1' })
+      listAllProjectFiles({ getOverview, readExportFiles, repairIndex, projectId: 'project-1' })
     ).resolves.toEqual([file('file-1')])
     expect(repairIndex).toHaveBeenCalledWith({ projectId: 'project-1' })
     expect(getOverview).toHaveBeenCalledTimes(2)
@@ -87,11 +74,11 @@ describe('Project Artifact download data', () => {
     }
     const getOverview = vi.fn().mockResolvedValue(incomplete)
     const repairIndex = vi.fn().mockResolvedValue(undefined)
-    const listFiles = vi.fn()
+    const readExportFiles = vi.fn()
 
     await expect(
-      listAllProjectFiles({ getOverview, listFiles, repairIndex, projectId: 'project-1' })
+      listAllProjectFiles({ getOverview, readExportFiles, repairIndex, projectId: 'project-1' })
     ).rejects.toThrow('Some Project Files could not be indexed yet.')
-    expect(listFiles).not.toHaveBeenCalled()
+    expect(readExportFiles).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/pages/workspace/project-artifact-download-data.ts
+++ b/src/renderer/src/pages/workspace/project-artifact-download-data.ts
@@ -1,25 +1,21 @@
 import type {
   GetProjectFilesOverviewRequest,
-  ListProjectFilesRequest,
+  ReadProjectExportFilesRequest,
   ProjectFileItem,
-  ProjectFilesOverview,
-  ProjectFilesPage
+  ProjectFilesOverview
 } from '../../../../shared/project-files'
 
 type ListAllProjectFilesOptions = {
   getOverview: (request: GetProjectFilesOverviewRequest) => Promise<ProjectFilesOverview>
-  listFiles: (request: ListProjectFilesRequest) => Promise<ProjectFilesPage>
+  readExportFiles: (request: ReadProjectExportFilesRequest) => Promise<ProjectFileItem[]>
   repairIndex: (request: { projectId: string }) => Promise<void>
   projectId: string
 }
 
-const PROJECT_FILE_PAGE_LIMIT = 100
-
-// Collects every Artifact and Upload in one Project through the flat 'all' collection, hiding cursor
-// traversal so the download action receives one complete snapshot. Mirrors listAllSessionArtifacts.
+// Repairs the legacy index when needed, then reads one consistent export selection.
 const listAllProjectFiles = async ({
   getOverview,
-  listFiles,
+  readExportFiles,
   repairIndex,
   projectId
 }: ListAllProjectFilesOptions): Promise<ProjectFileItem[]> => {
@@ -32,21 +28,7 @@ const listAllProjectFiles = async ({
     }
   }
 
-  const files: ProjectFileItem[] = []
-  let cursor: string | undefined
-
-  do {
-    const page = await listFiles({
-      projectId,
-      collection: { kind: 'all' },
-      ...(cursor ? { cursor } : {}),
-      limit: PROJECT_FILE_PAGE_LIMIT
-    })
-    files.push(...page.items)
-    cursor = page.nextCursor
-  } while (cursor)
-
-  return files
+  return readExportFiles({ projectId })
 }
 
 export { listAllProjectFiles }

--- a/src/renderer/src/pages/workspace/session-artifact-download-data.test.ts
+++ b/src/renderer/src/pages/workspace/session-artifact-download-data.test.ts
@@ -17,13 +17,10 @@ const artifact = (id: string): ProjectFileItem => ({
 })
 
 describe('Session Artifact download data', () => {
-  it('loads every page in one Source Session collection', async () => {
+  it('reads every session export member from one snapshot', async () => {
     const firstPage = Array.from({ length: 100 }, (_, index) => artifact(`artifact-${index}`))
     const finalArtifact = artifact('artifact-100')
-    const listFiles = vi
-      .fn()
-      .mockResolvedValueOnce({ items: firstPage, nextCursor: 'page-2', totalCount: 101 })
-      .mockResolvedValueOnce({ items: [finalArtifact], totalCount: 101 })
+    const readExportFiles = vi.fn().mockResolvedValue([...firstPage, finalArtifact])
     const getOverview = vi.fn().mockResolvedValue({
       totalCount: 101,
       uploadCount: 0,
@@ -36,23 +33,16 @@ describe('Session Artifact download data', () => {
     await expect(
       listAllSessionArtifacts({
         getOverview,
-        listFiles,
+        readExportFiles,
         repairIndex,
         projectId: 'project-1',
         sessionId: 'session-1'
       })
     ).resolves.toEqual([...firstPage, finalArtifact])
     expect(repairIndex).not.toHaveBeenCalled()
-    expect(listFiles).toHaveBeenNthCalledWith(1, {
+    expect(readExportFiles).toHaveBeenCalledExactlyOnceWith({
       projectId: 'project-1',
-      collection: { kind: 'sessionArtifacts', sessionId: 'session-1' },
-      limit: 100
-    })
-    expect(listFiles).toHaveBeenNthCalledWith(2, {
-      projectId: 'project-1',
-      collection: { kind: 'sessionArtifacts', sessionId: 'session-1' },
-      cursor: 'page-2',
-      limit: 100
+      sessionId: 'session-1'
     })
   })
 
@@ -74,12 +64,12 @@ describe('Session Artifact download data', () => {
         isIndexComplete: true
       })
     const repairIndex = vi.fn().mockResolvedValue(undefined)
-    const listFiles = vi.fn().mockResolvedValue({ items: [artifact('artifact-1')], totalCount: 1 })
+    const readExportFiles = vi.fn().mockResolvedValue([artifact('artifact-1')])
 
     await expect(
       listAllSessionArtifacts({
         getOverview,
-        listFiles,
+        readExportFiles,
         repairIndex,
         projectId: 'project-1',
         sessionId: 'session-1'
@@ -87,6 +77,6 @@ describe('Session Artifact download data', () => {
     ).resolves.toEqual([artifact('artifact-1')])
     expect(repairIndex).toHaveBeenCalledWith({ projectId: 'project-1' })
     expect(getOverview).toHaveBeenCalledTimes(2)
-    expect(listFiles).toHaveBeenCalledTimes(1)
+    expect(readExportFiles).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/pages/workspace/session-artifact-download-data.ts
+++ b/src/renderer/src/pages/workspace/session-artifact-download-data.ts
@@ -1,31 +1,28 @@
 import type {
   GetProjectFilesOverviewRequest,
-  ListProjectFilesRequest,
+  ReadProjectExportFilesRequest,
   ProjectFileItem,
-  ProjectFilesOverview,
-  ProjectFilesPage
+  ProjectFilesOverview
 } from '../../../../shared/project-files'
 
 type GetProjectFilesOverview = (
   request: GetProjectFilesOverviewRequest
 ) => Promise<ProjectFilesOverview>
-type ListProjectFiles = (request: ListProjectFilesRequest) => Promise<ProjectFilesPage>
+type ReadExportFiles = (request: ReadProjectExportFilesRequest) => Promise<ProjectFileItem[]>
 type RepairProjectFilesIndex = (request: { projectId: string }) => Promise<void>
 
 type ListAllSessionArtifactsOptions = {
   getOverview: GetProjectFilesOverview
-  listFiles: ListProjectFiles
+  readExportFiles: ReadExportFiles
   repairIndex: RepairProjectFilesIndex
   projectId: string
   sessionId: string
 }
 
-const SESSION_ARTIFACT_PAGE_LIMIT = 100
-
-// Hides cursor traversal from the dialog so its interface is one complete Source Session snapshot.
+// Repairs the legacy index when needed, then reads one consistent export selection.
 const listAllSessionArtifacts = async ({
   getOverview,
-  listFiles,
+  readExportFiles,
   repairIndex,
   projectId,
   sessionId
@@ -39,27 +36,13 @@ const listAllSessionArtifacts = async ({
     }
   }
 
-  const artifacts: ProjectFileItem[] = []
-  let cursor: string | undefined
-
-  do {
-    const page = await listFiles({
-      projectId,
-      collection: { kind: 'sessionArtifacts', sessionId },
-      ...(cursor ? { cursor } : {}),
-      limit: SESSION_ARTIFACT_PAGE_LIMIT
-    })
-    artifacts.push(...page.items)
-    cursor = page.nextCursor
-  } while (cursor)
-
-  return artifacts
+  return readExportFiles({ projectId, sessionId })
 }
 
 export { listAllSessionArtifacts }
 export type {
   GetProjectFilesOverview,
   ListAllSessionArtifactsOptions,
-  ListProjectFiles,
+  ReadExportFiles,
   RepairProjectFilesIndex
 }

--- a/src/shared/project-files.ts
+++ b/src/shared/project-files.ts
@@ -51,6 +51,12 @@ export type ListProjectFilesRequest = {
   limit: number
 }
 
+// One consistent selection for an export. Omit sessionId to include all Project sources.
+export type ReadProjectExportFilesRequest = {
+  projectId: string
+  sessionId?: string
+}
+
 export type ProjectFilesPage = {
   items: ProjectFileItem[]
   nextCursor?: string

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -270,6 +270,7 @@ import type {
   GetProjectFilesOverviewRequest,
   ListArtifactGroupsRequest,
   ListProjectFilesRequest,
+  ReadProjectExportFilesRequest,
   ProjectFileItem,
   ProjectFilesChangedEvent,
   ProjectFilesOverview,
@@ -1410,6 +1411,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'projectFiles.listFiles': callable<
     (request: ListProjectFilesRequest) => Promise<ProjectFilesPage>
   >()('project-files', ['project-files:list-files']),
+  'projectFiles.readExportFiles': callable<
+    (request: ReadProjectExportFilesRequest) => Promise<ProjectFileItem[]>
+  >()('project-files', ['project-files:read-export-files']),
   'projectFiles.resolveFile': callable<
     (request: ResolveProjectFileRequest) => Promise<ProjectFileItem | undefined>
   >()('project-files', ['project-files:resolve-file']),

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -145,6 +145,7 @@ export const WEB_INVOKE_CHANNELS = {
   'projectFiles.getOverview': 'project-files:get-overview',
   'projectFiles.listArtifactGroups': 'project-files:list-artifact-groups',
   'projectFiles.listFiles': 'project-files:list-files',
+  'projectFiles.readExportFiles': 'project-files:read-export-files',
   'projectFiles.repairIndex': 'project-files:repair-index',
   'projectFiles.resolveFile': 'project-files:resolve-file',
   'projectFiles.searchArtifacts': 'project-files:search-artifacts',


### PR DESCRIPTION
## Problem

Partial project ZIP retries silently narrowed the selection to failed files, so overwriting the same archive lost previously exported successes. Reopening a session download dialog could submit a stale version list while refreshing. Live catalog pagination could omit files whose current version advanced between pages. ZIP collision checks missed canonically equivalent Unicode names, and the project partial-result summary bypassed translation.

## Proposed change

- Keep the checked project selection after partial success and rebuild the complete selected ZIP on retry.
- Clear closed session download state so reopening waits for a fresh selection.
- Read project/session export members and immutable version IDs in one authoritative SQL statement, exposed through the existing project-files facade and typed Electron/Web command contract. Ordinary browsing stays paginated.
- Normalize ZIP collision keys to NFC before existing lowercase comparison; preserve display spelling and numbered suffixes.
- Render the project partial-result summary with the existing translated key and structured counts.

## Scope and non-goals

No database schema, migration, persistent export job, new dependency, or historical-data rewrite. The new API returns the existing metadata projection. The project dialog adds only transient partial/raw error state. Existing archives are unchanged and must be rebuilt to gain corrected contents/names. A complete metadata list is materialized for export; file bytes still stream through the existing save pipeline.

## Acceptance criteria and validation

Regression tests first failed on unchanged production behavior: consecutive runs showed five matching failures plus a passing no-update control. Expanded real-SQLite tests also demonstrated the omission for both Upload and Artifact versions with the original pagination helpers, while both no-update controls passed. The fixed helpers preserve all 101 members and their read-time versions; reopening sees the new head.

Checks ran after the last production edit; the consumer fixture adjustment was separately tested, linted and typechecked; the final test-only preload inventory correction also passed its focused suite and lint:

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| Catalog snapshots, scope, completeness, recovery admission and repository consumers | `npm run test:module -- project_files_repository` | 310 passed |
| ZIP output/collisions, dialogs, collection helpers, i18n, command registration and Electron/Web contracts | `npx vitest run src/main/file-save.test.ts src/main/data-content-application-commands.test.ts src/main/application-command-composition.test.ts src/main/application-command-wiring.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/renderer-contract.test.ts src/shared/web-rpc-contract.test.ts src/preload/electron-renderer-contract-adapter.test.ts src/renderer/src/pages/workspace/project-artifact-download-data.test.ts src/renderer/src/pages/workspace/session-artifact-download-data.test.ts src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.render.test.tsx src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx src/renderer/src/i18n/resources.test.ts` | 1,039 passed |
| Existing Files view consumer | `npx vitest run src/renderer/src/pages/workspace/ProjectFilesView.test.tsx --maxWorkers=2` | 87 passed |
| Pinned preload inventory and generated API adapters | `npx vitest run src/preload/index.test.ts src/preload/electron-renderer-contract-adapter.test.ts src/shared/renderer-contract-catalog.test.ts src/shared/renderer-contract.test.ts --maxWorkers=2` | 133 passed; inventory correction first reproduced as 1 failure / 88 passes |
| Main and renderer contracts | `npm run typecheck:node`; `npm run typecheck:web` | Passed |
| Source style | `npm run lint`; focused ESLint for the final consumer fixture | Passed |

Browser verification mounted the actual dialogs and production styles with controlled API fixtures: two project retries retained A and B, the partial summary rendered in Chinese, and a reopened session stayed disabled until refresh then submitted v2. Screenshots are retained as local review artifacts; this is component UI verification, not a packaged Electron end-to-end save-dialog test. The save suite separately exercises real IPC/ZIP/file publication.

The impact explain tool falls back to full verification because the shared application-command registry has no module owner. Per maintainer instruction, local validation used the explicit owner/contract/consumer set above, with complete and cross-platform verification delegated to final-head PR CI. No claim is made about every OS extractor; the Unicode regression asserts portable real-ZIP entry names. Large-catalog latency has not been benchmarked. Independent PR review and required CI remain the final verification gate.

## Review focus

The export-only SQL read must retain the existing authoritative visibility filters and immutable version selection. The new operation must pass project deletion-recovery admission in both Electron and Web dispatch. Project ZIP retry intentionally retains successes, while session individual-file retry continues selecting only failures.
