### PR TITLE
fix(renderer): preserve preview focus and keyboard event ownership

### DIFF
--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -738,6 +738,34 @@ describe('App startup routing', () => {
     expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
   })
 
+  it.each(['metaKey', 'ctrlKey'] as const)(
+    'ignores repeated global search shortcuts with %s and permits a fresh press',
+    async (modifier) => {
+      mocks.settings.isLoaded = true
+      await render()
+      const press = async (repeat: boolean): Promise<void> => {
+        await act(async () => {
+          window.dispatchEvent(
+            new KeyboardEvent('keydown', {
+              key: 'k',
+              [modifier]: true,
+              repeat,
+              cancelable: true
+            })
+          )
+        })
+      }
+      await press(false)
+      expect(document.querySelector('[data-testid="global-search"]')).not.toBeNull()
+      for (let index = 0; index < 2; index++) {
+        await press(true)
+        expect(document.querySelector('[data-testid="global-search"]')).not.toBeNull()
+      }
+      await press(false)
+      expect(document.querySelector('[data-testid="global-search"]')).toBeNull()
+    }
+  )
+
   it('opens global search without rerendering the active Literature library page', async () => {
     mocks.settings.isLoaded = true
     mocks.navigation.view = 'library'

--- a/src/renderer/src/hooks/useApplicationEventBindings.ts
+++ b/src/renderer/src/hooks/useApplicationEventBindings.ts
@@ -273,6 +273,7 @@ const useApplicationEventBindings = ({
       if (
         event.defaultPrevented ||
         event.isComposing ||
+        event.repeat ||
         event.key.toLowerCase() !== 'k' ||
         !(event.metaKey || event.ctrlKey) ||
         !presentation.allowsShortcut('globalSearch')

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -87,6 +87,7 @@ vi.mock('./ManagedVersionDiffContent', () => ({
 }))
 
 import { PreviewFileSurface } from './PreviewFileSurface'
+import { PreviewPanelSurface } from './PreviewPanel'
 import { createPreviewFileItemFromPdfContext } from './preview-file-item'
 import { FOCUS_COMPOSER_EVENT } from './composer-focus-events'
 
@@ -1088,6 +1089,43 @@ describe('PreviewFileSurface managed text versions', () => {
       fileId: 'dialog-file',
       versionId: 'dialog-v3'
     })
+  })
+
+  it('preserves fullscreen editor focus on updates and guards Escape until discard is approved', async () => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(managedUploadItem)
+    await act(async () => root.render(<PreviewPanelSurface activeAnnotations={[]} />))
+    await click(container.querySelector('[aria-label="Open full screen preview of README.md"]'))
+    const fullscreen = container.querySelector<HTMLElement>('[role="dialog"]')!
+    await click(container.querySelector('[aria-label="Edit README.md"]'))
+    const textarea = container.querySelector<HTMLTextAreaElement>('textarea')!
+    await changeTextarea(textarea, '# Unsaved draft\n')
+    textarea.focus()
+    await act(async () => root.render(<PreviewPanelSurface activeAnnotations={[]} />))
+    expect(container.querySelector('textarea')).toBe(textarea)
+    expect(document.activeElement).toBe(textarea)
+    expect(textarea.value).toBe('# Unsaved draft\n')
+
+    const escape = async (): Promise<void> => {
+      await act(async () =>
+        textarea.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+        )
+      )
+    }
+    await escape()
+    expect(discardConfirmation()).not.toBeNull()
+    expect(fullscreen.getAttribute('role')).toBe('dialog')
+    await cancelDiscard()
+    expect(discardConfirmation()).toBeNull()
+    expect(fullscreen.getAttribute('role')).toBe('dialog')
+    expect(textarea.value).toBe('# Unsaved draft\n')
+    textarea.focus()
+    await escape()
+    await confirmDiscard()
+    expect(discardConfirmation()).toBeNull()
+    expect(container.querySelector('[role="dialog"]')).toBeNull()
+    expect(document.activeElement).toBe(container.querySelector('[role="tab"]'))
+    expect(usePreviewWorkbenchStore.getState().items).toHaveLength(1)
   })
 
   it('inspects uploads with the database file id and edits raw Markdown in a plain textarea', async () => {

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -172,6 +172,170 @@ describe('PreviewPanel', () => {
     expect(content.dataset.annotationCount).toBe('1')
   })
 
+  const openFullscreenFile = async (): Promise<HTMLElement> => {
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
+    await renderPanel({ activeAnnotations: [] })
+    await act(async () => {
+      container
+        .querySelector<HTMLButtonElement>('[aria-label="Open full screen preview of file-1.png"]')!
+        .click()
+    })
+    const dialog = container.querySelector<HTMLElement>('[role="dialog"]')!
+    expect(dialog).not.toBeNull()
+    expect(document.activeElement).toBe(dialog)
+    return dialog
+  }
+
+  it('preserves fullscreen content focus when annotation props change', async () => {
+    const dialog = await openFullscreenFile()
+    const content = dialog.querySelector<HTMLButtonElement>('[data-testid="file-content"]')!
+    content.focus()
+    expect(document.activeElement).toBe(content)
+    await act(async () => {
+      root.render(
+        <PreviewPanel
+          panelRef={{ current: null }}
+          defaultSize="40%"
+          minSize="30%"
+          onResize={vi.fn()}
+          activeAnnotations={[]}
+        />
+      )
+    })
+    expect(container.querySelector('[role="dialog"]')).toBe(dialog)
+    expect(dialog.querySelector('[data-testid="file-content"]')).toBe(content)
+    expect(document.activeElement).toBe(content)
+  })
+
+  it('keeps fullscreen open for Escape during composition', async () => {
+    const dialog = await openFullscreenFile()
+    const content = dialog.querySelector<HTMLButtonElement>('[data-testid="file-content"]')!
+    content.focus()
+    await act(async () => {
+      content.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+          isComposing: true
+        })
+      )
+    })
+    expect(container.querySelector('[role="dialog"]')).toBe(dialog)
+    expect(document.activeElement).toBe(content)
+  })
+
+  it.each(['preventDefault', 'stopPropagation'] as const)(
+    'keeps fullscreen open when content consumes Escape with %s',
+    async (consume) => {
+      const dialog = await openFullscreenFile()
+      const content = dialog.querySelector<HTMLButtonElement>('[data-testid="file-content"]')!
+      content.focus()
+      const handler = vi.fn((event: KeyboardEvent) => event[consume]())
+      content.addEventListener('keydown', handler)
+      try {
+        await act(async () => {
+          content.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+          )
+        })
+        expect(handler).toHaveBeenCalledOnce()
+        expect(container.querySelector('[role="dialog"]')).toBe(dialog)
+      } finally {
+        content.removeEventListener('keydown', handler)
+      }
+    }
+  )
+
+  it('wraps backward tab navigation from the initial fullscreen surface', async () => {
+    const dialog = await openFullscreenFile()
+    const buttons = dialog.querySelectorAll<HTMLButtonElement>('button:not([disabled])')
+    expect(buttons.length).toBeGreaterThan(0)
+    const event = new KeyboardEvent('keydown', {
+      key: 'Tab',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    })
+    await act(async () => {
+      dialog.dispatchEvent(event)
+    })
+    expect(event.defaultPrevented).toBe(true)
+    expect(document.activeElement).toBe(buttons[buttons.length - 1])
+  })
+
+  it.each(['file', 'tool'] as const)(
+    'keeps %s fullscreen Tab boundaries local and restores its tab after Escape',
+    async (kind) => {
+      let dialog: HTMLElement
+      if (kind === 'file') dialog = await openFullscreenFile()
+      else {
+        usePreviewWorkbenchStore.getState().upsertAndActivateItem(createToolItem({}))
+        await renderPanel()
+        await act(async () => usePreviewWorkbenchStore.getState().setToolItemExpanded('tool-1'))
+        dialog = container.querySelector<HTMLElement>('[role="dialog"]')!
+      }
+      // Tool content may supply its own controls; no private hook export is needed.
+      const first = document.createElement('input')
+      const last = document.createElement('button')
+      dialog.prepend(first)
+      dialog.append(last)
+      const tab = async (start: HTMLElement, shiftKey: boolean): Promise<void> => {
+        start.focus()
+        const event = new KeyboardEvent('keydown', {
+          key: 'Tab',
+          shiftKey,
+          bubbles: true,
+          cancelable: true
+        })
+        await act(async () => {
+          start.dispatchEvent(event)
+        })
+        expect(event.defaultPrevented).toBe(true)
+      }
+      await tab(dialog, true)
+      expect(document.activeElement).toBe(last)
+      await tab(last, false)
+      expect(document.activeElement).toBe(first)
+      await tab(first, true)
+      expect(document.activeElement).toBe(last)
+
+      const upper = document.createElement('button')
+      document.body.append(upper)
+      try {
+        upper.focus()
+        const upperTab = new KeyboardEvent('keydown', {
+          key: 'Tab',
+          shiftKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+        upper.dispatchEvent(upperTab)
+        expect(upperTab.defaultPrevented).toBe(false)
+        expect(document.activeElement).toBe(upper)
+        upper.addEventListener('keydown', () => first.focus(), { once: true })
+        await act(async () =>
+          upper.dispatchEvent(
+            new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+          )
+        )
+        expect(dialog.getAttribute('role')).toBe('dialog')
+        expect(document.activeElement).toBe(first)
+      } finally {
+        upper.remove()
+      }
+      await act(async () =>
+        first.dispatchEvent(
+          new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, cancelable: true })
+        )
+      )
+      expect(container.querySelector('[role="dialog"]')).toBeNull()
+      expect(document.activeElement).toBe(container.querySelector('[role="tab"]'))
+      first.remove()
+      last.remove()
+    }
+  )
+
   const renderTwoFileTabs = async (): Promise<void> => {
     usePreviewWorkbenchStore.getState().upsertAndActivateItem(createFileItem({}))
     usePreviewWorkbenchStore.getState().upsertItem(

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -498,19 +498,23 @@ const usePreviewModalSurface = ({
     surface?.focus()
 
     const handleKeyDown = (event: KeyboardEvent): void => {
+      if (event.defaultPrevented || event.isComposing) return
+      // A portal may restore focus here while handling this same event. Its original target
+      // still belongs to the upper layer, so do not close or trap focus in the layer below.
+      if (
+        !surface ||
+        !(event.target instanceof Node) ||
+        !surface.contains(event.target) ||
+        !surface.contains(document.activeElement)
+      ) {
+        return
+      }
       if (event.key === 'Escape') {
-        if (
-          surface &&
-          document.activeElement !== surface &&
-          !surface.contains(document.activeElement)
-        ) {
-          return
-        }
         event.preventDefault()
         onClose()
         return
       }
-      if (event.key !== 'Tab' || !surface) return
+      if (event.key !== 'Tab') return
 
       const focusable = Array.from(
         surface.querySelectorAll<HTMLElement>(PREVIEW_MODAL_FOCUSABLE_SELECTOR)
@@ -523,7 +527,10 @@ const usePreviewModalSurface = ({
 
       const first = focusable[0]
       const last = focusable.at(-1)
-      if (event.shiftKey && document.activeElement === first) {
+      if (
+        event.shiftKey &&
+        (document.activeElement === surface || document.activeElement === first)
+      ) {
         event.preventDefault()
         last?.focus()
       } else if (!event.shiftKey && document.activeElement === last) {
@@ -532,9 +539,9 @@ const usePreviewModalSurface = ({
       }
     }
 
-    document.addEventListener('keydown', handleKeyDown, true)
+    document.addEventListener('keydown', handleKeyDown)
     return () => {
-      document.removeEventListener('keydown', handleKeyDown, true)
+      document.removeEventListener('keydown', handleKeyDown)
       document.body.style.overflow = previousOverflow
       document.getElementById(getPreviewTabId(itemId))?.focus()
     }
@@ -573,7 +580,7 @@ const PreviewFilePanel = ({
 
   usePreviewModalSurface({
     isOpen: isFullScreenOpen,
-    onClose: () => closeFullScreen(true),
+    onClose: closeFullScreen,
     surfaceRef,
     itemId: item.id
   })


### PR DESCRIPTION
## Problem

Fullscreen file previews move focus away from content when annotation props rerender the parent. The shared file/tool modal also handles Escape before content consumers and composition, and misses backward Tab from its initially focused container. Holding Cmd/Ctrl+K repeatedly toggles global search.

## Proposed change

Reuse the stable file close callback, handle unconsumed keyboard events during bubbling, retain portal priority using both event target and focus, wrap initial backward Tab, and ignore repeated global-search shortcut events. File closure still goes through `requestLeave`.

## Scope and non-goals

Renderer keyboard behavior only. No new state fields, enums, dependencies, architecture, data models, persistence, or historical-data compatibility. Layout is unchanged. No claims about deleted text or bypassed save protection.

## Acceptance criteria and validation

Seven regression cases failed on unchanged production code in two consecutive runs, with failures matching the reported focus/dismissal/repeat symptoms. The second baseline run passed all 133 existing tests. The same seven regressions pass after the fix. Additional coverage exercises real editor draft protection, cancellation/approved discard, file/tool focus boundaries, portal focus restoration, and tab focus after closing.

Checks below ran after the last material source/test edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Parent updates, composition/content Escape consumers, initial/edge Tab, portal priority, close focus | `PreviewPanel.test.tsx` | Pass |
| Real editor retains focus/draft and uses unsaved confirmation | `PreviewFileSurface.test.tsx` | Pass |
| File-dialog close contract, workbench mutations and leave guard | `FilePreviewDialog.escape.test.tsx`, `preview-leave-guard.test.ts`, `preview-workbench-store.test.ts`, `preview-draft-lifecycle.test.tsx` | Pass |
| Cmd/Ctrl repeat, fresh presses, presentation ownership and related shortcut consumers | `App.test.tsx`, `app-shell-presentation-owner.test.ts`, `app-shell-presentation-owner.architecture.test.ts`, `useCloseActivePaneShortcut.test.ts`, `SettingsSearchInput.test.tsx` | Pass |
| Renderer types and lint | `npm run typecheck:web`; `npm run lint` | Pass |

The 11 files above ran together: **393 tests passed**.

```sh
npm test -- src/renderer/src/pages/workspace/PreviewPanel.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx src/renderer/src/stores/preview-leave-guard.test.ts src/renderer/src/stores/preview-workbench-store.test.ts src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx src/renderer/src/App.test.tsx src/renderer/src/app-shell-presentation-owner.test.ts src/renderer/src/app-shell-presentation-owner.architecture.test.ts src/renderer/src/hooks/useCloseActivePaneShortcut.test.ts src/renderer/src/pages/settings/SettingsSearchInput.test.tsx
```

A temporary browser harness mounts the actual `PreviewPanelSurface` and editor with a fixture backend. Chromium native keyboard events kept initial Shift+Tab and 16 successive forward/backward Tab steps inside fullscreen. Parent annotation updates preserved editor node/focus/draft; Escape displayed the unsaved confirmation. Screenshots are supplied in the maintainer task.

`npm run test:affected:explain -- --base origin/main --head HEAD` requests full fallback because the manifest does not own these files. Per maintainer instruction, the full local suite was not run; exact-head PR CI remains authoritative. Related renderer consumers are included above; no main/preload, filesystem, migration or packaging behavior changes. Browser checks are not full Electron E2E or real OS IME verification.

## Review focus

Confirm event ordering and portal ownership, stable callback identity, and preservation of the existing leave-guard chain. CI and independent review remain required before marking the final state verified.
