### PR TITLE
fix(literature): preserve citation document and export fidelity

### DIFF
--- a/src/main/literature/citation-document.test.ts
+++ b/src/main/literature/citation-document.test.ts
@@ -101,7 +101,8 @@ describe('LiteratureCitationDocument', () => {
     expect(formatReferences).toHaveBeenCalledWith(
       [{ id: 'item-1', item: reference.item }],
       'vancouver',
-      'en-US'
+      'en-US',
+      'html'
     )
   })
 

--- a/src/main/literature/citation-document.ts
+++ b/src/main/literature/citation-document.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'node:crypto'
 
 import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate'
+import { parseFragment, type DefaultTreeAdapterMap } from 'parse5'
 
 import type {
   ArtifactCitationInput,
@@ -78,17 +79,82 @@ const xmlUnescape = (value: string): string =>
     .replaceAll('&lt;', '<')
     .replaceAll('&amp;', '&')
 
-const runProperties = (body: string): string => /<w:rPr\b[\s\S]*?<\/w:rPr>/u.exec(body)?.[0] ?? ''
+const runProperties = (body: string): string =>
+  /<w:rPr\b[^>]*(?:\/>|>[\s\S]*?<\/w:rPr>)/u.exec(body)?.[0] ?? ''
 
 const visibleRun = (text: string, properties = ''): string =>
   text ? `<w:r>${properties}<w:t xml:space="preserve">${xmlEscape(text)}</w:t></w:r>` : ''
 
+// Interpret only inline emphasis from the citation engine, never arbitrary HTML as Word XML.
+const citationSpans = (html: string): { text: string; properties: Record<string, string> }[] => {
+  const spans: { text: string; properties: Record<string, string> }[] = []
+  const visit = (node: DefaultTreeAdapterMap['node'], inherited: Record<string, string>): void => {
+    if (node.nodeName === '#text') {
+      spans.push({ text: (node as DefaultTreeAdapterMap['textNode']).value, properties: inherited })
+      return
+    }
+    if (!('childNodes' in node)) return
+    const properties = { ...inherited }
+    if ('tagName' in node) {
+      const tag = node.tagName
+      if (tag === 'i' || tag === 'em') properties.i = '<w:i/>'
+      if (tag === 'b' || tag === 'strong') properties.b = '<w:b/>'
+      if (tag === 'sup' || tag === 'sub')
+        properties.vertAlign = `<w:vertAlign w:val="${tag === 'sup' ? 'superscript' : 'subscript'}"/>`
+      for (const declaration of (
+        node.attrs.find(({ name }) => name === 'style')?.value ?? ''
+      ).split(';')) {
+        const [name, value] = declaration.split(':').map((part) => part.trim().toLowerCase())
+        if (name === 'font-style' && (value === 'italic' || value === 'normal'))
+          properties.i = `<w:i w:val="${value === 'italic' ? 'true' : 'false'}"/>`
+        if (name === 'font-weight' && (value === 'bold' || value === 'normal'))
+          properties.b = `<w:b w:val="${value === 'bold' ? 'true' : 'false'}"/>`
+        if (name === 'font-variant' && value === 'small-caps')
+          properties.smallCaps = '<w:smallCaps/>'
+        if (name === 'text-decoration' && value === 'underline')
+          properties.u = '<w:u w:val="single"/>'
+        if (name === 'vertical-align' && (value === 'super' || value === 'sub'))
+          properties.vertAlign = `<w:vertAlign w:val="${value === 'super' ? 'superscript' : 'subscript'}"/>`
+      }
+    }
+    for (const child of node.childNodes) visit(child, properties)
+  }
+  visit(parseFragment(html), {})
+  return spans
+}
+
+const citationRuns = (html: string, baseProperties: string): string =>
+  citationSpans(html)
+    .map(({ text, properties }) => {
+      if (!Object.keys(properties).length) return visibleRun(text, baseProperties)
+      let body = baseProperties.replace(/^<w:rPr[^>]*>|<\/w:rPr>$/gu, '')
+      for (const [tag, xml] of Object.entries(properties)) {
+        body = body.replace(new RegExp(`<w:${tag}\\b[^>]*(?:/>|>[\\s\\S]*?</w:${tag}>)`, 'gu'), '')
+        body += xml
+      }
+      return visibleRun(text, `<w:rPr>${body}</w:rPr>`)
+    })
+    .join('')
+
+const fieldProperties = (field: string, displayRuns: string): string => {
+  // New fields retain their base formatting on the begin run, separately from CSL emphasis.
+  // Older fields have no properties there; their first display run held the uniform formatting.
+  const firstRun = /<w:r\b[^>]*>([\s\S]*?)<\/w:r>/u
+  return (
+    runProperties(firstRun.exec(field)?.[1] ?? '') ||
+    runProperties(firstRun.exec(displayRuns)?.[1] ?? '')
+  )
+}
+
+const UNSUPPORTED_CITATION_CONTEXT =
+  'Cannot reformat citations with locators, affixes, or suppressed authors.'
+
 const fieldRuns = (instruction: string, display: string, properties = ''): string =>
   [
-    '<w:r><w:fldChar w:fldCharType="begin" w:dirty="true"/></w:r>',
+    `<w:r>${properties || '<w:rPr/>'}<w:fldChar w:fldCharType="begin" w:dirty="true"/></w:r>`,
     `<w:r><w:instrText xml:space="preserve"> ${xmlEscape(instruction)} </w:instrText></w:r>`,
     '<w:r><w:fldChar w:fldCharType="separate"/></w:r>',
-    visibleRun(display, properties),
+    citationRuns(display, properties),
     '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
   ].join('')
 
@@ -101,7 +167,9 @@ const zoteroCitationInstruction = (
     citationID: citation.citationId,
     properties: {
       formattedCitation,
-      plainCitation: formattedCitation,
+      plainCitation: citationSpans(formattedCitation)
+        .map(({ text }) => text)
+        .join(''),
       noteIndex: 0
     },
     citationItems: [
@@ -118,16 +186,16 @@ const bibliographyField = (references: readonly string[], properties = ''): stri
   const rendered = references
     .map(
       (reference, index) =>
-        `${index > 0 ? '<w:br/>' : ''}<w:t xml:space="preserve">${xmlEscape(reference)}</w:t>`
+        `${index > 0 ? '<w:r><w:br/></w:r>' : ''}${citationRuns(reference, properties)}`
     )
     .join('')
   return [
-    '<w:r><w:fldChar w:fldCharType="begin" w:dirty="true"/></w:r>',
+    `<w:r>${properties || '<w:rPr/>'}<w:fldChar w:fldCharType="begin" w:dirty="true"/></w:r>`,
     `<w:r><w:instrText xml:space="preserve"> ${xmlEscape(
       'ADDIN ZOTERO_BIBL {"uncited":[],"omitted":[],"custom":[]}'
     )} CSL_BIBLIOGRAPHY </w:instrText></w:r>`,
     '<w:r><w:fldChar w:fldCharType="separate"/></w:r>',
-    `<w:r>${properties}${rendered}</w:r>`,
+    rendered,
     '<w:r><w:fldChar w:fldCharType="end"/></w:r>'
   ].join('')
 }
@@ -136,11 +204,20 @@ const replaceRunText = (
   xml: string,
   replace: (text: string, properties: string) => string | undefined
 ): string =>
-  xml.replace(WORD_RUN_PATTERN, (run, _attributes: string, body: string) => {
+  xml.replace(WORD_RUN_PATTERN, (run, attributes: string, body: string) => {
     const textNodes = [...body.matchAll(WORD_TEXT_PATTERN)]
     if (textNodes.length !== 1) return run
-    const replacement = replace(xmlUnescape(textNodes[0]![1]!), runProperties(body))
-    return replacement ?? run
+    const node = textNodes[0]!
+    const properties = runProperties(body)
+    const replacement = replace(xmlUnescape(node[1]!), properties)
+    if (replacement === undefined) return run
+    const preserve = (fragment: string): string =>
+      fragment.trim() ? `<w:r${attributes}>${properties}${fragment}</w:r>` : ''
+    return (
+      preserve(body.slice(0, node.index).replace(properties, '')) +
+      replacement.replaceAll('<w:r>', `<w:r${attributes}>`) +
+      preserve(body.slice(node.index + node[0].length))
+    )
   })
 
 const sha256 = (content: Uint8Array): string => createHash('sha256').update(content).digest('hex')
@@ -190,7 +267,8 @@ class LiteratureCitationDocument {
     const formatted = await this.formatter.formatReferences(
       uniqueItemIds.map((id) => ({ id, item: itemsById.get(id)!.item })),
       request.styleId,
-      request.locale
+      request.locale,
+      'html'
     )
     const formattedById = new Map(formatted.map((entry) => [entry.itemId, entry]))
     const citations: ArtifactCitationInput[] = []
@@ -267,6 +345,14 @@ class LiteratureCitationDocument {
 
   async reformat(request: ReformatCitationDocumentRequest): Promise<ReformattedCitationDocument> {
     const literature = artifactLiteratureManifestSchema.parse(request.literature)
+    if (
+      literature.citations.some(
+        ({ locator, prefix, suffix, suppressAuthor }) =>
+          locator || prefix || suffix || suppressAuthor
+      )
+    ) {
+      throw new Error(UNSUPPORTED_CITATION_CONTEXT)
+    }
     const archive = this.openDocument(request.content)
     const documentXml = strFromU8(archive[DOCX_DOCUMENT_PATH]!)
     const referencesById = new Map(
@@ -275,7 +361,8 @@ class LiteratureCitationDocument {
     const formatted = await this.formatter.formatReferences(
       literature.references.map((reference) => ({ id: reference.itemId, item: reference.item })),
       request.styleId,
-      request.locale
+      request.locale,
+      'html'
     )
     const formattedById = new Map(formatted.map((entry) => [entry.itemId, entry]))
     const citationsById = new Map(
@@ -294,18 +381,26 @@ class LiteratureCitationDocument {
             literature.references.map(
               (reference) => formattedById.get(reference.itemId)!.reference
             ),
-            runProperties(displayRuns)
+            fieldProperties(field, displayRuns)
           )
         }
         const marker = /^ADDIN ZOTERO_ITEM CSL_CITATION (\{[\s\S]*\})$/u.exec(instruction)
         if (!marker) return field
-        let citationId: string | undefined
+        let parsed: { citationID?: unknown; citationItems?: Record<string, unknown>[] }
         try {
-          const parsed = JSON.parse(marker[1]!) as { citationID?: unknown }
-          citationId = typeof parsed.citationID === 'string' ? parsed.citationID : undefined
+          parsed = JSON.parse(marker[1]!) as typeof parsed
         } catch {
           throw new Error('Citation document contains an invalid Zotero citation field.')
         }
+        if (
+          Array.isArray(parsed.citationItems) &&
+          parsed.citationItems.some(
+            (item) => item.locator || item.prefix || item.suffix || item['suppress-author']
+          )
+        ) {
+          throw new Error(UNSUPPORTED_CITATION_CONTEXT)
+        }
+        const citationId = typeof parsed.citationID === 'string' ? parsed.citationID : undefined
         const citation = citationId ? citationsById.get(citationId) : undefined
         if (!citation || replacedCitationIds.has(citation.citationId)) {
           throw new Error('Citation document does not match its Literature manifest.')
@@ -319,7 +414,7 @@ class LiteratureCitationDocument {
         return fieldRuns(
           zoteroCitationInstruction(citation, reference.item, result.inText),
           result.inText,
-          runProperties(displayRuns)
+          fieldProperties(field, displayRuns)
         )
       }
     )

--- a/src/main/literature/citation-fidelity.test.ts
+++ b/src/main/literature/citation-fidelity.test.ts
@@ -1,0 +1,261 @@
+import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+
+import { createEngine } from 'citeme-engine-wasm'
+import { strFromU8, strToU8, unzipSync, zipSync } from 'fflate'
+import { describe, expect, it } from 'vitest'
+
+import type { ArtifactLiteratureManifest } from '../../shared/artifact-literature'
+import type { LiteratureItemView } from '../../shared/literature'
+import { toCslItem } from '../../shared/literature-csl'
+import { LiteratureCitationDocument } from './citation-document'
+import { LiteratureCitationFormatter } from './citation-formatter'
+import { citationResourceDirectory } from './citation-style-library'
+import { LiteratureLatexBundle } from './latex-bundle'
+
+const record = (id = 'library-id', author = 'Alpha'): LiteratureItemView => ({
+  id,
+  metadataRevision: 1,
+  createdAt: 0,
+  updatedAt: 0,
+  projectIds: [],
+  collectionIds: [],
+  attachments: [],
+  item: {
+    itemType: 'journalArticle',
+    title: `${author} paper`,
+    abstract: '',
+    issuedText: '2024',
+    issuedYear: 2024,
+    containerTitle: 'Journal of Tests',
+    shortTitle: '',
+    language: 'en',
+    rights: '',
+    url: '',
+    extra: '',
+    typeFields: { volume: '12', pages: '10-20' },
+    creators: [{ nameMode: 'person', givenName: 'Ada', familyName: author, creatorType: 'author' }],
+    identifiers: []
+  }
+})
+const docx = (body: string): Uint8Array =>
+  zipSync({
+    '[Content_Types].xml': strToU8('<Types/>'),
+    'word/document.xml': strToU8(
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${body}</w:body></w:document>`
+    )
+  })
+const xmlOf = (content: Uint8Array): string => strFromU8(unzipSync(content)['word/document.xml']!)
+const unescapeXml = (text: string): string =>
+  text
+    .replaceAll('&quot;', '"')
+    .replaceAll('&apos;', "'")
+    .replaceAll('&lt;', '<')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&amp;', '&')
+const visibleText = (xml: string): string =>
+  [...xml.matchAll(/<w:t\b[^>]*>([\s\S]*?)<\/w:t>/gu)]
+    .map((match) => unescapeXml(match[1]!))
+    .join('')
+const manifest = (
+  items: LiteratureItemView[],
+  citations: ArtifactLiteratureManifest['citations']
+): ArtifactLiteratureManifest => ({
+  schemaVersion: 1,
+  styleId: 'apa',
+  locale: 'en-US',
+  citations,
+  references: items.map(({ id, item, metadataRevision }) => ({
+    itemId: id,
+    item,
+    metadataRevision
+  }))
+})
+
+describe('Citation fidelity through document and export boundaries', () => {
+  it.each(['manifest and field', 'field only'] as const)(
+    'rejects reformatting rather than losing per-occurrence semantics in %s',
+    async (location) => {
+      const item = record()
+      const citation = {
+        citationId: 'citation-1',
+        itemId: item.id,
+        metadataRevision: 1,
+        locator: { label: 'page' as const, value: '17' },
+        prefix: 'See ',
+        suffix: ' for details',
+        suppressAuthor: true
+      }
+      const instruction = JSON.stringify({
+        citationID: citation.citationId,
+        properties: {
+          formattedCitation: 'See 2024, p. 17 for details',
+          plainCitation: 'See 2024, p. 17 for details',
+          noteIndex: 0
+        },
+        citationItems: [
+          {
+            id: item.id,
+            uris: [`https://open-science.local/literature/${item.id}`],
+            itemData: toCslItem(item.id, item.item),
+            locator: '17',
+            label: 'page',
+            prefix: 'See ',
+            suffix: ' for details',
+            'suppress-author': true
+          }
+        ]
+      })
+      const content = docx(
+        `<w:p><w:r><w:fldChar w:fldCharType="begin"/></w:r><w:r><w:instrText> ADDIN ZOTERO_ITEM CSL_CITATION ${instruction.replaceAll('&', '&amp;').replaceAll('<', '&lt;')}</w:instrText></w:r><w:r><w:fldChar w:fldCharType="separate"/></w:r><w:r><w:t>See 2024, p. 17 for details</w:t></w:r><w:r><w:fldChar w:fldCharType="end"/></w:r></w:p>`
+      )
+      await expect(
+        new LiteratureCitationDocument({ getMany: async () => [item] }).reformat({
+          content,
+          literature: manifest(
+            [item],
+            [
+              location === 'field only'
+                ? { citationId: citation.citationId, itemId: item.id, metadataRevision: 1 }
+                : citation
+            ]
+          ),
+          styleId: 'mla',
+          locale: 'en-US'
+        })
+      ).rejects.toThrow('Cannot reformat citations with locators, affixes, or suppressed authors.')
+    }
+  )
+
+  it('preserves tabs and line breaks around a citation in the same bold run', async () => {
+    const item = record()
+    const result = await new LiteratureCitationDocument({ getMany: async () => [item] }).format({
+      content: docx(
+        '<w:p><w:r><w:rPr><w:b/></w:rPr><w:tab/><w:t>Before {{cite:library-id}} after</w:t><w:br/></w:r></w:p>'
+      ),
+      styleId: 'apa',
+      locale: 'en-US'
+    })
+    const xml = xmlOf(result.content)
+    expect(visibleText(xml)).toBe('Before (Alpha, 2024) after')
+    expect(xml).toContain('<w:b/>')
+    expect.soft(xml).toContain('<w:tab/>')
+    expect.soft(xml).toContain('<w:br/>')
+    expect.soft(xml.indexOf('<w:tab/>')).toBeLessThan(xml.indexOf('Before '))
+    expect.soft(xml.indexOf('<w:br/>')).toBeGreaterThan(xml.indexOf(' after'))
+  })
+
+  it('keeps the stored BibTeX key consistently with LaTeX bundle export', async () => {
+    const item = record()
+    item.item = { ...item.item, citationKey: 'Alpha2024' }
+    const formatter = new LiteratureCitationFormatter()
+    const bundle = await new LiteratureLatexBundle({ getMany: async () => [item] }).prepare({
+      sourceName: 'paper.tex',
+      content:
+        '\\usepackage{biblatex}\n\\addbibresource{references.bib}\n{{cite:library-id}}\n{{bibliography}}'
+    })
+    const files = unzipSync(bundle.content)
+    expect(strFromU8(files['references.bib']!)).toContain('@article{Alpha2024,')
+    expect(strFromU8(files['paper.tex']!)).toContain('\\cite{Alpha2024}')
+    const exported = await formatter.exportReferences([{ id: item.id, item: item.item }], 'bibtex')
+    expect.soft(exported).toContain('@article{Alpha2024,')
+    expect.soft((await formatter.parseReferences(exported)).items[0]?.citationKey).toBe('Alpha2024')
+  })
+
+  it.each([2024, undefined])(
+    'preserves the complete publication date through RIS with issuedYear=%s',
+    async (issuedYear) => {
+      const item = { ...record().item, issuedText: '2024-03-12', issuedYear }
+      const formatter = new LiteratureCitationFormatter()
+      const exported = await formatter.exportReferences([{ id: 'dated', item }], 'ris')
+      const parsed = await formatter.parseReferences(exported)
+      expect(parsed.errors).toEqual([])
+      expect(parsed.items).toHaveLength(1)
+      expect(toCslItem('dated', parsed.items[0]!).issued).toEqual({ 'date-parts': [[2024, 3, 12]] })
+    }
+  )
+
+  it('preserves the local italics emitted by APA in the DOCX bibliography', async () => {
+    const item = record()
+    const require = createRequire(import.meta.url)
+    const engine = await createEngine(
+      await readFile(require.resolve('citeme-engine-wasm/pkg/citeme_engine_wasm_bg.wasm'))
+    )
+    try {
+      engine.loadStyle('apa', await readFile(join(citationResourceDirectory(), 'apa.csl'), 'utf8'))
+      engine.loadLocale(
+        'en-US',
+        await readFile(join(citationResourceDirectory(), 'locales-en-US.xml'), 'utf8')
+      )
+      const html = JSON.parse(
+        engine.formatOneWithOutput(
+          JSON.stringify(toCslItem(item.id, item.item)),
+          'apa',
+          'en-US',
+          false,
+          'html',
+          false
+        )
+      ) as { reference: string }
+      expect(html.reference).toMatch(/font-style:\s*italic/u)
+      expect(html.reference).toContain('Journal of Tests')
+      const result = await new LiteratureCitationDocument({ getMany: async () => [item] }).format({
+        content: docx(
+          '<w:p><w:r><w:t>{{cite:library-id}}</w:t></w:r></w:p><w:p><w:r><w:t>{{bibliography}}</w:t></w:r></w:p>'
+        ),
+        styleId: 'apa',
+        locale: 'en-US'
+      })
+      const xml = xmlOf(result.content).split('CSL_BIBLIOGRAPHY')[1]!
+      expect(visibleText(xml)).toContain('Journal of Tests')
+      const runs = [...xml.matchAll(/<w:r\b[^>]*>([\s\S]*?)<\/w:r>/gu)].map((match) => match[1]!)
+      expect(
+        runs.some(
+          (run) => /<w:i(?:\s|\/|>)/u.test(run) && visibleText(run).includes('Journal of Tests')
+        )
+      ).toBe(true)
+      expect(
+        runs.some(
+          (run) => !/<w:i(?:\s|\/|>)/u.test(run) && visibleText(run).includes('Alpha paper')
+        )
+      ).toBe(true)
+    } finally {
+      engine.free()
+    }
+  })
+  it('keeps inline emphasis separate from base formatting when changing styles again', async () => {
+    const item = record()
+    const service = new LiteratureCitationDocument({ getMany: async () => [item] })
+    const first = await service.format({
+      content: docx(
+        '<w:p><w:r><w:t>{{cite:library-id}}</w:t></w:r></w:p><w:p><w:r><w:t>{{bibliography}}</w:t></w:r></w:p>'
+      ),
+      styleId: 'nature',
+      locale: 'en-US'
+    })
+    expect(xmlOf(first.content)).toContain('w:val="superscript"')
+    const result = await service.reformat({
+      content: first.content,
+      literature: {
+        ...manifest(
+          [item],
+          first.literature.citations.map((citation) => ({ ...citation, metadataRevision: 1 }))
+        ),
+        styleId: 'nature'
+      },
+      styleId: 'apa',
+      locale: 'en-US'
+    })
+    const xml = xmlOf(result.content)
+    expect(xml).not.toContain('w:val="superscript"')
+    expect(xml).not.toMatch(/<w:b\b/u)
+    const runs = [...xml.matchAll(/<w:r\b[^>]*>([\s\S]*?)<\/w:r>/gu)].map((match) => match[1]!)
+    expect(
+      runs.some((run) => visibleText(run).includes('Alpha paper') && !/<w:i\b/u.test(run))
+    ).toBe(true)
+    expect(
+      runs.some((run) => visibleText(run).includes('Journal of Tests') && /<w:i\b/u.test(run))
+    ).toBe(true)
+  })
+})

--- a/src/main/literature/citation-formatter.test.ts
+++ b/src/main/literature/citation-formatter.test.ts
@@ -115,6 +115,28 @@ describe('LiteratureCitationFormatter', () => {
     await expect(formatter.exportReferences(references, 'ris')).resolves.toContain('TY  - JOUR')
   })
 
+  it('keeps duplicate keys observable to the complete export owner instead of silently renaming them', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const content = await formatter.exportReferences(
+      [
+        { id: 'first', item: { ...reference, citationKey: 'SameKey' } },
+        { id: 'second', item: { ...reference, title: 'Another paper', citationKey: 'SameKey' } }
+      ],
+      'bibtex'
+    )
+    expect(content.match(/@article\{SameKey,/gu)).toHaveLength(2)
+    expect(content).not.toContain('@article{SameKeya,')
+    await expect(
+      formatter.exportReferences(
+        [
+          { id: 'first', item: { ...reference, citationKey: 'SameKey' } },
+          { id: 'second', item: { ...reference, citationKey: 'SameKey' } }
+        ],
+        'ris'
+      )
+    ).resolves.toContain('TY  - JOUR')
+  })
+
   it('isolates an invalid stored custom style from formatting, export, and record import', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-invalid-csl-'))
     try {

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
@@ -21,6 +22,13 @@ import {
 } from './citation-style-library'
 
 const require = createRequire(import.meta.url)
+
+// Keep imported keys and the established LaTeX fallback stable across export paths.
+const citationKey = (id: string, item: LiteratureItemInput): string => {
+  const stored = item.citationKey?.trim()
+  if (stored && /^[A-Za-z0-9][A-Za-z0-9_:.+-]{0,127}$/u.test(stored)) return stored
+  return id
+}
 
 type CitationOutputFormat = 'bibtex' | 'ris'
 type FormattedReference = Readonly<{ itemId: string; reference: string; inText: string }>
@@ -227,7 +235,8 @@ class LiteratureCitationFormatter {
   async formatReferences(
     references: readonly CitationReference[],
     style: LiteratureCitationStyle,
-    locale: LiteratureCitationLocale
+    locale: LiteratureCitationLocale,
+    output: 'plain' | 'html' = 'plain'
   ): Promise<FormattedReference[]> {
     const engine = await this.engine()
     const result = JSON.parse(
@@ -236,7 +245,7 @@ class LiteratureCitationFormatter {
         style,
         locale,
         false,
-        'plain',
+        output,
         false
       )
     ) as unknown
@@ -265,8 +274,21 @@ class LiteratureCitationFormatter {
     format: CitationOutputFormat
   ): Promise<string> {
     const engine = await this.engine()
-    const input = JSON.stringify(references.map(({ id, item }) => toCslItem(id, item)))
-    return format === 'bibtex' ? engine.exportBibtex(input) : engine.exportRis(input)
+    if (format === 'ris') {
+      return engine.exportRis(JSON.stringify(references.map(({ id, item }) => toCslItem(id, item))))
+    }
+    // The engine silently renames duplicate IDs in a batch. Export records independently so the
+    // complete-output owner (Library export or LaTeX bundle) can reject collisions without renaming.
+    return references
+      .map(({ id, item }) => {
+        const fallback = /^[A-Za-z0-9][A-Za-z0-9_:.+-]{0,127}$/u.test(id)
+          ? id
+          : `os${createHash('sha256').update(id).digest('hex').slice(0, 12)}`
+        return engine
+          .exportBibtex(JSON.stringify(toCslItem(citationKey(fallback, item), item)))
+          .trim()
+      })
+      .join('\n\n')
   }
 
   async parseReferences(input: string): Promise<ParsedCitationRecords> {
@@ -301,7 +323,7 @@ class LiteratureCitationFormatter {
   }
 }
 
-export { LiteratureCitationFormatter }
+export { citationKey, LiteratureCitationFormatter }
 export type {
   CitationImportError,
   CitationOutputFormat,

--- a/src/main/literature/latex-bundle.ts
+++ b/src/main/literature/latex-bundle.ts
@@ -8,7 +8,7 @@ import {
   type ArtifactLiteratureSidecar
 } from '../../shared/artifact-literature'
 import type { LiteratureItemView } from '../../shared/literature'
-import { LiteratureCitationFormatter } from './citation-formatter'
+import { citationKey, LiteratureCitationFormatter } from './citation-formatter'
 
 const CITATION_MARKER_PATTERN = /\{\{cite:([A-Za-z0-9._-]{1,512})\}\}/gu
 const BIBLIOGRAPHY_MARKER = '{{bibliography}}'
@@ -32,12 +32,6 @@ type PreparedLatexBundle = Readonly<{
 
 const sha256 = (value: string | Uint8Array): string =>
   createHash('sha256').update(value).digest('hex')
-
-const citationKey = (item: LiteratureItemView): string => {
-  const imported = item.item.citationKey?.trim()
-  if (imported && /^[A-Za-z0-9][A-Za-z0-9_:.+-]{0,127}$/u.test(imported)) return imported
-  return `os${sha256(item.id).slice(0, 12)}`
-}
 
 class LiteratureLatexBundle {
   constructor(
@@ -70,7 +64,10 @@ class LiteratureLatexBundle {
     }
 
     const keysByItemId = new Map(
-      uniqueItemIds.map((itemId) => [itemId, citationKey(itemsById.get(itemId)!)])
+      uniqueItemIds.map((itemId) => [
+        itemId,
+        citationKey(`os${sha256(itemId).slice(0, 12)}`, itemsById.get(itemId)!.item)
+      ])
     )
     if (new Set(keysByItemId.values()).size !== keysByItemId.size) {
       throw new Error('Selected Literature Items have duplicate citation keys.')

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -4136,6 +4136,50 @@ describe('LiteratureLibraryPage', () => {
     expect(new TextDecoder().decode(request.data)).toContain('@article{item-1')
   })
 
+  it.each([2, 201])(
+    'rejects duplicate BibTeX keys among %s entries before saving a file',
+    async (count) => {
+      const entries = Array.from({ length: count }, (_, index) => createLibraryItem(index + 1))
+      search.mockImplementation(
+        (request: { scope: string; projectId?: string; offset?: number; limit?: number }) =>
+          Promise.resolve(
+            request.scope === 'library' && request.projectId === 'project-1'
+              ? {
+                  entries: entries.slice(
+                    request.offset ?? 0,
+                    (request.offset ?? 0) + (request.limit ?? 100)
+                  ),
+                  totalCount: entries.length,
+                  nextOffset:
+                    (request.offset ?? 0) + (request.limit ?? 100) < entries.length
+                      ? (request.offset ?? 0) + (request.limit ?? 100)
+                      : undefined
+                }
+              : { entries: [] }
+          )
+      )
+      formatReferences.mockImplementation(async ({ itemIds }: { itemIds: string[] }) => ({
+        references: [],
+        exports: {
+          bibtex: itemIds
+            .map((id) => `@article{${id === `item-${count}` ? 'item-1' : id}, title={Paper}}`)
+            .join('\n'),
+          ris: 'TY  - JOUR\nER  -'
+        }
+      }))
+      useNavigationStore.setState({ pendingLiteratureProjectId: 'project-1' })
+      render(<LiteratureLibraryPage />)
+      await screen.findByRole('heading', { name: 'Retrieval research' })
+      await openMenu(screen.getByTitle('More actions'))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'BibTeX' }))
+      await waitFor(() => expect(formatReferences).toHaveBeenCalledTimes(Math.ceil(count / 200)))
+      await waitFor(() =>
+        expect(screen.queryByText('References could not be exported.')).not.toBeNull()
+      )
+      expect(saveBlobFile).not.toHaveBeenCalled()
+    }
+  )
+
   it('exports every reference in the current Project', async () => {
     search.mockImplementation((request: { projectId?: string; scope: string; sortBy?: string }) =>
       Promise.resolve(

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -2661,12 +2661,22 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     setError(undefined)
     try {
       const chunks: string[] = []
+      const citationKeys = new Set<string>()
       for (let offset = 0; offset < itemIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
         const result = await window.api.literature.formatReferences({
           itemIds: itemIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE),
           styleId: citationStyleRef.current,
           locale: citationLocale
         })
+        if (format === 'bibtex') {
+          // These headers come from our BibTeX exporter, whose keys are validated before emission.
+          for (const match of result.exports.bibtex.matchAll(/^@[a-z]+\{([^,\r\n]+),/gimu)) {
+            const key = match[1]!
+            if (citationKeys.has(key))
+              throw new Error('Selected Literature Items have duplicate citation keys.')
+            citationKeys.add(key)
+          }
+        }
         chunks.push(result.exports[format].trim())
       }
       const content = `${chunks.filter(Boolean).join('\n\n')}\n`

--- a/src/shared/literature-csl.test.ts
+++ b/src/shared/literature-csl.test.ts
@@ -21,6 +21,26 @@ const item = (overrides: Partial<LiteratureItemInput> = {}): LiteratureItemInput
 })
 
 describe('toCslItem', () => {
+  it.each([
+    ['2024-03-12', 2023, [2024, 3, 12]],
+    ['2024-3-12', undefined, [2024, 3, 12]],
+    ['2024-02', undefined, [2024, 2]],
+    ['2024', undefined, [2024]],
+    ['2024-02-29', undefined, [2024, 2, 29]],
+    ['2023-02-29', 2023, [2023]],
+    ['2024-13-01', 2024, [2024]],
+    ['2024-04-31', 2024, [2024]],
+    ['Spring 2024', 2024, [2024]],
+    ['', 2024, [2024]]
+  ])(
+    'projects explicit date precision for %s with year fallback %s',
+    (issuedText, issuedYear, parts) => {
+      expect(toCslItem('dated', item({ issuedText, issuedYear })).issued).toEqual({
+        'date-parts': [parts]
+      })
+    }
+  )
+
   it('normalizes identifiers before projecting citation metadata', () => {
     expect(
       toCslItem(

--- a/src/shared/literature-csl.ts
+++ b/src/shared/literature-csl.ts
@@ -101,6 +101,29 @@ const creatorsFor = (
   return names.length > 0 ? names : undefined
 }
 
+const issuedDate = (item: LiteratureItemInput): CslDate | undefined => {
+  const match = /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/u.exec(item.issuedText.trim())
+  if (match) {
+    const year = Number(match[1])
+    const month = match[2] ? Number(match[2]) : undefined
+    const day = match[3] ? Number(match[3]) : undefined
+    const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+    const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+    if (
+      year > 0 &&
+      (month === undefined || (month >= 1 && month <= 12)) &&
+      (day === undefined || (day >= 1 && day <= days[month! - 1]!))
+    ) {
+      return {
+        'date-parts': [
+          [year, ...(month === undefined ? [] : [month]), ...(day === undefined ? [] : [day])]
+        ]
+      }
+    }
+  }
+  return item.issuedYear === undefined ? undefined : { 'date-parts': [[item.issuedYear]] }
+}
+
 const accessedDate = (accessedAt: number | undefined): CslDate | undefined => {
   if (accessedAt === undefined) return undefined
   const date = new Date(accessedAt)
@@ -130,6 +153,7 @@ const toCslItem = (id: string, item: LiteratureItemInput): CslItem => {
   const editor = creatorsFor(item.creators, 'editor')
   const translator = creatorsFor(item.creators, 'translator')
   const accessed = accessedDate(item.accessedAt)
+  const issued = issuedDate(item)
   const DOI = identifierFor(item, 'doi')
   const ISBN = identifierFor(item, 'isbn')
   const ISSN = identifierFor(item, 'issn')
@@ -147,7 +171,7 @@ const toCslItem = (id: string, item: LiteratureItemInput): CslItem => {
     ...(author ? { author } : {}),
     ...(editor ? { editor } : {}),
     ...(translator ? { translator } : {}),
-    ...(item.issuedYear !== undefined ? { issued: { 'date-parts': [[item.issuedYear]] } } : {}),
+    ...(issued ? { issued } : {}),
     ...(accessed ? { accessed } : {}),
     ...(item.containerTitle ? { 'container-title': item.containerTitle } : {}),
     ...(item.shortTitle ? { 'title-short': item.shortTitle } : {}),


### PR DESCRIPTION
## Problem

Citation formatting can silently remove Word run siblings and per-occurrence context, flatten CSL emphasis, replace stored BibTeX keys with library IDs, and discard publication-date precision.

## Proposed change

- Reject reformatting when the manifest or Word field has unsupported locators, affixes, or suppressed authors, before returning content for a new version.
- Preserve run siblings/attributes and render inline CSL emphasis as Word runs. Retain base formatting separately from generated emphasis so subsequent style changes do not inherit old superscripts or italics; retain the legacy uniform-run fallback.
- Reuse legal stored BibTeX keys and the established LaTeX key policy. Keep engine batch auto-renaming from hiding collisions; the Library rejects duplicate emitted keys across the entire export before saving, while LaTeX retains its existing pre-export duplicate check. RIS remains usable.
- Project explicitly parsed year/month/day dates with calendar validation and year fallback. A valid explicit date takes precedence over a conflicting standalone year; recognize the existing importer's unpadded month/day output.

## Scope and non-goals

No database migration, new persisted field, manifest version, state enum, IPC shape, dependency, or automatic historical rewrite. Future exports use saved keys; old `.tex` references are not rewritten and no legacy-key mode is added. Existing unparseable date-text behavior is unchanged. Generated DOCX field/run content changes through the existing artifact-version flow.

Full occurrence rendering, CSL bibliography ordering (requires a processor interface extension), and agent access to custom styles are separately scoped and deferred. Unsupported occurrence formatting is explicitly rejected rather than approximated. Clipboard/plain formatting continues to use plain output.

## Acceptance criteria and validation

- Restored unchanged production source and ran the final behavior regressions twice: the same 11 cases failed at the intended behavior assertions. Restored the fixes and reran the affected owner/consumer checks.
- DOCX context protection, sibling and emphasis preservation, key/date round trips, complete-export duplicate checks, and artifact contracts -> focused Literature/shared-CSL/manifest/page suites -> 415 passed.
- Runtime formatter/document/LaTeX consumers -> `vitest run src/main/acp/runtime-base-composition.test.ts src/main/acp/runtime.test.ts` -> 599 passed. The real local HTTP host required execution outside the sandbox; the initial sandbox run failed on `listen EPERM`.
- Main, sandbox and renderer types -> `npm run typecheck` -> passed.
- Linted sources -> `npm run lint` -> passed; formatting and `git diff --check` passed.
- Browser -> real Library and Sources components with controlled records and the real citation service: 201 references reached two format batches with zero save calls; an MLA reformat request with page 17 was rejected and the existing error UI appeared. Screenshots retained as local review artifacts. This is a component/service fixture, not a live application database or Word desktop test.

Checks reflect the final implementation. No full local portable suite was run, as requested by the maintainer; exact-head PR CI remains authoritative. Literature is not a declared selective Module in the impact manifest, so explicit owner and consumer boundaries were used locally instead of claiming the automatic selective plan was complete. OS packaging and Word desktop visual compatibility remain uncovered locally.

## Review focus

Complete-output collision validation must remain at the Library/LaTeX owners: intermediate BibTeX chunks deliberately retain keys, including conflicts, so no silent engine suffix can conceal a duplicate. Review the bounded inline-style conversion, field base-format fallback, and validation before artifact persistence. The four provider adapters, session branches, subscriptions and MCP schemas are unchanged; shared runtime consumers are covered above.
