### PR TITLE
fix(local-fs): enforce folder boundaries and recover browser operations

### DIFF
--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -720,3 +720,62 @@ describe('managed file reference resolver', () => {
     ).rejects.toThrow(/escapes the granted folder/i)
   })
 })
+
+describe.skipIf(process.platform === 'win32')('POSIX linked-folder scope', () => {
+  it.each(['ro', 'rw'] as const)(
+    'regression: rejects a backslash sibling symlink for %s access',
+    async (access) => {
+      root = await mkdtemp(join(tmpdir(), 'file-reference-scope-'))
+      const allowed = join(root, 'allowed')
+      const sibling = join(root, 'allowed\\outside')
+      await mkdir(allowed)
+      await mkdir(sibling)
+      await writeFile(join(sibling, 'audit.txt'), 'AUDIT OUTSIDE ROOT')
+      await symlink(join(sibling, 'audit.txt'), join(allowed, 'linked.txt'))
+      const resolver = createManagedFileReferenceResolver({
+        grantedRoots: { resolveRoot: async () => ({ path: allowed, access }) }
+      })
+      try {
+        await expect(
+          resolver.resolve(
+            { projectId: 'default-project', sessionId: 'scope-test' },
+            {
+              id: 'linked',
+              name: 'linked.txt',
+              source: 'linked-folder',
+              rootId: 'root',
+              relativePath: 'linked.txt'
+            }
+          )
+        ).rejects.toThrow(/escapes the granted folder/i)
+      } finally {
+        resolver.clear()
+      }
+    }
+  )
+})
+
+it.skipIf(process.platform === 'win32')(
+  'allows POSIX backslashes and dot-prefixed filenames inside a granted folder',
+  async () => {
+    root = await mkdtemp(join(tmpdir(), 'file-reference-names-'))
+    for (const name of ['..notes.txt', 'allowed\\outside.txt']) {
+      await writeFile(join(root, name), 'allowed')
+      const resolver = createManagedFileReferenceResolver({
+        grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'rw' }) }
+      })
+      const result = await resolver.resolve(
+        { projectId: 'test', sessionId: 'test' },
+        {
+          id: name,
+          name,
+          source: 'linked-folder',
+          rootId: 'root',
+          relativePath: name
+        }
+      )
+      expect(await readFile(result.absolutePath, 'utf8')).toBe('allowed')
+      resolver.clear()
+    }
+  }
+)

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -1,7 +1,7 @@
 import { createReadStream, createWriteStream, rmSync } from 'node:fs'
 import { mkdtemp, realpath, rm, stat } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { basename, join } from 'node:path'
+import { basename, isAbsolute, join, relative, sep } from 'node:path'
 import { Transform } from 'node:stream'
 import { pipeline } from 'node:stream/promises'
 import { pathToFileURL } from 'node:url'
@@ -10,7 +10,6 @@ import type { FileReference } from '../../shared/artifacts'
 import { parseArtifactVersionLocator } from '../../shared/artifact-provenance'
 import { parseLiteratureAttachmentVersionReference } from '../../shared/literature'
 import type { GrantedLocalRoot } from '../../shared/local-fs'
-import { isPathWithin } from '../../shared/local-fs'
 import { MAX_UPLOAD_FILE_BYTES } from '../../shared/uploads'
 import type { ArtifactRepository } from '../artifacts/repository'
 import { createLogger, errorLogFields } from '../logger'
@@ -473,7 +472,12 @@ export const createManagedFileReferenceResolver = (dependencies: {
           realpath(root.path),
           realpath(join(root.path, reference.relativePath))
         ])
-        if (!isPathWithin(resolvedFile, resolvedRoot)) {
+        const relativeFile = relative(resolvedRoot, resolvedFile)
+        if (
+          isAbsolute(relativeFile) ||
+          relativeFile === '..' ||
+          relativeFile.startsWith(`..${sep}`)
+        ) {
           throw new Error('Linked-folder reference escapes the granted folder.')
         }
         const fileInfo = await stat(resolvedFile)

--- a/src/main/acp/file-reference-resolver.windows-scope.test.ts
+++ b/src/main/acp/file-reference-resolver.windows-scope.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it, vi } from 'vitest'
+
+// Exercise the public resolver with Windows canonical paths on every CI host. The real native
+// filesystem cases remain in file-reference-resolver.test.ts; only OS boundaries are substituted.
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>()
+  return { ...actual, ...actual.win32 }
+})
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return {
+    ...actual,
+    realpath: vi.fn(async (path: string) => path),
+    stat: vi.fn(async () => ({ isFile: () => true, size: 20 }))
+  }
+})
+import { realpath } from 'node:fs/promises'
+import { createManagedFileReferenceResolver } from './file-reference-resolver'
+
+describe('Windows linked-folder canonical scope', () => {
+  it.each([
+    ['C:\\data', 'C:\\data\\audit.txt', true],
+    ['C:\\data\\', 'c:\\DATA\\audit.txt', true],
+    ['C:\\data', 'C:\\data\\..notes.txt', true],
+    ['C:\\data', 'C:\\data2\\audit.txt', false],
+    ['C:\\data', 'C:\\audit.txt', false],
+    ['C:\\data', 'D:\\data\\audit.txt', false],
+    ['\\server\\share\\data', '\\server\\share\\data\\audit.txt', true],
+    ['\\server\\share\\data', '\\server\\share\\data2\\audit.txt', false],
+    ['\\server\\share', '\\server\\other\\audit.txt', false],
+    ['\\server\\share', '\\other\\share\\audit.txt', false]
+  ])('checks %s against canonical target %s (allowed=%s)', async (root, candidate, allowed) => {
+    vi.mocked(realpath).mockResolvedValueOnce(root).mockResolvedValueOnce(candidate)
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root, access: 'rw' }) }
+    })
+    const result = resolver.resolve(
+      { projectId: 'test', sessionId: 'test' },
+      {
+        id: 'file',
+        name: 'audit.txt',
+        source: 'linked-folder',
+        rootId: 'root',
+        relativePath: 'audit.txt'
+      }
+    )
+    if (allowed) await expect(result).resolves.toMatchObject({ absolutePath: candidate })
+    else await expect(result).rejects.toThrow(/escapes the granted folder/)
+    resolver.clear()
+  })
+})

--- a/src/main/local-fs/service.test.ts
+++ b/src/main/local-fs/service.test.ts
@@ -317,6 +317,18 @@ describe('LocalFsService granted roots', () => {
     await rm(outside, { recursive: true, force: true })
   })
 
+  it('regression: rejects a regular file before stopping notebooks or persisting a grant', async () => {
+    const file = join(outside, 'audit.txt')
+    await writeFile(file, 'AUDIT OUTSIDE ROOT')
+    const outcome = await grantService.grantRoot({ path: file, access: 'ro' }).then(
+      () => 'accepted',
+      () => 'rejected'
+    )
+    expect.soft(outcome).toBe('rejected')
+    expect.soft(beforeGrantedRootsChange).not.toHaveBeenCalled()
+    expect(store).toEqual([])
+  })
+
   it('grants a folder inside home, canonicalized via realpath', async () => {
     const updated = await grantService.grantRoot({ path: join(home, 'Documents'), access: 'ro' })
 

--- a/src/main/local-fs/service.ts
+++ b/src/main/local-fs/service.ts
@@ -158,6 +158,7 @@ export class LocalFsService {
         throw new Error('The home folder is already browsable; it cannot be granted.')
       throw new Error('Local path must be absolute.')
     }
+    if (!(await stat(resolvedPath)).isDirectory()) throw new Error('Grant path is not a directory.')
     await this.beforeGrantedRootsChange()
     // De-dupe on the resolved path: re-granting an already granted folder updates its access and
     // keeps the existing id (the store upserts by path).

--- a/src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
@@ -799,3 +799,47 @@ describe('GrantFolderAccessDialog', () => {
     expect(winListDir).toHaveBeenCalledWith('D:\\')
   })
 })
+
+it('regression: disables granting after the candidate fails directory listing', async () => {
+  renderDialog()
+  await flush()
+  listDir.mockRejectedValueOnce(new Error('ENOTDIR: not a directory'))
+  await click(document.body.querySelector('[data-testid="grant-access-path-bar"]'))
+  await typeInto(pathInput()!, `${HOME}/audit.txt`)
+  await keyOn(pathInput()!, 'Enter')
+  await flush()
+  expect(document.body.textContent).toContain('Not a folder:')
+  expect(
+    document.querySelector<HTMLButtonElement>('[data-testid="grant-access-grant"]')?.disabled
+  ).toBe(true)
+  expect(grantRoot).not.toHaveBeenCalled()
+})
+
+it('regression: displays a dialog roots initialization failure', async () => {
+  window.api.localFs.getRoots = vi.fn().mockRejectedValue(new Error('Roots unavailable'))
+  renderDialog()
+  await flush()
+  expect(document.body.textContent).toContain('Roots unavailable')
+})
+
+it('retries dialog initialization and lists Home', async () => {
+  vi.mocked(window.api.localFs.getRoots).mockRejectedValueOnce(new Error('Roots unavailable'))
+  renderDialog()
+  await flush()
+  await click(
+    Array.from(document.querySelectorAll('button')).find((b) => b.textContent === 'Retry')
+  )
+  await flush()
+  expect(listDir).toHaveBeenCalledWith(HOME)
+  expect(document.body.textContent).not.toContain('Roots unavailable')
+})
+
+it('disables granting while the current directory has not finished loading', async () => {
+  renderDialog()
+  await flush()
+  listDir.mockReturnValueOnce(new Promise(() => undefined))
+  await click(document.querySelector('[data-testid="grant-access-folder-Projects"]'))
+  expect(
+    document.querySelector<HTMLButtonElement>('[data-testid="grant-access-grant"]')?.disabled
+  ).toBe(true)
+})

--- a/src/renderer/src/pages/workspace/GrantFolderAccessDialog.tsx
+++ b/src/renderer/src/pages/workspace/GrantFolderAccessDialog.tsx
@@ -2,6 +2,7 @@
 // browses any folder on any mounted drive via a breadcrumb + folder-only listing, picks an access
 // level, and grants the current folder. The breadcrumb bar doubles as a path field (click its
 // empty area to type a path), and its leading drive crumb opens a drive/volume switcher.
+import { ErrorNotice } from '@/components/error-notice'
 import { ChevronDown, CircleAlert, Folder, Home, Info, X } from 'lucide-react'
 import { RadioGroup } from 'radix-ui'
 import * as Dialog from '@/components/ui/dialog'
@@ -155,6 +156,8 @@ const GrantFolderAccessDialogContent = ({
   const grant = useGrantedFoldersStore((state) => state.grant)
   // Host platform drives path segmentation/joining ('win32' paths use '\' and drive roots).
   const platform = window.api?.platform ?? 'darwin'
+  const [initializationError, setInitializationError] = useState<string>()
+  const [initializeNonce, setInitializeNonce] = useState(0)
   const [home, setHome] = useState<string | undefined>(undefined)
   const [drives, setDrives] = useState<LocalDrive[]>([])
   const [cwd, setCwd] = useState('')
@@ -225,11 +228,13 @@ const GrantFolderAccessDialogContent = ({
       setCwd(fetchedRoots.home)
       setDrives(fetchedDrives)
       await refresh().catch(() => undefined)
-    })()
+    })().catch((error: Error) => {
+      if (!cancelled) setInitializationError(error.message)
+    })
     return () => {
       cancelled = true
     }
-  }, [refresh])
+  }, [refresh, initializeNonce])
 
   // List the current folder's subfolders. Browsing is not scope-confined ("Home start, full-disk
   // navigable"): any location the breadcrumb or path field points at gets listed.
@@ -302,13 +307,13 @@ const GrantFolderAccessDialogContent = ({
   const isHome = home !== undefined && sameLocalDirectory(cwd, home, platform)
 
   const handleGrant = async (): Promise<void> => {
-    if (grantingRef.current) return
+    if (grantingRef.current || isHome || listing.kind !== 'ok' || result?.kind !== 'ok') return
     grantingRef.current = true
     const attempt = ++grantAttemptRef.current
     setIsGranting(true)
     onGrantingChange(true)
     try {
-      const nextRoots = await grant(cwd, access)
+      const nextRoots = await grant(result.path, access)
       if (attempt !== grantAttemptRef.current) return
       const granted =
         nextRoots.find((root) => sameLocalDirectory(root.path, cwd, platform)) ??
@@ -548,7 +553,19 @@ const GrantFolderAccessDialogContent = ({
 
         {/* Subfolder listing */}
         <div className="flex max-h-[320px] min-h-[220px] flex-col overflow-y-auto px-5 pb-3 pt-2">
-          {listing.kind === 'loading' ? (
+          {initializationError ? (
+            <ErrorNotice
+              description={initializationError}
+              tone="amber"
+              primaryButton={{
+                label: t('Retry'),
+                onClick: () => {
+                  setInitializationError(undefined)
+                  setInitializeNonce((n) => n + 1)
+                }
+              }}
+            />
+          ) : listing.kind === 'loading' ? (
             <div className="flex flex-1 items-center justify-center text-[13px] text-text-300">
               {t('Loading…')}
             </div>
@@ -635,7 +652,7 @@ const GrantFolderAccessDialogContent = ({
             <Button
               type="button"
               data-testid="grant-access-grant"
-              disabled={isHome || isGranting}
+              disabled={isHome || isGranting || listing.kind !== 'ok'}
               onClick={() => setGrantConfirmationOpen(true)}
               className="bg-primary text-primary-foreground hover:bg-primary/80 disabled:bg-primary disabled:text-primary-foreground disabled:opacity-40"
             >

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.test.tsx
@@ -399,3 +399,135 @@ it('regression: local directory children match their ARIA container role', async
     result.violations.map(({ id, nodes }) => ({ id, html: nodes.map((node) => node.html) }))
   ).toEqual([])
 })
+
+describe('local browser initialization and persistence regressions', () => {
+  it('regression: starts browsing while optional bookmarks are pending', async () => {
+    const bookmarks = deferred<string[]>()
+    window.api.compute.bookmarksGet = vi.fn().mockReturnValue(bookmarks.promise)
+    await act(async () => root.render(<LocalFileBrowser />))
+    await flush()
+    try {
+      expect(listDir).toHaveBeenCalledWith(HOME)
+    } finally {
+      await act(async () => bookmarks.resolve([]))
+    }
+  })
+
+  it('regression: keeps browsing and reports a bookmark read failure', async () => {
+    window.api.compute.bookmarksGet = vi.fn().mockRejectedValue(new Error('Bookmark read failed'))
+    await act(async () => root.render(<LocalFileBrowser />))
+    await flush()
+    expect.soft(listDir).toHaveBeenCalledWith(HOME)
+    expect(document.body.textContent).toContain('Bookmark read failed')
+  })
+
+  it('regression: displays a roots initialization failure instead of remaining in loading', async () => {
+    window.api.localFs.getRoots = vi.fn().mockRejectedValue(new Error('Roots unavailable'))
+    await act(async () => root.render(<LocalFileBrowser />))
+    await flush()
+    expect(document.body.textContent).toContain('Roots unavailable')
+  })
+
+  it.each([false, true])(
+    'regression: preserves the saved bookmark state when a write fails (pinned=%s)',
+    async (pinned) => {
+      window.api.compute.bookmarksGet = vi.fn().mockResolvedValue(pinned ? [HOME] : [])
+      window.api.compute.bookmarksSet = vi
+        .fn()
+        .mockRejectedValue(new Error('Bookmark write failed'))
+      await act(async () => root.render(<LocalFileBrowser />))
+      await flush()
+      const label = pinned ? 'Remove bookmark' : 'Pin this folder'
+      await act(async () =>
+        document.querySelector<HTMLButtonElement>(`[aria-label="${label}"]`)!.click()
+      )
+      await flush()
+      expect(window.api.compute.bookmarksSet).toHaveBeenCalled()
+      expect.soft(document.querySelector(`[aria-label="${label}"]`)).not.toBeNull()
+      expect(document.body.textContent).toContain('Bookmark write failed')
+    }
+  )
+})
+
+it('retries roots initialization and opens Home', async () => {
+  vi.mocked(window.api.localFs.getRoots).mockRejectedValueOnce(new Error('Roots unavailable'))
+  await act(async () => root.render(<LocalFileBrowser />))
+  await flush()
+  await act(async () =>
+    Array.from(document.querySelectorAll('button'))
+      .find((b) => b.textContent === 'Retry')!
+      .click()
+  )
+  await flush()
+  expect(listDir).toHaveBeenCalledWith(HOME)
+  expect(document.body.textContent).not.toContain('Roots unavailable')
+})
+
+it('blocks writes until bookmark recovery preserves the saved list', async () => {
+  vi.mocked(window.api.compute.bookmarksGet)
+    .mockRejectedValueOnce(new Error('Bookmark read failed'))
+    .mockResolvedValueOnce([GRANTED])
+  await act(async () => root.render(<LocalFileBrowser />))
+  await flush()
+  expect(
+    document.querySelector<HTMLButtonElement>('[aria-label="Pin this folder"]')?.disabled
+  ).toBe(true)
+  expect(window.api.compute.bookmarksSet).not.toHaveBeenCalled()
+  await act(async () =>
+    Array.from(document.querySelectorAll('button'))
+      .find((b) => b.textContent === 'Retry')!
+      .click()
+  )
+  await flush()
+  await act(async () =>
+    document.querySelector<HTMLButtonElement>('[aria-label="Pin this folder"]')!.click()
+  )
+  expect(window.api.compute.bookmarksSet).toHaveBeenCalledWith(expect.any(String), [GRANTED, HOME])
+})
+
+it('serializes bookmark mutations and updates the pin only after saving', async () => {
+  const save = deferred<void>()
+  vi.mocked(window.api.compute.bookmarksSet).mockReturnValue(save.promise)
+  await act(async () => root.render(<LocalFileBrowser />))
+  await flush()
+  const pin = document.querySelector<HTMLButtonElement>('[aria-label="Pin this folder"]')!
+  await act(async () => {
+    pin.click()
+    pin.click()
+  })
+  expect(window.api.compute.bookmarksSet).toHaveBeenCalledTimes(1)
+  expect(pin.disabled).toBe(true)
+  expect(document.querySelector('[aria-label="Remove bookmark"]')).toBeNull()
+  await act(async () => save.resolve())
+  expect(document.querySelector('[aria-label="Remove bookmark"]')).not.toBeNull()
+})
+
+it('preserves a bookmark when removal from the Go to menu fails', async () => {
+  vi.mocked(window.api.compute.bookmarksGet).mockResolvedValue([GRANTED])
+  vi.mocked(window.api.compute.bookmarksSet).mockRejectedValue(new Error('Bookmark write failed'))
+  await act(async () => root.render(<LocalFileBrowser />))
+  await flush()
+  await act(async () =>
+    document.querySelector<HTMLButtonElement>(`[aria-label="Unpin ${GRANTED}"]`)!.click()
+  )
+  await flush()
+  expect(document.querySelector(`[aria-label="Unpin ${GRANTED}"]`)).not.toBeNull()
+  expect(document.body.textContent).toContain('Bookmark write failed')
+})
+
+it('keeps Home selected when an older folder request completes later', async () => {
+  await act(async () => root.render(<LocalFileBrowser />))
+  await flush()
+  const older = deferred<LocalDirListing>()
+  listDir.mockImplementation((path: string) =>
+    path === GRANTED
+      ? older.promise
+      : Promise.resolve({ entries: [], truncated: false, resolvedPath: path })
+  )
+  await act(async () =>
+    root.render(<LocalFileBrowser requestedPath={{ path: GRANTED, nonce: 1 }} />)
+  )
+  await act(async () => root.render(<LocalFileBrowser requestedPath={{ nonce: 2 }} />))
+  await act(async () => older.resolve({ entries: [], truncated: false, resolvedPath: GRANTED }))
+  expect(addressInput()?.value).toBe(HOME)
+})

--- a/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
+++ b/src/renderer/src/pages/workspace/LocalFileBrowser.tsx
@@ -7,6 +7,7 @@
 //   - opening a file does NOT show an inline detail panel; it opens a standalone preview-workbench
 //     tab (source:'local') that renders through the shared preview pipeline with a dedicated header
 //   - bookmarks persist under the reserved LOCAL_BOOKMARKS_KEY in the compute bookmark store
+import { ErrorNotice } from '@/components/error-notice'
 import {
   ArrowLeft,
   ChevronDown,
@@ -162,11 +163,13 @@ const GoToMenu = ({
   isBookmarked,
   onNavigate,
   onPinCurrent,
-  onRemoveBookmark
+  onRemoveBookmark,
+  bookmarksDisabled
 }: {
   drives: LocalDrive[]
   home: string | undefined
   bookmarks: string[]
+  bookmarksDisabled: boolean
   currentPath: string
   isBookmarked: boolean
   onNavigate: (path: string) => void
@@ -253,6 +256,7 @@ const GoToMenu = ({
                       e.stopPropagation()
                       onRemoveBookmark(path)
                     }}
+                    disabled={bookmarksDisabled}
                     aria-label={t('Unpin {{path}}', { path })}
                     className="flex size-6 shrink-0 items-center justify-center self-center rounded-md text-muted-foreground transition-colors hover:bg-surface-control-hover hover:text-text-000"
                   >
@@ -263,7 +267,11 @@ const GoToMenu = ({
             ))}
             {/* The pin action belongs to the Pinned category and always closes it. */}
             {!isBookmarked && currentPath ? (
-              <DropdownMenuItem className="items-start gap-2 text-xs" onSelect={onPinCurrent}>
+              <DropdownMenuItem
+                className="items-start gap-2 text-xs"
+                onSelect={onPinCurrent}
+                disabled={bookmarksDisabled}
+              >
                 <GoToRow
                   icon={<Pin className="size-3.5 text-muted-foreground" strokeWidth={1.5} />}
                   label={t('Pin current folder')}
@@ -452,9 +460,9 @@ export const LocalFileBrowser = ({
 }: {
   // Reports the visible entry count so the Files tab header can show it next to the source picker.
   onEntryCountChange?: (count: number | undefined) => void
-  // External navigation request (a granted folder picked in the filter menu). `nonce` makes repeat
+  // External navigation request; an omitted path explicitly requests Home. `nonce` makes repeat
   // requests observable even for the same path; requests for the current directory are no-ops.
-  requestedPath?: { path: string; nonce: number }
+  requestedPath?: { path?: string; nonce: number }
 }): React.JSX.Element => {
   const { t } = useTranslation()
 
@@ -463,7 +471,14 @@ export const LocalFileBrowser = ({
   const [cwd, setCwd] = useState('')
   const [state, setState] = useState<BrowserState>({ kind: 'loading' })
   const [addressInput, setAddressInput] = useState('')
-  const [bookmarks, setBookmarks] = useState<string[]>([])
+  const [bookmarks, setBookmarks] = useState<string[] | null>(null)
+  const [bookmarkError, setBookmarkError] = useState<string>()
+  const [savingBookmarks, setSavingBookmarks] = useState(false)
+  const savingBookmarksRef = useRef(false)
+  const [initializeNonce, setInitializeNonce] = useState(0)
+  const [initializationError, setInitializationError] = useState<string>()
+  const mountedRef = useRef(false)
+  const bookmarkReadRequestRef = useRef(0)
   const [pendingSensitiveEntry, setPendingSensitiveEntry] = useState<PendingSensitiveEntry | null>(
     null
   )
@@ -485,6 +500,9 @@ export const LocalFileBrowser = ({
   // A request already pending when the browser mounts replaces the initial Home landing instead
   // of racing it.
   const initialRequestedPathRef = useRef(requestedPath)
+  useEffect(() => {
+    initialRequestedPathRef.current = requestedPath
+  }, [requestedPath])
   const navigationRequestRef = useRef(0)
 
   // Clear the reported count when this container goes away, so the header stops showing a stale one.
@@ -524,34 +542,66 @@ export const LocalFileBrowser = ({
     }
   }, [])
 
-  // On mount: fetch roots + drives + bookmarks, then land in Home — or in a path already requested
-  // before the browser mounted (its nonce is marked handled so the effect below doesn't
-  // re-navigate).
-  useEffect(() => {
-    const navigationIntent = navigationRequestRef.current
-    void (async () => {
-      const [fetchedRoots, fetchedDrives, fetchedBookmarks] = await Promise.all([
-        window.api.localFs.getRoots(),
-        // A drive-enumeration failure must not take the whole browser down with it.
-        window.api.localFs.listDrives().catch(() => []),
-        window.api.compute.bookmarksGet(LOCAL_BOOKMARKS_KEY)
-      ])
-      setRoots(fetchedRoots)
-      setDrives(fetchedDrives)
-      setBookmarks(fetchedBookmarks)
-      if (navigationIntent !== navigationRequestRef.current) return
-      const pendingRequest = initialRequestedPathRef.current
-      await navigate(pendingRequest?.path ?? fetchedRoots.home)
-    })()
-  }, [navigate])
+  const loadBookmarks = useCallback((): Promise<void> => {
+    const request = ++bookmarkReadRequestRef.current
+    return window.api.compute
+      .bookmarksGet(LOCAL_BOOKMARKS_KEY)
+      .then((saved) => {
+        if (!mountedRef.current || request !== bookmarkReadRequestRef.current) return
+        setBookmarks(saved)
+        setBookmarkError(undefined)
+      })
+      .catch((error: Error) => {
+        if (mountedRef.current && request === bookmarkReadRequestRef.current)
+          setBookmarkError(error.message)
+      })
+  }, [])
 
-  // External navigation requests (granted folder picked in the filter menu) steer the browser.
+  useEffect(() => {
+    mountedRef.current = true
+    void loadBookmarks()
+    return () => {
+      mountedRef.current = false
+      bookmarkReadRequestRef.current += 1
+    }
+  }, [loadBookmarks])
+
+  // Required roots initialize independently of optional bookmarks and drive enumeration.
+  useEffect(() => {
+    let cancelled = false
+    const navigationIntent = navigationRequestRef.current
+    void window.api.localFs
+      .listDrives()
+      .then((drives) => {
+        if (!cancelled) setDrives(drives)
+      })
+      .catch(() => undefined)
+    void window.api.localFs
+      .getRoots()
+      .then(async (fetchedRoots) => {
+        if (cancelled) return
+        setRoots(fetchedRoots)
+        if (navigationIntent !== navigationRequestRef.current) return
+        const pendingRequest = initialRequestedPathRef.current
+        handledRequestNonceRef.current = pendingRequest?.nonce ?? 0
+        await navigate(pendingRequest?.path ?? fetchedRoots.home)
+      })
+      .catch((error: Error) => {
+        if (!cancelled) setInitializationError(error.message)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [navigate, initializeNonce])
+
   useEffect(() => {
     if (!requestedPath || requestedPath.nonce === handledRequestNonceRef.current) return
+    const target = requestedPath.path ?? roots?.home
+    if (!target) return
     handledRequestNonceRef.current = requestedPath.nonce
-    if (!sameLocalDirectory(requestedPath.path, cwdRef.current, window.api.platform))
-      void navigate(requestedPath.path)
-  }, [requestedPath, navigate])
+    if (state.kind !== 'ok' || !sameLocalDirectory(target, cwdRef.current, window.api.platform))
+      void navigate(target)
+  }, [requestedPath, roots, navigate, state.kind])
 
   const listing = state.kind === 'ok' ? state : null
   const currentPath = listing?.resolvedPath ?? cwd
@@ -611,20 +661,36 @@ export const LocalFileBrowser = ({
     openEntry(pending)
   }
 
-  const isBookmarked = bookmarks.includes(currentPath)
+  const isBookmarked = bookmarks?.includes(currentPath) ?? false
+  const bookmarksDisabled = bookmarks === null || savingBookmarks || !currentPath
+
+  const saveBookmarks = async (next: string[]): Promise<void> => {
+    if (bookmarks === null || savingBookmarksRef.current) return
+    savingBookmarksRef.current = true
+    setSavingBookmarks(true)
+    try {
+      await window.api.compute.bookmarksSet(LOCAL_BOOKMARKS_KEY, next)
+      if (!mountedRef.current) return
+      setBookmarks(next)
+      setBookmarkError(undefined)
+    } catch (error) {
+      if (mountedRef.current) setBookmarkError((error as Error).message)
+    } finally {
+      savingBookmarksRef.current = false
+      if (mountedRef.current) setSavingBookmarks(false)
+    }
+  }
 
   const handleToggleBookmark = async (): Promise<void> => {
-    const next = isBookmarked
-      ? bookmarks.filter((b) => b !== currentPath)
-      : [...bookmarks, currentPath]
-    setBookmarks(next)
-    await window.api.compute.bookmarksSet(LOCAL_BOOKMARKS_KEY, next)
+    if (bookmarksDisabled || !bookmarks) return
+    await saveBookmarks(
+      isBookmarked ? bookmarks.filter((b) => b !== currentPath) : [...bookmarks, currentPath]
+    )
   }
 
   const handleRemoveBookmark = async (path: string): Promise<void> => {
-    const next = bookmarks.filter((b) => b !== path)
-    setBookmarks(next)
-    await window.api.compute.bookmarksSet(LOCAL_BOOKMARKS_KEY, next)
+    if (bookmarksDisabled || !bookmarks) return
+    await saveBookmarks(bookmarks.filter((b) => b !== path))
   }
 
   return (
@@ -656,7 +722,8 @@ export const LocalFileBrowser = ({
           <GoToMenu
             drives={drives}
             home={roots?.home}
-            bookmarks={bookmarks}
+            bookmarks={bookmarks ?? []}
+            bookmarksDisabled={bookmarksDisabled}
             currentPath={currentPath}
             isBookmarked={isBookmarked}
             onNavigate={(path) => void navigate(path)}
@@ -682,7 +749,9 @@ export const LocalFileBrowser = ({
               variant="ghost"
               size="icon-sm"
               className={TOOLBAR_ICON_BUTTON}
-              onClick={() => void navigate(currentPath)}
+              onClick={() =>
+                roots ? void navigate(currentPath || roots.home) : setInitializeNonce((n) => n + 1)
+              }
               aria-label={t('Refresh directory')}
             >
               <RefreshCw className="size-4" strokeWidth={TOOLBAR_ICON_STROKE} />
@@ -700,6 +769,7 @@ export const LocalFileBrowser = ({
               variant="ghost"
               size="icon-sm"
               className={TOOLBAR_ICON_BUTTON}
+              disabled={bookmarksDisabled}
               onClick={() => void handleToggleBookmark()}
               aria-label={isBookmarked ? t('Remove bookmark') : t('Pin this folder')}
             >
@@ -715,8 +785,39 @@ export const LocalFileBrowser = ({
         </div>
       </TooltipProvider>
 
-      {/* Listing */}
-      <LocalListing state={state} onOpenEntry={handleOpenEntry} />
+      {bookmarkError ? (
+        <ErrorNotice
+          description={bookmarkError}
+          tone="amber"
+          primaryButton={
+            bookmarks === null
+              ? {
+                  label: t('Retry'),
+                  onClick: () => {
+                    setBookmarkError(undefined)
+                    void loadBookmarks()
+                  }
+                }
+              : undefined
+          }
+        />
+      ) : null}
+      {initializationError ? (
+        <ErrorNotice
+          description={initializationError}
+          tone="amber"
+          primaryButton={{
+            label: t('Retry'),
+            onClick: () => {
+              setInitializationError(undefined)
+              setInitializeNonce((n) => n + 1)
+            }
+          }}
+        />
+      ) : (
+        <LocalListing state={state} onOpenEntry={handleOpenEntry} />
+      )}
+
       <SensitiveLocalPathDialog
         pending={pendingSensitiveEntry}
         onCancel={() => setPendingSensitiveEntry(null)}

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -4488,6 +4488,39 @@ describe('ProjectFilesView — granted local folders', () => {
       el.textContent?.includes('TychoStation')
     )
 
+  it('regression: returns to Home when selecting the machine after a granted folder', async () => {
+    await renderFilesView()
+    await openFilterMenu()
+    await clickElement(document.querySelector('[data-testid="granted-root-root-1"]'))
+    expect(listDir).toHaveBeenCalledWith('/Users/roxi/Projects')
+    listDir.mockClear()
+    await openFilterMenu()
+    await clickElement(machineRow())
+    expect(listDir).toHaveBeenCalledWith('/Users/roxi')
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Directory path"]')?.value).toBe(
+      '/Users/roxi'
+    )
+  })
+
+  it('regression: navigates to another granted folder after selecting the machine', async () => {
+    const other = { ...grantedRoot, id: 'root-2', name: 'Results', path: '/Users/roxi/Results' }
+    vi.mocked(window.api.localFs.listGrantedRoots).mockResolvedValue([grantedRoot, other])
+    useGrantedFoldersStore.setState({ roots: [grantedRoot, other], loaded: true })
+    await renderFilesView()
+    await openFilterMenu()
+    await clickElement(document.querySelector('[data-testid="granted-root-root-1"]'))
+    await openFilterMenu()
+    await clickElement(machineRow())
+    listDir.mockClear()
+    await openFilterMenu()
+    await clickElement(document.querySelector('[data-testid="granted-root-root-2"]'))
+    expect(filterButton()?.textContent).toContain('Results')
+    expect(listDir).toHaveBeenCalledWith(other.path)
+    expect(container.querySelector<HTMLInputElement>('[aria-label="Directory path"]')?.value).toBe(
+      other.path
+    )
+  })
+
   it('moves the selected check between the machine row and a picked folder row', async () => {
     await renderFilesView()
     await openFilterMenu()

--- a/src/renderer/src/pages/workspace/ProjectFilesView.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.tsx
@@ -340,8 +340,9 @@ const ProjectFilesViewContent = ({
   // One-shot navigation request for the local browser, set when a granted folder is picked in the
   // filter menu. The nonce makes repeated picks of the same folder observable.
   const [localRequestedPath, setLocalRequestedPath] = useState<
-    { path: string; nonce: number } | undefined
+    { path?: string; nonce: number } | undefined
   >(undefined)
+  const localNavigationNonce = useRef(0)
   // Granted folder the local browser is scoped to; undefined means the machine itself.
   const [selectedLocalRootId, setSelectedLocalRootId] = useState<string | undefined>(undefined)
   const [grantDialogOpen, setGrantDialogOpen] = useState(false)
@@ -380,7 +381,7 @@ const ProjectFilesViewContent = ({
         const root = roots.find((candidate) => candidate.id === persisted.localRootId)
         if (!root) return
         setSelectedLocalRootId(root.id)
-        setLocalRequestedPath({ path: root.path, nonce: 1 })
+        setLocalRequestedPath({ path: root.path, nonce: ++localNavigationNonce.current })
       })
       .catch(() => undefined)
   }, [])
@@ -396,7 +397,7 @@ const ProjectFilesViewContent = ({
     (root: GrantedLocalRoot): void => {
       setSourceMode('local')
       setSelectedLocalRootId(root.id)
-      setLocalRequestedPath((previous) => ({ path: root.path, nonce: (previous?.nonce ?? 0) + 1 }))
+      setLocalRequestedPath({ path: root.path, nonce: ++localNavigationNonce.current })
       persistFilter({ sourceMode: 'local', localRootId: root.id })
     },
     [persistFilter]
@@ -407,7 +408,7 @@ const ProjectFilesViewContent = ({
   const handleBrowseLocal = useCallback((): void => {
     setSourceMode('local')
     setSelectedLocalRootId(undefined)
-    setLocalRequestedPath(undefined)
+    setLocalRequestedPath({ nonce: ++localNavigationNonce.current })
     persistFilter({ sourceMode: 'local' })
   }, [persistFilter])
 

--- a/src/shared/local-fs.test.ts
+++ b/src/shared/local-fs.test.ts
@@ -4,7 +4,6 @@ import {
   describeInvalidLocalPath,
   describeLocalListingError,
   isLocalPathRoot,
-  isPathWithin,
   isSensitiveLocalPath,
   localDriveRootFor,
   parentLocalPath,
@@ -227,30 +226,6 @@ describe('describeLocalListingError', () => {
   })
 })
 
-describe('isPathWithin', () => {
-  it('matches the root itself and descendants', () => {
-    expect(isPathWithin('/data', '/data')).toBe(true)
-    expect(isPathWithin('/data/x/y', '/data')).toBe(true)
-  })
-
-  it('does not match siblings sharing a prefix', () => {
-    expect(isPathWithin('/data2/x', '/data')).toBe(false)
-    expect(isPathWithin('/data', '/data/x')).toBe(false)
-  })
-
-  it('tolerates trailing separators on the root', () => {
-    expect(isPathWithin('/data/x', '/data/')).toBe(true)
-    expect(isPathWithin('/data', '/data/')).toBe(true)
-  })
-
-  it('treats Windows separators as separators', () => {
-    expect(isPathWithin('C:\\data\\x', 'C:\\data')).toBe(true)
-    expect(isPathWithin('C:\\data2\\x', 'C:\\data')).toBe(false)
-    // Mixed forms of the same path still match after separator normalization.
-    expect(isPathWithin('C:/data/x', 'C:\\data')).toBe(true)
-  })
-})
-
 describe('localDriveRootFor', () => {
   const posixDrives: LocalDrive[] = [
     { path: '/', label: '/' },
@@ -324,4 +299,10 @@ describe('validateGrantCandidate', () => {
       reason: 'is-home'
     })
   })
+})
+
+it('preserves POSIX backslashes when comparing a grant with Home', () => {
+  expect(validateGrantCandidate('/Users/research\\home', '/Users/research/home', 'darwin')).toEqual(
+    { ok: true }
+  )
 })

--- a/src/shared/local-fs.ts
+++ b/src/shared/local-fs.ts
@@ -184,19 +184,6 @@ export const resolveLocalPath = (cwd: string, input: string, platform: string): 
   return `${base}${separator}${input}`
 }
 
-// Normalizes separators for scope comparisons: both POSIX and Windows separators count as
-// separators (the app ships on mac/win), and trailing separators are dropped so a root recorded
-// as "/data/" still matches "/data/x". Case is left alone — comparison is exact on purpose.
-const normalizePathForScope = (path: string): string => path.replace(/\\/g, '/').replace(/\/+$/, '')
-
-// True when `path` is `root` itself or lives inside it. The separator boundary in the startsWith
-// check matters: "/data2/x" must NOT count as within "/data".
-export const isPathWithin = (path: string, root: string): boolean => {
-  const candidate = normalizePathForScope(path)
-  const base = normalizePathForScope(root)
-  return candidate === base || candidate.startsWith(`${base}/`)
-}
-
 // Validates a folder the user wants to grant. Any valid absolute path qualifies — granting is no
 // longer confined to home or already-granted roots (existence is guaranteed by the realpath in
 // grantRoot). Home itself is rejected because it is the implicit root and granting it would be a
@@ -207,8 +194,7 @@ export const validateGrantCandidate = (
   platform: string
 ): { ok: true } | { ok: false; reason: 'not-absolute' | 'is-home' } => {
   if (validateLocalPath(path, platform) !== undefined) return { ok: false, reason: 'not-absolute' }
-  if (normalizePathForScope(path) === normalizePathForScope(home))
-    return { ok: false, reason: 'is-home' }
+  if (sameLocalDirectory(path, home, platform)) return { ok: false, reason: 'is-home' }
   return { ok: true }
 }
 


### PR DESCRIPTION
## Problem

Canonical POSIX paths containing backslashes can incorrectly pass linked-folder containment after
separator rewriting. Local file browsing also loses Home/source navigation requests, blocks startup
on bookmark failures, permits ordinary-file grants, and displays bookmark writes as successful when
persistence rejects them.

## Proposed change

- Compare real paths with native `path.relative` in the main resolver and reject escapes before either
  read-only projection or writable path delivery. Preserve POSIX filename characters.
- Require a directory before the grant service stops Notebooks or writes records. Disable granting
  unvalidated/error/loading candidates and submit the validated directory.
- Give every source selection a parent-lifetime nonce and represent Home explicitly; preserve newer
  navigation intent when an older request finishes.
- Load bookmarks separately from required roots, expose initialization retry, and prevent bookmark
  writes until loading succeeds. Acknowledge writes only on success, preserve saved state on failure,
  and prevent duplicate mutations.

## Scope and non-goals

No database fields, persisted enums, IPC formats, dependencies, or migrations. Existing bookmark,
source-filter, and grant formats are unchanged. Previously saved invalid file grants are not silently
removed. New state is component-local loading/error/save status and request counters. The optional
renderer request path means Home when a request nonce is present. No execution-sandbox, provider
protocol, history-branch, or subscription changes.

## Acceptance criteria and validation

Before production changes, 12 new regressions failed identically in two runs while 171 existing tests
passed. They exercise real temporary-filesystem resolver/service boundaries and real React components,
including ProjectFilesView menu clicks. No extracted-source tests or production seams were added.
A further pending-navigation/Home race was reproduced with a failing test before correction.

After the final material edit:

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| Canonical containment and valid special filenames | `src/main/acp/file-reference-resolver{,.windows-scope}.test.ts`, `src/shared/local-fs.test.ts` | Passed |
| Directory grant validation and transport/persistence contracts | `src/main/local-fs/{service,ipc,granted-roots-repository}.test.ts`, `src/main/host-application-commands.test.ts` | Passed |
| Shared resolver consumers | `src/main/acp/{runtime-base-composition,prompt-content-owner,runtime-prompt-composition,provider-prompt-executor,runtime-provider-session-composition}.test.ts` | Passed |
| Navigation, initialization, bookmark saves and grant controls | `src/renderer/src/pages/workspace/{LocalFileBrowser,ProjectFilesView}.test.tsx`, `GrantFolderAccessDialog.{interaction,layers}.test.tsx`, `src/renderer/src/stores/granted-folders-store.test.ts` | Passed |
| Translations | `npx vitest run src/renderer/src/i18n/resources.test.ts` | Passed |
| Provider routes, including both Codex routes | `npx vitest run src/main/acp/handler-workflows.test.ts src/main/acp/provider-session-creator.test.ts` | 61 passed |
| Process typing and style | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint` | Passed |

The first five rows ran together via `npx vitest run` with those explicit paths: 18 files, 1152 tests
passed. Browser UI checks used real components with isolated API fixtures to confirm root retry,
invalid-path Grant disabled, and failed bookmark persistence retaining the original pin state.

The impact classifier has no declared owner for the resolver and falls back to full verification.
The maintainer requested focused local checks and full PR CI, so complete local npm test was not run.
Windows path semantics are exercised using `path.win32` at existing OS test boundaries; native
cross-platform behavior remains for CI. This does not claim full Electron disk-fault reproduction
or verification of downstream writable-path sandbox enforcement.

## Review focus

Canonical containment, stop-before-write ordering, stale navigation/read isolation, and preservation
of saved bookmarks after failed reads/writes. Full and native-platform CI remain required.
