### PR TITLE
fix(i18n): correct singular counts and metadata date locales

### DIFF
--- a/src/renderer/src/components/NotificationBell.test.tsx
+++ b/src/renderer/src/components/NotificationBell.test.tsx
@@ -99,6 +99,32 @@ const stubMutableViewport = (): { setMobile: (mobile: boolean) => void } => {
 }
 
 describe('NotificationBell', () => {
+  it.each([
+    ['minute', 60_000],
+    ['hour', 3_600_000],
+    ['day', 86_400_000],
+    ['week', 7 * 86_400_000],
+    ['month', 40 * 86_400_000],
+    ['year', 365 * 86_400_000]
+  ] as const)('renders English singular and plural %s timestamps', async (unit, duration) => {
+    const now = Date.now()
+    const item = useNotificationInboxStore.getState().items[0]!
+    useNotificationInboxStore.setState({
+      items: [1, 2].map((count) => ({
+        ...item,
+        id: `message-${count}`,
+        createdAt: now - duration * count
+      }))
+    })
+    await act(async () => root.render(<NotificationBell />))
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[aria-label^="Messages,"]')?.click()
+    )
+    expect(document.body.textContent).toContain(`1 ${unit} ago`)
+    expect(document.body.textContent).toContain(`2 ${unit}s ago`)
+    expect(document.body.textContent).not.toContain(`1 ${unit}s ago`)
+  })
+
   it('renders a red-dot entry point with an accessible unread count and pending state', async () => {
     await act(async () => root.render(<NotificationBell />))
 

--- a/src/renderer/src/components/NotificationBell.tsx
+++ b/src/renderer/src/components/NotificationBell.tsx
@@ -121,12 +121,12 @@ const NotificationBellContent = ({
     const { unit, count } = relativeTimeParts(timestamp)
     if (unit === 'now') return t('just now')
     const labels = {
-      minute: t('{{count}} minutes ago', { count }),
-      hour: t('{{count}} hours ago', { count }),
-      day: t('{{count}} days ago', { count }),
-      week: t('{{count}} weeks ago', { count }),
-      month: t('{{count}} months ago', { count }),
-      year: t('{{count}} years ago', { count })
+      minute: t('{{count}} minutes ago', { count, defaultValue_one: '{{count}} minute ago' }),
+      hour: t('{{count}} hours ago', { count, defaultValue_one: '{{count}} hour ago' }),
+      day: t('{{count}} days ago', { count, defaultValue_one: '{{count}} day ago' }),
+      week: t('{{count}} weeks ago', { count, defaultValue_one: '{{count}} week ago' }),
+      month: t('{{count}} months ago', { count, defaultValue_one: '{{count}} month ago' }),
+      year: t('{{count}} years ago', { count, defaultValue_one: '{{count}} year ago' })
     }
     return labels[unit]
   }

--- a/src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import { setI18nLocale } from '@/i18n'
+import { useLocaleStore } from '@/stores/locale-store'
 import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, expect, it, vi } from 'vitest'
 import type { LiteratureJobSummary } from '../../../../shared/literature-jobs'
@@ -145,3 +147,33 @@ it.each([
     expect(button.textContent).not.toContain('Searching…')
   }
 )
+
+// Exercise live app-language changes while Intl retains the host's default locale.
+it('updates metadata dates with the interface language on an unchanged host', async () => {
+  const timestamp = '2026-09-02T12:00:00.000Z'
+  const options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }
+  const hostLocale = new Intl.DateTimeFormat().resolvedOptions().locale
+  await show([{ ...job, createdAt: Date.parse(timestamp) }])
+  fireEvent.click(screen.getByRole('button', { name: 'Background tasks' }))
+  try {
+    for (const locale of ['en', 'zh-Hans', 'zh-Hant', 'de'] as const) {
+      await act(async () => {
+        setI18nLocale(locale)
+        useLocaleStore.setState({ locale })
+      })
+      const expected = new Intl.DateTimeFormat(locale, options).format(new Date(timestamp))
+      expect(document.body.textContent).toContain(expected)
+      expect(new Intl.DateTimeFormat().resolvedOptions().locale).toBe(hostLocale)
+      if (locale === 'zh-Hans') {
+        expect(expected).not.toBe(
+          new Intl.DateTimeFormat('en-US', options).format(new Date(timestamp))
+        )
+      }
+    }
+  } finally {
+    await act(async () => {
+      setI18nLocale('en')
+      useLocaleStore.setState({ locale: 'en' })
+    })
+  }
+})

--- a/src/renderer/src/pages/literature/LiteratureBackgroundTasks.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBackgroundTasks.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useEffectEvent, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
 import { AlertCircle, ListTodo, LoaderCircle, X } from 'lucide-react'
 import { LiteratureErrorNotice } from './LiteratureErrorNotice'
 import { Button } from '@/components/ui/button'
@@ -23,6 +24,7 @@ export function LiteratureBackgroundTasks({
   hidden?: boolean
 }): React.JSX.Element {
   const { t } = useTranslation()
+  const formatDate = useDateTimeFormat()
   const [open, setOpen] = useState(false)
   const [jobs, setJobs] = useState<LiteratureJobSummary[]>([])
   const [error, setError] = useState(false)
@@ -208,7 +210,7 @@ export function LiteratureBackgroundTasks({
                       {job.failed > 0 ? ` · ${t('Failed')}: ${job.failed}` : null}
                     </p>
                     <p className="text-xs text-muted-foreground">
-                      {new Date(job.createdAt).toLocaleString()}
+                      {formatDate(job.createdAt, 'dateTime')}
                     </p>
                   </div>
                   <div className="flex gap-2">

--- a/src/renderer/src/pages/settings/ComputeHostAuthenticationDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostAuthenticationDetail.tsx
@@ -1,6 +1,7 @@
 import { KeyRound } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
 
 import type {
   ComputeAuthenticationMode,
@@ -48,6 +49,7 @@ export function ComputeHostAuthenticationDetail({
   changeAuthentication
 }: Props): React.JSX.Element {
   const { t } = useTranslation()
+  const formatDate = useDateTimeFormat()
   const currentMode = host.authentication?.mode ?? 'ssh_config'
   const currentRevision = host.authentication?.revision ?? 1
   const [mode, setMode] = useState<ComputeAuthenticationMode>(currentMode)
@@ -282,7 +284,7 @@ export function ComputeHostAuthenticationDetail({
             <dt className="text-muted-foreground">{t('Last verified')}</dt>
             <dd className="col-span-2">
               {host.authentication?.lastVerifiedAt
-                ? new Date(host.authentication.lastVerifiedAt).toLocaleString()
+                ? formatDate(host.authentication.lastVerifiedAt, 'dateTime')
                 : t('Not yet verified')}
             </dd>
           </dl>

--- a/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
@@ -1,4 +1,6 @@
 // @vitest-environment jsdom
+import { setI18nLocale } from '@/i18n'
+import { useLocaleStore } from '@/stores/locale-store'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -1387,4 +1389,41 @@ it('keeps the draft and reloads a merge base after a details conflict', async ()
   expect(section.textContent).toContain('other writer')
   await click('Save')
   expect(saveDetails).toHaveBeenLastCalledWith('ssh:biowulf', 'my draft', 'other writer')
+})
+
+// Exercise live app-language changes while Intl retains the host's default locale.
+it('updates metadata dates with the interface language on an unchanged host', async () => {
+  const timestamp = '2026-09-02T12:00:00.000Z'
+  const options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }
+  const hostLocale = new Intl.DateTimeFormat().resolvedOptions().locale
+  useComputeStore.setState({
+    hosts: [
+      {
+        ...passwordHost(),
+        authentication: { ...passwordHost().authentication!, lastVerifiedAt: Date.parse(timestamp) }
+      }
+    ]
+  })
+  await act(async () => root.render(<ComputeHostDetail providerId="ssh:biowulf" />))
+  try {
+    for (const locale of ['en', 'zh-Hans', 'zh-Hant', 'de'] as const) {
+      await act(async () => {
+        setI18nLocale(locale)
+        useLocaleStore.setState({ locale })
+      })
+      const expected = new Intl.DateTimeFormat(locale, options).format(new Date(timestamp))
+      expect(document.body.textContent).toContain(expected)
+      expect(new Intl.DateTimeFormat().resolvedOptions().locale).toBe(hostLocale)
+      if (locale === 'zh-Hans') {
+        expect(expected).not.toBe(
+          new Intl.DateTimeFormat('en-US', options).format(new Date(timestamp))
+        )
+      }
+    }
+  } finally {
+    await act(async () => {
+      setI18nLocale('en')
+      useLocaleStore.setState({ locale: 'en' })
+    })
+  }
 })

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -493,6 +493,32 @@ afterEach(() => {
 })
 
 describe('ArtifactProvenancePanel', () => {
+  it.each([1, 2])('renders the English package count for %i installed packages', async (count) => {
+    const snapshot = provenance()
+    const environment = snapshot.evidence!.environment as { packages: unknown[] }
+    environment.packages = environment.packages.slice(0, count)
+    getVersionProvenance.mockResolvedValue(snapshot)
+    await act(async () => root.unmount())
+    root = createRoot(container)
+    await act(async () =>
+      root.render(
+        <ArtifactProvenancePanel
+          item={item}
+          projectId="project-1"
+          onClose={vi.fn()}
+          initialTab="environment"
+        />
+      )
+    )
+    await flush()
+    const capture = [...container.querySelectorAll('dt')].find(
+      (node) => node.textContent === 'Capture'
+    )
+    expect(capture?.nextElementSibling?.textContent).toBe(
+      `partial · ${count} package${count === 1 ? '' : 's'}`
+    )
+  })
+
   it('navigates to the previous Artifact version outside the loaded history page', async () => {
     act(() => root.unmount())
     container.replaceChildren()

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -1752,7 +1752,10 @@ const ArtifactProvenancePanel = ({
                   <dt className="text-text-300">{t('Capture')}</dt>
                   <dd className="text-text-100">
                     {asString(environment.capture_status) ?? t('partial')} ·{' '}
-                    {t('{{count}} packages', { count: environmentPackages.length })}
+                    {t('{{count}} packages', {
+                      count: environmentPackages.length,
+                      defaultValue_one: '{{count}} package'
+                    })}
                   </dd>
                 </dl>
                 {environmentWarnings.length > 0 ? (

--- a/src/renderer/src/pages/workspace/ArtifactSourcesPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactSourcesPanel.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { setI18nLocale } from '@/i18n'
+import { useLocaleStore } from '@/stores/locale-store'
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ArtifactLiteratureManifest } from '../../../../shared/artifact-literature'
@@ -303,4 +305,33 @@ describe('ArtifactSourcesPanel', () => {
     resolveSave({ mode: 'save', versionId: 'version-2', versionNumber: 2 })
     expect(await screen.findByText('Saved as version 2.')).not.toBeNull()
   })
+})
+
+// Exercise live app-language changes while Intl retains the host's default locale.
+it('updates metadata dates with the interface language on an unchanged host', async () => {
+  const timestamp = '2026-09-02T12:00:00.000Z'
+  const options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }
+  const hostLocale = new Intl.DateTimeFormat().resolvedOptions().locale
+  render(<ArtifactSourcesPanel literature={literature} />)
+  try {
+    for (const locale of ['en', 'zh-Hans', 'zh-Hant', 'de'] as const) {
+      await act(async () => {
+        setI18nLocale(locale)
+        useLocaleStore.setState({ locale })
+      })
+      const expected = new Intl.DateTimeFormat(locale, options).format(new Date(timestamp))
+      expect(document.body.textContent).toContain(expected)
+      expect(new Intl.DateTimeFormat().resolvedOptions().locale).toBe(hostLocale)
+      if (locale === 'zh-Hans') {
+        expect(expected).not.toBe(
+          new Intl.DateTimeFormat('en-US', options).format(new Date(timestamp))
+        )
+      }
+    }
+  } finally {
+    await act(async () => {
+      setI18nLocale('en')
+      useLocaleStore.setState({ locale: 'en' })
+    })
+  }
 })

--- a/src/renderer/src/pages/workspace/ArtifactSourcesPanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactSourcesPanel.tsx
@@ -2,6 +2,7 @@
 import { Check, Eye, LoaderCircle, SlidersHorizontal } from 'lucide-react'
 import { useEffect, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useDateTimeFormat } from '@/hooks/useDateTimeFormat'
 
 import type {
   ArtifactLiteratureManifest,
@@ -50,6 +51,7 @@ const ArtifactSourcesPanel = ({
   }
 }): React.JSX.Element => {
   const { t } = useTranslation()
+  const formatDate = useDateTimeFormat()
   const [selectedReference, setSelectedReference] = useState<
     ArtifactLiteratureReference | undefined
   >()
@@ -281,10 +283,7 @@ const ArtifactSourcesPanel = ({
                 defaultValue_one: '{{count}} reference'
               })}
               {' · '}
-              {new Intl.DateTimeFormat(undefined, {
-                dateStyle: 'medium',
-                timeStyle: 'short'
-              }).format(new Date(literature.corpus.capturedAt))}
+              {formatDate(literature.corpus.capturedAt, 'dateTime')}
             </span>
           </div>
           <ul className="mt-2 space-y-1 text-xs text-text-300">


### PR DESCRIPTION
## Problem

English notifications render “1 minutes ago” and the provenance environment summary renders “1 packages”. Background task creation, Compute Host authentication verification, and frozen literature corpus dates follow the host locale instead of the interface language.

## Proposed change

Supply explicit English singular defaults for six notification time units and package counts. Route the three metadata timestamps through the existing useDateTimeFormat hook and dateTime preset so they react to interface-language changes.

## Scope and non-goals

Renderer presentation only. No new fields, enum values, state, dependencies, architecture, persistence, data-model changes, or historical migrations. Existing timestamps retain their precision and local timezone behavior. Background task and authentication timestamps now display to the minute using the existing preset. Literature citation language is unchanged. Invalid dates use the shared empty-string fallback; absent authentication verification retains its existing message.

## Acceptance criteria and validation

All listed code checks ran after the final material source/test edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Notification singular/plural labels across six units | NotificationBell.test.tsx | Passed |
| One/two packages in the real provenance panel | ArtifactProvenancePanel.render.test.tsx | Passed |
| Live English, Simplified Chinese, Traditional Chinese, German date switching | LiteratureBackgroundTasks.test.tsx; ArtifactSourcesPanel.test.tsx; ComputeHostDetail.render.test.tsx | Passed |
| Date fallback, time buckets, catalog contracts | format-datetime.test.ts; format-relative-time.test.ts; resources.test.ts | Passed |
| Runtime typing | npm run typecheck | Passed |
| Source lint | npm run lint | Passed |
| Whitespace | git diff --check | Passed |

The eight targeted Vitest files passed 982 checks. Command:

```sh
npx vitest run src/renderer/src/components/NotificationBell.test.tsx src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx src/renderer/src/pages/workspace/ArtifactSourcesPanel.test.tsx src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx src/renderer/src/lib/format-datetime.test.ts src/renderer/src/lib/format-relative-time.test.ts src/renderer/src/i18n/resources.test.ts
```

Renderer components are shared by Electron and Web. The existing hook, locale store, main/preload contracts, and formatters are unchanged, so no additional platform, migration, or backend behavior lanes were run locally. CodeGraph identified direct component consumers; actual mounted component tests protect the changed rendering paths. The repository's automatic impact selector falls back to full because some changed files have no registered module owner. Per maintainer instruction, the complete local suite was not run; exact-head PR CI has now passed. The independent automated review of commit 0fee75479c25de8f6353e66f32c69edc27faea56 found no actionable findings, and no review threads remain unresolved.

Final CI: all three Ubuntu full-suite shards, module coverage, static checks, Linux Notebook isolation, Windows core, both Windows E2E shards, macOS build/E2E, CodeQL, and PR Gate passed. The first Windows E2E shard initially encountered a 60-second application-startup timeout waiting for the database phase to change from migrating to ready. The test passed on automatic retry, but the job failed under --fail-on-flaky-tests. Only that failed job was rerun once, without code changes; the rerun passed. The original failure remains in run 34130856231 attempt 1; the successful rerun and final gate are recorded in attempt 2.

Visual checks used real components in an isolated browser preview with fixture data, not a packaged-app end-to-end journey. English singular labels and metadata dates were captured in English, Simplified Chinese, Traditional Chinese, and German. Temporary preview files were removed.

## Review focus

Confirm minute precision is suitable for background-task creation and authentication verification metadata. Review the explicit singular defaults and application-locale subscriptions.

