### PR TITLE
fix(elicitation): preserve optional values and in-progress answers

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -696,6 +696,11 @@ colors communicate a successful or failed probe/migration result.
 - Ask-User elicitation uses the same content-bounded bottom resize behavior. Key the resize shell to
   the elicitation request so a new question starts at its natural height instead of inheriting the
   previous question's manual height.
+- Optional boolean fields distinguish an unanswered value from explicit Yes/No beside the switch,
+  with Clear selection returning to unanswered. Empty optional text and multi-select values are
+  omitted consistently by validation and submission. Choice-question input and the current step
+  survive Session navigation in renderer memory; they remain separate from confirmed steps and
+  are cleared when the request settles. Unsubmitted edits are not persisted across app restarts.
 - Plan approval uses the same content-bounded bottom panel shell and single-border embedded surface.
   Its compact summary normally has no hidden overflow, so the top resize handle cannot stretch it
   into empty space. The card shows the Plan lifecycle, task summary, confidence, and inline revision

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -74,7 +74,11 @@
           "src/renderer/src/stores/session-job-store.test.ts"
         ],
         "contract": ["src/shared/session-persistence.test.ts"],
-        "consumer": ["src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts"]
+        "consumer": [
+          "src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts",
+          "src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx",
+          "src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx"
+        ]
       },
       "capabilityOverlays": ["renderer_state"],
       "fallbackCapability": "renderer_view"

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -1521,6 +1521,91 @@ describe('ConversationPanel composer intake', () => {
     window.api = previousApi
   })
 
+  it('saves early elicitation edits when the correlated activity arrives later', async () => {
+    const fields = [
+      {
+        id: 'question_0',
+        label: 'Scope',
+        kind: 'single-select' as const,
+        options: [
+          { value: 'a', label: 'A' },
+          { value: 'b', label: 'B' }
+        ]
+      },
+      { id: 'question_0_custom', label: 'Other', kind: 'text' as const }
+    ]
+    const request = {
+      requestId: 'early-request',
+      sessionId: 'early-session',
+      toolCallId: 'early-activity',
+      message: 'Choose a scope',
+      fields
+    }
+    const session: ChatSession = {
+      id: request.sessionId,
+      projectId: 'project-a',
+      title: 'Early input',
+      cwd: '/workspace',
+      status: 'waiting-for-user',
+      messages: [],
+      activities: [],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    useSessionStore.setState({ ...createInitialSessionState(), sessions: [session] })
+    const show = (): void =>
+      renderPanel({
+        view: { activeSession: useSessionStore.getState().sessions[0] },
+        elicitation: { requests: [request] }
+      })
+    show()
+    const textarea = container.querySelector<HTMLTextAreaElement>(
+      '[aria-label="Type your own answer"]'
+    )!
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+        textarea,
+        'Written before activity'
+      )
+      textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(useSessionStore.getState().sessions[0].elicitationEditDrafts).toBeUndefined()
+    await act(async () =>
+      useSessionStore.setState({
+        sessions: [
+          {
+            ...session,
+            activities: [
+              {
+                id: request.toolCallId,
+                kind: 'tool',
+                title: 'AskUserQuestion',
+                status: 'in_progress',
+                eventIds: [],
+                sortIndex: 1,
+                createdAt: 1,
+                updatedAt: 1,
+                elicitation: { message: request.message, fields, state: 'pending' }
+              }
+            ]
+          }
+        ]
+      })
+    )
+    show()
+    expect(container.querySelector('textarea[aria-label="Type your own answer"]')).toBe(textarea)
+    expect(
+      useSessionStore.getState().sessions[0].elicitationEditDrafts?.[request.toolCallId]?.values
+        .question_0_custom
+    ).toBe('Written before activity')
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    show()
+    expect(
+      container.querySelector<HTMLTextAreaElement>('[aria-label="Type your own answer"]')?.value
+    ).toBe('Written before activity')
+  })
+
   it('shows structured input in a content-bounded lane without notebook chrome', async () => {
     const fields = [
       {

--- a/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
@@ -17,7 +17,11 @@ import {
   createInitialPreviewWorkbenchState,
   usePreviewWorkbenchStore
 } from '@/stores/preview-workbench-store'
-import type { ChatSession } from '@/stores/session-store'
+import {
+  useSessionStore,
+  createInitialSessionState,
+  type ChatSession
+} from '@/stores/session-store'
 import type { ActivePlanProjection } from '../../../../shared/session-plan/contract'
 import type { DelegatedQuestionRequest } from '../../../../shared/session-persistence'
 import { VISION_MODEL_NOT_CONFIGURED_MESSAGE } from '../../../../shared/run-error-classification'
@@ -1517,7 +1521,7 @@ describe('ConversationPanel composer intake', () => {
     window.api = previousApi
   })
 
-  it('shows structured input in a content-bounded lane without notebook chrome', () => {
+  it('shows structured input in a content-bounded lane without notebook chrome', async () => {
     const fields = [
       {
         id: 'question_0',
@@ -1562,6 +1566,7 @@ describe('ConversationPanel composer intake', () => {
       updatedAt: 1
     }
 
+    useSessionStore.setState({ ...createInitialSessionState(), sessions: [activeSession] })
     mockAllJobs = [{ job_id: 'job-1', status: 'done', created_at: 1 }]
     renderPanel({
       view: {
@@ -1591,6 +1596,23 @@ describe('ConversationPanel composer intake', () => {
       }
     })
 
+    const ownAnswer = container.querySelector<HTMLTextAreaElement>(
+      '[aria-label="Type your own answer"]'
+    )!
+    await act(async () => {
+      Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+        ownAnswer,
+        'Research draft'
+      )
+      ownAnswer.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+    expect(
+      useSessionStore.getState().sessions[0].elicitationEditDrafts?.['tool-ask-1']
+    ).toMatchObject({
+      requestId: 'elicitation-1',
+      activeQuestionIndex: 0,
+      values: { question_0_custom: 'Research draft' }
+    })
     const elicitationComposer = container.querySelector('[data-testid="elicitation-composer"]')
     expect(elicitationComposer).not.toBeNull()
     expect(elicitationComposer?.classList.contains('max-h-[min(70dvh,44rem)]')).toBe(true)

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -1508,20 +1508,19 @@ const ConversationPanel = ({
                                   ]
                                 : undefined
                             }
-                            onEditDraftChange={(draft) => {
-                              if (
-                                !activeSession ||
-                                !pendingElicitationActivity ||
-                                !pendingElicitationRequest
-                              )
-                                return
-                              setElicitationEditDraft(
-                                activeSession.id,
-                                pendingElicitationActivity.id,
-                                pendingElicitationRequest.requestId,
-                                draft
-                              )
-                            }}
+                            onEditDraftChange={
+                              activeSession &&
+                              pendingElicitationActivity &&
+                              pendingElicitationRequest
+                                ? (draft) =>
+                                    setElicitationEditDraft(
+                                      activeSession.id,
+                                      pendingElicitationActivity.id,
+                                      pendingElicitationRequest.requestId,
+                                      draft
+                                    )
+                                : undefined
+                            }
                             onDraftChange={(answers: ElicitationAnswer[]) => {
                               if (!activeSession || !pendingElicitationActivity) return
                               setElicitationDraftAnswers(

--- a/src/renderer/src/pages/workspace/ConversationPanel.tsx
+++ b/src/renderer/src/pages/workspace/ConversationPanel.tsx
@@ -622,6 +622,7 @@ const ConversationPanel = ({
     () => new Map<string, StopSubmissionState>()
   )
   const [messageQueueExpanded, setMessageQueueExpanded] = useState(false)
+  const setElicitationEditDraft = useSessionStore((state) => state.setElicitationEditDraft)
   const setElicitationDraftAnswers = useSessionStore((state) => state.setElicitationDraftAnswers)
   const fileInputRef = useRef<HTMLInputElement | null>(null)
   const globalSearchShortcut = window.api?.platform === 'darwin' ? '⌘K' : 'Ctrl+K'
@@ -1500,6 +1501,27 @@ const ConversationPanel = ({
                             request={pendingElicitationRequest}
                             embedded
                             onRespond={onRespondToElicitation}
+                            editDraft={
+                              pendingElicitationActivity
+                                ? activeSession?.elicitationEditDrafts?.[
+                                    pendingElicitationActivity.id
+                                  ]
+                                : undefined
+                            }
+                            onEditDraftChange={(draft) => {
+                              if (
+                                !activeSession ||
+                                !pendingElicitationActivity ||
+                                !pendingElicitationRequest
+                              )
+                                return
+                              setElicitationEditDraft(
+                                activeSession.id,
+                                pendingElicitationActivity.id,
+                                pendingElicitationRequest.requestId,
+                                draft
+                              )
+                            }}
                             onDraftChange={(answers: ElicitationAnswer[]) => {
                               if (!activeSession || !pendingElicitationActivity) return
                               setElicitationDraftAnswers(

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx
@@ -3,9 +3,16 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { validateElicitationAnswers } from '../../../../main/acp/elicitation-owner'
+import type { ElicitationField, PendingElicitationRequest } from '../../../../shared/elicitation'
+
 import { WorkspaceElicitationCard } from './WorkspaceElicitationCard'
 
-import type { ToolActivity } from '@/stores/session-store'
+import {
+  useSessionStore,
+  createInitialSessionState,
+  type ToolActivity
+} from '@/stores/session-store'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
@@ -1274,4 +1281,266 @@ describe('WorkspaceElicitationCard generic ACP form', () => {
       answers: [{ fieldId: 'rationale', value: 'The checks passed' }]
     })
   })
+})
+
+describe('elicitation reported input regressions', () => {
+  const button = (label: string): HTMLButtonElement => {
+    const result = Array.from(container.querySelectorAll('button')).find(
+      (item) => item.textContent?.trim() === label
+    )
+    expect(result).toBeDefined()
+    return result!
+  }
+  const mountForm = async (
+    formFields: ElicitationField[]
+  ): Promise<{ onRespond: ReturnType<typeof vi.fn>; formRequest: PendingElicitationRequest }> => {
+    const onRespond = vi.fn().mockResolvedValue(undefined)
+    const formRequest = { ...request, fields: formFields }
+    await act(async () =>
+      root.render(
+        <WorkspaceElicitationCard
+          elicitation={{ message: request.message, fields: formFields, state: 'pending' }}
+          request={formRequest}
+          onRespond={onRespond}
+        />
+      )
+    )
+    return { onRespond, formRequest }
+  }
+
+  it.each<ElicitationField>([
+    { id: 'optional', label: 'Email', kind: 'text', format: 'email' },
+    { id: 'optional', label: 'Text', kind: 'text', minLength: 2 },
+    {
+      id: 'optional',
+      label: 'Choices',
+      kind: 'multi-select',
+      minItems: 1,
+      options: [{ value: 'one', label: 'One' }]
+    }
+  ])('EL-01 permits omission after clearing $label', async (field) => {
+    const other: ElicitationField = {
+      id: 'other',
+      label: 'Other answer',
+      kind: 'text',
+      required: true,
+      defaultValue: 'Keep me'
+    }
+    const { onRespond, formRequest } = await mountForm([field, other])
+    const answers = [{ fieldId: 'other', value: 'Keep me' }]
+    expect(validateElicitationAnswers(formRequest, answers)).toEqual(answers)
+    expect(button('Continue').disabled).toBe(false)
+    const control = container.querySelector<HTMLInputElement | HTMLTextAreaElement>(
+      'input, textarea'
+    )!
+    if (field.kind === 'multi-select') {
+      await act(async () => control.click())
+    } else {
+      await act(async () => setTextControlValue(control, field.format ? 'a@example.com' : 'valid'))
+    }
+    expect(button('Continue').disabled).toBe(false)
+    await act(async () => {
+      if (field.kind === 'multi-select') control.click()
+      else setTextControlValue(control, '')
+    })
+    expect(button('Continue').disabled, 'cleared optional field must be omittable').toBe(false)
+    await act(async () => button('Continue').click())
+    expect(onRespond).toHaveBeenCalledWith({
+      requestId: request.requestId,
+      action: 'accept',
+      answers
+    })
+  })
+
+  it.each([20, undefined])('EL-02 edits a date-time with maxLength %s', async (maxLength) => {
+    const field: ElicitationField = {
+      id: 'time',
+      label: 'Time',
+      kind: 'text',
+      required: true,
+      format: 'date-time',
+      maxLength,
+      defaultValue: '2026-09-07T12:00:00Z'
+    }
+    const { onRespond, formRequest } = await mountForm([field])
+    expect(button('Continue').disabled).toBe(false)
+    const local = '2026-09-07T12:01:00'
+    const expected = new Date(local).toISOString().replace('.000Z', 'Z')
+    expect(validateElicitationAnswers(formRequest, [{ fieldId: 'time', value: expected }])).toEqual(
+      [{ fieldId: 'time', value: expected }]
+    )
+    await act(async () => setTextControlValue(container.querySelector('input')!, local))
+    expect(button('Continue').disabled, 'editing must not add unnecessary length').toBe(false)
+    await act(async () => button('Continue').click())
+    const sent = onRespond.mock.calls[0][0].answers[0].value
+    expect(new Date(sent).getTime()).toBe(new Date(local).getTime())
+    if (maxLength) expect(sent).toHaveLength(maxLength)
+  })
+
+  it.each([
+    { local: '2026-09-07T12:01:00.123', minLength: undefined, suffix: '.123Z' },
+    { local: '2026-09-07T12:01:00', minLength: 24, suffix: '.000Z' }
+  ])(
+    'EL-02 preserves precision and minimum length: $suffix',
+    async ({ local, minLength, suffix }) => {
+      const { onRespond } = await mountForm([
+        { id: 'time', label: 'Time', kind: 'text', format: 'date-time', minLength }
+      ])
+      await act(async () => setTextControlValue(container.querySelector('input')!, local))
+      expect(button('Continue').disabled).toBe(false)
+      await act(async () => button('Continue').click())
+      const sent = onRespond.mock.calls[0][0].answers[0].value
+      expect(sent.endsWith(suffix)).toBe(true)
+      expect(new Date(sent).getTime()).toBe(new Date(local).getTime())
+    }
+  )
+
+  it.each<ElicitationField>([
+    { id: 'value', label: 'Required', kind: 'text', required: true, minLength: 2 },
+    { id: 'value', label: 'Email', kind: 'text', format: 'email' },
+    { id: 'value', label: 'Minimum length', kind: 'text', minLength: 2 }
+  ])('EL-01 still rejects invalid nonempty $label', async (field) => {
+    const { onRespond } = await mountForm([field])
+    await act(async () => setTextControlValue(container.querySelector('input, textarea')!, 'x'))
+    expect(button('Continue').disabled).toBe(true)
+    await act(async () => setTextControlValue(container.querySelector('input, textarea')!, ''))
+    expect(button('Continue').disabled).toBe(Boolean(field.required))
+    if (field.required) {
+      await act(async () => button('Continue').click())
+      expect(onRespond).not.toHaveBeenCalled()
+    }
+  })
+
+  it('EL-03 distinguishes an omitted boolean from explicit false on screen', async () => {
+    const { onRespond } = await mountForm([{ id: 'enabled', label: 'Enabled', kind: 'boolean' }])
+    const initialView = container.textContent
+    const toggle = container.querySelector<HTMLButtonElement>('[role="switch"]')!
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    await act(async () => button('Continue').click())
+    expect(onRespond.mock.calls[0][0].answers).toEqual([])
+    await act(async () => toggle.click())
+    await act(async () => toggle.click())
+    expect(toggle.getAttribute('aria-checked')).toBe('false')
+    await act(async () => button('Continue').click())
+    expect(onRespond.mock.calls[1][0].answers).toEqual([{ fieldId: 'enabled', value: false }])
+    expect(
+      container.textContent,
+      'different submission meanings need a visible distinction'
+    ).not.toBe(initialView)
+    await act(async () => button('Clear selection').click())
+    expect(container.textContent).toContain('Not answered')
+    await act(async () => button('Continue').click())
+    expect(onRespond.mock.calls.at(-1)?.[0].answers).toEqual([])
+  })
+
+  it('EL-04 keeps edits after a failed response and clears only after acceptance', async () => {
+    const onRespond = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Try again'))
+      .mockResolvedValue(undefined)
+    const onEditDraftChange = vi.fn()
+    await act(async () =>
+      root.render(
+        <WorkspaceElicitationCard
+          elicitation={activity.elicitation!}
+          request={request}
+          onRespond={onRespond}
+          onEditDraftChange={onEditDraftChange}
+        />
+      )
+    )
+    await act(async () =>
+      setTextControlValue(container.querySelector('textarea')!, 'Keep this draft')
+    )
+    expect(onEditDraftChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        values: expect.objectContaining({ question_0_custom: 'Keep this draft' })
+      })
+    )
+    await act(async () => button('Finish').click())
+    expect(container.querySelector('[role="alert"]')?.textContent).toBe('Try again')
+    expect(onEditDraftChange).not.toHaveBeenCalledWith(undefined)
+    await act(async () => button('Finish').click())
+    expect(onEditDraftChange).toHaveBeenLastCalledWith(undefined)
+  })
+
+  it.each(['single', 'last', 'back'] as const)(
+    'EL-04 restores unsubmitted custom text: %s',
+    async (scenario) => {
+      const choiceRequest = scenario === 'single' ? request : multiQuestionRequest
+      useSessionStore.setState({
+        ...createInitialSessionState(),
+        sessions: [
+          {
+            id: request.sessionId,
+            projectId: 'project',
+            title: 'Test',
+            cwd: '/workspace',
+            status: 'waiting-for-user',
+            messages: [],
+            createdAt: 1,
+            updatedAt: 1,
+            activities: [
+              {
+                ...activity,
+                elicitation: {
+                  message: choiceRequest.message,
+                  fields: choiceRequest.fields,
+                  state: 'pending'
+                }
+              }
+            ]
+          }
+        ]
+      })
+      const onRespond = vi.fn().mockResolvedValue(undefined)
+      const DraftCard = (): React.JSX.Element => {
+        const session = useSessionStore((state) => state.sessions[0])
+        const owner = useSessionStore.getState()
+        return (
+          <WorkspaceElicitationCard
+            elicitation={session.activities![0].elicitation!}
+            request={choiceRequest}
+            onRespond={onRespond}
+            editDraft={session.elicitationEditDrafts?.[activity.id]}
+            onEditDraftChange={(draft) =>
+              owner.setElicitationEditDraft(session.id, activity.id, request.requestId, draft)
+            }
+            onDraftChange={(answers) =>
+              owner.setElicitationDraftAnswers(session.id, activity.id, answers)
+            }
+          />
+        )
+      }
+      const render = async (): Promise<void> => act(async () => root.render(<DraftCard />))
+      await render()
+      if (scenario !== 'single') {
+        await act(async () =>
+          container
+            .querySelector<HTMLButtonElement>('[data-testid="elicitation-option-clinical"]')!
+            .click()
+        )
+        await act(async () => button('Next').click())
+        if (scenario === 'back') {
+          await act(async () =>
+            container.querySelector<HTMLButtonElement>('[aria-label="Previous question"]')!.click()
+          )
+        }
+      }
+      await act(async () =>
+        setTextControlValue(container.querySelector('textarea')!, 'Unsaved custom answer')
+      )
+      const prompt = container.querySelector('h3')?.textContent
+      expect(onRespond).not.toHaveBeenCalled()
+      await act(async () => root.unmount())
+      root = createRoot(container)
+      await render()
+      expect(
+        container.querySelector('textarea')?.value,
+        'remount must restore the current input'
+      ).toBe('Unsaved custom answer')
+      expect(container.querySelector('h3')?.textContent).toBe(prompt)
+      expect(onRespond).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -501,6 +501,9 @@ const WorkspaceElicitationCard = ({
 
   // Capture edits without confirming a question or emitting an Agent response. The callback can
   // change on store updates; only local input/navigation changes should publish another snapshot.
+  // Requests can render before their activity is available to own the draft. Publish the current
+  // local edits once that correlation arrives, without depending on the callback's identity.
+  const canSaveEditDraft = onEditDraftChange !== undefined
   const publishEditDraft = useEffectEvent(() => {
     if (request && choiceQuestions && elicitation.state === 'pending') {
       onEditDraftChange?.({
@@ -512,7 +515,7 @@ const WorkspaceElicitationCard = ({
   })
   useEffect(() => {
     publishEditDraft()
-  }, [values, activeChoiceIndex])
+  }, [values, activeChoiceIndex, canSaveEditDraft])
 
   const respond = async (response: ElicitationResponse): Promise<boolean> => {
     if (!onRespond || isSubmitting) return false

--- a/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx
@@ -1,5 +1,14 @@
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
-import { useEffect, useLayoutEffect, useMemo, useRef, useState, type FormEvent } from 'react'
+import {
+  useId,
+  useEffectEvent,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent
+} from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   Bot,
@@ -30,6 +39,7 @@ import {
   type ElicitationValue,
   type PendingElicitationRequest
 } from '../../../../shared/acp'
+import type { ElicitationEditDraft } from '@/stores/session-store'
 import type { AnnotationPort } from './annotations/annotation-port'
 import { TextAnnotationSurface } from './annotations/TextAnnotationSurface'
 
@@ -92,10 +102,17 @@ const normalizeLocalDateTime = (value: string): string | undefined => {
   return date.toISOString()
 }
 
-const valueForSubmission = (field: ElicitationField, value: ElicitationValue): ElicitationValue =>
-  field.format === 'date-time' && typeof value === 'string'
-    ? (normalizeLocalDateTime(value) ?? value)
-    : value
+const valueForSubmission = (
+  field: ElicitationField,
+  value: ElicitationValue | undefined
+): ElicitationValue | undefined => {
+  if (value === '' || (Array.isArray(value) && value.length === 0)) return undefined
+  if (field.format !== 'date-time' || typeof value !== 'string') return value
+  const normalized = normalizeLocalDateTime(value)
+  if (!normalized) return value
+  const compact = normalized.replace('.000Z', 'Z')
+  return compact.length >= (field.minLength ?? 0) ? compact : normalized
+}
 
 const valueForTextInput = (
   field: ElicitationField,
@@ -115,10 +132,10 @@ const valueForTextInput = (
 }
 
 const hasValidValue = (field: ElicitationField, value: ElicitationValue | undefined): boolean => {
+  value = valueForSubmission(field, value)
   if (value === undefined) return !field.required
   if (field.required && typeof value === 'string' && value.trim().length === 0) return false
-  if (field.required && Array.isArray(value) && value.length === 0) return false
-  return isValidElicitationValue(field, valueForSubmission(field, value))
+  return isValidElicitationValue(field, value)
 }
 
 const submittedAnswers = (
@@ -126,10 +143,8 @@ const submittedAnswers = (
   values: Record<string, ElicitationValue | undefined>
 ): ElicitationAnswer[] =>
   fields.flatMap((field) => {
-    const value = values[field.id]
-    if (value === undefined || value === '' || (Array.isArray(value) && value.length === 0))
-      return []
-    return [{ fieldId: field.id, value: valueForSubmission(field, value) }]
+    const value = valueForSubmission(field, values[field.id])
+    return value === undefined ? [] : [{ fieldId: field.id, value }]
   })
 
 type WorkspaceElicitationCardProps = {
@@ -139,6 +154,8 @@ type WorkspaceElicitationCardProps = {
   embedded?: boolean
   onRespond?: (response: ElicitationResponse) => Promise<void>
   onDraftChange?: (answers: ElicitationAnswer[]) => void
+  editDraft?: ElicitationEditDraft
+  onEditDraftChange?: (draft: ElicitationEditDraft | undefined) => void
   annotationPort?: AnnotationPort
   annotationItemId?: string
   revealRequest?: Readonly<{ requestId: number; itemId: string; sectionId?: string }>
@@ -191,22 +208,31 @@ const WorkspaceElicitationCard = ({
   embedded = false,
   onRespond,
   onDraftChange,
+  editDraft,
+  onEditDraftChange,
   annotationPort,
   annotationItemId,
   revealRequest
 }: WorkspaceElicitationCardProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const fieldStatusId = useId()
   const choiceQuestions = request ? resolveAgentUserChoiceQuestions(request.fields) : undefined
   const restoredValues = initialValues(
     request?.fields ?? [],
     elicitation.state === 'pending' ? (elicitation.draftAnswers ?? []) : []
   )
+  const restoredEdit =
+    elicitation.state === 'pending' && editDraft?.requestId === request?.requestId
+      ? editDraft
+      : undefined
   const [values, setValues] = useState<Record<string, ElicitationValue | undefined>>(
-    () => restoredValues
+    () => restoredEdit?.values ?? restoredValues
   )
   const [confirmedValues, setConfirmedValues] = useState(() => restoredValues)
-  const [activeChoiceIndex, setActiveChoiceIndex] = useState(() =>
-    choiceQuestions ? firstUnansweredQuestionIndex(choiceQuestions, restoredValues) : 0
+  const [activeChoiceIndex, setActiveChoiceIndex] = useState(
+    () =>
+      restoredEdit?.activeQuestionIndex ??
+      (choiceQuestions ? firstUnansweredQuestionIndex(choiceQuestions, restoredValues) : 0)
   )
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [error, setError] = useState<string>()
@@ -473,6 +499,21 @@ const WorkspaceElicitationCard = ({
     }
   }, [annotationItemId, elicitation.answers, elicitation.state, request, revealRequest])
 
+  // Capture edits without confirming a question or emitting an Agent response. The callback can
+  // change on store updates; only local input/navigation changes should publish another snapshot.
+  const publishEditDraft = useEffectEvent(() => {
+    if (request && choiceQuestions && elicitation.state === 'pending') {
+      onEditDraftChange?.({
+        requestId: request.requestId,
+        values,
+        activeQuestionIndex: activeChoiceIndex
+      })
+    }
+  })
+  useEffect(() => {
+    publishEditDraft()
+  }, [values, activeChoiceIndex])
+
   const respond = async (response: ElicitationResponse): Promise<boolean> => {
     if (!onRespond || isSubmitting) return false
     setError(undefined)
@@ -482,6 +523,7 @@ const WorkspaceElicitationCard = ({
         ...response,
         ...(request?.durable ? { request } : {})
       })
+      onEditDraftChange?.(undefined)
       return true
     } catch (caught) {
       setError(caught instanceof Error ? caught.message : 'Could not submit the response.')
@@ -838,9 +880,9 @@ const WorkspaceElicitationCard = ({
       ) : elicitation.state === 'pending' && request ? (
         <form className="mt-3 space-y-4" onSubmit={handleSubmit}>
           <div className="space-y-4">
-            {request.fields.map((field) => {
+            {request.fields.map((field, fieldIndex) => {
               const value = values[field.id]
-              const setValue = (next: ElicitationValue): void =>
+              const setValue = (next: ElicitationValue | undefined): void =>
                 setValues((current) => ({ ...current, [field.id]: next }))
 
               if (field.kind === 'single-select') {
@@ -933,7 +975,7 @@ const WorkspaceElicitationCard = ({
 
               if (field.kind === 'boolean') {
                 return (
-                  <label key={field.id} className="flex items-center justify-between gap-3 text-sm">
+                  <div key={field.id} className="flex items-center justify-between gap-3 text-sm">
                     <span>
                       <span className="block font-medium">{field.label}</span>
                       {field.description ? (
@@ -942,12 +984,34 @@ const WorkspaceElicitationCard = ({
                         </span>
                       ) : null}
                     </span>
-                    <Switch
-                      checked={value === true}
-                      disabled={isSubmitting}
-                      onCheckedChange={(checked) => setValue(checked)}
-                    />
-                  </label>
+                    <div className="flex flex-wrap items-center justify-end gap-2">
+                      {!field.required ? (
+                        <span id={`${fieldStatusId}-${fieldIndex}`} className="text-text-100">
+                          {value === undefined ? t('Not answered') : value ? t('Yes') : t('No')}
+                        </span>
+                      ) : null}
+                      <Switch
+                        aria-label={field.label}
+                        aria-describedby={
+                          !field.required ? `${fieldStatusId}-${fieldIndex}` : undefined
+                        }
+                        checked={value === true}
+                        disabled={isSubmitting}
+                        onCheckedChange={(checked) => setValue(checked)}
+                      />
+                      {!field.required ? (
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          disabled={isSubmitting || value === undefined}
+                          onClick={() => setValue(undefined)}
+                        >
+                          {t('Clear selection')}
+                        </Button>
+                      ) : null}
+                    </div>
+                  </div>
                 )
               }
 
@@ -1009,7 +1073,11 @@ const WorkspaceElicitationCard = ({
                     <span className="block leading-5 text-text-100">{field.description}</span>
                   ) : null}
                   {inputType ? (
-                    <Input type={inputType} {...textProps} />
+                    <Input
+                      type={inputType}
+                      step={inputType === 'datetime-local' ? 'any' : undefined}
+                      {...textProps}
+                    />
                   ) : (
                     <Textarea {...textProps} />
                   )}

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -6,7 +6,7 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { StoreApi } from 'zustand'
 
-import type { ElicitationProjection } from '../../../shared/acp'
+import type { ElicitationProjection, ElicitationValue } from '../../../shared/acp'
 import type { ActivePlanProjection } from '../../../shared/session-plan/contract'
 import { DEFAULT_PERMISSION_PROFILE } from '../../../shared/permission-profiles'
 import type { PermissionProfileId } from '../../../shared/permission-profiles'
@@ -76,6 +76,13 @@ export type ToolActivity = {
 }
 export type ChatArtifact = PersistedArtifact & { isPublished?: boolean }
 
+// Renderer memory only: edits are separate from confirmed, durable draftAnswers.
+export type ElicitationEditDraft = {
+  requestId: string
+  values: Record<string, ElicitationValue | undefined>
+  activeQuestionIndex: number
+}
+
 export type ChatSession = Omit<
   PersistedChatSession,
   'messages' | 'activities' | 'permissionProfile' | 'artifacts'
@@ -84,6 +91,7 @@ export type ChatSession = Omit<
   permissionProfile?: PermissionProfileId
   messages: ChatMessage[]
   activities?: ToolActivity[]
+  elicitationEditDrafts?: Record<string, ElicitationEditDraft>
   activePlanProjection?: ActivePlanProjection
   planHistoryProjections?: ActivePlanProjection[]
   isPending?: boolean
@@ -305,6 +313,7 @@ export const toPersistedSession = (
     activeRunRuntimeSegmentId,
     specialistSwitchResetRequired,
     elicitationHistoryReplayRequestId,
+    elicitationEditDrafts,
     branchSwitchBlocked,
     conversationGraphSyncBlocked,
     pendingContextReplayMessageId,
@@ -332,6 +341,7 @@ export const toPersistedSession = (
   void agentPromptInFlight
   void activeRunRuntimeSegmentId
   void specialistSwitchResetRequired
+  void elicitationEditDrafts
   void elicitationHistoryReplayRequestId
   void branchSwitchBlocked
   void conversationGraphSyncBlocked
@@ -518,6 +528,18 @@ const withTransientSessionState = (
       source.branchContextResetRequired || hydrated.branchContextResetRequired,
     specialistSwitchResetRequired: source.specialistSwitchResetRequired,
     elicitationHistoryReplayRequestId: source.elicitationHistoryReplayRequestId,
+    elicitationEditDrafts: Object.fromEntries(
+      Object.entries(source.elicitationEditDrafts ?? {}).filter(([id, draft]) => {
+        const activity =
+          hydrated.activities?.find((item) => item.id === id) ??
+          hydrated.conversationGraph?.activities.find((item) => item.id === id)
+        return (
+          activity?.elicitation?.state === 'pending' &&
+          (!activity.elicitation.durable ||
+            activity.elicitation.durable.requestId === draft.requestId)
+        )
+      })
+    ),
     branchSwitchBlocked: source.branchSwitchBlocked,
     conversationGraphSyncBlocked: source.conversationGraphSyncBlocked,
     pendingContextReplayMessageId: source.pendingContextReplayMessageId,

--- a/src/renderer/src/stores/session-store-run-activity-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-activity-helpers.ts
@@ -181,9 +181,21 @@ export const projectToolActivity = (
 
   if (existingActivity) {
     if (existingActivity.eventIds.includes(input.eventId)) return session
+    let editDrafts = session.elicitationEditDrafts
+    if (
+      editDrafts?.[input.toolCallId] &&
+      input.elicitation &&
+      (input.elicitation.state !== 'pending' ||
+        (input.elicitation.durable &&
+          input.elicitation.durable.requestId !== editDrafts[input.toolCallId]?.requestId))
+    ) {
+      editDrafts = { ...editDrafts }
+      delete editDrafts[input.toolCallId]
+    }
     const activityWasTerminal = isTerminalToolActivityStatus(existingActivity.status)
     return {
       ...session,
+      elicitationEditDrafts: editDrafts,
       status: getToolActivitySessionStatus(session),
       activities: activities.map((activity) =>
         activity.id === input.toolCallId

--- a/src/renderer/src/stores/session-store-run-projection-owner.ts
+++ b/src/renderer/src/stores/session-store-run-projection-owner.ts
@@ -1,6 +1,11 @@
 import type { StoreApi } from 'zustand'
 
 import type { ActivePlanProjection } from '../../../shared/session-plan/contract'
+import {
+  MAX_ELICITATION_MESSAGE_CHARS,
+  MAX_ELICITATION_MULTI_SELECT_VALUES,
+  resolveAgentUserChoiceQuestions
+} from '../../../shared/elicitation'
 import type { AcpModelCallUsage, AcpTurnTokenUsage, ElicitationAnswer } from '../../../shared/acp'
 import type {
   PersistedChatSession,
@@ -49,7 +54,11 @@ import {
   projectPermissionPending,
   type RunTerminalContextWindowSample
 } from './session-store-run-terminal-helpers'
-import type { ChatSession, SessionStoreData } from './session-store-persistence-owner'
+import type {
+  ChatSession,
+  ElicitationEditDraft,
+  SessionStoreData
+} from './session-store-persistence-owner'
 import {
   materializeStreamingMessageContent,
   removeStreamingMessageContentForSession
@@ -134,6 +143,12 @@ export type SessionRunProjectionActions = {
   finishCompaction: (sessionId: string) => void
   failCompaction: (sessionId: string, error: string) => void
   upsertToolActivity: (input: UpsertToolActivityInput) => void
+  setElicitationEditDraft: (
+    sessionId: string,
+    activityId: string,
+    requestId: string,
+    draft: ElicitationEditDraft | undefined
+  ) => void
   setElicitationDraftAnswers: (
     sessionId: string,
     activityId: string,
@@ -377,6 +392,52 @@ export const createSessionRunProjectionOwner = <
         sessions: projectSession(state.sessions, input.sessionId, (session) =>
           projectToolActivity(session, input)
         )
+      }))
+    },
+
+    setElicitationEditDraft: (sessionId, activityId, requestId, draft) => {
+      const session = get().sessions.find((item) => item.id === sessionId)
+      const activity = session?.activities?.find((item) => item.id === activityId)
+      if (
+        !session ||
+        activity?.elicitation?.state !== 'pending' ||
+        (activity.elicitation.durable && activity.elicitation.durable.requestId !== requestId) ||
+        (draft && draft.requestId !== requestId)
+      )
+        return
+      if (!draft && session.elicitationEditDrafts?.[activityId]?.requestId !== requestId) return
+      const drafts = { ...session.elicitationEditDrafts }
+      if (draft) {
+        const questions = resolveAgentUserChoiceQuestions(activity.elicitation.fields)
+        if (
+          !questions ||
+          !Number.isInteger(draft.activeQuestionIndex) ||
+          draft.activeQuestionIndex < 0 ||
+          draft.activeQuestionIndex >= questions.length
+        )
+          return
+        drafts[activityId] = {
+          ...draft,
+          values: Object.fromEntries(
+            activity.elicitation.fields.map((field) => {
+              const value = draft.values[field.id]
+              return [
+                field.id,
+                typeof value === 'string'
+                  ? value.slice(0, MAX_ELICITATION_MESSAGE_CHARS)
+                  : Array.isArray(value)
+                    ? value.slice(0, MAX_ELICITATION_MULTI_SELECT_VALUES)
+                    : undefined
+              ]
+            })
+          )
+        }
+      } else delete drafts[activityId]
+      setSessionState((state) => ({
+        sessions: projectSession(state.sessions, sessionId, (current) => ({
+          ...current,
+          elicitationEditDrafts: drafts
+        }))
       }))
     },
 

--- a/src/renderer/src/stores/session-store.architecture.test.ts
+++ b/src/renderer/src/stores/session-store.architecture.test.ts
@@ -125,6 +125,7 @@ const publicTypeExports = [
   'ChatMessageRole',
   'ChatMessageStatus',
   'ChatSession',
+  'ElicitationEditDraft',
   'SessionActionAvailability',
   'SessionActionDisabledReason',
   'SessionActionabilityFacts',
@@ -986,6 +987,7 @@ describe('Session Store architecture', () => {
       'setAgentStatus',
       'setAwaitingFirstAgentOutput',
       'setElicitationDraftAnswers',
+      'setElicitationEditDraft',
       'setElicitationPending',
       'setPermissionPending',
       'upsertToolActivity'
@@ -1048,7 +1050,11 @@ describe('Session Store architecture', () => {
           'src/renderer/src/stores/session-job-store.test.ts'
         ],
         contract: ['src/shared/session-persistence.test.ts'],
-        consumer: ['src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts']
+        consumer: [
+          'src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts',
+          'src/renderer/src/pages/workspace/WorkspaceElicitationCard.interaction.test.tsx',
+          'src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx'
+        ]
       },
       capabilityOverlays: ['renderer_state'],
       fallbackCapability: 'renderer_view'

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -6326,6 +6326,7 @@ describe('session store public contract', () => {
         'setBranchSwitchBlocked',
         'setContextUsage',
         'setElicitationDraftAnswers',
+        'setElicitationEditDraft',
         'setElicitationHistoryReplayRequest',
         'setElicitationPending',
         'setFixLoopActive',
@@ -6391,6 +6392,7 @@ describe('session store public contract', () => {
       'src/renderer/src/pages/workspace/WorkspaceAgentLoadingRow.tsx',
       'src/renderer/src/pages/workspace/WorkspaceArtifactVisibility.tsx',
       'src/renderer/src/pages/workspace/WorkspaceContextCompactionActivityRow.tsx',
+      'src/renderer/src/pages/workspace/WorkspaceElicitationCard.tsx',
       'src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx',
       'src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx',
       'src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx',
@@ -7310,6 +7312,135 @@ describe('truncateSessionFromMessage', () => {
     seedSession({ filesRevision: 3 })
     useSessionStore.getState().truncateSessionFromMessage('session-1', 'user-2')
     expect(useSessionStore.getState().sessions[0].filesRevision).toBe(3)
+  })
+
+  const seedEditableElicitation = (): void => {
+    seedSession({
+      activities: [
+        {
+          ...createActivity('choice-1', baseTime + 200),
+          status: 'in_progress',
+          elicitation: {
+            message: 'Choose',
+            state: 'pending',
+            durable: { kind: 'agent-user-choice', requestId: 'request-1' },
+            fields: [
+              {
+                id: 'question_0',
+                label: 'Choice',
+                kind: 'single-select',
+                options: [
+                  { value: 'a', label: 'A' },
+                  { value: 'b', label: 'B' }
+                ]
+              },
+              { id: 'question_0_custom', label: 'Other', kind: 'text' }
+            ]
+          }
+        }
+      ]
+    })
+  }
+  const editSnapshot = {
+    requestId: 'request-1',
+    activeQuestionIndex: 0,
+    values: { question_0_custom: 'Unsubmitted text' }
+  }
+
+  it('keeps bounded elicitation edits in memory across save acknowledgements', () => {
+    seedEditableElicitation()
+    const before = useSessionStore.getState().sessions[0]
+    useSessionStore.getState().setElicitationEditDraft('session-1', 'choice-1', 'request-1', {
+      ...editSnapshot,
+      values: { question_0_custom: 'x'.repeat(5000), unknown: 'discard' }
+    })
+    const source = useSessionStore.getState().sessions[0]
+    expect(source.updatedAt).toBe(before.updatedAt)
+    expect(source.activities).toBe(before.activities)
+    expect(source.elicitationEditDrafts?.['choice-1'].values).toEqual({
+      question_0: undefined,
+      question_0_custom: 'x'.repeat(4000)
+    })
+    expect(source.activities?.[0].elicitation).not.toHaveProperty('answers')
+    expect(source.activities?.[0].elicitation).not.toHaveProperty('draftAnswers')
+    const persisted = toPersistedSession(source)
+    expect(persisted).not.toHaveProperty('elicitationEditDrafts')
+    expect(JSON.stringify(persisted)).not.toContain('x'.repeat(4000))
+    useSessionStore.getState().applyDurableSessionProjection({
+      source,
+      session: persisted,
+      mode: 'replace-persisted-if-current'
+    })
+    expect(useSessionStore.getState().sessions[0].elicitationEditDrafts).toEqual(
+      source.elicitationEditDrafts
+    )
+  })
+
+  it('rejects stale elicitation edits and clears snapshots when the request settles', () => {
+    seedEditableElicitation()
+    const owner = useSessionStore.getState()
+    const notify = vi.fn()
+    const unsubscribe = useSessionStore.subscribe(notify)
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'old-request', editSnapshot)
+    owner.setElicitationEditDraft('session-1', 'missing', 'request-1', editSnapshot)
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'request-1', {
+      ...editSnapshot,
+      activeQuestionIndex: 99
+    })
+    expect(notify).not.toHaveBeenCalled()
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'request-1', editSnapshot)
+    expect(notify).toHaveBeenCalledOnce()
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'old-request', undefined)
+    expect(notify).toHaveBeenCalledOnce()
+    const elicitation = useSessionStore.getState().sessions[0].activities![0].elicitation!
+    owner.upsertToolActivity({
+      sessionId: 'session-1',
+      toolCallId: 'choice-1',
+      eventId: 'settled',
+      elicitation: { ...elicitation, state: 'cancelled' }
+    })
+    expect(
+      useSessionStore.getState().sessions[0].elicitationEditDrafts?.['choice-1']
+    ).toBeUndefined()
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'request-1', editSnapshot)
+    expect(
+      useSessionStore.getState().sessions[0].elicitationEditDrafts?.['choice-1']
+    ).toBeUndefined()
+    unsubscribe()
+  })
+
+  it('retains hidden-branch elicitation edits without applying them to another activity', () => {
+    seedEditableElicitation()
+    const owner = useSessionStore.getState()
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'request-1', editSnapshot)
+    owner.truncateSessionFromMessage('session-1', 'user-2')
+    const source = useSessionStore.getState().sessions[0]
+    expect(source.activities?.some((item) => item.id === 'choice-1')).toBe(false)
+    const persisted = toPersistedSession(source)
+    expect(persisted.conversationGraph?.activities.some((item) => item.id === 'choice-1')).toBe(
+      true
+    )
+    owner.applyDurableSessionProjection({
+      source,
+      session: persisted,
+      mode: 'replace-persisted-if-current'
+    })
+    expect(
+      useSessionStore.getState().sessions[0].elicitationEditDrafts?.['choice-1']
+    ).toMatchObject(editSnapshot)
+    const before = useSessionStore.getState()
+    owner.setElicitationEditDraft('session-1', 'choice-1', 'request-1', {
+      ...editSnapshot,
+      values: {}
+    })
+    expect(useSessionStore.getState()).toBe(before)
+    owner.activateMessageBranch('session-1', persisted.conversationGraph!.branches[0].id)
+    expect(
+      useSessionStore.getState().sessions[0].activities?.some((item) => item.id === 'choice-1')
+    ).toBe(true)
+    expect(
+      useSessionStore.getState().sessions[0].elicitationEditDrafts?.['choice-1']
+    ).toMatchObject(editSnapshot)
   })
 
   it('persists completed steps for a pending multi-question elicitation', () => {

--- a/src/renderer/src/stores/session-store.ts
+++ b/src/renderer/src/stores/session-store.ts
@@ -31,6 +31,7 @@ export {
   getExternallyHydratedSessionAuthority,
   isExternallyHydratedSession,
   toPersistedSession,
+  type ElicitationEditDraft,
   type ActiveRun,
   type ChatMessage,
   type ChatMessageRole,

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -101,6 +101,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Not answered": "Nicht beantwortet",
     "Automatic contrast": "Automatischer Kontrast",
     "Display range": "Anzeigebereich",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Ihr Entwurf bleibt erhalten. Laden Sie die aktuellen Details neu und führen Sie sie vor dem Speichern mit Ihrem Entwurf zusammen.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Not answered": "Sin responder",
     "Automatic contrast": "Contraste automático",
     "Display range": "Rango de visualización",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Se conserva su borrador. Vuelva a cargar los detalles actuales y combínelos con su borrador antes de guardar.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Not answered": "Sans réponse",
     "Automatic contrast": "Contraste automatique",
     "Display range": "Plage d’affichage",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Votre brouillon est conservé. Rechargez les détails actuels, puis fusionnez-les avec votre brouillon avant de sauvegarder.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Not answered": "未回答",
     "Automatic contrast": "自動コントラスト",
     "Display range": "表示範囲",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "下書きは保持されています。現在の説明を再読み込みし、下書きに統合してから保存してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Not answered": "미응답",
     "Automatic contrast": "자동 대비",
     "Display range": "표시 범위",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "초안이 보존됩니다. 현재 설명을 다시 불러온 후 초안에 병합하고 저장하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -103,6 +103,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Not answered": "Нет ответа",
     "Automatic contrast": "Автоматическая контрастность",
     "Display range": "Диапазон отображения",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "Черновик сохранён. Загрузите актуальное описание и объедините его с черновиком перед сохранением.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Not answered": "未填写",
     "Automatic contrast": "自动对比度",
     "Display range": "显示范围",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "草稿已保留。请重新加载当前说明，将其合并到草稿后再保存。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Not answered": "未填寫",
     "Automatic contrast": "自動對比度",
     "Display range": "顯示範圍",
     "Your draft is preserved. Reload the current details, then merge them into your draft before saving.": "草稿已保留。請重新載入目前說明，將其合併至草稿後再儲存。",


### PR DESCRIPTION
## Problem

Four elicitation cases prevent users from expressing or retaining their intended answers:
optional fields cannot be cleared, editing a 20-character date-time introduces redundant milliseconds,
optional booleans hide the distinction between omission and false, and current choice-question edits
are lost on Session navigation.

## Proposed change

- Share empty-value normalization between renderer validation and submission; preserve required-field and nonempty-invalid-value rejection.
- Serialize zero milliseconds compactly while respecting minimum length, retain nonzero milliseconds and the same instant, and allow fractional native datetime-local input.
- Show Not answered / Yes / No next to optional switches and provide Clear selection, with all eight translations and an accessible state description.
- Keep bounded choice edits and the current step in the existing renderer Session owner. Restore them across navigation and save acknowledgements; keep confirmed draftAnswers separate and clear edits on response success or request settlement.

## Scope and non-goals

Adds renderer-only `elicitationEditDrafts` (request identity, values, current question) and a public store action. No new protocol enum, database column, migration, disk format, dependency or service. Edits do not survive app restart. Existing persisted confirmed steps retain their original meaning; no historical-data conversion is needed.

The common renderer path serves provider-native and app-owned questions. Claude Code, OpenCode, Codex Responses and Codex Bridge translation/replay/subscription mechanisms are unchanged. No provider execution or packaged Electron cross-platform certification is claimed from local component tests.

## Acceptance criteria and validation

Before fixing production code, real component input/click/remount tests reproduced eight failures and one passing control. The final regression cases were also replayed twice against the original component: the same eight assertion failures and one passing control each time. No production test seam was added.

Local validation (the activity-arrival follow-up reran session_renderer, lint and renderer typecheck after its last material edit; the unchanged contract/i18n checks retain their earlier passing result):

| Behavior / boundary | Check | Result |
| --- | --- | --- |
| Clearing, date-time precision, boolean omission, draft remount, response failure, real panel/store wiring, branch isolation, save acknowledgement, persistence exclusion, public contracts | `npm run test:module -- session_renderer` | 909 passed |
| Main answer validation, shared ACP, translations, test-impact contracts | `npm test -- src/shared/acp.test.ts src/main/acp/elicitation-owner.test.ts src/renderer/src/i18n/resources.test.ts scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts --maxWorkers=2` | 864 passed |
| Renderer types | `npm run typecheck:web` | Passed, including follow-up |
| Linted source | `npm run lint` | Passed |
| Browser behavior | ego-browser, real component and store with application CSS | Cleared optional values omitted; edited time sent as `2026-09-07T12:01:00Z`; current text and step restored after navigation; screenshots inspected locally |

No complete local npm test run, as requested by the maintainer. The session-renderer manifest changes only add consumer test files; its module and manifest checks were run. `test:affected:explain` currently selects full CI for this manifest change, so exact-head PR Gate remains authoritative for complete and platform coverage. Node production code and protocol types are unchanged, so no additional local Node build lane was selected. AI review and PR CI are pending.

## Review follow-up

The initial independent review identified a request-before-activity race. A real ConversationPanel
regression failed twice because an early edit was not captured when the activity arrived. The card
now publishes once when its save callback becomes available, using the existing local input and
question index without depending on callback identity. The new regression and module suite pass.

## Review focus

Check omission vs explicit false, normalization without weakening Main validation, and the separation
between transient editing and confirmed/persisted answers. Review request cleanup and active/hidden
branch handling. Screenshot fixtures and internal plans/logs remain local and are not included in this PR.
