### PR TITLE
fix(security): harden evidence and request error handling

### DIFF
--- a/packages/notebook-network-sandbox/vendor/windows-src/src/wfp.rs
+++ b/packages/notebook-network-sandbox/vendor/windows-src/src/wfp.rs
@@ -1,6 +1,7 @@
 use std::ffi::c_void;
+use std::ptr::NonNull;
 
-use anyhow::{Result, bail};
+use anyhow::{Context, Result, bail};
 use windows::Win32::Foundation::HANDLE;
 use windows::Win32::NetworkManagement::WindowsFilteringPlatform::{
     FWP_ACTION_BLOCK, FWP_ACTION_PERMIT, FWP_BYTE_BLOB, FWP_CONDITION_VALUE0,
@@ -64,17 +65,25 @@ impl Drop for AbortTransaction {
     }
 }
 
-struct WfpMemory<T>(*mut T);
+struct WfpMemory<T>(NonNull<T>);
 
 impl<T> WfpMemory<T> {
+    // Call only for successful WFP allocations; Drop retains the API's ownership contract.
+    fn from_raw(pointer: *mut T) -> Result<Self> {
+        Ok(Self(
+            NonNull::new(pointer).context("Windows Filtering Platform returned no object")?,
+        ))
+    }
+
     fn get(&self) -> &T {
-        unsafe { &*self.0 }
+        // The allocation is non-null and remains owned by self for the returned borrow.
+        unsafe { self.0.as_ref() }
     }
 }
 
 impl<T> Drop for WfpMemory<T> {
     fn drop(&mut self) {
-        let mut pointer = self.0.cast::<c_void>();
+        let mut pointer = self.0.as_ptr().cast::<c_void>();
         unsafe { FwpmFreeMemory0(&mut pointer) };
     }
 }
@@ -163,7 +172,7 @@ fn get_filter(engine: HANDLE, key: &GUID) -> Result<Option<WfpMemory<FWPM_FILTER
         return Ok(None);
     }
     check(code, "read Windows Filtering Platform filter")?;
-    Ok(Some(WfpMemory(pointer)))
+    Ok(Some(WfpMemory::from_raw(pointer)?))
 }
 
 fn get_sublayer(engine: HANDLE, key: &GUID) -> Result<Option<WfpMemory<FWPM_SUBLAYER0>>> {
@@ -173,7 +182,7 @@ fn get_sublayer(engine: HANDLE, key: &GUID) -> Result<Option<WfpMemory<FWPM_SUBL
         return Ok(None);
     }
     check(code, "read Windows Filtering Platform sublayer")?;
-    Ok(Some(WfpMemory(pointer)))
+    Ok(Some(WfpMemory::from_raw(pointer)?))
 }
 
 fn remove_owned_filter(
@@ -393,4 +402,25 @@ pub fn remove(descriptor: &FenceDescriptor<'_>) -> Result<()> {
         }
         Ok(())
     })
+}
+
+#[cfg(test)]
+mod memory_tests {
+    use super::*;
+    use std::mem::ManuallyDrop;
+
+    #[test]
+    fn rejects_null_wfp_outputs() {
+        assert!(WfpMemory::<FWPM_FILTER0>::from_raw(std::ptr::null_mut()).is_err());
+        assert!(WfpMemory::<FWPM_SUBLAYER0>::from_raw(std::ptr::null_mut()).is_err());
+    }
+
+    #[test]
+    fn borrows_a_non_null_object_without_transferring_ownership() {
+        let mut value = 42_u32;
+        // Stack storage is not a WFP allocation, so never run the WFP deallocator on it.
+        let memory = ManuallyDrop::new(WfpMemory::from_raw(&mut value).unwrap());
+        assert_eq!(*memory.get(), 42);
+        assert_eq!(*memory.get(), 42);
+    }
 }

--- a/src/main/reviewer/bounded-artifact-content.ts
+++ b/src/main/reviewer/bounded-artifact-content.ts
@@ -478,9 +478,9 @@ const xmlText = (xml: string): string =>
     .replace(/<[^>]+>/g, ' ')
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')
-    .replace(/&amp;/g, '&')
     .replace(/&quot;/g, '"')
     .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
     .replace(/\s+/g, ' ')
     .trim()
 

--- a/src/main/reviewer/host-sdk.test.ts
+++ b/src/main/reviewer/host-sdk.test.ts
@@ -653,6 +653,30 @@ describe('host.read_artifact — tabular CSV', () => {
     })
   })
 
+  it('decodes PPTX entities once when reading actual slide XML', async () => {
+    const versionId = 'entity-presentation-version'
+    const nativePath = join(tmpDir, 'entities.pptx')
+    await writeFile(
+      nativePath,
+      zipSync({
+        'ppt/slides/slide1.xml': strToU8(
+          '<p:sld><a:t>&amp;quot; &amp;apos; &quot;quoted&quot; &amp; &amp;lt;script&amp;gt;</a:t></p:sld>'
+        )
+      })
+    )
+    server = new ReviewerHostServer(
+      makeSession({ artifacts: [] }),
+      makeScope([versionId]),
+      tmpDir,
+      async () => ({ path: nativePath, filename: 'entities.pptx' })
+    )
+    await expect(server.readArtifact(versionId)).resolves.toMatchObject({
+      kind: 'paged',
+      format: 'pptx',
+      pages: [{ pageNumber: 1, text: '&quot; &apos; "quoted" & &lt;script&gt;' }]
+    })
+  })
+
   it('reads only requested PPTX slides and does not expand unrequested slide text', async () => {
     const versionId = 'native-presentation-version'
     const nativePath = join(tmpDir, 'review-targets.pptx')
@@ -1455,6 +1479,21 @@ describe('host.read_artifact — non-tabular', () => {
 // ---------------------------------------------------------------------------
 
 describe('host.read_artifact — read failures are not empty content', () => {
+  it.each([
+    new Error('private-native-path/secret'),
+    'private-stack/secret',
+    { toString: () => 'private-custom-error/secret' }
+  ])('keeps unexpected exception details out of HTTP responses: %s', async (failure) => {
+    server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir)
+    vi.spyOn(server, 'readTurn').mockImplementation(() => {
+      throw failure
+    })
+    ;({ endpoint, token } = await server.start())
+    expect(await post(endpoint, token, 'read_turn')).toEqual({
+      error: 'Failed to read reviewer evidence.'
+    })
+  })
+
   it('surfaces an error (not empty content) when the artifact file is missing on disk', async () => {
     // The version id is in scope, but no file was written to managed storage.
     server = new ReviewerHostServer(makeSession(), makeScope(), tmpDir)
@@ -1467,6 +1506,8 @@ describe('host.read_artifact — read failures are not empty content', () => {
     expect(body.result).toBeUndefined()
     expect(body.error).toBeTruthy()
     expect(body.error).toMatch(/results\.csv|read/i)
+    expect(body.error).not.toContain(tmpDir)
+    expect(body.error).not.toContain('ENOENT')
   })
 
   it('returns empty content WITHOUT error for a genuinely empty (0-byte) readable artifact', async () => {

--- a/src/main/reviewer/host-sdk.ts
+++ b/src/main/reviewer/host-sdk.ts
@@ -32,6 +32,7 @@ import {
   readBoundedJsonBody
 } from '../resource-budget'
 import { toErrorMessage } from '../error-message'
+import { createLogger, diagnosticErrorFields } from '../logger'
 import { extractPdfTextPages } from '../uploads/attachment-media'
 import {
   readBoundedPptx,
@@ -390,7 +391,10 @@ type ArtifactVerificationEntry = {
   verification: Promise<ArtifactVerification>
 }
 
-class ArtifactVersionChecksumMismatchError extends Error {}
+// Only owner-authored request errors may cross the compatibility HTTP boundary verbatim.
+class ReviewerRequestError extends Error {}
+class ArtifactVersionChecksumMismatchError extends ReviewerRequestError {}
+const log = createLogger('reviewer:host')
 
 // The complete set of RPC methods the host exposes. Single-sourced so the unknown-method error can
 // tell a guessing reviewer exactly what IS available (it likes to try e.g. `list_artifacts`).
@@ -470,7 +474,14 @@ export class ReviewerHostServer {
         res.writeHead(error instanceof ResourceBudgetExceededError ? 413 : 500, {
           'content-type': 'application/json'
         })
-        res.end(JSON.stringify({ error: toErrorMessage(error) }))
+        log.error('reviewer host request failed', diagnosticErrorFields(error))
+        const message =
+          error instanceof ReviewerRequestError ||
+          error instanceof ArtifactTargetRangeError ||
+          error instanceof ResourceBudgetExceededError
+            ? error.message
+            : 'Failed to read reviewer evidence.'
+        res.end(JSON.stringify({ error: message }))
       })
     })
   }
@@ -600,7 +611,7 @@ export class ReviewerHostServer {
 
     // Out-of-scope id: reject rather than silently returning empty.
     if (activityId !== undefined && target.length === 0) {
-      throw new Error(
+      throw new ReviewerRequestError(
         `Activity id ${JSON.stringify(activityId)} is not in this turn's scope. ` +
           `Allowed ids: ${[...activityIds].join(', ')}`
       )
@@ -632,7 +643,7 @@ export class ReviewerHostServer {
       ...this.sourceDocumentEvidenceByVersionId.keys()
     ]
     if (!allowedVersionIds.includes(id)) {
-      throw new Error(
+      throw new ReviewerRequestError(
         `File Version id ${JSON.stringify(id)} is not in this turn's scope. ` +
           `Allowed ids: ${allowedVersionIds.join(', ')}`
       )
@@ -648,7 +659,7 @@ export class ReviewerHostServer {
     // as an error, not degrade to empty content — otherwise the reviewer cannot distinguish "could
     // not read" from "the file is genuinely empty", which produces false "empty artifact" findings.
     if (options.offset !== undefined && hasStructuredTargets(options)) {
-      throw new Error(
+      throw new ReviewerRequestError(
         'Reviewer Artifact offset cannot be combined with structured content targets.'
       )
     }
@@ -675,10 +686,10 @@ export class ReviewerHostServer {
       const offset = options.offset ?? 0
       const requestedBytes = options.maxBytes ?? this.resourceBudget.readBytes
       if (!Number.isSafeInteger(offset) || offset < 0) {
-        throw new Error('Reviewer Artifact offset must be a non-negative integer.')
+        throw new ReviewerRequestError('Reviewer Artifact offset must be a non-negative integer.')
       }
       if (!Number.isSafeInteger(requestedBytes) || requestedBytes <= 0) {
-        throw new Error('Reviewer Artifact maxBytes must be a positive integer.')
+        throw new ReviewerRequestError('Reviewer Artifact maxBytes must be a positive integer.')
       }
       const remainingSessionBytes = this.resourceBudget.sessionBytes - this.reviewerBytesReturned
       if (remainingSessionBytes <= 0) {
@@ -724,14 +735,13 @@ export class ReviewerHostServer {
       } catch (error) {
         if (signal?.aborted) throw error
         if (error instanceof ArtifactVersionChecksumMismatchError) throw error
-        throw new Error(
-          `Failed to read artifact ${JSON.stringify(id)} at ${artifactPath}: ` +
-            `${toErrorMessage(error)}`
-        )
+        throw new ReviewerRequestError(`Failed to read artifact ${JSON.stringify(id)}.`, {
+          cause: error
+        })
       }
 
       if (offset > verification.sizeBytes) {
-        throw new Error(
+        throw new ReviewerRequestError(
           `Reviewer Artifact offset ${offset} exceeds file size ${verification.sizeBytes}.`
         )
       }
@@ -743,7 +753,7 @@ export class ReviewerHostServer {
       )
       if (structuredFormat) {
         if (!artifactPath) {
-          throw new Error(
+          throw new ReviewerRequestError(
             `Managed Artifact ${JSON.stringify(id)} does not expose a verified structured-content path.`
           )
         }
@@ -826,7 +836,9 @@ export class ReviewerHostServer {
               error instanceof ArtifactTargetRangeError ||
               (error instanceof Error && error.message.startsWith('Requested PDF page must'))
             ) {
-              throw error
+              throw error instanceof ArtifactTargetRangeError
+                ? error
+                : new ReviewerRequestError(error.message, { cause: error })
             }
             structured = {
               id,
@@ -897,9 +909,9 @@ export class ReviewerHostServer {
             sample: verification.sample
           }
         } catch (error) {
-          throw new Error(
-            `Failed to read managed Artifact ${JSON.stringify(id)}: ${toErrorMessage(error)}`
-          )
+          throw new ReviewerRequestError(`Failed to read managed Artifact ${JSON.stringify(id)}.`, {
+            cause: error
+          })
         }
       } else {
         try {
@@ -917,10 +929,9 @@ export class ReviewerHostServer {
           }
         } catch (error) {
           this.artifactVerifications.delete(id)
-          throw new Error(
-            `Failed to read artifact ${JSON.stringify(id)} at ${artifactPath}: ` +
-              `${toErrorMessage(error)}`
-          )
+          throw new ReviewerRequestError(`Failed to read artifact ${JSON.stringify(id)}.`, {
+            cause: error
+          })
         }
       }
       let result: ArtifactContent
@@ -929,7 +940,7 @@ export class ReviewerHostServer {
 
       if (imageMimeType) {
         if (offset !== 0) {
-          throw new Error('Reviewer image content reads do not accept an offset.')
+          throw new ReviewerRequestError('Reviewer image content reads do not accept an offset.')
         }
         const sourceComplete = read.returnedBytes === read.sizeBytes
         const baseMetadataBytes = Buffer.byteLength(
@@ -1080,11 +1091,11 @@ export class ReviewerHostServer {
     options: ReviewerArtifactReadOptions
   ): Promise<ArtifactTraceResult> {
     if (options.offset !== undefined) {
-      throw new Error('Reviewer Artifact offset is only valid for content reads.')
+      throw new ReviewerRequestError('Reviewer Artifact offset is only valid for content reads.')
     }
     const requestedBytes = options.maxBytes ?? this.resourceBudget.readBytes
     if (!Number.isSafeInteger(requestedBytes) || requestedBytes <= 0) {
-      throw new Error('Reviewer Artifact maxBytes must be a positive integer.')
+      throw new ReviewerRequestError('Reviewer Artifact maxBytes must be a positive integer.')
     }
     const remainingSessionBytes = this.resourceBudget.sessionBytes - this.reviewerBytesReturned
     if (remainingSessionBytes <= 0) {
@@ -1102,7 +1113,9 @@ export class ReviewerHostServer {
     const sourceEvidence = this.sourceDocumentEvidenceByVersionId.get(id)
     if (this.fileRole(id) === 'source_document') {
       if (!sourceEvidence) {
-        throw new Error(`Trusted Source Document provenance is unavailable for Version ${id}.`)
+        throw new ReviewerRequestError(
+          `Trusted Source Document provenance is unavailable for Version ${id}.`
+        )
       }
       const limitations: ReviewLimitation[] =
         sourceEvidence.contentStatus === 'available'
@@ -1314,7 +1327,9 @@ export class ReviewerHostServer {
   fileRole(id: string): 'work_product' | 'source_document' {
     if (this.sourceDocumentEvidenceByVersionId.has(id)) return 'source_document'
     if (this.scope.artifactVersionIds.includes(id)) return 'work_product'
-    throw new Error(`File Version ${JSON.stringify(id)} is not in this turn's scope.`)
+    throw new ReviewerRequestError(
+      `File Version ${JSON.stringify(id)} is not in this turn's scope.`
+    )
   }
 
   private commitStructuredResponse(
@@ -1674,7 +1689,7 @@ export const resolveArtifactPath = (
   const secondColon = versionId.indexOf(':', firstColon + 1)
 
   if (firstColon === -1 || secondColon === -1) {
-    throw new Error(`Malformed artifact version id ${JSON.stringify(versionId)}`)
+    throw new ReviewerRequestError(`Malformed artifact version id ${JSON.stringify(versionId)}`)
   }
 
   const sessionId = versionId.slice(0, firstColon)
@@ -1990,7 +2005,7 @@ host = _ReviewerHost(${JSON.stringify(endpoint)}, ${JSON.stringify(token)})
 // Verifies that a given block id is within the scope. Used by submit_findings to validate locators.
 export const assertBlockInScope = (block: ScopeBlock | undefined, id: string): ScopeBlock => {
   if (!block) {
-    throw new Error(`Block ${JSON.stringify(id)} is not in the turn scope.`)
+    throw new ReviewerRequestError(`Block ${JSON.stringify(id)} is not in the turn scope.`)
   }
   return block
 }

--- a/src/main/reviewer/mcp-server.test.ts
+++ b/src/main/reviewer/mcp-server.test.ts
@@ -589,6 +589,42 @@ describe('ReviewerMcpServer HTTP transport', () => {
     }
   }
 
+  it('does not echo malformed request content in the parse error', async () => {
+    const server = new ReviewerMcpServer(scope, vi.fn(), createReviewerEvidence(), 'initial')
+    const { endpoint, token } = await server.start()
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}`, 'content-type': 'application/json' },
+        body: '{"private-request-secret": invalid}'
+      })
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({ error: 'Invalid JSON body' })
+    } finally {
+      await server.stop()
+    }
+  })
+
+  it('does not expose unexpected transport failures', async () => {
+    const server = new ReviewerMcpServer(scope, vi.fn(), createReviewerEvidence(), 'initial')
+    vi.spyOn(
+      server as unknown as { handleHttpRequest: () => Promise<void> },
+      'handleHttpRequest'
+    ).mockRejectedValue(new Error('private-transport-path/secret'))
+    const { endpoint, token } = await server.start()
+    try {
+      const response = await fetch(endpoint, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${token}` },
+        body: '{}'
+      })
+      expect(response.status).toBe(500)
+      expect(await response.json()).toEqual({ error: 'Internal reviewer request failure.' })
+    } finally {
+      await server.stop()
+    }
+  })
+
   it('bounds declared and chunked HTTP bodies while accepting the exact request limit', async () => {
     const evidence = createReviewerEvidence()
     const onSubmit = vi.fn().mockResolvedValue(undefined)
@@ -619,6 +655,7 @@ describe('ReviewerMcpServer HTTP transport', () => {
         body: `${initializeBody} `
       })
       expect(declared.status).toBe(413)
+      expect(await declared.json()).toEqual({ error: 'Request body exceeds the size limit.' })
       expect(declared.headers.get('connection')).toBe('close')
 
       const chunked = await new Promise<{

--- a/src/main/reviewer/mcp-server.ts
+++ b/src/main/reviewer/mcp-server.ts
@@ -509,7 +509,7 @@ export class ReviewerMcpServer {
         log.error('reviewer MCP request failed', { error })
         if (!res.headersSent) {
           res.writeHead(500, { 'content-type': 'application/json' })
-          res.end(JSON.stringify({ error: toErrorMessage(error) }))
+          res.end(JSON.stringify({ error: 'Internal reviewer request failure.' }))
         } else {
           res.destroy(error instanceof Error ? error : undefined)
         }
@@ -1044,7 +1044,11 @@ export class ReviewerMcpServer {
           res.once('finish', () => req.destroy())
         }
         res.writeHead(exceeded ? 413 : 400, { 'content-type': 'application/json' })
-        res.end(JSON.stringify({ error: toErrorMessage(error) }))
+        res.end(
+          JSON.stringify({
+            error: exceeded ? 'Request body exceeds the size limit.' : 'Invalid JSON body'
+          })
+        )
         return
       }
     }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -1,7 +1,7 @@
 // @ts-expect-error The published ESM entry uses a sibling index.d.ts.
 import { OpenScienceClient } from '../../../packages/open-science/index.mjs'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
-import { request as httpRequest, type IncomingMessage, ServerResponse } from 'node:http'
+import { request as httpRequest, IncomingMessage, ServerResponse } from 'node:http'
 import { connect } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -142,6 +142,39 @@ const startBudgetTestServer = async (
   servers.push(server)
   return server
 }
+it('does not expose unexpected RPC body stream errors', async () => {
+  const original = IncomingMessage.prototype[Symbol.asyncIterator]
+  const iterator = vi
+    .spyOn(IncomingMessage.prototype, Symbol.asyncIterator)
+    .mockImplementation(function (this: IncomingMessage) {
+      if (this.url?.startsWith('/rpc/')) {
+        return (async function* () {
+          yield Buffer.from('{')
+          throw new Error('private-stream-path/secret')
+        })()
+      }
+      return original.call(this)
+    })
+  try {
+    const server = await startBudgetTestServer({
+      perRequestBytes: 1024,
+      perClientInFlightBytes: 2048,
+      serverInFlightBytes: 4096
+    })
+    const response = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: '{}'
+    })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toMatchObject({
+      error: { code: 'invalid_request', message: 'Failed to read request body.' }
+    })
+  } finally {
+    iterator.mockRestore()
+  }
+})
+
 const runWithCallerContext = <Result>(_context: CallerContext, operation: () => Result): Result =>
   operation()
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -1555,7 +1555,9 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             response,
             400,
             'invalid_request',
-            error instanceof SyntaxError ? 'Request body must be valid JSON.' : String(error)
+            error instanceof SyntaxError
+              ? 'Request body must be valid JSON.'
+              : 'Failed to read request body.'
           )
           return
         }


### PR DESCRIPTION
## Problem

PPTX review evidence can decode XML entities twice. Unexpected Reviewer HTTP/MCP and Web RPC body-read failures can expose internal exception details. Windows WFP wrappers can construct an unchecked null pointer after an FFI call.

Addresses code-scanning alerts #52, #45, #46, #48 and #59.

## Proposed change

- Decode ampersands last and test real PPTX slide extraction.
- Return safe request/internal error messages while preserving owner-authored scope, range, integrity and resource-budget errors. Keep native artifact-read causes in local diagnostics rather than response text.
- Store WFP allocations as `NonNull`, reject missing FFI outputs and retain the existing deallocator/ownership lifecycle. Add native null-output and borrow tests.

## Scope and non-goals

No database fields, state enums, migrations, credential formats, WFP resource identities or normal UI changes. Existing saved reviews are not rewritten. Exceptional response wording becomes less detailed.

CI alerts #24/#30/#31 and all workflow configuration are explicitly excluded at the maintainer's request. Existing migration checksums and credential fingerprints remain unchanged.

Separately, reviewed test/false-positive alerts #36/#39/#40/#41/#44/#49/#53/#54 were dismissed with individual evidence. Dependabot #37 was dismissed as tolerated installation risk: the only consumer is Electron installation with archive checksum validation, and upstream has no patched extract-zip release. This is risk acceptance, not a claim that extract-zip is fixed.

## Acceptance criteria and validation

After the last material edit, focused Vitest validation passed **209 tests**, with **2 Windows-only cases skipped on macOS**:

| Behavior / consumer | Project-owned check | Result |
| --- | --- | --- |
| PPTX text, expected error contracts, unexpected HTTP errors, artifact reads | `host-sdk.test.ts`, `host-sdk-tabular.test.ts` under `src/main/reviewer/` | 64 passed |
| MCP parse/internal responses, authentication and budget cleanup | `src/main/reviewer/mcp-server.test.ts` | 52 passed |
| Reviewer assessment and image evidence consumers | `review-assessment-owner.test.ts`, `image-content.integration.test.ts`, `image-generation-trace.integration.test.ts` under `src/main/reviewer/` | 22 passed |
| Web RPC errors and existing request/authentication contracts | `src/main/web-service/http-server.test.ts` | 62 passed |
| Windows adapter and resource contracts | `windows-appcontainer.test.ts`, `resources.test.ts` under `packages/notebook-network-sandbox/src/` | 9 passed, 2 platform skips |

Run these files with `node node_modules/vitest/vitest.mjs run <paths>`. `npm run typecheck:node` (including sandbox types), `npm run lint`, and `git diff --check` passed after the final material edit.

The affected-test explain plan falls back to the full suite because `wfp.rs` has no declared module owner. Per the maintainer's explicit instruction, the full suite is delegated to PR CI rather than run locally. The local set above additionally covers the shared reader's direct MCP/assessment/image consumers. Renderer layouts and IPC payloads are unchanged, so no screenshot or renderer typecheck was needed.

Windows native execution is not claimed locally: this macOS host has no Rust toolchain. Required Windows CI must run `cargo test --locked --manifest-path packages/notebook-network-sandbox/vendor/windows-src/Cargo.toml` and native packaging checks. Final independent review and exact-head CI are authoritative; do not infer cross-platform verification from the local pass.

## Review focus

Preserve actionable expected errors while blocking arbitrary exception serialization; ensure the WFP allocation is non-null and freed exactly once. Confirm the final CI plan covers native Windows code. Main-branch CodeQL must confirm alert resolution after merge.
