### PR TITLE
fix(transcript): preserve reading windows and segment identities

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.annotations.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.annotations.test.tsx
@@ -429,11 +429,15 @@ describe('WorkspaceMessageScroller annotation prop sync', () => {
       container.querySelector<HTMLButtonElement>('[data-testid="tool-group-header"]')?.click()
     )
     await render([target, ...fillers])
-    expect(container.querySelector('[data-message-id="activity-group-target-group"]')).toBeNull()
+    expect(
+      container.querySelector('[data-message-id="activity-group-notebook-reveal-target"]')
+    ).toBeNull()
 
     await act(async () => requestAnnotationReveal(annotation))
 
-    const targetGroup = container.querySelector('[data-message-id="activity-group-target-group"]')!
+    const targetGroup = container.querySelector(
+      '[data-message-id="activity-group-notebook-reveal-target"]'
+    )!
     expect(
       targetGroup.querySelector('[data-testid="tool-group-header"]')?.getAttribute('aria-expanded')
     ).toBe('true')

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -4241,6 +4241,27 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     }
   )
 
+  it('leaves ordinary transcript growth to the native scroller anchor policy', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    root = createRoot(container)
+    const messages = [createMessage({})]
+    const render = async (): Promise<void> => {
+      await act(async () =>
+        root.render(
+          <WorkspaceMessageScroller
+            activeSession={createSession({ status: 'idle', messages: [...messages] })}
+            onSendEditedMessage={vi.fn()}
+          />
+        )
+      )
+    }
+    await render()
+    scrollToEndMock.mockClear()
+    messages.push(createMessage({ id: 'ordinary-append', createdAt: 1710000000001 }))
+    await render()
+    expect(scrollToEndMock).not.toHaveBeenCalled()
+  })
+
   it('mounts the latest window before the end button measures its scroll target', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const messages = Array.from({ length: 240 }, (_, index) =>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -4241,6 +4241,34 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     }
   )
 
+  it('mounts only the tail when an initially empty session receives long history', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    root = createRoot(container)
+    const render = async (messages: ChatMessage[]): Promise<void> => {
+      await act(async () =>
+        root.render(
+          <WorkspaceMessageScroller
+            activeSession={createSession({ status: 'idle', messages })}
+            onSendEditedMessage={vi.fn()}
+          />
+        )
+      )
+    }
+    await render([])
+    await render(
+      Array.from({ length: 240 }, (_, index) =>
+        createMessage({
+          id: `hydrated-${index}`,
+          content: `History ${index}`,
+          createdAt: 1710000000000 + index
+        })
+      )
+    )
+    expect(container.querySelectorAll('[data-message-id^="hydrated-"]')).toHaveLength(80)
+    expect(container.querySelector('[data-message-id="hydrated-0"]')).toBeNull()
+    expect(container.querySelector('[data-message-id="hydrated-239"]')).not.toBeNull()
+  })
+
   it('leaves ordinary transcript growth to the native scroller anchor policy', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     root = createRoot(container)

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -4290,6 +4290,39 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
     expect(scrollToEndMock).not.toHaveBeenCalled()
   })
 
+  it('keeps new replies mounted within a short reading window', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    root = createRoot(container)
+    const messages = [createMessage({})]
+    const render = async (): Promise<void> => {
+      await act(async () =>
+        root.render(
+          <WorkspaceMessageScroller
+            activeSession={createSession({ status: 'idle', messages: [...messages] })}
+            onSendEditedMessage={vi.fn()}
+          />
+        )
+      )
+    }
+    await render()
+    const viewport = container.querySelector<HTMLDivElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )!
+    Object.defineProperties(viewport, {
+      clientHeight: { configurable: true, value: 800 },
+      scrollHeight: { configurable: true, value: 2000 },
+      scrollTop: { configurable: true, writable: true, value: 600 }
+    })
+    await act(async () => viewport.dispatchEvent(new Event('scroll', { bubbles: true })))
+    const original = container.querySelector('[data-message-id]')
+    scrollToEndMock.mockClear()
+    messages.push(createMessage({ id: 'ordinary-append', createdAt: 1710000000001 }))
+    await render()
+    expect(container.querySelector('[data-message-id="ordinary-append"]')).not.toBeNull()
+    expect(original?.isConnected).toBe(true)
+    expect(scrollToEndMock).not.toHaveBeenCalled()
+  })
+
   it('mounts the latest window before the end button measures its scroll target', async () => {
     const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
     const messages = Array.from({ length: 240 }, (_, index) =>

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx
@@ -65,7 +65,11 @@ vi.mock('pdfjs-dist', () => {
   }
 })
 
-const { agentMarkdownRenderMock } = vi.hoisted(() => ({ agentMarkdownRenderMock: vi.fn() }))
+const { agentMarkdownRenderMock, endScrollTargetMock, scrollToEndMock } = vi.hoisted(() => ({
+  agentMarkdownRenderMock: vi.fn(),
+  endScrollTargetMock: vi.fn(),
+  scrollToEndMock: vi.fn()
+}))
 const { flushSessionPersistenceMock } = vi.hoisted(() => ({
   flushSessionPersistenceMock: vi.fn(async (): Promise<void> => undefined)
 }))
@@ -173,9 +177,30 @@ vi.mock('@/components/ui/message-scroller', () => {
         size?: string
       }
     >
-  >(function MockMessageScrollerButton({ children, direction = 'end', size, ...props }, ref) {
+  >(function MockMessageScrollerButton(
+    { children, direction = 'end', size, onClick, ...props },
+    ref
+  ) {
     return (
-      <button ref={ref} type="button" data-direction={direction} data-size={size} {...props}>
+      <button
+        ref={ref}
+        type="button"
+        data-direction={direction}
+        data-size={size}
+        {...props}
+        onClick={(event) => {
+          onClick?.(event)
+          // Match the primitive: it measures the mounted end synchronously after the callback.
+          if (direction === 'end')
+            endScrollTargetMock(
+              Array.from(
+                event.currentTarget.parentElement?.querySelectorAll('[data-message-id]') ?? []
+              )
+                .at(-1)
+                ?.getAttribute('data-message-id')
+            )
+        }}
+      >
         {children ?? `Scroll to ${direction}`}
       </button>
     )
@@ -189,7 +214,7 @@ vi.mock('@/components/ui/message-scroller', () => {
     MessageScrollerItem: Item,
     MessageScrollerButton: Button,
     useMessageScroller: () => ({
-      scrollToEnd: vi.fn(),
+      scrollToEnd: scrollToEndMock,
       scrollToMessage: vi.fn(),
       scrollToStart: vi.fn()
     })
@@ -4151,6 +4176,227 @@ describe('WorkspaceMessageScroller artifact click behavior', () => {
         indicator.classList.contains('scale-x-[0.4]')
       )
     ).toBe(true)
+  })
+
+  it.each([
+    { count: 2, kind: 'messages' },
+    { count: 80, kind: 'messages' },
+    { count: 80, kind: 'activities' }
+  ])(
+    'retains the reading nodes when $count $kind arrive away from the bottom',
+    async ({ count, kind }) => {
+      const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+      const messages = Array.from({ length: 240 + count }, (_, index) =>
+        createMessage({
+          id: `reading-${index + 1}`,
+          content: `Reading message ${index + 1}`,
+          createdAt: 1710000000000 + index,
+          updatedAt: 1710000000000 + index
+        })
+      )
+      const render = async (length: number): Promise<void> => {
+        await act(async () =>
+          root.render(
+            <WorkspaceMessageScroller
+              activeSession={createSession({
+                status: 'idle',
+                messages: messages.slice(0, kind === 'activities' ? 240 : length),
+                activities:
+                  kind === 'activities'
+                    ? Array.from({ length: length - 240 }, (_, index) =>
+                        createActivity({
+                          id: `appended-activity-${index}`,
+                          activityGroupId: `appended-group-${index}`,
+                          status: 'completed',
+                          createdAt: 1710000001000 + index,
+                          sortIndex: 1000 + index
+                        })
+                      )
+                    : []
+              })}
+              onSendEditedMessage={vi.fn()}
+            />
+          )
+        )
+      }
+      root = createRoot(container)
+      await render(240)
+      const rows = Array.from(container.querySelectorAll('[data-message-id^="reading-"]'))
+      expect(rows).toHaveLength(80)
+      const viewport = container.querySelector<HTMLElement>(
+        '[data-testid="message-scroller-viewport"]'
+      )!
+      Object.defineProperties(viewport, {
+        clientHeight: { configurable: true, value: 800 },
+        scrollHeight: { configurable: true, value: 10_000 },
+        scrollTop: { configurable: true, writable: true, value: 9000 }
+      })
+      await act(async () => viewport.dispatchEvent(new Event('scroll', { bubbles: true })))
+      viewport.scrollTop = 5000
+      await act(async () => viewport.dispatchEvent(new Event('scroll', { bubbles: true })))
+      scrollToEndMock.mockClear()
+      await render(240 + count)
+      expect(scrollToEndMock).not.toHaveBeenCalled()
+      expect(rows.filter((node) => node.isConnected)).toHaveLength(80)
+    }
+  )
+
+  it('mounts the latest window before the end button measures its scroll target', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `end-message-${index + 1}`,
+        content: `End message ${index + 1}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+    root = createRoot(container)
+    await act(async () =>
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    )
+    await act(async () =>
+      document.body.querySelector<HTMLButtonElement>('[aria-label^="Go to run 1:"]')!.click()
+    )
+    expect(container.querySelector('[data-message-id="end-message-240"]')).toBeNull()
+    endScrollTargetMock.mockClear()
+    await act(async () =>
+      container.querySelector<HTMLButtonElement>('[data-direction="end"]')!.click()
+    )
+    expect(endScrollTargetMock).toHaveBeenLastCalledWith('end-message-240')
+    scrollToEndMock.mockClear()
+    const appended = [
+      ...messages,
+      ...Array.from({ length: 80 }, (_, index) =>
+        createMessage({
+          id: `new-end-${index}`,
+          content: `New end ${index}`,
+          createdAt: 1710000001000 + index,
+          updatedAt: 1710000001000 + index
+        })
+      )
+    ]
+    await act(async () =>
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages: appended })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    )
+    expect(container.querySelector('[data-message-id="new-end-79"]')).not.toBeNull()
+    expect(scrollToEndMock).toHaveBeenCalledWith({ behavior: 'auto' })
+  })
+
+  it('retains the run selected during find after closing find', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const messages = Array.from({ length: 240 }, (_, index) =>
+      createMessage({
+        id: `find-reading-${index + 1}`,
+        content: `Find reading ${index + 1}`,
+        createdAt: 1710000000000 + index,
+        updatedAt: 1710000000000 + index
+      })
+    )
+    root = createRoot(container)
+    await act(async () =>
+      root.render(
+        <WorkspaceMessageScroller
+          activeSession={createSession({ status: 'idle', messages })}
+          onSendEditedMessage={vi.fn()}
+        />
+      )
+    )
+    expect(container.querySelector('[data-message-id="find-reading-1"]')).toBeNull()
+    await act(async () => showWindowFindListener?.())
+    const target = container.querySelector('[data-message-id="find-reading-1"]')!
+    expect(target).not.toBeNull()
+    const viewport = container.querySelector<HTMLElement>(
+      '[data-testid="message-scroller-viewport"]'
+    )!
+    viewport.scrollTo = vi.fn()
+    const firstRun = document.body.querySelector<HTMLButtonElement>('[aria-label^="Go to run 1:"]')!
+    expect(firstRun).not.toBeNull()
+    await act(async () => firstRun.click())
+    expect(viewport.scrollTo).toHaveBeenCalled()
+    await act(async () => hideWindowFindListener?.())
+    expect(target.isConnected).toBe(true)
+    expect(
+      container.querySelectorAll('[data-message-id^="find-reading-"]').length
+    ).toBeLessThanOrEqual(80)
+  })
+
+  it('collapses only the selected contiguous segment of a named tool group', async () => {
+    const { WorkspaceMessageScroller } = await import('./WorkspaceMessageScroller')
+    const { projectActivityGroupStart, projectToolActivity } =
+      await import('@/stores/session-store-run-activity-helpers')
+    const { createWorkspaceConversationTimeline } =
+      await import('./workspace-conversation-timeline')
+    let session = projectActivityGroupStart(
+      createSession({ messages: [createMessage({})] }),
+      'named-reading',
+      'Inspect sources',
+      'message-1'
+    )
+    for (const [index, id] of ['read-before', 'question-between', 'read-after'].entries()) {
+      session = projectToolActivity(session, {
+        sessionId: session.id,
+        toolCallId: id,
+        eventId: `event-${id}`,
+        promptMessageId: 'message-1',
+        title: id,
+        status: 'completed',
+        toolKind: 'read',
+        timestamp: 1710000000100 + index,
+        ...(index === 1
+          ? {
+              elicitation: {
+                message: 'Choose a source',
+                fields: [{ id: 'source', label: 'Source', kind: 'text' as const }],
+                state: 'answered' as const,
+                answers: [{ fieldId: 'source', value: 'Both' }]
+              }
+            }
+          : {})
+      })
+    }
+    expect(session.activities?.map((item) => item.activityGroupId)).toEqual(
+      Array(3).fill('named-reading')
+    )
+    const segments = createWorkspaceConversationTimeline(session).filter(
+      (item) => item.type === 'activity-group'
+    )
+    expect(segments).toHaveLength(2)
+    const errors = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    root = createRoot(container)
+    try {
+      await act(async () =>
+        root.render(
+          <WorkspaceMessageScroller activeSession={session} onSendEditedMessage={vi.fn()} />
+        )
+      )
+      const headings = Array.from(
+        container.querySelectorAll<HTMLButtonElement>('button[aria-expanded]')
+      ).filter((button) => button.textContent?.includes('Inspect sources'))
+      expect(headings).toHaveLength(2)
+      expect(headings.map((button) => button.getAttribute('aria-expanded'))).toEqual([
+        'true',
+        'true'
+      ])
+      await act(async () => headings[0].click())
+      expect
+        .soft(headings.map((button) => button.getAttribute('aria-expanded')))
+        .toEqual(['false', 'true'])
+      expect.soft(new Set(segments.map((item) => item.id)).size).toBe(2)
+      expect.soft(errors.mock.calls.some((call) => call.join(' ').includes('same key'))).toBe(false)
+    } finally {
+      errors.mockRestore()
+    }
   })
 
   it('mounts a bounded long transcript and reveals an older run on demand', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1,10 +1,12 @@
+import { flushSync } from 'react-dom'
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import {
   MessageScroller,
   MessageScrollerButton,
   MessageScrollerContent,
   MessageScrollerProvider,
-  MessageScrollerViewport
+  MessageScrollerViewport,
+  useMessageScroller
 } from '@/components/ui/message-scroller'
 import {
   usePreviewWorkbenchStore,
@@ -99,6 +101,40 @@ import { setWorkspacePresentationRevealing } from './workspace-presentation-reve
 import { useTranscriptWindow } from './use-transcript-window'
 import { subscribeAnnotationRevealPreparation } from './annotations/annotation-reveal'
 import type { AnnotationPort } from './annotations/annotation-port'
+
+// Replacing a bounded tail can keep the same row count. Tell the existing scroller to follow
+// after that replacement commits; its normal resize/streaming behavior remains authoritative.
+const TranscriptEndSync = ({
+  scopeId,
+  itemCount,
+  following
+}: {
+  scopeId: string | undefined
+  itemCount: number
+  following: boolean
+}): null => {
+  const { scrollToEnd } = useMessageScroller()
+  const previousRef = useRef<{ scopeId: string | undefined; itemCount: number } | undefined>(
+    undefined
+  )
+  useLayoutEffect(() => {
+    const previous = previousRef.current
+    previousRef.current = { scopeId, itemCount }
+    if (following && previous?.scopeId === scopeId && previous && itemCount > previous.itemCount) {
+      // Content processes the replaced rows in a MutationObserver, which can select a new
+      // prompt anchor. Restore follow intent after that observer, before the next paint.
+      let cancelled = false
+      queueMicrotask(() => {
+        if (!cancelled) scrollToEnd({ behavior: 'auto' })
+      })
+      return () => {
+        cancelled = true
+      }
+    }
+    return undefined
+  }, [following, itemCount, scopeId, scrollToEnd])
+  return null
+}
 
 type WorkspaceMessageScrollerProps = {
   activeSession: ChatSession | undefined
@@ -1336,6 +1372,20 @@ const WorkspaceMessageScrollerImpl = ({
             ref={handleMessageScrollerViewportRef}
             aria-label={t('Conversation')}
             onScroll={handleMessageScrollerScroll}
+            onWheel={transcriptWindow.recordUserScroll}
+            onTouchMove={transcriptWindow.recordUserScroll}
+            onPointerDown={(event) => {
+              if (event.target === event.currentTarget) transcriptWindow.recordUserScroll()
+            }}
+            onKeyDown={(event) => {
+              if (
+                ['ArrowUp', 'ArrowDown', 'PageUp', 'PageDown', 'Home', 'End', ' '].includes(
+                  event.key
+                )
+              ) {
+                transcriptWindow.recordUserScroll()
+              }
+            }}
           >
             {/* No wrapper div: message-scroller only measures/anchors Content's direct children. */}
             <MessageScrollerContent
@@ -1816,6 +1866,11 @@ const WorkspaceMessageScrollerImpl = ({
               ) : null}
             </MessageScrollerContent>
           </MessageScrollerViewport>
+          <TranscriptEndSync
+            scopeId={currentPresentationScopeId}
+            itemCount={conversationItems.length}
+            following={transcriptWindow.isFollowingEnd}
+          />
 
           {showScrollToFirstMessage ? (
             <MessageScrollerButton
@@ -1840,6 +1895,10 @@ const WorkspaceMessageScrollerImpl = ({
           ) : null}
 
           <MessageScrollerButton
+            onClick={() => {
+              // The primitive's click handler measures the end immediately after this callback.
+              flushSync(transcriptWindow.followEnd)
+            }}
             size="icon-lg"
             className="z-10 rounded-full border-transparent bg-bg-000 shadow-card hover:bg-bg-200 data-[direction=end]:bottom-3"
           />

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -107,20 +107,28 @@ import type { AnnotationPort } from './annotations/annotation-port'
 const TranscriptEndSync = ({
   scopeId,
   itemCount,
+  mountedItemCount,
   following
 }: {
   scopeId: string | undefined
   itemCount: number
+  mountedItemCount: number
   following: boolean
 }): null => {
   const { scrollToEnd } = useMessageScroller()
-  const previousRef = useRef<{ scopeId: string | undefined; itemCount: number } | undefined>(
-    undefined
-  )
+  const previousRef = useRef<
+    { scopeId: string | undefined; itemCount: number; mountedItemCount: number } | undefined
+  >(undefined)
   useLayoutEffect(() => {
     const previous = previousRef.current
-    previousRef.current = { scopeId, itemCount }
-    if (following && previous?.scopeId === scopeId && previous && itemCount > previous.itemCount) {
+    previousRef.current = { scopeId, itemCount, mountedItemCount }
+    if (
+      following &&
+      previous &&
+      previous.scopeId === scopeId &&
+      itemCount > previous.itemCount &&
+      mountedItemCount === previous.mountedItemCount
+    ) {
       // Content processes the replaced rows in a MutationObserver, which can select a new
       // prompt anchor. Restore follow intent after that observer, before the next paint.
       let cancelled = false
@@ -132,7 +140,7 @@ const TranscriptEndSync = ({
       }
     }
     return undefined
-  }, [following, itemCount, scopeId, scrollToEnd])
+  }, [following, itemCount, mountedItemCount, scopeId, scrollToEnd])
   return null
 }
 
@@ -1869,6 +1877,7 @@ const WorkspaceMessageScrollerImpl = ({
           <TranscriptEndSync
             scopeId={currentPresentationScopeId}
             itemCount={conversationItems.length}
+            mountedItemCount={transcriptWindow.entries.length}
             following={transcriptWindow.isFollowingEnd}
           />
 

--- a/src/renderer/src/pages/workspace/WorkspaceRunMarks.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceRunMarks.tsx
@@ -139,8 +139,8 @@ const WorkspaceRunMarks = ({
   const scrollToRun = (mark: RunMark, index: number): void => {
     if (!viewport) return
     const target = findMessageTarget(viewport, mark.id)
+    onRevealMessage?.(mark.id)
     if (!target) {
-      onRevealMessage?.(mark.id)
       setCurrentIndex(index)
       return
     }

--- a/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
+++ b/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
@@ -11,7 +11,11 @@ import type { WorkspaceConversationTimelineItem } from './workspace-conversation
 const items = Array.from(
   { length: 120 },
   (_, index) =>
-    ({ id: `message-${index + 1}`, type: 'message' }) as WorkspaceConversationTimelineItem
+    ({
+      id: `message-${index + 1}`,
+      type: 'message',
+      message: { id: `message-${index + 1}` }
+    }) as WorkspaceConversationTimelineItem
 )
 
 describe('useTranscriptWindow', () => {
@@ -35,6 +39,151 @@ describe('useTranscriptWindow', () => {
     act(() => result.current.revealMessage('message-1'))
     expect(result.current.entries).toHaveLength(120)
 
+    act(() => root.unmount())
+  })
+
+  it('keeps a stable reading row through insertions, resumes following, and resets scope', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const viewport = document.createElement('div')
+    Object.defineProperties(viewport, {
+      clientHeight: { value: 800 },
+      scrollHeight: { value: 10000 },
+      scrollTop: { writable: true, value: 5000 }
+    })
+    viewport.getBoundingClientRect = () => ({ top: 100, bottom: 900 }) as DOMRect
+    const readingNode = document.createElement('div')
+    readingNode.dataset.messageId = 'message-81'
+    readingNode.getBoundingClientRect = () => ({ top: 108, bottom: 208 }) as DOMRect
+    viewport.appendChild(readingNode)
+    const ref = { current: viewport }
+    let current!: ReturnType<typeof useTranscriptWindow>
+    const Harness = ({ scope, rows }: { scope: string; rows: typeof items }): null => {
+      current = useTranscriptWindow(scope, rows, -1, ref)
+      return null
+    }
+    const render = (scope: string, rows = items): void =>
+      act(() => root.render(<Harness scope={scope} rows={rows} />))
+    render('session:branch-a')
+    act(() => current.expandAtScrollEdge(9000))
+    const originalIds = current.entries.map(({ item }) => item.id)
+    const inserted = [
+      {
+        id: 'inserted',
+        type: 'message',
+        message: { id: 'inserted' }
+      } as WorkspaceConversationTimelineItem,
+      ...items
+    ]
+    render('session:branch-a', inserted)
+    expect(current.entries.map(({ item }) => item.id)).toEqual(originalIds)
+    const interleaved = [
+      ...inserted.slice(0, 60),
+      ...Array.from(
+        { length: 100 },
+        (_, index) =>
+          ({
+            id: `late-${index}`,
+            type: 'message',
+            message: { id: `late-${index}` }
+          }) as WorkspaceConversationTimelineItem
+      ),
+      ...inserted.slice(60)
+    ]
+    render('session:branch-a', interleaved)
+    expect(current.entries.some(({ item }) => item.id === 'message-81')).toBe(true)
+    act(() => current.followEnd())
+    const appended = [
+      ...inserted,
+      {
+        id: 'appended',
+        type: 'message',
+        message: { id: 'appended' }
+      } as WorkspaceConversationTimelineItem
+    ]
+    render('session:branch-a', appended)
+    expect(current.entries.at(-1)?.item.id).toBe('appended')
+    act(() => current.revealAll())
+    act(() => current.revealMessage('message-1'))
+    render('session:branch-b', appended)
+    act(() => current.restoreWindow())
+    expect(current.entries).toHaveLength(80)
+    expect(current.entries.at(-1)?.item.id).toBe('appended')
+    expect(current.entries.some(({ item }) => item.id === 'message-1')).toBe(false)
+    render('another-session:branch-a', appended)
+    expect(current.entries).toHaveLength(80)
+    render('session:branch-a', appended)
+    expect(current.entries.some(({ item }) => item.id === 'message-1')).toBe(false)
+    expect(current.entries.at(-1)?.item.id).toBe('appended')
+    act(() => root.unmount())
+  })
+
+  it.each([false, true])(
+    'keeps a find navigation target unless manually scrolled afterwards: %s',
+    (manualScroll) => {
+      const container = document.createElement('div')
+      const root = createRoot(container)
+      const viewport = document.createElement('div')
+      viewport.getBoundingClientRect = () => ({ top: 100, bottom: 900 }) as DOMRect
+      const visible = document.createElement('div')
+      visible.dataset.messageId = 'message-1'
+      visible.getBoundingClientRect = () => ({ top: 108, bottom: 208 }) as DOMRect
+      const ref = { current: viewport }
+      let current!: ReturnType<typeof useTranscriptWindow>
+      const Harness = (): null => {
+        current = useTranscriptWindow('session', items, -1, ref)
+        return null
+      }
+      act(() => root.render(<Harness />))
+      act(() => current.revealAll())
+      act(() => current.revealMessage('message-100'))
+      // Simulate an intermediate native scroll position before the selected run has arrived.
+      viewport.appendChild(visible)
+      viewport.scrollTop = 500
+      if (manualScroll) act(() => current.recordUserScroll())
+      act(() => current.restoreWindow())
+      expect(
+        current.entries.some(({ item }) => item.id === (manualScroll ? 'message-1' : 'message-100'))
+      ).toBe(true)
+      expect(
+        current.entries.some(({ item }) => item.id === (manualScroll ? 'message-100' : 'message-1'))
+      ).toBe(false)
+      act(() => root.unmount())
+    }
+  )
+
+  it('shrinks find around the visible old row with its viewport offset', () => {
+    const container = document.createElement('div')
+    const root = createRoot(container)
+    const viewport = document.createElement('div')
+    viewport.getBoundingClientRect = () => ({ top: 100, bottom: 900 }) as DOMRect
+    viewport.scrollTo = (options?: ScrollToOptions | number, y?: number): void => {
+      viewport.scrollTop = typeof options === 'number' ? (y ?? 0) : (options?.top ?? 0)
+    }
+    const target = document.createElement('div')
+    target.dataset.messageId = 'message-1'
+    // Only the current visible row is observable; other rows are outside the mocked viewport.
+    let targetTop = 108
+    target.getBoundingClientRect = () => ({ top: targetTop, bottom: targetTop + 100 }) as DOMRect
+    const ref = { current: viewport }
+    let current!: ReturnType<typeof useTranscriptWindow>
+    const Harness = ({ rows = items }: { rows?: typeof items }): null => {
+      current = useTranscriptWindow('session:branch', rows, -1, ref)
+      return null
+    }
+    act(() => root.render(<Harness />))
+    act(() => current.revealAll())
+    viewport.appendChild(target)
+    viewport.scrollTop = 500
+    act(() => current.expandAtScrollEdge(9000))
+    act(() => current.restoreWindow())
+    expect(current.entries[0].item.id).toBe('message-1')
+    expect(current.entries).toHaveLength(80)
+    expect(viewport.scrollTop).toBe(500)
+    // A prepend changes DOM geometry; the saved relative offset remains 8 pixels.
+    targetTop = 208
+    act(() => root.render(<Harness rows={[...items]} />))
+    expect(viewport.scrollTop).toBe(600)
     act(() => root.unmount())
   })
 

--- a/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
+++ b/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
@@ -90,6 +90,39 @@ describe('useTranscriptWindow', () => {
     act(() => root.unmount())
   })
 
+  it('honors find scrolling after an explicit end selection settles', () => {
+    const root = createRoot(document.createElement('div'))
+    const viewport = document.createElement('div')
+    Object.defineProperties(viewport, {
+      clientHeight: { value: 800 },
+      scrollHeight: { value: 10000 }
+    })
+    viewport.getBoundingClientRect = () => ({ top: 100, bottom: 900 }) as DOMRect
+    const ref = { current: viewport }
+    let current!: ReturnType<typeof useTranscriptWindow>
+    const Harness = (): null => {
+      current = useTranscriptWindow('session', items, -1, ref)
+      return null
+    }
+    act(() => root.render(<Harness />))
+    act(() => current.revealAll())
+    act(() => current.followEnd())
+    act(() => current.revealAll())
+    viewport.scrollTop = 9200
+    act(() => current.expandAtScrollEdge(0))
+    const match = document.createElement('div')
+    match.dataset.messageId = 'message-1'
+    match.getBoundingClientRect = () => ({ top: 108, bottom: 208 }) as DOMRect
+    viewport.appendChild(match)
+    // Text find scrolls programmatically; no wheel or key event reaches the transcript viewport.
+    viewport.scrollTop = 500
+    act(() => current.expandAtScrollEdge(9200))
+    act(() => current.restoreWindow())
+    expect(current.isFollowingEnd).toBe(false)
+    expect(current.entries[0].item.id).toBe('message-1')
+    act(() => root.unmount())
+  })
+
   it('keeps a stable reading row through insertions, resumes following, and resets scope', () => {
     const container = document.createElement('div')
     const root = createRoot(container)

--- a/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
+++ b/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
@@ -42,6 +42,54 @@ describe('useTranscriptWindow', () => {
     act(() => root.unmount())
   })
 
+  it('bounds items arriving after an empty session mounts', () => {
+    const root = createRoot(document.createElement('div'))
+    const ref = createRef<HTMLDivElement>()
+    let current!: ReturnType<typeof useTranscriptWindow>
+    const Harness = ({ rows }: { rows: typeof items }): null => {
+      current = useTranscriptWindow('empty-session', rows, -1, ref)
+      return null
+    }
+    act(() => root.render(<Harness rows={[]} />))
+    expect(current.entries).toHaveLength(0)
+    act(() => root.render(<Harness rows={items} />))
+    expect(current.entries).toHaveLength(80)
+    expect(current.entries[0].item.id).toBe('message-41')
+    expect(current.entries.at(-1)?.item.id).toBe('message-120')
+    expect(current.isFollowingEnd).toBe(true)
+    act(() => root.unmount())
+  })
+
+  it('keeps an explicit end selection when find closes', () => {
+    const root = createRoot(document.createElement('div'))
+    const ref = createRef<HTMLDivElement>()
+    let current!: ReturnType<typeof useTranscriptWindow>
+    const Harness = ({ rows = items }: { rows?: typeof items }): null => {
+      current = useTranscriptWindow('session', rows, -1, ref)
+      return null
+    }
+    act(() => root.render(<Harness />))
+    act(() => current.revealAll())
+    act(() => current.revealMessage('message-1'))
+    act(() => current.followEnd())
+    // The owner keeps whole-window find mounted until its hide event arrives.
+    act(() => current.revealAll())
+    act(() => current.restoreWindow())
+    expect(current.isFollowingEnd).toBe(true)
+    const appended = [
+      ...items,
+      {
+        id: 'latest',
+        type: 'message',
+        message: { id: 'latest' }
+      } as WorkspaceConversationTimelineItem
+    ]
+    act(() => root.render(<Harness rows={appended} />))
+    expect(current.entries).toHaveLength(80)
+    expect(current.entries.at(-1)?.item.id).toBe('latest')
+    act(() => root.unmount())
+  })
+
   it('keeps a stable reading row through insertions, resumes following, and resets scope', () => {
     const container = document.createElement('div')
     const root = createRoot(container)

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -18,6 +18,34 @@ type TranscriptWindowState = {
   itemCount: number
   start: number
   end: number
+  anchorId?: string
+  anchorIndexOffset?: number
+  followEnd?: boolean
+  finding?: boolean
+}
+
+type ReadingAnchor = { scopeId: string | undefined; messageId: string; offset: number }
+type FindSnapshot = {
+  window: TranscriptWindowState
+  scrollTop: number
+  anchor?: ReadingAnchor
+  target?: ReadingAnchor
+}
+
+// Use the registered transcript nodes, including standalone activities, as the reading boundary.
+const captureReadingAnchor = (
+  scopeId: string | undefined,
+  viewport: HTMLDivElement | null
+): ReadingAnchor | undefined => {
+  if (!viewport) return undefined
+  const bounds = viewport.getBoundingClientRect()
+  for (const node of viewport.querySelectorAll<HTMLElement>('[data-message-id]')) {
+    const rect = node.getBoundingClientRect()
+    if (node.dataset.messageId && rect.bottom > bounds.top && rect.top < bounds.bottom) {
+      return { scopeId, messageId: node.dataset.messageId, offset: rect.top - bounds.top }
+    }
+  }
+  return undefined
 }
 
 const useTranscriptWindow = (
@@ -32,6 +60,9 @@ const useTranscriptWindow = (
   revealAll: () => void
   restoreWindow: () => void
   expandAtScrollEdge: (previousScrollTop: number) => void
+  followEnd: () => void
+  isFollowingEnd: boolean
+  recordUserScroll: () => void
 } => {
   const [state, setState] = useState<TranscriptWindowState>(() => ({
     scopeId: undefined,
@@ -39,22 +70,50 @@ const useTranscriptWindow = (
     start: 0,
     end: 0
   }))
+  const pendingTargetRef = useRef<ReadingAnchor | undefined>(undefined)
+  const readingAnchorRef = useRef<ReadingAnchor | undefined>(undefined)
+  const findRestoreRef = useRef<FindSnapshot | undefined>(undefined)
+  const finding = state.scopeId === scopeId && state.finding === true
   const initialStart = Math.max(0, items.length - TRANSCRIPT_WINDOW_SIZE)
+  if (state.scopeId !== scopeId) {
+    setState({
+      scopeId,
+      itemCount: items.length,
+      start: initialStart,
+      end: items.length,
+      followEnd: true
+    })
+  }
+  useLayoutEffect(() => {
+    readingAnchorRef.current = undefined
+    pendingTargetRef.current = undefined
+    findRestoreRef.current = undefined
+  }, [scopeId])
   const stateMatchesScope = state.scopeId === scopeId && state.itemCount > 0
-  const wasPinnedToEnd = stateMatchesScope && state.end === state.itemCount
-  const retainedWindowSize = state.end - state.start
-  const start = stateMatchesScope
-    ? wasPinnedToEnd
-      ? Math.max(0, items.length - retainedWindowSize)
-      : Math.min(state.start, items.length)
-    : initialStart
-  const end = stateMatchesScope
-    ? state.end === state.itemCount
-      ? items.length
-      : Math.min(state.end, items.length)
-    : items.length
-  const pendingTargetRef = useRef<string | undefined>(undefined)
-  const findRestoreRef = useRef<TranscriptWindowState | undefined>(undefined)
+  const wasPinnedToEnd =
+    stateMatchesScope && state.followEnd !== false && state.end === state.itemCount
+  const retainedWindowSize = Math.max(
+    wasPinnedToEnd ? TRANSCRIPT_WINDOW_SIZE : 0,
+    state.end - state.start
+  )
+  const retainedStart =
+    stateMatchesScope && state.anchorId ? items.findIndex((item) => item.id === state.anchorId) : -1
+  const start = finding
+    ? 0
+    : stateMatchesScope
+      ? wasPinnedToEnd
+        ? Math.max(0, items.length - retainedWindowSize)
+        : retainedStart >= 0
+          ? Math.max(0, retainedStart - (state.anchorIndexOffset ?? 0))
+          : Math.min(state.start, Math.max(0, items.length - retainedWindowSize))
+      : initialStart
+  const end = finding
+    ? items.length
+    : stateMatchesScope
+      ? wasPinnedToEnd
+        ? items.length
+        : Math.min(start + retainedWindowSize, items.length)
+      : items.length
 
   const revealMessage = useCallback(
     (messageId: string): void => {
@@ -65,96 +124,192 @@ const useTranscriptWindow = (
       if (itemIndex < 0) return
 
       const nextStart = Math.max(0, itemIndex - Math.floor(TRANSCRIPT_WINDOW_SIZE / 4))
-      pendingTargetRef.current = messageId
-      if (findRestoreRef.current?.scopeId === scopeId) return
+      const anchor = { scopeId, messageId, offset: 0 }
+      readingAnchorRef.current = anchor
+      const snapshot = findRestoreRef.current
+      if (snapshot && snapshot.window.scopeId === scopeId) {
+        snapshot.target = anchor
+        return
+      }
+      if (viewportRef.current && findMessageTarget(viewportRef.current, messageId)) {
+        setState({
+          scopeId,
+          itemCount: items.length,
+          start,
+          end,
+          anchorId: items[start]?.id,
+          followEnd: false
+        })
+        return
+      }
+      pendingTargetRef.current = anchor
       setState({
         scopeId,
         itemCount: items.length,
         start: nextStart,
+        anchorId: items[nextStart]?.id,
+        followEnd: false,
         end: Math.min(items.length, nextStart + TRANSCRIPT_WINDOW_SIZE)
       })
     },
-    [items, scopeId]
+    [end, items, scopeId, start, viewportRef]
   )
 
   const revealAll = useCallback((): void => {
-    if (findRestoreRef.current?.scopeId !== scopeId) {
-      findRestoreRef.current = { scopeId, itemCount: items.length, start, end }
+    if (!findRestoreRef.current || findRestoreRef.current.window.scopeId !== scopeId) {
+      findRestoreRef.current = {
+        window: {
+          scopeId,
+          itemCount: items.length,
+          start,
+          end,
+          anchorId: stateMatchesScope ? state.anchorId : items[start]?.id,
+          anchorIndexOffset: stateMatchesScope ? state.anchorIndexOffset : 0,
+          followEnd: stateMatchesScope ? state.followEnd : true
+        },
+        scrollTop: viewportRef.current?.scrollTop ?? 0,
+        anchor: captureReadingAnchor(scopeId, viewportRef.current)
+      }
     }
-    setState({
-      scopeId,
-      itemCount: items.length,
-      start: 0,
-      end: items.length
-    })
-  }, [end, items.length, scopeId, start])
+    setState({ scopeId, itemCount: items.length, start: 0, end: items.length, finding: true })
+  }, [
+    end,
+    items,
+    scopeId,
+    start,
+    state.anchorId,
+    state.anchorIndexOffset,
+    state.followEnd,
+    stateMatchesScope,
+    viewportRef
+  ])
 
   const restoreWindow = useCallback((): void => {
-    const previous = findRestoreRef.current
+    const snapshot = findRestoreRef.current
     findRestoreRef.current = undefined
-    if (!previous || previous.scopeId !== scopeId) return
+    if (!snapshot || snapshot.window.scopeId !== scopeId) return
 
-    const wasPinnedToEnd = previous.end === previous.itemCount
-    const previousWindowSize = previous.end - previous.start
+    const viewport = viewportRef.current
+    const visibleAnchor = captureReadingAnchor(scopeId, viewport)
+    // An explicit run selection wins even if its smooth scroll has not reached the target yet.
+    const anchor = snapshot.target
+      ? visibleAnchor?.messageId === snapshot.target.messageId
+        ? visibleAnchor
+        : snapshot.target
+      : ((viewport && viewport.scrollTop !== snapshot.scrollTop ? visibleAnchor : undefined) ??
+        snapshot.anchor)
+    const changedReading =
+      snapshot.target !== undefined || anchor?.messageId !== snapshot.anchor?.messageId
+    const anchorIndex = anchor ? items.findIndex((item) => item.id === anchor.messageId) : -1
+    if (changedReading && anchorIndex >= 0) {
+      const nextStart = Math.max(0, anchorIndex - Math.floor(TRANSCRIPT_WINDOW_SIZE / 4))
+      pendingTargetRef.current = anchor
+      readingAnchorRef.current = anchor
+      setState({
+        scopeId,
+        itemCount: items.length,
+        start: nextStart,
+        end: Math.min(items.length, nextStart + TRANSCRIPT_WINDOW_SIZE),
+        anchorId: items[nextStart]?.id,
+        followEnd: false
+      })
+    } else {
+      // Keep the original window (including follow intent) when find did not navigate.
+      pendingTargetRef.current = anchor
+      setState(snapshot.window)
+    }
+  }, [items, scopeId, viewportRef])
+
+  const recordUserScroll = (): void => {
+    const snapshot = findRestoreRef.current
+    if (snapshot?.window.scopeId === scopeId && snapshot) snapshot.target = undefined
+  }
+
+  const followEnd = (): void => {
+    readingAnchorRef.current = undefined
+    pendingTargetRef.current = undefined
     setState({
       scopeId,
       itemCount: items.length,
-      start: wasPinnedToEnd
-        ? Math.max(0, items.length - previousWindowSize)
-        : Math.min(previous.start, items.length),
-      end: wasPinnedToEnd ? items.length : Math.min(previous.end, items.length)
+      start: initialStart,
+      end: items.length,
+      followEnd: true
     })
-  }, [items.length, scopeId])
+  }
 
   const expandAtScrollEdge = (previousScrollTop: number): void => {
     const viewport = viewportRef.current
     if (!viewport || presentationBarrierIndex >= 0) return
     const prefetchDistance = Math.max(64, viewport.clientHeight)
+    readingAnchorRef.current = captureReadingAnchor(scopeId, viewport)
+    if (finding) return
+    const following =
+      end === items.length &&
+      viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 0.5
+    if (following) readingAnchorRef.current = undefined
+    let nextStart = start
+    let nextEnd = end
 
     if (
       viewport.scrollTop < previousScrollTop &&
       viewport.scrollTop <= prefetchDistance &&
       start > 0
     ) {
-      startTransition(() => {
-        setState({
-          scopeId,
-          itemCount: items.length,
-          start: Math.max(0, start - TRANSCRIPT_WINDOW_SIZE),
-          end
-        })
-      })
+      nextStart = Math.max(0, start - TRANSCRIPT_WINDOW_SIZE)
     } else if (
       viewport.scrollTop > previousScrollTop &&
       viewport.scrollTop + viewport.clientHeight >= viewport.scrollHeight - prefetchDistance &&
       end < items.length
     ) {
-      startTransition(() => {
+      nextEnd = Math.min(items.length, end + TRANSCRIPT_WINDOW_SIZE)
+    }
+    const readingId = readingAnchorRef.current?.messageId
+    const readingIndex = readingId ? items.findIndex((item) => item.id === readingId) : -1
+    const anchorIndex =
+      readingIndex >= nextStart && readingIndex < nextEnd ? readingIndex : nextStart
+    const anchorId = items[anchorIndex]?.id
+    const anchorIndexOffset = anchorIndex - nextStart
+    if (
+      nextStart !== start ||
+      nextEnd !== end ||
+      !stateMatchesScope ||
+      state.followEnd !== following ||
+      state.itemCount !== items.length ||
+      state.anchorId !== anchorId ||
+      state.anchorIndexOffset !== anchorIndexOffset
+    ) {
+      startTransition(() =>
         setState({
           scopeId,
           itemCount: items.length,
-          start,
-          end: Math.min(items.length, end + TRANSCRIPT_WINDOW_SIZE)
+          start: nextStart,
+          end: nextEnd,
+          anchorId,
+          anchorIndexOffset,
+          followEnd: following
         })
-      })
+      )
     }
   }
 
   useLayoutEffect(() => {
-    const messageId = pendingTargetRef.current
+    const anchor = pendingTargetRef.current ?? readingAnchorRef.current
     const viewport = viewportRef.current
-    if (!messageId || !viewport) return
-    const target = findMessageTarget(viewport, messageId)
+    if (!anchor || anchor.scopeId !== scopeId || !viewport || finding) return
+    const target = findMessageTarget(viewport, anchor.messageId)
     if (!target) return
 
     pendingTargetRef.current = undefined
     const top = Math.max(
       0,
-      viewport.scrollTop + target.getBoundingClientRect().top - viewport.getBoundingClientRect().top
+      viewport.scrollTop +
+        target.getBoundingClientRect().top -
+        viewport.getBoundingClientRect().top -
+        anchor.offset
     )
     if (typeof viewport.scrollTo === 'function') viewport.scrollTo({ top, behavior: 'auto' })
     else viewport.scrollTop = top
-  }, [end, start, viewportRef])
+  }, [end, finding, items, scopeId, start, viewportRef])
 
   const presentationStart = Math.max(0, presentationBarrierIndex - TRANSCRIPT_WINDOW_SIZE + 1)
   const entries =
@@ -168,7 +323,17 @@ const useTranscriptWindow = (
         })
       : items.slice(start, end).map((item, offset) => ({ item, itemIndex: start + offset }))
 
-  return { entries, end, revealMessage, revealAll, restoreWindow, expandAtScrollEdge }
+  return {
+    entries,
+    end,
+    revealMessage,
+    revealAll,
+    restoreWindow,
+    expandAtScrollEdge,
+    followEnd,
+    recordUserScroll,
+    isFollowingEnd: !finding && (!stateMatchesScope || wasPinnedToEnd)
+  }
 }
 
 export { useTranscriptWindow }

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -30,6 +30,7 @@ type FindSnapshot = {
   scrollTop: number
   anchor?: ReadingAnchor
   target?: ReadingAnchor
+  followEnd?: boolean
 }
 
 // Use the registered transcript nodes, including standalone activities, as the reading boundary.
@@ -129,6 +130,7 @@ const useTranscriptWindow = (
       const snapshot = findRestoreRef.current
       if (snapshot && snapshot.window.scopeId === scopeId) {
         snapshot.target = anchor
+        snapshot.followEnd = false
         return
       }
       if (viewportRef.current && findMessageTarget(viewportRef.current, messageId)) {
@@ -188,6 +190,18 @@ const useTranscriptWindow = (
     const snapshot = findRestoreRef.current
     findRestoreRef.current = undefined
     if (!snapshot || snapshot.window.scopeId !== scopeId) return
+    if (snapshot.followEnd) {
+      readingAnchorRef.current = undefined
+      pendingTargetRef.current = undefined
+      setState({
+        scopeId,
+        itemCount: items.length,
+        start: Math.max(0, items.length - TRANSCRIPT_WINDOW_SIZE),
+        end: items.length,
+        followEnd: true
+      })
+      return
+    }
 
     const viewport = viewportRef.current
     const visibleAnchor = captureReadingAnchor(scopeId, viewport)
@@ -222,10 +236,18 @@ const useTranscriptWindow = (
 
   const recordUserScroll = (): void => {
     const snapshot = findRestoreRef.current
-    if (snapshot?.window.scopeId === scopeId && snapshot) snapshot.target = undefined
+    if (snapshot && snapshot.window.scopeId === scopeId) {
+      snapshot.target = undefined
+      snapshot.followEnd = false
+    }
   }
 
   const followEnd = (): void => {
+    const snapshot = findRestoreRef.current
+    if (snapshot && snapshot.window.scopeId === scopeId) {
+      snapshot.target = undefined
+      snapshot.followEnd = true
+    }
     readingAnchorRef.current = undefined
     pendingTargetRef.current = undefined
     setState({

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -94,10 +94,7 @@ const useTranscriptWindow = (
   const stateMatchesScope = state.scopeId === scopeId && state.itemCount > 0
   const wasPinnedToEnd =
     stateMatchesScope && state.followEnd !== false && state.end === state.itemCount
-  const retainedWindowSize = Math.max(
-    TRANSCRIPT_WINDOW_SIZE,
-    state.end - state.start
-  )
+  const retainedWindowSize = Math.max(TRANSCRIPT_WINDOW_SIZE, state.end - state.start)
   const retainedStart =
     stateMatchesScope && state.anchorId ? items.findIndex((item) => item.id === state.anchorId) : -1
   const start = finding

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -95,7 +95,7 @@ const useTranscriptWindow = (
   const wasPinnedToEnd =
     stateMatchesScope && state.followEnd !== false && state.end === state.itemCount
   const retainedWindowSize = Math.max(
-    wasPinnedToEnd ? TRANSCRIPT_WINDOW_SIZE : 0,
+    TRANSCRIPT_WINDOW_SIZE,
     state.end - state.start
   )
   const retainedStart =

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -30,6 +30,7 @@ type FindSnapshot = {
   scrollTop: number
   anchor?: ReadingAnchor
   target?: ReadingAnchor
+  followEndReached?: boolean
   followEnd?: boolean
 }
 
@@ -247,6 +248,9 @@ const useTranscriptWindow = (
     if (snapshot && snapshot.window.scopeId === scopeId) {
       snapshot.target = undefined
       snapshot.followEnd = true
+      const viewport = viewportRef.current
+      snapshot.followEndReached =
+        !!viewport && viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 0.5
     }
     readingAnchorRef.current = undefined
     pendingTargetRef.current = undefined
@@ -264,7 +268,15 @@ const useTranscriptWindow = (
     if (!viewport || presentationBarrierIndex >= 0) return
     const prefetchDistance = Math.max(64, viewport.clientHeight)
     readingAnchorRef.current = captureReadingAnchor(scopeId, viewport)
-    if (finding) return
+    if (finding) {
+      const snapshot = findRestoreRef.current
+      if (snapshot?.followEnd) {
+        const atEnd = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 0.5
+        if (atEnd) snapshot.followEndReached = true
+        else if (snapshot.followEndReached) snapshot.followEnd = false
+      }
+      return
+    }
     const following =
       end === items.length &&
       viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight <= 0.5

--- a/src/renderer/src/pages/workspace/workspace-conversation-timeline.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-timeline.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import type { ChatMessage, ChatSession, ToolActivity } from '@/stores/session-store'
 import { ACP_CONTEXT_COMPACTION_ACTIVITY_TOOL_NAME } from '../../../../shared/acp'
@@ -51,6 +51,51 @@ const timelineIds = (
 ): string[] => createWorkspaceConversationTimeline(input, handoffEvents).map(({ id }) => id)
 
 describe('workspace conversation timeline', () => {
+  it('avoids a full prompt-array scan for every completed turn', () => {
+    const turnCount = 250
+    const messages = Array.from({ length: turnCount }, (_, index) => [
+      message({ id: `prompt-${index}`, createdAt: index * 2, sortIndex: index * 2 }),
+      message({
+        id: `reply-${index}`,
+        role: 'agent',
+        responseToMessageId: `prompt-${index}`,
+        createdAt: index * 2 + 1,
+        sortIndex: index * 2 + 1,
+        completedAt: index * 2 + 2
+      })
+    ]).flat()
+    // Count the reported repeated scan, rather than imposing a hardware-dependent time limit.
+    // The production projection remains unmocked; restore instrumentation before assertions.
+    const originalForEach = Array.prototype.forEach
+    let promptVisits = 0
+    const scan = vi.spyOn(Array.prototype, 'forEach').mockImplementation(function (
+      this: unknown[],
+      callback,
+      thisArg
+    ) {
+      const isPromptArray =
+        this.length === messages.length &&
+        typeof this[0] === 'string' &&
+        this[0].startsWith('prompt-')
+      if (isPromptArray) promptVisits += this.length
+      return originalForEach.call(this, callback, thisArg)
+    })
+    let result: ReturnType<typeof createWorkspaceConversationTimeline>
+    try {
+      result = createWorkspaceConversationTimeline(session({ messages }))
+    } finally {
+      scan.mockRestore()
+    }
+    expect(result.map((item) => item.id)).toEqual(
+      Array.from({ length: turnCount }, (_, index) => [
+        `prompt-${index}`,
+        `reply-${index}`,
+        `turn-completion-reply-${index}`
+      ]).flat()
+    )
+    expect(promptVisits).toBeLessThanOrEqual(messages.length)
+  })
+
   it('places one turn completion after a tool that follows the final Agent fragment', () => {
     const input = session({
       messages: [

--- a/src/renderer/src/pages/workspace/workspace-conversation-timeline.ts
+++ b/src/renderer/src/pages/workspace/workspace-conversation-timeline.ts
@@ -97,9 +97,11 @@ const createWorkspaceConversationTimeline = (
   const terminalMessageIds = resolveTurnTerminalAgentMessageIds(session.messages)
   const activePromptMessageId = openPromptMessageId(session)
   const resolveActivityPrompt = createActivityPromptResolver(session)
-  const promptByItemIndex = groupedItems.map((item) =>
-    resolveTimelineItemPrompt(item, resolveActivityPrompt)
-  )
+  const lastItemIndexByPromptId = new Map<string, number>()
+  groupedItems.forEach((item, index) => {
+    const promptId = resolveTimelineItemPrompt(item, resolveActivityPrompt)
+    if (promptId) lastItemIndexByPromptId.set(promptId, index)
+  })
   const itemIndexById = new Map(groupedItems.map((item, index) => [item.id, index]))
   const completionsByItemIndex = new Map<number, ConversationTurnCompletionItem[]>()
 
@@ -114,10 +116,10 @@ const createWorkspaceConversationTimeline = (
     if (messageIndex === undefined) continue
     let completionIndex = messageIndex
     if (promptMessageId) {
-      promptByItemIndex.forEach((candidatePromptMessageId, index) => {
-        if (candidatePromptMessageId === promptMessageId)
-          completionIndex = Math.max(completionIndex, index)
-      })
+      completionIndex = Math.max(
+        completionIndex,
+        lastItemIndexByPromptId.get(promptMessageId) ?? messageIndex
+      )
     }
 
     const completion: ConversationTurnCompletionItem = {

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.test.ts
@@ -148,6 +148,43 @@ describe('groupConversationItems', () => {
     ])
   })
 
+  it.each(['elicitation', 'plan', 'compaction'] as const)(
+    'keeps %s-separated segment identities through appends and status updates',
+    (kind) => {
+      const first = activityItem(createActivity({ id: 'segment-first', activityGroupId: 'shared' }))
+      const last = activityItem(createActivity({ id: 'segment-last', activityGroupId: 'shared' }))
+      const separatorActivity = createActivity({ id: 'separator', activityGroupId: 'shared' })
+      const separator =
+        kind === 'plan'
+          ? planActivityItem(separatorActivity)
+          : kind === 'compaction'
+            ? compactionActivityItem(separatorActivity)
+            : activityItem({
+                ...separatorActivity,
+                elicitation: { message: 'Choose', fields: [], state: 'answered' }
+              })
+      const source = [first, separator, last]
+      const ids = groupConversationItems(source).map((item) => item.id)
+      expect(new Set(ids).size).toBe(3)
+      const appended = activityItem(createActivity({ id: 'appended', activityGroupId: 'shared' }))
+      const updated = groupConversationItems([
+        activityItem(
+          createActivity({ id: 'segment-first', activityGroupId: 'shared', status: 'completed' })
+        ),
+        separator,
+        last,
+        appended
+      ])
+      expect(updated.map((item) => item.id)).toEqual(ids)
+      expect(updated.at(-1)).toMatchObject({
+        activities: [
+          expect.objectContaining({ id: 'segment-last' }),
+          expect.objectContaining({ id: 'appended' })
+        ]
+      })
+    }
+  )
+
   it('splits adjacent activities at declared group boundaries', () => {
     const grouped = groupConversationItems(
       [
@@ -175,8 +212,8 @@ describe('groupConversationItems', () => {
     )
 
     expect(grouped).toEqual([
-      expect.objectContaining({ id: 'activity-group-g1', title: 'Inspect files' }),
-      expect.objectContaining({ id: 'activity-group-g2', title: 'Apply changes' })
+      expect.objectContaining({ id: 'activity-group-a1', title: 'Inspect files' }),
+      expect.objectContaining({ id: 'activity-group-a2', title: 'Apply changes' })
     ])
   })
 

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -66,9 +66,8 @@ const groupConversationItems = (
     }
 
     groupedItems.push({
-      id: activityGroupId
-        ? `activity-group-${activityGroupId}`
-        : `activity-group-${item.activity.id}`,
+      // Business groups can span standalone cards; each contiguous row owns its identity.
+      id: `activity-group-${item.activity.id}`,
       type: 'activity-group',
       createdAt: item.createdAt,
       sortIndex: item.sortIndex,


### PR DESCRIPTION
## Problem

New timeline rows can displace history being read, closing find can discard a newly selected run, and standalone cards can split a named tool group into rows with duplicate identities. Completion placement also scans all timeline ownership entries once per completed turn.

## Proposed change

- Retain a scope-bound reading anchor and follow intent; preserve explicit run/end selections through find close until the user scrolls elsewhere, and reset on session/branch changes. Cover empty-to-populated initialization through both the hook and mounted component (120/240 input rows → 80 mounted rows), and preserve find navigation after explicit end-following has settled.
- Reuse the existing scroller after a bounded tail replacement with unchanged mounted row count, leaving ordinary growth to its native anchor policy. Commit the tail before the end button measures it and restore following after the primitive processes new prompt anchors.
- Derive contiguous tool-segment row IDs from the first activity while retaining business group relationships.
- Index each prompt's latest timeline position once, preserving every completion row and its order.

## Scope and non-goals

Renderer-only changes. No persisted fields, migration, historical-data backfill, business enum, new dependency, worker or replacement scrolling architecture. Existing message/activity IDs suffice for historical records; synthetic group IDs are transient UI identities. Main-process execution frameworks and subscription contracts are unchanged.

## Acceptance criteria and validation

Before implementation, two repeated runs against unchanged production code failed on the same five new assertions: loss of 2/80 and 80/80 reading nodes, loss of a run selected during find, coupled group collapse/duplicate keys, and 125,000 ownership visits for 250 turns. Existing cases in those files passed.

Checks below ran after the last production/test edit:

| Behavior / boundary | Check | Result |
| --- | --- | --- |
| Window anchors, appends, find, scope changes; segment IDs and completion order; mounted scroller, Run Marks, annotation and provenance consumers | `npx vitest run src/renderer/src/pages/workspace/{use-transcript-window.test.tsx,WorkspaceMessageScroller.interaction.test.tsx,WorkspaceMessageScroller.annotations.test.tsx,WorkspaceMessageScroller.render.test.tsx,WorkspaceRunMarks.interaction.test.tsx,workspace-tool-activity-groups.test.ts,workspace-conversation-timeline.test.ts,ArtifactProvenancePanel.render.test.tsx,ArtifactProvenanceMessages.integration.test.tsx}` | 9 files, 288 passed |
| Workspace owner/contracts and session-store consumer coverage | `npm run test:module -- workspace_page` | 31 files, 873 passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Real component scrolling, immediate find close, bottom following and independent segment collapse | Local Chromium fixture with actual WorkspaceMessageScroller/MessageScroller, real wheel input and Run Marks | Passed; screenshots supplied in the task |

The same one-warm-up/five-sample Node benchmark at 4,000 completed turns improved from 112.40 ms to 3.23 ms median, retaining all 12,000 rows. Regression assertions count the reported scan instead of using a hardware-dependent timing threshold.

The affected-test explain command routes this diff to the full suite because the manifest has no explicit owner for the scroller test file. The focused local set above was selected from actual owner/consumer paths; no full local portable suite was run, as requested by the maintainer. Exact-head PR CI remains authoritative. Browser validation uses fixture IPC/data and does not claim Electron native text-find end-to-end coverage. No main-process, migration or OS-specific behavior changed, so those local lanes were excluded.

## Review focus

For empty scopes, unmatched state still derives `start = max(0, items.length - 80)` and renders `items.slice(start, end)`; both hook and actual scroller tests exercise this without changing initialization logic. Review reading-anchor/follow transitions, scope cleanup, the ordering around the scroller MutationObserver, and synthetic row-ID consumers. Confirm the evidence mapping covers the final diff; do not treat unselected CI lanes as proof.

The latest review's initial-end find scenario was also exercised directly against head `a864b253`: viewport at 9,200 / 10,000 with height 800, open find, first programmatic scroll to the old message, then close. It retains the old message and clears following (10 hook checks passed including this temporary reproduction). Opening find stores prior follow intent in `snapshot.window.followEnd`; `snapshot.followEnd` stays unset until an explicit end selection during find. The review's premise that opening find initializes the latter to true does not match the code. No production change was made for this unreproduced finding. The temporary reproduction and output are retained in local verification evidence.

The exact-head macOS gate exposed a short-window regression: after scrolling away with fewer than 80 rows, the retained capacity could freeze at that smaller count and omit later replies. A mounted component regression failed on the missing appended node before the follow-up fix. Retained capacity now stays at least 80 while keeping the reading start unchanged. The two failing Electron scenarios (permission/file preview and representative conversation/project/recovery) each passed twice locally after the fix; renderer types, lint, the 288 focused checks and 873 workspace checks also passed. Full exact-head CI passed after the follow-up and formatting correction.

The formatting-only head `83b1726c` has the same production behavior as `2b806a14` (which received a mergeable review). Its review repeats the empty-hydration and initial-find claims addressed above; these are contradicted by the mounted-component/hook checks and direct reproduction evidence, rather than accepted as verified defects. Formatting now passes the repository Prettier check.

Final CI verification: all checks passed (or were intentionally skipped) on `83b1726ccd3f98556341b6d41789d42156768ca6`, including three full Ubuntu test shards, module coverage, static checks, CodeQL, Windows core and both E2E shards, macOS build/E2E/accessibility/visual, and Linux Notebook isolation. The automated review job completed, but its textual verdict remains needs changes for the two disproved claims documented above; this is not represented as review approval.
