### PR TITLE
fix(notebook): skip disabled interpreter probes during binding

### DIFF
--- a/src/main/notebook/environment-discovery.ts
+++ b/src/main/notebook/environment-discovery.ts
@@ -6,7 +6,11 @@ import { join, win32 } from 'node:path'
 import { promisify } from 'node:util'
 
 import type { NotebookLanguage } from '../../shared/notebook'
-import type { DiscoveredInterpreter, EnvProvenance } from '../../shared/notebook-runtime'
+import type {
+  DiscoveredInterpreter,
+  EnvProvenance,
+  RuntimeEnablement
+} from '../../shared/notebook-runtime'
 import { createLogger } from '../logger'
 import { isMacOSDeveloperToolsPythonStub, isPython3Version } from './python-command'
 import { parseRVersion, rHasJsonlite } from './r-command'
@@ -409,7 +413,8 @@ const condaEnvName = (interpreterPath: string): string | undefined => {
 // runnability and classified by provenance. The orchestration is pure over the injected deps.
 export const discoverInterpreters = async (
   language: NotebookLanguage,
-  deps: DiscoveryDeps
+  deps: DiscoveryDeps,
+  enablement?: RuntimeEnablement
 ): Promise<DiscoveredInterpreter[]> => {
   // Dedup by real path FIRST, then probe unique candidates with BOUNDED concurrency. Each probe spawns
   // subprocesses (a `--version` probe, plus a jsonlite probe for R); serial made discovery scale with
@@ -420,6 +425,9 @@ export const discoverInterpreters = async (
   const unique: { path: string; envId: string }[] = []
   for (const path of await deps.candidatePaths(language)) {
     const envId = deps.realpath(path)
+    // Execution discovery must not wait for a disabled interpreter to time out. Inventory and
+    // repair callers omit enablement so they can still inspect disabled or broken environments.
+    if (enablement?.enabled[envId] === false) continue
     if (language === 'python' && isMacOSDeveloperToolsPythonStub(envId, deps.platform)) continue
     if (seen.has(envId)) continue
     seen.add(envId)

--- a/src/main/notebook/runtime-binding.discovery.test.ts
+++ b/src/main/notebook/runtime-binding.discovery.test.ts
@@ -1,0 +1,90 @@
+import { win32, posix, join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import * as discovery from './environment-discovery'
+import { NotebookRuntimeBindingOwner } from './runtime-binding'
+import { createRootNotebookLane } from './lane-identity'
+
+// Keep the real binding/discovery orchestration. Only machine enumeration and interpreter
+// subprocesses are controlled through the existing discovery factory boundary.
+afterEach(() => vi.restoreAllMocks())
+
+describe('runtime discovery enablement', () => {
+  it.each(['win32', 'darwin', 'linux'] as const)(
+    '%s: lists the enabled system Python without probing the disabled managed Python',
+    async (platform) => {
+      const paths = platform === 'win32' ? win32 : posix
+      const dataRoot = platform === 'win32' ? 'C:\\OpenScience' : '/OpenScience'
+      const runtimeRoot = join(dataRoot, 'runtime')
+      const managed = paths.join(dataRoot, 'runtime', 'envs', 'default-python', 'python')
+      const system = paths.join(dataRoot, 'anaconda3', 'python')
+      let finishDisabledProbe!: () => void
+      const disabledProbe = new Promise<void>((resolve) => {
+        finishDisabledProbe = resolve
+      })
+      const probeVersion = vi.fn(async (path: string) => {
+        if (path === managed) {
+          await disabledProbe // Models a probe that only returns when its timeout expires.
+          return undefined
+        }
+        return '3.13.9'
+      })
+      vi.spyOn(discovery, 'defaultDiscoveryDeps').mockReturnValue({
+        runtimeRoot,
+        platform,
+        candidatePaths: async (language) => (language === 'python' ? [managed, system] : []),
+        realpath: (path) => path,
+        probeVersion,
+        rRunnable: async () => true
+      })
+      const owner = new NotebookRuntimeBindingOwner({
+        dataRoot,
+        platform,
+        repository: { setRuntimeBindings: vi.fn(), findExisting: vi.fn() },
+        runtimeSettings: {
+          getSnapshot: async (language) => ({
+            language,
+            runtimeEnablement: {
+              enabled: { [managed]: false, [system]: true },
+              installAuthorized: {}
+            },
+            manualInterpreters: [],
+            packageMirror: {}
+          })
+        },
+        repairPolicy: {
+          bindingRequirement: () => ({ required: false, keys: [], protectedIdentity: false })
+        }
+      })
+      const session = {
+        projectId: 'project',
+        sessionId: 'new-session',
+        lane: createRootNotebookLane('project', 'new-session', 'root-frame'),
+        runtimeBinding: () => undefined,
+        setRuntimeBinding: vi.fn()
+      }
+      const listing = owner.list(session)
+      try {
+        await vi.waitFor(() => expect(probeVersion).toHaveBeenCalledWith(system, 'python'))
+        expect(probeVersion).not.toHaveBeenCalledWith(managed, 'python')
+        await expect(listing).resolves.toMatchObject({
+          runtimes: [{ runtimeId: system, version: '3.13.9', runnable: true }]
+        })
+        await expect(owner.bind(session, 'python', system)).resolves.toMatchObject({
+          bound: { runtimeId: system, source: 'external' }
+        })
+        expect(probeVersion).not.toHaveBeenCalledWith(managed, 'python')
+      } finally {
+        finishDisabledProbe()
+        await listing
+      }
+      // Settings/repair inventory must still be able to inspect disabled interpreters.
+      probeVersion.mockClear()
+      const inventory = await discovery.discoverInterpreters(
+        'python',
+        discovery.defaultDiscoveryDeps(runtimeRoot)
+      )
+      expect(inventory.map(({ envId }) => envId)).toContain(managed)
+      expect(probeVersion).toHaveBeenCalledWith(managed, 'python')
+    }
+  )
+})

--- a/src/main/notebook/runtime-binding.ts
+++ b/src/main/notebook/runtime-binding.ts
@@ -8,7 +8,8 @@ import {
   type NotebookRuntimeBindings,
   type NotebookRuntimeListing,
   type RuntimeBindingUnavailableReason,
-  type RuntimeTargetReceipt
+  type RuntimeTargetReceipt,
+  type RuntimeEnablement
 } from '../../shared/notebook-runtime'
 import type { NotebookRuntimeSettings } from '../settings/capabilities'
 import { createLogger, diagnosticErrorFields } from '../logger'
@@ -569,7 +570,8 @@ export class NotebookRuntimeBindingOwner {
 
   private async discover(
     language: NotebookLanguage,
-    manualInterpreters: string[]
+    manualInterpreters: string[],
+    enablement?: RuntimeEnablement
   ): Promise<DiscoveredInterpreter[]> {
     try {
       const injected = this.options.discoverRuntimes
@@ -579,7 +581,8 @@ export class NotebookRuntimeBindingOwner {
             language,
             defaultDiscoveryDeps(getRuntimeRoot(this.options.dataRoot), () => manualInterpreters, {
               platform: this.options.platform
-            })
+            }),
+            enablement
           )
     } catch {
       return []
@@ -590,7 +593,11 @@ export class NotebookRuntimeBindingOwner {
     language: NotebookLanguage
   ): Promise<DiscoveredInterpreter[]> {
     const settings = await this.runtimeSettingsSnapshot(language)
-    const discovered = await this.discover(language, settings?.manualInterpreters ?? [])
+    const discovered = await this.discover(
+      language,
+      settings?.manualInterpreters ?? [],
+      settings?.runtimeEnablement
+    )
     return discovered.filter((env) => isEnvEnabled(env, settings?.runtimeEnablement))
   }
 


### PR DESCRIPTION
## Problem

With app-managed Python disabled and a system interpreter enabled, Notebook runtime listing and
binding still probe the disabled interpreter. A stalled version probe delays the enabled result
until the irrelevant probe returns or times out.

## Proposed change

Pass the existing runtime enablement snapshot into execution-facing discovery and skip explicitly
disabled canonical interpreter IDs before probing. Settings inventory and repair retain full discovery.

## Scope and non-goals

No schema, persisted fields, enum, migration, new state owner, or UI changes. This does not introduce
automatic runtime fallback or alter historical binding repair. Startup/retention reports were also
investigated, but no unproven cleanup or performance change is included.

## Acceptance criteria and validation

- Public list/bind regression fails twice on baseline because the disabled probe is invoked, then
  passes on the fix for Windows/macOS/Linux policy inputs; full inventory still sees disabled IDs.
- Final owner/consumer test selection: 407 tests across 10 Notebook test files passed.
- Main/sandbox typecheck, lint, formatting and patch checks passed after the last material edit.
- Impact classifier selects full fallback because this Notebook path has no registered module owner.
  Per maintainer instruction, full portable/native platform validation is delegated to PR CI.
- No native Windows or live model execution was performed locally. Independent review is pending.

## Review focus

Verify that only execution-facing discovery supplies enablement, that canonical IDs match Settings,
and that repair/inventory retain their existing behavior. No production subprocess behavior or provider protocol changes are included.


### Final local evidence map

All checks ran after the last material edit on commit `7d08ba6ad666a32be947e1aeab401ff7d268ad8d`.

| Behavior | Command | Result |
| --- | --- | --- |
| Probe exclusion, external binding, inventory preservation; discovery and Settings/runtime/repair/transport consumers | `npm test -- src/main/notebook/runtime-binding.discovery.test.ts src/main/notebook/environment-discovery.test.ts src/main/notebook/runtime-workflows.test.ts src/main/notebook/runtime-service.test.ts src/main/notebook/runtime-service.architecture.test.ts src/main/notebook/runtime-application-commands.test.ts src/main/notebook/runtime-ipc.test.ts src/main/notebook/runtime-repair-policy.test.ts src/main/notebook/python-command.test.ts src/main/notebook/r-command.test.ts --maxWorkers=1` | 407 passed |
| Main/sandbox type contracts | `npm run typecheck:node` | Passed |
| Source lint | `npm run lint` | Passed |
| Patch integrity | `git diff --check` | Passed |
| Impact selection | `npm run test:affected:explain -- --base 34f6576a --head HEAD` | Unknown Notebook module owner selects full fallback |

The final diff changes one optional discovery argument and its execution-facing caller. Inventory callers retain the existing two-argument behavior; no renderer, schema, filesystem mutation, Agent replay or subscription contract changed. Native OS and full portable checks remain CI responsibilities; the three platform-policy regression cases are not native OS certification.
