### PR TITLE
fix(composer): align mention selection with displayed order

### DIFF
--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -194,13 +194,12 @@ export const ArtifactMentionPopup = ({
 
   // Fuzzy-match the query against each filename, ranked best-first. Ranking happens within each section
   // so uploads still render before outputs — the flat highlight index depends on that order. Empty
-  // query shows every artifact untouched.
+  // query preserves the incoming order within each section.
   const matches = useMemo<ArtifactRow[]>(() => {
     const needle = query.trim()
-    if (needle.length === 0) return rows
 
     const rankSection = (tag: ArtifactRow['tag']): ArtifactRow[] =>
-      tag === 'library'
+      needle.length === 0 || tag === 'library'
         ? rows.filter((row) => row.tag === tag)
         : rows
             .filter((row) => row.tag === tag)

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -324,6 +324,31 @@ describe('ComposerEditor mention input safety', () => {
     await flushProjectFiles()
   }
 
+  it.each([
+    { key: 'Enter', query: '@', outputFirst: true },
+    { key: 'Tab', query: '@', outputFirst: true },
+    { key: 'Enter', query: '@seq', outputFirst: true },
+    { key: 'Enter', query: '@', outputFirst: false }
+  ])(
+    'inserts the hovered upload with $key for $query (output first: $outputFirst)',
+    async ({ key, query, outputFirst }) => {
+      window.api.projectFiles.listFiles = vi.fn().mockResolvedValue({
+        items: outputFirst ? [pickerProjectFiles[1], pickerProjectFiles[0]] : pickerProjectFiles,
+        totalCount: 2
+      })
+      renderEditor()
+      await typeQuery(query)
+      const upload = Array.from(
+        document.body.querySelectorAll<HTMLElement>('[role="option"]')
+      ).find((option) => option.textContent?.includes('sequence.csv'))!
+      act(() => upload.dispatchEvent(new MouseEvent('mouseover', { bubbles: true })))
+      expect(upload.getAttribute('aria-selected')).toBe('true')
+      dispatchKey(editor(), key)
+      await flushProjectFiles()
+      expect(editor().querySelector('[data-mention-type]')?.textContent).toBe('@sequence.csv')
+    }
+  )
+
   it.each(['/lit', '@seq', '#'])(
     'preserves %s while Enter confirms IME composition',
     async (query) => {


### PR DESCRIPTION
## Problem

Typing `@` and hovering an upload can insert a different generated file when Enter or Tab is pressed. Project Files returns files in time order, while the popup renders uploads before outputs. Empty-query keyboard selection indexed the original mixed order instead of the displayed order.

## Proposed change

Apply the existing section ordering to empty queries as well, preserving incoming order within each section. Add a regression through the real Composer input, hover, keypress, and inserted-mention boundary.

## Scope and non-goals

Two files only. No new field, enum, React state, dependency, public interface, architecture, data model, persistence format, or historical migration. Existing sections, fuzzy ranking, and direct-click selection remain intact. This does not deduplicate same-named uploads or rewrite previously sent references.

## Acceptance criteria and validation

All final checks below ran after the last material edit. Independent Standards and Spec reviews found no actionable issues and confirmed the test impact mapping.

| Behavior / check | Command or interaction | Result |
| --- | --- | --- |
| Regression on unmodified production code | `npx vitest run src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx -t 'inserts the hovered upload'` | Three runs reproduced Enter/Tab failures: expected `@sequence.csv`, received `@report.pdf`; nonempty-query and upload-first controls passed |
| Regression after fix | Same targeted command | 4 passed |
| Composer owner and consumer behavior, mention popup/trigger/document | `npx vitest run src/renderer/src/pages/workspace/composer` | 17 files, 307 tests passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |
| Web renderer build | `npm run build:web` | Passed |
| Real browser interaction | Isolated headless Web UI + ego-browser: hover upload → Enter; output → Tab; ArrowDown → Enter; direct output click | Correct file inserted in all cases; hover and inserted-chip screenshots captured |

Browser verification used deterministic Project Files and version-inspection API fixtures, with the real built Composer and real mouse/keyboard events. The local Web profile does not expose `managedFileVersions.inspect`, so this is renderer interaction evidence, not an end-to-end backend certification. No model requests were sent.

The changed code is shared renderer selection logic. No main/preload/API contract, filesystem/path, ACP, or persistence behavior changed, so local OS/backend/migration lanes are excluded. Full local tests were intentionally not run at the maintainer's request; PR CI remains authoritative for full and platform validation.

## Review focus

Confirm the flat keyboard-selection sequence matches section-render order for empty queries without changing nonempty-query ranking.


## Rebase and CI follow-up

Rebased onto `main` at `0ff09ec3` as `0a3b4128`; no conflicts. `git range-diff` confirms the original fix is unchanged. Composer tests (17 files / 307 tests), renderer typecheck, and lint passed again after rebasing.

The previous PR Gate failure came from Windows E2E shard 2: startup remained in `migrating` for the 60-second readiness assertion during the Spanish settings test, which passed on retry but was rejected by `--fail-on-flaky-tests`. The shard later exceeded its 25-minute job limit; GitHub annotations explicitly confirm the timeout. The Composer suites, portable tests, static checks, coverage, Windows core and macOS E2E passed on that head. No assertions were weakened or workflows changed. The rebased head is undergoing fresh CI validation.
