### PR TITLE
fix(project-files): preserve selection and expanded ranges on refresh

### DIFF
--- a/e2e/workspace-files.spec.ts
+++ b/e2e/workspace-files.spec.ts
@@ -456,3 +456,53 @@ test.describe('Workspace dividers', () => {
     })
   }
 })
+
+test('preserves expanded uploads after saving a file version', async ({ app }, testInfo) => {
+  test.setTimeout(180_000)
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await createProject(page)
+
+  for (let batch = 0; batch < 4; batch += 1) {
+    const attachments = Array.from({ length: 10 }, (_, index) => ({
+      name: `research-${String(batch * 10 + index).padStart(2, '0')}.md`,
+      mimeType: 'text/markdown',
+      buffer: Buffer.from('# Research notes\n\nOriginal findings.')
+    }))
+    await page.locator('input[type="file"][multiple]').setInputFiles(attachments)
+    await expect(page.getByRole('button', { name: /^Remove attachment research-/ })).toHaveCount(10)
+    await sendPrompt(page, `Keep research batch ${batch}.`, 'Deterministic reply:')
+  }
+
+  await page.getByRole('button', { name: 'Files', exact: true }).click()
+  const files = page.getByTestId('files-view')
+  const rows = files.getByRole('button', { name: /^Preview uploaded file/ })
+  await expect(rows).toHaveCount(20)
+  await files.getByRole('button', { name: 'Load more uploaded files' }).click()
+  await expect(rows).toHaveCount(40)
+  const previousLabels = await rows.evaluateAll((elements) =>
+    elements.map((element) => element.getAttribute('aria-label')).sort()
+  )
+  await files
+    .getByRole('button', { name: 'Preview uploaded file research-00.md', exact: true })
+    .click()
+  const preview = page.getByRole('dialog', { name: 'Preview research-00.md', exact: true })
+  await saveTextVersion(
+    preview,
+    '# Research notes\n\nOriginal findings.',
+    '# Research notes\n\nUpdated findings.',
+    'research-00.md'
+  )
+  await expect(
+    preview.getByTestId('managed-preview-version-navigation').getByText('v2', { exact: true })
+  ).toBeVisible()
+  await preview.getByRole('button', { name: 'Close preview of research-00.md' }).click()
+  await expect(rows).toHaveCount(40)
+  expect(
+    await rows.evaluateAll((elements) =>
+      elements.map((element) => element.getAttribute('aria-label')).sort()
+    )
+  ).toEqual(previousLabels)
+  await rows.last().scrollIntoViewIfNeeded()
+  await page.screenshot({ path: testInfo.outputPath('expanded-uploads-after-save.png') })
+})

--- a/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
+++ b/src/renderer/src/pages/workspace/ProjectFilesView.test.tsx
@@ -1856,7 +1856,16 @@ describe('ProjectFilesView', () => {
 
   it('offers a retry when loading every session option fails', async () => {
     const sessions = createArtifactSessions(12)
-    await renderView(sessions)
+    await renderView(sessions, false, () => {
+      vi.mocked(window.api.projectFiles.listArtifactGroups).mockImplementation(async (request) => ({
+        items: (request.cursor ? sessions.slice(10) : sessions.slice(0, 10)).map((session) => ({
+          sessionId: session.id,
+          artifactCount: 1
+        })),
+        nextCursor: request.cursor ? undefined : 'page-2',
+        totalCount: 12
+      }))
+    })
 
     let continuationAttempts = 0
     vi.mocked(window.api.projectFiles.listArtifactGroups).mockImplementation(async (request) => {
@@ -1962,7 +1971,16 @@ describe('ProjectFilesView', () => {
 
   it('refreshes a collapsed selected session outside the catalog group page', async () => {
     const sessions = createArtifactSessions(12)
-    await renderView(sessions)
+    await renderView(sessions, false, () => {
+      vi.mocked(window.api.projectFiles.listArtifactGroups).mockImplementation(async (request) => ({
+        items: (request.cursor ? sessions.slice(10) : sessions.slice(0, 10)).map((session) => ({
+          sessionId: session.id,
+          artifactCount: 1
+        })),
+        nextCursor: request.cursor ? undefined : 'page-2',
+        totalCount: 12
+      }))
+    })
     let selectedSessionCount = 1
     let selectedOriginState: 'active' | 'deleting' = 'active'
     const catalogListener = vi.mocked(window.api.projectFiles.onChanged).mock.calls[0]?.[0]
@@ -2287,6 +2305,147 @@ describe('ProjectFilesView', () => {
     expect(container.textContent).toContain('Session 11')
     expect(container.textContent).toContain('file-11.png')
     expect(container.textContent).not.toContain('file-1.png')
+  })
+
+  it.each([
+    { outcome: 'files', kind: 'upsert', complete: true, clears: false },
+    { outcome: 'error', kind: 'upsert', complete: true, clears: false },
+    { outcome: 'empty', kind: 'upsert', complete: false, clears: false },
+    { outcome: 'overview-error', kind: 'upsert', complete: true, clears: false },
+    { outcome: 'empty', kind: 'upsert', complete: true, clears: true },
+    { outcome: 'empty', kind: 'reset', complete: true, clears: true },
+    { outcome: 'files', kind: 'reset', complete: true, clears: false }
+  ] as const)(
+    'validates a summary session filter after $kind with $outcome (complete: $complete)',
+    async ({ outcome, kind, complete, clears }) => {
+      const file: ProjectFileItem = {
+        id: 'artifact-summary',
+        source: 'artifact',
+        sourceFileId: 'artifact-summary',
+        sourceVersionId: 'version-summary',
+        projectId: 'default',
+        sessionId: 'session-1',
+        name: 'summary-result.csv',
+        path: '/workspace/summary-result.csv',
+        size: 10,
+        sortAtMs: 10
+      }
+      await renderView(
+        [createSession({ contentLoaded: false, artifactCount: 1, artifacts: undefined })],
+        false,
+        () => {
+          vi.mocked(window.api.projectFiles.getOverview).mockResolvedValue({
+            totalCount: 1,
+            uploadCount: 0,
+            artifactCount: 1,
+            artifactGroupCount: 1,
+            isIndexComplete: true
+          })
+          vi.mocked(window.api.projectFiles.listArtifactGroups).mockResolvedValue({
+            items: [{ sessionId: 'session-1', artifactCount: 1 }],
+            totalCount: 1
+          })
+          vi.mocked(window.api.projectFiles.listFiles).mockImplementation(async (request) => ({
+            items: request.collection.kind === 'uploads' ? [] : [file],
+            totalCount: request.collection.kind === 'uploads' ? 0 : 1
+          }))
+        }
+      )
+      const filterButton = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Filter project files"]'
+      )
+      await act(async () => clickDropdownTrigger(filterButton))
+      await act(async () => {
+        const option = document.body.querySelector<HTMLButtonElement>(
+          '[data-filter-id="session:session-1"]'
+        )
+        expect(option).not.toBeNull()
+        option!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+      })
+      expect(filterButton?.textContent).toContain('Analysis session')
+      expect(container.textContent).toContain(file.name)
+      if (outcome === 'error') {
+        vi.mocked(window.api.projectFiles.listFiles).mockRejectedValue(
+          new Error('File query failed')
+        )
+      } else if (outcome === 'empty' || outcome === 'overview-error') {
+        vi.mocked(window.api.projectFiles.listFiles).mockResolvedValue({ items: [], totalCount: 0 })
+        vi.mocked(window.api.projectFiles.listArtifactGroups).mockResolvedValue({
+          items: [],
+          totalCount: 0
+        })
+      }
+      if (outcome === 'overview-error') {
+        vi.mocked(window.api.projectFiles.getOverview).mockRejectedValue(
+          new Error('Overview query failed')
+        )
+      } else {
+        vi.mocked(window.api.projectFiles.getOverview).mockResolvedValue({
+          totalCount: outcome === 'empty' ? 0 : 1,
+          uploadCount: 0,
+          artifactCount: outcome === 'empty' ? 0 : 1,
+          artifactGroupCount: outcome === 'empty' ? 0 : 1,
+          isIndexComplete: complete
+        })
+      }
+      await act(async () => {
+        projectFilesChangedListener?.({
+          projectId: 'default',
+          sessionId: 'session-1',
+          sources: ['artifact'],
+          kind
+        })
+      })
+      if (outcome === 'files') expect(container.textContent).toContain(file.name)
+      expect(filterButton?.textContent).toContain(clears ? 'Artifacts' : 'Analysis session')
+    }
+  )
+
+  it('retains expanded upload rows after a background refresh', async () => {
+    const files: ProjectFileItem[] = Array.from({ length: 40 }, (_, index) => ({
+      id: `upload:${index}`,
+      source: 'upload',
+      sourceFileId: `${index}`,
+      sourceVersionId: `${index}`,
+      projectId: 'default',
+      sessionId: 'session-1',
+      name: `upload-${index}.csv`,
+      path: `/uploads/upload-${index}.csv`,
+      size: 10,
+      sortAtMs: 40 - index
+    }))
+    await renderView([], false, () => {
+      vi.mocked(window.api.projectFiles.getOverview).mockResolvedValue({
+        totalCount: 40,
+        uploadCount: 40,
+        artifactCount: 0,
+        artifactGroupCount: 0,
+        isIndexComplete: true
+      })
+      vi.mocked(window.api.projectFiles.listFiles).mockImplementation(async (request) => {
+        const offset = Number(request.cursor ?? 0)
+        const end = offset + request.limit!
+        return {
+          items: files.slice(offset, end),
+          totalCount: files.length,
+          nextCursor: end < files.length ? String(end) : undefined
+        }
+      })
+    })
+    expect(container.querySelectorAll('[aria-label^="Preview uploaded file"]')).toHaveLength(20)
+    await act(async () => {
+      const button = container.querySelector<HTMLButtonElement>(
+        '[aria-label="Load more uploaded files"]'
+      )
+      expect(button).not.toBeNull()
+      button!.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+    expect(container.querySelectorAll('[aria-label^="Preview uploaded file"]')).toHaveLength(40)
+    await act(async () => {
+      projectFilesChangedListener?.({ projectId: 'default', sources: ['upload'], kind: 'upsert' })
+    })
+    expect(container.querySelectorAll('[aria-label^="Preview uploaded file"]')).toHaveLength(40)
+    expect(container.textContent).toContain('upload-39.csv')
   })
 
   it('returns to All when the selected session loses its final artifact', async () => {

--- a/src/renderer/src/pages/workspace/project-files-query-model.ts
+++ b/src/renderer/src/pages/workspace/project-files-query-model.ts
@@ -171,16 +171,6 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
 
   const handleIndexChanged = useCallback(
     (event: ProjectFilesChangedEvent): void => {
-      const currentSessions = useSessionStore.getState().sessions
-      const changedSession = event.sessionId
-        ? currentSessions.find(
-            (session) => session.projectId === activeProjectId && session.id === event.sessionId
-          )
-        : undefined
-      const changedSessionHasArtifacts = (changedSession?.artifacts ?? []).some(
-        (artifact) => artifact.kind === 'managed-file' && Boolean(artifact.path)
-      )
-
       if (
         event.kind === 'delete' &&
         event.sessionId &&
@@ -188,21 +178,9 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
       ) {
         setSelectedFilterId('all')
         setSelectedSessionFallback(undefined)
-      } else if (
-        event.kind === 'upsert' &&
-        event.sources.includes('artifact') &&
-        event.sessionId &&
-        changedSession &&
-        selectedFilterId === `session:${event.sessionId}` &&
-        !changedSessionHasArtifacts
-      ) {
-        // Removing the final artifact is a session upsert, so clear a selected session only after the
-        // authoritative renderer session confirms that no managed artifact references remain.
-        setSelectedFilterId('all')
-        setSelectedSessionFallback(undefined)
       }
     },
-    [activeProjectId, selectedFilterId]
+    [selectedFilterId]
   )
 
   useEffect(() => {
@@ -365,7 +343,16 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
   ])
 
   useEffect(() => {
-    if (!selectedSessionId || selectedSessionStillExists || selectedSessionIsLoaded) return
+    if (!selectedSessionId) return
+
+    if (
+      !catalogIndex.isOverviewLoaded ||
+      catalogIndex.overviewError ||
+      !catalogIndex.overview.isIndexComplete ||
+      catalogIndex.isRepairing ||
+      catalogIndex.repairError
+    )
+      return
 
     const groupsSettled =
       catalogIndex.groups.isLoaded && !catalogIndex.groups.isLoading && !catalogIndex.groups.error
@@ -376,8 +363,8 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
     if (!groupsSettled || !sessionPageSettled || selectedCatalogSessionPage.totalCount > 0) return
 
     let canceled = false
-    // A DB-only session can remain in the selected fallback after reset. Clear it only after both the
-    // refreshed group headers and its independent file page confirm that no artifact rows remain.
+    // Session summaries do not carry authoritative artifact contents. Clear selection only when
+    // the unsearched file query succeeds against a complete index, including after a reset.
     void Promise.resolve().then(() => {
       if (canceled) return
       setSelectedFilterId('all')
@@ -391,8 +378,11 @@ const useProjectFilesQueryModel = (activeProjectId: string | undefined): Project
     catalogIndex.groups,
     selectedCatalogSessionPage,
     selectedSessionId,
-    selectedSessionIsLoaded,
-    selectedSessionStillExists
+    catalogIndex.isOverviewLoaded,
+    catalogIndex.overviewError,
+    catalogIndex.overview.isIndexComplete,
+    catalogIndex.isRepairing,
+    catalogIndex.repairError
   ])
 
   const effectiveFilterId =

--- a/src/renderer/src/pages/workspace/use-project-files-index.test.tsx
+++ b/src/renderer/src/pages/workspace/use-project-files-index.test.tsx
@@ -100,6 +100,224 @@ describe('useProjectFilesIndex', () => {
     })
   }
 
+  it.each([
+    { count: 40, kind: 'upsert' },
+    { count: 60, kind: 'upsert' },
+    { count: 40, kind: 'reset' }
+  ] as const)('retains $count loaded session artifacts after $kind', async ({ count, kind }) => {
+    const files = Array.from({ length: count }, (_, index) => artifact(`artifact-${index}`))
+    listFiles.mockImplementation(async (request) => {
+      if (request.collection.kind === 'uploads') return { items: [], totalCount: 0 }
+      const offset = Number(request.cursor ?? 0)
+      const end = offset + request.limit
+      return {
+        items: files.slice(offset, end),
+        totalCount: files.length,
+        nextCursor: end < files.length ? String(end) : undefined
+      }
+    })
+    await renderHook()
+    for (let offset = 0; offset < count; offset += 20) {
+      await act(async () => current.loadMoreArtifacts('session-1'))
+    }
+    expect(current.artifactsBySession['session-1']?.items).toHaveLength(count)
+    await act(async () =>
+      changedListener?.({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        sources: ['artifact'],
+        kind
+      })
+    )
+    expect(current.artifactsBySession['session-1']?.items).toHaveLength(count)
+  })
+
+  it('retains expanded session groups after an artifact refresh', async () => {
+    const groups = Array.from({ length: 20 }, (_, index) => ({
+      sessionId: `session-${index + 1}`,
+      artifactCount: 1
+    }))
+    vi.mocked(window.api.projectFiles.listArtifactGroups).mockImplementation(async (request) => {
+      const offset = Number(request.cursor ?? 0)
+      const end = offset + request.limit!
+      return {
+        items: groups.slice(offset, end),
+        totalCount: groups.length,
+        nextCursor: end < groups.length ? String(end) : undefined
+      }
+    })
+    await renderHook()
+    await act(async () => current.loadMoreGroups())
+    expect(current.groups.items).toHaveLength(20)
+    await act(async () =>
+      changedListener?.({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        sources: ['artifact'],
+        kind: 'upsert'
+      })
+    )
+    expect(current.groups.items).toHaveLength(20)
+    expect(current.groups.items.at(-1)?.sessionId).toBe('session-20')
+  })
+
+  it.each(['uploads', 'groups', 'artifacts'] as const)(
+    'keeps the previous %s range on second-page refresh failure and retries with fresh cursors',
+    async (collection) => {
+      const pageSize = collection === 'groups' ? 10 : 20
+      let ids = Array.from({ length: pageSize * 2 }, (_, index) => String(index))
+      let failTail = false
+      const query = vi.fn(async (request: { cursor?: string; limit?: number }) => {
+        if (request.cursor && failTail) throw new Error('Refresh tail unavailable')
+        const offset = Number(request.cursor ?? 0)
+        const end = offset + request.limit!
+        return {
+          items: ids.slice(offset, end),
+          totalCount: ids.length,
+          nextCursor: end < ids.length ? String(end) : undefined
+        }
+      })
+      listFiles.mockImplementation(async (request) => {
+        const page = await query(request)
+        return { ...page, items: page.items.map(collection === 'uploads' ? upload : artifact) }
+      })
+      vi.mocked(window.api.projectFiles.listArtifactGroups).mockImplementation(async (request) => {
+        const page = await query(request)
+        return { ...page, items: page.items.map((id) => ({ sessionId: id, artifactCount: 1 })) }
+      })
+      const read = (): string[] =>
+        collection === 'groups'
+          ? current.groups.items.map((group) => group.sessionId)
+          : (collection === 'uploads'
+              ? current.uploads
+              : current.artifactsBySession['session-1'])!.items.map((file) => file.sourceFileId)
+      const state = (): {
+        isLoading: boolean
+        error?: string
+        totalCount: number
+        nextCursor?: string
+      } =>
+        collection === 'groups'
+          ? current.groups
+          : collection === 'uploads'
+            ? current.uploads
+            : current.artifactsBySession['session-1']!
+      const load = (): Promise<void> =>
+        collection === 'groups'
+          ? current.loadMoreGroups()
+          : collection === 'uploads'
+            ? current.loadMoreUploads()
+            : current.loadMoreArtifacts('session-1')
+      await renderHook()
+      if (collection === 'artifacts') await act(async () => load())
+      await act(async () => load())
+      const previous = [...ids]
+      expect(read()).toEqual(previous)
+      // Remove the old tail and move the next newest file to the front; no stale tail may survive.
+      ids = [ids.at(-2)!, ...ids.slice(0, -2)]
+      failTail = true
+      await act(async () =>
+        changedListener?.({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          sources: [collection === 'uploads' ? 'upload' : 'artifact'],
+          kind: 'upsert'
+        })
+      )
+      expect(state().isLoading).toBe(false)
+      expect(state().error).toBe('Refresh tail unavailable')
+      expect(read()).toEqual(previous)
+      failTail = false
+      query.mockClear()
+      await act(async () => load())
+      expect(query.mock.calls.map(([request]) => request.cursor)).toEqual([
+        undefined,
+        String(pageSize)
+      ])
+      expect(state().error).toBeUndefined()
+      expect(read()).toEqual(ids)
+      expect(state().totalCount).toBe(ids.length)
+      expect(state().nextCursor).toBeUndefined()
+    }
+  )
+
+  it('discards an older refresh tail after a second notification', async () => {
+    let files = Array.from({ length: 60 }, (_, index) => upload(String(index)))
+    let releaseTail: (() => void) | undefined
+    let holdTail = false
+    listFiles.mockImplementation(async (request) => {
+      const snapshot = files
+      const offset = Number(request.cursor ?? 0)
+      const end = offset + request.limit
+      if (holdTail && request.cursor) {
+        holdTail = false
+        await new Promise<void>((resolve) => {
+          releaseTail = resolve
+        })
+      }
+      return {
+        items: snapshot.slice(offset, end),
+        totalCount: snapshot.length,
+        nextCursor: end < snapshot.length ? String(end) : undefined
+      }
+    })
+    await renderHook(undefined, { kind: 'uploads' })
+    await act(async () => current.loadMoreUploads())
+    await act(async () => current.loadMoreUploads())
+    const previous = current.uploads.items
+    holdTail = true
+    await act(async () =>
+      changedListener?.({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+    )
+    expect(releaseTail).toBeTypeOf('function')
+    expect(current.uploads.isLoading).toBe(true)
+    expect(current.uploads.items).toEqual(previous)
+    files = files.slice(0, 59).reverse()
+    await act(async () =>
+      changedListener?.({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+    )
+    expect(current.uploads.items).toEqual(files)
+    await act(async () => releaseTail!())
+    expect(current.uploads.items).toEqual(files)
+  })
+
+  it('ignores an in-flight refresh when the filename search changes', async () => {
+    let search: ProjectFilesSearch = { filenameContains: 'old' }
+    let releaseTail: (() => void) | undefined
+    let holdTail = false
+    listFiles.mockImplementation(async (request) => {
+      if (request.search.filenameContains === 'new')
+        return { items: [upload('new')], totalCount: 1 }
+      if (holdTail && request.cursor)
+        await new Promise<void>((resolve) => {
+          releaseTail = resolve
+        })
+      const offset = Number(request.cursor ?? 0)
+      return {
+        items: Array.from({ length: 20 }, (_, index) => upload(`old-${index + offset}`)),
+        totalCount: 40,
+        nextCursor: offset === 0 ? '20' : undefined
+      }
+    })
+    const Harness = (): null => {
+      current = useProjectFilesIndex('project-1', undefined, search, { kind: 'uploads' })
+      return null
+    }
+    root = createRoot(container)
+    await act(async () => root.render(<Harness />))
+    await act(async () => current.loadMoreUploads())
+    holdTail = true
+    await act(async () =>
+      changedListener?.({ projectId: 'project-1', sources: ['upload'], kind: 'upsert' })
+    )
+    expect(releaseTail).toBeTypeOf('function')
+    search = { filenameContains: 'new' }
+    await act(async () => root.render(<Harness />))
+    expect(current.uploads.items).toEqual([upload('new')])
+    await act(async () => releaseTail!())
+    expect(current.uploads.items).toEqual([upload('new')])
+  })
+
   it('loads overview, uploads, and groups without loading session artifacts', async () => {
     await renderHook()
 
@@ -288,7 +506,10 @@ describe('useProjectFilesIndex', () => {
     })
 
     expect(current.uploads.items.map((item) => item.sourceFileId)).toEqual(['upload-1', 'upload-2'])
-    expect(current.artifactsBySession['session-1']?.items).toEqual([artifact('artifact-1')])
+    expect(current.artifactsBySession['session-1']?.items).toEqual([
+      artifact('artifact-1'),
+      artifact('artifact-2')
+    ])
   })
 
   it('preserves loaded artifact pages when only uploads change', async () => {

--- a/src/renderer/src/pages/workspace/use-project-files-index.test.tsx
+++ b/src/renderer/src/pages/workspace/use-project-files-index.test.tsx
@@ -241,6 +241,40 @@ describe('useProjectFilesIndex', () => {
     }
   )
 
+  it.each(['reset', 'upsert'] as const)(
+    'invalidates a first artifact request before its loading state renders on %s',
+    async (kind) => {
+      await renderHook()
+      let releaseStale: (() => void) | undefined
+      let artifactReads = 0
+      listFiles.mockImplementation(async (request) => {
+        if (request.collection.kind === 'uploads') return { items: [], totalCount: 0 }
+        artifactReads += 1
+        if (artifactReads === 1) {
+          await new Promise<void>((resolve) => {
+            releaseStale = resolve
+          })
+          return { items: [artifact('deleted-artifact')], totalCount: 1 }
+        }
+        return { items: [], totalCount: 0 }
+      })
+
+      await act(async () => {
+        const pending = current.loadMoreArtifacts('session-1')
+        expect(releaseStale).toBeTypeOf('function')
+        // React has not committed the loading page yet; the public request is already in flight.
+        expect(current.artifactsBySession['session-1']).toBeUndefined()
+        changedListener?.({ projectId: 'project-1', sources: ['artifact'], kind })
+        releaseStale!()
+        await pending
+      })
+
+      expect(current.artifactsBySession['session-1']?.items).toEqual([])
+      expect(current.artifactsBySession['session-1']?.isLoading).toBe(false)
+      expect(artifactReads).toBe(2)
+    }
+  )
+
   it('discards an older refresh tail after a second notification', async () => {
     let files = Array.from({ length: 60 }, (_, index) => upload(String(index)))
     let releaseTail: (() => void) | undefined

--- a/src/renderer/src/pages/workspace/use-project-files-index.ts
+++ b/src/renderer/src/pages/workspace/use-project-files-index.ts
@@ -602,6 +602,8 @@ const useProjectFilesIndex = (
           ? [
               ...new Set([
                 ...Object.keys(pagesRef.current.artifactsBySession),
+                // Requests register synchronously, before React commits their loading pages.
+                ...loadingArtifactsRef.current.keys(),
                 ...(scopeSessionId ? [scopeSessionId] : [])
               ])
             ]

--- a/src/renderer/src/pages/workspace/use-project-files-index.ts
+++ b/src/renderer/src/pages/workspace/use-project-files-index.ts
@@ -133,6 +133,22 @@ const appendUnique = <Item>(
   return [...current, ...incoming.filter((item) => !ids.has(getId(item)))]
 }
 
+// Rebuild a previously loaded range using only fresh cursors. Callers retain the old snapshot until
+// every page succeeds, so a failed continuation never publishes a shortened or mixed collection.
+const readPageRange = async <Item>(
+  read: (cursor?: string) => Promise<{ items: Item[]; totalCount: number; nextCursor?: string }>,
+  minimumCount: number,
+  cursor?: string
+): Promise<{ items: Item[]; totalCount: number; nextCursor?: string }> => {
+  let page = await read(cursor)
+  const items = [...page.items]
+  while (page.nextCursor && items.length < minimumCount) {
+    page = await read(page.nextCursor)
+    items.push(...page.items)
+  }
+  return { ...page, items }
+}
+
 type InitialProjectFilesLoad = {
   projectId: string
   filenameContains?: string
@@ -248,6 +264,9 @@ const useProjectFilesIndex = (
   const [artifactsBySession, setArtifactsBySession] = useState<
     Record<string, PageState<ProjectFileItem> | undefined>
   >({})
+  // Event subscriptions read the last rendered range without resubscribing for every loaded page.
+  const pagesRef = useRef({ uploads, groups, artifactsBySession })
+  pagesRef.current = { uploads, groups, artifactsBySession }
   const [refreshVersion, setRefreshVersion] = useState(0)
   // generation invalidates the whole project view; the per-layer counters invalidate only one first
   // page. Per-session versions allow artifact requests for different groups to remain independent.
@@ -419,12 +438,8 @@ const useProjectFilesIndex = (
       if (!projectId || event.projectId !== projectId) return
 
       onChanged?.(event)
-      if (event.kind === 'reset' || (event.sources.includes('artifact') && !event.sessionId)) {
-        // Scope is unknown, so all three cursor layers must restart together.
-        generationRef.current += 1
-        setRefreshVersion((version) => version + 1)
-        return
-      }
+      const refreshAll =
+        event.kind === 'reset' || (event.sources.includes('artifact') && !event.sessionId)
 
       const generation = generationRef.current
       if (scopeKind === 'all') {
@@ -461,24 +476,36 @@ const useProjectFilesIndex = (
           })
       }
 
-      if (event.sources.includes('upload') && (scopeKind === 'all' || scopeKind === 'uploads')) {
-        // Upload mutations replace the first page and cursor. Appending here would retain deleted rows
-        // or preserve an order captured before the mutation.
+      if (
+        (refreshAll || event.sources.includes('upload')) &&
+        (scopeKind === 'all' || scopeKind === 'uploads')
+      ) {
+        // Rebuild the loaded upload range from a fresh cursor without hiding the previous snapshot.
         const uploadsRequest = ++uploadsRequestRef.current
         const requestKey = `${generation}:${uploadsRequest}:first`
         loadingUploadsRef.current = requestKey
-        setUploads({ ...emptyPage(), isLoading: true })
-        void requestLimiterRef
-          .current(() =>
-            generation === generationRef.current && uploadsRequest === uploadsRequestRef.current
-              ? window.api.projectFiles.listFiles({
-                  projectId,
-                  collection: { kind: 'uploads' },
-                  ...withProjectFilesSearch(filenameContains, excludedSessionIds),
-                  limit: FILE_PAGE_SIZE
-                })
-              : Promise.reject(new Error('Stale project files request.'))
-          )
+        setUploads((current) => ({
+          ...current,
+          nextCursor: undefined,
+          isLoading: true,
+          error: undefined,
+          failedCursor: undefined
+        }))
+        void readPageRange(
+          (cursor) =>
+            requestLimiterRef.current(() =>
+              generation === generationRef.current && uploadsRequest === uploadsRequestRef.current
+                ? window.api.projectFiles.listFiles({
+                    projectId,
+                    collection: { kind: 'uploads' },
+                    ...withProjectFilesSearch(filenameContains, excludedSessionIds),
+                    cursor,
+                    limit: FILE_PAGE_SIZE
+                  })
+                : Promise.reject(new Error('Stale project files request.'))
+            ),
+          pagesRef.current.uploads.items.length
+        )
           .then((page) => {
             if (
               generation !== generationRef.current ||
@@ -495,16 +522,21 @@ const useProjectFilesIndex = (
             ) {
               return
             }
-            setUploads({ ...emptyPage(), isLoaded: true, error: getErrorMessage(error) })
+            setUploads((current) => ({
+              ...current,
+              isLoading: false,
+              isLoaded: true,
+              error: getErrorMessage(error)
+            }))
           })
           .finally(() => {
             if (loadingUploadsRef.current === requestKey) loadingUploadsRef.current = undefined
           })
       }
 
-      if (event.sources.includes('artifact') && event.sessionId) {
+      if (refreshAll || (event.sources.includes('artifact') && event.sessionId)) {
         // The group list shares the same DB projection. Invalidate any page captured before this
-        // session mutation, then rebuild its first page and cursor from the updated projection.
+        // session mutation, then rebuild its loaded range from the updated projection.
         if (scopeKind === 'all' || scopeKind === 'artifactGroups') {
           const groupsRequest = ++groupsRequestRef.current
           const groupsRequestKey = `${generation}:${groupsRequest}:first`
@@ -516,16 +548,20 @@ const useProjectFilesIndex = (
             error: undefined,
             failedCursor: undefined
           }))
-          void requestLimiterRef
-            .current(() =>
-              generation === generationRef.current && groupsRequest === groupsRequestRef.current
-                ? window.api.projectFiles.listArtifactGroups({
-                    projectId,
-                    ...withProjectFilesSearch(filenameContains, excludedSessionIds),
-                    limit: GROUP_PAGE_SIZE
-                  })
-                : Promise.reject(new Error('Stale project files request.'))
-            )
+          void readPageRange(
+            (cursor) =>
+              requestLimiterRef.current(() =>
+                generation === generationRef.current && groupsRequest === groupsRequestRef.current
+                  ? window.api.projectFiles.listArtifactGroups({
+                      projectId,
+                      ...withProjectFilesSearch(filenameContains, excludedSessionIds),
+                      cursor,
+                      limit: GROUP_PAGE_SIZE
+                    })
+                  : Promise.reject(new Error('Stale project files request.'))
+              ),
+            pagesRef.current.groups.items.length
+          )
             .then((page) => {
               if (
                 generation !== generationRef.current ||
@@ -562,74 +598,94 @@ const useProjectFilesIndex = (
             })
         }
 
-        const sessionId = event.sessionId
-        if (
-          scopeKind === 'uploads' ||
-          scopeKind === 'artifactGroups' ||
-          (scopeKind === 'sessionArtifacts' && scopeSessionId !== sessionId)
-        ) {
-          return
-        }
-        // Session files refresh independently from the group list. Their response never edits group
-        // ordering; only listArtifactGroups owns groupSortAtMs ordering and its continuation cursor.
-        const artifactRequest = (artifactRequestVersionsRef.current.get(sessionId) ?? 0) + 1
-        artifactRequestVersionsRef.current.set(sessionId, artifactRequest)
-        const requestKey = `${generation}:${artifactRequest}:first`
-        loadingArtifactsRef.current.set(sessionId, requestKey)
-        setArtifactsBySession((current) => ({
-          ...current,
-          [sessionId]: { ...emptyPage(), isLoading: true }
-        }))
-        void requestLimiterRef
-          .current(() =>
-            generation === generationRef.current &&
-            artifactRequest === artifactRequestVersionsRef.current.get(sessionId)
-              ? window.api.projectFiles.listFiles({
-                  projectId,
-                  collection: { kind: 'sessionArtifacts', sessionId },
-                  ...withProjectFilesSearch(filenameContains, excludedSessionIds),
-                  limit: FILE_PAGE_SIZE
-                })
-              : Promise.reject(new Error('Stale project files request.'))
+        const sessionIds = refreshAll
+          ? [
+              ...new Set([
+                ...Object.keys(pagesRef.current.artifactsBySession),
+                ...(scopeSessionId ? [scopeSessionId] : [])
+              ])
+            ]
+          : [event.sessionId!]
+        for (const sessionId of sessionIds) {
+          if (
+            scopeKind === 'uploads' ||
+            scopeKind === 'artifactGroups' ||
+            (scopeKind === 'sessionArtifacts' && scopeSessionId !== sessionId)
+          ) {
+            continue
+          }
+          // Session files refresh independently from the group list. Their response never edits group
+          // ordering; only listArtifactGroups owns groupSortAtMs ordering and its continuation cursor.
+          const artifactRequest = (artifactRequestVersionsRef.current.get(sessionId) ?? 0) + 1
+          artifactRequestVersionsRef.current.set(sessionId, artifactRequest)
+          const requestKey = `${generation}:${artifactRequest}:first`
+          loadingArtifactsRef.current.set(sessionId, requestKey)
+          setArtifactsBySession((current) => ({
+            ...current,
+            [sessionId]: {
+              ...(current[sessionId] ?? emptyPage()),
+              nextCursor: undefined,
+              isLoading: true,
+              error: undefined,
+              failedCursor: undefined
+            }
+          }))
+          void readPageRange(
+            (cursor) =>
+              requestLimiterRef.current(() =>
+                generation === generationRef.current &&
+                artifactRequest === artifactRequestVersionsRef.current.get(sessionId)
+                  ? window.api.projectFiles.listFiles({
+                      projectId,
+                      collection: { kind: 'sessionArtifacts', sessionId },
+                      ...withProjectFilesSearch(filenameContains, excludedSessionIds),
+                      cursor,
+                      limit: FILE_PAGE_SIZE
+                    })
+                  : Promise.reject(new Error('Stale project files request.'))
+              ),
+            pagesRef.current.artifactsBySession[sessionId]?.items.length ?? 0
           )
-          .then((page) => {
-            if (
-              generation !== generationRef.current ||
-              artifactRequest !== artifactRequestVersionsRef.current.get(sessionId)
-            ) {
-              return
-            }
-            setArtifactsBySession((current) => ({
-              ...current,
-              [sessionId]: {
-                ...page,
-                isLoading: false,
-                isLoaded: true,
-                failedCursor: undefined
+            .then((page) => {
+              if (
+                generation !== generationRef.current ||
+                artifactRequest !== artifactRequestVersionsRef.current.get(sessionId)
+              ) {
+                return
               }
-            }))
-          })
-          .catch((error: unknown) => {
-            if (
-              generation !== generationRef.current ||
-              artifactRequest !== artifactRequestVersionsRef.current.get(sessionId)
-            ) {
-              return
-            }
-            setArtifactsBySession((current) => ({
-              ...current,
-              [sessionId]: {
-                ...emptyPage(),
-                isLoaded: true,
-                error: getErrorMessage(error)
+              setArtifactsBySession((current) => ({
+                ...current,
+                [sessionId]: {
+                  ...page,
+                  isLoading: false,
+                  isLoaded: true,
+                  failedCursor: undefined
+                }
+              }))
+            })
+            .catch((error: unknown) => {
+              if (
+                generation !== generationRef.current ||
+                artifactRequest !== artifactRequestVersionsRef.current.get(sessionId)
+              ) {
+                return
               }
-            }))
-          })
-          .finally(() => {
-            if (loadingArtifactsRef.current.get(sessionId) === requestKey) {
-              loadingArtifactsRef.current.delete(sessionId)
-            }
-          })
+              setArtifactsBySession((current) => ({
+                ...current,
+                [sessionId]: {
+                  ...(current[sessionId] ?? emptyPage()),
+                  isLoading: false,
+                  isLoaded: true,
+                  error: getErrorMessage(error)
+                }
+              }))
+            })
+            .finally(() => {
+              if (loadingArtifactsRef.current.get(sessionId) === requestKey) {
+                loadingArtifactsRef.current.delete(sessionId)
+              }
+            })
+        }
       }
     },
     [excludedSessionIds, filenameContains, onChanged, projectId, scopeKind, scopeSessionId]
@@ -681,23 +737,28 @@ const useProjectFilesIndex = (
     setUploads((page) => ({ ...page, isLoading: true, error: undefined }))
 
     try {
-      const page = await requestLimiterRef.current(() =>
-        generation === generationRef.current
-          ? window.api.projectFiles.listFiles({
-              projectId,
-              collection: { kind: 'uploads' },
-              ...withProjectFilesSearch(filenameContains, excludedSessionIds),
-              cursor,
-              limit: FILE_PAGE_SIZE
-            })
-          : Promise.reject(new Error('Stale project files request.'))
+      const page = await readPageRange(
+        (nextCursor) =>
+          requestLimiterRef.current(() =>
+            generation === generationRef.current && uploadsRequest === uploadsRequestRef.current
+              ? window.api.projectFiles.listFiles({
+                  projectId,
+                  collection: { kind: 'uploads' },
+                  ...withProjectFilesSearch(filenameContains, excludedSessionIds),
+                  cursor: nextCursor,
+                  limit: FILE_PAGE_SIZE
+                })
+              : Promise.reject(new Error('Stale project files request.'))
+          ),
+        cursor ? 0 : uploads.items.length,
+        cursor
       )
       if (generation !== generationRef.current || uploadsRequest !== uploadsRequestRef.current) {
         return
       }
       setUploads((current) => ({
         ...page,
-        items: appendUnique(current.items, page.items, (item) => item.id),
+        items: cursor ? appendUnique(current.items, page.items, (item) => item.id) : page.items,
         isLoading: false,
         isLoaded: true,
         error: undefined,
@@ -736,15 +797,20 @@ const useProjectFilesIndex = (
     setGroups((page) => ({ ...page, isLoading: true, error: undefined }))
 
     try {
-      const page = await requestLimiterRef.current(() =>
-        generation === generationRef.current
-          ? window.api.projectFiles.listArtifactGroups({
-              projectId,
-              ...withProjectFilesSearch(filenameContains, excludedSessionIds),
-              cursor,
-              limit: GROUP_PAGE_SIZE
-            })
-          : Promise.reject(new Error('Stale project files request.'))
+      const page = await readPageRange(
+        (nextCursor) =>
+          requestLimiterRef.current(() =>
+            generation === generationRef.current && groupsRequest === groupsRequestRef.current
+              ? window.api.projectFiles.listArtifactGroups({
+                  projectId,
+                  ...withProjectFilesSearch(filenameContains, excludedSessionIds),
+                  cursor: nextCursor,
+                  limit: GROUP_PAGE_SIZE
+                })
+              : Promise.reject(new Error('Stale project files request.'))
+          ),
+        cursor ? 0 : groups.items.length,
+        cursor
       )
       if (generation !== generationRef.current || groupsRequest !== groupsRequestRef.current) return
       setGroups((current) => ({
@@ -795,16 +861,22 @@ const useProjectFilesIndex = (
       }))
 
       try {
-        const page = await requestLimiterRef.current(() =>
-          generation === generationRef.current
-            ? window.api.projectFiles.listFiles({
-                projectId,
-                collection: { kind: 'sessionArtifacts', sessionId },
-                ...withProjectFilesSearch(filenameContains, excludedSessionIds),
-                cursor,
-                limit: FILE_PAGE_SIZE
-              })
-            : Promise.reject(new Error('Stale project files request.'))
+        const page = await readPageRange(
+          (nextCursor) =>
+            requestLimiterRef.current(() =>
+              generation === generationRef.current &&
+              artifactRequest === (artifactRequestVersionsRef.current.get(sessionId) ?? 0)
+                ? window.api.projectFiles.listFiles({
+                    projectId,
+                    collection: { kind: 'sessionArtifacts', sessionId },
+                    ...withProjectFilesSearch(filenameContains, excludedSessionIds),
+                    cursor: nextCursor,
+                    limit: FILE_PAGE_SIZE
+                  })
+                : Promise.reject(new Error('Stale project files request.'))
+            ),
+          cursor ? 0 : (currentPage?.items.length ?? 0),
+          cursor
         )
         if (
           generation !== generationRef.current ||
@@ -816,7 +888,9 @@ const useProjectFilesIndex = (
           ...current,
           [sessionId]: {
             ...page,
-            items: appendUnique(current[sessionId]?.items ?? [], page.items, (item) => item.id),
+            items: cursor
+              ? appendUnique(current[sessionId]?.items ?? [], page.items, (item) => item.id)
+              : page.items,
             isLoading: false,
             isLoaded: true,
             error: undefined,


### PR DESCRIPTION
## Problem

An artifact update can reset a selected summary session to All even though the database still returns its files. Background refreshes also discard expanded upload, session-group, and session-file pages, shortening a 40-row list to 20 rows.

## Proposed change

Determine empty-session selection from a successful unsearched file query against a complete index, not missing `Session.artifacts`. Keep selection during query failures or incomplete indexing and retain existing archive/delete behavior.

Rebuild each invalidated collection from fresh cursors to its previously loaded depth, including reset events. Keep the old rows until the entire replacement succeeds; on failure retain them with the existing retry control. Retry starts with a fresh cursor and removes stale/deleted rows. Existing request versions reject superseded responses.

## Scope and non-goals

Renderer query ownership only; no database, persisted-format, migration, historical-compatibility, IPC, public enum, or dependency changes. One renderer-only ref reads the current loaded ranges. Existing controls and layout remain. Exact scroll anchoring and retaining identities moved outside the rebuilt range are not included.

## Acceptance criteria and validation

Before production edits, five minimal regressions failed in two consecutive runs: selected title changed to Artifacts while its file remained; 40 uploads became 20; 20 groups became 10; and 40/60 session artifacts became 20. The real component tests use IPC results independent of Session Store. No production test seam was added.

The module tests, renderer typecheck, and lint were rerun after the latest request-race fix. The Electron build and journey below ran on the preceding implementation commit; no layout or interaction changed in the follow-up.

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| Selection, empty/reset/error/incomplete-index handling; pagination, deleted/reordered tails, second-page retry, overlapping notifications, search changes; preview consumers | `npm run test:module -- project_files_view` | 312 tests passed across 6 files |
| Renderer types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Electron build | `npm run build:e2e` | Passed |
| Real database/preload/renderer refresh after saving a version of one of 40 uploaded files | `npm run test:e2e -- e2e/workspace-files.spec.ts -g 'preserves expanded uploads after saving'` | Passed; all 40 identities remain; screenshot captured |

The module explain plan includes ProjectFilesView, index owner, workspace components, PreviewFileSurface, and PreviewToolContent consumers. Public interfaces are unchanged. CodeGraph identified the index → query model → view chain; its worktree warning required checking the final local source directly. Complete local tests were intentionally omitted as requested; PR CI remains authoritative. Windows/Linux execution and precise scroll offsets were not measured locally. The initial AI review identified a same-tick reset race. The follow-up includes active artifact requests in invalidation, with two regressions that failed twice before the fix and now pass. Updated independent review is pending.

## Review focus

Empty-query confirmation must never use a search-filtered page. Refresh failures must not mix fresh heads with stale tails, and queued responses must respect request versions on every page.
