### PR TITLE
fix(literature): keep collection workflows consistent

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -423,7 +423,7 @@ jobs:
     env:
       VITEST_DEFER_COVERAGE_THRESHOLDS: '1'
       VITEST_PORTABLE_CI: '1'
-    timeout-minutes: 15
+    timeout-minutes: 25
     strategy:
       fail-fast: false
       matrix:

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -1503,6 +1503,142 @@ describe('LiteratureCatalog', () => {
     })
   })
 
+  it.each(['collection', 'project', 'project batch'] as const)(
+    'rejects stale merged identities when linking a single reference to a %s',
+    async (destination) => {
+      const catalog = await setup()
+      const survivor = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      const alias = await catalog.transact({
+        kind: 'create-item',
+        item: candidate({ doi: '10.1234/alias', title: 'Alias' }).item
+      })
+      const reviewed = (await Promise.all([catalog.get(survivor.id), catalog.get(alias.id)])).map(
+        (view) => view!
+      )
+      await catalog.transact({
+        kind: 'merge-items',
+        survivorId: survivor.id,
+        duplicateIds: [alias.id],
+        expectedMetadataRevision: reviewed[0].metadataRevision,
+        expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+          id,
+          metadataRevision,
+          updatedAt
+        })),
+        item: reviewed[0].item
+      })
+      const collection = await catalog.transact({ kind: 'create-collection', name: 'Target' })
+      await expect(catalog.get(alias.id)).resolves.toMatchObject({ id: survivor.id })
+      await expect(
+        catalog.transact(
+          destination === 'collection'
+            ? {
+                kind: 'set-collection-item',
+                collectionId: collection.id,
+                itemId: alias.id,
+                included: true
+              }
+            : destination === 'project batch'
+              ? {
+                  kind: 'set-project-items',
+                  projectId: 'project-1',
+                  itemIds: [alias.id],
+                  included: true,
+                  source: 'library'
+                }
+              : {
+                  kind: 'set-project-item',
+                  projectId: 'project-1',
+                  itemId: alias.id,
+                  included: true,
+                  source: 'library'
+                }
+        )
+      ).rejects.toThrow(/unavailable/i)
+      expect(await client!.literatureCollectionItem.count({ where: { itemId: alias.id } })).toBe(0)
+      expect(await client!.projectLiterature.count({ where: { itemId: alias.id } })).toBe(0)
+    }
+  )
+
+  it.each(['collection', 'project', 'project batch'] as const)(
+    'rejects deleted identities when linking a single reference to a %s',
+    async (destination) => {
+      const catalog = await setup()
+      const item = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      const collection = await catalog.transact({ kind: 'create-collection', name: 'Target' })
+      await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [item.id], state: 'deleted' })
+      await expect(
+        catalog.transact(
+          destination === 'collection'
+            ? {
+                kind: 'set-collection-item',
+                collectionId: collection.id,
+                itemId: item.id,
+                included: true
+              }
+            : destination === 'project batch'
+              ? {
+                  kind: 'set-project-items',
+                  projectId: 'project-1',
+                  itemIds: [item.id],
+                  included: true,
+                  source: 'library'
+                }
+              : {
+                  kind: 'set-project-item',
+                  projectId: 'project-1',
+                  itemId: item.id,
+                  included: true,
+                  source: 'library'
+                }
+        )
+      ).rejects.toThrow(/unavailable/i)
+      expect(await client!.literatureCollectionItem.count({ where: { itemId: item.id } })).toBe(0)
+      expect(await client!.projectLiterature.count({ where: { itemId: item.id } })).toBe(0)
+    }
+  )
+
+  it('preserves an earlier committed collection batch when a later command rejects', async () => {
+    const catalog = await setup()
+    const source = await catalog.transact({ kind: 'create-collection', name: 'Source' })
+    const target = await catalog.transact({ kind: 'create-collection', name: 'Target' })
+    const ids: string[] = []
+    for (let index = 0; index < 201; index++) {
+      const item = await catalog.transact({
+        kind: 'create-item',
+        item: candidate({ doi: `10.1234/batch-${index}`, title: `Reference ${index}` }).item
+      })
+      ids.push(item.id)
+      await catalog.transact({
+        kind: 'set-collection-item',
+        collectionId: source.id,
+        itemId: item.id,
+        included: true
+      })
+    }
+    await catalog.transact({
+      kind: 'move-collection-items',
+      sourceCollectionId: source.id,
+      targetCollectionId: target.id,
+      itemIds: ids.slice(0, 200)
+    })
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [ids[200]], state: 'deleted' })
+    await expect(
+      catalog.transact({
+        kind: 'move-collection-items',
+        sourceCollectionId: source.id,
+        targetCollectionId: target.id,
+        itemIds: [ids[200]]
+      })
+    ).rejects.toThrow(/unavailable/i)
+    await expect(
+      catalog.search({ scope: 'library', collectionId: target.id })
+    ).resolves.toMatchObject({ totalCount: 200 })
+    expect(
+      await client!.literatureCollectionItem.count({ where: { collectionId: source.id } })
+    ).toBe(1)
+  })
+
   it('moves Items between Collections', async () => {
     const catalog = await setup()
     const first = await catalog.transact({ kind: 'create-item', item: candidate().item })

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -1493,6 +1493,10 @@ class LiteratureCatalog {
       return { kind: 'item', id: command.itemId, state: 'unlinked' }
     }
     await client.$transaction(async (transaction) => {
+      const available = await transaction.literatureItem.count({
+        where: { id: command.itemId, deletedAt: null, mergedIntoItemId: null }
+      })
+      if (!available) throw new Error('One or more Literature Items are unavailable.')
       const last = await transaction.literatureCollectionItem.findFirst({
         where: { collectionId: command.collectionId },
         orderBy: { sortOrder: 'desc' },
@@ -1516,25 +1520,11 @@ class LiteratureCatalog {
   private async setProjectItem(
     command: Extract<LiteratureCatalogCommand, { kind: 'set-project-item' }>
   ): Promise<LiteratureCatalogReceipt> {
-    const client = await this.getClient()
-    if (!command.included) {
-      await client.$transaction((transaction) =>
-        transaction.projectLiterature.deleteMany({
-          where: { projectId: command.projectId, itemId: command.itemId }
-        })
-      )
-      return { kind: 'item', id: command.itemId, state: 'unlinked' }
-    }
-    const source = normalizeSpace(command.source)
-    if (!source) throw new Error('Project Literature source is required.')
-    await client.$transaction((transaction) =>
-      transaction.projectLiterature.upsert({
-        where: { projectId_itemId: { projectId: command.projectId, itemId: command.itemId } },
-        create: { projectId: command.projectId, itemId: command.itemId, source },
-        update: { source }
-      })
-    )
-    return { kind: 'item', id: command.itemId, state: 'linked' }
+    return this.setProjectItems({
+      ...command,
+      kind: 'set-project-items',
+      itemIds: [command.itemId]
+    })
   }
 
   private async setProjectItems(
@@ -1552,8 +1542,13 @@ class LiteratureCatalog {
     }
     const source = normalizeSpace(command.source)
     if (!source) throw new Error('Project Literature source is required.')
-    await client.$transaction((transaction) =>
-      Promise.all(
+    await client.$transaction(async (transaction) => {
+      const available = await transaction.literatureItem.count({
+        where: { id: { in: itemIds }, deletedAt: null, mergedIntoItemId: null }
+      })
+      if (available !== itemIds.length)
+        throw new Error('One or more Literature Items are unavailable.')
+      await Promise.all(
         itemIds.map((itemId) =>
           transaction.projectLiterature.upsert({
             where: { projectId_itemId: { projectId: command.projectId, itemId } },
@@ -1562,7 +1557,7 @@ class LiteratureCatalog {
           })
         )
       )
-    )
+    })
     return { kind: 'item', id: itemIds[0]!, state: 'linked' }
   }
 

--- a/src/renderer/src/components/error-notice.tsx
+++ b/src/renderer/src/components/error-notice.tsx
@@ -28,6 +28,7 @@ type ErrorNoticeButton = {
 }
 
 type ErrorNoticeProps = {
+  className?: string
   fullPage?: boolean
   // Announce the summary without reading technical diagnostics or recovery controls.
   role?: 'alert' | 'status'
@@ -102,6 +103,7 @@ const NoticeButton = ({
 }
 
 const ErrorNotice = ({
+  className,
   fullPage = false,
   role,
   children,
@@ -136,7 +138,8 @@ const ErrorNotice = ({
     <section
       className={cn(
         'flex w-full min-w-0 flex-col text-left',
-        compact ? 'gap-3 rounded-lg border border-border bg-card p-4' : 'max-w-md gap-4'
+        compact ? 'gap-3 rounded-lg border border-border bg-card p-4' : 'max-w-md gap-4',
+        className
       )}
     >
       {fullPage ? <FlaskLogo className="mb-4 size-18 self-center text-text-300" /> : null}

--- a/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
+++ b/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
@@ -163,6 +163,7 @@ export const CollectionEditorDialog = forwardRef<
                 </label>
                 <Input
                   id="collection-form-name"
+                  disabled={saving}
                   aria-required={true}
                   value={name}
                   onChange={(event) => setName(event.target.value)}
@@ -203,6 +204,7 @@ export const CollectionEditorDialog = forwardRef<
                 </div>
                 <Textarea
                   id="collection-form-description"
+                  disabled={saving}
                   value={description}
                   onChange={(event) => setDescription(event.target.value)}
                   placeholder={t('Describe what this collection is for…')}

--- a/src/renderer/src/pages/literature/LiteratureBatchDestinationMenus.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchDestinationMenus.tsx
@@ -41,6 +41,10 @@ const LiteratureBatchDestinationMenus = ({
   const { t } = useTranslation()
   const [collectionCreateMode, setCollectionCreateMode] = useState(false)
   const [collectionName, setCollectionName] = useState('')
+  const [collectionQuery, setCollectionQuery] = useState('')
+  const visibleCollections = collections.filter((collection) =>
+    collection.name.toLocaleLowerCase().includes(collectionQuery.trim().toLocaleLowerCase())
+  )
   const [projectQuery, setProjectQuery] = useState('')
   const normalizedProjectQuery =
     projects.length > SEARCH_THRESHOLD ? projectQuery.trim().toLocaleLowerCase() : ''
@@ -57,6 +61,7 @@ const LiteratureBatchDestinationMenus = ({
           if (!open) {
             setCollectionCreateMode(false)
             setCollectionName('')
+            setCollectionQuery('')
           }
         }}
       >
@@ -83,9 +88,24 @@ const LiteratureBatchDestinationMenus = ({
           <div className="px-2 pb-1 pt-0.5 text-xs font-medium text-muted-foreground">
             {t('Collections')}
           </div>
+          {collections.length > SEARCH_THRESHOLD ? (
+            <Input
+              type="search"
+              aria-label={t('Search collections')}
+              placeholder={t('Search collections…')}
+              value={collectionQuery}
+              onChange={(event) => setCollectionQuery(event.target.value)}
+              className="mb-1 h-8 text-xs"
+            />
+          ) : null}
           {collections.length > 0 ? (
             <div className="max-h-56 overflow-y-auto">
-              {collections.map((collection) => (
+              {visibleCollections.length === 0 ? (
+                <p className="px-2 py-3 text-sm text-muted-foreground">
+                  {t('No matching collections')}
+                </p>
+              ) : null}
+              {visibleCollections.map((collection) => (
                 <PopoverClose key={collection.id} asChild>
                   <button
                     type="button"
@@ -133,6 +153,7 @@ const LiteratureBatchDestinationMenus = ({
               >
                 <Input
                   autoFocus
+                  disabled={disabled}
                   value={collectionName}
                   onChange={(event) => setCollectionName(event.target.value)}
                   placeholder={t('New collection')}

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -4815,6 +4815,7 @@ describe('LiteratureLibraryPage', () => {
           createdAt: 1,
           updatedAt: 1
         })
+      get.mockImplementation(async (id: string) => createLibraryItem(Number(id.slice(5))))
       let linked = 0
       search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
         if (request.scope === 'collections')
@@ -4921,6 +4922,93 @@ describe('LiteratureLibraryPage', () => {
         destination === 'new collection' ? 1 : 0
       )
       expect(linked).toBe(201)
+      transact.mockReset().mockResolvedValue({ kind: 'item', id: 'item-1', state: 'present' })
+    }
+  )
+
+  it.each(['navigation', 'deleted', 'merged'] as const)(
+    'finishes valid batch references after %s changes',
+    async (change) => {
+      const entries = Array.from({ length: 202 }, (_, index) => createLibraryItem(index))
+      let invalid = false
+      const linked: string[] = []
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => {
+        if (request.scope === 'collections')
+          return {
+            entries: [
+              {
+                id: 'source',
+                name: 'Source',
+                description: '',
+                itemCount: 202,
+                createdAt: 1,
+                updatedAt: 1
+              },
+              {
+                id: 'target',
+                name: 'Target',
+                description: '',
+                itemCount: linked.length,
+                createdAt: 1,
+                updatedAt: 1
+              }
+            ]
+          }
+        if (request.scope !== 'library') return { entries: [] }
+        const active = entries.filter(
+          (e) => !(invalid && e.id === 'item-200') && !linked.includes(e.id)
+        )
+        const offset = request.offset ?? 0
+        const limit = request.limit ?? 100
+        return {
+          entries: active.slice(offset, offset + limit),
+          totalCount: active.length,
+          nextOffset: offset + limit < active.length ? offset + limit : undefined
+        }
+      })
+      get.mockImplementation(async (id: string) => {
+        if (invalid && id === 'item-200') return change === 'merged' ? entries[0] : undefined
+        return entries.find((e) => e.id === id)
+      })
+      let release!: () => void
+      transact.mockImplementation(async (command) => {
+        if (!linked.length && change === 'navigation')
+          await new Promise<void>((resolve) => {
+            release = resolve
+          })
+        if (command.itemIds.includes('item-200') && change !== 'navigation') {
+          invalid = true
+          throw new Error('One or more Literature Items are unavailable.')
+        }
+        linked.push(...command.itemIds)
+        return { kind: 'item', id: command.itemIds[0], state: 'linked' }
+      })
+      useNavigationStore.setState({ pendingLiteratureCollectionId: 'source' })
+      render(<LiteratureLibraryPage />)
+      await screen.findByText('Reference 0')
+      fireEvent.click(screen.getByLabelText('Select all references'))
+      fireEvent.click(screen.getByRole('button', { name: 'Select all matching references 202' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }))
+      fireEvent.click(
+        within(
+          document.querySelector<HTMLElement>('[data-slot="literature-batch-collection-popover"]')!
+        ).getByRole('button', { name: 'Target' })
+      )
+      if (change === 'navigation') {
+        await waitFor(() => expect(release).toBeDefined())
+        fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+        await act(async () => {})
+        await act(async () => release())
+        expect(linked).toHaveLength(202)
+      } else {
+        await screen.findByText('Updated: 200. Not updated: 2.')
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        await act(async () => {})
+        expect(linked).toHaveLength(201)
+        expect(transact.mock.calls.at(-1)?.[0].itemIds).toEqual(['item-201'])
+        expect(screen.getByText('Updated: 201. Not updated: 0. Unavailable: 1.')).not.toBeNull()
+        expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+      }
       transact.mockReset().mockResolvedValue({ kind: 'item', id: 'item-1', state: 'present' })
     }
   )

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -417,6 +417,7 @@ describe('LiteratureLibraryPage', () => {
   afterEach(() => {
     cleanup()
     vi.clearAllMocks()
+    transact.mockReset().mockResolvedValue({ kind: 'item', id: 'item-1', state: 'present' })
     vi.unstubAllGlobals()
   })
 
@@ -4785,6 +4786,358 @@ describe('LiteratureLibraryPage', () => {
     expect(screen.getByRole('menuitem', { name: 'Edit' })).not.toBeNull()
     expect(filePreviewRenderCount.value).toBe(0)
   })
+
+  it.each([
+    ['collection', 2],
+    ['project', 2],
+    ['new collection', 2],
+    ['new collection', 1]
+  ] as const)(
+    'synchronizes partial %s batches after command %i fails and retries only remaining references',
+    async (destination, failedBatch) => {
+      let items = Array.from({ length: 201 }, (_, index) => createLibraryItem(index))
+      const collections = [
+        {
+          id: 'source',
+          name: 'Source',
+          description: '',
+          itemCount: 201,
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ]
+      if (destination !== 'new collection')
+        collections.push({
+          id: 'target',
+          name: 'Target',
+          description: '',
+          itemCount: 0,
+          createdAt: 1,
+          updatedAt: 1
+        })
+      let linked = 0
+      search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+        if (request.scope === 'collections')
+          return Promise.resolve({
+            entries: collections.map((c) => ({
+              ...c,
+              itemCount: c.id === 'source' ? items.length : linked
+            })),
+            totalCount: collections.length
+          })
+        if (request.scope === 'project-counts')
+          return Promise.resolve({
+            entries: linked ? [{ projectId: 'project-1', itemCount: linked }] : []
+          })
+        if (request.scope !== 'library') return Promise.resolve({ entries: [], totalCount: 0 })
+        const offset = request.offset ?? 0
+        const limit = request.limit ?? 100
+        return Promise.resolve({
+          entries: items.slice(offset, offset + limit),
+          totalCount: items.length,
+          nextOffset: offset + limit < items.length ? offset + limit : undefined
+        })
+      })
+      let batches = 0
+      transact.mockImplementation(async (command) => {
+        if (command.kind === 'create-collection') {
+          if (collections.some((c) => c.id === 'target'))
+            throw new Error('literature_collection_name_conflict')
+          collections.push({
+            id: 'target',
+            name: command.name,
+            description: '',
+            itemCount: 0,
+            createdAt: 1,
+            updatedAt: 1
+          })
+          return { kind: 'collection', id: 'target' }
+        }
+        batches++
+        if (batches === failedBatch)
+          throw new Error('One or more Literature Items are unavailable.')
+        linked += command.itemIds.length
+        if (destination !== 'project')
+          items = items.filter(({ id }) => !command.itemIds.includes(id))
+        return { kind: 'item', id: command.itemIds[0], state: 'linked' }
+      })
+      useNavigationStore.setState({ pendingLiteratureCollectionId: 'source' })
+      render(<LiteratureLibraryPage />)
+      await screen.findByText('Reference 0')
+      fireEvent.click(screen.getByLabelText('Select all references'))
+      fireEvent.click(screen.getByRole('button', { name: 'Select all matching references 201' }))
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: destination === 'project' ? 'Add to project' : 'Move to collection'
+        })
+      )
+      const popover = document.querySelector<HTMLElement>(
+        destination === 'project'
+          ? '[data-slot="literature-batch-project-popover"]'
+          : '[data-slot="literature-batch-collection-popover"]'
+      )!
+      if (destination === 'new collection') {
+        fireEvent.click(within(popover).getByRole('button', { name: 'New collection' }))
+        fireEvent.change(within(popover).getByLabelText('Collection name'), {
+          target: { value: 'Target' }
+        })
+        fireEvent.click(within(popover).getByRole('button', { name: 'Create collection' }))
+      } else {
+        fireEvent.click(
+          within(popover).getByRole('button', {
+            name: destination === 'project' ? 'Retrieval research' : 'Target'
+          })
+        )
+      }
+      await act(async () => {})
+      const completed = (failedBatch - 1) * 200
+      expect(batches).toBe(failedBatch)
+      expect(linked).toBe(completed)
+      if (destination !== 'project' && completed > 0)
+        expect.soft(screen.queryByText('Reference 0')).toBeNull()
+      expect.soft(screen.queryByText(`${201 - completed} selected`)).not.toBeNull()
+      expect
+        .soft(screen.queryByText(`Updated: ${completed}. Not updated: ${201 - completed}.`))
+        .not.toBeNull()
+      const countButton = screen
+        .queryAllByRole('button', {
+          name: destination === 'project' ? 'Retrieval research' : 'Target'
+        })
+        .find((button) => button.hasAttribute('aria-label'))
+      expect.soft(countButton).toBeDefined()
+      if (countButton)
+        expect.soft(within(countButton).queryByText(String(completed))).not.toBeNull()
+      const retry = screen.queryByRole('button', { name: 'Retry' })
+      expect(retry).not.toBeNull()
+      fireEvent.click(retry!)
+      await act(async () => {})
+      expect(transact.mock.calls.at(-1)?.[0]).toMatchObject({
+        itemIds: ['item-200'],
+        ...(destination === 'project'
+          ? { projectId: 'project-1' }
+          : { targetCollectionId: 'target' })
+      })
+      expect(transact.mock.calls.filter(([c]) => c.kind === 'create-collection')).toHaveLength(
+        destination === 'new collection' ? 1 : 0
+      )
+      expect(linked).toBe(201)
+      transact.mockReset().mockResolvedValue({ kind: 'item', id: 'item-1', state: 'present' })
+    }
+  )
+
+  it('ignores a failed collection request after navigating to a different scope', async () => {
+    const sourceItem = createLibraryItem(0)
+    const otherItem = createLibraryItem(1)
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve(
+        request.scope === 'collections'
+          ? {
+              entries: [
+                {
+                  id: 'source',
+                  name: 'Source',
+                  description: '',
+                  itemCount: 1,
+                  createdAt: 1,
+                  updatedAt: 1
+                },
+                {
+                  id: 'target',
+                  name: 'Target',
+                  description: '',
+                  itemCount: 0,
+                  createdAt: 1,
+                  updatedAt: 1
+                }
+              ]
+            }
+          : request.scope === 'library'
+            ? { entries: request.collectionId ? [sourceItem] : [otherItem], totalCount: 1 }
+            : { entries: [] }
+      )
+    )
+    let reject!: (error: Error) => void
+    transact.mockImplementationOnce(
+      () =>
+        new Promise((_resolve, fail) => {
+          reject = fail
+        })
+    )
+    useNavigationStore.setState({ pendingLiteratureCollectionId: 'source' })
+    render(<LiteratureLibraryPage />)
+    await screen.findByText('Reference 0')
+    fireEvent.click(screen.getByLabelText('Select all references'))
+    fireEvent.click(screen.getByRole('button', { name: 'Move to collection' }))
+    fireEvent.click(
+      within(
+        document.querySelector<HTMLElement>('[data-slot="literature-batch-collection-popover"]')!
+      ).getByRole('button', { name: 'Target' })
+    )
+    await waitFor(() => expect(transact).toHaveBeenCalledTimes(1))
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await screen.findByText('Reference 1')
+    await act(async () => {})
+    fireEvent.click(screen.getByLabelText('Select all references'))
+    await act(async () => reject(new Error('Unavailable')))
+    expect(screen.queryByText('Collection link could not be updated.')).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+    expect((screen.getByLabelText('Select Reference 1') as HTMLInputElement).checked).toBe(true)
+    expect(screen.getByText('1 selected')).not.toBeNull()
+  })
+
+  it('removes an unlinked reference from its current collection and selection', async () => {
+    let included = true
+    const entry = { ...libraryItem, collectionIds: ['source'] }
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve(
+        request.scope === 'collections'
+          ? {
+              entries: [
+                {
+                  id: 'source',
+                  name: 'Source',
+                  description: '',
+                  itemCount: included ? 1 : 0,
+                  createdAt: 1,
+                  updatedAt: 1
+                }
+              ]
+            }
+          : request.scope === 'library'
+            ? { entries: included ? [entry] : [], totalCount: included ? 1 : 0 }
+            : { entries: [], totalCount: 0 }
+      )
+    )
+    transact.mockImplementationOnce(async () => {
+      included = false
+      return { kind: 'item', id: entry.id, state: 'unlinked' }
+    })
+    useNavigationStore.setState({ pendingLiteratureCollectionId: 'source' })
+    render(<LiteratureLibraryPage />)
+    await screen.findByText(entry.item.title)
+    fireEvent.click(screen.getByLabelText('Select all references'))
+    await openReferenceDetail(screen.getByText(entry.item.title))
+    fireEvent.click(await screen.findByRole('checkbox', { name: 'Source' }))
+    await act(async () => {})
+    expect(included).toBe(false)
+    expect(transact).toHaveBeenCalledWith({
+      kind: 'set-collection-item',
+      collectionId: 'source',
+      itemId: entry.id,
+      included: false
+    })
+    const detail = screen.queryByRole('dialog')
+    if (detail) fireEvent.click(within(detail).getByRole('button', { name: 'Close' }))
+    await act(async () => {})
+    expect.soft(screen.queryByRole('checkbox', { name: `Select ${entry.item.title}` })).toBeNull()
+    expect.soft(screen.queryByText('1 selected')).toBeNull()
+    expect(within(screen.getByRole('button', { name: 'Source' })).getByText('0')).not.toBeNull()
+  })
+
+  it('distinguishes nested collection paths in navigation, destinations and detail links', async () => {
+    const collections = [
+      { id: 'a', name: 'Parent A' },
+      { id: 'b', name: 'Parent B' },
+      { id: 'ar', name: 'Review', parentId: 'a' },
+      { id: 'br', name: 'Review', parentId: 'b' },
+      { id: 'extra1', name: 'Extra 1' },
+      { id: 'extra2', name: 'Extra 2' }
+    ].map((c) => ({ ...c, description: '', itemCount: 0, createdAt: 1, updatedAt: 1 }))
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve(
+        request.scope === 'collections'
+          ? { entries: collections, totalCount: 4 }
+          : request.scope === 'library'
+            ? { entries: [libraryItem], totalCount: 1 }
+            : { entries: [] }
+      )
+    )
+    render(<LiteratureLibraryPage />)
+    await act(async () => {})
+    expect.soft(screen.queryByRole('button', { name: 'Parent A / Review' })).not.toBeNull()
+    expect.soft(screen.queryByRole('button', { name: 'Parent B / Review' })).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await screen.findByText(libraryItem.item.title)
+    fireEvent.click(screen.getByLabelText('Select all references'))
+    fireEvent.click(screen.getByRole('button', { name: 'Add to collection' }))
+    const popover = document.querySelector<HTMLElement>(
+      '[data-slot="literature-batch-collection-popover"]'
+    )!
+    expect.soft(within(popover).queryByRole('button', { name: 'Parent A / Review' })).not.toBeNull()
+    expect.soft(within(popover).queryByRole('button', { name: 'Parent B / Review' })).not.toBeNull()
+    const searchCollections = within(popover).queryByLabelText('Search collections')
+    expect.soft(searchCollections).not.toBeNull()
+    if (searchCollections) {
+      fireEvent.change(searchCollections, { target: { value: 'Parent A / Review' } })
+      expect
+        .soft(within(popover).queryByRole('button', { name: 'Parent A / Review' }))
+        .not.toBeNull()
+      expect.soft(within(popover).queryByRole('button', { name: 'Parent B / Review' })).toBeNull()
+    }
+    fireEvent.keyDown(popover, { key: 'Escape' })
+    await openReferenceDetail(screen.getByText(libraryItem.item.title))
+    expect.soft(screen.queryByRole('checkbox', { name: 'Parent A / Review' })).not.toBeNull()
+    expect.soft(screen.queryByRole('checkbox', { name: 'Parent B / Review' })).not.toBeNull()
+    fireEvent.change(screen.getByLabelText('Search collections'), {
+      target: { value: 'Parent B / Review' }
+    })
+    expect.soft(screen.queryByRole('checkbox', { name: 'Parent B / Review' })).not.toBeNull()
+    expect.soft(screen.queryByRole('checkbox', { name: 'Parent A / Review' })).toBeNull()
+  })
+
+  it.each(['create', 'edit'] as const)(
+    'locks collection drafts during a pending %s save',
+    async (mode) => {
+      search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+        Promise.resolve(
+          request.scope === 'collections'
+            ? {
+                entries: [
+                  {
+                    id: 'source',
+                    name: 'Original',
+                    description: '',
+                    itemCount: 0,
+                    createdAt: 1,
+                    updatedAt: 1
+                  }
+                ]
+              }
+            : { entries: [] }
+        )
+      )
+      let finish!: () => void
+      transact.mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = () => resolve({ kind: 'collection', id: 'source' })
+          })
+      )
+      if (mode === 'edit') useNavigationStore.setState({ pendingLiteratureCollectionId: 'source' })
+      render(<LiteratureLibraryPage />)
+      if (mode === 'edit') {
+        await screen.findByRole('heading', { name: 'Original' })
+        await openMenu(screen.getByRole('button', { name: 'Collection actions' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Edit collection' }))
+      } else fireEvent.click(screen.getByRole('button', { name: 'New collection' }))
+      const dialog = await screen.findByRole('dialog')
+      fireEvent.change(within(dialog).getByLabelText('Name'), { target: { value: 'Original' } })
+      fireEvent.click(
+        within(dialog).getByRole('button', {
+          name: mode === 'create' ? 'Create collection' : 'Save changes'
+        })
+      )
+      await act(async () => {})
+      expect.soft((within(dialog).getByLabelText('Name') as HTMLInputElement).disabled).toBe(true)
+      expect
+        .soft((within(dialog).getByLabelText('Description') as HTMLTextAreaElement).disabled)
+        .toBe(true)
+      await act(async () => finish())
+      expect(screen.queryByRole('dialog')).toBeNull()
+      expect(transact).toHaveBeenCalledTimes(1)
+      expect(transact.mock.calls[0][0]).toMatchObject({ name: 'Original', description: '' })
+    }
+  )
 
   it('refreshes committed references when a later lifecycle batch fails', async () => {
     let items = Array.from({ length: 201 }, (_, index) => createLibraryItem(index))

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1264,6 +1264,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     itemIds: readonly string[]
     completed: number
     scopeKey: string
+    skipped: number
   }>()
   const [linkedItemError, setLinkedItemError] = useState<string>()
   const [pendingCandidateId, setPendingCandidateId] = useState<string>()
@@ -2653,7 +2654,9 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const runLinkBatch = async (
     command: NonNullable<typeof linkFailure>['command'],
     itemIds?: readonly string[],
-    previousCompleted = 0
+    previousCompleted = 0,
+    previousSkipped = 0,
+    reconcile = false
   ): Promise<void> => {
     const scopeKey = entriesKey
     setIsBatching(true)
@@ -2661,15 +2664,43 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     setLinkFailure(undefined)
     let resolvedIds: readonly string[] = itemIds ?? []
     let completed = 0
+    let skipped = previousSkipped
     try {
       resolvedIds = itemIds ?? (await resolveSelectedItemIds())
+      if (reconcile) {
+        const activeIds: string[] = []
+        for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
+          const batch = resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE)
+          const entries = await Promise.all(batch.map((id) => window.api.literature.get(id)))
+          entries.forEach((entry, index) => {
+            // get resolves merged aliases; never redirect the original association intent.
+            if (
+              entry?.id === batch[index] &&
+              entry.deletedAt === undefined &&
+              entry.mergedIntoItemId === undefined
+            )
+              activeIds.push(batch[index])
+          })
+        }
+        skipped += resolvedIds.length - activeIds.length
+        resolvedIds = activeIds
+      }
       for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
-        if (linkScopeRef.current !== scopeKey) return
         const batch = resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE)
         await window.api.literature.transact({ ...command, itemIds: [...batch] })
         completed += batch.length
       }
-      if (linkScopeRef.current === scopeKey) clearSelection()
+      if (linkScopeRef.current === scopeKey) {
+        clearSelection()
+        if (skipped)
+          setLinkFailure({
+            command,
+            itemIds: [],
+            completed: previousCompleted + completed,
+            scopeKey,
+            skipped
+          })
+      }
     } catch {
       if (linkScopeRef.current === scopeKey) {
         if (resolvedIds.length) {
@@ -2679,6 +2710,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
             command,
             itemIds: remaining,
             completed: previousCompleted + completed,
+            skipped,
             scopeKey
           })
         } else {
@@ -2723,16 +2755,14 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       if (linkScopeRef.current !== scopeKey) return false
       const receipt = await window.api.literature.transact({ kind: 'create-collection', name })
       void loadCollections().catch(() => undefined)
-      if (linkScopeRef.current === scopeKey) {
-        await runLinkBatch(
-          {
-            kind: 'move-collection-items',
-            targetCollectionId: receipt.id,
-            ...(collectionId ? { sourceCollectionId: collectionId } : {})
-          },
-          itemIds
-        )
-      }
+      await runLinkBatch(
+        {
+          kind: 'move-collection-items',
+          targetCollectionId: receipt.id,
+          ...(collectionId ? { sourceCollectionId: collectionId } : {})
+        },
+        itemIds
+      )
       // Creation succeeded even if association needs Retry; retire the creation form.
       return true
     } catch (error) {
@@ -3814,20 +3844,37 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
             <div className="mt-2">
               <LiteratureErrorNotice
                 className="w-fit max-w-full rounded-md px-3 py-1.5 [&>div]:items-center"
-                description={t('Updated: {{completed}}. Not updated: {{remaining}}.', {
-                  completed: linkFailure.completed,
-                  remaining: linkFailure.itemIds.length
-                })}
-                primaryButton={{
-                  label: t('Retry'),
-                  disabled: isBatching,
-                  onClick: () =>
-                    void runLinkBatch(
-                      linkFailure.command,
-                      linkFailure.itemIds,
-                      linkFailure.completed
-                    )
-                }}
+                description={
+                  linkFailure.skipped
+                    ? t(
+                        'Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.',
+                        {
+                          completed: linkFailure.completed,
+                          remaining: linkFailure.itemIds.length,
+                          skipped: linkFailure.skipped
+                        }
+                      )
+                    : t('Updated: {{completed}}. Not updated: {{remaining}}.', {
+                        completed: linkFailure.completed,
+                        remaining: linkFailure.itemIds.length
+                      })
+                }
+                primaryButton={
+                  linkFailure.itemIds.length
+                    ? {
+                        label: t('Retry'),
+                        disabled: isBatching,
+                        onClick: () =>
+                          void runLinkBatch(
+                            linkFailure.command,
+                            linkFailure.itemIds,
+                            linkFailure.completed,
+                            linkFailure.skipped,
+                            true
+                          )
+                      }
+                    : undefined
+                }
               />
             </div>
           ) : null}

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -3811,18 +3811,14 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
             />
           ) : null}
           {linkFailure && linkFailure.scopeKey === entriesKey ? (
-            <div className="mt-5">
+            <div className="mt-2">
               <LiteratureErrorNotice
-                title={
-                  linkFailure.command.kind === 'move-collection-items'
-                    ? t('Collection link could not be updated.')
-                    : t('Project link could not be updated.')
-                }
+                className="w-fit max-w-full rounded-md px-3 py-1.5 [&>div]:items-center"
                 description={t('Updated: {{completed}}. Not updated: {{remaining}}.', {
                   completed: linkFailure.completed,
                   remaining: linkFailure.itemIds.length
                 })}
-                secondaryButton={{
+                primaryButton={{
                   label: t('Retry'),
                   disabled: isBatching,
                   onClick: () =>

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -102,6 +102,7 @@ import { LiteratureBackgroundTasks } from './LiteratureBackgroundTasks'
 import { LiteratureTable, LiteratureTextTooltip } from './LiteratureTable'
 import { buildLiteratureMergeItem, mergeScalarFields } from './literature-merge'
 import type {
+  LiteratureCatalogCommand,
   LiteratureCatalogSearchRequest,
   LiteratureCatalogSearchPage,
   LiteratureCollectionView,
@@ -1256,6 +1257,14 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     state: 'active' | 'deleted'
     completed: number
   }>()
+  const [linkFailure, setLinkFailure] = useState<{
+    command:
+      | Omit<Extract<LiteratureCatalogCommand, { kind: 'move-collection-items' }>, 'itemIds'>
+      | Omit<Extract<LiteratureCatalogCommand, { kind: 'set-project-items' }>, 'itemIds'>
+    itemIds: readonly string[]
+    completed: number
+    scopeKey: string
+  }>()
   const [linkedItemError, setLinkedItemError] = useState<string>()
   const [pendingCandidateId, setPendingCandidateId] = useState<string>()
   const [dismissedCandidateUndo, setDismissedCandidateUndo] = useState<DismissedCandidateUndo>()
@@ -1489,6 +1498,13 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       tagId
     ]
   )
+  const linkScopeRef = useRef(entriesKey)
+  useLayoutEffect(() => {
+    linkScopeRef.current = entriesKey
+    return () => {
+      linkScopeRef.current = ''
+    }
+  }, [entriesKey])
   const entriesPage = Math.floor(entriesOffset / entriesPageSize) + 1
   const entriesPageCount = Math.max(1, Math.ceil(entriesTotalCount / entriesPageSize))
   const displayedEntryCount = section === 'inbox' ? candidates.length : items.length
@@ -1650,6 +1666,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       setEntriesOffset(0)
       clearSelection()
       setLifecycleFailure(undefined)
+      setLinkFailure(undefined)
     }, 0)
     return () => window.clearTimeout(timeout)
   }, [clearSelection, entriesKey])
@@ -1701,9 +1718,25 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     window.sessionStorage.setItem(LITERATURE_REVIEW_CTA_ATTENTION_KEY, 'true')
   }, [shouldCueLiteratureReview, showLiteratureReviewAction])
 
+  const displayCollections = useMemo(() => {
+    const byId = new Map(collections.map((collection) => [collection.id, collection]))
+    return collections.map((collection) => {
+      const names = [collection.name]
+      const seen = new Set([collection.id])
+      let parentId = collection.parentId
+      while (parentId && !seen.has(parentId)) {
+        seen.add(parentId)
+        const parent = byId.get(parentId)
+        if (!parent) break
+        names.unshift(parent.name)
+        parentId = parent.parentId
+      }
+      return { ...collection, name: names.join(' / ') }
+    })
+  }, [collections])
   const batchCollections = useMemo(
-    () => collections.filter((collection) => collection.id !== collectionId),
-    [collectionId, collections]
+    () => displayCollections.filter((collection) => collection.id !== collectionId),
+    [collectionId, displayCollections]
   )
   const itemTypeLabels = useMemo<Record<LiteratureItemType, string>>(
     () => ({
@@ -2066,6 +2099,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         included
       })
       updateCollectionLinkState(included)
+      if (!included && targetCollectionId === collectionId) {
+        selectionStore.remove(itemId)
+        setItems((current) => current.filter((item) => item.id !== itemId))
+        setEntriesTotalCount((current) => Math.max(0, current - 1))
+        await loadEntries(true)
+      }
       return true
     } catch {
       setCollectionLinkError(t('Collection link could not be updated.'))
@@ -2611,37 +2650,64 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     }
   }
 
-  const linkSelectedItemsToCollection = async (targetCollectionId: string): Promise<void> => {
-    const resolvedIds = await resolveSelectedItemIds()
-    for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
-      await window.api.literature.transact({
-        kind: 'move-collection-items',
-        itemIds: resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE),
-        targetCollectionId,
-        ...(collectionId ? { sourceCollectionId: collectionId } : {})
-      })
+  const runLinkBatch = async (
+    command: NonNullable<typeof linkFailure>['command'],
+    itemIds?: readonly string[],
+    previousCompleted = 0
+  ): Promise<void> => {
+    const scopeKey = entriesKey
+    setIsBatching(true)
+    setError(undefined)
+    setLinkFailure(undefined)
+    let resolvedIds: readonly string[] = itemIds ?? []
+    let completed = 0
+    try {
+      resolvedIds = itemIds ?? (await resolveSelectedItemIds())
+      for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
+        if (linkScopeRef.current !== scopeKey) return
+        const batch = resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE)
+        await window.api.literature.transact({ ...command, itemIds: [...batch] })
+        completed += batch.length
+      }
+      if (linkScopeRef.current === scopeKey) clearSelection()
+    } catch {
+      if (linkScopeRef.current === scopeKey) {
+        if (resolvedIds.length) {
+          const remaining = resolvedIds.slice(completed)
+          selectionStore.replace(remaining)
+          setLinkFailure({
+            command,
+            itemIds: remaining,
+            completed: previousCompleted + completed,
+            scopeKey
+          })
+        } else {
+          setError(t('Selected references could not be loaded.'))
+        }
+      }
+    } finally {
+      const refreshed = await Promise.allSettled([
+        ...(linkScopeRef.current === scopeKey ? [loadEntries(true)] : []),
+        loadCollections(),
+        loadProjectCounts()
+      ])
+      if (
+        linkScopeRef.current === scopeKey &&
+        refreshed.some((result) => result.status === 'rejected')
+      ) {
+        setError(t('Literature could not be loaded.'))
+      }
+      setIsBatching(false)
     }
   }
 
   const moveSelectedItems = async (targetCollectionId: string): Promise<void> => {
-    const selection = selectionStore.getSnapshot()
-    if (
-      !targetCollectionId ||
-      (!selection.allMatchingSelected && selection.selectedIds.size === 0) ||
-      isBatching
-    )
-      return
-    setIsBatching(true)
-    setError(undefined)
-    try {
-      await linkSelectedItemsToCollection(targetCollectionId)
-      clearSelection()
-      await Promise.all([loadEntries(true), loadCollections()])
-    } catch {
-      setError(t('Collection link could not be updated.'))
-    } finally {
-      setIsBatching(false)
-    }
+    if (!targetCollectionId || isBatching) return
+    await runLinkBatch({
+      kind: 'move-collection-items',
+      targetCollectionId,
+      ...(collectionId ? { sourceCollectionId: collectionId } : {})
+    })
   }
 
   const createCollectionForSelection = async (name: string): Promise<boolean> => {
@@ -2650,22 +2716,32 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       return false
     setIsBatching(true)
     setError(undefined)
-    let collectionCreated = false
+    const scopeKey = entriesKey
     try {
+      // Resolve before creating so every continuation has a fixed reference set.
+      const itemIds = await resolveSelectedItemIds()
+      if (linkScopeRef.current !== scopeKey) return false
       const receipt = await window.api.literature.transact({ kind: 'create-collection', name })
-      collectionCreated = true
-      await linkSelectedItemsToCollection(receipt.id)
-      clearSelection()
-      await Promise.all([loadEntries(true), loadCollections()])
+      void loadCollections().catch(() => undefined)
+      if (linkScopeRef.current === scopeKey) {
+        await runLinkBatch(
+          {
+            kind: 'move-collection-items',
+            targetCollectionId: receipt.id,
+            ...(collectionId ? { sourceCollectionId: collectionId } : {})
+          },
+          itemIds
+        )
+      }
+      // Creation succeeded even if association needs Retry; retire the creation form.
       return true
     } catch (error) {
-      setError(
-        collectionCreated
-          ? t('Collection link could not be updated.')
-          : error instanceof Error && error.message.includes(LITERATURE_COLLECTION_NAME_CONFLICT)
+      if (linkScopeRef.current === scopeKey)
+        setError(
+          error instanceof Error && error.message.includes(LITERATURE_COLLECTION_NAME_CONFLICT)
             ? t('A collection with this name already exists at this level. Choose another name.')
             : t('Collection could not be created.')
-      )
+        )
       return false
     } finally {
       setIsBatching(false)
@@ -2673,33 +2749,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }
 
   const addSelectedItemsToProject = async (projectId: string): Promise<void> => {
-    const selection = selectionStore.getSnapshot()
-    if (
-      !projectId ||
-      (!selection.allMatchingSelected && selection.selectedIds.size === 0) ||
-      isBatching
-    )
-      return
-    setIsBatching(true)
-    setError(undefined)
-    try {
-      const resolvedIds = await resolveSelectedItemIds()
-      for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
-        await window.api.literature.transact({
-          kind: 'set-project-items',
-          projectId,
-          itemIds: resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE),
-          included: true,
-          source: 'library'
-        })
-      }
-      clearSelection()
-      await Promise.all([loadEntries(true), loadProjectCounts()])
-    } catch {
-      setError(t('Project link could not be updated.'))
-    } finally {
-      setIsBatching(false)
-    }
+    if (!projectId || isBatching) return
+    await runLinkBatch({ kind: 'set-project-items', projectId, included: true, source: 'library' })
   }
 
   const batchProjectFormDialog = useProjectFormDialog({
@@ -3138,7 +3189,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                 />
                 <LiteratureSidebarGroup
                   collapsed={sidebarCollapsed}
-                  entries={collections}
+                  entries={displayCollections}
                   groupId="literature-sidebar-collections"
                   label={t('Collections')}
                   action={
@@ -3758,6 +3809,31 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
               onClose={() => setBatchLookup(undefined)}
               onChanged={receiveBackgroundItems}
             />
+          ) : null}
+          {linkFailure && linkFailure.scopeKey === entriesKey ? (
+            <div className="mt-5">
+              <LiteratureErrorNotice
+                title={
+                  linkFailure.command.kind === 'move-collection-items'
+                    ? t('Collection link could not be updated.')
+                    : t('Project link could not be updated.')
+                }
+                description={t('Updated: {{completed}}. Not updated: {{remaining}}.', {
+                  completed: linkFailure.completed,
+                  remaining: linkFailure.itemIds.length
+                })}
+                secondaryButton={{
+                  label: t('Retry'),
+                  disabled: isBatching,
+                  onClick: () =>
+                    void runLinkBatch(
+                      linkFailure.command,
+                      linkFailure.itemIds,
+                      linkFailure.completed
+                    )
+                }}
+              />
+            </div>
           ) : null}
           {lifecycleFailure ? (
             <div className="mt-5">
@@ -5142,7 +5218,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                           <LiteratureDetailLinkList
                             key={`${selectedItem.id}:collections`}
                             checkedIds={selectedItem.collectionIds}
-                            entries={collections}
+                            entries={displayCollections}
                             error={collectionLinkError}
                             kind="collections"
                             onCheckedChange={setCollectionLink}

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4845,6 +4845,7 @@
     "{{count}} background tasks_other": "{{count}} Hintergrundaufgaben",
     "{{count}} running background tasks_one": "{{count}} laufende Hintergrundaufgabe",
     "{{count}} running background tasks_other": "{{count}} laufende Hintergrundaufgaben",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "Aktualisiert: {{completed}}. Nicht aktualisiert: {{remaining}}. Nicht verfügbar: {{skipped}}.",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "Aktualisiert: {{completed}}. Nicht aktualisiert: {{remaining}}.",
     "Conflicting identifiers": "Widersprüchliche Kennungen",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Einige Kennungen widersprechen sich oder passen zu verschiedenen Referenzen. Korrigieren Sie die Quelldatei oder behalten Sie jede Referenz dieses Imports als separate Kopie.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5006,6 +5006,7 @@
     "{{count}} running background tasks_one": "{{count}} tarea en segundo plano en ejecución",
     "{{count}} running background tasks_many": "{{count}} tareas en segundo plano en ejecución",
     "{{count}} running background tasks_other": "{{count}} tareas en segundo plano en ejecución",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "Actualizadas: {{completed}}. Sin actualizar: {{remaining}}. No disponibles: {{skipped}}.",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "Actualizadas: {{completed}}. Sin actualizar: {{remaining}}.",
     "Conflicting identifiers": "Identificadores en conflicto",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Algunos identificadores se contradicen o coinciden con referencias diferentes. Corrija el archivo de origen o conserve copias independientes de todas las referencias de esta importación.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5006,6 +5006,7 @@
     "{{count}} running background tasks_one": "{{count}} tâche en arrière-plan en cours",
     "{{count}} running background tasks_many": "{{count}} tâches en arrière-plan en cours",
     "{{count}} running background tasks_other": "{{count}} tâches en arrière-plan en cours",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "Mis à jour : {{completed}}. Non mis à jour : {{remaining}}. Indisponibles : {{skipped}}.",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "Références mises à jour : {{completed}}. Non mises à jour : {{remaining}}.",
     "Conflicting identifiers": "Identifiants contradictoires",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Certains identifiants se contredisent ou correspondent à des références différentes. Corrigez le fichier source ou conservez une copie distincte de chaque référence de cet import.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4692,6 +4692,7 @@
     "{{count}} tasks_other": "{{count}} 件のタスク",
     "{{count}} background tasks_other": "{{count}} 件のバックグラウンドタスク",
     "{{count}} running background tasks_other": "実行中のバックグラウンドタスク {{count}} 件",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "更新済み：{{completed}}。未更新：{{remaining}}。利用不可：{{skipped}}。",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "更新済み：{{completed}}。未更新：{{remaining}}。",
     "Conflicting identifiers": "識別子の競合",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "一部の識別子が矛盾しているか、異なる文献に一致しています。元のファイルを修正するか、今回インポートするすべての文献を個別のコピーとして保持してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4690,6 +4690,7 @@
     "{{count}} tasks_other": "작업 {{count}}개",
     "{{count}} background tasks_other": "백그라운드 작업 {{count}}개",
     "{{count}} running background tasks_other": "실행 중인 백그라운드 작업 {{count}}개",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "업데이트됨: {{completed}}. 업데이트되지 않음: {{remaining}}. 사용할 수 없음: {{skipped}}.",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "업데이트됨: {{completed}}. 업데이트되지 않음: {{remaining}}.",
     "Conflicting identifiers": "식별자 충돌",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "일부 식별자가 서로 모순되거나 서로 다른 문헌과 일치합니다. 원본 파일을 수정하거나 이번에 가져오는 모든 문헌을 별도의 사본으로 유지하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5138,6 +5138,7 @@
     "{{count}} running background tasks_few": "{{count}} фоновые задачи выполняются",
     "{{count}} running background tasks_many": "{{count}} фоновых задач выполняется",
     "{{count}} running background tasks_other": "{{count}} фоновые задачи выполняются",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "Обновлено: {{completed}}. Не обновлено: {{remaining}}. Недоступно: {{skipped}}.",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "Обновлено: {{completed}}. Не обновлено: {{remaining}}.",
     "Conflicting identifiers": "Конфликтующие идентификаторы",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "Некоторые идентификаторы противоречат друг другу или соответствуют разным источникам. Исправьте исходный файл или сохраните отдельную копию каждого импортируемого источника.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4692,6 +4692,7 @@
     "{{count}} tasks_other": "{{count}} 个任务",
     "{{count}} background tasks_other": "{{count}} 个后台任务",
     "{{count}} running background tasks_other": "{{count}} 个后台任务正在运行",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "已更新：{{completed}}。未更新：{{remaining}}。不可用：{{skipped}}。",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。",
     "Conflicting identifiers": "标识符冲突",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "部分标识符存在矛盾或匹配不同文献。请修正源文件，或将本次导入的每篇文献保留为独立副本。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4692,6 +4692,7 @@
     "{{count}} tasks_other": "{{count}} 個任務",
     "{{count}} background tasks_other": "{{count}} 個背景工作",
     "{{count}} running background tasks_other": "{{count}} 個背景工作正在執行",
+    "Updated: {{completed}}. Not updated: {{remaining}}. Unavailable: {{skipped}}.": "已更新：{{completed}}。未更新：{{remaining}}。無法使用：{{skipped}}。",
     "Updated: {{completed}}. Not updated: {{remaining}}.": "已更新：{{completed}}。未更新：{{remaining}}。",
     "Conflicting identifiers": "識別碼衝突",
     "Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.": "部分識別碼互相矛盾或符合不同文獻。請修正來源檔案，或將本次匯入的每篇文獻保留為獨立副本。",


### PR DESCRIPTION
## Problem

Collection/project association batches could commit partially while leaving stale rows, counts and selection. Retrying a newly created target could repeat creation. Current-collection unlink left obsolete rows, stale association commands accepted merged/deleted identities, pending saves accepted unsaved edits, and nested collection names were ambiguous.

## Proposed change

- Retain the resolved IDs, destination and committed count in page memory. Continue started batches after navigation while suppressing stale scope updates. Retry reconciles remaining identities through catalog get, excludes unavailable references without redirecting merged aliases, and shows cumulative updated/pending/unavailable counts in a compact notice.
- Preserve a successfully created destination and continue association without recreating it.
- Remove current-collection rows/selection after unlink and reload the page.
- Validate active identities inside collection/project association transactions. Disable collection inputs during save and derive parent paths for destination display/search.
- Raise the portable test shard deadline from 15 to 25 minutes after the runner explicitly reported exceeding the 15-minute limit. Retain coverage thresholds and failure gates.

## Scope and non-goals

No schema, migration, public command, persisted state or enum changes. The skipped count is renderer memory only; retry receipts are scoped to the current view and do not survive restart. Navigation no longer cancels started batches. Historical invisible associations are not migrated or reassigned. Existing nested collection names and parent IDs remain unchanged. No hierarchy editor or durable job system.

## Acceptance criteria and validation

Public-boundary regression tests use real migrated SQLite and the real React Library page with controlled IPC. The original repairs reproduced 15 expected failures twice; the navigation/deleted/merged retry additions also failed before repair with the reported partial counts.

Checks after the final material changes:

- Library behavior and selection/retry consumers → `npx vitest run src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000` → 130 passed.
- Translation contracts → `npx vitest run src/renderer/src/i18n/resources.test.ts --maxWorkers=1` → 804 passed.
- Workflow contracts → `npx vitest run scripts/ci/pr-gate-workflow.test.ts` → 31 passed.
- Renderer types, lint and formatting → `npm run typecheck:web`, `npm run lint`, targeted Prettier check → passed.
- Real browser fixture → 201 updated, 0 pending, 1 unavailable after retry; no Retry button when nothing remains. Compact presentation retained.

Earlier catalog and application-command/Electron/preload/connector validation covered 1,368 distinct targeted cases before the renderer review changes. Those production boundaries are unchanged by the review fixes. Full portable/platform and global workflow validation remain PR CI authority; no full local npm test run, per maintainer instruction.

## Review focus

Transaction-local active identity checks; fixed destination and resolved IDs across navigation; alias-safe retry reconciliation; read failures retaining retry input; derived paths staying out of persistence. A lifecycle change after reconciliation can still reject a transaction safely and be reconciled on the next retry. Independent AI review must assess the latest head before this is considered ready.
