### PR TITLE
fix(literature): preserve metadata integrity during completion

### DIFF
--- a/src/main/literature/batch-jobs.test.ts
+++ b/src/main/literature/batch-jobs.test.ts
@@ -27,6 +27,7 @@ const item = (id: string): LiteratureItemView => ({
 })
 const preview = (id: string): LiteratureMetadataCompletionResult => ({
   mode: 'preview',
+  reviewVersion: 1,
   provider: 'crossref',
   sourceUrl: 'https://crossref.org',
   item: item(id),
@@ -408,3 +409,172 @@ it.each(['pmc', 'arxiv'] as const)(
     expect((await state(reopened, jobId)).rows[0].status).toBe('done')
   }
 )
+
+it('keeps a failed apply checkpoint in review and allows the same command to be retried', async () => {
+  const { rename } = await import('node:fs/promises')
+  const { jobs, path, options } = await setup()
+  const jobId = randomUUID()
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  const directory = `${path}.d`
+  const backup = `${path}.saved`
+  const checkpoint = await readFile(join(directory, `${jobId}.json`), 'utf8')
+  await rename(directory, backup)
+  try {
+    await writeFile(directory, 'block checkpoint directory creation')
+    await expect(
+      jobs.run({ action: 'apply', jobId, selections: [{ itemId: 'a' }] })
+    ).rejects.toThrow()
+  } finally {
+    await rm(directory, { force: true })
+    await rename(backup, directory)
+  }
+  expect(await readFile(join(directory, `${jobId}.json`), 'utf8')).toBe(checkpoint)
+  expect(options.metadata.applyReviewed).not.toHaveBeenCalled()
+  expect(await state(jobs, jobId)).toMatchObject({ state: 'review', phase: 'search' })
+  await jobs.run({ action: 'apply', jobId, selections: [{ itemId: 'a' }] })
+  await vi.waitFor(() => expect(options.metadata.applyReviewed).toHaveBeenCalledOnce())
+})
+
+it('offers identifier-only metadata additions as a ready batch row', async () => {
+  const { LiteratureMetadataEnricher } = await import('./metadata-enricher')
+  const { jobs: initial, options } = await setup()
+  await initial.close()
+  const current = item('a')
+  current.item.url = 'https://pubmed.ncbi.nlm.nih.gov/12345678/'
+  current.item.identifiers = [{ scheme: 'pmid', value: '12345678', isPrimary: true }]
+  const applyMetadata = vi.fn(async (input) => ({ ...current, item: input.item }))
+  const enricher = new LiteratureMetadataEnricher(
+    { get: async () => current, applyMetadata },
+    vi.fn(
+      async () =>
+        new Response(
+          JSON.stringify({
+            result: {
+              '12345678': {
+                uid: '12345678',
+                articleids: [
+                  { idtype: 'doi', value: '10.2000/example' },
+                  { idtype: 'pmc', value: 'PMC1234567' }
+                ]
+              }
+            }
+          })
+        )
+    )
+  )
+  const jobs = new LiteratureBatchJobs({
+    ...options,
+    catalog: { get: async () => current },
+    metadata: enricher
+  })
+  cleanup.push(() => jobs.close())
+  const jobId = randomUUID()
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
+  await vi.waitFor(async () =>
+    expect(['review', 'completed']).toContain((await state(jobs, jobId)).state)
+  )
+  expect((await state(jobs, jobId)).rows[0]!.status).toBe('ready')
+  await jobs.run({ action: 'apply', jobId, selections: [{ itemId: 'a' }] })
+  await vi.waitFor(() => expect(applyMetadata).toHaveBeenCalledOnce())
+  expect(applyMetadata.mock.calls[0]![0].item.identifiers).toHaveLength(3)
+})
+
+it.each(['review', 'retry', 'resume', 'remove'] as const)(
+  'preserves accepted task state when %s cannot be persisted',
+  async (action) => {
+    const { rename, mkdir } = await import('node:fs/promises')
+    const setupResult = await setup()
+    const { path, options } = setupResult
+    let jobs = setupResult.jobs
+    const jobId = randomUUID()
+    await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
+    await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+    if (action === 'resume') {
+      await jobs.close()
+      const record = JSON.parse(await readFile(join(`${path}.d`, `${jobId}.json`), 'utf8'))
+      record.state = 'paused'
+      await writeFile(join(`${path}.d`, `${jobId}.json`), JSON.stringify(record))
+      jobs = new LiteratureBatchJobs(options)
+      cleanup.push(() => jobs.close())
+    }
+    const before = await state(jobs, jobId)
+    // Block the real write destination, retaining all original files for restoration.
+    const target = action === 'remove' ? path : `${path}.d`
+    const backup = `${target}.saved`
+    await rename(target, backup)
+    try {
+      if (action === 'remove') await mkdir(target)
+      else await writeFile(target, 'unavailable directory')
+      await expect(
+        jobs.run(
+          action === 'review'
+            ? { action, jobId, selections: [{ itemId: 'a', checked: false }] }
+            : { action, jobId }
+        )
+      ).rejects.toThrow()
+      expect(await state(jobs, jobId)).toEqual(before)
+    } finally {
+      await rm(target, { force: true, recursive: true })
+      await rename(backup, target)
+    }
+    await jobs.run(
+      action === 'review'
+        ? { action, jobId, selections: [{ itemId: 'a', checked: false }] }
+        : { action, jobId }
+    )
+    if (action === 'remove') expect((await jobs.run({ action: 'list' })).summaries).toEqual([])
+    else if (action === 'review') expect((await state(jobs, jobId)).rows[0]!.checked).toBe(false)
+    else await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  }
+)
+
+it('does not pause an active worker when the pause checkpoint fails', async () => {
+  const { rename } = await import('node:fs/promises')
+  const { jobs, path, metadata } = await setup()
+  let release!: () => void
+  metadata.mockImplementationOnce(async () => {
+    await new Promise<void>((resolve) => {
+      release = resolve
+    })
+    return preview('a')
+  })
+  const jobId = randomUUID()
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a', 'b'], requestId: jobId })
+  await vi.waitFor(() => expect(release).toBeTypeOf('function'))
+  const target = `${path}.d`
+  await rename(target, `${target}.saved`)
+  try {
+    await writeFile(target, 'unavailable directory')
+    await expect(jobs.run({ action: 'pause', jobId })).rejects.toThrow()
+    expect((await state(jobs, jobId)).state).toBe('running')
+  } finally {
+    await rm(target, { force: true })
+    await rename(`${target}.saved`, target)
+    release()
+  }
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  expect(metadata).toHaveBeenCalledTimes(2)
+})
+
+it('marks a persisted legacy review for a fresh search without applying it', async () => {
+  const { jobs, metadata, options } = await setup()
+  metadata.mockImplementation(async ({ itemId }) => {
+    const old = preview(itemId)
+    delete old.reviewVersion
+    return old
+  })
+  const jobId = randomUUID()
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  await jobs.close()
+  const reopened = new LiteratureBatchJobs(options)
+  cleanup.push(() => reopened.close())
+  await reopened.run({ action: 'apply', jobId, selections: [{ itemId: 'a' }] })
+  await vi.waitFor(async () => expect((await state(reopened, jobId)).state).toBe('completed'))
+  expect(options.metadata.applyReviewed).not.toHaveBeenCalled()
+  expect((await state(reopened, jobId)).rows[0]).toMatchObject({
+    status: 'error',
+    message: 'Search again to refresh this older metadata review.'
+  })
+})

--- a/src/main/literature/batch-jobs.test.ts
+++ b/src/main/literature/batch-jobs.test.ts
@@ -490,14 +490,15 @@ it.each(['review', 'retry', 'resume', 'remove'] as const)(
     const jobId = randomUUID()
     await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
     await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+    // Finish the search checkpoint before injecting a command-only write failure.
+    await jobs.close()
     if (action === 'resume') {
-      await jobs.close()
       const record = JSON.parse(await readFile(join(`${path}.d`, `${jobId}.json`), 'utf8'))
       record.state = 'paused'
       await writeFile(join(`${path}.d`, `${jobId}.json`), JSON.stringify(record))
-      jobs = new LiteratureBatchJobs(options)
-      cleanup.push(() => jobs.close())
     }
+    jobs = new LiteratureBatchJobs(options)
+    cleanup.push(() => jobs.close())
     const before = await state(jobs, jobId)
     // Block the real write destination, retaining all original files for restoration.
     const target = action === 'remove' ? path : `${path}.d`

--- a/src/main/literature/batch-jobs.ts
+++ b/src/main/literature/batch-jobs.ts
@@ -108,8 +108,8 @@ export class LiteratureBatchJobs {
     this.writes = this.writes.then(write, write)
     return this.writes
   }
-  private saveIndex(): Promise<void> {
-    const contents = JSON.stringify({ version: 2, jobIds: this.jobs.map((job) => job.id) })
+  private saveIndex(jobs = this.jobs): Promise<void> {
+    const contents = JSON.stringify({ version: 2, jobIds: jobs.map((job) => job.id) })
     const write = (): Promise<void> => writeDurableJsonFile(this.options.path, contents)
     this.writes = this.writes.then(write, write)
     return this.writes
@@ -159,7 +159,7 @@ export class LiteratureBatchJobs {
           throw new Error('Task request identity was already used for different references.')
         return { jobs: [this.snapshot(existing)] }
       }
-      const previousJobs = [...this.jobs]
+      const nextJobs = [...this.jobs]
       let prunedId: string | undefined
       if (this.jobs.length >= 50) {
         const settled = this.jobs.findLastIndex(
@@ -168,7 +168,7 @@ export class LiteratureBatchJobs {
             job.rows.every(({ status }) => status !== 'ready' && status !== 'error')
         )
         if (settled < 0) throw new Error('Remove completed Literature tasks before adding more.')
-        prunedId = this.jobs.splice(settled, 1)[0]?.id
+        prunedId = nextJobs.splice(settled, 1)[0]?.id
       }
       const now = Date.now()
       const job: LiteratureJob = {
@@ -180,20 +180,17 @@ export class LiteratureBatchJobs {
         updatedAt: now,
         rows: [...new Set(request.itemIds)].map((id) => ({ id, status: 'pending', checked: true }))
       }
-      this.jobs.unshift(job)
-      try {
-        await this.save(job)
-        await this.saveIndex()
-      } catch (error) {
-        this.jobs = previousJobs
-        throw error
-      }
+      nextJobs.unshift(job)
+      await this.save(job)
+      await this.saveIndex(nextJobs)
+      this.jobs = nextJobs
       if (prunedId) await rm(this.jobPath(prunedId), { force: true }).catch(this.options.onError)
       this.kick()
       return { jobs: [this.snapshot(job)] }
     }
-    const job = this.jobs.find(({ id }) => id === request.jobId)
-    if (!job) throw new Error('Literature task not found.')
+    const publishedJob = this.jobs.find(({ id }) => id === request.jobId)
+    if (!publishedJob) throw new Error('Literature task not found.')
+    const job = request.action === 'get' ? publishedJob : structuredClone(publishedJob)
     if (request.action === 'get') {
       const snapshot = request.ifUpdatedAt === job.updatedAt ? undefined : this.snapshot(job)
       let download: LiteratureJob['progress']
@@ -232,8 +229,7 @@ export class LiteratureBatchJobs {
     } else {
       if (job.state === 'running' || job.state === 'pausing')
         throw new Error('Pause this Literature task first.')
-      if (request.action === 'remove') this.jobs = this.jobs.filter(({ id }) => id !== job.id)
-      else if (request.action === 'apply') {
+      if (request.action === 'apply') {
         if (
           new Set(request.selections.map(({ itemId }) => itemId)).size !== request.selections.length
         )
@@ -286,11 +282,26 @@ export class LiteratureBatchJobs {
     }
     job.updatedAt = Math.max(Date.now(), job.updatedAt + 1)
     if (request.action === 'remove') {
-      await this.saveIndex()
-      await rm(this.jobPath(job.id), { force: true })
-    } else await this.save(job)
+      const nextJobs = this.jobs.filter(({ id }) => id !== job.id)
+      await this.saveIndex(nextJobs)
+      this.jobs = nextJobs
+      await rm(this.jobPath(job.id), { force: true }).catch(this.options.onError)
+    } else {
+      await this.save(job)
+      // Active provider calls retain these objects. Publish only command-owned fields so a
+      // completed row is not replaced by the earlier draft while its checkpoint is waiting.
+      if (request.action === 'pause') publishedJob.state = job.state
+      else if (request.action === 'review') {
+        for (const selection of request.selections) {
+          const row = publishedJob.rows.find(({ id }) => id === selection.itemId)!
+          row.checked = selection.checked
+          row.candidateId = selection.candidateId
+        }
+      } else Object.assign(publishedJob, job)
+      publishedJob.updatedAt = Math.max(publishedJob.updatedAt, job.updatedAt)
+    }
     this.kick()
-    return { jobs: request.action === 'remove' ? [] : [this.snapshot(job)] }
+    return { jobs: request.action === 'remove' ? [] : [this.snapshot(publishedJob)] }
   }
 
   private currentJobId?: string
@@ -321,11 +332,14 @@ export class LiteratureBatchJobs {
 
   private async drain(): Promise<void> {
     while (!this.closed) {
+      await this.commands
+      if (this.closed) break
       const job = [...this.jobs].reverse().find(({ state }) => state === 'running')
       if (!job) break
       this.currentJobId = job.id
       job.updatedAt = Math.max(Date.now(), job.updatedAt + 1)
       for (const row of job.rows) {
+        await this.commands
         if (this.closed || job.state !== 'running') break
         if (
           job.phase === 'search' ? row.status !== 'pending' : row.status !== 'ready' || !row.checked
@@ -349,11 +363,13 @@ export class LiteratureBatchJobs {
         } finally {
           this.active = undefined
         }
+        await this.commands
         job.updatedAt = Math.max(Date.now(), job.updatedAt + 1)
         await this.save(job)
         if (job.state === 'running' && !this.closed)
           await new Promise((resolve) => setTimeout(resolve, this.options.spacingMs ?? 350))
       }
+      await this.commands
       job.state =
         this.closed || job.state !== 'running'
           ? 'paused'
@@ -422,6 +438,11 @@ export class LiteratureBatchJobs {
       throw new Error('Reference changed')
     if (job.mode === 'metadata') {
       if (!row.metadata) throw new Error('Metadata review unavailable')
+      if (row.metadata.reviewVersion !== 1) {
+        row.status = 'error'
+        row.message = 'Search again to refresh this older metadata review.'
+        return
+      }
       await this.options.metadata.applyReviewed(row.metadata)
     } else {
       const candidate = row.candidates?.find(({ id }) => id === row.candidateId)

--- a/src/main/literature/metadata-enricher.test.ts
+++ b/src/main/literature/metadata-enricher.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import type { LiteratureItemInput, LiteratureItemView } from '../../shared/literature'
 import { LiteratureMetadataEnricher } from './metadata-enricher'
@@ -106,7 +106,7 @@ describe('LiteratureMetadataEnricher', () => {
         'pages',
         'publisher',
         'volume',
-        'year'
+        'publicationDate'
       ])
     )
     expect(applyMetadata).not.toHaveBeenCalled()
@@ -262,4 +262,279 @@ describe('LiteratureMetadataEnricher', () => {
     await expect(enricher.applyReviewed(review)).rejects.toThrow('Reference changed')
     expect(applyMetadata).toHaveBeenCalledTimes(1)
   })
+})
+
+// Exercise the public review/commit boundary; the receiver observes the actual catalog payload.
+const regressionEnricher = (
+  current: LiteratureItemInput,
+  response: Response
+): {
+  enricher: LiteratureMetadataEnricher
+  applyMetadata: Mock<(input: { item: LiteratureItemInput }) => Promise<LiteratureItemView>>
+} => {
+  const applyMetadata = vi.fn(async (input: { item: LiteratureItemInput }) => ({
+    ...view,
+    item: input.item
+  }))
+  const enricher = new LiteratureMetadataEnricher(
+    { get: vi.fn().mockResolvedValue({ ...view, item: current }), applyMetadata },
+    vi.fn().mockResolvedValue(response)
+  )
+  return { enricher, applyMetadata }
+}
+const crossref = (message: Record<string, unknown>): Response =>
+  new Response(JSON.stringify({ message }))
+
+it('retains editors and translators in the author-only commit payload and citation', async () => {
+  const { toCslItem } = await import('../../shared/literature-csl')
+  const creators = ['editor', 'author', 'translator', 'editor'].map((creatorType, index) => ({
+    creatorType,
+    nameMode: 'person' as const,
+    familyName: `Person${index}`,
+    givenName: ''
+  }))
+  const { enricher, applyMetadata } = regressionEnricher(
+    { ...item, creators },
+    crossref({ author: [{ family: 'Online' }] })
+  )
+  const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+  await enricher.complete({
+    mode: 'commit',
+    itemId: view.id,
+    reviewToken: review.reviewToken,
+    expectedMetadataRevision: 2,
+    overwriteFields: ['authors']
+  })
+  const saved = applyMetadata.mock.calls[0]![0].item
+  expect(saved.creators.filter((creator) => creator.creatorType !== 'author')).toEqual(
+    creators.filter((creator) => creator.creatorType !== 'author')
+  )
+  expect(toCslItem(view.id, saved)).toMatchObject({
+    author: [{ family: 'Online' }],
+    editor: [{ family: 'Person0' }, { family: 'Person3' }],
+    translator: [{ family: 'Person2' }]
+  })
+})
+
+it('fills missing authors when the reference contains only an editor', async () => {
+  const editor = {
+    creatorType: 'editor',
+    nameMode: 'person' as const,
+    familyName: 'Editor',
+    givenName: ''
+  }
+  const { enricher } = regressionEnricher(
+    { ...item, creators: [editor] },
+    crossref({ author: [{ family: 'Online' }] })
+  )
+  const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+  expect(review.conflicts.filter(({ field }) => field === 'authors')).toEqual([])
+  expect(review.filled).toContainEqual({ field: 'authors', value: 'Online' })
+  expect(review.item.item.creators).toContainEqual(editor)
+})
+
+it('reports identifier-only additions as reviewable changes', async () => {
+  const { enricher } = regressionEnricher(
+    {
+      ...item,
+      url: 'https://pubmed.ncbi.nlm.nih.gov/12345678/',
+      identifiers: [{ scheme: 'pmid', value: '12345678', isPrimary: true }]
+    },
+    new Response(
+      JSON.stringify({
+        result: {
+          '12345678': {
+            uid: '12345678',
+            articleids: [
+              { idtype: 'doi', value: '10.2000/example' },
+              { idtype: 'pmc', value: 'PMC1234567' }
+            ]
+          }
+        }
+      })
+    )
+  )
+  const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+  expect(review.item.item.identifiers).toHaveLength(3)
+  expect(review.filled.length).toBeGreaterThan(0)
+})
+
+it('exposes entered identifier replacements and primary changes for review', async () => {
+  const { enricher } = regressionEnricher(item, crossref({ DOI: '10.2000/replacement' }))
+  const review = await enricher.complete({
+    mode: 'preview',
+    itemId: view.id,
+    identifier: { scheme: 'doi', value: '10.2000/replacement' }
+  })
+  expect(review.filled.length + review.conflicts.length).toBeGreaterThan(0)
+})
+
+it.each([{ issuedYear: 2020, issuedText: '' }, { issuedText: '2020-04-05' }])(
+  'keeps the existing publication year coherent in preview and commit: %j',
+  async (date) => {
+    const { enricher, applyMetadata } = regressionEnricher(
+      { ...item, ...date },
+      crossref({ issued: { 'date-parts': [[2021, 2, 3]] } })
+    )
+    const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+    await enricher.complete({
+      mode: 'commit',
+      itemId: view.id,
+      reviewToken: review.reviewToken,
+      expectedMetadataRevision: 2,
+      overwriteFields: []
+    })
+    for (const candidate of [review.item.item, applyMetadata.mock.calls[0]![0].item]) {
+      expect(candidate.issuedYear).toBe(2020)
+      expect(candidate.issuedText === '' || candidate.issuedText.startsWith('2020')).toBe(true)
+    }
+  }
+)
+
+it('cancels an oversized response before consuming the full stream', async () => {
+  let consumed = 0
+  const cancel = vi.fn()
+  const body = new ReadableStream<Uint8Array>(
+    {
+      pull(controller) {
+        if (consumed === 4 * 1024 * 1024) return controller.close()
+        consumed += 64 * 1024
+        controller.enqueue(new Uint8Array(64 * 1024).fill(32))
+      },
+      cancel
+    },
+    { highWaterMark: 0 }
+  )
+  const { enricher } = regressionEnricher(item, new Response(body))
+  await expect(enricher.complete({ mode: 'preview', itemId: view.id })).rejects.toThrow(
+    'Metadata response is too large'
+  )
+  expect(consumed).toBeLessThan(4 * 1024 * 1024)
+  expect(cancel).toHaveBeenCalledOnce()
+})
+
+it('enforces the response limit in UTF-8 bytes before retaining raw metadata', async () => {
+  const { enricher } = regressionEnricher(item, crossref({ extra: '汉'.repeat(800_000) }))
+  await expect(enricher.complete({ mode: 'preview', itemId: view.id })).rejects.toThrow(
+    'Metadata response is too large'
+  )
+})
+
+it.each([false, true])(
+  'applies an entered identifier replacement only when selected: %s',
+  async (selected) => {
+    const original = {
+      ...item,
+      identifiers: [
+        { scheme: 'doi' as const, value: '10.1000/example', isPrimary: true },
+        { scheme: 'pmid' as const, value: '12345678', isPrimary: false }
+      ]
+    }
+    const { enricher, applyMetadata } = regressionEnricher(
+      original,
+      crossref({ DOI: '10.2000/new', publisher: 'Press' })
+    )
+    const review = await enricher.complete({
+      mode: 'preview',
+      itemId: view.id,
+      identifier: { scheme: 'doi', value: '10.2000/new' }
+    })
+    expect(review.conflicts).toContainEqual({
+      field: 'identifiers',
+      currentValue: 'DOI: 10.1000/example ★; PMID: 12345678',
+      value: 'PMID: 12345678; DOI: 10.2000/new ★'
+    })
+    await enricher.complete({
+      mode: 'commit',
+      itemId: view.id,
+      reviewToken: review.reviewToken,
+      expectedMetadataRevision: 2,
+      overwriteFields: selected ? ['identifiers'] : []
+    })
+    expect(applyMetadata.mock.calls[0]![0].item.identifiers).toEqual(
+      selected ? review.item.item.identifiers : original.identifiers
+    )
+  }
+)
+
+it('shows changes to primary flags even when identifier values are unchanged', async () => {
+  const original = {
+    ...item,
+    identifiers: [
+      { scheme: 'doi' as const, value: '10.1000/example', isPrimary: false },
+      { scheme: 'pmid' as const, value: '12345678', isPrimary: true }
+    ]
+  }
+  const { enricher } = regressionEnricher(original, crossref({}))
+  const review = await enricher.complete({
+    mode: 'preview',
+    itemId: view.id,
+    identifier: { scheme: 'doi', value: '10.1000/example' }
+  })
+  expect(review.conflicts).toContainEqual({
+    field: 'identifiers',
+    currentValue: 'DOI: 10.1000/example; PMID: 12345678 ★',
+    value: 'PMID: 12345678; DOI: 10.1000/example ★'
+  })
+})
+
+it('uses one publication-date choice to replace both date and year', async () => {
+  const { enricher, applyMetadata } = regressionEnricher(
+    { ...item, issuedYear: 2020 },
+    crossref({ issued: { 'date-parts': [[2021, 2, 3]] } })
+  )
+  const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+  expect(review.conflicts).toEqual([
+    { field: 'publicationDate', currentValue: '2020', value: '2021-02-03' }
+  ])
+  await enricher.complete({
+    mode: 'commit',
+    itemId: view.id,
+    reviewToken: review.reviewToken,
+    expectedMetadataRevision: 2,
+    overwriteFields: ['publicationDate']
+  })
+  expect(applyMetadata.mock.calls[0]![0].item).toMatchObject({
+    issuedYear: 2021,
+    issuedText: '2021-02-03'
+  })
+})
+
+it.each(['forthcoming', 'Spring 2020', '2020-02-30'])(
+  'preserves ambiguous or invalid publication text without inventing a year: %s',
+  async (issuedText) => {
+    const { enricher, applyMetadata } = regressionEnricher(
+      { ...item, issuedText },
+      crossref({ issued: { 'date-parts': [[2021]] } })
+    )
+    const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+    await enricher.complete({
+      mode: 'commit',
+      itemId: view.id,
+      reviewToken: review.reviewToken,
+      expectedMetadataRevision: 2,
+      overwriteFields: []
+    })
+    expect(applyMetadata.mock.calls[0]![0].item.issuedText).toBe(issuedText)
+    expect(applyMetadata.mock.calls[0]![0].item.issuedYear).toBeUndefined()
+  }
+)
+
+it('requires a fresh search before applying a persisted legacy review', async () => {
+  const { enricher, applyMetadata } = regressionEnricher(item, crossref({ publisher: 'Press' }))
+  const review = await enricher.complete({ mode: 'preview', itemId: view.id })
+  delete review.reviewVersion
+  await expect(enricher.applyReviewed(review)).rejects.toThrow(
+    'Search again to refresh this older metadata review'
+  )
+  expect(applyMetadata).not.toHaveBeenCalled()
+})
+
+it('accepts a valid JSON response exactly at the byte limit', async () => {
+  const empty = JSON.stringify({ message: { extra: '' } })
+  const { enricher } = regressionEnricher(
+    item,
+    crossref({ extra: 'a'.repeat(2 * 1024 * 1024 - Buffer.byteLength(empty)) })
+  )
+  expect((await enricher.complete({ mode: 'preview', itemId: view.id })).source).toBeDefined()
 })

--- a/src/main/literature/metadata-enricher.test.ts
+++ b/src/main/literature/metadata-enricher.test.ts
@@ -538,3 +538,25 @@ it('accepts a valid JSON response exactly at the byte limit', async () => {
   )
   expect((await enricher.complete({ mode: 'preview', itemId: view.id })).source).toBeDefined()
 })
+
+it.each(['10.1000/example', 'https://doi.org/10.1000/EXAMPLE'])(
+  'preserves unchanged identifier values and order after an explicit lookup: %s',
+  async (doi) => {
+    const original = {
+      ...item,
+      identifiers: [
+        { scheme: 'doi' as const, value: doi, isPrimary: true },
+        { scheme: 'pmid' as const, value: '12345678', isPrimary: false }
+      ]
+    }
+    const { enricher } = regressionEnricher(original, crossref({ DOI: '10.1000/example' }))
+    const review = await enricher.complete({
+      mode: 'preview',
+      itemId: view.id,
+      identifier: { scheme: 'doi', value: '10.1000/example' }
+    })
+    expect(review.filled).toEqual([])
+    expect(review.conflicts).toEqual([])
+    expect(review.item.item.identifiers).toEqual(original.identifiers)
+  }
+)

--- a/src/main/literature/metadata-enricher.ts
+++ b/src/main/literature/metadata-enricher.ts
@@ -129,17 +129,17 @@ const reviewIdentifiers = (
   current: LiteratureItemInput,
   merged: ReturnType<typeof mergeCrossrefMetadata>
 ): void => {
+  const key = ({ scheme, value, isPrimary }: LiteratureItemInput['identifiers'][number]): string =>
+    JSON.stringify([scheme, normalizeIdentifier(scheme, value), Boolean(isPrimary)])
+  const existingKeys = new Set(current.identifiers.map(key))
+  const incomingKeys = new Set(merged.item.identifiers.map(key))
+  const onlyAdded = [...existingKeys].every((value) => incomingKeys.has(value))
+  if (onlyAdded && existingKeys.size === incomingKeys.size) {
+    merged.item.identifiers = structuredClone(current.identifiers)
+    return
+  }
   const existing = identifierText(current)
   const value = identifierText(merged.item)
-  if (existing === value) return
-  const onlyAdded = current.identifiers.every((identifier) =>
-    merged.item.identifiers.some(
-      (next) =>
-        next.scheme === identifier.scheme &&
-        next.value === identifier.value &&
-        next.isPrimary === identifier.isPrimary
-    )
-  )
   if (onlyAdded) merged.filled.push({ field: 'identifiers', value })
   else merged.conflicts.push({ field: 'identifiers', currentValue: existing, value })
 }

--- a/src/main/literature/metadata-enricher.ts
+++ b/src/main/literature/metadata-enricher.ts
@@ -105,8 +105,48 @@ const pubmedDateParts = (value: string | undefined): readonly number[] | undefin
   return [Number(match[1]), ...(month > 0 ? [month] : []), ...(match[3] ? [Number(match[3])] : [])]
 }
 
+const publicationYear = (text: string): number | undefined => {
+  const match = /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/u.exec(text.trim())
+  if (!match) return undefined
+  const year = Number(match[1])
+  const month = Number(match[2] ?? 1)
+  const day = Number(match[3] ?? 1)
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  return year > 0 && month >= 1 && month <= 12 && day >= 1 && day <= days[month - 1]!
+    ? year
+    : undefined
+}
+
+const identifierText = (item: LiteratureItemInput): string =>
+  item.identifiers
+    .map(
+      ({ scheme, value, isPrimary }) => `${scheme.toUpperCase()}: ${value}${isPrimary ? ' ★' : ''}`
+    )
+    .join('; ')
+
+const reviewIdentifiers = (
+  current: LiteratureItemInput,
+  merged: ReturnType<typeof mergeCrossrefMetadata>
+): void => {
+  const existing = identifierText(current)
+  const value = identifierText(merged.item)
+  if (existing === value) return
+  const onlyAdded = current.identifiers.every((identifier) =>
+    merged.item.identifiers.some(
+      (next) =>
+        next.scheme === identifier.scheme &&
+        next.value === identifier.value &&
+        next.isPrimary === identifier.isPrimary
+    )
+  )
+  if (onlyAdded) merged.filled.push({ field: 'identifiers', value })
+  else merged.conflicts.push({ field: 'identifiers', currentValue: existing, value })
+}
+
 const creatorText = (item: LiteratureItemInput): string =>
   item.creators
+    .filter(({ creatorType }) => creatorType === 'author')
     .map((creator) =>
       creator.nameMode === 'organization'
         ? creator.literalName
@@ -170,7 +210,6 @@ const mergeCrossrefMetadata = (
   mergeString('title', 'title', firstText(message.title))
   mergeString('containerTitle', 'journal', firstText(message['container-title']))
   mergeString('shortTitle', 'shortTitle', firstText(message['short-title']))
-  mergeString('issuedText', 'publicationDate', formatDate(parts))
   mergeString('language', 'language', message.language ?? '')
   mergeString('url', 'url', message.URL ?? '')
   mergeTypeField('volume', 'volume', message.volume ?? '')
@@ -178,21 +217,31 @@ const mergeCrossrefMetadata = (
   mergeTypeField('pages', 'pages', message.page ?? message['article-number'] ?? '')
   mergeTypeField('publisher', 'publisher', message.publisher ?? '')
 
-  if (incomingYear !== undefined) {
-    if (item.issuedYear === undefined) {
+  // Only unambiguous numeric dates participate in automatic year inference.
+  const existingDateYear = publicationYear(item.issuedText)
+  if (item.issuedYear === undefined && existingDateYear !== undefined) {
+    item.issuedYear = existingDateYear
+    filled.push({ field: 'publicationDate', value: item.issuedText })
+  }
+  const incomingDate = formatDate(parts)
+  if (incomingYear !== undefined && publicationYear(incomingDate) !== undefined) {
+    const existing = item.issuedText || String(item.issuedYear ?? '')
+    const differs =
+      (item.issuedYear !== undefined && item.issuedYear !== incomingYear) ||
+      (Boolean(item.issuedText) && item.issuedText !== incomingDate)
+    if (differs && !overwriteFields.has('publicationDate')) {
+      conflicts.push({
+        field: 'publicationDate',
+        currentValue:
+          item.issuedText && item.issuedYear !== undefined && existingDateYear !== item.issuedYear
+            ? `${existing} [${item.issuedYear}]`
+            : existing,
+        value: incomingDate
+      })
+    } else if (item.issuedText !== incomingDate || item.issuedYear !== incomingYear) {
+      item.issuedText = incomingDate
       item.issuedYear = incomingYear
-      filled.push({ field: 'year', value: String(incomingYear) })
-    } else if (item.issuedYear !== incomingYear) {
-      if (overwriteFields.has('year')) {
-        item.issuedYear = incomingYear
-        filled.push({ field: 'year', value: String(incomingYear) })
-      } else {
-        conflicts.push({
-          field: 'year',
-          currentValue: String(item.issuedYear),
-          value: String(incomingYear)
-        })
-      }
+      filled.push({ field: 'publicationDate', value: incomingDate })
     }
   }
 
@@ -211,12 +260,13 @@ const mergeCrossrefMetadata = (
     ) ?? []
   if (incomingCreators.length > 0) {
     const incomingText = creatorText({ ...item, creators: incomingCreators })
-    if (item.creators.length === 0) {
-      item.creators = incomingCreators
+    const otherCreators = item.creators.filter(({ creatorType }) => creatorType !== 'author')
+    if (!item.creators.some(({ creatorType }) => creatorType === 'author')) {
+      item.creators = [...incomingCreators, ...otherCreators]
       filled.push({ field: 'authors', value: incomingText })
     } else if (comparable(creatorText(item)) !== comparable(incomingText)) {
       if (overwriteFields.has('authors')) {
-        item.creators = incomingCreators
+        item.creators = [...incomingCreators, ...otherCreators]
         filled.push({ field: 'authors', value: incomingText })
       } else {
         conflicts.push({ field: 'authors', currentValue: creatorText(item), value: incomingText })
@@ -240,7 +290,6 @@ const mergeCrossrefMetadata = (
     )
       continue
     item.identifiers.push(identifier)
-    filled.push({ field: identifier.scheme, value: identifier.value })
   }
 
   return { item, filled, conflicts }
@@ -368,10 +417,24 @@ class LiteratureMetadataEnricher {
         `${identifier.scheme === 'doi' ? 'Crossref' : 'PubMed'} metadata request failed with HTTP ${response.status}.`
       )
     }
-    const body = await response.text()
     const maxBytes =
       identifier.scheme === 'doi' ? CROSSREF_MAX_RESPONSE_BYTES : PUBMED_MAX_RESPONSE_BYTES
-    if (body.length > maxBytes) throw new Error('Metadata response is too large.')
+    if (!response.body) throw new Error('Metadata response is empty.')
+    const reader = response.body.getReader()
+    const chunks: Uint8Array[] = []
+    let length = 0
+    try {
+      while (true) {
+        const { done, value: chunk } = await reader.read()
+        if (done) break
+        length += chunk.byteLength
+        if (length > maxBytes) throw new Error('Metadata response is too large.')
+        chunks.push(chunk)
+      }
+    } finally {
+      await reader.cancel()
+    }
+    const body = Buffer.concat(chunks).toString('utf8')
     const overwriteFields = new Set<LiteratureMetadataField>()
     let provider: 'crossref' | 'pubmed'
     let rawMetadata: Record<string, unknown>
@@ -391,6 +454,7 @@ class LiteratureMetadataEnricher {
       rawMetadata = summary
       merged = mergePubmedMetadata(lookupItem, summary, overwriteFields)
     }
+    reviewIdentifiers(current.item, merged)
     const source: LiteratureSourceInput = {
       provider,
       externalId: value,
@@ -400,6 +464,7 @@ class LiteratureMetadataEnricher {
 
     const result: LiteratureMetadataCompletionResult = {
       mode: 'preview',
+      reviewVersion: 1,
       provider,
       sourceUrl,
       item: { ...current, item: merged.item },
@@ -426,7 +491,8 @@ class LiteratureMetadataEnricher {
       current.metadataRevision !== review.item.metadataRevision
     )
       throw new Error('Reference changed. Search again and review the metadata.')
-    if (!review.source) throw new Error('Search again to refresh this older metadata review.')
+    if (!review.source || review.reviewVersion !== 1)
+      throw new Error('Search again to refresh this older metadata review.')
     const merged =
       review.provider === 'crossref'
         ? mergeCrossrefMetadata(
@@ -439,6 +505,16 @@ class LiteratureMetadataEnricher {
             pubmedSummarySchema.parse(review.source.rawMetadata),
             new Set(overwriteFields)
           )
+    // Identifier proposals are atomic: an unselected replacement must not ride along with fills.
+    const identifierConflict = review.conflicts.find(({ field }) => field === 'identifiers')
+    if (identifierConflict) {
+      if (overwriteFields.includes('identifiers'))
+        merged.filled.push({ field: 'identifiers', value: identifierConflict.value })
+      else {
+        merged.item.identifiers = structuredClone(current.item.identifiers)
+        merged.conflicts.push(identifierConflict)
+      }
+    }
     const persistedItem = await this.catalog.applyMetadata({
       itemId: current.id,
       expectedMetadataRevision: review.item.metadataRevision,

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
@@ -283,3 +283,26 @@ it('retries the failed apply command instead of only refreshing the task', async
   ])
   expect(screen.queryByRole('alert')).toBeNull()
 })
+
+it('retires a failed apply request when the user changes the selection', async () => {
+  job.state = 'review'
+  job.rows[0]!.status = 'ready'
+  jobs.mockImplementation(async (request) => {
+    if (request.action === 'apply') throw new Error('checkpoint unavailable')
+    return { jobs: [structuredClone(job)] }
+  })
+  open(id)
+  await flush()
+  fireEvent.click(screen.getByRole('button', { name: 'Apply metadata (1)' }))
+  await act(async () => {})
+  fireEvent.click(screen.getByRole('checkbox'))
+  await act(async () => {})
+  jobs.mockRejectedValueOnce(new Error('read unavailable'))
+  fireEvent(window, new Event('literature-job-refresh'))
+  await act(async () => {})
+  expect(screen.getByRole('alert')).toBeTruthy()
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+  await act(async () => {})
+  expect(jobs.mock.calls.filter(([request]) => request.action === 'apply')).toHaveLength(1)
+  expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
+})

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
@@ -247,8 +247,6 @@ it('retries failed review saves without losing the selected source or applying a
   await act(async () => {})
   expect(screen.queryByRole('alert')).toBeNull()
   expect(job.rows[0]).toMatchObject({ checked: true, candidateId: 'chosen-source' })
-  fireEvent.click(screen.getByRole('button', { name: 'Add attachment (1)' }))
-  await act(async () => {})
   expect(jobs.mock.calls.filter(([request]) => request.action === 'apply')).toEqual([
     [
       {

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
@@ -259,3 +259,27 @@ it('retries failed review saves without losing the selected source or applying a
     ]
   ])
 })
+
+it('retries the failed apply command instead of only refreshing the task', async () => {
+  job.state = 'review'
+  job.rows[0]!.status = 'ready'
+  let writable = false
+  jobs.mockImplementation(async (request) => {
+    if (request.action === 'apply' && !writable) throw new Error('checkpoint unavailable')
+    return { jobs: [structuredClone(job)] }
+  })
+  open(id)
+  await flush()
+  fireEvent.click(screen.getByRole('button', { name: 'Apply metadata (1)' }))
+  await act(async () => {})
+  const first = jobs.mock.calls.find(([request]) => request.action === 'apply')![0]
+  expect(screen.getByRole('alert')).toBeTruthy()
+  writable = true
+  fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+  await act(async () => {})
+  expect(jobs.mock.calls.filter(([request]) => request.action === 'apply')).toEqual([
+    [first],
+    [first]
+  ])
+  expect(screen.queryByRole('alert')).toBeNull()
+})

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
@@ -176,6 +176,7 @@ export const LiteratureBatchLookupDialog = ({
   const update = (id: string, patch: Partial<Row>): void => {
     const row = rows.find((row) => row.id === id)
     if (!job || !row) return
+    failedCommand.current = undefined
     const selected = { ...row, ...patch }
     setRows((current) => current.map((row) => (row.id === id ? { ...row, ...patch } : row)))
     pendingDrafts.current.set(id, {

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
@@ -22,7 +22,10 @@ import {
 } from '@/components/ui/dialog-chrome'
 import type { LiteratureItemView, LiteratureMetadataField } from '../../../../shared/literature'
 import { formatBytes } from '../../../../shared/update'
-import { literatureJobProgress } from '../../../../shared/literature-jobs'
+import {
+  literatureJobProgress,
+  type LiteratureJobRequest
+} from '../../../../shared/literature-jobs'
 
 type BatchLookupMode = 'metadata' | 'full-text'
 const progressClassName =
@@ -61,6 +64,7 @@ export const LiteratureBatchLookupDialog = ({
   const [error, setError] = useState(false)
   const [sending, setSending] = useState(false)
   const jobRef = useRef<Job | undefined>(undefined)
+  const failedCommand = useRef<LiteratureJobRequest | undefined>(undefined)
   const draftWrites = useRef(Promise.resolve())
   const pendingDrafts = useRef(
     new Map<string, { itemId: string; checked: boolean; candidateId?: string }>()
@@ -117,7 +121,7 @@ export const LiteratureBatchLookupDialog = ({
         } else if (!jobRef.current) throw new Error('Task unavailable')
         else if (result.progress || jobRef.current.progress)
           setJob((current) => (current ? { ...current, progress: result.progress } : current))
-        if (pendingDrafts.current.size === 0) setError(false)
+        if (pendingDrafts.current.size === 0 && !failedCommand.current) setError(false)
       } catch {
         if (active) setError(true)
       } finally {
@@ -184,22 +188,14 @@ export const LiteratureBatchLookupDialog = ({
       () => setError(true)
     )
   }
-  const command = async (action: 'apply' | 'retry' | 'resume' | 'pause'): Promise<void> => {
-    if (!job || sending) return
+  const sendCommand = async (request: LiteratureJobRequest): Promise<void> => {
+    if (sending) return
     setSending(true)
     try {
       await saveDrafts()
-      const result = await window.api.literature.jobs(
-        action === 'apply'
-          ? {
-              action,
-              jobId: job.id,
-              selections: rows
-                .filter((row) => row.status === 'ready' && row.checked)
-                .map((row) => ({ itemId: row.id, candidateId: row.candidateId }))
-            }
-          : { action, jobId: job.id }
-      )
+      failedCommand.current = request
+      const result = await window.api.literature.jobs(request)
+      failedCommand.current = undefined
       if (result.jobs[0]) receive(result.jobs[0])
       setError(false)
     } catch {
@@ -208,7 +204,24 @@ export const LiteratureBatchLookupDialog = ({
       setSending(false)
     }
   }
+  const command = async (action: 'apply' | 'retry' | 'resume' | 'pause'): Promise<void> => {
+    if (!job) return
+    await sendCommand(
+      action === 'apply'
+        ? {
+            action,
+            jobId: job.id,
+            selections: rows
+              .filter((row) => row.status === 'ready' && row.checked)
+              .map((row) => ({ itemId: row.id, candidateId: row.candidateId }))
+          }
+        : { action, jobId: job.id }
+    )
+  }
   const messageLabels: Record<string, string> = {
+    'Search again to refresh this older metadata review.': t(
+      'Search again to refresh this older metadata review.'
+    ),
     'Needs identifiers': t('Needs identifiers'),
     'No missing metadata was found.': t('No missing metadata was found.'),
     'PDF already attached': t('PDF already attached'),
@@ -286,7 +299,12 @@ export const LiteratureBatchLookupDialog = ({
                 title={t('Background task could not be updated. Try again.')}
                 primaryButton={{
                   label: t('Retry'),
+                  disabled: sending,
                   onClick: () => {
+                    if (failedCommand.current) {
+                      void sendCommand(failedCommand.current)
+                      return
+                    }
                     void saveDrafts().then(
                       () => window.dispatchEvent(new Event('literature-job-refresh')),
                       () => setError(true)

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
@@ -193,11 +193,11 @@ export const LiteratureBatchLookupDialog = ({
     if (sending) return
     setSending(true)
     try {
-      await saveDrafts()
       failedCommand.current = request
+      await saveDrafts()
       const result = await window.api.literature.jobs(request)
-      failedCommand.current = undefined
       if (result.jobs[0]) receive(result.jobs[0])
+      failedCommand.current = undefined
       setError(false)
     } catch {
       setError(true)

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -2747,6 +2747,43 @@ describe('LiteratureLibraryPage', () => {
     ).not.toBeNull()
   })
 
+  it('shows identifier-only additions and submits one publication-date conflict choice', async () => {
+    search.mockImplementation((request: { scope: string }) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })
+    )
+    completeMetadata.mockResolvedValue({
+      mode: 'preview',
+      provider: 'crossref',
+      reviewVersion: 1,
+      reviewToken: '9323d39a-2ae2-49c8-8826-a589c78f1f5d',
+      sourceUrl: 'https://api.crossref.org/works/10.0000/example',
+      item: libraryItem,
+      filled: [{ field: 'identifiers', value: 'DOI: 10.0000/example ★; PMID: 12345678' }],
+      conflicts: [{ field: 'publicationDate', currentValue: '2020', value: '2021-02-03' }]
+    })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await openReferenceDetail(await screen.findByText('Corrective Retrieval Augmented Generation'))
+    const detail = screen.getByRole('dialog')
+    await openMenu(within(detail).getByRole('button', { name: 'More actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+    fireEvent.click(within(detail).getByRole('button', { name: 'Search' }))
+    expect(await screen.findByText('Identifiers (★ primary)')).toBeTruthy()
+    expect(screen.getByText('DOI: 10.0000/example ★; PMID: 12345678')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Apply metadata' })).toBeTruthy()
+    expect(screen.getAllByRole('button', { name: 'Use Crossref' })).toHaveLength(1)
+    fireEvent.click(screen.getByRole('button', { name: 'Use Crossref' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Apply metadata' }))
+    await waitFor(() =>
+      expect(completeMetadata).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          mode: 'commit',
+          overwriteFields: ['publicationDate']
+        })
+      )
+    )
+  })
+
   it('previews and applies missing publication metadata from Crossref', async () => {
     search.mockImplementation((request: { scope: string }) =>
       Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -2087,6 +2087,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         return t('Title')
       case 'authors':
         return t('Authors')
+      case 'identifiers':
+        return t('Identifiers (★ primary)')
       case 'publicationDate':
         return t('Publication date')
       case 'year':

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -101,6 +101,8 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Identifiers (★ primary)": "Identifikatoren (★ primär)",
+    "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
     "Not answered": "Nicht beantwortet",
     "Automatic contrast": "Automatischer Kontrast",
     "Display range": "Anzeigebereich",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -102,6 +102,8 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Identifiers (★ primary)": "Identificadores (★ principal)",
+    "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
     "Not answered": "Sin responder",
     "Automatic contrast": "Contraste automático",
     "Display range": "Rango de visualización",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -102,6 +102,8 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Identifiers (★ primary)": "Identifiants (★ principal)",
+    "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
     "Not answered": "Sans réponse",
     "Automatic contrast": "Contraste automatique",
     "Display range": "Plage d’affichage",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Identifiers (★ primary)": "識別子（★ 主要）",
+    "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
     "Not answered": "未回答",
     "Automatic contrast": "自動コントラスト",
     "Display range": "表示範囲",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Identifiers (★ primary)": "식별자(★ 기본)",
+    "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
     "Not answered": "미응답",
     "Automatic contrast": "자동 대비",
     "Display range": "표시 범위",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -103,6 +103,8 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Identifiers (★ primary)": "Идентификаторы (★ основной)",
+    "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
     "Not answered": "Нет ответа",
     "Automatic contrast": "Автоматическая контрастность",
     "Display range": "Диапазон отображения",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Identifiers (★ primary)": "标识符（★ 主标识）",
+    "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
     "Not answered": "未填写",
     "Automatic contrast": "自动对比度",
     "Display range": "显示范围",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -100,6 +100,8 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Identifiers (★ primary)": "識別碼（★ 主要識別碼）",
+    "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
     "Not answered": "未填寫",
     "Automatic contrast": "自動對比度",
     "Display range": "顯示範圍",

--- a/src/shared/literature.ts
+++ b/src/shared/literature.ts
@@ -57,6 +57,7 @@ const LITERATURE_IMPORT_WARNINGS = [
 const LITERATURE_METADATA_FIELDS = [
   'title',
   'authors',
+  'identifiers',
   'publicationDate',
   'year',
   'journal',
@@ -796,6 +797,7 @@ const literatureMetadataCompletionResultSchema = z
     filled: z.array(literatureMetadataValueSchema),
     conflicts: z.array(literatureMetadataConflictSchema),
     reviewToken: z.string().uuid().optional(),
+    reviewVersion: z.literal(1).optional(),
     source: literatureSourceInputSchema.optional()
   })
   .strict()


### PR DESCRIPTION
## Problem

Metadata completion could delete editors/translators when replacing authors, omit identifier changes from review/readiness, and combine a retained publication year with a different source date. Failed task checkpoint writes could publish unscheduled work, while the error Retry only refreshed the task. The advertised response limit was checked after full decoding and counted characters instead of bytes.

## Proposed change

- Merge only author creators, preserving other roles and their relative order.
- Derive identifier review entries from normalized original and candidate values/primary flags, ignoring order-only changes while preserving the original list; require selection for replacements and primary changes. Identifier-only additions now make batch rows ready and single-item completion actionable.
- Review publication date/year together, infer missing years only from valid numeric dates, and preserve ambiguous text unless explicitly replaced.
- Persist command drafts before publication, coordinate worker checkpoints with commands, and retry the actual failed request even when saving its pending review draft failed. Changing the selection retires a stale failed request.
- Cancel metadata streams as soon as received bytes exceed 2 MiB.

## Scope and non-goals

No database schema/migration, new task state, dependency, or networking subsystem. Existing references are not rewritten and previously lost contributors are not reconstructed.

Compatibility: adds `identifiers` to the metadata review field enum and optional `reviewVersion: 1` to persisted review results. Unversioned reviews remain readable but require a fresh search before application. Older binaries may reject new checkpoints; no downgrade conversion is provided. Task journal versions remain unchanged.

## Acceptance criteria and validation

Regression tests use public preview/commit and run/get boundaries, real temporary checkpoint files, controlled response streams, and the actual renderer components. The expanded test set ran twice against the original implementations: 63 cases with the same 25 expected failures and 38 passes each time. The fixed implementation passes. Separate regressions reproduce stale apply retries, lost commands after failed draft saves, and false identifier changes from reordering or equivalent DOI spelling. All fail before their fixes and pass afterward. Command persistence fault tests close and reopen the service before injection so a finishing worker cannot race the fault fixture.

Checks below ran after the final production edits; the command fault fixture was then stabilized and its suite rerun:

| Behavior | Command | Result |
| --- | --- | --- |
| Metadata/catalog, reference resolver, CSL, jobs/storage, Library/batch consumers | `npx vitest run src/main/literature src/shared/literature.test.ts src/shared/literature-csl.test.ts src/shared/literature-jobs.test.ts src/renderer/src/pages/literature src/main/storage/durable-json-file.test.ts` | 457 passed (including focused reruns) |
| IPC catalog, composition, Electron and preload contracts | `npx vitest run src/shared/renderer-contract-catalog.test.ts src/main/application-command-composition.test.ts src/main/application-command-electron-adapter.test.ts src/preload/index.test.ts` | 119 passed |
| Eight translated locales | `npx vitest run src/renderer/src/i18n/resources.test.ts` | 804 passed (including isolated scan rerun) |
| Main/sandbox/renderer types | `npm run typecheck` | passed |
| Lint and patch hygiene | `npm run lint`; `git diff --check` | passed |

Focused reruns: `npx vitest run src/main/literature/batch-jobs.test.ts src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx --maxWorkers=1 --testTimeout=60000` (129 passed); `npx vitest run src/renderer/src/i18n/resources.test.ts -t 'no t\(\) call passes a dotted semantic path' --maxWorkers=1` (1 passed, 803 skipped).

The first broad rerun under concurrent local validation had scan/page timeouts and exposed the fault-fixture race; focused reruns are reported separately rather than treating that run as green.

Browser QA used real Library and batch components with controlled API fixtures, without the user database. Captured identifier/date review and checkpoint-error screenshots; verified the selected date field and identical apply retry payloads. The Literature module has no module-impact owner yet, so the local set follows inspected owner/consumer and IPC relationships rather than a claimed automatic selective plan. Per maintainer request, no full local test suite was run. Full portable/platform CI and independent PR review remain authoritative; live providers and packaging were not exercised locally.

## Review focus

Worker/command ordering and object identity during active searches; identifier consent and primary flags; coupled publication dates; legacy-review refusal and downgrade implications.
