### PR TITLE
fix(projects): preserve drafts and authoritative project state

### DIFF
--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -3295,6 +3295,55 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
+  it.each([
+    { hasPriorOwner: true, changedProjectId: 'project-a' },
+    { hasPriorOwner: false, changedProjectId: 'project-a' },
+    { hasPriorOwner: false, changedProjectId: 'project-b' }
+  ])(
+    'scopes pending adoption retirement to $changedProjectId (prior owner: $hasPriorOwner)',
+    async ({ hasPriorOwner, changedProjectId }) => {
+      const adoption = createDeferred<void>()
+      const created: ReturnType<typeof createFakeRuntime>[] = []
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: [`session-${created.length}`],
+          callbacks,
+          ...(created.length === 0 ? {} : { beforeResume: () => adoption.promise })
+        })
+        created.push(fake)
+        return fake.runtime
+      })
+      const sessionId = hasPriorOwner
+        ? (await coordinator.createSession({ projectId: 'project-a' })).sessionId
+        : 'restored-session'
+      const resume = coordinator.resumeSession({
+        sessionId,
+        projectId: 'project-a',
+        cwd: '/workspace',
+        previousFrameworkId: 'claude-code',
+        agentTarget: {
+          frameworkId: 'claude-code',
+          providerId: 'incoming-provider',
+          model: 'model',
+          reasoningEffort: 'high'
+        }
+      })
+      await vi.waitFor(() => expect(created[1]?.resumeSession).toHaveBeenCalledOnce())
+      await coordinator.requestProjectAgentContextReload(changedProjectId)
+      adoption.resolve()
+      if (changedProjectId === 'project-a') {
+        expect.soft(created[1].requestRetirement).toHaveBeenCalledOnce()
+        await expect(resume).rejects.toThrow('adoption was superseded')
+      } else {
+        expect(created[1].requestRetirement).not.toHaveBeenCalled()
+        await expect(resume).resolves.toMatchObject({ sessionId })
+        await coordinator.sendPrompt({ sessionId, text: 'Continue without another resume' })
+        expect(created[1].sendPrompt).toHaveBeenCalledOnce()
+      }
+    }
+  )
+
   it('publishes prompt ownership only from the runtime that currently owns the session', async () => {
     const retirement = createDeferred<void>()
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -3344,6 +3344,60 @@ describe('AcpRuntimeCoordinator', () => {
     }
   )
 
+  it.each(['project-a', 'project-b'])(
+    'scopes unpublished session creation retirement to %s',
+    async (changedProjectId) => {
+      const creation = createDeferred<void>()
+      const created: ReturnType<typeof createFakeRuntime>[] = []
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: [`session-${created.length}`],
+          callbacks
+        })
+        const createSession =
+          fake.createSession.getMockImplementation() as AcpRuntime['createSession']
+        fake.createSession.mockImplementation(async (request) => {
+          await creation.promise
+          return createSession(request)
+        })
+        created.push(fake)
+        return fake.runtime
+      })
+      const pending = coordinator.createSession({ projectId: 'project-a' })
+      await vi.waitFor(() => expect(created[0].createSession).toHaveBeenCalledOnce())
+      await coordinator.requestProjectAgentContextReload(changedProjectId)
+      creation.resolve()
+      const session = await pending
+      const prompt = coordinator.sendPrompt({
+        sessionId: session.sessionId,
+        text: 'Use current project context'
+      })
+      if (changedProjectId === 'project-a') {
+        expect.soft(created[0].requestRetirement).toHaveBeenCalledOnce()
+        await expect(prompt).rejects.toThrow('resume')
+      } else {
+        expect(created[0].requestRetirement).not.toHaveBeenCalled()
+        await expect(prompt).resolves.toMatchObject({ stopReason: 'end_turn' })
+      }
+    }
+  )
+
+  it('removes failed session creations from project-context retirement', async () => {
+    const created: ReturnType<typeof createFakeRuntime>[] = []
+    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+      const fake = createFakeRuntime({ frameworkId: 'claude-code', sessionIds: [], callbacks })
+      fake.createSession.mockRejectedValue(new Error('creation failed'))
+      created.push(fake)
+      return fake.runtime
+    })
+    await expect(coordinator.createSession({ projectId: 'project-a' })).rejects.toThrow(
+      'creation failed'
+    )
+    await coordinator.requestProjectAgentContextReload('project-a')
+    expect(created[0].requestRetirement).not.toHaveBeenCalled()
+  })
+
   it('publishes prompt ownership only from the runtime that currently owns the session', async () => {
     const retirement = createDeferred<void>()
     const created: ReturnType<typeof createFakeRuntime>[] = []

--- a/src/main/acp/runtime-coordinator.test.ts
+++ b/src/main/acp/runtime-coordinator.test.ts
@@ -3199,79 +3199,101 @@ describe('AcpRuntimeCoordinator', () => {
     await reloadRequest
   })
 
-  it('uses a fresh runtime generation on the next prompt after Project Agent Context changes', async () => {
-    let storedAgentContext = 'Always cite DOIs.'
-    const promptContexts: string[] = []
-    const created: ReturnType<typeof createFakeRuntime>[] = []
-    const coordinator = new AcpRuntimeCoordinator((callbacks) => {
-      const generationAgentContext = storedAgentContext
-      const fake = createFakeRuntime({
-        frameworkId: 'claude-code',
-        sessionIds: created.length === 0 ? ['agent-session'] : ['fresh-session'],
-        callbacks,
-        prompt: async () => {
-          promptContexts.push(generationAgentContext)
-          return { stopReason: 'end_turn' }
-        }
+  it.each(['Prefer Python.', ''])(
+    'reloads only the affected project runtime when context becomes %j',
+    async (nextContext) => {
+      let storedAgentContext = 'Always cite DOIs.'
+      const promptContexts: string[] = []
+      const created: ReturnType<typeof createFakeRuntime>[] = []
+      const coordinator = new AcpRuntimeCoordinator((callbacks) => {
+        const generationAgentContext = storedAgentContext
+        const fake = createFakeRuntime({
+          frameworkId: 'claude-code',
+          sessionIds: created.length === 0 ? ['agent-session'] : ['fresh-session'],
+          callbacks,
+          prompt: async () => {
+            promptContexts.push(generationAgentContext)
+            return { stopReason: 'end_turn' }
+          }
+        })
+        created.push(fake)
+        return fake.runtime
       })
-      created.push(fake)
-      return fake.runtime
-    })
-    const project = {
-      id: 'project-1',
-      name: 'Research',
-      description: '',
-      agentContext: storedAgentContext,
-      isExample: false,
-      createdAt: 1,
-      updatedAt: 2
-    }
-    const repository = {
-      list: vi.fn(),
-      get: vi.fn(async () => ({ ...project, agentContext: storedAgentContext })),
-      create: vi.fn(),
-      update: vi.fn(async (request) => {
-        storedAgentContext = request.agentContext ?? storedAgentContext
-        return { ...project, agentContext: storedAgentContext, updatedAt: 3 }
-      })
-    }
-    const handlers = createProjectHandlers(
-      repository,
-      {
-        deleteProject: vi.fn(),
-        listDeletionCleanup: vi.fn().mockResolvedValue([]),
-        retryDeletionCleanup: vi.fn(),
-        waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
-      },
-      {
-        updateArchive: vi.fn(),
-        onAgentContextChanged: () => {
-          void coordinator.requestProjectAgentContextReload()
-        }
+      const project = {
+        id: 'project-1',
+        name: 'Research',
+        description: '',
+        agentContext: storedAgentContext,
+        isExample: false,
+        createdAt: 1,
+        updatedAt: 2
       }
-    )
-    const session = await coordinator.createSession({ projectId: project.id })
+      const repository = {
+        list: vi.fn(),
+        get: vi.fn(async () => ({ ...project, agentContext: storedAgentContext })),
+        create: vi.fn(),
+        update: vi.fn(async (request) => {
+          storedAgentContext = request.agentContext ?? storedAgentContext
+          return { ...project, agentContext: storedAgentContext, updatedAt: 3 }
+        })
+      }
+      const handlers = createProjectHandlers(
+        repository,
+        {
+          deleteProject: vi.fn(),
+          listDeletionCleanup: vi.fn().mockResolvedValue([]),
+          retryDeletionCleanup: vi.fn(),
+          waitForProjectOperations: vi.fn().mockResolvedValue(undefined)
+        },
+        {
+          updateArchive: vi.fn(),
+          onAgentContextChanged: (projectId) => {
+            void coordinator.requestProjectAgentContextReload(projectId)
+          }
+        }
+      )
+      const session = await coordinator.createSession({ projectId: project.id })
 
-    await handlers.update({
-      id: project.id,
-      agentContext: 'Prefer Python.',
-      expectedUpdatedAt: project.updatedAt
-    })
+      const other = await coordinator.createSession({
+        projectId: 'project-b',
+        agentTarget: {
+          frameworkId: 'claude-code',
+          providerId: 'provider-b',
+          model: 'model',
+          reasoningEffort: 'high'
+        }
+      })
+      const otherRuntime = created.find((fake) =>
+        fake.createSession.mock.calls.some(([request]) => request?.projectId === 'project-b')
+      )!
+      const affectedRuntime = created[0]
 
-    expect(coordinator.getSnapshot().sessionIds).not.toContain(session.sessionId)
-    await coordinator.resumeSession({
-      sessionId: session.sessionId,
-      cwd: '/workspace',
-      projectId: project.id,
-      previousFrameworkId: 'claude-code'
-    })
-    await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'Use the current policy' })
+      await handlers.update({
+        id: project.id,
+        agentContext: nextContext,
+        expectedUpdatedAt: project.updatedAt
+      })
 
-    expect(promptContexts).toEqual(['Prefer Python.'])
-    expect(created[0].sendPrompt).not.toHaveBeenCalled()
-    expect(created[1].resumeSession).toHaveBeenCalledOnce()
-    expect(created[1].sendPrompt).toHaveBeenCalledOnce()
-  })
+      expect.soft(otherRuntime.requestRetirement).not.toHaveBeenCalled()
+      expect.soft(coordinator.getSnapshot().sessionIds).toContain(other.sessionId)
+      expect(affectedRuntime.requestRetirement).toHaveBeenCalledOnce()
+      expect(coordinator.getSnapshot().sessionIds).not.toContain(session.sessionId)
+      await coordinator.resumeSession({
+        sessionId: session.sessionId,
+        cwd: '/workspace',
+        projectId: project.id,
+        previousFrameworkId: 'claude-code'
+      })
+      await coordinator.sendPrompt({ sessionId: session.sessionId, text: 'Use the current policy' })
+
+      expect(promptContexts).toEqual([nextContext])
+      expect(created[0].sendPrompt).not.toHaveBeenCalled()
+      expect(created.at(-1)!.resumeSession).toHaveBeenCalledOnce()
+      expect(created.at(-1)!.sendPrompt).toHaveBeenCalledOnce()
+      await coordinator.sendPrompt({ sessionId: other.sessionId, text: 'Continue without resume' })
+      expect(otherRuntime.sendPrompt).toHaveBeenCalledOnce()
+    }
+  )
 
   it('publishes prompt ownership only from the runtime that currently owns the session', async () => {
     const retirement = createDeferred<void>()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -1416,10 +1416,14 @@ class AcpRuntimeCoordinator {
     await this.retireRuntimeGenerations(this.runtimes)
   }
 
-  async requestProjectAgentContextReload(): Promise<void> {
-    // Project Agent Context is captured during Session setup. Retire every generation so its idle
-    // Sessions resume with the current Project value before their next prompt.
-    await this.retireRuntimeGenerations(this.runtimes)
+  async requestProjectAgentContextReload(projectId: string): Promise<void> {
+    // Context is captured during Session setup. Shared generations still retire together,
+    // but generations serving only unrelated Projects can keep their Sessions connected.
+    const affected = new Set<AcpRuntime>()
+    for (const [sessionId, runtime] of this.sessionRuntimes) {
+      if (runtime.liveSessionProjectId(sessionId) === projectId) affected.add(runtime)
+    }
+    await this.retireRuntimeGenerations(affected)
   }
 
   async requestSkillsReloadForFramework(frameworkId: AgentFrameworkId): Promise<void> {

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -174,6 +174,7 @@ class AcpRuntimeCoordinator {
   ) => Promise<void>
   private promptAdmissionClosedForQuit = false
   private providerShutdownStartedForQuit = false
+  private readonly pendingSessionCreations = new Set<{ runtime: AcpRuntime; projectId?: string }>()
   private readonly pendingSessionAdoptions = new Map<
     string,
     { runtime: AcpRuntime; projectId?: string }
@@ -554,12 +555,16 @@ class AcpRuntimeCoordinator {
   async createSession(request: AcpCreateSessionRequest = {}): Promise<AcpCreateSessionResponse> {
     await this.waitForInitialization()
     const runtime = this.runtimeForTarget(request.agentTarget)
+    const pending = { runtime, projectId: request.projectId }
+    this.pendingSessionCreations.add(pending)
     let response: AcpCreateSessionResponse
     try {
       response = await runtime.createSession(request)
     } catch (error) {
       await this.retireUnusedTargetedRuntime(runtime)
       throw error
+    } finally {
+      this.pendingSessionCreations.delete(pending)
     }
     this.sessionRuntimes.set(response.sessionId, runtime)
     this.lastRuntime = runtime
@@ -1442,6 +1447,9 @@ class AcpRuntimeCoordinator {
     for (const pending of this.pendingSessionAdoptions.values()) {
       if (pending.projectId === projectId) affected.add(pending.runtime)
     }
+    for (const pending of this.pendingSessionCreations) {
+      if (pending.projectId === projectId) affected.add(pending.runtime)
+    }
     await this.retireRuntimeGenerations(affected)
   }
 
@@ -2064,6 +2072,7 @@ class AcpRuntimeCoordinator {
     this.retiredRuntimes.clear()
     this.targetedRuntimes.clear()
     this.sessionRuntimes.clear()
+    this.pendingSessionCreations.clear()
     this.pendingSessionAdoptions.clear()
     this.pendingResumeReconciliations.clear()
     for (const pending of this.pendingSessionDrains.values()) pending.resolve()

--- a/src/main/acp/runtime-coordinator.ts
+++ b/src/main/acp/runtime-coordinator.ts
@@ -174,7 +174,10 @@ class AcpRuntimeCoordinator {
   ) => Promise<void>
   private promptAdmissionClosedForQuit = false
   private providerShutdownStartedForQuit = false
-  private readonly pendingSessionAdoptions = new Map<string, AcpRuntime>()
+  private readonly pendingSessionAdoptions = new Map<
+    string,
+    { runtime: AcpRuntime; projectId?: string }
+  >()
   private readonly pendingResumeReconciliations = new Map<string, PendingResumeReconciliation>()
   private readonly pendingSessionDrains = new Map<string, PendingSessionDrain>()
   // The latest user-originated prompt is retained only long enough to construct an app-owned
@@ -592,13 +595,21 @@ class AcpRuntimeCoordinator {
     // Keep the prior owner authoritative until adoption finishes. The renderer does not create the
     // incoming optimistic run until this promise resolves, so terminal events emitted while the old
     // generation drains can still settle its own Runtime Segment without touching the next one.
-    if (transfersOwnership) this.pendingSessionAdoptions.set(request.sessionId, runtime)
+    if (transfersOwnership) {
+      this.pendingSessionAdoptions.set(request.sessionId, {
+        runtime,
+        projectId: request.projectId ?? owner?.liveSessionProjectId(request.sessionId)
+      })
+    }
 
     let response: AcpCreateSessionResponse
     try {
       response = await runtime.resumeSession(request)
     } catch (error) {
-      if (transfersOwnership && this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
+      if (
+        transfersOwnership &&
+        this.pendingSessionAdoptions.get(request.sessionId)?.runtime === runtime
+      ) {
         this.pendingSessionAdoptions.delete(request.sessionId)
       }
       await this.retireUnusedTargetedRuntime(runtime)
@@ -614,17 +625,20 @@ class AcpRuntimeCoordinator {
 
     if (
       transfersOwnership &&
-      (this.pendingSessionAdoptions.get(request.sessionId) !== runtime ||
+      (this.pendingSessionAdoptions.get(request.sessionId)?.runtime !== runtime ||
         !this.runtimes.has(runtime) ||
         this.retiredRuntimes.has(runtime))
     ) {
-      if (this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
+      if (this.pendingSessionAdoptions.get(request.sessionId)?.runtime === runtime) {
         this.pendingSessionAdoptions.delete(request.sessionId)
       }
       throw new Error('ACP session adoption was superseded before ownership could commit')
     }
 
-    if (transfersOwnership && this.pendingSessionAdoptions.get(request.sessionId) === runtime) {
+    if (
+      transfersOwnership &&
+      this.pendingSessionAdoptions.get(request.sessionId)?.runtime === runtime
+    ) {
       this.pendingSessionAdoptions.delete(request.sessionId)
     }
 
@@ -1423,6 +1437,11 @@ class AcpRuntimeCoordinator {
     for (const [sessionId, runtime] of this.sessionRuntimes) {
       if (runtime.liveSessionProjectId(sessionId) === projectId) affected.add(runtime)
     }
+    // A resume may have captured context before publishing any live Session. Its request's
+    // Project identity must participate even while the prior owner remains authoritative.
+    for (const pending of this.pendingSessionAdoptions.values()) {
+      if (pending.projectId === projectId) affected.add(pending.runtime)
+    }
     await this.retireRuntimeGenerations(affected)
   }
 
@@ -1835,7 +1854,7 @@ class AcpRuntimeCoordinator {
       // resumeSession owns the handoff commit. AcpRuntime emits its attached snapshot just before the
       // resume promise resolves; treating that intermediate state as ownership would again suppress
       // terminal events from the draining generation during the adoption window.
-      if (this.pendingSessionAdoptions.get(sessionId) === runtime) continue
+      if (this.pendingSessionAdoptions.get(sessionId)?.runtime === runtime) continue
 
       const owner = this.sessionRuntimes.get(sessionId)
       // A late state emission from a retiring runtime must not steal back a session already adopted by
@@ -1896,7 +1915,7 @@ class AcpRuntimeCoordinator {
       this.onSessionUnavailable?.(sessionId)
     }
     for (const [sessionId, incoming] of this.pendingSessionAdoptions) {
-      if (incoming === runtime) this.pendingSessionAdoptions.delete(sessionId)
+      if (incoming.runtime === runtime) this.pendingSessionAdoptions.delete(sessionId)
     }
     for (const [sessionId, pending] of this.pendingResumeReconciliations) {
       if (pending.runtime === runtime) this.pendingResumeReconciliations.delete(sessionId)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1301,10 +1301,10 @@ const createApplicationModules = async (
   })
   const projectHandlers = createProjectHandlers(projectRepository, projectDeletionCoordinator, {
     updateArchive: (request) => archiveCoordinator.updateProjectArchive(request),
-    onAgentContextChanged: () => {
+    onAgentContextChanged: (projectId) => {
       // Runtime generations capture Project Agent Context during Session setup. Retiring them marks
       // idle Sessions for resume immediately; an in-flight turn drains before its next prompt.
-      void runtimeRef.current?.requestProjectAgentContextReload()
+      void runtimeRef.current?.requestProjectAgentContextReload(projectId)
     }
   })
   const projectFilesHandlers = createProjectFilesHandlers(

--- a/src/renderer/src/pages/home/HomePage.render.test.tsx
+++ b/src/renderer/src/pages/home/HomePage.render.test.tsx
@@ -1736,6 +1736,33 @@ describe('HomePage activity overview', () => {
     expect(recentRow?.textContent?.match(/Live analysis/g)).toHaveLength(1)
   })
 
+  it('shows loading until the first project list resolves, then shows the empty state', async () => {
+    let resolve!: (projects: Project[]) => void
+    window.api.projects = {
+      list: vi.fn(
+        () =>
+          new Promise<Project[]>((done) => {
+            resolve = done
+          })
+      )
+    } as never
+    const load = useProjectStore.getState().loadProjects()
+    await act(async () =>
+      root.render(
+        <HomePage canDeleteProjects hasCompleteSessionCatalog onOpenGlobalSearch={vi.fn()} />
+      )
+    )
+    const section = container.querySelector('[aria-label="Projects"]')!
+    expect.soft(section.textContent).not.toContain('No projects yet.')
+    expect.soft(section.querySelector('[role="status"]')?.textContent).toBe('Loading…')
+    await act(async () => {
+      resolve([])
+      await load
+    })
+    expect(section.textContent).toContain('No projects yet. Create one to get started.')
+    expect(section.querySelector('[role="status"]')).toBeNull()
+  })
+
   it('offers a Retry action when loading Projects fails', async () => {
     const loadProjects = vi.fn().mockResolvedValue(undefined)
     useProjectStore.setState({

--- a/src/renderer/src/pages/home/HomePage.tsx
+++ b/src/renderer/src/pages/home/HomePage.tsx
@@ -176,6 +176,7 @@ const HomePage = ({
 }: HomePageProps): React.JSX.Element => {
   const { t } = useTranslation()
   const projects = useProjectStore((state) => state.projects)
+  const isProjectsLoaded = useProjectStore((state) => state.isLoaded)
   const loadError = useProjectStore((state) => state.loadError)
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const updateProject = useProjectStore((state) => state.updateProject)
@@ -912,6 +913,10 @@ const HomePage = ({
                   >
                     {isRetryingProjects ? t('Retrying...') : t('Retry')}
                   </Button>
+                </div>
+              ) : !isProjectsLoaded && projectSummaries.length === 0 ? (
+                <div role="status" className="px-4 py-10 text-center text-sm text-muted-foreground">
+                  {t('Loading…')}
                 </div>
               ) : projectSummaries.length === 0 ? (
                 <div className="rounded-2xl border border-dashed border-border-200/70 px-4 py-10 text-center text-sm text-muted-foreground">

--- a/src/renderer/src/pages/home/ProjectFormDialog.behavior.test.tsx
+++ b/src/renderer/src/pages/home/ProjectFormDialog.behavior.test.tsx
@@ -49,12 +49,21 @@ describe('project form public submission behavior', () => {
       render(<Harness />)
       fireEvent.click(screen.getByText(mode === 'create' ? 'Create fixture' : 'Edit fixture'))
       fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Research' } })
+      fireEvent.change(screen.getByLabelText('Description'), {
+        target: { value: 'Draft description' }
+      })
+      fireEvent.change(screen.getByLabelText('Agent Context'), {
+        target: { value: 'Draft context' }
+      })
       const submit = screen.getByRole('button', {
         name: mode === 'create' ? 'Create project' : 'Save'
       }) as HTMLButtonElement
       fireEvent.click(submit)
       expect(request).toHaveBeenCalledOnce()
       try {
+        for (const label of ['Name', 'Description', 'Agent Context']) {
+          expect.soft((screen.getByLabelText(label) as HTMLInputElement).disabled).toBe(true)
+        }
         expect
           .soft((screen.getByRole('button', { name: 'Close' }) as HTMLButtonElement).disabled)
           .toBe(true)
@@ -70,7 +79,17 @@ describe('project form public submission behavior', () => {
       expect((screen.getByRole('button', { name: 'Cancel' }) as HTMLButtonElement).disabled).toBe(
         false
       )
-      expect(screen.getByLabelText('Name').getAttribute('value')).toBe('Research')
+      for (const [label, value] of [
+        ['Name', 'Research'],
+        ['Description', 'Draft description'],
+        ['Agent Context', 'Draft context']
+      ]) {
+        const field = screen.getByLabelText(label) as HTMLInputElement
+        expect(field.disabled).toBe(false)
+        expect(field.value).toBe(value)
+        fireEvent.change(field, { target: { value: value + ' recovered' } })
+        expect(field.value).toBe(value + ' recovered')
+      }
     }
   )
 

--- a/src/renderer/src/pages/home/ProjectFormDialog.tsx
+++ b/src/renderer/src/pages/home/ProjectFormDialog.tsx
@@ -107,6 +107,7 @@ const ProjectFormDialog = ({
                 </label>
                 <Input
                   id="project-form-name"
+                  disabled={isSubmitting}
                   aria-required={true}
                   value={nameDraft}
                   onChange={(event) => onNameChange(event.target.value)}
@@ -127,6 +128,7 @@ const ProjectFormDialog = ({
                 </p>
                 <textarea
                   id="project-form-description"
+                  disabled={isSubmitting}
                   aria-describedby="project-form-description-help"
                   value={descriptionDraft}
                   onChange={(event) => onDescriptionChange(event.target.value)}
@@ -147,6 +149,7 @@ const ProjectFormDialog = ({
                 </p>
                 <textarea
                   id="project-form-agent-context"
+                  disabled={isSubmitting}
                   aria-describedby="project-form-agent-context-help"
                   value={agentContextDraft}
                   onChange={(event) => onAgentContextChange(event.target.value)}

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -174,7 +174,8 @@ describe('project store', () => {
   it('does not let a late update result replace a newer lifecycle projection', async () => {
     const original = createProject({ name: 'Original', updatedAt: 1 })
     const command = createDeferred<Project>()
-    setProjectsApi({ update: vi.fn().mockReturnValue(command.promise) })
+    const list = vi.fn()
+    setProjectsApi({ update: vi.fn().mockReturnValue(command.promise), list })
     useProjectStore.setState({ projects: [original], isLoaded: true })
 
     const update = useProjectStore
@@ -187,6 +188,7 @@ describe('project store', () => {
     await update
 
     expect(useProjectStore.getState().projects).toEqual([lifecycle])
+    expect(list).not.toHaveBeenCalled()
   })
 
   it.each([
@@ -219,6 +221,80 @@ describe('project store', () => {
       expect(useProjectStore.getState().projects).toEqual([authority])
     }
   )
+
+  it.each(['update', 'archive', 'delete'] as const)(
+    'refreshes authority when a later list reads before an earlier %s commits',
+    async (operation) => {
+      const original = createProject()
+      const updated = createProject({
+        name: 'Committed update',
+        updatedAt: 30,
+        archivedAt: 40,
+        archiveRevision: 1
+      })
+      const command = createDeferred<Project>()
+      const deletion = createDeferred<{ status: 'cleanup-pending' }>()
+      const authority = operation === 'delete' ? [] : [updated]
+      const cleanup = [{ projectId: original.id, phase: 'running' as const, failureCount: 0 }]
+      const list = vi.fn().mockResolvedValueOnce([original]).mockResolvedValue(authority)
+      setProjectsApi({
+        list,
+        update: vi.fn().mockReturnValue(command.promise),
+        updateArchive: vi.fn().mockReturnValue(command.promise),
+        delete: vi.fn().mockReturnValue(deletion.promise),
+        listDeletionCleanup: vi.fn().mockResolvedValue(cleanup)
+      })
+      useProjectStore.setState({ projects: [original] })
+      const mutation =
+        operation === 'delete'
+          ? useProjectStore.getState().deleteProject(original.id)
+          : operation === 'archive'
+            ? useProjectStore.getState().updateProjectArchive({
+                id: original.id,
+                archived: true,
+                expectedArchiveRevision: 0
+              })
+            : useProjectStore.getState().updateProject({
+                id: original.id,
+                name: updated.name,
+                expectedUpdatedAt: original.updatedAt
+              })
+      await useProjectStore.getState().loadProjects()
+      expect(useProjectStore.getState().projects).toEqual([original])
+      command.resolve(updated)
+      deletion.resolve({ status: 'cleanup-pending' })
+      await mutation
+      expect(useProjectStore.getState().projects).toEqual(authority)
+      expect(list).toHaveBeenCalledTimes(2)
+      if (operation === 'delete')
+        expect(useProjectStore.getState().deletionCleanup).toEqual(cleanup)
+    }
+  )
+
+  it('keeps the accepted projection and successful mutation result when reconciliation fails', async () => {
+    const command = createDeferred<Project>()
+    const accepted = createProject({ name: 'Accepted', updatedAt: 30 })
+    const result = createProject({ name: 'Delayed reply', updatedAt: 20 })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+    setProjectsApi({
+      update: vi.fn().mockReturnValue(command.promise),
+      list: vi.fn().mockResolvedValueOnce([accepted]).mockRejectedValue(new Error('read failed'))
+    })
+    try {
+      const update = useProjectStore
+        .getState()
+        .updateProject({ id: result.id, name: result.name, expectedUpdatedAt: 1 })
+      await useProjectStore.getState().loadProjects()
+      command.resolve(result)
+      await expect(update).resolves.toEqual(result)
+      expect(useProjectStore.getState().projects).toEqual([accepted])
+      expect(useProjectStore.getState().loadError).toBe(
+        'Open Science could not load projects. Retry to continue.'
+      )
+    } finally {
+      warn.mockRestore()
+    }
+  })
 
   it('allows a later-started pending update to commit after an earlier list resolves', async () => {
     const snapshot = createDeferred<Project[]>()

--- a/src/renderer/src/stores/project-store.test.ts
+++ b/src/renderer/src/stores/project-store.test.ts
@@ -189,6 +189,71 @@ describe('project store', () => {
     expect(useProjectStore.getState().projects).toEqual([lifecycle])
   })
 
+  it.each([
+    { name: 'content', nameValue: 'Authority', updatedAt: 30 },
+    { name: 'management fields', nameValue: 'Original', updatedAt: 1 }
+  ])(
+    'keeps a later list projection over an old update reply: $name',
+    async ({ nameValue, updatedAt }) => {
+      const original = createProject()
+      const command = createDeferred<Project>()
+      const authority = createProject({
+        name: nameValue,
+        updatedAt,
+        pinned: true,
+        archivedAt: 40,
+        archiveRevision: 2
+      })
+      setProjectsApi({
+        update: vi.fn().mockReturnValue(command.promise),
+        list: vi.fn().mockResolvedValue([authority])
+      })
+      useProjectStore.setState({ projects: [original] })
+      const update = useProjectStore
+        .getState()
+        .updateProject({ id: original.id, name: 'Command', expectedUpdatedAt: 1 })
+      await useProjectStore.getState().loadProjects()
+      expect(useProjectStore.getState().projects).toEqual([authority])
+      command.resolve(createProject({ name: 'Command', updatedAt: 20 }))
+      await update
+      expect(useProjectStore.getState().projects).toEqual([authority])
+    }
+  )
+
+  it('allows a later-started pending update to commit after an earlier list resolves', async () => {
+    const snapshot = createDeferred<Project[]>()
+    const command = createDeferred<Project>()
+    const updated = createProject({ name: 'Updated', updatedAt: 30 })
+    setProjectsApi({
+      list: vi.fn().mockReturnValue(snapshot.promise),
+      update: vi.fn().mockReturnValue(command.promise)
+    })
+    const load = useProjectStore.getState().loadProjects()
+    const update = useProjectStore
+      .getState()
+      .updateProject({ id: updated.id, name: updated.name, expectedUpdatedAt: 1 })
+    snapshot.resolve([createProject()])
+    await load
+    command.resolve(updated)
+    await update
+    expect(useProjectStore.getState().projects).toEqual([updated])
+  })
+
+  it('refreshes an older pending list after a newer update completes', async () => {
+    const staleList = createDeferred<Project[]>()
+    const authority = createProject({ name: 'Updated', updatedAt: 30 })
+    const list = vi.fn().mockReturnValueOnce(staleList.promise).mockResolvedValueOnce([authority])
+    setProjectsApi({ list, update: vi.fn().mockResolvedValue(authority) })
+    const load = useProjectStore.getState().loadProjects()
+    await useProjectStore
+      .getState()
+      .updateProject({ id: authority.id, name: authority.name, expectedUpdatedAt: 1 })
+    staleList.resolve([createProject()])
+    await load
+    expect(list).toHaveBeenCalledTimes(2)
+    expect(useProjectStore.getState().projects).toEqual([authority])
+  })
+
   it('lets the later-started update win when both commands begin from the same projection', async () => {
     const original = createProject({ name: 'Original', updatedAt: 1 })
     const first = createDeferred<Project>()

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -179,6 +179,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
 
   // Applies an editable Project patch and merges the updated row into the cache.
   updateProject: async (request) => {
+    const loadSequence = projectLoadSequence
     const generation = beginProjectProjection()
     const project = await window.api.projects.update(request)
     if (!project) return undefined
@@ -189,12 +190,16 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     projectMutationSequence += 1
     if (commitProjectProjection(project.id, generation)) {
       set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+    } else if (loadSequence !== projectLoadSequence) {
+      // The overlapping read may predate the DB commit. Re-read instead of applying a stale reply.
+      await get().loadProjects()
     }
 
     return project
   },
 
   updateProjectArchive: async (request) => {
+    const loadSequence = projectLoadSequence
     const generation = beginProjectProjection()
     let project: Project
     try {
@@ -216,12 +221,16 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
     projectMutationSequence += 1
     if (commitProjectProjection(project.id, generation)) {
       set((state) => ({ projects: upsertProjectList(state.projects, project) }))
+    } else if (loadSequence !== projectLoadSequence) {
+      // The overlapping read may predate the DB commit. Re-read instead of applying a stale reply.
+      await get().loadProjects()
     }
     return project
   },
 
   // Drops committed Project deletion from the cache. Session cascade is handled by the session store.
   deleteProject: async (id) => {
+    const loadSequence = projectLoadSequence
     const projectionGeneration = beginProjectProjection()
     const generation = ++projectOperationGeneration
     set((state) => {
@@ -264,6 +273,9 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
         projectDeletionRequests
       }
     })
+    if (!ownsProjection && loadSequence !== projectLoadSequence) {
+      await Promise.all([get().loadProjects(), get().loadDeletionCleanup()])
+    }
     return outcome
   },
 

--- a/src/renderer/src/stores/project-store.ts
+++ b/src/renderer/src/stores/project-store.ts
@@ -109,6 +109,7 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
   loadProjects: async () => {
     const loadSequence = ++projectLoadSequence
     const mutationSequence = projectMutationSequence
+    const generation = beginProjectProjection()
     try {
       const projects = await window.api.projects.list()
       if (loadSequence !== projectLoadSequence) return
@@ -117,6 +118,11 @@ export const useProjectStore = create<ProjectStore>((set, get) => ({
         return
       }
 
+      // An accepted snapshot supersedes earlier replies, including rows it has removed.
+      // Use the read's start order so a later-started pending command can still commit.
+      for (const project of [...get().projects, ...projects]) {
+        commitProjectProjection(project.id, generation)
+      }
       set({ projects: sortByUpdatedDesc(projects), isLoaded: true, loadError: undefined })
     } catch (error) {
       if (loadSequence !== projectLoadSequence) return


### PR DESCRIPTION
Project saves could accept edits that were discarded when an older submission closed the dialog, and delayed update replies could roll the renderer cache back after a newer list refresh. Changing one project's Agent Context also retired independent runtimes serving other projects, while initial loading incorrectly displayed the empty-project message.

This change:
- Disables all three shared create/edit form inputs while saving; failures retain the draft and restore editing.
- Applies accepted list snapshots to the existing per-project projection generations, preserving request ordering without relying on timestamps for pin/archive state.
- Passes the changed project ID through the production callback and retires only runtime generations owning sessions in that project. Shared generations retain the existing conservative retirement behavior.
- Uses the existing loaded flag and translated loading text before displaying the empty-project state.

No database schema, persistent fields, dependencies, or runtime architecture changes.

Validation:
- Added/extended public-boundary regression tests before production changes. Two runs on unfixed code produced the same seven failures matching PH-01 through PH-04.
- Covers create/edit pending and failed submissions, both list/update return orders, lifecycle projection control, management fields, context replacement/clearing, independent-runtime continuity, and initial loading-to-empty transition.
- Final focused suite: 1,023 tests passed across seven files, including the i18n guard.
- Full suite: `npm test -- --maxWorkers=4` — 27,012 passed, 246 skipped (1,494 files passed, 17 skipped). Run outside the outer agent sandbox because local HTTP/RPC tests require loopback listeners.
- Node, sandbox, and renderer typechecks passed; changed-file ESLint and diff checks passed.
