### PR TITLE
fix(literature): recover failed operations and preserve editing state

### DIFF
--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -78,6 +78,94 @@ describe('LiteratureCatalog', () => {
     return new LiteratureCatalog(async () => client!)
   }
 
+  it.each([
+    ['deleted', 'missing'],
+    ['active', 'missing'],
+    ['deleted', 'alias'],
+    ['active', 'alias']
+  ] as const)(
+    'rolls back an unavailable lifecycle batch when setting %s with a %s item',
+    async (state, unavailable) => {
+      const catalog = await setup()
+      const item = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      let unavailableId = 'missing-item'
+      if (unavailable === 'alias') {
+        const alias = await catalog.transact({
+          kind: 'create-item',
+          item: candidate({ doi: '10.1234/alias', title: 'Alias' }).item
+        })
+        const reviewed = (await Promise.all([catalog.get(item.id), catalog.get(alias.id)])).map(
+          (view) => view!
+        )
+        await catalog.transact({
+          kind: 'merge-items',
+          survivorId: item.id,
+          duplicateIds: [alias.id],
+          expectedMetadataRevision: reviewed[0].metadataRevision,
+          expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+            id,
+            metadataRevision,
+            updatedAt
+          })),
+          item: reviewed[0].item
+        })
+        unavailableId = alias.id
+      }
+      if (state === 'active') {
+        await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [item.id], state: 'deleted' })
+      }
+      const before = await client!.literatureItem.findUniqueOrThrow({ where: { id: item.id } })
+      await expect(
+        catalog.transact({
+          kind: 'set-item-lifecycle',
+          itemIds: [item.id, unavailableId],
+          state
+        })
+      ).rejects.toThrow('One or more Literature Items are unavailable.')
+      const after = await client!.literatureItem.findUniqueOrThrow({ where: { id: item.id } })
+      expect(after.deletedAt).toEqual(before.deletedAt)
+    }
+  )
+
+  it.each(['project', 'collection'] as const)(
+    'counts only visible references in %s navigation while preserving restore links',
+    async (scope) => {
+      const catalog = await setup()
+      const item = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      const collection = await catalog.transact({ kind: 'create-collection', name: 'Reading' })
+      await catalog.transact({
+        kind: 'set-project-item',
+        projectId: 'project-1',
+        itemId: item.id,
+        included: true,
+        source: 'library'
+      })
+      await catalog.transact({
+        kind: 'set-collection-item',
+        collectionId: collection.id,
+        itemId: item.id,
+        included: true
+      })
+      for (const state of ['active', 'deleted', 'active'] as const) {
+        await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [item.id], state })
+        const list = await catalog.search({
+          scope: 'library',
+          ...(scope === 'project' ? { projectId: 'project-1' } : { collectionId: collection.id })
+        })
+        expect(list.totalCount).toBe(state === 'deleted' ? 0 : 1)
+        const navigation = await catalog.search({
+          scope: scope === 'project' ? 'project-counts' : 'collections'
+        })
+        const row = navigation.entries.find((entry) =>
+          scope === 'project'
+            ? 'projectId' in entry && entry.projectId === 'project-1'
+            : 'id' in entry && entry.id === collection.id
+        )
+        expect(row && 'itemCount' in row ? row.itemCount : 0).toBe(list.totalCount)
+      }
+    }
+  )
+
   it('shares duplicate scans across count and page requests and invalidates on metadata mutations', async () => {
     const catalog = await setup()
     const findMany = vi.spyOn(client!.literatureItem, 'findMany')

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -595,6 +595,7 @@ class LiteratureCatalog {
     if (request.scope === 'project-counts') {
       const rows = await client.projectLiterature.groupBy({
         by: ['projectId'],
+        where: { item: { deletedAt: null, mergedIntoItemId: null } },
         _count: { itemId: true },
         orderBy: { projectId: 'asc' }
       })
@@ -615,7 +616,11 @@ class LiteratureCatalog {
         client.literatureCollection.count({ where }),
         client.literatureCollection.findMany({
           where,
-          include: { _count: { select: { items: true } } },
+          include: {
+            _count: {
+              select: { items: { where: { item: { deletedAt: null, mergedIntoItemId: null } } } }
+            }
+          },
           orderBy: [{ sortOrder: 'asc' }, { name: 'asc' }],
           skip: offset,
           take: limit + 1
@@ -1481,13 +1486,15 @@ class LiteratureCatalog {
     const itemIds = [...new Set(command.itemIds)]
     const client = await this.getClient()
     const now = new Date()
-    const updated = await client.literatureItem.updateMany({
-      where: { id: { in: itemIds }, mergedIntoItemId: null },
-      data: command.state === 'deleted' ? { deletedAt: now } : { deletedAt: null }
+    await client.$transaction(async (transaction) => {
+      const updated = await transaction.literatureItem.updateMany({
+        where: { id: { in: itemIds }, mergedIntoItemId: null },
+        data: command.state === 'deleted' ? { deletedAt: now } : { deletedAt: null }
+      })
+      if (updated.count !== itemIds.length) {
+        throw new Error('One or more Literature Items are unavailable.')
+      }
     })
-    if (updated.count !== itemIds.length) {
-      throw new Error('One or more Literature Items are unavailable.')
-    }
     return { kind: 'item', id: itemIds[0]!, state: command.state }
   }
 

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -419,6 +419,93 @@ describe('LiteratureLibraryPage', () => {
     vi.unstubAllGlobals()
   })
 
+  it('shows the load error after the initial Inbox request settles', async () => {
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      request.scope === 'inbox' && request.limit !== 1
+        ? Promise.reject(new Error('Inbox unavailable'))
+        : Promise.resolve({ entries: [], totalCount: 0 })
+    )
+    render(<LiteratureLibraryPage />)
+    await act(async () => {})
+    expect(
+      search.mock.calls.some(([request]) => request.scope === 'inbox' && request.limit !== 1)
+    ).toBe(true)
+    expect(screen.queryByText('Literature could not be loaded.')).not.toBeNull()
+    expect(screen.queryByText('Loading…')).toBeNull()
+    expect(screen.queryByText('Inbox is clear')).toBeNull()
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve(request.scope === 'inbox' ? inboxPage : { entries: [] })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await screen.findByText(libraryItem.item.title)
+    expect(screen.queryByText('Literature could not be loaded.')).toBeNull()
+  })
+
+  it('makes every collection reachable when navigation spans multiple pages', async () => {
+    const collections = Array.from({ length: 101 }, (_, index) => ({
+      id: `collection-${index + 1}`,
+      name: `Collection ${index + 1}`,
+      description: '',
+      itemCount: 0,
+      createdAt: 1,
+      updatedAt: 1
+    }))
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+      const offset = request.offset ?? 0
+      return Promise.resolve(
+        request.scope === 'collections'
+          ? {
+              entries: collections.slice(offset, offset + 100),
+              totalCount: 101,
+              nextOffset: offset === 0 ? 100 : undefined
+            }
+          : { entries: [], totalCount: 0 }
+      )
+    })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(await screen.findByRole('button', { name: 'Show all collections' }))
+    await act(async () => {})
+    expect(screen.queryByRole('button', { name: 'Collection 100' })).not.toBeNull()
+    expect(screen.queryByRole('button', { name: 'Collection 101' })).not.toBeNull()
+  })
+
+  it('prevents metadata edits from being lost while a save is in flight', async () => {
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })
+    )
+    get.mockResolvedValue(libraryItem)
+    let finish: () => void = () => {}
+    transact.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = () => resolve({ kind: 'item', id: libraryItem.id, state: 'present' })
+        })
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await openReferenceDetail(await screen.findByText(libraryItem.item.title))
+    await openMenu(screen.getByRole('button', { name: 'More actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Edit metadata' }))
+    const title = screen.getByLabelText('Title') as HTMLInputElement
+    fireEvent.change(title, { target: { value: 'Submitted title' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(true)
+    const locked = title.matches(':disabled') || title.readOnly
+    if (!locked) fireEvent.change(title, { target: { value: 'New unsaved title' } })
+    expect(title.value).toBe(locked ? 'Submitted title' : 'New unsaved title')
+    get.mockResolvedValue({
+      ...libraryItem,
+      metadataRevision: 2,
+      item: { ...libraryItem.item, title: 'Submitted title' }
+    })
+    await act(async () => finish())
+    expect(transact).toHaveBeenCalledTimes(1)
+    expect(
+      locked ||
+        (screen.queryByLabelText('Title') as HTMLInputElement | null)?.value === 'New unsaved title'
+    ).toBe(true)
+  })
+
   it('previews selected duplicate groups before committing and reports the batch result', async () => {
     let merged = false
     search.mockImplementation(async (request: { scope: string }) =>
@@ -4565,6 +4652,140 @@ describe('LiteratureLibraryPage', () => {
 
     expect(screen.getByRole('menuitem', { name: 'Edit' })).not.toBeNull()
     expect(filePreviewRenderCount.value).toBe(0)
+  })
+
+  it('refreshes committed references when a later lifecycle batch fails', async () => {
+    let items = Array.from({ length: 201 }, (_, index) => createLibraryItem(index))
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+      if (request.scope !== 'library') return Promise.resolve({ entries: [] })
+      const offset = request.offset ?? 0
+      const limit = request.limit ?? 100
+      return Promise.resolve({
+        entries: items.slice(offset, offset + limit),
+        totalCount: items.length,
+        nextOffset: offset + limit < items.length ? offset + limit : undefined
+      })
+    })
+    transact
+      .mockImplementationOnce(async (command) => {
+        items = items.filter(({ id }) => !command.itemIds.includes(id))
+        return { kind: 'item', id: command.itemIds[0], state: 'deleted' }
+      })
+      .mockRejectedValueOnce(new Error('One or more Literature Items are unavailable.'))
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await screen.findByText('Reference 0')
+    fireEvent.click(screen.getByLabelText('Select all references'))
+    fireEvent.click(screen.getByRole('button', { name: 'Select all matching references 201' }))
+    const toolbar = document.querySelector<HTMLElement>(
+      '[data-slot="literature-selection-toolbar"]'
+    )!
+    await openMenu(within(toolbar).getByRole('button', { name: 'More actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Move to Trash' }))
+    await act(async () => {})
+    expect(items).toHaveLength(1)
+    expect(
+      transact.mock.calls.filter(([command]) => command.kind === 'set-item-lifecycle')
+    ).toHaveLength(2)
+    expect(screen.queryByText('Reference 0')).toBeNull()
+    expect(screen.queryByText('Reference 200')).not.toBeNull()
+    expect(screen.getByText('Updated: 200. Not updated: 1.')).not.toBeNull()
+    expect(screen.getByText('1 selected')).not.toBeNull()
+    transact.mockImplementationOnce(async (command) => {
+      items = items.filter(({ id }) => !command.itemIds.includes(id))
+      return { kind: 'item', id: command.itemIds[0], state: 'deleted' }
+    })
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await act(async () => {})
+    expect(transact).toHaveBeenLastCalledWith({
+      kind: 'set-item-lifecycle',
+      itemIds: ['item-200'],
+      state: 'deleted'
+    })
+    expect(items).toHaveLength(0)
+    expect(screen.queryByText('Updated: 200. Not updated: 1.')).toBeNull()
+  })
+
+  it('refreshes project and collection counts through delete and restore, including zero', async () => {
+    let deleted = false
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+      if (request.scope === 'project-counts')
+        return Promise.resolve({
+          entries: deleted ? [] : [{ projectId: 'project-1', itemCount: 1 }]
+        })
+      if (request.scope === 'collections')
+        return Promise.resolve({
+          entries: [
+            {
+              id: 'c1',
+              name: 'Reading',
+              description: '',
+              itemCount: deleted ? 0 : 1,
+              createdAt: 1,
+              updatedAt: 1
+            }
+          ]
+        })
+      if (request.scope === 'library') {
+        const visible = (request.lifecycle === 'deleted') === deleted
+        return Promise.resolve({
+          entries: visible ? [libraryItem] : [],
+          totalCount: visible ? 1 : 0
+        })
+      }
+      return Promise.resolve({ entries: [] })
+    })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    for (const [action, expectedCount] of [
+      ['Move to Trash', '0'],
+      ['Restore', '1']
+    ] as const) {
+      const row = (await screen.findByText(libraryItem.item.title)).closest('tr')!
+      await openMenu(within(row).getByRole('button', { name: 'More actions' }))
+      transact.mockImplementationOnce(async () => {
+        deleted = !deleted
+        return { kind: 'item', id: libraryItem.id, state: deleted ? 'deleted' : 'active' }
+      })
+      fireEvent.click(screen.getByRole('menuitem', { name: action }))
+      await act(async () => {})
+      expect(
+        within(screen.getByRole('button', { name: 'Retrieval research' })).getByText(expectedCount)
+      ).not.toBeNull()
+      expect(
+        within(screen.getByRole('button', { name: 'Reading' })).getByText(expectedCount)
+      ).not.toBeNull()
+      if (deleted) fireEvent.click(screen.getByRole('button', { name: 'Trash' }))
+    }
+  })
+
+  it('does not publish a truncated collection navigation when a continuation fails and permits retry', async () => {
+    const collections = Array.from({ length: 101 }, (_, index) => ({
+      id: `c-${index}`,
+      name: `Collection ${index}`,
+      description: '',
+      itemCount: 0,
+      createdAt: 1,
+      updatedAt: 1
+    }))
+    let fail = true
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+      if (request.scope !== 'collections') return Promise.resolve({ entries: [] })
+      if (request.offset === 100 && fail) return Promise.reject(new Error('Page unavailable'))
+      return Promise.resolve({
+        entries: collections.slice(request.offset ?? 0, (request.offset ?? 0) + 100),
+        nextOffset: request.offset === 100 ? undefined : 100,
+        totalCount: 101
+      })
+    })
+    render(<LiteratureLibraryPage />)
+    await act(async () => {})
+    expect(screen.getByText('Literature could not be loaded.')).not.toBeNull()
+    expect(screen.queryByRole('button', { name: 'Collection 0' })).toBeNull()
+    fail = false
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'Show all collections' }))
+    expect(screen.getByRole('button', { name: 'Collection 100' })).not.toBeNull()
   })
 
   it('applies a bulk action to every matching page in bounded command batches', async () => {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1248,6 +1248,11 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const [entriesTotalCount, setEntriesTotalCount] = useState(0)
   const [nextEntriesOffset, setNextEntriesOffset] = useState<number>()
   const [error, setError] = useState<string>()
+  const [lifecycleFailure, setLifecycleFailure] = useState<{
+    itemIds: string[]
+    state: 'active' | 'deleted'
+    completed: number
+  }>()
   const [linkedItemError, setLinkedItemError] = useState<string>()
   const [pendingCandidateId, setPendingCandidateId] = useState<string>()
   const [dismissedCandidateUndo, setDismissedCandidateUndo] = useState<DismissedCandidateUndo>()
@@ -1411,9 +1416,18 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     })
   }, [clearSelection, consumeLiteratureCollection, pendingLiteratureCollectionId])
 
+  const collectionsGenerationRef = useRef(0)
   const loadCollections = useCallback(async (): Promise<void> => {
-    const page = await window.api.literature.search({ scope: 'collections', limit: 100 })
-    setCollections(page.entries.filter(isCollection))
+    const generation = ++collectionsGenerationRef.current
+    const collections: LiteratureCollectionView[] = []
+    let offset: number | undefined = 0
+    do {
+      const page = await window.api.literature.search({ scope: 'collections', limit: 100, offset })
+      if (generation !== collectionsGenerationRef.current) return
+      collections.push(...page.entries.filter(isCollection))
+      offset = page.nextOffset
+    } while (offset !== undefined)
+    setCollections(collections)
   }, [])
 
   const loadInboxPendingCount = useCallback(async (): Promise<void> => {
@@ -1425,16 +1439,18 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     setInboxPendingCount(page.totalCount ?? page.entries.length)
   }, [])
 
+  const projectCountsGenerationRef = useRef(0)
   const loadProjectCounts = useCallback(async (): Promise<void> => {
+    const generation = ++projectCountsGenerationRef.current
     const page = await window.api.literature.search({ scope: 'project-counts' })
-    setProjectItemCounts((current) => ({
-      ...current,
-      ...Object.fromEntries(
+    if (generation !== projectCountsGenerationRef.current) return
+    setProjectItemCounts(
+      Object.fromEntries(
         page.entries
           .filter(isProjectCount)
           .map(({ projectId, itemCount }) => [projectId, itemCount])
       )
-    }))
+    )
   }, [])
 
   const selectedCollection = useMemo(
@@ -1585,6 +1601,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const entriesRequest = useMemo(() => buildEntriesRequest(), [buildEntriesRequest])
   const {
     loading: entriesLoading,
+    failed: entriesFailed,
     pageTransitionLoading: entriesPageTransitionLoading,
     reload: reloadEntries,
     refreshItems
@@ -1629,6 +1646,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     const timeout = window.setTimeout(() => {
       setEntriesOffset(0)
       clearSelection()
+      setLifecycleFailure(undefined)
     }, 0)
     return () => window.clearTimeout(timeout)
   }, [clearSelection, entriesKey])
@@ -2387,20 +2405,37 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     if ((!allMatchingSelected && (itemIds?.length ?? 0) === 0) || isBatching) return
     setIsBatching(true)
     setError(undefined)
+    setLifecycleFailure(undefined)
+    let resolvedIds: readonly string[] = []
+    let completed = 0
     try {
-      const resolvedIds = itemIds ?? (await resolveSelectedItemIds())
+      resolvedIds = itemIds ?? (await resolveSelectedItemIds())
       for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
-        await window.api.literature.transact({
-          kind: 'set-item-lifecycle',
-          itemIds: resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE),
-          state
-        })
+        const batch = resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE)
+        await window.api.literature.transact({ kind: 'set-item-lifecycle', itemIds: batch, state })
+        completed += batch.length
       }
       clearSelection()
-      await loadEntries(true)
     } catch {
-      setError(t('Literature could not be updated.'))
+      if (resolvedIds.length) {
+        const remaining = resolvedIds.slice(completed)
+        selectionStore.replace(remaining)
+        setLifecycleFailure({ itemIds: remaining, state, completed })
+      } else {
+        setError(t('Literature could not be updated.'))
+      }
     } finally {
+      if (resolvedIds.length) {
+        // Refresh even after a failed command: earlier batches may already be committed.
+        const refreshed = await Promise.allSettled([
+          loadEntries(true),
+          loadCollections(),
+          loadProjectCounts()
+        ])
+        if (refreshed.some((result) => result.status === 'rejected')) {
+          setError(t('Literature could not be loaded.'))
+        }
+      }
       setIsBatching(false)
     }
   }
@@ -3692,14 +3727,48 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
               onChanged={receiveBackgroundItems}
             />
           ) : null}
+          {lifecycleFailure ? (
+            <div className="mt-5">
+              <LiteratureErrorNotice
+                title={t('Literature could not be updated.')}
+                description={t('Updated: {{completed}}. Not updated: {{remaining}}.', {
+                  completed: lifecycleFailure.completed,
+                  remaining: lifecycleFailure.itemIds.length
+                })}
+                secondaryButton={{
+                  label: t('Retry'),
+                  disabled: isBatching,
+                  onClick: () =>
+                    void setItemsLifecycle(lifecycleFailure.itemIds, lifecycleFailure.state)
+                }}
+              />
+            </div>
+          ) : null}
           {(linkedItemError || error) && !entriesLoading ? (
             <div className="mt-5">
-              <LiteratureErrorNotice title={linkedItemError || error || undefined} />
+              <LiteratureErrorNotice
+                title={linkedItemError || error || undefined}
+                secondaryButton={
+                  !linkedItemError && error === t('Literature could not be loaded.')
+                    ? {
+                        label: t('Retry'),
+                        disabled: isBatching,
+                        onClick: () => {
+                          void Promise.all([
+                            loadEntries(true),
+                            loadCollections(),
+                            loadProjectCounts()
+                          ]).catch(() => setError(t('Literature could not be loaded.')))
+                        }
+                      }
+                    : undefined
+                }
+              />
             </div>
           ) : null}
 
           <div className="mt-6 flex min-h-0 flex-1 flex-col gap-2">
-            {entriesLoading && !entriesPageTransitionLoading ? (
+            {entriesFailed ? null : entriesLoading && !entriesPageTransitionLoading ? (
               <div
                 role="status"
                 className="flex min-h-0 flex-1 justify-center py-20 text-muted-foreground"

--- a/src/renderer/src/pages/literature/LiteratureMetadataEditor.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataEditor.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { literatureItemInputSchema } from '../../../../shared/literature'
+import { LiteratureMetadataEditor } from './LiteratureMetadataEditor'
+
+afterEach(cleanup)
+
+describe('LiteratureMetadataEditor', () => {
+  it('locks every editable control while saving and retains the draft after failure', () => {
+    const item = literatureItemInputSchema.parse({
+      itemType: 'journalArticle',
+      title: 'Original',
+      typeFields: { volume: '1' },
+      creators: [{ nameMode: 'person', givenName: 'A', familyName: 'B', creatorType: 'author' }],
+      identifiers: [{ scheme: 'doi', value: '10.1234/example', isPrimary: true }]
+    })
+    const onSave = vi.fn()
+    const props = { item, onSave, onCancel: vi.fn() }
+    const { container, rerender } = render(<LiteratureMetadataEditor {...props} saving={false} />)
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Draft title' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ title: 'Draft title' }))
+    rerender(<LiteratureMetadataEditor {...props} saving />)
+    const controls = [...container.querySelectorAll('input, textarea, button')]
+    expect(controls.length).toBeGreaterThan(15)
+    expect(controls.filter((control) => !control.matches(':disabled'))).toEqual([])
+    rerender(<LiteratureMetadataEditor {...props} saving={false} error="Save failed" />)
+    expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Draft title')
+    expect(screen.getByRole('alert').textContent).toBe('Save failed')
+    expect(screen.getByRole('button', { name: 'Add author' }).matches(':disabled')).toBe(false)
+    expect(screen.getByRole('combobox', { name: 'Reference type' }).matches(':disabled')).toBe(
+      false
+    )
+  })
+})

--- a/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
@@ -123,6 +123,7 @@ const LiteratureMetadataEditor = ({
   }
 
   const submit = (): void => {
+    if (saving) return
     const creators = draft.creators.filter((creator) =>
       creator.nameMode === 'organization'
         ? creator.literalName.trim()
@@ -133,13 +134,17 @@ const LiteratureMetadataEditor = ({
   }
 
   return (
-    <div className={cn('max-h-[70vh] space-y-5 overflow-y-auto p-5 text-sm', className)}>
+    <fieldset
+      disabled={saving}
+      className={cn('min-w-0 max-h-[70vh] space-y-5 overflow-y-auto p-5 text-sm', className)}
+    >
       {beforeFields}
       <div className="block space-y-1.5">
         <label htmlFor="literature-reference-type" className="font-medium">
           {t('Reference type')}
         </label>
         <Select
+          disabled={saving}
           value={draft.itemType}
           onValueChange={(value) =>
             setDraft((current) => ({
@@ -325,6 +330,7 @@ const LiteratureMetadataEditor = ({
           {draft.identifiers.map((identifier, index) => (
             <div key={index} className="flex items-center gap-2">
               <Select
+                disabled={saving}
                 value={identifier.scheme}
                 onValueChange={(value) =>
                   updateIdentifier(index, {
@@ -413,7 +419,7 @@ const LiteratureMetadataEditor = ({
           {t('Save')}
         </Button>
       </div>
-    </div>
+    </fieldset>
   )
 }
 

--- a/src/renderer/src/pages/literature/useLiteratureEntries.test.tsx
+++ b/src/renderer/src/pages/literature/useLiteratureEntries.test.tsx
@@ -18,12 +18,14 @@ type HookProps = { enabled: boolean; scopeKey: string; request: LiteratureCatalo
 
 const setup = (): RenderHookResult<ReturnType<typeof useLiteratureEntries>, HookProps> & {
   onPage: ReturnType<typeof vi.fn>
+  onError: ReturnType<typeof vi.fn>
 } => {
   const onPage = vi.fn()
   const onEmptyPage = vi.fn()
   const onError = vi.fn()
   return {
     onPage,
+    onError,
     ...renderHook<ReturnType<typeof useLiteratureEntries>, HookProps>(
       ({ enabled, scopeKey, request }) =>
         useLiteratureEntries({ enabled, scopeKey, request, onPage, onEmptyPage, onError }),
@@ -42,6 +44,82 @@ describe('useLiteratureEntries', () => {
   afterEach(() => {
     cleanup()
     vi.useRealTimers()
+  })
+
+  it.each(['initial', 'next page', 'filter'] as const)(
+    'ends loading after a failed %s request and permits retry',
+    async (kind) => {
+      if (kind === 'initial') search.mockRejectedValueOnce(new Error('Unavailable'))
+      const { result, rerender, onError } = setup()
+      await act(async () => {})
+      if (kind !== 'initial') {
+        search.mockRejectedValueOnce(new Error('Unavailable'))
+        rerender({
+          enabled: true,
+          scopeKey: kind === 'filter' ? 'filtered' : 'library',
+          request: { ...request, ...(kind === 'filter' ? { query: 'new' } : { offset: 50 }) }
+        })
+        await act(async () => {
+          await vi.runAllTimersAsync()
+        })
+      }
+      expect(onError).toHaveBeenLastCalledWith(true)
+      expect(result.current.loading).toBe(false)
+      expect(result.current.pageTransitionLoading).toBe(false)
+      search.mockResolvedValueOnce({
+        entries: [
+          {
+            id: 'retry',
+            item: literatureItemInputSchema.parse({
+              itemType: 'journalArticle',
+              title: 'Recovered'
+            }),
+            attachments: [],
+            collectionIds: [],
+            projectIds: [],
+            metadataRevision: 1,
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        totalCount: 51
+      })
+      await act(() => result.current.reload(true))
+      expect(onError).toHaveBeenLastCalledWith(false)
+      expect(result.current.loading).toBe(false)
+    }
+  )
+
+  it('returns from a failed scope to the cached page without another request', async () => {
+    const { result, rerender, onError, onPage } = setup()
+    await act(async () => {})
+    search.mockRejectedValueOnce(new Error('Unavailable'))
+    rerender({ enabled: true, scopeKey: 'filtered', request: { ...request, query: 'new' } })
+    await act(async () => {})
+    expect(onError).toHaveBeenLastCalledWith(true)
+    rerender({ enabled: true, scopeKey: 'library', request })
+    await act(async () => {})
+    expect(onError).toHaveBeenLastCalledWith(false)
+    expect(result.current.loading).toBe(false)
+    expect(onPage).toHaveBeenCalledTimes(1)
+    expect(onPage).toHaveBeenLastCalledWith(page, request, false)
+    expect(search).toHaveBeenCalledTimes(2)
+  })
+
+  it('ignores an old rejection after a new scope succeeds', async () => {
+    let reject: (error: Error) => void = () => {}
+    search.mockImplementationOnce(
+      () =>
+        new Promise((_, fail) => {
+          reject = fail
+        })
+    )
+    const { result, rerender, onError } = setup()
+    rerender({ enabled: true, scopeKey: 'filtered', request: { ...request, query: 'new' } })
+    await act(async () => {})
+    await act(async () => reject(new Error('Old failure')))
+    expect(onError).not.toHaveBeenCalledWith(true)
+    expect(result.current.loading).toBe(false)
   })
 
   it('starts first-page navigation without waiting for a debounce timer', async () => {

--- a/src/renderer/src/pages/literature/useLiteratureEntries.ts
+++ b/src/renderer/src/pages/literature/useLiteratureEntries.ts
@@ -31,12 +31,14 @@ const useLiteratureEntries = ({
   onError
 }: LiteratureEntriesOptions): {
   loading: boolean
+  failed: boolean
   pageTransitionLoading: boolean
   reload: (force?: boolean) => Promise<void>
   refreshItems: (itemIds: string[]) => Promise<void>
 } => {
   const [loading, setLoading] = useState(true)
   const [loadedKey, setLoadedKey] = useState<string>()
+  const [failedKey, setFailedKey] = useState<string>()
   const generationRef = useRef(0)
   const cacheRef = useRef(new Map<string, LiteratureCatalogSearchPage>())
   const dirtyKeys = useRef(new Set<string>())
@@ -56,11 +58,13 @@ const useLiteratureEntries = ({
         setCachedKeys(new Set())
         appliedPageRef.current = undefined
         setLoadedKey(undefined)
+        setFailedKey(undefined)
       }
       if (!enabled) return
       const generation = ++generationRef.current
       const cached =
         force || dirtyKeys.current.has(pageKey) ? undefined : cacheRef.current.get(pageKey)
+      setFailedKey(undefined)
       onError(false)
       if (
         cached &&
@@ -91,7 +95,10 @@ const useLiteratureEntries = ({
         appliedPageRef.current = { key: pageKey, page }
         setLoadedKey(pageKey)
       } catch {
-        if (generation === generationRef.current) onError(true)
+        if (generation === generationRef.current) {
+          setFailedKey(pageKey)
+          onError(true)
+        }
       } finally {
         if (generation === generationRef.current) setLoading(false)
       }
@@ -155,9 +162,11 @@ const useLiteratureEntries = ({
     }
   }, [pageKey, reload, request.offset, request.query, scopeKey])
 
-  const pending = !cachedKeys.has(pageKey) && (loading || loadedKey !== pageKey)
+  const pending =
+    failedKey !== pageKey && !cachedKeys.has(pageKey) && (loading || loadedKey !== pageKey)
   return {
     loading: pending,
+    failed: failedKey === pageKey,
     pageTransitionLoading: pending && loadedKey?.startsWith(`${scopeKey}:`) === true,
     reload,
     refreshItems

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4844,6 +4844,7 @@
     "{{count}} background tasks_one": "{{count}} Hintergrundaufgabe",
     "{{count}} background tasks_other": "{{count}} Hintergrundaufgaben",
     "{{count}} running background tasks_one": "{{count}} laufende Hintergrundaufgabe",
-    "{{count}} running background tasks_other": "{{count}} laufende Hintergrundaufgaben"
+    "{{count}} running background tasks_other": "{{count}} laufende Hintergrundaufgaben",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Aktualisiert: {{completed}}. Nicht aktualisiert: {{remaining}}."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5005,6 +5005,7 @@
     "{{count}} background tasks_other": "{{count}} tareas en segundo plano",
     "{{count}} running background tasks_one": "{{count}} tarea en segundo plano en ejecución",
     "{{count}} running background tasks_many": "{{count}} tareas en segundo plano en ejecución",
-    "{{count}} running background tasks_other": "{{count}} tareas en segundo plano en ejecución"
+    "{{count}} running background tasks_other": "{{count}} tareas en segundo plano en ejecución",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Actualizadas: {{completed}}. Sin actualizar: {{remaining}}."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5005,6 +5005,7 @@
     "{{count}} background tasks_other": "{{count}} tâches en arrière-plan",
     "{{count}} running background tasks_one": "{{count}} tâche en arrière-plan en cours",
     "{{count}} running background tasks_many": "{{count}} tâches en arrière-plan en cours",
-    "{{count}} running background tasks_other": "{{count}} tâches en arrière-plan en cours"
+    "{{count}} running background tasks_other": "{{count}} tâches en arrière-plan en cours",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Références mises à jour : {{completed}}. Non mises à jour : {{remaining}}."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4691,6 +4691,7 @@
     "Local Runs and remote Compute Jobs for this Session. Click to show or hide the ledger.": "このセッションのローカル実行とリモートの Compute Job。クリックで一覧の表示を切り替えます。",
     "{{count}} tasks_other": "{{count}} 件のタスク",
     "{{count}} background tasks_other": "{{count}} 件のバックグラウンドタスク",
-    "{{count}} running background tasks_other": "実行中のバックグラウンドタスク {{count}} 件"
+    "{{count}} running background tasks_other": "実行中のバックグラウンドタスク {{count}} 件",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "更新済み：{{completed}}。未更新：{{remaining}}。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4689,6 +4689,7 @@
     "Local Runs and remote Compute Jobs for this Session. Click to show or hide the ledger.": "이 세션의 로컬 실행 및 원격 Compute Job입니다. 클릭하여 목록을 표시하거나 숨깁니다.",
     "{{count}} tasks_other": "작업 {{count}}개",
     "{{count}} background tasks_other": "백그라운드 작업 {{count}}개",
-    "{{count}} running background tasks_other": "실행 중인 백그라운드 작업 {{count}}개"
+    "{{count}} running background tasks_other": "실행 중인 백그라운드 작업 {{count}}개",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "업데이트됨: {{completed}}. 업데이트되지 않음: {{remaining}}."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5137,6 +5137,7 @@
     "{{count}} running background tasks_one": "{{count}} фоновая задача выполняется",
     "{{count}} running background tasks_few": "{{count}} фоновые задачи выполняются",
     "{{count}} running background tasks_many": "{{count}} фоновых задач выполняется",
-    "{{count}} running background tasks_other": "{{count}} фоновые задачи выполняются"
+    "{{count}} running background tasks_other": "{{count}} фоновые задачи выполняются",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Обновлено: {{completed}}. Не обновлено: {{remaining}}."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4691,6 +4691,7 @@
     "Local Runs and remote Compute Jobs for this Session. Click to show or hide the ledger.": "此会话的本地运行与远程 Compute 作业。点击以显示或隐藏台账。",
     "{{count}} tasks_other": "{{count}} 个任务",
     "{{count}} background tasks_other": "{{count}} 个后台任务",
-    "{{count}} running background tasks_other": "{{count}} 个后台任务正在运行"
+    "{{count}} running background tasks_other": "{{count}} 个后台任务正在运行",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4691,6 +4691,7 @@
     "Local Runs and remote Compute Jobs for this Session. Click to show or hide the ledger.": "此工作階段的本機執行與遠端 Compute 作業。點擊以顯示或隱藏清單。",
     "{{count}} tasks_other": "{{count}} 個任務",
     "{{count}} background tasks_other": "{{count}} 個背景工作",
-    "{{count}} running background tasks_other": "{{count}} 個背景工作正在執行"
+    "{{count}} running background tasks_other": "{{count}} 個背景工作正在執行",
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。"
   }
 }


### PR DESCRIPTION
## Problem

Literature query failures could leave the page loading indefinitely and hide recovery. Trash commands could reject after partially committing a single batch, while a later batch failure left already-changed rows visible. Metadata edits made during saving were discarded. Sidebar counts included trashed references, and collection navigation stopped at the first 100 results.

## Proposed change

- End failed-page loading, show the existing error with Retry, and hide unconfirmed rows/empty states. Preserve cache reuse and stale-response rejection.
- Make each lifecycle command atomic. For multiple commands, refresh committed results, report completed/incomplete counts, keep unresolved selections, and retry only unresolved IDs.
- Disable the shared metadata form while saving, including author/identifier controls and selects; preserve drafts when saving fails.
- Count active, unmerged references without removing relationships; refresh navigation through delete/restore, including transitions to zero.
- Read collection navigation through `nextOffset` and publish only a complete snapshot; reject older successful refreshes.

## Scope and non-goals

No database schema, migration, persisted enum, data relationship or external IPC contract changes. Existing `deletedAt` writes gain a per-command rollback boundary. New state is renderer memory only: failed page key (with a derived `failed` flag), unresolved batch IDs/count, and navigation request generations. Existing `saving` state is reused.

Existing databases remain compatible without conversion. This does not reconstruct past partial operations or discarded drafts. It does not introduce a long bulk transaction, autosave, persistent drafts or a new state framework. Collection editor behavior outside the shared metadata editor is unchanged.

## Acceptance criteria and validation

Regression-first evidence uses mounted real page/components and real SQLite through existing public catalog commands. No production test seam was added. Before implementation, two identical runs had 154 passing and the same 11 expected failing cases; failures matched the reported behaviors. Expanded unchanged-source reruns also cover merged aliases, all editable controls, count refresh and continuation failure: both runs had the same 16 expected failures and 2 passing controls.

Final local behavior-to-check mapping (run after the last material edit):

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| Loading settlement/retry, cached return, stale rejection; actual error, batch, count and collection navigation UI; metadata draft/controls; SQLite rollback and counts; all locale guards | `npx vitest run src/main/literature/catalog.test.ts src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx src/renderer/src/pages/literature/useLiteratureEntries.test.tsx src/renderer/src/pages/literature/LiteratureMetadataEditor.test.tsx src/renderer/src/i18n/resources.test.ts` | 974 passed |
| Shared literature contract, MCP callers, PDF import, batch jobs, Electron/HTTP command adapters/composition, table/count consumers | Targeted tests in `src/shared/literature.test.ts`, `src/main/literature/{library-mcp-server,mcp-server,pdf-importer,batch-jobs}.test.ts`, `src/main/application-command-{electron-adapter,http-adapter,composition}.test.ts`, and renderer `Literature{Table.render,LibraryCount}.test.tsx` | 77 passed |
| Main, sandbox and renderer types | `npm run typecheck` | Passed |
| Lint and patch whitespace | `npm run lint`; `git diff --check` | Passed |
| Actual rendered interaction | ego-browser, real LiteratureLibraryPage with controlled IPC fixtures | Error/Retry, disabled save form, 200/1 partial result and collection 101 verified; screenshots captured |

The local full suite was intentionally not run at maintainer request. Literature has no curated module ID in the impact manifest, so the local plan explicitly includes catalog owners, shared contracts, renderer consumers and command/MCP adapters based on call-site and CodeGraph evidence. PR Gate remains the authority for complete and platform verification. No provider protocol, OS path handling, schema or packaging implementation changed; those complete/platform checks remain CI coverage, not claimed local evidence. Browser screenshots use controlled fixtures rather than a user's live library.

## Review focus

Per-command rollback versus explicit multi-command partial success; preserving failed-page/cached-page distinctions; native fieldset plus portal-select disabling; active-count cache invalidation and complete collection pagination. Independent PR review should confirm the evidence mapping covers the final diff before merge.
