### PR TITLE
fix(lifecycle): release obsolete confirmations and restore dock windows

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -1053,6 +1053,65 @@ describe('installAppLifecycle', () => {
     expect(quit).toHaveBeenCalledTimes(1)
   })
 
+  it('restores the same tray-hidden main window on macOS activate', () => {
+    const h = setup({ platform: 'darwin' })
+    const original = h.windows[0]
+    h.trayHandlers?.onHide()
+    expect(original.visible).toBe(false)
+    expect(h.isMainWindowHidden()).toBe(true)
+
+    h.app.emit('activate')
+
+    expect.soft(original.visible).toBe(true)
+    expect.soft(original.focused).toBe(true)
+    expect.soft(h.isMainWindowHidden()).toBe(false)
+    expect(h.windows).toHaveLength(1)
+    expect(h.getMainWindow()).toBe(original)
+    // Control: the existing Show action already restores this exact window.
+    h.trayHandlers?.onShow()
+    expect(original.visible).toBe(true)
+    expect(original.focused).toBe(true)
+  })
+
+  it('restores a minimized main window on macOS activate', () => {
+    const h = setup({ platform: 'darwin' })
+    h.windows[0].minimized = true
+    h.windows[0].visible = false
+    h.app.emit('activate')
+    expect(h.windows).toHaveLength(1)
+    expect(h.windows[0]).toMatchObject({ minimized: false, visible: true, focused: true })
+  })
+
+  it('does not create a main window on activation before headless mode opens one', () => {
+    const h = setup({ platform: 'darwin', createInitialWindow: false })
+    h.app.emit('activate')
+    expect(h.windows).toHaveLength(0)
+    h.trayHandlers?.onShow()
+    h.trayHandlers?.onHide()
+    h.app.emit('activate')
+    expect(h.windows).toHaveLength(1)
+    expect(h.windows[0].visible).toBe(true)
+  })
+
+  it('does not reopen a destroyed window during committed shutdown', async () => {
+    let finishPreparation!: () => void
+    const h = setup({
+      platform: 'darwin',
+      shutdownTrigger: () => 'system',
+      prepareForQuit: () =>
+        new Promise<void>((resolve) => {
+          finishPreparation = resolve
+        })
+    })
+    h.app.emit('before-quit')
+    await flush()
+    h.windows[0].destroyed = true
+    h.app.emit('activate')
+    expect(h.windows).toHaveLength(1)
+    finishPreparation()
+    await flush()
+  })
+
   it('recreates a window on macOS activate when none are open', () => {
     const { app, windows } = setup({ platform: 'darwin' })
     windows[0].destroyed = true

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -81,7 +81,7 @@ export type AppLifecycleDeps = {
   isMigrationInProgress: () => boolean
   // Requests an app quit (app.quit); the before-quit handler below turns it into an awaited teardown.
   quit: () => void
-  // Number of live BrowserWindows, used to decide whether to recreate on macOS activate.
+  // Number of live BrowserWindows (retained for existing lifecycle compositions).
   countWindows: () => number
   // Headless web mode starts the backend and tray without opening a renderer window.
   createInitialWindow?: boolean
@@ -613,9 +613,11 @@ export const installAppLifecycle = (
     })()
   })
 
-  // macOS: recreate a window when the dock icon is clicked with no windows open.
+  // Dock activation targets the main window, including one hidden to the tray.
   deps.app.on('activate', () => {
-    if (deps.countWindows() === 0) mainWindow = openWindow()
+    if (shutdownStarted || shutdownFinished || quitConfirmed || systemShutdownRequested) return
+    if (deps.createInitialWindow === false && !mainWindow) return
+    showMainWindow()
   })
 
   // With a tray the app stays resident (windows only hide), so window-all-closed shouldn't quit. Without

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -1,9 +1,13 @@
+import { EventEmitter } from 'node:events'
+import { installAppLifecycle } from './app-lifecycle'
+import { clearApplicationShutdownTrigger } from './application-shutdown-trigger'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { BrowserWindow } from 'electron'
 import type { ActiveSessionInfo } from '../shared/storage'
 import type { CloseConfirmRequest, CloseConfirmResponse } from '../shared/window-controls'
 import {
+  WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL,
   WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
   WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL
 } from '../shared/window-controls'
@@ -524,7 +528,11 @@ describe('createElectronCloseConfirm — send path', () => {
     expect(window.restore).not.toHaveBeenCalled() // not minimized
     expect(window.show).toHaveBeenCalledTimes(1)
     expect(window.focus).toHaveBeenCalledTimes(1)
-    expect(window.webContents.send).toHaveBeenCalledTimes(1)
+    expect(
+      window.webContents.send.mock.calls.filter(
+        ([channel]) => channel === WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL
+      )
+    ).toHaveLength(1)
   })
 
   it('focuses the window and forwards the payload to the renderer', async () => {
@@ -788,5 +796,251 @@ describe('createElectronCloseConfirm — nativeFallback', () => {
     ]
     expect(onlyArg.buttons).toEqual(['Cancel', 'Quit'])
     expect(electronMocks.showMessageBox.mock.calls[0]).toHaveLength(1)
+  })
+})
+
+describe('close confirmation page lifetime', () => {
+  it.each(['destroyed', 'did-start-navigation'])(
+    'releases an acknowledged confirmation after %s',
+    async (eventName) => {
+      vi.useFakeTimers()
+      electronMocks.ipcMainListeners.clear()
+      electronMocks.showMessageBox.mockReset()
+      electronMocks.showMessageBox.mockResolvedValue({ response: 0, checkboxChecked: false })
+      const window = createFakeWindow()
+      const confirm = createElectronCloseConfirm(
+        () => window as unknown as BrowserWindow,
+        emptyPreferences
+      )
+      const completed = vi.fn()
+      const pending = confirm('quit', [session]).then(completed)
+      const payload = window.webContents.send.mock.calls[0][1] as CloseConfirmRequest
+      const respond = (response: CloseConfirmResponse): void => {
+        for (const listener of electronMocks.ipcMainListeners.get(
+          WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL
+        ) ?? []) {
+          listener({ sender: window.webContents }, response)
+        }
+      }
+      try {
+        respond({ requestId: payload.requestId, ack: true })
+        if (eventName === 'destroyed') {
+          window.isDestroyed.mockReturnValue(true)
+          window.webContents.isDestroyed.mockReturnValue(true)
+        }
+        for (const listener of window.webContents.__listeners.get(eventName) ?? []) {
+          listener(
+            {
+              url: 'file:///app/index.html',
+              isSameDocument: false,
+              isMainFrame: true,
+              frame: null
+            },
+            'file:///app/index.html',
+            false,
+            true,
+            1,
+            1
+          )
+        }
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect
+          .soft(completed, 'lost page must not retain the confirmation promise')
+          .toHaveBeenCalledWith('cancel')
+        expect
+          .soft(
+            electronMocks.ipcMainListeners.get(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL) ?? [],
+            'settled confirmation must release its response listener'
+          )
+          .toHaveLength(0)
+      } finally {
+        // Cleanup only: the lost page cannot naturally send this response.
+        respond({ requestId: payload.requestId, choice: 'cancel' })
+        await pending
+        vi.useRealTimers()
+      }
+    }
+  )
+})
+
+describe('confirmation decision ownership', () => {
+  it('keeps native ownership after transfer even when the renderer recovers and chooses quit', async () => {
+    let resolveNative!: (result: NativeCloseConfirmResult) => void
+    const dismiss = vi.fn()
+    const h = makeHarness({
+      dismiss,
+      nativeFallback: () =>
+        new Promise((resolve) => {
+          resolveNative = resolve
+        })
+    })
+    const completed = vi.fn()
+    const pending = h.confirm('quit', [session]).then(completed)
+    h.ack()
+    h.fireGone()
+    expect(dismiss).toHaveBeenCalledWith('req-1')
+    h.fireRecover()
+    h.choose('quit')
+    await flushPreferenceRead()
+    expect(completed).not.toHaveBeenCalled()
+    resolveNative({ choice: 'cancel' })
+    await pending
+    expect(completed).toHaveBeenCalledWith('cancel')
+  })
+
+  it('releases the request even when dismissal delivery throws', async () => {
+    const h = makeHarness({
+      dismiss: () => {
+        throw new Error('page unavailable')
+      }
+    })
+    const pending = h.confirm('quit', [session])
+    h.ack()
+    h.choose('cancel')
+    await expect(pending).resolves.toBe('cancel')
+  })
+
+  it.each([
+    { isMainFrame: false, isSameDocument: false },
+    { isMainFrame: true, isSameDocument: true }
+  ])(
+    'preserves an acknowledged modal for navigation $isMainFrame/$isSameDocument',
+    async (details) => {
+      vi.useFakeTimers()
+      electronMocks.ipcMainListeners.clear()
+      electronMocks.showMessageBox.mockReset()
+      const window = createFakeWindow()
+      const confirm = createElectronCloseConfirm(
+        () => window as unknown as BrowserWindow,
+        emptyPreferences
+      )
+      const completed = vi.fn()
+      const pending = confirm('quit', [session]).then(completed)
+      const payload = window.webContents.send.mock.calls[0][1] as CloseConfirmRequest
+      const respond = (response: CloseConfirmResponse): void => {
+        for (const listener of electronMocks.ipcMainListeners.get(
+          WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL
+        ) ?? [])
+          listener({ sender: window.webContents }, response)
+      }
+      try {
+        respond({ requestId: payload.requestId, ack: true })
+        for (const listener of window.webContents.__listeners.get('did-start-navigation') ?? [])
+          listener(details)
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect(completed).not.toHaveBeenCalled()
+        expect(electronMocks.showMessageBox).not.toHaveBeenCalled()
+      } finally {
+        respond({ requestId: payload.requestId, choice: 'cancel' })
+        await pending
+        vi.useRealTimers()
+      }
+    }
+  )
+
+  it('keeps pending listeners and dismissal bound to the original window', async () => {
+    electronMocks.ipcMainListeners.clear()
+    const original = createFakeWindow()
+    const replacement = createFakeWindow()
+    let current = original
+    const confirm = createElectronCloseConfirm(
+      () => current as unknown as BrowserWindow,
+      emptyPreferences
+    )
+    const completed = vi.fn()
+    const pending = confirm('quit', [session]).then(completed)
+    const payload = original.webContents.send.mock.calls[0][1] as CloseConfirmRequest
+    const respond = (sender: FakeWebContents, response: CloseConfirmResponse): void => {
+      for (const listener of electronMocks.ipcMainListeners.get(
+        WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL
+      ) ?? [])
+        listener({ sender }, response)
+    }
+    respond(original.webContents, { requestId: payload.requestId, ack: true })
+    current = replacement
+    respond(replacement.webContents, { requestId: payload.requestId, choice: 'quit' })
+    await flushPreferenceRead()
+    expect(completed).not.toHaveBeenCalled()
+    for (const listener of original.webContents.__listeners.get('did-start-navigation') ?? [])
+      listener({ isMainFrame: true, isSameDocument: false })
+    await pending
+    expect(completed).toHaveBeenCalledWith('cancel')
+    expect(original.webContents.send).toHaveBeenCalledWith(WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL, {
+      requestId: payload.requestId
+    })
+    expect(replacement.webContents.send).not.toHaveBeenCalled()
+    expect(
+      [...original.webContents.__listeners.values()].every((listeners) => listeners.size === 0)
+    ).toBe(true)
+  })
+
+  it('allows another normal quit after the acknowledged window is destroyed and reopened', async () => {
+    electronMocks.ipcMainListeners.clear()
+    const app = Object.assign(new EventEmitter(), { exit: vi.fn() })
+    const windows: FakeWindow[] = []
+    const quit = vi.fn()
+    const owner = installAppLifecycle({
+      app: app as unknown as Parameters<typeof installAppLifecycle>[0]['app'],
+      platform: 'darwin',
+      createMainWindow: () => {
+        const window = Object.assign(createFakeWindow(), { on: vi.fn() })
+        windows.push(window)
+        return window as unknown as BrowserWindow
+      },
+      createTray: () => undefined,
+      quit,
+      countWindows: () => windows.filter((window) => !window.isDestroyed()).length,
+      shutdownBackends: async () => undefined,
+      prepareForQuit: async () => undefined,
+      holdSettingsInstallAdmission: () => () => undefined,
+      abortQuitPreparation: () => undefined,
+      flushSessionPersistence: async () => 'completed',
+      isMigrationInProgress: () => false,
+      detectActiveSessions: () => [session],
+      hasActiveReviewerWork: () => false,
+      getActiveSettingsInstallId: () => undefined,
+      createConfirmClose: (getWindow) => createElectronCloseConfirm(getWindow, emptyPreferences)
+    })
+    const requestQuit = (): void => {
+      app.emit('before-quit', { preventDefault: vi.fn(), defaultPrevented: false })
+    }
+    const respond = (window: FakeWindow, response: CloseConfirmResponse): void => {
+      for (const listener of electronMocks.ipcMainListeners.get(
+        WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL
+      ) ?? [])
+        listener({ sender: window.webContents }, response)
+    }
+    try {
+      requestQuit()
+      const first = windows[0]
+      const firstPayload = first.webContents.send.mock.calls[0][1] as CloseConfirmRequest
+      respond(first, { requestId: firstPayload.requestId, ack: true })
+      first.isDestroyed.mockReturnValue(true)
+      first.webContents.isDestroyed.mockReturnValue(true)
+      for (const listener of first.webContents.__listeners.get('destroyed') ?? []) listener()
+      // Flush the coordinator settlement and the lifecycle owner's finally.
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(
+        electronMocks.ipcMainListeners.get(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL)
+      ).toHaveLength(0)
+      owner.showMainWindow()
+      requestQuit()
+      const second = windows[1]
+      expect(second.webContents.send).toHaveBeenCalledWith(
+        WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
+        expect.any(Object)
+      )
+      const secondPayload = second.webContents.send.mock.calls[0][1] as CloseConfirmRequest
+      expect(secondPayload.requestId).not.toBe(firstPayload.requestId)
+      respond(first, { requestId: firstPayload.requestId, choice: 'quit' })
+      respond(second, { requestId: secondPayload.requestId, choice: 'cancel' })
+      await new Promise((resolve) => setTimeout(resolve, 0))
+      expect(quit).not.toHaveBeenCalled()
+      expect(
+        electronMocks.ipcMainListeners.get(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL)
+      ).toHaveLength(0)
+    } finally {
+      clearApplicationShutdownTrigger()
+    }
   })
 })

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -1,9 +1,16 @@
-import { BrowserWindow, dialog, ipcMain } from 'electron'
+import {
+  BrowserWindow,
+  dialog,
+  ipcMain,
+  type IpcMainEvent,
+  type WebContentsDidStartNavigationEventParams
+} from 'electron'
 import { randomUUID } from 'node:crypto'
 
 import { hasDelegatedActiveSession, type ActiveSessionInfo } from '../shared/storage'
 import { englishNativeTranslator, type NativeTranslator } from './locale/main-process-messages'
 import {
+  WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL,
   WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
   WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL,
   type CloseActionPreference,
@@ -29,6 +36,10 @@ export type CloseConfirmDeps = {
   isRendererAvailable: () => boolean
   // Subscribe to render-process-gone for the confirm window; returns an unsubscribe.
   onRenderGone: (cb: () => void) => () => void
+  // Destruction or cross-document main-frame navigation invalidates this page's request.
+  onPageLost?: (cb: () => void) => () => void
+  // Withdraw only this request from the renderer, including when native UI takes ownership.
+  dismiss?: (requestId: string) => void
   // Subscribe to the confirm window's paired 'unresponsive'/'responsive' events; returns an
   // unsubscribe. Lets the coordinator fall back only on a SUSTAINED hang (renderer alive but wedged,
   // so render-process-gone never fires), never on a slow-but-alive renderer. Optional: absent in
@@ -118,6 +129,14 @@ export const createCloseConfirm = (
       let fallbackStarted = false
       let hangTimer: ReturnType<typeof setTimeout> | undefined
 
+      const dismiss = (): void => {
+        try {
+          deps.dismiss?.(requestId)
+        } catch {
+          // A disappearing renderer must not retain the confirmation lock.
+        }
+      }
+
       const finish = (choice: CloseConfirmChoice, remember = false): void => {
         if (settled) return
         settled = true
@@ -126,25 +145,24 @@ export const createCloseConfirm = (
         offResponse()
         offGone()
         offHang?.()
+        offPageLost?.()
+        dismiss()
         const enforcedChoice = enforceDelegatedBlock(choice)
         void persistPreference(enforcedChoice, remember).then(() => resolve(enforcedChoice))
       }
 
-      // Known limitation (cosmetic): when a fallback settles the confirm, a modal the renderer had
-      // already shown (ack path) stays on screen. A late click on it is dropped — the response
-      // listener is removed and `settled` guards it — so it merely closes locally with no effect.
-      // Fully dismissing it would need a main->renderer dismiss message; not worth the protocol
-      // surface for a rare hang/timeout case.
+      // Native UI owns the decision as soon as fallback starts, even if the renderer recovers.
       const startFallback = (): void => {
-        if (fallbackStarted) return
+        if (settled || fallbackStarted) return
         fallbackStarted = true
         clearTimeout(ackTimer)
         clearTimeout(hangTimer)
+        dismiss()
         void safeFallback().then(finish)
       }
 
       const offResponse = deps.onResponse((payload) => {
-        if (payload.requestId !== requestId) return
+        if (settled || fallbackStarted || payload.requestId !== requestId) return
         if (payload.ack) {
           acked = true
           clearTimeout(ackTimer)
@@ -154,18 +172,24 @@ export const createCloseConfirm = (
       })
 
       const offGone = deps.onRenderGone(startFallback)
+      const offPageLost = deps.onPageLost?.(() => {
+        // Once a native dialog is open, page navigation no longer owns its decision.
+        if (!fallbackStarted) finish('cancel')
+      })
 
       // A sustained hang AFTER ack: the pre-ack window is already covered by ackTimer, and the modal
       // legitimately waits on the user, so only arm the grace timer once the renderer actually reports
-      // 'unresponsive'; a paired 'responsive' cancels it. This chain is deliberately separate from
-      // onRenderGone: a crash/reload never emits 'responsive' (recovery is same-process only), so a
-      // reloaded renderer is covered by render-process-gone -> startFallback, not by this timer.
+      // 'unresponsive'; a paired 'responsive' cancels it. Crashes use onRenderGone; reloads and
+      // normal destruction use onPageLost, independently of this timer.
       const offHang = deps.onRendererUnresponsive?.({
         onHang: () => {
-          if (!acked || settled) return
+          if (!acked || settled || fallbackStarted || hangTimer !== undefined) return
           hangTimer = setTimeout(startFallback, hangGraceMs)
         },
-        onRecover: () => clearTimeout(hangTimer)
+        onRecover: () => {
+          clearTimeout(hangTimer)
+          hangTimer = undefined
+        }
       })
 
       const ackTimer = setTimeout(() => {
@@ -258,54 +282,75 @@ const nativeFallback = async (
 
 // Wires createCloseConfirm to Electron IPC + the current main window (via getWindow, since the window
 // can be recreated). Response listeners are per-confirm and removed when it settles.
-export const createElectronCloseConfirm = (
-  getWindow: () => BrowserWindow | undefined,
-  preferences: ClosePreferenceAccess,
-  translate: NativeTranslator = englishNativeTranslator
-): ((
-  variant: CloseConfirmVariant,
-  sessions: ActiveSessionInfo[],
-  unlistedWorkActive?: boolean
-) => Promise<CloseConfirmChoice>) =>
-  createCloseConfirm({
-    // Reveal the window before asking: a tray/Ctrl+Q quit can arrive while the window is hidden
-    // (minimized to tray), and a modal sent to a hidden window would never be seen — leaving the
-    // confirm (and thus the quit) stuck. Restoring/showing/focusing guarantees the modal is visible.
-    send: (payload) => {
-      const window = getWindow()
-      if (!window || window.isDestroyed()) return
-      if (window.isMinimized()) window.restore()
-      if (!window.isVisible()) window.show()
-      window.focus()
-      window.webContents.send(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, payload)
-    },
-    onResponse: (cb) => {
-      const listener = (_event: unknown, payload: CloseConfirmResponse): void => cb(payload)
-      ipcMain.on(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, listener)
-      return () => ipcMain.removeListener(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, listener)
-    },
-    isRendererAvailable: () => {
-      const window = getWindow()
-      return Boolean(window && !window.isDestroyed() && !window.webContents.isDestroyed())
-    },
-    onRenderGone: (cb) => {
-      const window = getWindow()
-      if (!window) return () => undefined
-      window.webContents.on('render-process-gone', cb)
-      return () => window.webContents.off('render-process-gone', cb)
-    },
-    onRendererUnresponsive: ({ onHang, onRecover }) => {
-      const window = getWindow()
-      if (!window) return () => undefined
-      window.webContents.on('unresponsive', onHang)
-      window.webContents.on('responsive', onRecover)
-      return () => {
-        window.webContents.off('unresponsive', onHang)
-        window.webContents.off('responsive', onRecover)
-      }
-    },
-    nativeFallback: (variant, sessions) => nativeFallback(getWindow, variant, sessions, translate),
-    getClosePreference: preferences.get,
-    setClosePreference: preferences.set,
-    newRequestId: () => randomUUID()
-  })
+export const createElectronCloseConfirm =
+  (
+    getWindow: () => BrowserWindow | undefined,
+    preferences: ClosePreferenceAccess,
+    translate: NativeTranslator = englishNativeTranslator
+  ): ((
+    variant: CloseConfirmVariant,
+    sessions: ActiveSessionInfo[],
+    unlistedWorkActive?: boolean
+  ) => Promise<CloseConfirmChoice>) =>
+  (variant, sessions, unlistedWorkActive) => {
+    const window = getWindow()
+    const webContents = window?.webContents
+    return createCloseConfirm({
+      // Reveal the window before asking: a tray/Ctrl+Q quit can arrive while the window is hidden
+      // (minimized to tray), and a modal sent to a hidden window would never be seen — leaving the
+      // confirm (and thus the quit) stuck. Restoring/showing/focusing guarantees the modal is visible.
+      send: (payload) => {
+        if (!window || window.isDestroyed()) return
+        if (window.isMinimized()) window.restore()
+        if (!window.isVisible()) window.show()
+        window.focus()
+        window.webContents.send(WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL, payload)
+      },
+      onResponse: (cb) => {
+        const listener = (event: IpcMainEvent, payload: CloseConfirmResponse): void => {
+          if (event.sender === webContents) cb(payload)
+        }
+        ipcMain.on(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, listener)
+        return () => ipcMain.removeListener(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, listener)
+      },
+      isRendererAvailable: () => {
+        return Boolean(window && !window.isDestroyed() && !window.webContents.isDestroyed())
+      },
+      onRenderGone: (cb) => {
+        if (!window) return () => undefined
+        window.webContents.on('render-process-gone', cb)
+        return () => window.webContents.off('render-process-gone', cb)
+      },
+      onPageLost: (cb) => {
+        if (!webContents) return () => undefined
+        const onNavigation = (details: WebContentsDidStartNavigationEventParams): void => {
+          if (details.isMainFrame && !details.isSameDocument) cb()
+        }
+        webContents.on('destroyed', cb)
+        webContents.on('did-start-navigation', onNavigation)
+        return () => {
+          webContents.off('destroyed', cb)
+          webContents.off('did-start-navigation', onNavigation)
+        }
+      },
+      dismiss: (requestId) => {
+        if (webContents && !webContents.isDestroyed()) {
+          webContents.send(WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL, { requestId })
+        }
+      },
+      onRendererUnresponsive: ({ onHang, onRecover }) => {
+        if (!window) return () => undefined
+        window.webContents.on('unresponsive', onHang)
+        window.webContents.on('responsive', onRecover)
+        return () => {
+          window.webContents.off('unresponsive', onHang)
+          window.webContents.off('responsive', onRecover)
+        }
+      },
+      nativeFallback: (variant, sessions) =>
+        nativeFallback(() => window, variant, sessions, translate),
+      getClosePreference: preferences.get,
+      setClosePreference: preferences.set,
+      newRequestId: () => randomUUID()
+    })(variant, sessions, unlistedWorkActive)
+  }

--- a/src/preload/electron-renderer-contract-adapter.test.ts
+++ b/src/preload/electron-renderer-contract-adapter.test.ts
@@ -320,20 +320,30 @@ describe('electron renderer contract adapter', () => {
     })
   })
 
-  it('strips Electron events and removes the exact wrapped listener on unsubscribe', () => {
+  it.each([
+    {
+      publicPath: 'specialist.onPendingSwitch',
+      channel: 'specialist:pending-switch',
+      payload: { specialistId: 'specialist-1' }
+    },
+    {
+      publicPath: 'window.onCloseConfirmDismiss',
+      channel: 'window:close-confirm-dismiss',
+      payload: { requestId: 'close-1' }
+    }
+  ])('strips Electron events and unsubscribes $publicPath', ({ publicPath, channel, payload }) => {
     const port = createPort()
     const adapter = createElectronRendererContractAdapter(port)
     const listener = vi.fn()
 
-    const unsubscribe = adapter.subscribe('specialist.onPendingSwitch', listener)
+    const unsubscribe = adapter.subscribe(publicPath, listener)
     const wrappedListener = port.on.mock.calls[0]?.[1]
-    const payload = { specialistId: 'specialist-1' }
 
     wrappedListener?.({ sender: 'electron' }, payload)
     unsubscribe()
 
-    expect(port.on).toHaveBeenCalledWith('specialist:pending-switch', wrappedListener)
+    expect(port.on).toHaveBeenCalledWith(channel, wrappedListener)
     expect(listener).toHaveBeenCalledWith(payload)
-    expect(port.removeListener).toHaveBeenCalledWith('specialist:pending-switch', wrappedListener)
+    expect(port.removeListener).toHaveBeenCalledWith(channel, wrappedListener)
   })
 })

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -730,6 +730,7 @@ describe('preload bridge — public surface inventory', () => {
       'window.closeFind',
       'window.findInPage',
       'window.onCloseActivePane',
+      'window.onCloseConfirmDismiss',
       'window.onCloseConfirmRequest',
       'window.onFindInPageResult',
       'window.onHideWindowFind',

--- a/src/renderer/src/components/CloseConfirmModal.render.test.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.render.test.tsx
@@ -1,4 +1,12 @@
 // @vitest-environment jsdom
+import { EventEmitter } from 'node:events'
+import type { BrowserWindow } from 'electron'
+import { createElectronCloseConfirm } from '../../../main/window-close-confirm'
+import {
+  WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL,
+  WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL,
+  WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL
+} from '../../../shared/window-controls'
 import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -7,11 +15,27 @@ import { CloseConfirmModal } from './CloseConfirmModal'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useProjectStore } from '@/stores/project-store'
 import { useSessionStore } from '@/stores/session-store'
-import type { CloseConfirmRequest } from '../../../shared/window-controls'
+import type { CloseConfirmDismissal, CloseConfirmRequest } from '../../../shared/window-controls'
 
 ;(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true
 
+const electronBoundary = vi.hoisted(() => ({
+  ipc: undefined as EventEmitter | undefined,
+  showMessageBox: vi.fn()
+}))
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+  dialog: { showMessageBox: electronBoundary.showMessageBox },
+  ipcMain: {
+    on: (channel: string, listener: (...args: unknown[]) => void) =>
+      electronBoundary.ipc!.on(channel, listener),
+    removeListener: (channel: string, listener: (...args: unknown[]) => void) =>
+      electronBoundary.ipc!.removeListener(channel, listener)
+  }
+}))
+
 let requestListener: ((payload: CloseConfirmRequest) => void) | undefined
+let dismissListener: ((payload: CloseConfirmDismissal) => void) | undefined
 const sendResponse = vi.fn()
 
 let container: HTMLDivElement
@@ -20,12 +44,17 @@ let root: Root
 beforeEach(() => {
   sendResponse.mockClear()
   requestListener = undefined
+  dismissListener = undefined
   // Test double: only window.api.window is exercised by this component.
   window.api = {
     window: {
       onCloseConfirmRequest: (cb: (payload: CloseConfirmRequest) => void) => {
         requestListener = cb
         return () => (requestListener = undefined)
+      },
+      onCloseConfirmDismiss: (cb: (payload: CloseConfirmDismissal) => void) => {
+        dismissListener = cb
+        return () => (dismissListener = undefined)
       },
       sendCloseConfirmResponse: sendResponse
     }
@@ -76,6 +105,85 @@ const findButtonByName = async (pattern: RegExp): Promise<HTMLButtonElement> => 
 }
 
 describe('CloseConfirmModal', () => {
+  it('removes the web confirmation when the native fallback cancels quit', async () => {
+    vi.useFakeTimers()
+    const ipc = new EventEmitter()
+    electronBoundary.ipc = ipc
+    electronBoundary.showMessageBox.mockResolvedValue({ response: 0, checkboxChecked: false })
+    const contents = Object.assign(new EventEmitter(), {
+      isDestroyed: () => false,
+      send: (channel: string, payload: CloseConfirmRequest): void => {
+        if (channel === WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL) emit(payload)
+        if (channel === WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL) dismissListener?.(payload)
+      }
+    })
+    const ownerWindow = {
+      isDestroyed: () => false,
+      isMinimized: () => false,
+      isVisible: () => true,
+      focus: vi.fn(),
+      webContents: contents
+    } as unknown as BrowserWindow
+    sendResponse.mockImplementation((payload) =>
+      ipc.emit(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL, { sender: contents }, payload)
+    )
+    const confirm = createElectronCloseConfirm(() => ownerWindow, {
+      get: async () => undefined,
+      set: async () => undefined
+    })
+    let pending: ReturnType<typeof confirm> | undefined
+    try {
+      render()
+      act(() => {
+        pending = confirm('quit', [], true)
+      })
+      expect(sendResponse).toHaveBeenCalledWith(expect.objectContaining({ ack: true }))
+      expect(document.querySelector('[role="alertdialog"]')).not.toBeNull()
+      await act(async () => {
+        contents.emit('unresponsive')
+        await vi.advanceTimersByTimeAsync(10_001)
+        await pending
+      })
+      await expect(pending).resolves.toBe('cancel')
+      expect(electronBoundary.showMessageBox).toHaveBeenCalledTimes(1)
+      expect(ipc.listenerCount(WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL)).toBe(0)
+      expect
+        .soft(
+          document.querySelector('[role="alertdialog"]'),
+          'native cancel must not leave actionable stale web controls'
+        )
+        .toBeNull()
+      const staleQuit = Array.from(document.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Quit'
+      )
+      if (staleQuit) {
+        act(() => staleQuit.click())
+        expect(sendResponse).toHaveBeenLastCalledWith(expect.objectContaining({ choice: 'quit' }))
+        await expect(pending).resolves.toBe('cancel')
+      }
+    } finally {
+      sendResponse.mockReset()
+      vi.useRealTimers()
+    }
+  })
+
+  it('withdraws only the matching request and reports visibility without replying', () => {
+    const onOpenChange = vi.fn()
+    act(() => root.render(<CloseConfirmModal onOpenChange={onOpenChange} />))
+    act(() => emit({ requestId: 'old', variant: 'quit', sessions: [] }))
+    act(() => emit({ requestId: 'new', variant: 'quit', sessions: [] }))
+    act(() => dismissListener?.({ requestId: 'old' }))
+    expect(document.querySelector('[role="alertdialog"]')).not.toBeNull()
+    expect(onOpenChange).toHaveBeenLastCalledWith(true)
+    act(() => dismissListener?.({ requestId: 'new' }))
+    expect(document.querySelector('[role="alertdialog"]')).toBeNull()
+    expect(onOpenChange).toHaveBeenLastCalledWith(false)
+    expect(sendResponse.mock.calls.every(([response]) => response.ack === true)).toBe(true)
+    act(() => root.render(<></>))
+    expect(requestListener).toBeUndefined()
+    expect(dismissListener).toBeUndefined()
+  })
+
   it('keeps a long running-task list separate from the close actions', async () => {
     render()
     act(() =>

--- a/src/renderer/src/components/CloseConfirmModal.tsx
+++ b/src/renderer/src/components/CloseConfirmModal.tsx
@@ -1,5 +1,5 @@
 import { AlertDialog } from 'radix-ui'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -45,20 +45,33 @@ export const CloseConfirmModal = ({
 }): React.JSX.Element | null => {
   const { t } = useTranslation()
   const [request, setRequest] = useState<ActiveRequest | undefined>(undefined)
+  const activeRequestId = useRef<string | undefined>(undefined)
   const [remember, setRemember] = useState(true)
 
   useEffect(() => {
     const windowApi = window.api.window
     if (!windowApi.onCloseConfirmRequest) return undefined
-    return windowApi.onCloseConfirmRequest((payload: CloseConfirmRequest) => {
+    const offRequest = windowApi.onCloseConfirmRequest((payload: CloseConfirmRequest) => {
+      activeRequestId.current = payload.requestId
       windowApi.sendCloseConfirmResponse?.({ requestId: payload.requestId, ack: true })
       setRemember(true)
       setRequest(payload)
       onOpenChange?.(true)
     })
+    const offDismiss = windowApi.onCloseConfirmDismiss?.(({ requestId }) => {
+      if (activeRequestId.current !== requestId) return
+      activeRequestId.current = undefined
+      setRequest(undefined)
+      onOpenChange?.(false)
+    })
+    return () => {
+      offRequest()
+      offDismiss?.()
+    }
   }, [onOpenChange])
 
   const reply = (choice: CloseConfirmChoice): void => {
+    activeRequestId.current = undefined
     if (request) {
       window.api.window.sendCloseConfirmResponse?.({
         requestId: request.requestId,

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -486,6 +486,7 @@ import type {
   RemoveMarketplaceSourceRequest
 } from './specialist-marketplace'
 import type {
+  CloseConfirmDismissal,
   CloseConfirmRequest,
   CloseConfirmResponse,
   WindowFindAppearance,
@@ -2428,6 +2429,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     ['shortcut:close-active-pane', CLOSE_PANE_EVENT],
     { optionalMember: true }
   ),
+  'window.onCloseConfirmDismiss': callable<
+    (listener: (payload: CloseConfirmDismissal) => void) => RemoveListener
+  >()('window', ['window:close-confirm-dismiss', ELECTRON_EVENT], { optionalMember: true }),
   'window.onCloseConfirmRequest': callable<
     (listener: (payload: CloseConfirmRequest) => void) => RemoveListener
   >()('window', ['window:close-confirm-request', ELECTRON_EVENT], { optionalMember: true }),

--- a/src/shared/renderer-surface-inventory.test.ts
+++ b/src/shared/renderer-surface-inventory.test.ts
@@ -134,6 +134,7 @@ const GENERATED_SOURCE_OMISSIONS = [
   'window.closeFind',
   'window.findInPage',
   'window.onCloseActivePane',
+  'window.onCloseConfirmDismiss',
   'window.onCloseConfirmRequest',
   'window.onFindInPageResult',
   'window.onHideWindowFind',

--- a/src/shared/window-controls.ts
+++ b/src/shared/window-controls.ts
@@ -178,6 +178,10 @@ export const isFindInPageChord = (input: KeyChordInput, platform: string): boole
 // Main -> renderer: show the close/quit confirmation modal for `variant`, listing `sessions`.
 export const WINDOW_CLOSE_CONFIRM_REQUEST_CHANNEL = 'window:close-confirm-request'
 
+// Main -> renderer: withdraw this request after settlement or transfer to native UI.
+export const WINDOW_CLOSE_CONFIRM_DISMISS_CHANNEL = 'window:close-confirm-dismiss'
+export type CloseConfirmDismissal = { requestId: string }
+
 // Renderer -> main: modal mounted (ack) or the user chose an action (choice), keyed by requestId.
 export const WINDOW_CLOSE_CONFIRM_RESPONSE_CHANNEL = 'window:close-confirm-response'
 


### PR DESCRIPTION
## Problem

An acknowledged quit confirmation could retain its promise and lifecycle lock after its window was normally destroyed or its main document reloaded. Native fallback could also leave an obsolete web dialog visible, while macOS Dock activation did not restore a tray-hidden main window.

## Proposed change

Bind each confirmation to its original window/webContents. Cancel renderer-owned requests on destruction or cross-document main-frame navigation; preserve same-document/subframe navigation and unlimited healthy user decision time. Release listeners so reopening the window permits another normal quit.

Send a requestId-scoped dismissal at settlement and native handoff. Once native fallback starts, ignore late renderer choices. Restore the main window through the existing show/restore/focus path on activation, with headless and committed-shutdown guards.

## Scope and non-goals

One optional desktop IPC event (`window:close-confirm-dismiss`); existing choice/status enums are unchanged. Captured window references and the renderer requestId ref are memory-only. No database, persisted format, preference, historical-data migration, dependency or translation changes. No forced decision timeout or new window/dialog ownership framework.

## Acceptance criteria and validation

The original reproductions failed consistently on unchanged production code in two runs: four behavioral failures and 133 passing controls. They now pass, with further boundary coverage. All checks below ran after the last material source/test edit.

| Behavior / boundary | Project-owned check | Result |
| --- | --- | --- |
| Page loss, listener disposal, next quit, native ownership, Dock restoration and headless/shutdown guards | `npm test -- src/main/window-close-confirm.test.ts src/main/app-lifecycle.test.ts` | Pass |
| Startup and adjacent window entry paths | `npm test -- src/main/app-startup.test.ts src/main/second-instance-router.test.ts src/shared/window-controls.test.ts` | Pass |
| IPC registration, payload delivery, unsubscribe and desktop-only scope | `npm test -- src/shared/renderer-contract-catalog.test.ts src/shared/renderer-contract.test.ts src/shared/renderer-surface-inventory.test.ts src/shared/renderer-surface-matrix.test.ts src/preload/index.test.ts src/preload/electron-renderer-contract-adapter.test.ts` | Pass |
| Real modal dismissal and presentation visibility | `npm test -- src/renderer/src/components/CloseConfirmModal.render.test.tsx src/renderer/src/app-shell-presentation-owner.test.ts` | Pass |
| Web consumers omit the desktop-only event | `npm test -- src/renderer/web/api-installer.test.ts src/renderer/web/api-map.generated.test.ts` | Pass |
| Main/preload/sandbox and renderer types | `npm run typecheck:node`; `npm run typecheck:web` | Pass |
| Source hygiene | `npm run lint`; `git diff --check` | Pass |

An additional isolated real-Electron probe also passed: actual renderer IPC ACK followed by `BrowserWindow.close()` or `webContents.reload()` resolved `cancel`, invoked no native fallback and retained no response listener. It used a separate process and temporary userData directory.

The combined focused run passed 377 tests across 15 files. The real modal was also checked in Chromium with production CSS and Chinese translations: matching dismissal removes it after its exit animation; stale dismissal preserves a newer request and sends no choice. Local screenshots were captured for the maintainer.

Impact selection reports full fallback because lifecycle files lack a declared module owner. Per maintainer request, local verification uses the explicitly mapped checks above; full and platform verification belongs to PR CI. CodeGraph identifies the existing facade consumers but its index belongs to the parent checkout, so changed source and dynamic IPC/event boundaries were checked directly. No framework, session-history, persistence or provider-adapter behavior changed.

## Review focus

Check the cancellation-on-page-loss policy, exclusive native ownership after handoff, matching-only dismissal and activation guards. Portable regressions use Electron event/native-dialog doubles; the additional real-Electron probe covers normal close/reload delivery. Actual OS Dock clicks, sustained renderer hangs and packaged-app behavior remain outside the manual probes. Full/platform CI and independent review remain the final authority.
