### PR TITLE
fix(literature): preserve import identities and author metadata

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4620,8 +4620,14 @@ const createApplicationModules = async (
       get: (itemId) => literatureCatalog.get(itemId),
       importPdf: (request) => literaturePdfImporter.import(request),
       importRecords: async (request) => {
-        const parsed = await literatureCitationFormatter.parseReferences(request.content)
-        const entries = await literatureCatalog.inspectImportItems(parsed.items, parsed.errors)
+        const { warnings, ...parsed } = await literatureCitationFormatter.parseReferences(
+          request.content
+        )
+        const entries = await literatureCatalog.inspectImportItems(
+          parsed.items,
+          parsed.errors,
+          warnings
+        )
         if (request.mode === 'preview') return { ...parsed, entries }
         if (parsed.items.length === 0) throw new Error('No valid references were found.')
         return {

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -11,9 +11,12 @@ import {
   literatureItemInputSchema,
   type LiteratureCandidateInput
 } from '../../shared/literature'
+import { toCslItem } from '../../shared/literature-csl'
+import { buildLiteratureMergeItem } from '../../renderer/src/pages/literature/literature-merge'
 import { migrateApplicationDatabase } from '../database/migration-service'
 import { createProjectDbClient } from '../projects/prisma-client'
 import { LiteratureCatalog, normalizeIdentifier } from './catalog'
+import { LiteratureCitationFormatter } from './citation-formatter'
 
 describe('Literature identifier normalization', () => {
   it('removes text joined to the end of a DOI before provider lookup', () => {
@@ -166,6 +169,251 @@ describe('LiteratureCatalog', () => {
     }
   )
 
+  it.each(['reuse', 'fill-missing'] as const)(
+    'does not silently reuse conflicting import identities with %s',
+    async (policy) => {
+      const catalog = await setup()
+      const a = candidate({ doi: '10.1234/one' }).item
+      const b = {
+        ...candidate().item,
+        identifiers: [{ scheme: 'pmid' as const, value: '12345', isPrimary: true }]
+      }
+      await catalog.importItems([a, b], undefined, 'separate')
+      const incoming = { ...a, identifiers: [...a.identifiers, ...b.identifiers] }
+      await expect(catalog.importItems([incoming], undefined, policy)).rejects.toThrow(
+        'conflicting identifiers'
+      )
+    }
+  )
+
+  it('does not classify identifiers pointing to different records as an ordinary existing import', async () => {
+    const catalog = await setup()
+    const a = candidate({ doi: '10.1234/one' }).item
+    const b = {
+      ...candidate().item,
+      identifiers: [{ scheme: 'pmid' as const, value: '12345', isPrimary: true }]
+    }
+    await catalog.importItems([a, b], undefined, 'separate')
+    for (const identifiers of [
+      [...a.identifiers, ...b.identifiers],
+      [...b.identifiers, ...a.identifiers]
+    ]) {
+      const [preview] = await catalog.inspectImportItems([{ ...a, identifiers }], [])
+      expect(preview.status).not.toBe('existing')
+    }
+  })
+
+  it('does not fill an empty identifier field with an identity owned by another record', async () => {
+    const catalog = await setup()
+    const a = candidate({ doi: '10.1234/one' }).item
+    const b = {
+      ...candidate().item,
+      identifiers: [{ scheme: 'pmid' as const, value: '12345', isPrimary: true }]
+    }
+    const { itemIds } = await catalog.importItems([a, b], undefined, 'separate')
+    await catalog
+      .importItems(
+        [{ ...a, identifiers: [...a.identifiers, ...b.identifiers] }],
+        undefined,
+        'fill-missing'
+      )
+      .catch(() => undefined)
+    expect((await catalog.get(itemIds[0]))!.item.identifiers).toEqual(
+      a.identifiers.map((id) => ({ ...id, value: '10.1234/one' }))
+    )
+  })
+
+  it('projects the survivor DOI after persisting a reviewed merge with a primary PMID', async () => {
+    const catalog = await setup()
+    const a = candidate({ doi: '10.1234/obsolete', title: 'Old title' }).item
+    const b = {
+      ...candidate({ title: 'Preferred title' }).item,
+      identifiers: [
+        { scheme: 'pmid' as const, value: '67890', isPrimary: true },
+        { scheme: 'doi' as const, value: '10.1234/preferred', isPrimary: false }
+      ]
+    }
+    const { itemIds } = await catalog.importItems([a, b], undefined, 'separate')
+    const views = await Promise.all(itemIds.map(async (id) => (await catalog.get(id))!))
+    await catalog.transact({
+      kind: 'merge-items',
+      survivorId: itemIds[1],
+      duplicateIds: [itemIds[0]],
+      expectedItems: views.map(({ id, metadataRevision, updatedAt }) => ({
+        id,
+        metadataRevision,
+        updatedAt
+      })),
+      expectedMetadataRevision: views[1].metadataRevision,
+      item: buildLiteratureMergeItem(views, itemIds[1], {})
+    })
+    const merged = (await catalog.get(itemIds[1]))!
+    expect(merged.item.title).toBe('Preferred title')
+    expect(toCslItem(merged.id, merged.item).DOI).toBe('10.1234/preferred')
+  })
+
+  it.each(['reuse', 'fill-missing', 'separate'] as const)(
+    'handles conflicts within one file with %s atomically',
+    async (policy) => {
+      const catalog = await setup()
+      const a = candidate({ doi: '10.1234/one' }).item
+      const b = {
+        ...a,
+        identifiers: [{ scheme: 'pmid' as const, value: '12345', isPrimary: true }]
+      }
+      const c = { ...a, identifiers: [...a.identifiers, ...b.identifiers] }
+      const entries = await catalog.inspectImportItems([a, b, c], [])
+      expect(entries[2]).toMatchObject({
+        status: 'conflict',
+        conflict: { matches: [{ inputIndex: 0 }, { inputIndex: 1 }] }
+      })
+      if (policy === 'separate') {
+        await expect(catalog.importItems([a, b, c], undefined, policy)).resolves.toMatchObject({
+          createdCount: 3,
+          reusedCount: 0
+        })
+      } else {
+        await expect(catalog.importItems([a, b, c], undefined, policy)).rejects.toThrow(
+          'conflicting identifiers'
+        )
+        expect(await client!.literatureItem.count()).toBe(0)
+      }
+    }
+  )
+
+  it.each([false, true])(
+    'rejects contradictory values of one strong scheme with existing target=%s',
+    async (existing) => {
+      const catalog = await setup()
+      const a = candidate({ doi: '10.1234/one' }).item
+      const pmid = { scheme: 'pmid' as const, value: '12345', isPrimary: false }
+      if (existing) await catalog.importItems([{ ...a, identifiers: [...a.identifiers, pmid] }])
+      const incoming = {
+        ...a,
+        identifiers: [
+          ...(!existing ? a.identifiers : []),
+          { scheme: 'doi' as const, value: '10.1234/two', isPrimary: true },
+          pmid
+        ]
+      }
+      expect((await catalog.inspectImportItems([incoming], []))[0].status).toBe('conflict')
+      await expect(catalog.importItems([incoming])).rejects.toThrow('conflicting identifiers')
+      await expect(catalog.importItems([incoming], undefined, 'separate')).resolves.toMatchObject({
+        createdCount: 1
+      })
+    }
+  )
+
+  it('reuses consistent identifiers and restores a unique Trash match', async () => {
+    const catalog = await setup()
+    const input = {
+      ...candidate().item,
+      identifiers: [
+        ...candidate().item.identifiers,
+        { scheme: 'pmid' as const, value: '12345', isPrimary: true }
+      ]
+    }
+    const {
+      itemIds: [id]
+    } = await catalog.importItems([input])
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [id], state: 'deleted' })
+    for (const identifiers of [input.identifiers, [...input.identifiers].reverse()]) {
+      expect((await catalog.inspectImportItems([{ ...input, identifiers }], []))[0]).toMatchObject({
+        status: 'existing',
+        existingItemId: id
+      })
+      await expect(catalog.importItems([{ ...input, identifiers }])).resolves.toMatchObject({
+        itemIds: [id],
+        reusedCount: 1
+      })
+    }
+    expect(await client!.literatureItem.findUnique({ where: { id } })).toMatchObject({
+      deletedAt: null
+    })
+  })
+
+  it('rechecks the current database after preview and preserves Trash and collection links on conflict', async () => {
+    const catalog = await setup()
+    const a = candidate({ doi: '10.1234/one' }).item
+    const b = { ...a, identifiers: [{ scheme: 'pmid' as const, value: '12345', isPrimary: true }] }
+    const {
+      itemIds: [id]
+    } = await catalog.importItems([a])
+    const incoming = { ...a, identifiers: [...a.identifiers, ...b.identifiers] }
+    expect((await catalog.inspectImportItems([incoming], []))[0].status).toBe('existing')
+    await catalog.importItems([b])
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [id], state: 'deleted' })
+    const collection = await catalog.transact({ kind: 'create-collection', name: 'Target' })
+    await expect(
+      catalog.importItems(
+        [candidate({ doi: '10.1234/new' }).item, incoming],
+        collection.id,
+        'fill-missing'
+      )
+    ).rejects.toThrow('conflicting identifiers')
+    expect(await client!.literatureItem.count()).toBe(2)
+    expect(await client!.literatureCollectionItem.count()).toBe(0)
+    expect((await client!.literatureItem.findUnique({ where: { id } }))!.deletedAt).not.toBeNull()
+  })
+
+  it('keeps preview and commit aligned when later rows use an earlier matching row alias', async () => {
+    const catalog = await setup()
+    const a = candidate().item
+    const {
+      itemIds: [id]
+    } = await catalog.importItems([a])
+    const pmid = { scheme: 'pmid' as const, value: '12345', isPrimary: false }
+    const inputs = [
+      { ...a, identifiers: [...a.identifiers, pmid] },
+      { ...a, identifiers: [pmid] }
+    ]
+    expect(
+      (await catalog.inspectImportItems(inputs, [])).map(({ existingItemId }) => existingItemId)
+    ).toEqual([id, id])
+    await expect(catalog.importItems(inputs)).resolves.toMatchObject({
+      itemIds: [id],
+      reusedCount: 2
+    })
+  })
+
+  it('normalizes multiple primary flags per scheme on explicit writes without discarding history', async () => {
+    const catalog = await setup()
+    const input = {
+      ...candidate().item,
+      identifiers: [
+        { scheme: 'doi' as const, value: '10.1234/z', isPrimary: true },
+        { scheme: 'doi' as const, value: '10.1234/a', isPrimary: true },
+        { scheme: 'pmid' as const, value: '12345', isPrimary: true }
+      ]
+    }
+    const {
+      itemIds: [id]
+    } = await catalog.importItems([input], undefined, 'separate')
+    const view = (await catalog.get(id))!
+    expect(view.item.identifiers).toHaveLength(3)
+    expect(
+      view.item.identifiers
+        .filter(({ isPrimary }) => isPrimary)
+        .map(({ value }) => value)
+        .sort()
+    ).toEqual(['10.1234/a', '12345'])
+  })
+
+  it('preserves NBIB author warnings through preview and ordered creators through SQLite', async () => {
+    const catalog = await setup()
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'PMID- 12345\nTI  - Paper\nAU  - Smith JA\nCN  - Research Consortium\nFAU - Unsplit Name\n'
+    )
+    const entries = await catalog.inspectImportItems(parsed.items, parsed.errors, parsed.warnings)
+    expect(entries[0].warnings).toContain('uncertain-author-name')
+    const {
+      itemIds: [id]
+    } = await catalog.importItems(parsed.items)
+    const persisted = (await catalog.get(id))!.item
+    expect(persisted.creators).toEqual(parsed.items[0].creators)
+    expect(persisted.extra).toBe('FAU - Unsplit Name')
+  })
+
   it('shares duplicate scans across count and page requests and invalidates on metadata mutations', async () => {
     const catalog = await setup()
     const findMany = vi.spyOn(client!.literatureItem, 'findMany')
@@ -194,10 +442,7 @@ describe('LiteratureCatalog', () => {
       duplicatePolicy: 'separate'
     })
     expect(separate.id).not.toBe(first.id)
-    await expect(catalog.importItems([input])).resolves.toMatchObject({
-      itemIds: [first.id],
-      reusedCount: 1
-    })
+    await expect(catalog.importItems([input])).rejects.toThrow('conflicting identifiers')
     await expect(
       catalog.transact({ kind: 'stage-candidate', candidate: candidate() })
     ).resolves.toMatchObject({ id: first.id, kind: 'item' })
@@ -212,16 +457,16 @@ describe('LiteratureCatalog', () => {
       item: { personalNote: 'Independent note' }
     })
     await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [first.id], state: 'deleted' })
-    await expect(catalog.importItems([input])).resolves.toMatchObject({ itemIds: [separate.id] })
+    await expect(catalog.importItems([input])).rejects.toThrow('conflicting identifiers')
   })
 
   it('fills missing fields without overwriting conflicts and applies the import policy within a file', async () => {
     const catalog = await setup()
     const collection = await catalog.transact({ kind: 'create-collection', name: 'Target' })
     const input = candidate().item
-    const receipt = await catalog.importItems([input, input], collection.id, 'separate')
-    expect(receipt.createdCount).toBe(2)
-    expect(receipt.reusedCount).toBe(0)
+    const receipt = await catalog.importItems([input, input], collection.id, 'reuse')
+    expect(receipt.createdCount).toBe(1)
+    expect(receipt.reusedCount).toBe(1)
     for (const id of receipt.itemIds)
       await expect(catalog.get(id)).resolves.toMatchObject({ collectionIds: [collection.id] })
     await catalog.importItems(

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -356,6 +356,30 @@ describe('LiteratureCatalog', () => {
     expect((await client!.literatureItem.findUnique({ where: { id } }))!.deletedAt).not.toBeNull()
   })
 
+  it('does not let a conflicting row create aliases for later import rows', async () => {
+    const catalog = await setup()
+    const existing = candidate({ doi: '10.1234/one' }).item
+    const incoming = candidate({ doi: '10.1234/two' }).item
+    const {
+      itemIds: [id]
+    } = await catalog.importItems([existing])
+    const independent = await catalog.inspectImportItems([incoming, existing], [])
+    const entries = await catalog.inspectImportItems(
+      [
+        { ...existing, identifiers: [...existing.identifiers, ...incoming.identifiers] },
+        incoming,
+        existing
+      ],
+      []
+    )
+    expect(entries[0].status).toBe('conflict')
+    expect(
+      entries.slice(1).map(({ status, existingItemId }) => ({ status, existingItemId }))
+    ).toEqual(independent.map(({ status, existingItemId }) => ({ status, existingItemId })))
+    expect(entries[2].existingItemId).toBe(id)
+    expect(await client!.literatureItem.count()).toBe(1)
+  })
+
   it('keeps preview and commit aligned when later rows use an earlier matching row alias', async () => {
     const catalog = await setup()
     const a = candidate().item

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -408,6 +408,7 @@ const resolveImportItems = (
 ): ReturnType<typeof importIdentity>[] =>
   items.map((item, inputIndex) => {
     const resolution = importIdentity(identities, item)
+    if (resolution.conflict) return resolution
     const target = resolution.target ?? inputIndex
     const previous = identities.records.get(target)
     rememberImportIdentity(identities, target, {

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -6,10 +6,12 @@ import { planLiteratureMerge, supplementLiteratureMetadata } from './duplicate-m
 
 import {
   LITERATURE_IDENTITY_SCHEMES,
+  LITERATURE_IMPORT_IDENTITY_CONFLICT,
   LITERATURE_COLLECTION_NAME_CONFLICT,
   literatureCandidateInputSchema,
   literatureItemInputSchema,
   normalizeLiteratureIdentifierValue,
+  normalizeLiteratureIdentifierPreferences,
   type LiteratureCatalogCommand,
   type LiteratureDuplicatePolicy,
   type LiteratureCollectionView,
@@ -122,15 +124,15 @@ const sha256 = (value: string): string => createHash('sha256').update(value).dig
 const normalizedIdentifiers = (
   identifiers: readonly LiteratureIdentifierInput[]
 ): Array<LiteratureIdentifierInput & { normalizedValue: string }> => {
-  const seen = new Set<string>()
-  return identifiers.flatMap((identifier) => {
+  const unique = new Map<string, LiteratureIdentifierInput & { normalizedValue: string }>()
+  for (const identifier of identifiers) {
     const normalizedValue = normalizeIdentifier(identifier.scheme, identifier.value)
     if (!normalizedValue) throw new Error(`Literature ${identifier.scheme} identifier is empty.`)
     const key = `${identifier.scheme}:${normalizedValue}`
-    if (seen.has(key)) return []
-    seen.add(key)
-    return [{ ...identifier, normalizedValue }]
-  })
+    if (!unique.has(key) || identifier.isPrimary)
+      unique.set(key, { ...identifier, normalizedValue })
+  }
+  return normalizeLiteratureIdentifierPreferences([...unique.values()])
 }
 
 const candidateDedupeKey = (candidate: LiteratureCandidateInput): string => {
@@ -294,43 +296,126 @@ const restoreExistingItem = (
 
 const identityKey = (scheme: string, value: string): string => `${scheme}:${value}`
 
-// Inspect identifiers in bounded queries instead of opening one request per reference.
+type ImportIdentityIndex = {
+  byIdentifier: Map<string, Set<string | number>>
+  records: Map<string | number, Pick<LiteratureItemInput, 'title' | 'identifiers'>>
+}
+
+const rememberImportIdentity = (
+  index: ImportIdentityIndex,
+  target: string | number,
+  item: Pick<LiteratureItemInput, 'title' | 'identifiers'>
+): void => {
+  index.records.set(target, item)
+  for (const { scheme, normalizedValue } of normalizedIdentifiers(item.identifiers)) {
+    if (!identitySchemes.has(scheme)) continue
+    const key = identityKey(scheme, normalizedValue)
+    const targets = index.byIdentifier.get(key) ?? new Set<string | number>()
+    targets.add(target)
+    index.byIdentifier.set(key, targets)
+  }
+}
+
+// Include all owners, including Trash and explicitly independent duplicates.
 const importIdentityMap = async (
   transaction: Prisma.TransactionClient,
   items: readonly LiteratureItemInput[]
-): Promise<Map<string, string>> => {
+): Promise<ImportIdentityIndex> => {
   const identifiers = items.flatMap((item) =>
     normalizedIdentifiers(item.identifiers).filter(({ scheme }) => identitySchemes.has(scheme))
   )
-  const result = new Map<string, string>()
+  const result: ImportIdentityIndex = { byIdentifier: new Map(), records: new Map() }
   for (let offset = 0; offset < identifiers.length; offset += 200) {
-    const matches = await transaction.literatureIdentifier.findMany({
+    const matches = await transaction.literatureItem.findMany({
       where: {
-        item: { mergedIntoItemId: null },
-        OR: identifiers.slice(offset, offset + 200).map(({ scheme, normalizedValue }) => ({
-          scheme,
-          normalizedValue
-        }))
+        mergedIntoItemId: null,
+        identifiers: {
+          some: {
+            OR: identifiers
+              .slice(offset, offset + 200)
+              .map(({ scheme, normalizedValue }) => ({ scheme, normalizedValue }))
+          }
+        }
       },
-      select: { scheme: true, normalizedValue: true, itemId: true },
-      orderBy: [{ item: { deletedAt: 'asc' } }, { item: { createdAt: 'asc' } }, { itemId: 'asc' }]
+      select: { id: true, title: true, identifiers: true }
     })
     for (const match of matches) {
-      const key = identityKey(match.scheme, match.normalizedValue)
-      if (!result.has(key)) result.set(key, match.itemId)
+      rememberImportIdentity(result, match.id, {
+        title: match.title,
+        identifiers: match.identifiers.map((identifier) => ({
+          scheme: identifier.scheme as LiteratureIdentifierScheme,
+          value: identifier.rawValue,
+          isPrimary: identifier.isPrimary
+        }))
+      })
     }
   }
   return result
 }
 
 const importIdentity = (
-  identities: ReadonlyMap<string, string>,
+  index: ImportIdentityIndex,
   item: LiteratureItemInput
-): string | undefined =>
-  normalizedIdentifiers(item.identifiers)
-    .filter(({ scheme }) => identitySchemes.has(scheme))
-    .map(({ scheme, normalizedValue }) => identities.get(identityKey(scheme, normalizedValue)))
-    .find((id) => id !== undefined)
+): { target?: string | number; conflict?: LiteratureRecordImportEntry['conflict'] } => {
+  const identifiers = normalizedIdentifiers(item.identifiers).filter(({ scheme }) =>
+    identitySchemes.has(scheme)
+  )
+  const targets = [
+    ...new Set(
+      identifiers.flatMap(({ scheme, normalizedValue }) => [
+        ...(index.byIdentifier.get(identityKey(scheme, normalizedValue)) ?? [])
+      ])
+    )
+  ]
+  const contradictory = identifiers.some((identifier) =>
+    identifiers.some(
+      (other) =>
+        other.scheme === identifier.scheme && other.normalizedValue !== identifier.normalizedValue
+    )
+  )
+  const target = targets[0]
+  const existing =
+    target === undefined ? [] : normalizedIdentifiers(index.records.get(target)!.identifiers)
+  const disagrees = identifiers.some((identifier) => {
+    const sameScheme = existing.filter(({ scheme }) => scheme === identifier.scheme)
+    return (
+      sameScheme.length > 0 &&
+      !sameScheme.some(({ normalizedValue }) => normalizedValue === identifier.normalizedValue)
+    )
+  })
+  if (targets.length > 1 || contradictory || disagrees)
+    return {
+      conflict: {
+        identifiers: identifiers.map(({ scheme, value, isPrimary }) => ({
+          scheme,
+          value,
+          isPrimary
+        })),
+        matches: targets.map((target) => ({
+          ...(typeof target === 'string' ? { itemId: target } : { inputIndex: target }),
+          title: index.records.get(target)!.title
+        }))
+      }
+    }
+  return { target }
+}
+
+// Plan the entire batch before any write. Virtual targets retain input indexes,
+// so bridges between earlier rows are checked identically in preview and commit.
+const resolveImportItems = (
+  identities: ImportIdentityIndex,
+  items: readonly LiteratureItemInput[]
+): ReturnType<typeof importIdentity>[] =>
+  items.map((item, inputIndex) => {
+    const resolution = importIdentity(identities, item)
+    const target = resolution.target ?? inputIndex
+    const previous = identities.records.get(target)
+    rememberImportIdentity(identities, target, {
+      title: previous?.title ?? item.title,
+      identifiers: [...(previous?.identifiers ?? []), ...item.identifiers]
+    })
+    return resolution
+  })
 
 const createItem = async (
   transaction: Prisma.TransactionClient,
@@ -1044,35 +1129,33 @@ class LiteratureCatalog {
           }
 
           const identities = await importIdentityMap(transaction, items)
+          const resolutions =
+            duplicatePolicy === 'separate' ? [] : resolveImportItems(identities, items)
+          if (resolutions.some(({ conflict }) => conflict))
+            throw new Error(LITERATURE_IMPORT_IDENTITY_CONFLICT)
+          const importedTargets = new Map<number, string>()
           const itemIds: string[] = []
           let createdCount = 0
           let reusedCount = 0
-          for (const item of items) {
-            const identifiers = normalizedIdentifiers(item.identifiers)
+          for (const [inputIndex, item] of items.entries()) {
+            const target = resolutions[inputIndex]?.target
             const existingId =
-              duplicatePolicy === 'separate' ? undefined : importIdentity(identities, item)
+              typeof target === 'string'
+                ? target
+                : target === undefined
+                  ? undefined
+                  : importedTargets.get(target)
             const itemId = existingId ?? (await createItem(transaction, item))
             if (existingId) {
               await restoreExistingItem(transaction, existingId)
               if (duplicatePolicy === 'fill-missing') {
-                const filled = await supplementExistingItem(transaction, existingId, item)
-                for (const { scheme, normalizedValue } of normalizedIdentifiers(
-                  filled.identifiers
-                )) {
-                  const key = identityKey(scheme, normalizedValue)
-                  if (identitySchemes.has(scheme) && !identities.has(key))
-                    identities.set(key, existingId)
-                }
+                await supplementExistingItem(transaction, existingId, item)
               }
               reusedCount += 1
             } else {
               createdCount += 1
-              for (const { scheme, normalizedValue } of identifiers) {
-                if (identitySchemes.has(scheme)) {
-                  identities.set(identityKey(scheme, normalizedValue), itemId)
-                }
-              }
             }
+            importedTargets.set(inputIndex, itemId)
             if (!itemIds.includes(itemId)) itemIds.push(itemId)
             if (collectionId) {
               await transaction.literatureCollectionItem.upsert({
@@ -1094,25 +1177,20 @@ class LiteratureCatalog {
 
   async inspectImportItems(
     inputs: readonly LiteratureItemInput[],
-    errors: readonly LiteratureRecordImportError[]
+    errors: readonly LiteratureRecordImportError[],
+    parserWarnings: readonly LiteratureRecordImportEntry['warnings'][] = []
   ): Promise<LiteratureRecordImportEntry[]> {
     const items = inputs.map((item) => literatureItemInputSchema.parse(item))
     const client = await this.getClient()
     const entries: LiteratureRecordImportEntry[] = []
     await client.$transaction(async (transaction) => {
       const identities = await importIdentityMap(transaction, items)
+      const resolutions = resolveImportItems(identities, items)
       for (const [index, item] of items.entries()) {
-        const match = importIdentity(identities, item)
-        const existingItemId = match || undefined
-        if (match === undefined) {
-          for (const { scheme, normalizedValue } of normalizedIdentifiers(item.identifiers)) {
-            if (identitySchemes.has(scheme)) {
-              // An empty ID marks an earlier reference in this file, not a persisted Item.
-              identities.set(identityKey(scheme, normalizedValue), '')
-            }
-          }
-        }
+        const { target, conflict } = resolutions[index]!
+        const existingItemId = !conflict && typeof target === 'string' ? target : undefined
         const warnings: LiteratureRecordImportEntry['warnings'] = [
+          ...(parserWarnings[index] ?? []),
           ...(item.creators.length === 0 ? (['missing-authors'] as const) : []),
           ...(item.issuedYear === undefined && !item.issuedText ? (['missing-year'] as const) : []),
           ...(!item.containerTitle &&
@@ -1123,7 +1201,14 @@ class LiteratureCatalog {
         entries.push({
           index,
           title: item.title,
-          status: match !== undefined ? 'existing' : warnings.length > 0 ? 'warning' : 'ready',
+          status: conflict
+            ? 'conflict'
+            : target !== undefined
+              ? 'existing'
+              : warnings.length > 0
+                ? 'warning'
+                : 'ready',
+          ...(conflict ? { conflict } : {}),
           warnings,
           item,
           ...(existingItemId ? { existingItemId } : {})

--- a/src/main/literature/citation-formatter.test.ts
+++ b/src/main/literature/citation-formatter.test.ts
@@ -31,6 +31,63 @@ const reference: LiteratureItemInput = {
 }
 
 describe('LiteratureCitationFormatter', () => {
+  it.each([
+    [
+      'CN  - Research Consortium',
+      [{ nameMode: 'organization', literalName: 'Research Consortium', creatorType: 'author' }]
+    ],
+    [
+      'AU  - Smith JA',
+      [{ nameMode: 'person', familyName: 'Smith', givenName: 'JA', creatorType: 'author' }]
+    ],
+    [
+      'FAU - Smith, Jane Ann\nAU  - Smith JA\nCN  - Research Consortium\nFAU - Jones, Mary\nAU  - Jones M',
+      [
+        { nameMode: 'person', familyName: 'Smith', givenName: 'Jane Ann', creatorType: 'author' },
+        { nameMode: 'organization', literalName: 'Research Consortium', creatorType: 'author' },
+        { nameMode: 'person', familyName: 'Jones', givenName: 'Mary', creatorType: 'author' }
+      ]
+    ]
+  ])('preserves NBIB author semantics and sequence for %s', async (authors, expected) => {
+    const result = await new LiteratureCitationFormatter().parseReferences(
+      `PMID- 12345\nTI  - Group authored paper\nDP  - 2024\n${authors}\n`
+    )
+    expect(result.errors).toEqual([])
+    expect(result.items[0].creators).toEqual(expected)
+  })
+
+  it('preserves uncertain personal names and warns without dropping the record', async () => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'PMID- 12345\nTI  - Paper\nFAU - Unsplit Name\n'
+    )
+    expect(parsed.errors).toEqual([])
+    expect(parsed.warnings).toEqual([['uncertain-author-name']])
+    expect(parsed.items[0]).toMatchObject({
+      creators: [{ nameMode: 'person', familyName: 'Unsplit Name', givenName: '' }],
+      extra: 'FAU - Unsplit Name'
+    })
+  })
+
+  it('does not drop unmatched abbreviated authors or collapse repeated people', async () => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'PMID- 12345\nTI  - Paper\nAU  - Smith JA\nFAU - Jones, Mary\nAU  - Jones M\nFAU - Jones, Mary\nAU  - Jones M\n'
+    )
+    expect(parsed.items[0].creators).toEqual([
+      { nameMode: 'person', familyName: 'Smith', givenName: 'JA', creatorType: 'author' },
+      { nameMode: 'person', familyName: 'Jones', givenName: 'Mary', creatorType: 'author' },
+      { nameMode: 'person', familyName: 'Jones', givenName: 'Mary', creatorType: 'author' }
+    ])
+  })
+
+  it('keeps adjacent people with the same surname and different initials distinct', async () => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'PMID- 12345\nTI  - Paper\nAU  - Smith JA\nFAU - Smith, Mary\nAU  - Smith M\n'
+    )
+    expect(parsed.items[0].creators).toHaveLength(2)
+    expect(parsed.items[0].creators[0]).toMatchObject({ familyName: 'Smith', givenName: 'JA' })
+    expect(parsed.items[0].creators[1]).toMatchObject({ familyName: 'Smith', givenName: 'Mary' })
+  })
+
   it('formats every pinned built-in style without network access', async () => {
     const formatter = new LiteratureCitationFormatter()
 
@@ -222,7 +279,7 @@ TI  - A useful PubMed paper
 AB  - The first line of the abstract.
       The second line continues it.
 FAU - Smith, Jane A
-FAU - Research Consortium
+CN  - Research Consortium
 JT  - Journal of Useful Results
 TA  - J Useful Results
 VI  - 12

--- a/src/main/literature/citation-formatter.test.ts
+++ b/src/main/literature/citation-formatter.test.ts
@@ -38,7 +38,7 @@ describe('LiteratureCitationFormatter', () => {
     ],
     [
       'AU  - Smith JA',
-      [{ nameMode: 'person', familyName: 'Smith', givenName: 'JA', creatorType: 'author' }]
+      [{ nameMode: 'person', familyName: 'Smith', givenName: 'J. A.', creatorType: 'author' }]
     ],
     [
       'FAU - Smith, Jane Ann\nAU  - Smith JA\nCN  - Research Consortium\nFAU - Jones, Mary\nAU  - Jones M',
@@ -73,7 +73,7 @@ describe('LiteratureCitationFormatter', () => {
       'PMID- 12345\nTI  - Paper\nAU  - Smith JA\nFAU - Jones, Mary\nAU  - Jones M\nFAU - Jones, Mary\nAU  - Jones M\n'
     )
     expect(parsed.items[0].creators).toEqual([
-      { nameMode: 'person', familyName: 'Smith', givenName: 'JA', creatorType: 'author' },
+      { nameMode: 'person', familyName: 'Smith', givenName: 'J. A.', creatorType: 'author' },
       { nameMode: 'person', familyName: 'Jones', givenName: 'Mary', creatorType: 'author' },
       { nameMode: 'person', familyName: 'Jones', givenName: 'Mary', creatorType: 'author' }
     ])
@@ -84,8 +84,21 @@ describe('LiteratureCitationFormatter', () => {
       'PMID- 12345\nTI  - Paper\nAU  - Smith JA\nFAU - Smith, Mary\nAU  - Smith M\n'
     )
     expect(parsed.items[0].creators).toHaveLength(2)
-    expect(parsed.items[0].creators[0]).toMatchObject({ familyName: 'Smith', givenName: 'JA' })
+    expect(parsed.items[0].creators[0]).toMatchObject({ familyName: 'Smith', givenName: 'J. A.' })
     expect(parsed.items[0].creators[1]).toMatchObject({ familyName: 'Smith', givenName: 'Mary' })
+  })
+
+  it('preserves all abbreviated personal initials in formatted citations', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const parsed = await formatter.parseReferences(
+      'PMID- 12345\nTI  - Older personal author paper\nDP  - 1998\nAU  - Smith JA\n'
+    )
+    const [formatted] = await formatter.formatReferences(
+      [{ id: 'paper', item: parsed.items[0] }],
+      'vancouver',
+      'en-US'
+    )
+    expect(formatted.reference).toContain('Smith JA')
   })
 
   it('formats every pinned built-in style without network access', async () => {

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -13,6 +13,7 @@ import {
   type LiteratureCitationLocale,
   type LiteratureCitationStyle,
   type LiteratureItemInput,
+  type LiteratureRecordImportEntry,
   type LiteratureRecordImportFormat
 } from '../../shared/literature'
 import { fromCslItem, toCslItem } from '../../shared/literature-csl'
@@ -38,11 +39,12 @@ type ParsedCitationRecords = Readonly<{
   format: LiteratureRecordImportFormat
   items: LiteratureItemInput[]
   errors: CitationImportError[]
+  warnings?: LiteratureRecordImportEntry['warnings'][]
   truncated: boolean
   scannedEntries: number
 }>
 
-type NbibRecord = Map<string, string[]>
+type NbibRecord = Array<{ field: string; value: string }>
 
 const citationStyleExample: LiteratureItemInput = {
   itemType: 'journalArticle',
@@ -64,7 +66,8 @@ const citationStyleExample: LiteratureItemInput = {
   identifiers: []
 }
 
-const nbibValues = (record: NbibRecord, field: string): string[] => record.get(field) ?? []
+const nbibValues = (record: NbibRecord, field: string): string[] =>
+  record.filter((entry) => entry.field === field).map(({ value }) => value)
 const nbibText = (record: NbibRecord, field: string): string =>
   nbibValues(record, field).join(' ').replace(/\s+/gu, ' ').trim()
 
@@ -72,43 +75,78 @@ const parseNbibRecords = (input: string): NbibRecord[] | undefined => {
   if (!/^PMID\s*-\s*\S+/mu.test(input)) return undefined
   const records: NbibRecord[] = []
   let record: NbibRecord | undefined
-  let lastField: string | undefined
   for (const line of input.replaceAll('\r\n', '\n').split('\n')) {
     const field = /^([A-Z0-9]{2,4})\s*-\s*(.*)$/u.exec(line)
     if (field) {
       const [, name, value] = field
-      if (name === 'PMID' && record?.size) {
+      if (name === 'PMID' && record?.length) {
         records.push(record)
-        record = new Map()
+        record = []
       }
-      record ??= new Map()
-      const values = record.get(name!) ?? []
-      values.push(value!.trim())
-      record.set(name!, values)
-      lastField = name
+      record ??= []
+      record.push({ field: name!, value: value!.trim() })
       continue
     }
     const continuation = /^\s{2,}(\S.*)$/u.exec(line)
-    if (!continuation || !record || !lastField) continue
-    const values = record.get(lastField)
-    if (!values?.length) continue
-    values[values.length - 1] = `${values.at(-1)} ${continuation[1]}`.trim()
+    const previous = record?.at(-1)
+    if (continuation && previous) previous.value = `${previous.value} ${continuation[1]}`.trim()
   }
-  if (record?.size) records.push(record)
+  if (record?.length) records.push(record)
   return records
 }
 
-const nbibCreator = (name: string): LiteratureItemInput['creators'][number] => {
-  const comma = name.indexOf(',')
-  if (comma < 0) {
-    return { nameMode: 'organization', literalName: name.trim(), creatorType: 'author' }
+const nbibCreators = (
+  record: NbibRecord
+): {
+  creators: LiteratureItemInput['creators']
+  uncertain: string[]
+} => {
+  const authors = record.filter(({ field }) => ['FAU', 'AU', 'CN'].includes(field))
+  const creators: LiteratureItemInput['creators'] = []
+  const uncertain: string[] = []
+  for (let index = 0; index < authors.length; index += 1) {
+    let { field, value } = authors[index]!
+    if (field === 'CN') {
+      creators.push({ nameMode: 'organization', literalName: value, creatorType: 'author' })
+      continue
+    }
+    // MEDLINE emits FAU followed by AU for the same person. Pair locally, never
+    // deduplicate all names: two different authors can have identical initials.
+    const next = authors[index + 1]
+    const full = field === 'FAU' ? value : next?.field === 'FAU' ? next.value : undefined
+    const short = field === 'AU' ? value : next?.field === 'AU' ? next.value : undefined
+    const family = full?.split(',')[0]?.trim()
+    const abbreviatedFamily = short
+      ? /^(.*?)\s+[A-Z]+(?:\s+(?:Jr|Sr|II|III|IV))?$/u.exec(short)?.[1]
+      : undefined
+    const fullInitials = full
+      ?.split(',')[1]
+      ?.trim()
+      .replace(/\s+(?:Jr|Sr|II|III|IV)$/u, '')
+      .match(/\p{L}+/gu)
+      ?.map((part) => part[0].toUpperCase())
+      .join('')
+    const shortInitials = short
+      ? /\s+([A-Z]+)(?:\s+(?:Jr|Sr|II|III|IV))?$/u.exec(short)?.[1]
+      : undefined
+    if (
+      next &&
+      full?.includes(',') &&
+      family === abbreviatedFamily &&
+      fullInitials === shortInitials
+    ) {
+      if (field === 'AU') ({ field, value } = next)
+      index += 1
+    }
+    const comma = value.indexOf(',')
+    const abbreviated =
+      field === 'AU' ? /^(.*?)\s+([A-Z]+(?:\s+(?:Jr|Sr|II|III|IV))?)$/u.exec(value) : null
+    const familyName = comma >= 0 ? value.slice(0, comma).trim() : (abbreviated?.[1] ?? value)
+    const givenName = comma >= 0 ? value.slice(comma + 1).trim() : (abbreviated?.[2] ?? '')
+    if (comma < 0 && !abbreviated) uncertain.push(`${field} - ${value}`)
+    creators.push({ nameMode: 'person', familyName, givenName, creatorType: 'author' })
   }
-  return {
-    nameMode: 'person',
-    familyName: name.slice(0, comma).trim(),
-    givenName: name.slice(comma + 1).trim(),
-    creatorType: 'author'
-  }
+  return { creators, uncertain }
 }
 
 const parseNbib = (input: string): ParsedCitationRecords | undefined => {
@@ -117,6 +155,7 @@ const parseNbib = (input: string): ParsedCitationRecords | undefined => {
   const limited = records.slice(0, LITERATURE_RECORD_IMPORT_MAX_RECORDS)
   const items: LiteratureItemInput[] = []
   const errors: CitationImportError[] = []
+  const warnings: LiteratureRecordImportEntry['warnings'][] = []
   for (const record of limited) {
     const title = nbibText(record, 'TI')
     const pmid = nbibText(record, 'PMID')
@@ -139,6 +178,8 @@ const parseNbib = (input: string): ParsedCitationRecords | undefined => {
       ...(pmcid ? [{ scheme: 'pmcid' as const, value: pmcid, isPrimary: false }] : []),
       ...(issn ? [{ scheme: 'issn' as const, value: issn, isPrimary: false }] : [])
     ]
+    const authors = nbibCreators(record)
+    warnings.push(authors.uncertain.length ? ['uncertain-author-name'] : [])
     items.push({
       itemType: publicationTypes.includes('review') ? 'review' : 'journalArticle',
       title,
@@ -150,21 +191,19 @@ const parseNbib = (input: string): ParsedCitationRecords | undefined => {
       language: nbibText(record, 'LA'),
       rights: '',
       url: pmid ? `https://pubmed.ncbi.nlm.nih.gov/${encodeURIComponent(pmid)}/` : '',
-      extra: '',
+      extra: authors.uncertain.join('\n'),
       typeFields: {
         ...(nbibText(record, 'VI') ? { volume: nbibText(record, 'VI') } : {}),
         ...(nbibText(record, 'IP') ? { issue: nbibText(record, 'IP') } : {}),
         ...(nbibText(record, 'PG') ? { pages: nbibText(record, 'PG') } : {})
       },
-      creators: (nbibValues(record, 'FAU').length
-        ? nbibValues(record, 'FAU')
-        : nbibValues(record, 'AU')
-      ).map(nbibCreator),
+      creators: authors.creators,
       identifiers
     })
   }
   return {
     format: 'nbib',
+    warnings,
     items,
     errors,
     truncated: records.length > limited.length,

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -142,7 +142,12 @@ const nbibCreators = (
     const abbreviated =
       field === 'AU' ? /^(.*?)\s+([A-Z]+(?:\s+(?:Jr|Sr|II|III|IV))?)$/u.exec(value) : null
     const familyName = comma >= 0 ? value.slice(0, comma).trim() : (abbreviated?.[1] ?? value)
-    const givenName = comma >= 0 ? value.slice(comma + 1).trim() : (abbreviated?.[2] ?? '')
+    const givenName =
+      comma >= 0
+        ? value.slice(comma + 1).trim()
+        : (abbreviated?.[2]?.replace(/^[A-Z]+/u, (initials) =>
+            [...initials].map((initial) => `${initial}.`).join(' ')
+          ) ?? '')
     if (comma < 0 && !abbreviated) uncertain.push(`${field} - ${value}`)
     creators.push({ nameMode: 'person', familyName, givenName, creatorType: 'author' })
   }

--- a/src/renderer/src/pages/literature/LiteratureImportIdentity.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureImportIdentity.render.test.tsx
@@ -1,0 +1,112 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import {
+  LITERATURE_ITEM_TYPES,
+  literatureItemInputSchema,
+  type LiteratureItemType
+} from '../../../../shared/literature'
+import { LiteratureRecordImportDialog } from './LiteratureRecordImportDialog'
+import { LiteratureMetadataEditor } from './LiteratureMetadataEditor'
+
+afterEach(cleanup)
+const item = literatureItemInputSchema.parse({
+  itemType: 'journalArticle',
+  title: 'Imported paper',
+  identifiers: [
+    { scheme: 'doi', value: '10.1234/one', isPrimary: true },
+    { scheme: 'pmid', value: '12345', isPrimary: true }
+  ]
+})
+
+it('blocks conflicting reuse and supplementation, exposes matches, and permits explicit separate import', () => {
+  const onImport = vi.fn()
+  const props = {
+    recordImport: {
+      fileName: 'references.nbib',
+      content: '',
+      preview: {
+        format: 'nbib' as const,
+        items: [item],
+        errors: [],
+        scannedEntries: 1,
+        truncated: false,
+        entries: [
+          {
+            index: 0,
+            title: item.title,
+            status: 'conflict' as const,
+            warnings: ['uncertain-author-name' as const],
+            item,
+            conflict: {
+              identifiers: item.identifiers,
+              matches: [
+                { itemId: 'a', title: 'Library paper' },
+                { inputIndex: 1, title: 'Earlier paper' }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    isImportingRecords: false,
+    destination: 'Library',
+    itemDescription: () => '',
+    itemTypeLabels: Object.fromEntries(LITERATURE_ITEM_TYPES.map((type) => [type, type])) as Record<
+      LiteratureItemType,
+      string
+    >,
+    onClose: vi.fn(),
+    onDuplicatePolicyChange: vi.fn(),
+    onImport
+  }
+  const { rerender } = render(<LiteratureRecordImportDialog {...props} duplicatePolicy="reuse" />)
+  const submit = (): HTMLButtonElement =>
+    screen.getByRole('button', { name: 'Import references' }) as HTMLButtonElement
+  expect(submit().disabled).toBe(true)
+  fireEvent.click(submit())
+  expect(onImport).not.toHaveBeenCalled()
+  expect(screen.getByText('Library reference: Library paper')).not.toBeNull()
+  expect(screen.getByText('File reference 2: Earlier paper')).not.toBeNull()
+  expect(screen.getByText('Check author names. Original text is kept in Extra.')).not.toBeNull()
+  rerender(<LiteratureRecordImportDialog {...props} duplicatePolicy="fill-missing" />)
+  expect(submit().disabled).toBe(true)
+  rerender(<LiteratureRecordImportDialog {...props} duplicatePolicy="separate" />)
+  expect(submit().disabled).toBe(false)
+  fireEvent.click(submit())
+  expect(onImport).toHaveBeenCalledOnce()
+})
+
+it('selects a preferred DOI without clearing the preferred PMID', () => {
+  const onSave = vi.fn()
+  render(
+    <LiteratureMetadataEditor
+      item={{
+        ...item,
+        identifiers: [
+          ...item.identifiers,
+          { scheme: 'doi', value: '10.1234/two', isPrimary: false }
+        ]
+      }}
+      saving={false}
+      onCancel={vi.fn()}
+      onSave={onSave}
+    />
+  )
+  const dois = screen.getAllByRole('radio', { name: 'Preferred for DOI' }) as HTMLInputElement[]
+  const pmid = screen.getByRole('radio', { name: 'Preferred for PMID' }) as HTMLInputElement
+  fireEvent.click(dois[1])
+  expect(dois[0].checked).toBe(false)
+  expect(dois[1].checked).toBe(true)
+  expect(pmid.checked).toBe(true)
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+  expect(onSave).toHaveBeenCalledWith(
+    expect.objectContaining({
+      identifiers: [
+        { scheme: 'doi', value: '10.1234/one', isPrimary: false },
+        { scheme: 'pmid', value: '12345', isPrimary: true },
+        { scheme: 'doi', value: '10.1234/two', isPrimary: true }
+      ]
+    })
+  )
+})

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { LITERATURE_IMPORT_IDENTITY_CONFLICT } from '../../../../shared/literature'
 import type {
   LiteratureCatalogSearchPage,
   LiteratureCatalogSearchRequest,
@@ -3706,6 +3707,56 @@ describe('LiteratureLibraryPage', () => {
     await waitFor(() =>
       expect(importRecords).toHaveBeenCalledWith({ mode: 'commit', content, duplicatePolicy })
     )
+  })
+
+  it('refreshes conflict details when identities change between preview and commit', async () => {
+    let changed = false
+    importRecords.mockImplementation(async (request: { mode: 'commit' | 'preview' }) => {
+      if (request.mode === 'commit') {
+        changed = true
+        throw new Error(LITERATURE_IMPORT_IDENTITY_CONFLICT)
+      }
+      return {
+        format: 'bibtex',
+        items: [libraryItem.item],
+        errors: [],
+        scannedEntries: 1,
+        truncated: false,
+        entries: [
+          {
+            index: 0,
+            title: libraryItem.item.title,
+            item: libraryItem.item,
+            warnings: [],
+            status: changed ? 'conflict' : 'ready',
+            ...(changed
+              ? {
+                  conflict: {
+                    identifiers: libraryItem.item.identifiers,
+                    matches: [{ itemId: 'new-owner', title: 'New matching reference' }]
+                  }
+                }
+              : {})
+          }
+        ]
+      }
+    })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const file = new File(['reference'], 'references.bib')
+    Object.defineProperty(file, 'text', { value: async () => 'reference' })
+    fireEvent.change(screen.getByLabelText('Import references'), { target: { files: [file] } })
+    await screen.findByRole('dialog')
+    fireEvent.click(await screen.findByRole('button', { name: 'Import references' }))
+    expect(await screen.findByText('Library reference: New matching reference')).not.toBeNull()
+    expect(
+      (screen.getByRole('button', { name: 'Import references' }) as HTMLButtonElement).disabled
+    ).toBe(true)
+    expect(importRecords.mock.calls.map(([request]) => request.mode)).toEqual([
+      'preview',
+      'commit',
+      'preview'
+    ])
   })
 
   it('previews and imports BibTeX records into the Library', async () => {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1,4 +1,7 @@
-import { LITERATURE_COLLECTION_NAME_CONFLICT } from '../../../../shared/literature'
+import {
+  LITERATURE_COLLECTION_NAME_CONFLICT,
+  LITERATURE_IMPORT_IDENTITY_CONFLICT
+} from '../../../../shared/literature'
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import { AlertDialog } from 'radix-ui'
 import * as Dialog from '@/components/ui/dialog'
@@ -2343,7 +2346,24 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         loadCollections(),
         ...(projectId ? [loadProjectCounts()] : [])
       ])
-    } catch {
+    } catch (error) {
+      if (error instanceof Error && error.message.includes(LITERATURE_IMPORT_IDENTITY_CONFLICT)) {
+        const preview = await window.api.literature
+          .importRecords({ mode: 'preview', content: recordImport.content })
+          .catch(() => undefined)
+        setRecordImport((current) =>
+          current
+            ? {
+                ...current,
+                ...(preview ? { preview } : {}),
+                error: t(
+                  'Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.'
+                )
+              }
+            : current
+        )
+        return
+      }
       setRecordImport((current) =>
         current
           ? {

--- a/src/renderer/src/pages/literature/LiteratureMergeReview.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMergeReview.tsx
@@ -11,6 +11,7 @@ import type {
 } from '../../../../shared/literature'
 import {
   literatureMergeRows,
+  buildLiteratureMergeItem,
   mergeFieldSource,
   mergeValueKey,
   type LiteratureMergeField,
@@ -41,6 +42,9 @@ export function LiteratureMergeReview({
   const { t, i18n } = useTranslation()
   const [showAll, setShowAll] = useState(false)
   const rows = literatureMergeRows(entries)
+  const merged = entries.some(({ id }) => id === survivorId)
+    ? buildLiteratureMergeItem(entries, survivorId, sources)
+    : undefined
   const differences = rows.filter(({ different }) => different)
   const date = (value: number): string =>
     new Intl.DateTimeFormat(i18n.language, {
@@ -183,7 +187,15 @@ export function LiteratureMergeReview({
                     {fieldName}
                     {field.startsWith('identifier:') && different ? (
                       <span className="ml-2 font-normal text-muted-foreground">
-                        {t('All identifiers are kept.')}
+                        {t(
+                          'All identifiers are kept. Preferred values come from the kept reference when available.'
+                        )}{' '}
+                        {
+                          merged?.identifiers.find(
+                            (identifier) =>
+                              identifier.scheme === field.slice(11) && identifier.isPrimary
+                          )?.value
+                        }
                       </span>
                     ) : null}
                   </th>

--- a/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
@@ -9,6 +9,7 @@ import { Textarea } from '@/components/ui/textarea'
 import { cn } from '@/lib/utils'
 import {
   LITERATURE_IDENTIFIER_SCHEMES,
+  normalizeLiteratureIdentifierPreferences,
   LITERATURE_ITEM_TYPES,
   type LiteratureCreatorInput,
   type LiteratureIdentifierInput,
@@ -76,7 +77,7 @@ const LiteratureMetadataEditor = ({
   const [draft, setDraft] = useState<LiteratureItemInput>(() => ({
     ...item,
     creators: item.creators.map((creator) => ({ ...creator })),
-    identifiers: item.identifiers.map((identifier) => ({ ...identifier })),
+    identifiers: normalizeLiteratureIdentifierPreferences(item.identifiers),
     typeFields: { ...item.typeFields }
   }))
   const [advancedOpen, setAdvancedOpen] = useState(() =>
@@ -103,7 +104,7 @@ const LiteratureMetadataEditor = ({
           ? identifier.isPrimary
             ? { ...identifier, isPrimary: true }
             : identifier
-          : identifier.isPrimary
+          : identifier.isPrimary && entry.scheme === identifier.scheme
             ? { ...entry, isPrimary: false }
             : entry
       )
@@ -361,11 +362,11 @@ const LiteratureMetadataEditor = ({
               <label className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
                 <input
                   type="radio"
-                  name="primary-literature-identifier"
+                  name={`primary-literature-identifier-${identifier.scheme}`}
                   checked={identifier.isPrimary}
                   onChange={() => updateIdentifier(index, { ...identifier, isPrimary: true })}
                 />
-                {t('Primary')}
+                {t('Preferred for {{scheme}}', { scheme: identifier.scheme.toUpperCase() })}
               </label>
               <Button
                 type="button"

--- a/src/renderer/src/pages/literature/LiteratureRecordImportDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteratureRecordImportDialog.tsx
@@ -67,6 +67,9 @@ export const LiteratureRecordImportDialog = ({
   const skippedImportCount = invalidImportCount + truncatedImportCount
   const existingCount =
     recordImport.preview?.entries.filter((entry) => entry.status === 'existing').length ?? 0
+  const conflictCount =
+    recordImport.preview?.entries.filter((entry) => entry.status === 'conflict').length ?? 0
+  const blockedByConflict = conflictCount > 0 && duplicatePolicy !== 'separate'
   return (
     <Dialog.Root
       open
@@ -137,11 +140,16 @@ export const LiteratureRecordImportDialog = ({
                   </span>
                 </div>
                 {!recordImport.preview.imported && recordImport.failedCount === undefined ? (
-                  <div className="grid grid-cols-3 divide-x divide-border-300/80 border-y border-border-300/80 py-3 text-center">
+                  <div
+                    className={cn(
+                      'grid divide-x divide-border-300/80 border-y border-border-300/80 py-3 text-center',
+                      conflictCount > 0 ? 'grid-cols-4' : 'grid-cols-3'
+                    )}
+                  >
                     <div>
                       <strong className="block text-xl tabular-nums">
                         {recordImport.preview.items.length -
-                          (duplicatePolicy === 'separate' ? 0 : existingCount)}
+                          (duplicatePolicy === 'separate' ? 0 : existingCount + conflictCount)}
                       </strong>
                       <span className="text-xs text-muted-foreground">{t('New references')}</span>
                     </div>
@@ -153,6 +161,14 @@ export const LiteratureRecordImportDialog = ({
                       <strong className="block text-xl tabular-nums">{skippedImportCount}</strong>
                       <span className="text-xs text-muted-foreground">{t('Skipped')}</span>
                     </div>
+                    {conflictCount > 0 ? (
+                      <div>
+                        <strong className="block text-xl tabular-nums">{conflictCount}</strong>
+                        <span className="text-xs text-muted-foreground">
+                          {t('Conflicting identifiers')}
+                        </span>
+                      </div>
+                    ) : null}
                   </div>
                 ) : null}
                 {!recordImport.preview.imported ? (
@@ -160,6 +176,14 @@ export const LiteratureRecordImportDialog = ({
                     value={duplicatePolicy}
                     onChange={onDuplicatePolicyChange}
                     disabled={isImportingRecords}
+                  />
+                ) : null}
+                {conflictCount > 0 && !recordImport.preview.imported ? (
+                  <LiteratureErrorNotice
+                    title={t('Conflicting identifiers')}
+                    description={t(
+                      'Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.'
+                    )}
                   />
                 ) : null}
                 {recordImport.preview.truncated && !recordImport.preview.imported ? (
@@ -186,7 +210,7 @@ export const LiteratureRecordImportDialog = ({
                   </p>
                 ) : (
                   <p className="text-xs leading-relaxed text-muted-foreground">
-                    {duplicatePolicy === 'reuse'
+                    {duplicatePolicy === 'reuse' && conflictCount === 0
                       ? t(
                           'Matching DOI, PMID or PMCID references will be reused. PDFs are not downloaded.'
                         )
@@ -285,11 +309,13 @@ export const LiteratureRecordImportDialog = ({
                               </p>
                               {entry.status !== 'ready' ? (
                                 <span className="shrink-0 rounded bg-bg-200 px-2 py-0.5 text-[11px] text-muted-foreground">
-                                  {entry.status === 'existing'
-                                    ? t('Existing')
-                                    : entry.status === 'warning'
-                                      ? t('Warning')
-                                      : t('Invalid')}
+                                  {entry.status === 'conflict'
+                                    ? t('Conflicting identifiers')
+                                    : entry.status === 'existing'
+                                      ? t('Existing')
+                                      : entry.status === 'warning'
+                                        ? t('Warning')
+                                        : t('Invalid')}
                                 </span>
                               ) : null}
                             </div>
@@ -298,15 +324,36 @@ export const LiteratureRecordImportDialog = ({
                                 {itemDescription(entry.item) || itemTypeLabels[entry.item.itemType]}
                               </p>
                             ) : null}
+                            {entry.conflict ? (
+                              <div className="mt-1 space-y-1 text-xs [overflow-wrap:anywhere]">
+                                <p>
+                                  {entry.conflict.identifiers
+                                    .map(({ scheme, value }) => `${scheme.toUpperCase()}: ${value}`)
+                                    .join(' · ')}
+                                </p>
+                                {entry.conflict.matches.map((match) => (
+                                  <p key={match.itemId ?? match.inputIndex}>
+                                    {match.inputIndex === undefined
+                                      ? t('Library reference: {{title}}', { title: match.title })
+                                      : t('File reference {{number}}: {{title}}', {
+                                          number: match.inputIndex + 1,
+                                          title: match.title
+                                        })}
+                                  </p>
+                                ))}
+                              </div>
+                            ) : null}
                             {entry.warnings.length > 0 ? (
                               <p className="mt-1 text-xs text-status-warning-foreground dark:text-status-warning-dark-foreground">
                                 {entry.warnings
                                   .map((warning) =>
-                                    warning === 'missing-authors'
-                                      ? t('Missing authors')
-                                      : warning === 'missing-year'
-                                        ? t('Missing year')
-                                        : t('Missing journal or venue')
+                                    warning === 'uncertain-author-name'
+                                      ? t('Check author names. Original text is kept in Extra.')
+                                      : warning === 'missing-authors'
+                                        ? t('Missing authors')
+                                        : warning === 'missing-year'
+                                          ? t('Missing year')
+                                          : t('Missing journal or venue')
                                   )
                                   .join(' · ')}
                               </p>
@@ -361,6 +408,7 @@ export const LiteratureRecordImportDialog = ({
                   type="button"
                   disabled={
                     isImportingRecords ||
+                    blockedByConflict ||
                     !recordImport.preview ||
                     recordImport.preview.items.length === 0
                   }

--- a/src/renderer/src/pages/literature/literature-merge.ts
+++ b/src/renderer/src/pages/literature/literature-merge.ts
@@ -1,4 +1,10 @@
-import type { LiteratureItemInput, LiteratureItemView } from '../../../../shared/literature'
+import {
+  preferredLiteratureIdentifier,
+  normalizeLiteratureIdentifierValue,
+  normalizeLiteratureIdentifierPreferences,
+  type LiteratureItemInput,
+  type LiteratureItemView
+} from '../../../../shared/literature'
 
 export const mergeScalarFields = [
   'title',
@@ -112,13 +118,43 @@ export function buildLiteratureMergeItem(
     else Object.assign(merged, { [field]: value })
   }
   const seen = new Set<string>()
-  merged.identifiers = entries
-    .flatMap(({ item }) => item.identifiers)
-    .filter((identifier) => {
-      const key = `${identifier.scheme}:${identifier.value.trim().toLowerCase()}`
-      if (seen.has(key)) return false
-      seen.add(key)
-      return true
-    })
+  const ordered = [
+    survivor,
+    ...entries.filter((entry) => entry.id !== survivorId).sort((a, b) => a.id.localeCompare(b.id))
+  ]
+  const preferred = new Map<
+    LiteratureItemInput['identifiers'][number]['scheme'],
+    LiteratureItemInput['identifiers'][number] | undefined
+  >(
+    ordered.flatMap(({ item }) =>
+      item.identifiers.map(({ scheme }) => [scheme, undefined] as const)
+    )
+  )
+  for (const scheme of preferred.keys()) {
+    const source = ordered.find(({ item }) =>
+      item.identifiers.some((identifier) => identifier.scheme === scheme)
+    )!
+    preferred.set(scheme, preferredLiteratureIdentifier(source.item.identifiers, scheme))
+  }
+  merged.identifiers = normalizeLiteratureIdentifierPreferences(
+    ordered
+      .flatMap(({ item }) =>
+        item.identifiers.map((identifier) => ({
+          ...identifier,
+          isPrimary:
+            normalizeLiteratureIdentifierValue(
+              identifier.scheme,
+              preferred.get(identifier.scheme)!.value
+            ).toLowerCase() ===
+            normalizeLiteratureIdentifierValue(identifier.scheme, identifier.value).toLowerCase()
+        }))
+      )
+      .filter((identifier) => {
+        const key = `${identifier.scheme}:${normalizeLiteratureIdentifierValue(identifier.scheme, identifier.value).toLowerCase()}`
+        if (seen.has(key)) return false
+        seen.add(key)
+        return true
+      })
+  )
   return merged
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -151,7 +151,6 @@
     "{{count}} missing fields_one": "{{count}} fehlendes Feld",
     "{{count}} missing fields_other": "{{count}} fehlende Felder",
     "After merging": "Nach dem Zusammenführen",
-    "All identifiers are kept.": "Alle Kennungen bleiben erhalten.",
     "Compare references": "Literatureinträge vergleichen",
     "Date accessed": "Zugriffsdatum",
     "Date added": "Hinzugefügt am",
@@ -4502,7 +4501,6 @@
     "Patent": "Patent",
     "Place": "Ort",
     "Preprint": "Preprint",
-    "Primary": "Primär",
     "Project link could not be updated.": "Die Projektzuordnung konnte nicht aktualisiert werden.",
     "PubMed NBIB": "PubMed NBIB",
     "Publication": "Publikation",
@@ -4845,6 +4843,13 @@
     "{{count}} background tasks_other": "{{count}} Hintergrundaufgaben",
     "{{count}} running background tasks_one": "{{count}} laufende Hintergrundaufgabe",
     "{{count}} running background tasks_other": "{{count}} laufende Hintergrundaufgaben",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "Aktualisiert: {{completed}}. Nicht aktualisiert: {{remaining}}."
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Aktualisiert: {{completed}}. Nicht aktualisiert: {{remaining}}.",
+    "Conflicting identifiers": "Widersprüchliche Kennungen",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Einige Kennungen widersprechen sich oder passen zu verschiedenen Referenzen. Korrigieren Sie die Quelldatei oder behalten Sie jede Referenz dieses Imports als separate Kopie.",
+    "Library reference: {{title}}": "Referenz in der Bibliothek: {{title}}",
+    "File reference {{number}}: {{title}}": "Referenz {{number}} in der Datei: {{title}}",
+    "Check author names. Original text is kept in Extra.": "Prüfen Sie die Autorennamen. Der Originaltext bleibt unter Zusatzinformationen erhalten.",
+    "Preferred for {{scheme}}": "Bevorzugt für {{scheme}}",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "Alle Kennungen bleiben erhalten. Bevorzugte Werte stammen, sofern vorhanden, aus der beibehaltenen Referenz."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -153,7 +153,6 @@
     "{{count}} missing fields_many": "{{count}} campos faltantes",
     "{{count}} missing fields_other": "{{count}} campos faltantes",
     "After merging": "Después de combinar",
-    "All identifiers are kept.": "Se conservan todos los identificadores.",
     "Compare references": "Comparar referencias",
     "Date accessed": "Fecha de consulta",
     "Date added": "Fecha de incorporación",
@@ -4716,7 +4715,6 @@
     "Organization": "Organización",
     "Remove author": "Eliminar autor",
     "Add identifier": "Añadir identificador",
-    "Primary": "Principal",
     "Remove identifier": "Eliminar identificador",
     "URL": "URL",
     "Add reference": "Añadir referencia",
@@ -5006,6 +5004,13 @@
     "{{count}} running background tasks_one": "{{count}} tarea en segundo plano en ejecución",
     "{{count}} running background tasks_many": "{{count}} tareas en segundo plano en ejecución",
     "{{count}} running background tasks_other": "{{count}} tareas en segundo plano en ejecución",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "Actualizadas: {{completed}}. Sin actualizar: {{remaining}}."
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Actualizadas: {{completed}}. Sin actualizar: {{remaining}}.",
+    "Conflicting identifiers": "Identificadores en conflicto",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Algunos identificadores se contradicen o coinciden con referencias diferentes. Corrija el archivo de origen o conserve copias independientes de todas las referencias de esta importación.",
+    "Library reference: {{title}}": "Referencia de la biblioteca: {{title}}",
+    "File reference {{number}}: {{title}}": "Referencia {{number}} del archivo: {{title}}",
+    "Check author names. Original text is kept in Extra.": "Revise los nombres de los autores. El texto original se conserva en la información adicional.",
+    "Preferred for {{scheme}}": "Valor preferido para {{scheme}}",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "Se conservan todos los identificadores. Se utilizan los valores preferidos de la referencia conservada cuando están disponibles."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -153,7 +153,6 @@
     "{{count}} missing fields_many": "{{count}} champs manquants",
     "{{count}} missing fields_other": "{{count}} champs manquants",
     "After merging": "Après fusion",
-    "All identifiers are kept.": "Tous les identifiants sont conservés.",
     "Compare references": "Comparer les références",
     "Date accessed": "Date de consultation",
     "Date added": "Date d’ajout",
@@ -4716,7 +4715,6 @@
     "Organization": "Organisation",
     "Remove author": "Supprimer l’auteur",
     "Add identifier": "Ajouter un identifiant",
-    "Primary": "Principal",
     "Remove identifier": "Supprimer l’identifiant",
     "URL": "URL",
     "Add reference": "Ajouter une référence",
@@ -5006,6 +5004,13 @@
     "{{count}} running background tasks_one": "{{count}} tâche en arrière-plan en cours",
     "{{count}} running background tasks_many": "{{count}} tâches en arrière-plan en cours",
     "{{count}} running background tasks_other": "{{count}} tâches en arrière-plan en cours",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "Références mises à jour : {{completed}}. Non mises à jour : {{remaining}}."
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Références mises à jour : {{completed}}. Non mises à jour : {{remaining}}.",
+    "Conflicting identifiers": "Identifiants contradictoires",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Certains identifiants se contredisent ou correspondent à des références différentes. Corrigez le fichier source ou conservez une copie distincte de chaque référence de cet import.",
+    "Library reference: {{title}}": "Référence de la bibliothèque : {{title}}",
+    "File reference {{number}}: {{title}}": "Référence {{number}} du fichier : {{title}}",
+    "Check author names. Original text is kept in Extra.": "Vérifiez les noms des auteurs. Le texte original est conservé dans les informations supplémentaires.",
+    "Preferred for {{scheme}}": "Valeur préférée pour {{scheme}}",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "Tous les identifiants sont conservés. Les valeurs préférées proviennent de la référence conservée, si elles sont disponibles."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -149,7 +149,6 @@
     "The selected source changed. Search again and review the results.": "選択したソースが変更されました。再検索して結果を確認してください。",
     "{{count}} missing fields_other": "未入力の項目 {{count}} 件",
     "After merging": "統合後",
-    "All identifiers are kept.": "すべての識別子を保持します。",
     "Compare references": "文献を比較",
     "Date accessed": "アクセス日時",
     "Date added": "追加日時",
@@ -4410,7 +4409,6 @@
     "Organization": "組織",
     "Remove author": "著者を削除",
     "Add identifier": "識別子を追加",
-    "Primary": "主要",
     "Remove identifier": "識別子を削除",
     "URL": "URL",
     "Add reference": "文献を追加",
@@ -4692,6 +4690,13 @@
     "{{count}} tasks_other": "{{count}} 件のタスク",
     "{{count}} background tasks_other": "{{count}} 件のバックグラウンドタスク",
     "{{count}} running background tasks_other": "実行中のバックグラウンドタスク {{count}} 件",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "更新済み：{{completed}}。未更新：{{remaining}}。"
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "更新済み：{{completed}}。未更新：{{remaining}}。",
+    "Conflicting identifiers": "識別子の競合",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "一部の識別子が矛盾しているか、異なる文献に一致しています。元のファイルを修正するか、今回インポートするすべての文献を個別のコピーとして保持してください。",
+    "Library reference: {{title}}": "ライブラリの文献：{{title}}",
+    "File reference {{number}}: {{title}}": "ファイル内の文献 {{number}}：{{title}}",
+    "Check author names. Original text is kept in Extra.": "著者名を確認してください。元のテキストは追加情報に保持されています。",
+    "Preferred for {{scheme}}": "{{scheme}} の優先値",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "すべての識別子が保持されます。保持する文献に優先値があれば、その値を使用します。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -149,7 +149,6 @@
     "The selected source changed. Search again and review the results.": "선택한 출처가 변경되었습니다. 다시 검색하고 결과를 검토하세요.",
     "{{count}} missing fields_other": "누락된 필드 {{count}}개",
     "After merging": "병합 후",
-    "All identifiers are kept.": "모든 식별자가 유지됩니다.",
     "Compare references": "문헌 비교",
     "Date accessed": "접근 날짜",
     "Date added": "추가 날짜",
@@ -4408,7 +4407,6 @@
     "Organization": "기관",
     "Remove author": "저자 제거",
     "Add identifier": "식별자 추가",
-    "Primary": "기본",
     "Remove identifier": "식별자 제거",
     "URL": "URL",
     "Add reference": "문헌 추가",
@@ -4690,6 +4688,13 @@
     "{{count}} tasks_other": "작업 {{count}}개",
     "{{count}} background tasks_other": "백그라운드 작업 {{count}}개",
     "{{count}} running background tasks_other": "실행 중인 백그라운드 작업 {{count}}개",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "업데이트됨: {{completed}}. 업데이트되지 않음: {{remaining}}."
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "업데이트됨: {{completed}}. 업데이트되지 않음: {{remaining}}.",
+    "Conflicting identifiers": "식별자 충돌",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "일부 식별자가 서로 모순되거나 서로 다른 문헌과 일치합니다. 원본 파일을 수정하거나 이번에 가져오는 모든 문헌을 별도의 사본으로 유지하세요.",
+    "Library reference: {{title}}": "라이브러리 문헌: {{title}}",
+    "File reference {{number}}: {{title}}": "파일의 문헌 {{number}}: {{title}}",
+    "Check author names. Original text is kept in Extra.": "저자 이름을 확인하세요. 원문은 추가 정보에 보존됩니다.",
+    "Preferred for {{scheme}}": "{{scheme}}의 기본값",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "모든 식별자가 유지됩니다. 유지할 문헌에 기본값이 있으면 해당 값을 사용합니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -155,7 +155,6 @@
     "{{count}} missing fields_many": "{{count}} незаполненных полей",
     "{{count}} missing fields_other": "{{count}} незаполненного поля",
     "After merging": "После объединения",
-    "All identifiers are kept.": "Все идентификаторы сохраняются.",
     "Compare references": "Сравнение записей",
     "Date accessed": "Дата обращения",
     "Date added": "Дата добавления",
@@ -4844,7 +4843,6 @@
     "Organization": "Организация",
     "Remove author": "Удалить автора",
     "Add identifier": "Добавить идентификатор",
-    "Primary": "Основной",
     "Remove identifier": "Удалить идентификатор",
     "URL": "URL",
     "Add reference": "Добавить источник",
@@ -5138,6 +5136,13 @@
     "{{count}} running background tasks_few": "{{count}} фоновые задачи выполняются",
     "{{count}} running background tasks_many": "{{count}} фоновых задач выполняется",
     "{{count}} running background tasks_other": "{{count}} фоновые задачи выполняются",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "Обновлено: {{completed}}. Не обновлено: {{remaining}}."
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "Обновлено: {{completed}}. Не обновлено: {{remaining}}.",
+    "Conflicting identifiers": "Конфликтующие идентификаторы",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Некоторые идентификаторы противоречат друг другу или соответствуют разным источникам. Исправьте исходный файл или сохраните отдельную копию каждого импортируемого источника.",
+    "Library reference: {{title}}": "Источник в библиотеке: {{title}}",
+    "File reference {{number}}: {{title}}": "Источник {{number}} в файле: {{title}}",
+    "Check author names. Original text is kept in Extra.": "Проверьте имена авторов. Исходный текст сохранён в дополнительных сведениях.",
+    "Preferred for {{scheme}}": "Предпочтительный для {{scheme}}",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "Все идентификаторы сохраняются. Предпочтительные значения берутся из сохраняемого источника, если они доступны."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -149,7 +149,6 @@
     "The selected source changed. Search again and review the results.": "所选来源已变化，请重新搜索并审阅结果。",
     "{{count}} missing fields_other": "{{count}} 个待补字段",
     "After merging": "合并后",
-    "All identifiers are kept.": "保留所有标识符。",
     "Compare references": "比较题录",
     "Date accessed": "访问时间",
     "Date added": "添加时间",
@@ -4411,7 +4410,6 @@
     "Organization": "机构",
     "Remove author": "移除作者",
     "Add identifier": "添加标识符",
-    "Primary": "主要",
     "Remove identifier": "移除标识符",
     "URL": "URL",
     "Add reference": "添加题录",
@@ -4692,6 +4690,13 @@
     "{{count}} tasks_other": "{{count}} 个任务",
     "{{count}} background tasks_other": "{{count}} 个后台任务",
     "{{count}} running background tasks_other": "{{count}} 个后台任务正在运行",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。"
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。",
+    "Conflicting identifiers": "标识符冲突",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "部分标识符存在矛盾或匹配不同文献。请修正源文件，或将本次导入的每篇文献保留为独立副本。",
+    "Library reference: {{title}}": "文献库中的文献：{{title}}",
+    "File reference {{number}}: {{title}}": "文件中的第 {{number}} 篇文献：{{title}}",
+    "Check author names. Original text is kept in Extra.": "请核对作者姓名。原文已保留在附加信息中。",
+    "Preferred for {{scheme}}": "{{scheme}} 首选值",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "所有标识符均会保留。如有可用值，将优先采用保留文献中的首选值。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -149,7 +149,6 @@
     "The selected source changed. Search again and review the results.": "所選來源已變更，請重新搜尋並檢閱結果。",
     "{{count}} missing fields_other": "{{count}} 個待補欄位",
     "After merging": "合併後",
-    "All identifiers are kept.": "保留所有識別碼。",
     "Compare references": "比較題錄",
     "Date accessed": "存取時間",
     "Date added": "新增時間",
@@ -4411,7 +4410,6 @@
     "Organization": "機構",
     "Remove author": "移除作者",
     "Add identifier": "新增識別碼",
-    "Primary": "主要",
     "Remove identifier": "移除識別碼",
     "URL": "URL",
     "Add reference": "新增題錄",
@@ -4692,6 +4690,13 @@
     "{{count}} tasks_other": "{{count}} 個任務",
     "{{count}} background tasks_other": "{{count}} 個背景工作",
     "{{count}} running background tasks_other": "{{count}} 個背景工作正在執行",
-    "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。"
+    "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。",
+    "Conflicting identifiers": "識別碼衝突",
+    "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "部分識別碼互相矛盾或符合不同文獻。請修正來源檔案，或將本次匯入的每篇文獻保留為獨立副本。",
+    "Library reference: {{title}}": "文獻庫中的文獻：{{title}}",
+    "File reference {{number}}: {{title}}": "檔案中的第 {{number}} 篇文獻：{{title}}",
+    "Check author names. Original text is kept in Extra.": "請核對作者姓名。原文已保留於額外資訊中。",
+    "Preferred for {{scheme}}": "{{scheme}} 首選值",
+    "All identifiers are kept. Preferred values come from the kept reference when available.": "所有識別碼都會保留。如有可用值，將優先採用保留文獻中的首選值。"
   }
 }

--- a/src/shared/literature-csl.test.ts
+++ b/src/shared/literature-csl.test.ts
@@ -41,6 +41,20 @@ describe('toCslItem', () => {
     }
   )
 
+  it.each([false, true])(
+    'selects a deterministic legacy DOI with primary flags=%s',
+    (isPrimary) => {
+      const identifiers: LiteratureItemInput['identifiers'] = [
+        { scheme: 'doi', value: '10.1234/z', isPrimary },
+        { scheme: 'doi', value: '10.1234/a', isPrimary }
+      ]
+      expect(toCslItem('legacy', item({ identifiers })).DOI).toBe('10.1234/a')
+      expect(toCslItem('legacy', item({ identifiers: [...identifiers].reverse() })).DOI).toBe(
+        '10.1234/a'
+      )
+    }
+  )
+
   it('normalizes identifiers before projecting citation metadata', () => {
     expect(
       toCslItem(

--- a/src/shared/literature-csl.ts
+++ b/src/shared/literature-csl.ts
@@ -1,6 +1,7 @@
 import {
   literatureItemInputSchema,
   normalizeLiteratureIdentifierValue,
+  preferredLiteratureIdentifier,
   type LiteratureCreatorInput,
   type LiteratureIdentifierInput,
   type LiteratureItemInput,
@@ -136,8 +137,7 @@ const identifierFor = (
   item: LiteratureItemInput,
   scheme: 'doi' | 'isbn' | 'issn'
 ): string | undefined => {
-  const identifiers = item.identifiers.filter((identifier) => identifier.scheme === scheme)
-  const identifier = identifiers.find(({ isPrimary }) => isPrimary) ?? identifiers[0]
+  const identifier = preferredLiteratureIdentifier(item.identifiers, scheme)
   return identifier
     ? normalizeLiteratureIdentifierValue(identifier.scheme, identifier.value)
     : undefined

--- a/src/shared/literature.ts
+++ b/src/shared/literature.ts
@@ -42,17 +42,20 @@ const LITERATURE_CSL_MAX_BYTES = 1024 * 1024
 const LITERATURE_RECORD_IMPORT_FORMATS = ['bibtex', 'ris', 'nbib'] as const
 const LITERATURE_RECORD_IMPORT_MAX_BYTES = 32 * 1024 * 1024
 const LITERATURE_RECORD_IMPORT_MAX_RECORDS = 1_000
+export const LITERATURE_IMPORT_IDENTITY_CONFLICT =
+  'Import contains conflicting identifiers. Keep separate copies or correct the source file.'
 const LITERATURE_COLLECTION_NAME_CONFLICT = 'literature_collection_name_conflict'
 const LITERATURE_COLLECTION_NAME_MAX_LENGTH = 200
 const LITERATURE_COLLECTION_DESCRIPTION_MAX_LENGTH = 1_000
 const LITERATURE_LIFECYCLE_STATES = ['active', 'deleted'] as const
 const LITERATURE_SORT_FIELDS = ['updated', 'created', 'title', 'year', 'rating'] as const
 const LITERATURE_SORT_DIRECTIONS = ['asc', 'desc'] as const
-const LITERATURE_IMPORT_STATUSES = ['ready', 'existing', 'warning', 'invalid'] as const
+const LITERATURE_IMPORT_STATUSES = ['ready', 'warning', 'existing', 'conflict', 'invalid'] as const
 const LITERATURE_IMPORT_WARNINGS = [
   'missing-authors',
   'missing-year',
-  'missing-container-title'
+  'missing-container-title',
+  'uncertain-author-name'
 ] as const
 const LITERATURE_METADATA_FIELDS = [
   'title',
@@ -725,6 +728,21 @@ const literatureRecordImportEntrySchema = z
     warnings: z.array(z.enum(LITERATURE_IMPORT_WARNINGS)),
     item: literatureItemInputSchema.optional(),
     existingItemId: nonEmptyTextSchema.optional(),
+    conflict: z
+      .object({
+        identifiers: z.array(literatureIdentifierInputSchema),
+        matches: z.array(
+          z
+            .object({
+              itemId: nonEmptyTextSchema.optional(),
+              inputIndex: z.number().int().nonnegative().optional(),
+              title: z.string()
+            })
+            .strict()
+        )
+      })
+      .strict()
+      .optional(),
     error: nonEmptyTextSchema.optional()
   })
   .strict()
@@ -934,6 +952,39 @@ type LiteratureIdentityScheme = (typeof LITERATURE_IDENTITY_SCHEMES)[number]
 type LiteratureInboxState = (typeof LITERATURE_INBOX_STATES)[number]
 type LiteratureCreatorInput = z.infer<typeof literatureCreatorInputSchema>
 type LiteratureIdentifierInput = z.infer<typeof literatureIdentifierInputSchema>
+// A preferred identifier is scoped to its scheme. Legacy ties use normalized value order.
+export function preferredLiteratureIdentifier(
+  identifiers: readonly LiteratureIdentifierInput[],
+  scheme: LiteratureIdentifierScheme
+): LiteratureIdentifierInput | undefined {
+  return identifiers
+    .filter((identifier) => identifier.scheme === scheme)
+    .sort((a, b) => {
+      const priority = Number(b.isPrimary) - Number(a.isPrimary)
+      const left = normalizeLiteratureIdentifierValue(scheme, a.value).toLowerCase()
+      const right = normalizeLiteratureIdentifierValue(scheme, b.value).toLowerCase()
+      return (
+        priority ||
+        (left < right ? -1 : left > right ? 1 : a.value < b.value ? -1 : a.value > b.value ? 1 : 0)
+      )
+    })[0]
+}
+
+export function normalizeLiteratureIdentifierPreferences<T extends LiteratureIdentifierInput>(
+  identifiers: readonly T[]
+): T[] {
+  const preferred = new Map(
+    [...new Set(identifiers.map(({ scheme }) => scheme))].map((scheme) => [
+      scheme,
+      preferredLiteratureIdentifier(identifiers, scheme)
+    ])
+  )
+  return identifiers.map((identifier) => ({
+    ...identifier,
+    isPrimary: identifier.isPrimary && preferred.get(identifier.scheme) === identifier
+  }))
+}
+
 type LiteratureItemInput = z.infer<typeof literatureItemInputSchema>
 type LiteratureSourceInput = z.infer<typeof literatureSourceInputSchema>
 type LiteratureCandidateOrigin = z.infer<typeof literatureCandidateOriginSchema>


### PR DESCRIPTION
## Problem

An imported reference whose DOI belongs to one record and PMID to another silently reused whichever identifier appeared first. Filling missing fields could copy the other record's identity onto that target. Reviewed merges could retain a discarded record's primary DOI in citations even when a different survivor was selected. NBIB imports dropped collective authors and interpreted abbreviated personal names as organizations.

## Proposed change

- Resolve every strong-identifier owner, including Trash and earlier rows in the same file, through one batch resolver for preview and transactional commit. Conflicting values or owners block reuse/fill-missing before any writes. Explicit separate import remains available for the entire batch. Refresh conflict details if the database changes after preview.
- Define `isPrimary` as at most one explicit preference per scheme. Preserve the survivor's effective preferred value during reviewed merges and keep historical identifiers as nonpreferred. Use deterministic legacy fallback in citation projection and independent scheme choices in the editor.
- Preserve NBIB author field order: CN is an organization, AU/FAU are personal names, matching adjacent abbreviated/full forms represent one person, and initials remain separate during citation formatting. Preserve uncertain text in existing Extra metadata and show a preview warning.

## Scope and non-goals

No new database columns, tables, migrations, identifier uniqueness constraint, or automatic historical repair. Existing explicit metadata writes normalize primary flags; old stored records remain readable. Previously dropped authors require original source data to recover, and prior merges cannot reliably reveal the user's intended preferred identifier.

Transient contract additions: import `conflict` status and match details, plus `uncertain-author-name` warning. Existing duplicate-policy and creator-mode enums are unchanged. This does not introduce a per-record target picker or persistent review queue, and does not redesign Add/Inbox matching.

## Acceptance criteria and validation

Before production changes, eight new assertions failed identically in two runs against real SQLite, the public parser, and merge/write/read/CSL boundaries. The failures reproduced the reported behavior; all 53 existing tests in that initial slice passed. A further public Vancouver regression failed twice when adjacent initials were treated as one given-name token; it now preserves both initials. No test seam was added.

Checks below ran after the final material edit:

| Behavior | Check | Result |
| --- | --- | --- |
| SQLite identity conflicts, all three policies, Trash, batch rollback, preview/commit race, identifier preferences, NBIB parsing/persistence, citation/export and catalog consumers, renderer interactions, shared contracts and all locale guards | `npx vitest run src/main/literature src/shared/literature.test.ts src/shared/literature-csl.test.ts src/shared/renderer-contract-catalog.test.ts src/renderer/src/pages/literature src/renderer/src/i18n/resources.test.ts src/main/acp/literature-reference-prompt.test.ts` | 1,260 passed |
| Main, renderer and sandbox types | `npm run typecheck` | Passed |
| Source/style checks | `npm run lint`; `git diff --check` | Passed |
| Import blocking/separate option, independent DOI/PMID preference and merge preference display | ego lite, actual components and project CSS with controlled data; page-scoped screenshots | Passed |

CodeGraph established baseline ownership; its index belongs to the primary checkout, so final worktree helper consumers were checked directly. The batch resolver stays private to the catalog. The affected-plan explain command requests full coverage because `src/main/ipc.ts` lacks a module owner. Per maintainer direction, local validation used the explicit owner/consumer slice above; full and platform validation is left to PR Gate. No database schema or platform-specific filesystem logic changed. Packaged Electron and external live providers were not exercised locally. Independent review of `764e1eaf93f7569639d4ce8d8e152cc47ef6dfa6` concluded [mergeable with no actionable findings](https://github.com/aipoch/open-science/pull/2332#issuecomment-5573645286). PR Gate supplies the full/platform results.

## Review focus

Identity ambiguity must never restore, supplement or link a record before the batch is accepted. Explicit separate records remain supported. Inspect the transient IPC warning/detail flow and preferred identifier selection after persistence. NBIB interpretation follows [NLM's author-field and ordering guidance](https://www.nlm.nih.gov/pubs/techbull/mj06/mj06_corp_author.html).
