### PR TITLE
fix(session): preserve saved model preferences and provider defaults

### DIFF
--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -14,6 +14,60 @@ const CONTEXT_COMPACTION_PROMPT = 'Preview context compaction.'
 const CITATION_PREVIEW_PROMPT = 'Preview a cited source.'
 const AXE_PATH = resolve(process.cwd(), 'node_modules/axe-core/axe.min.js')
 
+test('preserves an unavailable saved model until an explicit replacement is selected', async ({
+  app
+}, testInfo) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await createProject(page)
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill(USER_MESSAGE)
+  await page.getByRole('button', { name: 'Send message' }).click()
+  await expect(page.getByText(AGENT_REPLY, { exact: false })).toBeVisible()
+  const saved = await page.evaluate(async () => {
+    const loaded = await window.api.sessions.loadAll()
+    return loaded.sessions[0].agentConfiguration!
+  })
+  expect(saved?.providerId).toBeTruthy()
+  const fallback = await page.evaluate(async () => {
+    const snapshot = await window.api.settings.upsertProvider({
+      type: 'custom',
+      name: 'Replacement provider',
+      apiEndpoints: ['openai'],
+      baseUrl: 'http://127.0.0.1:9/v1',
+      model: 'replacement-model',
+      key: 'e2e-key',
+      reasoningEffortPreset: 'standard-5'
+    })
+    return snapshot.providers.find((provider) => provider.name === 'Replacement provider')!.id
+  })
+  await page.evaluate(async (id) => window.api.settings.deleteProvider({ id }), saved.providerId)
+  const unavailable = page.getByRole('button', { name: 'Session model unavailable', exact: true })
+  await expect(unavailable).toBeVisible()
+  await page.getByRole('textbox', { name: 'Ask anything' }).fill('Do not send this draft.')
+  await expect(page.getByRole('button', { name: 'Send message' })).toBeDisabled()
+  await unavailable.click()
+  await page.getByRole('menuitem', { name: /Model Provider and model for this chat/ }).hover()
+  await expect(page.getByRole('menuitemradio', { name: /replacement-model/ })).toBeVisible()
+  await page.screenshot({ path: testInfo.outputPath('unavailable-session-model.png') })
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        async () => (await window.api.sessions.loadAll()).sessions[0].agentConfiguration
+      )
+    )
+    .toEqual(saved)
+  await page.getByRole('menuitemradio', { name: /replacement-model/ }).focus()
+  await page.keyboard.press('Enter')
+  await expect(unavailable).toHaveCount(0)
+  await expect
+    .poll(async () =>
+      page.evaluate(
+        async () => (await window.api.sessions.loadAll()).sessions[0].agentConfiguration
+      )
+    )
+    .toMatchObject({ providerId: fallback, model: 'replacement-model' })
+})
+
 test('keeps source icons inside table cells after expanding a message table', async ({ app }) => {
   await app.completeOnboarding()
   const page = await app.configureFakeAgent()

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -134,3 +134,13 @@ console.log(cancelled.status) // cancelled
 
 The client discovers the local daemon and reads its authentication token from the Open Science config
 directory. Tokens are sent in request headers and are never included in normal command output.
+
+### Automation new-session defaults
+
+`project session-defaults show|update` manages defaults for new Sessions created through the
+Task CLI/API. Explicit run options override these defaults. Existing Sessions and desktop New
+conversation drafts are not changed.
+
+`--provider-default-model` keeps following the provider-owned default instead of pinning the
+first model in its catalog. An explicit `--model` stays fixed. If a saved selection becomes
+unavailable, choose a replacement explicitly or wait for it to become available again.

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -42,7 +42,7 @@ Commands:
   project list
   project create <name> [--description <text>] [--agent-context <text> | --agent-context-file <path>]
   project update <id-or-name> [--name <name>] [--description <text>] [--agent-context <text> | --agent-context-file <path> | --clear-agent-context]
-  project session-defaults show <id-or-name>
+  project session-defaults show <id-or-name>  Automation new-session defaults
   project session-defaults update <id-or-name> [session options]
   run --project <id-or-name> (--prompt <text> | --prompt-file <path>) [--compute-host <provider-id>] [--wait]
   run status <run-id>
@@ -76,7 +76,7 @@ Options:
   --approval-profile <profile>  ask, auto, or full (default: ask)
   --provider <provider-id>  Configured Main provider
   --model <model-id>       Main model
-  --provider-default-model Use the provider-owned default model
+  --provider-default-model Follow the provider-owned default model
   --reasoning-effort <effort>  default, low, medium, high, xhigh, or max
   --skill <id>           Force-load a skill for this run (repeatable)
   --compute-host <provider-id>  Select a Compute Host execution target (repeatable)
@@ -93,7 +93,7 @@ Options:
   --reviewer-inherit | --reviewer-provider <id> --reviewer-model <id> [--reviewer-effort <effort>]
   --subagent-inherit | --subagent-provider <id> --subagent-model <id> [--subagent-effort <effort>]
   --clear-provider | --clear-approval-profile | --clear-auto-review | --clear-memory
-  --clear-delegation | --clear-specialist  Clear one Project Session default
+  --clear-delegation | --clear-specialist  Clear one automation new-session default
   --wait                 Wait for the run to finish
   --return-on-attention  With --wait, return when the Plan needs approval
   --timeout-ms <ms>      Stop waiting after this many milliseconds

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -588,32 +588,42 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
-  it('reconnects only targeted runtimes using the edited provider', async () => {
-    const created: ReturnType<typeof createFakeRuntime>[] = []
-    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
-      const fake = createFakeRuntime({
-        frameworkId: 'claude-code',
-        sessionIds: [`session-${created.length}`],
-        callbacks
+  it.each([
+    ['claude-code', 'model'],
+    ['claude-code', undefined],
+    ['opencode', 'model'],
+    ['opencode', undefined],
+    ['codex', 'model'],
+    ['codex', undefined]
+  ] as const)(
+    'reconnects only targeted runtimes using the changed provider for %s with model %s',
+    async (frameworkId, model) => {
+      const created: ReturnType<typeof createFakeRuntime>[] = []
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId,
+          sessionIds: [`session-${created.length}`],
+          callbacks
+        })
+        created.push(fake)
+        return fake.runtime
       })
-      created.push(fake)
-      return fake.runtime
-    })
-    const target = (providerId: string): AcpSessionAgentTarget => ({
-      frameworkId: 'claude-code',
-      providerId,
-      model: 'model',
-      reasoningEffort: 'high'
-    })
+      const target = (providerId: string): AcpSessionAgentTarget => ({
+        frameworkId,
+        providerId,
+        ...(model ? { model } : {}),
+        reasoningEffort: 'high'
+      })
 
-    await coordinator.createSession({ agentTarget: target('provider-a') })
-    await coordinator.createSession({ agentTarget: target('provider-b') })
-    await coordinator.requestProviderReconnect(['provider-a'], false)
+      await coordinator.createSession({ agentTarget: target('provider-a') })
+      await coordinator.createSession({ agentTarget: target('provider-b') })
+      await coordinator.requestProviderReconnect(['provider-a'], false)
 
-    expect(created[0].requestProviderReconnect).not.toHaveBeenCalled()
-    expect(created[1].requestProviderReconnect).toHaveBeenCalledOnce()
-    expect(created[2].requestProviderReconnect).not.toHaveBeenCalled()
-  })
+      expect(created[0].requestProviderReconnect).not.toHaveBeenCalled()
+      expect(created[1].requestProviderReconnect).toHaveBeenCalledOnce()
+      expect(created[2].requestProviderReconnect).not.toHaveBeenCalled()
+    }
+  )
 
   it('retires an unused targeted runtime after Session creation fails', async () => {
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/session-agent-target.test.ts
+++ b/src/main/acp/session-agent-target.test.ts
@@ -104,8 +104,8 @@ describe('Session agent target', () => {
     })
   })
 
-  it('falls back to the Settings Active Model when the Session target is gone', () => {
-    expect(
+  it('rejects an unavailable Session target despite an available Settings Active Model', () => {
+    expect(() =>
       resolveValidatedSessionAgentTarget(
         {
           agentConfiguration: {
@@ -119,12 +119,54 @@ describe('Session agent target', () => {
           activeModel: 'settings-model'
         })
       )
-    ).toEqual({
+    ).toThrow('Session agent target is unavailable')
+  })
+
+  it('validates the actual provider default without pinning it or accepting another available model', () => {
+    const configuration = { providerId: 'ready', reasoningEffort: 'high' as const }
+    const source = { agentConfiguration: configuration }
+    const originalProvider = {
+      ...provider('ready', 'default-model'),
+      models: ['other-model', 'default-model']
+    }
+    const snapshot = settings({ providers: [originalProvider] })
+    expect(resolveValidatedSessionAgentTarget(source, snapshot)).toEqual({
       frameworkId: 'opencode',
-      providerId: 'ready',
-      model: 'settings-model',
-      reasoningEffort: 'high'
+      ...configuration
     })
+    const failed = settings({
+      providers: [
+        {
+          ...originalProvider,
+          lastValidationFailure: {
+            at: 1,
+            category: 'network',
+            target: { model: 'default-model', endpoint: 'openai' }
+          }
+        }
+      ]
+    })
+    expect(() => resolveValidatedSessionAgentTarget(source, failed)).toThrow(
+      'Session agent target is unavailable'
+    )
+    expect(resolveValidatedSessionAgentTarget(source, snapshot)).toEqual({
+      frameworkId: 'opencode',
+      ...configuration
+    })
+    expect(
+      resolveValidatedSessionAgentTarget(
+        source,
+        settings({
+          providers: [
+            {
+              ...failed.providers[0],
+              model: 'other-model'
+            }
+          ]
+        })
+      )
+    ).toEqual({ frameworkId: 'opencode', ...configuration })
+    expect(source.agentConfiguration).toEqual(configuration)
   })
 
   it('fails closed when neither the Session target nor Settings is selectable', () => {

--- a/src/main/acp/session-agent-target.ts
+++ b/src/main/acp/session-agent-target.ts
@@ -84,6 +84,7 @@ const resolveValidatedSessionAgentTarget = (
     frameworkEndpoints: framework?.supportedApiTypes ?? ['anthropic']
   })
   const resolution = resolveSessionAgentConfiguration({
+    providers: settings.providers,
     session: source,
     catalog,
     activeProviderId: settings.activeProviderId,

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4154,6 +4154,7 @@ const createApplicationModules = async (
       }
     },
     settingsCore: {
+      runtime: settingsWorkflows.runtime,
       service: settingsService,
       appearance: settingsWorkflows.appearance,
       snapshotCommits: settingsSnapshotCommits,

--- a/src/main/settings/application-commands.test.ts
+++ b/src/main/settings/application-commands.test.ts
@@ -133,6 +133,7 @@ const createDependencies = (
     appearance,
     dependencies: {
       service,
+      runtime: { refreshProviderModels: (request) => service.refreshProviderModels(request) },
       appearance: { setAppIconVariant: appearance },
       snapshotCommits,
       emitInstallEvent,
@@ -144,6 +145,25 @@ const createDependencies = (
 }
 
 describe('Settings core application commands', () => {
+  it('routes model refresh through the runtime workflow before publishing the snapshot', async () => {
+    const { dependencies, serviceMethod } = createDependencies()
+    const result = { ok: true, category: 'ok', models: ['new-default'] } as const
+    const refreshProviderModels = vi.fn().mockResolvedValue(result)
+    const router = createApplicationCommandRouter()
+    registerCoreSettingsApplicationCommands(router.registrar, {
+      ...dependencies,
+      runtime: { refreshProviderModels }
+    })
+    await expect(
+      router.dispatcher.invoke(
+        settingsCoreApplicationCommands.refreshProviderModels,
+        invocation([{ providerId: 'provider-1' }])
+      )
+    ).resolves.toEqual(result)
+    expect(refreshProviderModels).toHaveBeenCalledWith({ providerId: 'provider-1' })
+    expect(serviceMethod('refreshProviderModels')).not.toHaveBeenCalled()
+  })
+
   it('returns and publishes current snapshots when an older command result resolves late', async () => {
     const currentSnapshot = {
       claude: {},

--- a/src/main/settings/application-commands.ts
+++ b/src/main/settings/application-commands.ts
@@ -49,6 +49,7 @@ import {
   readVisionModel
 } from './transport-validation'
 import type { AppearanceSettingsWorkflows } from './workflows/appearance'
+import type { RuntimeSettingsWorkflows } from './workflows/runtime'
 
 type CoreSettingsCommandStore = Pick<
   SettingsService,
@@ -400,6 +401,7 @@ const settingsCoreApplicationCommandGroup = defineApplicationCommandGroup('setti
 
 type CoreSettingsApplicationCommandDependencies = Readonly<{
   service: CoreSettingsCommandStore
+  runtime: Pick<RuntimeSettingsWorkflows, 'refreshProviderModels'>
   appearance: Pick<AppearanceSettingsWorkflows, 'setAppIconVariant'>
   snapshotCommits: SettingsSnapshotCommitOwner
   emitInstallEvent: (event: ClaudeInstallEvent) => void
@@ -501,7 +503,7 @@ const registerCoreSettingsApplicationCommands = (
       'settings:preview-skill-zip': ({ args }) => dependencies.service.previewSkillZip(args[0]),
       'settings:refresh-provider-models': ({ args }) =>
         dependencies.snapshotCommits.projectAfter(
-          dependencies.service.refreshProviderModels(args[0])
+          dependencies.runtime.refreshProviderModels(args[0])
         ),
       'settings:scan-repo-skills': ({ args }) => dependencies.service.scanRepoSkills(args[0]),
       'settings:save-github-token': ({ args, callerContext }) => {

--- a/src/main/settings/ipc.test.ts
+++ b/src/main/settings/ipc.test.ts
@@ -5,6 +5,8 @@ import {
   CLAUDE_SHARED_PROVIDER_ID,
   CODEX_SUBSCRIPTION_PROVIDER_ID
 } from '../../shared/settings'
+import { resolveProviderEffectiveModel } from '../../shared/provider-reasoning-effort'
+import type { ProviderView } from '../../shared/settings'
 import type { SettingsService } from './service'
 import type { SettingsIpcOptions } from './ipc'
 import type { SettingsWorkflowEffects } from './workflows'
@@ -748,6 +750,62 @@ describe('settings IPC handlers', () => {
       })
 
       expect(onActiveProviderChanged).toHaveBeenCalledOnce()
+    }
+  )
+
+  it.each(['p1', 'other'])(
+    'reconnects provider-default Sessions after catalog refresh with active provider %s',
+    async (activeProviderId) => {
+      handlers.clear()
+      const service = createFakeService()
+      let provider: ProviderView = {
+        id: 'p1',
+        type: 'official',
+        vendorId: 'anthropic',
+        name: 'Anthropic',
+        models: ['claude-sonnet-4-6', 'claude-opus-4-6'],
+        supportsImageInput: true,
+        hasKey: true,
+        needsKey: false
+      }
+      service.getSettingsView.mockImplementation(async () => ({
+        claude: {},
+        activeProviderId,
+        providers: [provider]
+      }))
+      const onActiveProviderChanged = vi.fn()
+      registerTestSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+      expect(resolveProviderEffectiveModel(provider, undefined)).toBe('claude-sonnet-4-6')
+      service.refreshProviderModels.mockImplementation(async () => {
+        provider = { ...provider, models: ['claude-opus-4-6', 'claude-sonnet-4-6'] }
+        return { ok: true, category: 'ok', models: provider.models }
+      })
+      await invoke('settings:refresh-provider-models', { providerId: 'p1' })
+      expect(resolveProviderEffectiveModel(provider, undefined)).toBe('claude-opus-4-6')
+      expect(onActiveProviderChanged).toHaveBeenCalledWith(['p1'], activeProviderId === 'p1')
+    }
+  )
+
+  it.each(['unchanged', 'failed'])(
+    'does not reconnect existing Sessions after an %s catalog refresh',
+    async (outcome) => {
+      handlers.clear()
+      const service = createFakeService()
+      const provider = { id: 'p1', models: ['claude-opus-4-6', 'claude-sonnet-4-6'] }
+      service.getSettingsView.mockResolvedValue({
+        claude: {},
+        activeProviderId: 'p1',
+        providers: [provider]
+      })
+      service.refreshProviderModels.mockResolvedValue(
+        outcome === 'failed'
+          ? { ok: false, category: 'network' }
+          : { ok: true, category: 'ok', models: provider.models }
+      )
+      const onActiveProviderChanged = vi.fn()
+      registerTestSettingsIpcHandlers({ service: asService(service), onActiveProviderChanged })
+      await invoke('settings:refresh-provider-models', { providerId: 'p1' })
+      expect(onActiveProviderChanged).not.toHaveBeenCalled()
     }
   )
 

--- a/src/main/settings/ipc.ts
+++ b/src/main/settings/ipc.ts
@@ -335,7 +335,7 @@ const registerSettingsIpcHandlers = ({
   ipcMainHandle(
     'settings:refresh-provider-models',
     (_event, request: RefreshProviderModelsRequest) =>
-      snapshotCommits.projectAfter(service.refreshProviderModels(request))
+      snapshotCommits.projectAfter(workflows.runtime.refreshProviderModels(request))
   )
   ipcMainHandle('settings:mark-onboarding-complete', () =>
     snapshotCommits.currentSnapshotAfter(service.markOnboardingComplete())

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -15,6 +15,39 @@ const { ProviderRuntimeProjectionOwner } = await import('./provider-runtime-proj
 const { encryptKey } = await import('./crypto')
 
 describe('ProviderRuntimeProjectionOwner', () => {
+  it.each(['claude-code', 'opencode', 'codex'] as const)(
+    'resolves an omitted model from the changing provider default for %s',
+    (frameworkId) => {
+      const owner = new ProviderRuntimeProjectionOwner()
+      const provider: StoredProvider = {
+        id: 'anthropic',
+        type: 'official',
+        vendorId: 'anthropic',
+        name: 'Anthropic',
+        model: 'claude-opus-4-6',
+        fetchedModels: ['claude-sonnet-4-6', 'claude-opus-4-6']
+      }
+      const framework = getAgentFramework(frameworkId)
+      expect(
+        owner.resolveRuntimeTarget(provider, { kind: 'configured' }, framework).effectiveModel
+      ).toBe('claude-opus-4-6')
+      const changed = { ...provider, model: 'claude-sonnet-4-6' }
+      expect(
+        owner.resolveRuntimeTarget(changed, { kind: 'configured' }, framework).effectiveModel
+      ).toBe('claude-sonnet-4-6')
+      expect(
+        owner.resolveRuntimeTarget(
+          changed,
+          {
+            kind: 'configured',
+            requestedModel: 'claude-opus-4-6'
+          },
+          framework
+        ).effectiveModel
+      ).toBe('claude-opus-4-6')
+    }
+  )
+
   it('fails closed when a required model is outside the provider catalog', () => {
     const owner = new ProviderRuntimeProjectionOwner()
     const provider: StoredProvider = {

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -69,6 +69,7 @@ const snapshot = (overrides: Partial<SettingsSnapshot> = {}): SettingsSnapshot =
 const fakeStore = () => {
   const store = {
     getSettingsView: vi.fn().mockResolvedValue(snapshot()),
+    refreshProviderModels: vi.fn().mockResolvedValue({ ok: true, models: [] }),
     getConnectors: vi.fn().mockResolvedValue(undefined),
     uninstallClaude: vi.fn(),
     uninstallOpencode: vi.fn(),

--- a/src/main/settings/workflows/runtime.ts
+++ b/src/main/settings/workflows/runtime.ts
@@ -4,6 +4,7 @@ import {
   CODEX_SUBSCRIPTION_PROVIDER_ID,
   XAI_SUBSCRIPTION_PROVIDER_ID,
   type ProviderDeletionScenarioModelHandling,
+  type RefreshProviderModelsRequest,
   type SetActiveProviderRequest,
   type SetAgentFrameworkRequest,
   type SetAgentRoutingRequest,
@@ -16,6 +17,7 @@ import type { SettingsService } from '../service'
 type RuntimeSettingsWorkflowStore = Pick<
   SettingsService,
   | 'getSettingsView'
+  | 'refreshProviderModels'
   | 'uninstallClaude'
   | 'uninstallOpencode'
   | 'uninstallCodeBuddy'
@@ -93,6 +95,27 @@ class RuntimeSettingsWorkflows {
     }
 
     return snapshot
+  }
+
+  async refreshProviderModels(
+    request: RefreshProviderModelsRequest
+  ): Promise<Awaited<ReturnType<RuntimeSettingsWorkflowStore['refreshProviderModels']>>> {
+    const before = await this.settings.getSettingsView()
+    const result = await this.settings.refreshProviderModels(request)
+    if (!result.ok) return result
+    const after = await this.settings.getSettingsView()
+    const previous = before.providers.find((provider) => provider.id === request.providerId)
+    const current = after.providers.find((provider) => provider.id === request.providerId)
+    // Catalog order can own an omitted model's default. Reconnect existing provider generations
+    // through the same deferred transition used for provider edits; do not interrupt active turns.
+    if (previous && current && JSON.stringify(previous.models) !== JSON.stringify(current.models)) {
+      this.effects.requestProviderReconnect(
+        affectedProviderIds(request.providerId),
+        request.providerId === before.activeProviderId ||
+          request.providerId === after.activeProviderId
+      )
+    }
+    return result
   }
 
   async deleteProvider(

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import { ComputeHostPreferenceValidationError } from '../../shared/compute'
 import type { Project } from '../../shared/projects'
+import { resolveProviderEffectiveModel } from '../../shared/provider-reasoning-effort'
 import type { SettingsSnapshot } from '../../shared/settings'
 import {
   materializeSessionConversationGraph,
@@ -224,6 +225,69 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
   })
 }
 describe('TaskRunner', () => {
+  it.each([
+    ['claude-sonnet-4-6', 'claude-opus-4-6'],
+    ['claude-opus-4-6', 'claude-sonnet-4-6']
+  ])('keeps provider-default intent independent of catalog order %j', async (...models) => {
+    const providerSettings: SettingsSnapshot = {
+      ...configuredSettings,
+      activeModel: 'claude-opus-4-6',
+      providers: [
+        {
+          ...configuredSettings.providers[0],
+          type: 'official',
+          vendorId: 'anthropic',
+          model: 'claude-opus-4-6',
+          models
+        }
+      ]
+    }
+    expect(resolveProviderEffectiveModel(providerSettings.providers[0], undefined)).toBe(
+      'claude-opus-4-6'
+    )
+    let current: PersistedChatSession = {
+      ...session,
+      agentConfiguration: {
+        providerId: 'provider-1',
+        model: 'claude-sonnet-4-6',
+        reasoningEffort: 'high' as const
+      }
+    }
+    const updateConfiguration = vi.fn(async (value: PersistedChatSession) => {
+      current = value
+      return value
+    })
+    const update = vi.fn(
+      async (request: Parameters<NonNullable<TaskProjectPort['update']>>[0]) => ({
+        ...project,
+        sessionDefaults: request.sessionDefaults
+      })
+    )
+    const runner = createRunner({
+      settings: { get: async () => providerSettings },
+      sessions: { list: async () => [current], updateConfiguration },
+      projects: { list: async () => [project], create: async () => project, update }
+    })
+    const result = await runner.updateSessionConfiguration(session.id, {
+      expectedRevision: 0,
+      agentConfiguration: { model: null }
+    })
+    expect.soft(result.persisted.agentConfiguration).toEqual({
+      providerId: 'provider-1',
+      reasoningEffort: 'high'
+    })
+    const defaults = await runner.updateProjectSessionDefaults(project.id, {
+      expectedUpdatedAt: 1,
+      patch: {
+        agentConfiguration: { providerId: 'provider-1', model: null, reasoningEffort: 'high' }
+      }
+    })
+    expect(defaults.configured.agentConfiguration).toEqual({
+      providerId: 'provider-1',
+      reasoningEffort: 'high'
+    })
+  })
+
   it('updates an idle Session configuration atomically with revision and availability checks', async () => {
     let current: PersistedChatSession = {
       ...session,

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -638,7 +638,8 @@ const validateTaskAgentConfiguration = (
     taskModelCatalog(settings),
     configuration.providerId,
     configuration.model,
-    configuration.reasoningEffort
+    configuration.reasoningEffort,
+    settings.providers
   )
   if (!resolved) {
     throw new TaskRunnerError(
@@ -654,6 +655,7 @@ const effectiveTaskAgentConfiguration = (
   settings: SettingsSnapshot
 ): SessionAgentConfiguration | undefined => {
   const resolution = resolveSessionAgentConfiguration({
+    providers: settings.providers,
     session,
     catalog: taskModelCatalog(settings),
     activeProviderId: settings.activeProviderId,

--- a/src/renderer/src/lib/acp/session-agent-configuration.test.ts
+++ b/src/renderer/src/lib/acp/session-agent-configuration.test.ts
@@ -3,12 +3,13 @@ import { describe, expect, it } from 'vitest'
 import type { ConfiguredModelCatalogEntry } from '../../../../shared/configured-model-catalog'
 import {
   CODEX_ISOLATED_PROVIDER_ID,
-  CODEX_SUBSCRIPTION_PROVIDER_ID
+  CODEX_SUBSCRIPTION_PROVIDER_ID,
+  type ProviderView
 } from '../../../../shared/settings'
 import {
   isConfigurationSelectable,
   resolveSelectableConfiguration,
-  resolveSessionAgentConfiguration
+  resolveSessionAgentConfiguration as resolveConfiguration
 } from './session-agent-configuration'
 
 const option = (
@@ -26,6 +27,21 @@ const option = (
   selectable,
   supportsImageInput: false
 })
+
+const providersFromCatalog = (catalog: readonly ConfiguredModelCatalogEntry[]): ProviderView[] =>
+  [...new Set(catalog.map((entry) => entry.providerId))].map((id) => ({
+    id,
+    name: id,
+    type: catalog.find((entry) => entry.providerId === id)!.providerType,
+    models: catalog.filter((entry) => entry.providerId === id).map((entry) => entry.model),
+    supportsImageInput: false,
+    hasKey: true,
+    needsKey: false
+  }))
+const resolveSessionAgentConfiguration = (
+  input: Omit<Parameters<typeof resolveConfiguration>[0], 'providers'>
+): ReturnType<typeof resolveConfiguration> =>
+  resolveConfiguration({ ...input, providers: providersFromCatalog(input.catalog) })
 
 describe('Session agent configuration', () => {
   it('keeps a selectable Session configuration', () => {
@@ -45,7 +61,9 @@ describe('Session agent configuration', () => {
     const configuration = { providerId: 'session', reasoningEffort: 'high' as const }
     const catalog = [option('session', 'provider-default'), option('active', 'new')]
 
-    expect(isConfigurationSelectable(configuration, catalog)).toBe(true)
+    expect(isConfigurationSelectable(configuration, catalog, providersFromCatalog(catalog))).toBe(
+      true
+    )
     expect(
       resolveSessionAgentConfiguration({
         session: { agentConfiguration: configuration },
@@ -58,7 +76,6 @@ describe('Session agent configuration', () => {
       status: 'ready',
       configuration: {
         providerId: 'session',
-        model: 'provider-default',
         reasoningEffort: 'high'
       },
       changed: false
@@ -73,8 +90,18 @@ describe('Session agent configuration', () => {
       option('active', 'new')
     ]
 
-    expect(isConfigurationSelectable(configuration, catalog)).toBe(true)
-    expect(resolveSelectableConfiguration(catalog, 'codex', undefined, 'default')).toEqual({
+    expect(isConfigurationSelectable(configuration, catalog, providersFromCatalog(catalog))).toBe(
+      true
+    )
+    expect(
+      resolveSelectableConfiguration(
+        catalog,
+        'codex',
+        undefined,
+        'default',
+        providersFromCatalog(catalog)
+      )
+    ).toEqual({
       providerId: 'codex',
       reasoningEffort: 'default'
     })
@@ -151,7 +178,7 @@ describe('Session agent configuration', () => {
     })
   })
 
-  it('lazily replaces an unavailable Session model with a valid active default', () => {
+  it('preserves an unavailable Session model despite a valid active default', () => {
     expect(
       resolveSessionAgentConfiguration({
         session: {
@@ -167,9 +194,8 @@ describe('Session agent configuration', () => {
         activeReasoningEffort: 'medium'
       })
     ).toEqual({
-      status: 'ready',
-      configuration: { providerId: 'active', model: 'new', reasoningEffort: 'medium' },
-      changed: true
+      status: 'unavailable',
+      configuration: { providerId: 'deleted', model: 'gone', reasoningEffort: 'high' }
     })
   })
 
@@ -185,7 +211,6 @@ describe('Session agent configuration', () => {
       status: 'ready',
       configuration: {
         providerId: 'custom',
-        model: 'custom-model',
         reasoningEffort: 'default'
       },
       changed: true

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.characterization.test.tsx
@@ -521,7 +521,7 @@ describe('workspace Agent Runtime hook contract', () => {
     })
   })
 
-  it('falls back to the Settings Active Model instead of the provider base model', async () => {
+  it('preserves the unavailable legacy preference instead of replacing it with the Settings Active Model', async () => {
     useSettingsStore.setState({
       activeProviderId: 'custom',
       activeModel: 'settings-selected',
@@ -564,12 +564,12 @@ describe('workspace Agent Runtime hook contract', () => {
     await render()
 
     expect(latest.resolveSessionRuntimeSelection('session-1')).toMatchObject({
-      agentBackendId: 'claude-code:custom',
-      agentModel: 'settings-selected',
+      agentBackendId: undefined,
+      agentModel: 'gone',
       agentTarget: {
         frameworkId: 'claude-code',
-        providerId: 'custom',
-        model: 'settings-selected',
+        providerId: 'deleted-provider',
+        model: 'gone',
         reasoningEffort: 'low'
       }
     })

--- a/src/renderer/src/lib/acp/workspace-runtime-selection-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-selection-owner.ts
@@ -2,6 +2,7 @@ import { useCallback, useMemo } from 'react'
 
 import type { AcpSessionAgentTarget } from '../../../../shared/acp'
 import { buildConfiguredModelCatalog } from '../../../../shared/configured-model-catalog'
+import { resolveProviderEffectiveModel } from '../../../../shared/provider-reasoning-effort'
 import { resolveModelContextWindow } from '../../../../shared/provider-registry'
 import type { SessionAgentConfiguration } from '../../../../shared/settings'
 import { useSessionStore } from '../../stores/session-store'
@@ -82,7 +83,7 @@ const useWorkspaceRuntimeSelectionOwner = (): {
       const provider = configuration
         ? providers.find((candidate) => candidate.id === configuration.providerId)
         : activeProvider
-      const model = configuration?.model ?? provider?.model ?? provider?.models[0]
+      const model = configuration?.model ?? resolveProviderEffectiveModel(provider, undefined)
       const modelOption = configuredModelCatalog.find(
         (option) => option.providerId === provider?.id && option.model === (model ?? '')
       )
@@ -121,6 +122,7 @@ const useWorkspaceRuntimeSelectionOwner = (): {
         .sessions.find((candidate) => candidate.id === sessionId)
       if (!session) return undefined
       return resolveSessionAgentConfiguration({
+        providers,
         session,
         catalog: configuredModelCatalog,
         activeProviderId: activeProvider?.id,
@@ -128,7 +130,7 @@ const useWorkspaceRuntimeSelectionOwner = (): {
         activeReasoningEffort: reasoningEffort
       })
     },
-    [activeModel, activeProvider, configuredModelCatalog, reasoningEffort]
+    [activeModel, activeProvider, configuredModelCatalog, reasoningEffort, providers]
   )
   const resolveStoredSessionConfiguration = useCallback(
     (sessionId: string | undefined): SessionAgentConfiguration | undefined =>
@@ -173,7 +175,7 @@ const useWorkspaceRuntimeSelectionOwner = (): {
         ? undefined
         : resolveStoredSessionResolution(input.sessionId)
       const agentConfiguration = input.agentConfiguration
-        ? isConfigurationSelectable(input.agentConfiguration, configuredModelCatalog)
+        ? isConfigurationSelectable(input.agentConfiguration, configuredModelCatalog, providers)
           ? input.agentConfiguration
           : undefined
         : storedResolution?.status === 'ready'
@@ -185,7 +187,7 @@ const useWorkspaceRuntimeSelectionOwner = (): {
       }
       return agentConfiguration
     },
-    [agentFrameworkId, configuredModelCatalog, resolveStoredSessionResolution]
+    [agentFrameworkId, configuredModelCatalog, resolveStoredSessionResolution, providers]
   )
 
   return {

--- a/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.draft-preservation.test.tsx
@@ -319,6 +319,22 @@ describe('WorkspacePage draft preservation', () => {
     })
   }
 
+  it('starts desktop drafts with application settings despite automation Project defaults', async () => {
+    useProjectStore.setState({
+      projects: useProjectStore.getState().projects.map((project) => ({
+        ...project,
+        sessionDefaults: { autoReviewEnabled: true, permissionProfile: 'full' as const }
+      }))
+    })
+    useSessionStore.setState({ selectedSessionId: undefined })
+    await renderPage()
+    expect(conversationProps.agentControls.autoReviewEnabled).toBe(false)
+    expect(conversationProps.permissions.permissionProfile).toBe('ask')
+    await act(async () => sidebarProps.onNewConversation())
+    expect(conversationProps.agentControls.autoReviewEnabled).toBe(false)
+    expect(conversationProps.permissions.permissionProfile).toBe('ask')
+  })
+
   it('opens and closes the Artifact download dialog for the selected sidebar Session', async () => {
     await renderPage()
     const sessionB = useSessionStore.getState().sessions.find((session) => session.id === 'sess-b')!

--- a/src/renderer/src/pages/workspace/workspace-session-agent-configuration-controller.availability.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-agent-configuration-controller.availability.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { act, createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { ProviderView } from '../../../../shared/settings'
+import type { ChatSession } from '@/stores/session-store'
+
+const mocks = vi.hoisted(() => ({
+  providers: [] as ProviderView[],
+  setAgentConfiguration: vi.fn(),
+  endpoints: ['anthropic']
+}))
+vi.mock('@/stores/settings-store', () => ({
+  selectFrameworkApiEndpoints: () => mocks.endpoints,
+  selectVisionRelayAvailable: () => false,
+  useSettingsStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      providers: mocks.providers,
+      activeProviderId: 'fallback',
+      activeModel: 'model',
+      reasoningEffort: 'low',
+      agentFrameworkId: 'claude-code'
+    })
+}))
+vi.mock('@/stores/session-store', () => ({
+  useSessionStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({ setAgentConfiguration: mocks.setAgentConfiguration })
+}))
+import { useWorkspaceSessionAgentConfiguration } from './workspace-session-agent-configuration-controller'
+
+;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
+const roots: ReturnType<typeof createRoot>[] = []
+const provider = (id: string): ProviderView => ({
+  id,
+  name: id,
+  type: 'custom',
+  model: 'model',
+  models: ['model'],
+  apiEndpoints: ['anthropic'],
+  supportsImageInput: false,
+  hasKey: true,
+  needsKey: false
+})
+const original = { providerId: 'original', model: 'model', reasoningEffort: 'high' as const }
+const fallback = { providerId: 'fallback', model: 'model', reasoningEffort: 'low' as const }
+const mount = (
+  contentLoaded = true
+): {
+  render: () => void
+  result: () => ReturnType<typeof useWorkspaceSessionAgentConfiguration>
+} => {
+  let session = { id: 'session-1', contentLoaded, agentConfiguration: original } as ChatSession
+  let result: ReturnType<typeof useWorkspaceSessionAgentConfiguration>
+  const root = createRoot(document.createElement('div'))
+  roots.push(root)
+  const Harness = (): null => {
+    result = useWorkspaceSessionAgentConfiguration(session)
+    return null
+  }
+  const render = (): void => act(() => root.render(createElement(Harness)))
+  mocks.setAgentConfiguration.mockImplementation((_id, configuration) => {
+    session = { ...session, agentConfiguration: configuration }
+  })
+  render()
+  return { render, result: () => result! }
+}
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+  mocks.setAgentConfiguration.mockReset()
+})
+describe('saved Session model availability', () => {
+  it.each(['removed provider', 'targeted network failure'])(
+    'preserves the saved preference across %s and recovery',
+    (failure) => {
+      mocks.providers = [provider('original'), provider('fallback')]
+      const hook = mount()
+      expect(hook.result().activeAgentConfiguration).toEqual(original)
+      expect(mocks.setAgentConfiguration).not.toHaveBeenCalled()
+      mocks.providers =
+        failure === 'removed provider'
+          ? [provider('fallback')]
+          : [
+              {
+                ...provider('original'),
+                lastValidationFailure: {
+                  at: 1,
+                  category: 'network',
+                  target: { model: 'model', endpoint: 'anthropic' }
+                }
+              },
+              provider('fallback')
+            ]
+      hook.render()
+      expect.soft(mocks.setAgentConfiguration).not.toHaveBeenCalled()
+      expect.soft(hook.result().agentConfigurationUnavailable).toBe(true)
+      expect.soft(hook.result().activeAgentConfiguration).toEqual(original)
+      hook.render()
+      mocks.providers = [provider('original'), provider('fallback')]
+      hook.render()
+      expect(hook.result().activeAgentConfiguration).toEqual(original)
+    }
+  )
+  it('does not write before content loads', () => {
+    mocks.providers = [provider('fallback')]
+    mount(false)
+    expect(mocks.setAgentConfiguration).not.toHaveBeenCalled()
+  })
+  it('persists an explicit replacement selected by the user', () => {
+    mocks.providers = [provider('original'), provider('fallback')]
+    const hook = mount()
+    act(() => hook.result().changeAgentConfiguration(fallback))
+    expect(mocks.setAgentConfiguration).toHaveBeenCalledWith('session-1', fallback)
+    hook.render()
+    expect(hook.result().activeAgentConfiguration).toEqual(fallback)
+  })
+})

--- a/src/renderer/src/pages/workspace/workspace-session-agent-configuration-controller.ts
+++ b/src/renderer/src/pages/workspace/workspace-session-agent-configuration-controller.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
 
 import { buildConfiguredModelCatalog } from '../../../../shared/configured-model-catalog'
+import { resolveProviderEffectiveModel } from '../../../../shared/provider-reasoning-effort'
 import type { SessionAgentConfiguration } from '../../../../shared/settings'
 import {
   isConfigurationSelectable,
@@ -62,14 +63,16 @@ const useWorkspaceSessionAgentConfiguration = (
         configuredModelCatalog,
         activeProviderId,
         activeModel,
-        activeReasoningEffort
+        activeReasoningEffort,
+        providers
       ),
-    [activeModel, activeProviderId, activeReasoningEffort, configuredModelCatalog]
+    [activeModel, activeProviderId, activeReasoningEffort, configuredModelCatalog, providers]
   )
   const sessionAgentConfiguration = useMemo(
     () =>
       activeSession
         ? resolveSessionAgentConfiguration({
+            providers,
             session: activeSession,
             catalog: configuredModelCatalog,
             activeProviderId,
@@ -77,7 +80,14 @@ const useWorkspaceSessionAgentConfiguration = (
             activeReasoningEffort
           })
         : undefined,
-    [activeModel, activeProviderId, activeReasoningEffort, activeSession, configuredModelCatalog]
+    [
+      activeModel,
+      activeProviderId,
+      activeReasoningEffort,
+      activeSession,
+      configuredModelCatalog,
+      providers
+    ]
   )
   useEffect(() => {
     if (
@@ -99,13 +109,17 @@ const useWorkspaceSessionAgentConfiguration = (
     : (newConversationAgentConfiguration ?? defaultAgentConfiguration)
   const agentConfigurationUnavailable = activeSession
     ? sessionAgentConfiguration?.status === 'unavailable'
-    : !isConfigurationSelectable(activeAgentConfiguration, configuredModelCatalog)
+    : !isConfigurationSelectable(activeAgentConfiguration, configuredModelCatalog, providers)
+  const effectiveModel =
+    activeAgentConfiguration?.model ??
+    resolveProviderEffectiveModel(
+      providers.find((provider) => provider.id === activeAgentConfiguration?.providerId),
+      undefined
+    )
   const activeModelOption = configuredModelCatalog.find(
     (option) =>
       option.providerId === activeAgentConfiguration?.providerId &&
-      (activeAgentConfiguration?.model === undefined
-        ? option.selectable
-        : option.model === activeAgentConfiguration.model)
+      (effectiveModel === undefined ? option.selectable : option.model === effectiveModel)
   )
   const supportsImageInput = activeModelOption?.supportsImageInput === true || visionRelayAvailable
   const changeAgentConfiguration = useCallback(

--- a/src/shared/session-agent-configuration.ts
+++ b/src/shared/session-agent-configuration.ts
@@ -1,9 +1,9 @@
 import type { ConfiguredModelCatalogEntry } from './configured-model-catalog'
+import { resolveProviderEffectiveModel } from './provider-reasoning-effort'
 import type { PersistedChatSession } from './session-persistence'
 import {
   canonicalSessionProviderId,
-  isClaudeSubscriptionProvider,
-  isCodexSubscriptionProvider,
+  type ProviderView,
   type ReasoningEffort,
   type SessionAgentConfiguration
 } from './settings'
@@ -32,49 +32,51 @@ const providerIdFromBackendId = (backendId: string | undefined): string | undefi
   return normalized ? canonicalSessionProviderId(normalized) : undefined
 }
 
-const isConfigurationSelectable = (
-  configuration: SessionAgentConfiguration | undefined,
-  catalog: readonly ConfiguredModelCatalogEntry[]
-): configuration is SessionAgentConfiguration =>
-  Boolean(
-    configuration &&
-    catalog.some(
-      (option) =>
-        option.selectable &&
-        option.providerId === canonicalSessionProviderId(configuration.providerId) &&
-        (configuration.model === undefined || option.model === configuration.model)
-    )
-  )
-
 const resolveSelectableConfiguration = (
   catalog: readonly ConfiguredModelCatalogEntry[],
   providerId: string | undefined,
   model: string | undefined,
-  reasoningEffort: ReasoningEffort
+  reasoningEffort: ReasoningEffort,
+  providers: readonly ProviderView[]
 ): SessionAgentConfiguration | undefined => {
   if (!providerId) return undefined
   const resolvedProviderId = canonicalSessionProviderId(providerId)
+  const provider = providers.find((candidate) => candidate.id === resolvedProviderId)
+  if (!provider) return undefined
+  const effectiveModel = model ?? resolveProviderEffectiveModel(provider, undefined)
   const option = catalog.find(
     (candidate) =>
       candidate.selectable &&
       candidate.providerId === resolvedProviderId &&
-      (model === undefined || candidate.model === model)
+      (effectiveModel === undefined || candidate.model === effectiveModel)
   )
   if (!option) return undefined
-  // Subscription defaults are account/CLI-owned. Copying the first catalog model would pin
-  // foreground turns to an explicit id while Main resume still uses provider-default.
-  const preserveAccountOwnedDefault =
-    model === undefined &&
-    (isCodexSubscriptionProvider(option.providerType) ||
-      isClaudeSubscriptionProvider(option.providerType))
+  // Persist selection intent; only execution resolves an omitted provider-owned default.
   return {
     providerId: option.providerId,
-    ...(!preserveAccountOwnedDefault && option.model ? { model: option.model } : {}),
+    ...(model !== undefined ? { model } : {}),
     reasoningEffort
   }
 }
 
+const isConfigurationSelectable = (
+  configuration: SessionAgentConfiguration | undefined,
+  catalog: readonly ConfiguredModelCatalogEntry[],
+  providers: readonly ProviderView[]
+): configuration is SessionAgentConfiguration =>
+  Boolean(
+    configuration &&
+    resolveSelectableConfiguration(
+      catalog,
+      configuration.providerId,
+      configuration.model,
+      configuration.reasoningEffort,
+      providers
+    )
+  )
+
 const resolveSessionAgentConfiguration = (input: {
+  providers: readonly ProviderView[]
   session: SessionAgentConfigurationSource
   catalog: readonly ConfiguredModelCatalogEntry[]
   activeProviderId?: string
@@ -97,7 +99,8 @@ const resolveSessionAgentConfiguration = (input: {
         input.catalog,
         preferred.providerId,
         preferred.model,
-        preferred.reasoningEffort
+        preferred.reasoningEffort,
+        input.providers
       )
     : undefined
   if (selectablePreferred) {
@@ -110,11 +113,14 @@ const resolveSessionAgentConfiguration = (input: {
     }
   }
 
+  if (preferred) return { status: 'unavailable', configuration: preferred }
+
   const fallback = resolveSelectableConfiguration(
     input.catalog,
     input.activeProviderId,
     input.activeModel,
-    input.activeReasoningEffort
+    input.activeReasoningEffort,
+    input.providers
   )
   if (fallback) {
     return { status: 'ready', configuration: fallback, changed: true }

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -163,6 +163,7 @@ export type TaskSessionConfiguration = Readonly<{
   }>
 }>
 
+/** Defaults for new Sessions created through Task automation (CLI/API), not desktop New drafts. */
 export type TaskProjectSessionDefaults = Readonly<{
   projectId: string
   updatedAt: number


### PR DESCRIPTION
## Problem

Opening a saved Session after its provider disappears or a targeted model validation fails silently replaced its provider/model/effort with the active application choice. A provider-default reset also pinned the first selectable catalog model, even when the provider saved a different default.

## Proposed change

Preserve unavailable saved preferences and expose the existing unavailable/send-blocked interaction until recovery or an explicit replacement. Preserve an omitted model as provider-default intent, validate the actual default through the existing provider resolver, and use the same effective-model rule for renderer capabilities. Route successful catalog changes through the existing scoped runtime reconnect workflow in both desktop IPC and application commands, so provider-default connections resolve the new default after active work drains. Failed or unchanged refreshes leave connections intact. Clarify that Project Session defaults apply to automation-created Sessions (CLI/API).

## Scope and non-goals

No new persisted fields, enums, database migrations, configuration layers, or dependencies. Alias normalization and lazy-content protection remain. Explicit models stay fixed; omitted subscription models remain account-owned. Desktop New still uses desktop defaults.

Persistence changes: availability refresh no longer overwrites a saved choice; an explicit provider-default reset stores an omitted model. Historical omitted API models now follow the saved provider default rather than catalog order. Previously overwritten explicit choices cannot be distinguished from deliberate choices and are not reverse-migrated.

## Acceptance criteria and validation

The real hook/catalog/resolver regression and public TaskRunner tests failed on unmodified production code in two consecutive runs: four failures for provider removal, targeted network failure, and two catalog orders; lazy-content/manual-selection controls passed. After the fix all pass. No production test seam was added.

Initial local checks for saved-selection/default-intent behavior (completed before the catalog-refresh follow-up):

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Saved selection, default reset, alias/subscription compatibility and actual-default validation | `npm test -- src/renderer/src/pages/workspace/workspace-session-agent-configuration-controller.availability.test.ts src/renderer/src/lib/acp/session-agent-configuration.test.ts src/main/tasks/task-runner.test.ts src/main/acp/session-agent-target.test.ts src/main/settings/provider-runtime-projection.test.ts` | 128 passed |
| Runtime admission, replay/branches, cleanup and renderer consumers | `npm run test:module -- workspace_runtime` | 516 passed |
| New draft scope, manual controls, send gate and Session store consumers | `npm run test:module -- workspace_page` | 870 passed |
| Catalog/default rules, backend routes, CLI/SDK and Task HTTP adapter | Targeted tests in `configured-model-catalog`, `provider-reasoning-effort`, `backend-resolver`, `backend-route-planner`, `backend-selection-owner`, CLI/client and web-service Task API | Passed; backend resolver rerun with loopback-listen permission: 66 passed |
| Types and lint | `npm run typecheck`; final `npm run typecheck:web`; `npm run lint` | Passed |
| Real Electron unavailable UI, disabled send, preserved database value and explicit replacement persistence | `npm run build:e2e`; `npx playwright test e2e/workspace-conversation.spec.ts -g 'preserves an unavailable saved model'` | Passed on final build; screenshot generated |

The Electron test uses isolated storage and a fake agent. No real provider content was sent. Backend tests cover Claude Code, OpenCode, Codex Responses and Codex bridge routing; live external-provider certification was not run. No filesystem/path/schema changes require new platform or migration tests.

`npm run test:affected:explain -- --base 34f6576a41a2a8ca08879028a554632c3458626f --head HEAD` selects the full plan due to the E2E path and README ownership ambiguity. Per maintainer instruction, full local Vitest was not run; PR CI is the complete/platform validation authority. Independent review and CI remain required before merging.

### Catalog refresh follow-up verification

The review finding was reproduced twice through the production Settings IPC/workflow boundary: catalog reordering changed the shared resolver's provider default, but emitted zero reconnect requests for both active and non-active providers. Both cases pass after wiring refresh through the existing runtime workflow. No runtime identity/version field was added.

Final follow-up checks after the last material edit:

- IPC/API routing, unchanged/failed refresh controls, scoped coordinator targets (explicit and omitted models for Claude Code, OpenCode and Codex), composition, provider completion races and transition ownership: `npm test -- src/main/settings/settings-backend.architecture.test.ts src/main/settings/application-commands.test.ts src/main/settings/workflows.test.ts src/main/settings/ipc.test.ts src/main/application-command-composition.test.ts src/main/settings/provider-runtime-projection.test.ts src/main/settings/provider-completion-races.test.ts src/main/acp/runtime-coordinator.test.ts src/main/acp/connection-transition-owner.test.ts` — **309 passed**.
- Real runtime deferred reconnect while startup/active work drains: `npm test -- src/main/acp/runtime.test.ts -t 'provider reconnect'` — **7 passed**.
- `npm run typecheck:node` and `npm run lint` — passed.

The follow-up changes only main-process notification wiring; the renderer, schema and earlier screenshot are unchanged. The existing reconnect barrier and backend-resolution paths are reused, including Codex Responses/bridge. The initial head's complete CI passed; the new head must pass CI and independent review again.

## Review focus

Confirm the preserved-intent versus effective-model boundary, unavailable default validation, existing alias behavior, and the final validation mapping. UI reuses the existing translated unavailable label and replacement submenu; no new renderer copy was introduced.
