### PR TITLE
fix(tasks): preserve cancelled outcomes and recover run identities

### DIFF
--- a/src/main/acp/prompt-outcome-finalizer.test.ts
+++ b/src/main/acp/prompt-outcome-finalizer.test.ts
@@ -546,3 +546,19 @@ describe('AcpPromptOutcomeFinalizer', () => {
     expect(harness.handles.prepared?.close).toHaveBeenCalledOnce()
   })
 })
+
+it('publishes a prompt-scoped cancellation when the provider resolves cancelled without a local request', async () => {
+  const harness = createHarness()
+  expect(harness.interactions.captureTerminal(harness.interaction, 'cancelled')).toBe(true)
+  await expect(
+    new AcpPromptOutcomeFinalizer().finalize(harness.handles, stopped({ stopReason: 'cancelled' }))
+  ).resolves.toMatchObject({ stopReason: 'cancelled' })
+  expect(harness.events).toContainEqual(
+    expect.objectContaining({
+      kind: 'stop',
+      sessionId: 's1',
+      promptMessageId: 'prompt-1',
+      text: 'cancelled'
+    })
+  )
+})

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -22775,7 +22775,8 @@ describe('ACP runtime session management', () => {
     const session = await runtime.createSession({ cwd: '/workspace' })
     const promptPromise = runtime.sendPrompt({
       sessionId: session.sessionId,
-      text: 'first prompt'
+      text: 'first prompt',
+      provenanceContext: { promptMessageId: 'cancelled-task-prompt' }
     })
 
     await promptStarted.promise
@@ -22787,11 +22788,14 @@ describe('ACP runtime session management', () => {
       runtime.sendPrompt({ sessionId: session.sessionId, text: 'second prompt' })
     ).rejects.toThrow(/already running/)
 
-    await promptPromise
+    await expect(promptPromise).resolves.toMatchObject({ stopReason: 'cancelled' })
 
     expect(runtime.getSnapshot().promptInFlightSessionIds).toEqual([])
     expect(prompts).toEqual(['first prompt'])
     expect(runtime.getSnapshot().events.find((event) => event.kind === 'stop')).toMatchObject({
+      text: 'cancelled',
+      sessionId: session.sessionId,
+      promptMessageId: 'cancelled-task-prompt',
       turnUsage: { inputTokens: 19, cacheTokens: 5, outputTokens: 3 }
     })
   })

--- a/src/main/tasks/task-run-journal.test.ts
+++ b/src/main/tasks/task-run-journal.test.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { FileTaskRunJournal, type TaskRunJournalEntry } from './task-run-journal'
+
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+const fixture = (): TaskRunJournalEntry => ({
+  id: 'run-1',
+  sessionId: 'session-1',
+  projectId: 'project-1',
+  cwd: tmpdir(),
+  status: 'completed',
+  startedAt: 1,
+  completedAt: 2,
+  artifacts: [],
+  preferredComputeHostIds: []
+})
+const setup = async (): Promise<{ journal: FileTaskRunJournal; path: string }> => {
+  const root = await mkdtemp(join(tmpdir(), 'task-journal-'))
+  roots.push(root)
+  return { journal: new FileTaskRunJournal(root), path: join(root, 'task-runs.json') }
+}
+
+describe('Task Run journal validation', () => {
+  it('roundtrips a valid run', async () => {
+    const { journal } = await setup()
+    await journal.replace([fixture()])
+    await expect(journal.load()).resolves.toEqual([fixture()])
+  })
+
+  it.each([
+    ['null artifact', { artifacts: [null] }],
+    [
+      'invalid artifact size',
+      {
+        artifacts: [
+          {
+            id: 'artifact-1',
+            projectId: 'project-1',
+            sessionId: 'session-1',
+            name: 'result.txt',
+            path: join(tmpdir(), 'result.txt'),
+            fileUrl: 'file:///result.txt',
+            size: -1,
+            mtimeMs: 1
+          }
+        ]
+      }
+    ],
+    ['missing approval plan', { attention: { kind: 'plan-approval' } }],
+    ['invalid review flag', { review: { started: 'yes' } }],
+    ['empty run identity', { id: '' }],
+    ['empty session identity', { sessionId: ' ' }],
+    ['empty project identity', { projectId: '' }],
+    ['commit without prompt identity', { sessionCommitStatus: 'completed' }],
+    ['invalid review outcome', { review: { started: true, outcome: 'unknown' } }]
+  ])('rejects %s without replacing the original journal', async (_name, patch) => {
+    const { journal, path } = await setup()
+    const bytes = JSON.stringify({ version: 1, runs: [{ ...fixture(), ...patch }] })
+    await writeFile(path, bytes)
+    await expect.soft(journal.load()).rejects.toThrow(/journal/i)
+    expect(await readFile(path, 'utf8')).toBe(bytes)
+  })
+
+  it('rejects duplicate run identities across sessions without replacing the journal', async () => {
+    const { journal, path } = await setup()
+    const bytes = JSON.stringify({
+      version: 1,
+      runs: [fixture(), { ...fixture(), sessionId: 'session-2', projectId: 'project-2' }]
+    })
+    await writeFile(path, bytes)
+    await expect.soft(journal.load()).rejects.toThrow(/journal/i)
+    expect(await readFile(path, 'utf8')).toBe(bytes)
+  })
+
+  it('roundtrips nested data and legacy optional fields without stripping compatible extensions', async () => {
+    const { journal } = await setup()
+    const run: TaskRunJournalEntry = {
+      ...fixture(),
+      artifacts: [
+        {
+          id: 'artifact',
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          name: 'result.txt',
+          path: join(tmpdir(), 'result.txt'),
+          fileUrl: 'file:///result.txt',
+          size: 1,
+          mtimeMs: 1
+        }
+      ],
+      review: { started: true, id: 'review', lifecycle: 'complete', outcome: 'pass' },
+      attention: {
+        kind: 'plan-approval',
+        plan: {
+          artifactId: 'plan',
+          artifactVersionId: 'version',
+          artifactChecksum: 'checksum',
+          revision: 0,
+          approval: 'pending',
+          lifecycle: 'awaiting_approval',
+          document: {
+            schema_version: 1,
+            task_summary: 'Task',
+            phases: [],
+            desired_outputs: [],
+            feasibility: { confidence: 'high', rationale: 'Ready' }
+          },
+          stepStatuses: { step: { status: 'completed', updatedAt: 1 } },
+          stepStates: { step: { status: 'completed' } },
+          counts: { phases: 0, delegations: 0, steps: 1, completed: 1, inProgress: 0 }
+        }
+      }
+    }
+    const extended = { ...run, compatibleExtension: 'keep' }
+    await journal.replace([extended])
+    await expect(journal.load()).resolves.toEqual([extended])
+  })
+
+  it.each(['nested corruption', 'future version'])(
+    'blocks recovery of older temporary data when a candidate contains %s',
+    async (kind) => {
+      const { journal, path } = await setup()
+      const older = `${path}.111.tmp`
+      const newer = `${path}.222.tmp`
+      const oldBytes = JSON.stringify({ version: 1, runs: [fixture()] })
+      const badBytes = JSON.stringify({
+        version: kind === 'future version' ? 2 : 1,
+        runs: [{ ...fixture(), artifacts: [null] }]
+      })
+      await writeFile(older, oldBytes)
+      await writeFile(newer, badBytes)
+      await expect(journal.load()).rejects.toThrow(/journal/i)
+      expect(await readFile(older, 'utf8')).toBe(oldBytes)
+      expect(await readFile(newer, 'utf8')).toBe(badBytes)
+      await expect(readFile(path)).rejects.toMatchObject({ code: 'ENOENT' })
+    }
+  )
+
+  it('rejects a future version and preserves its bytes', async () => {
+    const { journal, path } = await setup()
+    const bytes = JSON.stringify({ version: 2, runs: [fixture()] })
+    await writeFile(path, bytes)
+    await expect(journal.load()).rejects.toThrow(/Unsupported Task Run journal version/)
+    expect(await readFile(path, 'utf8')).toBe(bytes)
+  })
+})

--- a/src/main/tasks/task-run-journal.ts
+++ b/src/main/tasks/task-run-journal.ts
@@ -1,6 +1,18 @@
 import { join } from 'node:path'
+import { z } from 'zod'
 
-import type { TaskRun, TaskRunFailureCode, TaskRunStatus } from '../../shared/task-api'
+import type { ArtifactFile } from '../../shared/artifacts'
+import {
+  generatePlanContentSchema,
+  type ActivePlanProjection
+} from '../../shared/session-plan/contract'
+
+import type {
+  TaskRun,
+  TaskRunFailureCode,
+  TaskRunStatus,
+  TaskRunReview
+} from '../../shared/task-api'
 import {
   DurableJsonRecoveryBarrierError,
   readDurableJsonFile,
@@ -34,15 +46,108 @@ const isOptionalFiniteNumber = (value: unknown): value is number | undefined =>
 const isStringArray = (value: unknown): value is string[] =>
   Array.isArray(value) && value.every((entry) => typeof entry === 'string')
 
+const identity = z
+  .string()
+  .refine((value) => value.trim().length > 0, 'Expected a nonempty identity')
+const count = z.number().int().nonnegative()
+const artifactSchema = z.object({
+  id: identity,
+  projectId: identity,
+  sessionId: identity,
+  messageId: identity.optional(),
+  runId: identity.optional(),
+  name: z.string(),
+  path: z.string(),
+  fileUrl: z.string(),
+  mimeType: z.string().optional(),
+  size: count,
+  mtimeMs: z.number(),
+  artifactId: identity.optional(),
+  versionId: identity.optional(),
+  versionNumber: count.optional(),
+  isPublished: z.boolean().optional(),
+  checksum: z.string().optional(),
+  createdAt: z.string().optional(),
+  producerRunId: identity.optional(),
+  environment: z.string().optional()
+}) satisfies z.ZodType<ArtifactFile>
+
+const stepStatus = z.enum(['in_progress', 'completed', 'blocked', 'skipped'])
+const planSchema = z.object({
+  artifactId: identity,
+  artifactVersionId: identity,
+  artifactChecksum: identity,
+  originatingPromptMessageId: identity.optional(),
+  materializedAt: z.number().optional(),
+  revision: count,
+  approval: z.enum(['pending', 'approved', 'rejected']),
+  lifecycle: z.enum([
+    'awaiting_approval',
+    'approved',
+    'in_progress',
+    'blocked',
+    'completed',
+    'rejected'
+  ]),
+  document: generatePlanContentSchema.extend({ schema_version: z.literal(1) }),
+  stepStatuses: z.record(
+    z.string(),
+    z.object({
+      status: stepStatus,
+      updatedAt: z.number(),
+      notes: z.string().optional()
+    })
+  ),
+  stepStates: z.record(
+    z.string(),
+    z.object({
+      status: z.enum([...stepStatus.options, 'not_started', 'not_run']),
+      notes: z.string().optional()
+    })
+  ),
+  counts: z.object({
+    phases: count,
+    delegations: count,
+    steps: count,
+    completed: count,
+    inProgress: count
+  })
+}) satisfies z.ZodType<ActivePlanProjection>
+
+const reviewSchema = z.object({
+  started: z.boolean(),
+  reason: z
+    .enum([
+      'already-in-flight',
+      'not-found',
+      'load-failed',
+      'run-failed',
+      'already-reviewed',
+      'idempotency-check-failed'
+    ])
+    .optional(),
+  id: identity.optional(),
+  lifecycle: z.enum(['running', 'complete', 'error']).optional(),
+  outcome: z.enum(['pass', 'flagged']).nullable().optional(),
+  errorMessage: z.string().optional()
+}) satisfies z.ZodType<TaskRunReview>
+
+const nestedRunSchema = z.object({
+  artifacts: z.array(artifactSchema),
+  attention: z.object({ kind: z.literal('plan-approval'), plan: planSchema }).optional(),
+  review: reviewSchema.optional()
+})
+
 const TASK_RUN_STATUSES = new Set<TaskRunStatus>(['running', 'completed', 'failed', 'cancelled'])
 const TASK_RUN_FAILURE_CODES = new Set<TaskRunFailureCode>(['process_restarted'])
 
 const decodeRun = (value: unknown): TaskRunJournalEntry => {
-  if (!isRecord(value)) throw new Error('Task Run journal contains a non-object Run.')
+  if (!isRecord(value))
+    throw new DurableJsonRecoveryBarrierError('Task Run journal contains a non-object Run.')
   if (
-    typeof value.id !== 'string' ||
-    typeof value.sessionId !== 'string' ||
-    typeof value.projectId !== 'string' ||
+    !identity.safeParse(value.id).success ||
+    !identity.safeParse(value.sessionId).success ||
+    !identity.safeParse(value.projectId).success ||
     typeof value.cwd !== 'string' ||
     typeof value.status !== 'string' ||
     !TASK_RUN_STATUSES.has(value.status as TaskRunStatus) ||
@@ -61,17 +166,27 @@ const decodeRun = (value: unknown): TaskRunJournalEntry => {
       value.sessionCommitStatus !== 'completed' &&
       value.sessionCommitStatus !== 'cancelled' &&
       value.sessionCommitStatus !== 'failed') ||
-    !Array.isArray(value.artifacts) ||
+    (value.sessionCommitStatus !== undefined &&
+      (!identity.safeParse(value.promptMessageId).success || value.completedAt === undefined)) ||
     !isStringArray(value.preferredComputeHostIds)
   ) {
-    throw new Error('Task Run journal contains an invalid Run.')
+    throw new DurableJsonRecoveryBarrierError('Task Run journal contains an invalid Run.')
   }
+  const nested = nestedRunSchema.safeParse(value)
+  if (!nested.success) {
+    const issue = nested.error.issues[0]
+    throw new DurableJsonRecoveryBarrierError(
+      `Task Run journal contains an invalid Run at ${issue.path.join('.')}: ${issue.message}`
+    )
+  }
+  // Validation must not strip unknown fields from a compatible document during recovery.
   return value as TaskRunJournalEntry
 }
 
 const decodeDocument = (contents: string): TaskRunJournalEntry[] => {
   const value = JSON.parse(contents) as unknown
-  if (!isRecord(value)) throw new Error('Task Run journal must contain an object.')
+  if (!isRecord(value))
+    throw new DurableJsonRecoveryBarrierError('Task Run journal must contain an object.')
   if (
     typeof value.version === 'number' &&
     Number.isInteger(value.version) &&
@@ -80,9 +195,19 @@ const decodeDocument = (contents: string): TaskRunJournalEntry[] => {
     throw new DurableJsonRecoveryBarrierError('Unsupported Task Run journal version.')
   }
   if (value.version !== TASK_RUN_JOURNAL_VERSION || !Array.isArray(value.runs)) {
-    throw new Error('Task Run journal has an invalid format.')
+    throw new DurableJsonRecoveryBarrierError('Task Run journal has an invalid format.')
   }
-  return value.runs.map(decodeRun)
+  const runs = value.runs.map(decodeRun)
+  const ids = new Set<string>()
+  for (const run of runs) {
+    if (ids.has(run.id)) {
+      throw new DurableJsonRecoveryBarrierError(
+        `Task Run journal contains duplicate Run id: ${run.id}`
+      )
+    }
+    ids.add(run.id)
+  }
+  return runs
 }
 
 export class FileTaskRunJournal implements TaskRunJournal {

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, realpath, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, sep } from 'node:path'
 import { queryObjects } from 'node:v8'
@@ -19,7 +19,7 @@ import {
 import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
-import type { TaskRunJournalEntry } from './task-run-journal'
+import { FileTaskRunJournal, type TaskRunJournalEntry } from './task-run-journal'
 import {
   TASK_RUN_DISPOSAL_BUDGET_MS,
   TaskRunner,
@@ -5150,5 +5150,421 @@ describe('TaskRunner', () => {
 
     finishPrompt?.()
     await runner.waitForRun(accepted.id)
+  })
+})
+
+describe('runtime terminal outcomes and recovery retention', () => {
+  it.each(['cancelled', 'end_turn'] as const)(
+    'honors a prompt-scoped %s stop when the prompt resolves normally',
+    async (stopReason) => {
+      let emit: ((event: AcpRuntimeEvent) => void) | undefined
+      const review = vi.fn(async () => ({ started: true }))
+      const root = await mkdtemp(join(tmpdir(), 'task-outcome-'))
+      temporaryRoots.push(root)
+      const runJournal = new FileTaskRunJournal(root)
+      const runner = createRunner({
+        runJournal,
+        reviewer: { review },
+        runtimeEvents: {
+          subscribe: (listener) => {
+            emit = listener
+            return () => undefined
+          }
+        },
+        agent: {
+          prompt: async (request) => {
+            const scope = { sessionId: request.sessionId, promptMessageId: request.promptMessageId }
+            emit?.({
+              id: 'partial',
+              timestamp: 2,
+              kind: 'message',
+              level: 'info',
+              role: 'assistant',
+              text: 'Partial output.',
+              ...scope
+            })
+            emit?.({
+              id: 'terminal',
+              timestamp: 3,
+              kind: 'stop',
+              level: 'info',
+              text: stopReason,
+              ...scope
+            })
+          }
+        }
+      })
+      try {
+        const started = await runner.startRun({
+          project: project.id,
+          prompt: 'Write a report.',
+          autoReviewEnabled: true
+        })
+        const result = await runner.waitForRun(started.id)
+        expect.soft(result.status).toBe(stopReason === 'cancelled' ? 'cancelled' : 'completed')
+        expect.soft(result.output).toBe('Partial output.')
+        expect
+          .soft(result.cancelledAt)
+          .toEqual(stopReason === 'cancelled' ? expect.any(Number) : undefined)
+        expect(result.cancelRequestedAt).toBeUndefined()
+        expect(await runJournal.load()).toContainEqual(
+          expect.objectContaining({
+            id: result.id,
+            status: result.status,
+            output: 'Partial output.'
+          })
+        )
+        expect((await runJournal.load()).find((run) => run.id === result.id)?.cancelledAt).toBe(
+          result.cancelledAt
+        )
+        expect.soft(review).toHaveBeenCalledTimes(stopReason === 'cancelled' ? 0 : 1)
+      } finally {
+        await runner.dispose()
+      }
+    }
+  )
+
+  it.each(['another-session', 'another-prompt', 'unscoped'] as const)(
+    'ignores cancellation from %s',
+    async (source) => {
+      let emit: ((event: AcpRuntimeEvent) => void) | undefined
+      const runner = createRunner({
+        runtimeEvents: {
+          subscribe: (listener) => {
+            emit = listener
+            return () => undefined
+          }
+        },
+        agent: {
+          prompt: async (request) => {
+            emit?.({
+              id: 'unrelated-stop',
+              kind: 'stop',
+              level: 'info',
+              timestamp: 2,
+              text: 'cancelled',
+              sessionId: source === 'another-session' ? 'other-session' : request.sessionId,
+              promptMessageId:
+                source === 'unscoped'
+                  ? undefined
+                  : source === 'another-prompt'
+                    ? 'other-prompt'
+                    : request.promptMessageId
+            })
+          }
+        }
+      })
+      try {
+        const started = await runner.startRun({ project: project.id, prompt: 'Complete normally.' })
+        expect(await runner.waitForRun(started.id)).toMatchObject({
+          status: 'completed',
+          cancelledAt: undefined
+        })
+      } finally {
+        await runner.dispose()
+      }
+    }
+  )
+
+  it.each(['prompt', 'artifact', 'session', 'journal'] as const)(
+    'preserves a real %s failure after a runtime cancellation',
+    async (owner) => {
+      let emit: ((event: AcpRuntimeEvent) => void) | undefined
+      const review = vi.fn(async () => ({ started: true }))
+      const failure = new Error(`${owner} failed`)
+      const runner = createRunner({
+        reviewer: { review },
+        runtimeEvents: {
+          subscribe: (listener) => {
+            emit = listener
+            return () => undefined
+          }
+        },
+        agent: {
+          prompt: async (request) => {
+            const scope = { sessionId: request.sessionId, promptMessageId: request.promptMessageId }
+            emit?.({
+              id: 'partial',
+              kind: 'message',
+              role: 'assistant',
+              level: 'info',
+              timestamp: 2,
+              text: 'Partial output.',
+              ...scope
+            })
+            emit?.({
+              id: 'claim',
+              kind: 'artifact',
+              artifactClaimId: 'claim-1',
+              runId: 'artifact-run',
+              artifacts: [],
+              level: 'info',
+              timestamp: 2,
+              ...scope
+            })
+            emit?.({
+              id: 'stop',
+              kind: 'stop',
+              level: 'info',
+              timestamp: 3,
+              text: 'cancelled',
+              ...scope
+            })
+            if (owner === 'prompt') throw failure
+          }
+        },
+        ...(owner === 'artifact'
+          ? {
+              artifacts: {
+                finalizeRun: async () => {
+                  throw failure
+                }
+              }
+            }
+          : {}),
+        ...(owner === 'session'
+          ? {
+              sessions: {
+                settleCompletion: async () => {
+                  throw failure
+                }
+              }
+            }
+          : {}),
+        ...(owner === 'journal'
+          ? {
+              runJournal: {
+                load: async () => [],
+                replace: async (runs: readonly TaskRunJournalEntry[]) => {
+                  if (runs.some((run) => run.sessionCommitStatus === 'cancelled')) throw failure
+                }
+              }
+            }
+          : {})
+      })
+      try {
+        const started = await runner.startRun({
+          project: project.id,
+          prompt: 'Write output.',
+          autoReviewEnabled: true
+        })
+        expect(await runner.waitForRun(started.id)).toMatchObject({
+          status: 'failed',
+          cancelledAt: undefined,
+          error:
+            owner === 'journal'
+              ? 'Task Run terminal state could not be persisted.'
+              : failure.message
+        })
+        expect(review).not.toHaveBeenCalled()
+      } finally {
+        await runner.dispose()
+      }
+    }
+  )
+
+  it('retains interrupted runs, committed witnesses and pending repairs ahead of completed history', async () => {
+    const base: TaskRunJournalEntry = {
+      id: 'active',
+      sessionId: 'active-session',
+      projectId: project.id,
+      cwd: session.cwd,
+      status: 'running',
+      startedAt: 1,
+      artifacts: [],
+      preferredComputeHostIds: [],
+      promptMessageId: 'prompt'
+    }
+    const pendingRepair = {
+      ...base,
+      id: 'repair',
+      sessionId: 'repair-session',
+      status: 'failed' as const,
+      error: 'original failure'
+    }
+    const witness = {
+      ...base,
+      id: 'witness',
+      sessionId: 'witness-session',
+      sessionCommitStatus: 'completed' as const,
+      completedAt: 2
+    }
+    let persisted: TaskRunJournalEntry[] = []
+    const save = vi.fn(async (value: PersistedChatSession) => value)
+    const runner = createRunner({
+      sessions: {
+        list: async () => [
+          { ...session, id: 'witness-session', taskRunCommitId: 'witness' },
+          {
+            ...session,
+            id: 'repair-session',
+            status: 'running',
+            activeRun: { promptMessageId: 'prompt', startedAt: 1 }
+          }
+        ],
+        save
+      },
+      runJournal: {
+        load: async () => [
+          base,
+          pendingRepair,
+          witness,
+          ...Array.from({ length: 210 }, (_, index) => ({
+            ...base,
+            id: `history-${index}`,
+            status: 'completed' as const,
+            completedAt: 2
+          }))
+        ],
+        replace: async (runs) => {
+          persisted = structuredClone([...runs])
+        }
+      }
+    })
+    try {
+      await runner.initialize()
+      expect(runner.getRun('active')).toMatchObject({
+        status: 'failed',
+        failureCode: 'process_restarted'
+      })
+      expect(runner.getRun('witness')).toMatchObject({ status: 'completed' })
+      expect(runner.getRun('repair')).toMatchObject({ status: 'failed', error: 'original failure' })
+      expect(save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'repair-session',
+          status: 'error',
+          taskRunCommitId: 'repair'
+        })
+      )
+      expect(persisted).toHaveLength(200)
+      expect(() => runner.getRun('history-0')).toThrow('Run not found')
+      expect(runner.getRun('history-209').status).toBe('completed')
+    } finally {
+      await runner.dispose()
+    }
+  })
+
+  it('preserves legacy entries without prompt identities when recovery rewrites the journal', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'task-legacy-journal-'))
+    temporaryRoots.push(root)
+    const journal = new FileTaskRunJournal(root)
+    const base: TaskRunJournalEntry = {
+      id: 'legacy',
+      sessionId: session.id,
+      projectId: project.id,
+      cwd: session.cwd,
+      status: 'completed',
+      startedAt: 1,
+      artifacts: [],
+      preferredComputeHostIds: []
+    }
+    await journal.replace([base, { ...base, id: 'interrupted', status: 'running' }])
+    const runner = createRunner({ runJournal: journal })
+    try {
+      await runner.initialize()
+      const runs = await journal.load()
+      expect(runs.find((run) => run.id === 'legacy')?.promptMessageId).toBeUndefined()
+      expect(runs.find((run) => run.id === 'interrupted')).toMatchObject({
+        status: 'failed',
+        failureCode: 'process_restarted'
+      })
+    } finally {
+      await runner.dispose()
+    }
+  })
+
+  it('rejects corrupt journal initialization before rewriting any bytes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'task-corrupt-journal-'))
+    temporaryRoots.push(root)
+    const journal = new FileTaskRunJournal(root)
+    const bytes = JSON.stringify({
+      version: 1,
+      runs: [
+        {
+          id: 'corrupt',
+          sessionId: session.id,
+          projectId: project.id,
+          cwd: session.cwd,
+          status: 'running',
+          startedAt: 1,
+          artifacts: [null],
+          preferredComputeHostIds: []
+        }
+      ]
+    })
+    const path = join(root, 'task-runs.json')
+    await writeFile(path, bytes)
+    const runner = createRunner({ runJournal: journal })
+    try {
+      await expect(runner.initialize()).rejects.toThrow(/journal/i)
+      expect(await readFile(path, 'utf8')).toBe(bytes)
+    } finally {
+      await runner.dispose()
+    }
+  })
+
+  it('recovers every accepted identity when active runs exceed the history retention target', async () => {
+    let durableRuns: TaskRunJournalEntry[] = []
+    const durableSessions = new Map<string, PersistedChatSession>()
+    let nextId = 0
+    let nextSession = 0
+    let release: (() => void) | undefined
+    const pending = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const runner = createRunner({
+      createId: () => `identity-${++nextId}`,
+      sessions: {
+        list: async () => structuredClone([...durableSessions.values()]),
+        save: async (value) => {
+          durableSessions.set(value.id, structuredClone(value))
+        }
+      },
+      runJournal: {
+        load: async () => [],
+        replace: async (runs) => {
+          durableRuns = structuredClone([...runs])
+        }
+      },
+      agent: {
+        createSession: async () => ({ sessionId: `active-session-${++nextSession}` }),
+        prompt: async () => pending
+      }
+    })
+    let recovered: TaskRunner | undefined
+    const accepted: TaskRun[] = []
+    try {
+      for (let index = 0; index < 201; index++) {
+        accepted.push(await runner.startRun({ project: project.id, prompt: 'Remain active.' }))
+      }
+      expect(runner.getRun(accepted[0].id).status).toBe('running')
+      expect(durableRuns).toHaveLength(201)
+      const frozenRuns = structuredClone(durableRuns)
+      const frozenSessions = structuredClone([...durableSessions.values()])
+      let recoveredJournal: TaskRunJournalEntry[] = []
+      recovered = createRunner({
+        sessions: { list: async () => structuredClone(frozenSessions) },
+        runJournal: {
+          load: async () => structuredClone(frozenRuns),
+          replace: async (runs) => {
+            recoveredJournal = structuredClone([...runs])
+          }
+        }
+      })
+      await recovered.initialize()
+      expect.soft(recoveredJournal).toHaveLength(201)
+      for (const run of accepted) {
+        expect.soft(() => recovered!.getRun(run.id)).not.toThrow()
+        const restored = recoveredJournal.find((entry) => entry.id === run.id)
+        expect
+          .soft(restored)
+          .toMatchObject({ id: run.id, status: 'failed', failureCode: 'process_restarted' })
+      }
+    } finally {
+      release?.()
+      await Promise.all(accepted.map((run) => runner.waitForRun(run.id)))
+      await runner.dispose()
+      await recovered?.dispose()
+    }
   })
 })

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -248,6 +248,7 @@ type TaskRunEventAccumulator = {
   assistantEventIds: string[]
   images: PersistedMessageImage[]
   imageBytes: number
+  runtimeCancelled?: boolean
   terminalStop?: Pick<AcpRuntimeEvent, 'turnUsage' | 'modelCallUsage'>
   runtimeError?: Pick<AcpRuntimeEvent, 'text' | 'providerError'>
   activities: Map<string, PendingTaskRunActivity>
@@ -424,7 +425,7 @@ const cloneRunForJournal = (run: MutableTaskRun): TaskRunJournalEntry => {
   return {
     ...cloneRun(run),
     status: run.terminalStatus ?? run.status,
-    promptMessageId: run.promptMessageId,
+    ...(run.promptMessageId ? { promptMessageId: run.promptMessageId } : {}),
     ...(sessionCommit
       ? {
           sessionCommitStatus: sessionCommit.status,
@@ -2084,6 +2085,7 @@ class TaskRunner {
     promptError: unknown,
     cancellationAtPromptFailure: MutableTaskRun['cancellation']
   ): Promise<void> {
+    const runtimeCancelled = run.eventAccumulator?.runtimeCancelled === true
     const acceptedSession =
       promptError === undefined ? consumePendingHistoryReplay(admittedSession) : admittedSession
 
@@ -2119,7 +2121,7 @@ class TaskRunner {
       await sessionCommitCancellation.dispatch.catch(() => undefined)
     }
     const sessionCommitStatus =
-      sessionCommitCancellation?.accepted === true ? 'cancelled' : 'completed'
+      runtimeCancelled || sessionCommitCancellation?.accepted === true ? 'cancelled' : 'completed'
     completed!.session = { ...completed!.session, taskRunCommitId: run.id }
     const sessionCommitAt = this.dependencies.now()
     const sessionCommit: NonNullable<MutableTaskRun['sessionCommit']> = {
@@ -2166,7 +2168,12 @@ class TaskRunner {
       return
     }
     run.eventAccumulator = undefined
-    if (!this.disposed && !run.cancellation && completed!.session.autoReviewEnabled === true) {
+    if (
+      !this.disposed &&
+      !runtimeCancelled &&
+      !run.cancellation &&
+      completed!.session.autoReviewEnabled === true
+    ) {
       const reviewedMessage = [...completed!.session.messages]
         .reverse()
         .find(
@@ -2199,7 +2206,7 @@ class TaskRunner {
     }
     const terminalCancellation = run.cancellation
     if (terminalCancellation) await terminalCancellation.dispatch.catch(() => undefined)
-    const terminalCancellationAccepted = terminalCancellation?.accepted === true
+    const terminalCancellationAccepted = runtimeCancelled || terminalCancellation?.accepted === true
     if (terminalCancellationAccepted) run.attention = undefined
     const terminalStatus = terminalCancellationAccepted ? 'cancelled' : 'completed'
     run.output = completed!.output
@@ -2376,7 +2383,18 @@ class TaskRunner {
       if (event.promptMessageId !== undefined && event.promptMessageId !== run.promptMessageId) {
         continue
       }
-      if (run.eventAccumulator) accumulateTaskRunEvent(run.eventAccumulator, event)
+      if (run.eventAccumulator) {
+        // Only the current prompt's terminal fact can cancel this Run. Unscoped compatibility
+        // events may still contribute output/usage, but cannot decide its terminal status.
+        if (
+          event.kind === 'stop' &&
+          event.text === 'cancelled' &&
+          event.promptMessageId === run.promptMessageId
+        ) {
+          run.eventAccumulator.runtimeCancelled = true
+        }
+        accumulateTaskRunEvent(run.eventAccumulator, event)
+      }
       if (event.kind === 'plan' && event.planProjection) {
         run.attention =
           event.planProjection.lifecycle === 'awaiting_approval'
@@ -2459,12 +2477,30 @@ class TaskRunner {
     this.runs.clear()
     this.activeRunBySession.clear()
     const loadedRuns = await journal.load()
-    const storedRuns = loadedRuns.slice(-MAX_RETAINED_RUNS)
-    const sessions = storedRuns.some(
+    const sessions = loadedRuns.some(
       (run) => (run.status === 'running' || run.status === 'failed') && run.promptMessageId
     )
       ? await this.dependencies.sessions.list()
       : []
+    // Retention is a history target, not an admission limit. Reconcile every unsettled identity
+    // and keep its result queryable this startup, even when recovery alone exceeds the target.
+    const needsRecovery = new Set(
+      loadedRuns.filter(
+        (run) =>
+          run.status === 'running' ||
+          (run.status === 'failed' &&
+            sessions.some(
+              (session) =>
+                session.taskRunCommitId !== run.id && sessionOwnsTaskRunPrompt(session, run)
+            ))
+      )
+    )
+    const historyBudget = Math.max(0, MAX_RETAINED_RUNS - needsRecovery.size)
+    const history = loadedRuns.filter((run) => !needsRecovery.has(run))
+    const retainedHistory = new Set(historyBudget > 0 ? history.slice(-historyBudget) : [])
+    const storedRuns = loadedRuns.filter(
+      (run) => needsRecovery.has(run) || retainedHistory.has(run)
+    )
     const interrupted: MutableTaskRun[] = []
     const terminalSessionRepairs: MutableTaskRun[] = []
     let normalized = false


### PR DESCRIPTION
## Problem

A normally resolved ACP cancellation could become a completed Task and trigger automatic review. Restart recovery also truncated accepted active runs before reconciling them, and the journal reader accepted malformed nested data and duplicate run identities.

## Proposed change

- Use the current session/prompt's cancelled stop fact for Task commit, review admission and terminal status. Preserve partial output and existing failure precedence.
- Retain all unsettled runs and pending Session repairs during startup, allocating remaining retention space to ordinary history.
- Validate nested artifacts, plan attention, review metadata, nonempty run/session/project identities, duplicate IDs and commit prerequisites. Reject structurally invalid recovery candidates without rewriting them or falling back to older data.

## Scope and compatibility

Production changes stay in TaskRunner and FileTaskRunJournal. No public fields, status enums, journal version, database migration, new dependency or UI change.

Valid version-1 data remains readable. Legacy missing/empty optional prompt IDs remain supported when there is no commit marker; rewrites omit empty optional IDs. Commit markers require a nonempty prompt ID and completion time. Structurally corrupt historical data now blocks initialization explicitly and preserves the original files. Previously lost identities or misclassified completions cannot safely be reconstructed.

Persistence changes are limited to correct cancellation status/timestamps, recovery retention, and validation. Existing durable publication and future-version barriers remain in place.

## Acceptance criteria and validation

Regression tests ran against unchanged production code twice: **103 passed / 17 failed**, with identical failing names and assertion reasons. After repair: **120/120 Task runner/journal tests pass**. No production test seam was added.

The final local impact set ran after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Task outcomes, partial output, reviewer suppression, foreign/unscoped stops, API cancellation and genuine failure races, 201 accepted runs, mixed history/repair/witness recovery | `vitest run src/main/tasks/task-runner.test.ts src/main/tasks/task-run-journal.test.ts` | 120 passed |
| Resolved provider cancellation, prompt identity, adapter/workflow contracts | `vitest run src/main/acp/prompt-outcome-finalizer.test.ts src/main/acp/task-agent-port.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/acp/prompt-turn-workflow.test.ts src/main/acp/claude-turn-adapter.test.ts src/main/acp/opencode-turn-adapter.test.ts src/main/acp/codex-turn-adapter.test.ts` | passed |
| Real ACP protocol cancellation; Claude Code, OpenCode, Codex Responses and Codex Bridge lifecycle/replay/subscriptions | `vitest run src/main/acp/runtime.test.ts` | 594 passed |
| Durable recovery, Task HTTP/event consumers, CLI/SDK | `vitest run src/main/storage/durable-json-file.test.ts src/main/web-service/task-api.test.ts src/main/web-service/controller.test.ts src/main/web-service/public-task-event-stream.test.ts packages/open-science/cli.test.ts packages/open-science/client.test.ts` | passed |
| Main-process and sandbox types | `npm run typecheck:node` | passed |
| Lint and whitespace | `npm run lint`; `git diff --check` | passed |

The combined owner/adapter/consumer invocation passed 397 tests; with ACP runtime, **991 unique tests passed**. Three initial runtime failures were sandbox loopback-listen restrictions; the scoped unsandboxed rerun passed all 594 tests.

`test:affected --base origin/main --head HEAD --explain` requests full CI because the finalizer test has no declared module owner. Per maintainer direction, the full suite is deferred to PR CI rather than run locally; routing/configuration was not changed to bypass the fallback.

## Review focus

Check cancellation attribution and error precedence; recovery ordering before history retention; malformed-document barriers versus legitimate optional legacy fields. The existing application-event subscription and Task/CLI result contract remain stable. Tests use fake provider processes and actual temporary files, not live external models. Native cross-platform certification remains CI's responsibility; no renderer change requires screenshots. Independent PR review and CI remain pending.
