### PR TITLE
fix(sessions): preserve artifact bindings and recover failed quit

### DIFF
--- a/src/main/app-lifecycle.test.ts
+++ b/src/main/app-lifecycle.test.ts
@@ -819,7 +819,7 @@ describe('installAppLifecycle', () => {
     expect(windows[0].focused).toBe(true)
   })
 
-  it.each(['send-failed', 'timeout'] as const)(
+  it.each(['send-failed', 'timeout', 'renderer-failed'] as const)(
     'aborts ordinary quit and asks for consent when the renderer persistence preflight returns %s',
     async (outcome) => {
       const flushSessionPersistence = vi.fn(async () => outcome)
@@ -859,30 +859,34 @@ describe('installAppLifecycle', () => {
     expect(app.exit).not.toHaveBeenCalled()
   })
 
-  it('uses the current degraded shutdown only after the user explicitly chooses force quit', async () => {
-    const flushSessionPersistence = vi.fn(async () => 'timeout' as const)
-    const confirmClose = vi.fn(async () => 'force-quit' as never)
-    const { app, closeOpts, quit, prepareForQuit, abortQuitPreparation, shutdownBackends } = setup({
-      flushSessionPersistence,
-      confirmClose
-    })
-    closeOpts[0].requestQuit()
+  it.each(['timeout', 'renderer-failed'] as const)(
+    'uses degraded shutdown for %s only after explicit force quit',
+    async (outcome) => {
+      const flushSessionPersistence = vi.fn(async () => outcome)
+      const confirmClose = vi.fn(async () => 'force-quit' as never)
+      const { app, closeOpts, quit, prepareForQuit, abortQuitPreparation, shutdownBackends } =
+        setup({
+          flushSessionPersistence,
+          confirmClose
+        })
+      closeOpts[0].requestQuit()
 
-    app.emit('before-quit')
-    await flush()
+      app.emit('before-quit')
+      await flush()
 
-    expect(quit).toHaveBeenCalledTimes(2)
-    expect(app.exit).not.toHaveBeenCalled()
+      expect(quit).toHaveBeenCalledTimes(2)
+      expect(app.exit).not.toHaveBeenCalled()
 
-    app.emit('before-quit')
-    await flush()
+      app.emit('before-quit')
+      await flush()
 
-    expect(flushSessionPersistence).toHaveBeenCalledTimes(3)
-    expect(prepareForQuit).toHaveBeenCalledOnce()
-    expect(abortQuitPreparation).toHaveBeenCalledOnce()
-    expect(shutdownBackends).toHaveBeenCalledOnce()
-    expect(app.exit).toHaveBeenCalledWith(0)
-  })
+      expect(flushSessionPersistence).toHaveBeenCalledTimes(3)
+      expect(prepareForQuit).toHaveBeenCalledOnce()
+      expect(abortQuitPreparation).toHaveBeenCalledOnce()
+      expect(shutdownBackends).toHaveBeenCalledOnce()
+      expect(app.exit).toHaveBeenCalledWith(0)
+    }
+  )
 
   it('requires persistence consent again after delegated work interrupts a force-quit attempt', async () => {
     let active: ActiveSessionInfo[] = []
@@ -976,7 +980,7 @@ describe('installAppLifecycle', () => {
     expect(windows[0].focused).toBe(true)
   })
 
-  it.each(['send-failed', 'timeout'] as const)(
+  it.each(['send-failed', 'timeout', 'renderer-failed'] as const)(
     'aborts ordinary quit and asks for consent when the terminal renderer flush returns %s',
     async (outcome) => {
       const flushSessionPersistence = vi

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -169,7 +169,7 @@ export const installAppLifecycle = (
     outcome === 'conflict' || outcome === 'renderer-failed' ? outcome : undefined
   const rendererPersistenceNeedsConsent = (
     outcome: RendererSessionPersistenceFlushOutcome
-  ): boolean => outcome === 'timeout' || outcome === 'send-failed'
+  ): boolean => outcome === 'timeout' || outcome === 'send-failed' || outcome === 'renderer-failed'
   const shutdownTrigger = (): ApplicationShutdownTrigger => {
     try {
       return deps.shutdownTrigger?.() ?? currentApplicationShutdownTrigger()

--- a/src/main/artifacts/provenance-message-snapshot.test.ts
+++ b/src/main/artifacts/provenance-message-snapshot.test.ts
@@ -9,7 +9,7 @@ import {
   projectConversationMessage,
   synchronizeActiveConversationActivities
 } from '../../shared/conversation-graph'
-import type { PersistedChatSession } from '../../shared/session-persistence'
+import { normalizeSessionFile, type PersistedChatSession } from '../../shared/session-persistence'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { ReviewRepository } from '../reviewer/repository'
 import { createPngInlineSource } from './artifact-test-fixtures'
@@ -43,7 +43,7 @@ describe('Provenance Message snapshots', () => {
     })
     const graph = synchronizeActiveConversationActivities(
       createLinearConversationGraph({
-        sessionId: 'session-1',
+        sessionId: 'pending-session-123-1',
         messages: [
           {
             id: 'prompt-1',
@@ -165,6 +165,12 @@ describe('Provenance Message snapshots', () => {
       getClient: () => Promise.resolve(client)
     })
     const findVersions = vi.spyOn(client.artifactVersion, 'findMany')
+
+    const restoredSession = normalizeSessionFile({ version: 1, session })
+    if (!restoredSession) throw new Error('Expected a restored Session.')
+    await expect(
+      snapshots.validateFinalizedMessageBindings(restoredSession)
+    ).resolves.toBeUndefined()
 
     const staleSession = structuredClone(session)
     if (!staleSession.conversationGraph) {

--- a/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
+++ b/src/main/session-persistence/artifact-finalization-recovery.integration.test.ts
@@ -590,36 +590,53 @@ describe('artifact finalization startup recovery', () => {
     )
   })
 
-  it('repairs a provisional root before recovering its pending Version', async () => {
-    const compatibility = new ArtifactRepository(storageRoot)
-    const { provenance, version } = await prepareRecovery(compatibility)
-    const persisted = await sessions.loadSession(PROJECT_ID, SESSION_ID)
-    if (!persisted?.conversationGraph) throw new Error('Recovery fixture Session graph is missing.')
-    await sessions.saveSession({
-      ...persisted,
-      conversationGraph: rebindConversationGraphSessionId(
-        persisted.conversationGraph,
-        SESSION_ID,
-        'pending-session-123-1'
+  it.each([false, true])(
+    'preserves a historical root during recovery with conflicting Artifact scope: %s',
+    async (conflicting) => {
+      const historicalSessionId = 'pending-session-123-1'
+      const compatibility = new ArtifactRepository(storageRoot)
+      const { provenance, version } = await prepareRecovery(
+        compatibility,
+        1,
+        conflicting ? SESSION_ID : historicalSessionId
       )
-    })
-    const coordinator = new SessionPersistenceCoordinator(
-      sessions,
-      files,
-      undefined,
-      undefined,
-      undefined,
-      provenance
-    )
+      const persisted = await sessions.loadSession(PROJECT_ID, SESSION_ID)
+      if (!persisted?.conversationGraph)
+        throw new Error('Recovery fixture Session graph is missing.')
+      await sessions.saveSession({
+        ...persisted,
+        conversationGraph: rebindConversationGraphSessionId(
+          persisted.conversationGraph,
+          SESSION_ID,
+          historicalSessionId
+        )
+      })
+      const coordinator = new SessionPersistenceCoordinator(
+        sessions,
+        files,
+        undefined,
+        undefined,
+        undefined,
+        provenance
+      )
 
-    const loaded = await coordinator.loadAll()
+      const loaded = await coordinator.loadAll()
 
-    expect(loaded.sessions[0].conversationGraph?.rootFrameId).toBe(`root-frame-${SESSION_ID}`)
-    expect(loaded.sessions[0].messages[1].artifactIds).toEqual([version.versionId])
-    await expect(
-      client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
-    ).resolves.toMatchObject({ state: 'finalized', messageId: 'message-1' })
-  })
+      expect(loaded.sessions[0].conversationGraph?.rootFrameId).toBe(
+        `root-frame-${historicalSessionId}`
+      )
+      expect(loaded.sessions[0].messages[1].artifactIds).toEqual(
+        conflicting ? undefined : [version.versionId]
+      )
+      await expect(
+        client.artifactVersion.findUniqueOrThrow({ where: { id: version.versionId } })
+      ).resolves.toMatchObject(
+        conflicting
+          ? { state: 'pending', messageId: null }
+          : { state: 'finalized', messageId: 'message-1' }
+      )
+    }
+  )
 
   it('replays an explicitly requested finalized Version that is already linked', async () => {
     const compatibility = new ArtifactRepository(storageRoot)
@@ -1534,7 +1551,8 @@ describe('artifact finalization startup recovery', () => {
 
   const prepareRecovery = async (
     compatibility: ArtifactRepository,
-    outputCount = 1
+    outputCount = 1,
+    graphSessionId = SESSION_ID
   ): Promise<{
     versions: Awaited<ReturnType<ArtifactProvenanceRepository['createVersion']>>[]
     provenance: ArtifactProvenanceRepository
@@ -1572,7 +1590,7 @@ describe('artifact finalization startup recovery', () => {
       updatedAt: 2
     }
     const conversationGraph = createLinearConversationGraph({
-      sessionId: SESSION_ID,
+      sessionId: graphSessionId,
       messages: [prompt, message],
       frameworkId: 'codex',
       createdAt: 1,

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -1517,6 +1517,7 @@ describe('App startup routing', () => {
     const alert = container.querySelector('[data-testid="session-persistence-alert"]')
     expect(alert?.textContent).toContain('Conversation storage limit reached')
     expect(container.querySelector('[data-testid="session-persistence-retry"]')).toBeNull()
+    expect(alert?.querySelector('[data-testid="session-persistence-dismiss"]')).toBeNull()
 
     container
       .querySelector<HTMLButtonElement>('[data-testid="session-persistence-action"]')

--- a/src/renderer/src/App.test.tsx
+++ b/src/renderer/src/App.test.tsx
@@ -118,6 +118,7 @@ const mocks = vi.hoisted(() => {
       persistenceBlockedSessionIds: [] as string[],
       reportSessionSizeLimit: vi.fn(),
       dismissLoadWarning: vi.fn(),
+      dismissWriteWarning: vi.fn(),
       startNewConversationAfterSizeLimit: vi.fn(),
       retryLoad: vi.fn(),
       retryWrites: vi.fn()
@@ -488,6 +489,7 @@ describe('App startup routing', () => {
     mocks.update.status.state = 'idle'
     mocks.update.closeDialog.mockClear()
     mocks.sessionPersistence.dismissLoadWarning.mockClear()
+    mocks.sessionPersistence.dismissWriteWarning.mockClear()
     mocks.sessionPersistence.startNewConversationAfterSizeLimit.mockClear()
     mocks.sessionPersistence.retryLoad.mockClear()
     mocks.sessionPersistence.retryWrites.mockClear()
@@ -1494,6 +1496,9 @@ describe('App startup routing', () => {
       'Open Science could not save the latest conversation changes. Retry before closing the app.'
     )
     expect(alert?.textContent).not.toContain('could not confirm')
+    expect(alert?.querySelector('[data-testid="session-persistence-dismiss"]')).not.toBeNull()
+    alert?.querySelector<HTMLButtonElement>('[data-testid="session-persistence-dismiss"]')?.click()
+    expect(mocks.sessionPersistence.dismissWriteWarning).toHaveBeenCalledOnce()
 
     container.querySelector<HTMLButtonElement>('[data-testid="session-persistence-retry"]')?.click()
     expect(mocks.sessionPersistence.retryWrites).toHaveBeenCalledOnce()

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -158,7 +158,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           : t('Conversation storage limit reached')
       }
       message={sessions.writeError}
-      onDismiss={sessions.dismissWriteWarning}
+      onDismiss={sessions.writeErrorRetryable ? sessions.dismissWriteWarning : undefined}
       onRetry={sessions.writeErrorRetryable ? sessions.retryWrites : undefined}
       onAction={
         sessions.writeErrorRetryable

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -158,6 +158,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           : t('Conversation storage limit reached')
       }
       message={sessions.writeError}
+      onDismiss={sessions.dismissWriteWarning}
       onRetry={sessions.writeErrorRetryable ? sessions.retryWrites : undefined}
       onAction={
         sessions.writeErrorRetryable

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -114,6 +114,13 @@ describe('session persistence startup', () => {
         <button type="button" data-testid="retry-load" onClick={persistence.retryLoad}>
           Retry load
         </button>
+        <button
+          type="button"
+          data-testid="dismiss-write-warning"
+          onClick={persistence.dismissWriteWarning}
+        >
+          Dismiss write warning
+        </button>
         <button type="button" data-testid="retry-writes" onClick={persistence.retryWrites}>
           Retry writes
         </button>
@@ -327,6 +334,14 @@ describe('session persistence startup', () => {
     await expect(flushSessionPersistence()).rejects.toThrow('could not write')
 
     await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="dismiss-write-warning"]')?.click()
+    })
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toBe(
+      'changes saved'
+    )
+    await expect(flushSessionPersistence()).rejects.toThrow('could not write')
+
+    await act(async () => {
       useSessionStore.getState().appendUserMessage({
         sessionId: 'session-1',
         content: 'Latest version',
@@ -334,6 +349,13 @@ describe('session persistence startup', () => {
       })
       await Promise.resolve()
     })
+
+    await act(async () => {
+      await expect(flushSessionPersistence()).rejects.toThrow('could not write')
+    })
+    expect(container.querySelector('[data-testid="write-error"]')?.textContent).toContain(
+      'Open Science could not save'
+    )
 
     writesFail = false
     await act(async () =>

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -1216,6 +1216,7 @@ type SessionPersistenceState = {
   writeErrorRetryable: boolean
   persistenceBlockedSessionIds: readonly string[]
   reportSessionSizeLimit: (sessionId: string) => void
+  dismissWriteWarning: () => void
   dismissLoadWarning: () => void
   startNewConversationAfterSizeLimit: () => void
   retryLoad: () => void
@@ -1789,6 +1790,8 @@ const useSessionPersistence = (): SessionPersistenceState => {
     },
     [presentOutstandingWriteFailures]
   )
+  // Dismiss only the presentation; failed targets still block flush and remain retryable.
+  const dismissWriteWarning = useCallback(() => setWriteError(undefined), [])
   const dismissLoadWarning = useCallback(() => setLoadWarning(undefined), [])
   const startNewConversationAfterSizeLimit = useCallback(() => {
     for (const target of sizeLimitTargets.current) {
@@ -2120,6 +2123,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
     persistenceBlockedSessionIds,
     reportSessionSizeLimit,
     dismissLoadWarning,
+    dismissWriteWarning,
     startNewConversationAfterSizeLimit,
     retryLoad,
     retryWrites

--- a/src/renderer/src/stores/session-store.test.ts
+++ b/src/renderer/src/stores/session-store.test.ts
@@ -22,6 +22,7 @@ import { DEFAULT_PERMISSION_PROFILE } from '../../../shared/permission-profiles'
 import {
   INTERRUPTED_SESSION_ERROR,
   SESSION_MANIFEST_VERSION,
+  normalizeSessionFile,
   type PersistedChatSession,
   type SessionPdfContext
 } from '../../../shared/session-persistence'
@@ -3515,78 +3516,89 @@ describe('session store', () => {
     expect(activeBranch?.headMessageId).toBeUndefined()
   })
 
-  it('binds a pending session to the runtime session id without rewriting the prompt', () => {
-    const pending = useSessionStore.getState().appendPendingUserMessage({
-      content: 'Help me inspect this notebook',
-      cwd: '/workspace/project',
-      delegationPolicy: 'deny'
-    })
-
-    const bound = useSessionStore.getState().bindPendingSession({
-      pendingSessionId: pending?.sessionId ?? '',
-      sessionId: 'transport-session-1',
-      cwd: '/workspace/project',
-      agentFrameworkId: 'codex',
-      agentBackendId: 'codex:codex-shared'
-    })
-
-    expect(bound).toEqual({
-      sessionId: 'transport-session-1',
-      messageId: pending?.messageId
-    })
-    expect(useSessionStore.getState().selectedSessionId).toBe('transport-session-1')
-    expect(useSessionStore.getState().sessions).toEqual([
-      expect.objectContaining({
-        id: 'transport-session-1',
-        isPending: false,
+  it.each([
+    ['claude-code', undefined],
+    ['opencode', undefined],
+    ['codex', 'codex-responses'],
+    ['codex', 'codex-bridge']
+  ] as const)(
+    'binds and restores a pending session with %s / %s without rewriting durable identities',
+    (agentFrameworkId, agentBackendId) => {
+      const pending = useSessionStore.getState().appendPendingUserMessage({
+        content: 'Help me inspect this notebook',
         cwd: '/workspace/project',
-        agentFrameworkId: 'codex',
-        agentBackendId: 'codex:codex-shared',
-        delegationPolicy: 'deny',
-        status: 'running',
-        activeRun: {
-          promptMessageId: pending?.messageId,
-          startedAt: Date.now()
-        },
+        delegationPolicy: 'deny'
+      })
+
+      const bound = useSessionStore.getState().bindPendingSession({
+        pendingSessionId: pending?.sessionId ?? '',
+        sessionId: 'transport-session-1',
+        cwd: '/workspace/project',
+        agentFrameworkId,
+        agentBackendId
+      })
+
+      expect(bound).toEqual({
+        sessionId: 'transport-session-1',
+        messageId: pending?.messageId
+      })
+      expect(useSessionStore.getState().selectedSessionId).toBe('transport-session-1')
+      expect(useSessionStore.getState().sessions).toEqual([
+        expect.objectContaining({
+          id: 'transport-session-1',
+          isPending: false,
+          cwd: '/workspace/project',
+          agentFrameworkId,
+          agentBackendId,
+          delegationPolicy: 'deny',
+          status: 'running',
+          activeRun: {
+            promptMessageId: pending?.messageId,
+            startedAt: Date.now()
+          },
+          messages: [
+            expect.objectContaining({
+              id: pending?.messageId,
+              content: 'Help me inspect this notebook'
+            })
+          ]
+        })
+      ])
+      expect(useSessionStore.getState().sessions[0].conversationGraph).toMatchObject({
+        rootFrameId: 'root-frame-transport-session-1',
+        activeFrameId: 'root-frame-transport-session-1',
+        frames: [
+          {
+            id: 'root-frame-transport-session-1',
+            activeBranchId: 'message-branch-transport-session-1'
+          }
+        ],
+        branches: [
+          {
+            id: 'message-branch-transport-session-1',
+            agentFrameId: 'root-frame-transport-session-1'
+          }
+        ],
         messages: [
-          expect.objectContaining({
+          {
             id: pending?.messageId,
-            content: 'Help me inspect this notebook'
-          })
+            agentFrameId: 'root-frame-transport-session-1',
+            introducedOnBranchId: 'message-branch-transport-session-1',
+            runtimeSegmentId: 'runtime-segment-transport-session-1'
+          }
+        ],
+        runtimeSegments: [
+          {
+            id: 'runtime-segment-transport-session-1',
+            agentFrameId: 'root-frame-transport-session-1'
+          }
         ]
       })
-    ])
-    expect(useSessionStore.getState().sessions[0].conversationGraph).toMatchObject({
-      rootFrameId: 'root-frame-transport-session-1',
-      activeFrameId: 'root-frame-transport-session-1',
-      frames: [
-        {
-          id: 'root-frame-transport-session-1',
-          activeBranchId: 'message-branch-transport-session-1'
-        }
-      ],
-      branches: [
-        {
-          id: 'message-branch-transport-session-1',
-          agentFrameId: 'root-frame-transport-session-1'
-        }
-      ],
-      messages: [
-        {
-          id: pending?.messageId,
-          agentFrameId: 'root-frame-transport-session-1',
-          introducedOnBranchId: 'message-branch-transport-session-1',
-          runtimeSegmentId: 'runtime-segment-transport-session-1'
-        }
-      ],
-      runtimeSegments: [
-        {
-          id: 'runtime-segment-transport-session-1',
-          agentFrameId: 'root-frame-transport-session-1'
-        }
-      ]
-    })
-  })
+      const persisted = toPersistedSession(useSessionStore.getState().sessions[0])
+      const restored = normalizeSessionFile(persisted, { preserveRuntimeState: true })
+      expect(restored?.conversationGraph).toEqual(persisted.conversationGraph)
+    }
+  )
 
   it('appends follow-up user messages to the same session and restarts the run', () => {
     const first = useSessionStore.getState().appendUserMessage({

--- a/src/shared/session-persistence.test.ts
+++ b/src/shared/session-persistence.test.ts
@@ -315,7 +315,7 @@ const createHistoricalPlan = (): ActivePlanProjection => ({
 })
 
 describe('conversation graph materialization diagnostics', () => {
-  it('repairs a bound Session persisted with its provisional conversation root', () => {
+  it('preserves durable graph identities even when they retain a provisional prefix', () => {
     const pendingSessionId = 'pending-session-123-1'
     const messages: PersistedChatMessage[] = [
       {
@@ -328,41 +328,49 @@ describe('conversation graph materialization diagnostics', () => {
         updatedAt: 1
       }
     ]
+    const graph = createLinearConversationGraph({
+      sessionId: pendingSessionId,
+      messages,
+      createdAt: 1,
+      updatedAt: 1
+    })
+    graph.frames.push({
+      id: 'child-frame',
+      parentFrameId: graph.rootFrameId,
+      originMessageId: 'message-1',
+      originBindingState: 'validated',
+      kind: 'delegate',
+      status: 'completed',
+      activeBranchId: 'child-branch',
+      createdAt: 2,
+      completedAt: 3
+    })
+    graph.branches.push(
+      {
+        id: 'inactive-branch',
+        agentFrameId: graph.rootFrameId,
+        parentBranchId: graph.branches[0].id,
+        forkMessageId: 'message-1',
+        headMessageId: 'message-1',
+        createdAt: 2,
+        updatedAt: 2
+      },
+      { id: 'child-branch', agentFrameId: 'child-frame', createdAt: 2, updatedAt: 3 }
+    )
     const restored = normalizeSessionFile({
       ...createSessionWithActivity(undefined),
       id: 'runtime-session-1',
       messages,
-      conversationGraph: createLinearConversationGraph({
-        sessionId: pendingSessionId,
-        messages,
-        createdAt: 1,
-        updatedAt: 1
-      })
+      conversationGraph: graph
     })
+    expect(restored?.conversationGraph?.frames).toEqual(graph.frames)
+    expect(restored?.conversationGraph?.branches).toEqual(graph.branches)
+    expect(restored?.conversationGraph?.runtimeSegments).toEqual(graph.runtimeSegments)
 
     expect(restored?.conversationGraph).toMatchObject({
-      rootFrameId: 'root-frame-runtime-session-1',
-      activeFrameId: 'root-frame-runtime-session-1',
-      frames: [
-        {
-          id: 'root-frame-runtime-session-1',
-          activeBranchId: 'message-branch-runtime-session-1'
-        }
-      ],
-      branches: [
-        {
-          id: 'message-branch-runtime-session-1',
-          agentFrameId: 'root-frame-runtime-session-1'
-        }
-      ],
-      messages: [
-        {
-          id: 'message-1',
-          agentFrameId: 'root-frame-runtime-session-1',
-          introducedOnBranchId: 'message-branch-runtime-session-1',
-          runtimeSegmentId: 'runtime-segment-runtime-session-1'
-        }
-      ]
+      rootFrameId: graph.rootFrameId,
+      activeFrameId: graph.activeFrameId,
+      messages: graph.messages
     })
   })
 

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -54,7 +54,6 @@ import {
   createLinearConversationGraph,
   materializeNestedDelegateActivities,
   projectConversationMessage,
-  rebindConversationGraphSessionId,
   resolveActiveConversationActivities,
   resolveActiveConversationMessages,
   synchronizeActiveConversationActivities,
@@ -4502,16 +4501,10 @@ const sanitizeSession = (
   }
 
   if (session.conversationGraph !== undefined) {
-    const sanitizedGraph = sanitizeConversationGraph(session.conversationGraph, options)
-    if (!sanitizedGraph) return undefined
-    const pendingRootFramePrefix = 'root-frame-pending-session-'
-    const graph = sanitizedGraph.rootFrameId.startsWith(pendingRootFramePrefix)
-      ? rebindConversationGraphSessionId(
-          sanitizedGraph,
-          sanitizedGraph.rootFrameId.slice('root-frame-'.length),
-          sanitized.id
-        )
-      : sanitizedGraph
+    // Persisted graph IDs are durable identities referenced by Artifact Versions and other stores.
+    // A historical pending-session prefix is not permission to rebind only the Session side.
+    const graph = sanitizeConversationGraph(session.conversationGraph, options)
+    if (!graph) return undefined
     const nestedDelegateActivities = projectActiveNestedDelegateActivities(graph)
     const activityIds = new Set((sanitized.activities ?? []).map(({ id }) => id))
     sanitized.conversationGraph = graph


### PR DESCRIPTION
## Problem

Restoring a Session whose persisted root retains a `pending-session-*` identity rewrites its Frame, Branch, and Runtime Segment IDs while finalized Artifact Versions retain the original bindings. The next save rejects with `FinalizedArtifactBindingConflictError: Artifact Message snapshot root Frame does not match the Session graph.` The save warning also lacks dismissal, and explicit renderer save failures cancel quit without offering the existing persistence-failure confirmation.

## Proposed change

Preserve established conversation graph identities during decoding. New pending Sessions continue to bind through the existing creation owner, and finalized Artifact binding validation stays strict. Wire retryable save warnings' existing close button to presentation-only dismissal, retaining failed writes and flush protection. Route `renderer-failed` through existing Stay / Retry saving / Force quit consent at both preflight and final flush.

## Scope and compatibility

- Historical Sessions retain their existing Frame/Branch/Runtime Segment IDs, including pending-prefixed IDs. No database migration or repair of user data is performed.
- Persistence format, schema and enums are unchanged. Warning dismissal only clears transient renderer presentation; it does not acknowledge a save.
- Non-retryable capacity-limit notices keep their New conversation action visible and cannot be dismissed. Revision conflicts and delegated-work quit guards retain their existing policy.
- Shared pending-binding/decoder fixtures cover claude-code, opencode, codex-responses and codex-bridge configurations. This is not live launcher/model certification: no ACP wire protocol, subscriptions, provider adapter or model behavior changed.

## Acceptance criteria and validation

All three reported failure paths were reproduced before implementation. The final owner/interface/consumer Test Impact Set is the union of `session_persistence` and `artifact_provenance` module files, changed regression files, and explicit quit/Notebook/renderer consumers (49 files), each run with `npm test -- <file>` on Node 22.23.1. The automatic planner falls back to full because the lifecycle file has no declared module owner; this explicit local selection follows the maintainer's request to leave full verification to PR CI.

| Behavior | Project-owned checks |
| --- | --- |
| Durable identities, inactive branches, child Frames, restore/finalize/save | shared session-persistence and conversation-graph; Artifact provenance message snapshot/durability/write/lifecycle; Session coordinator/save IPC consumer module checks |
| New Session binding across four configurations | session-store pending-binding/restore regression; ACP runtime module consumer |
| Historical Notebook Frame aliases | Notebook repository, runtime-service, NotebookPreview gate; Notebook RPC consumers |
| Dismissal retains failed writes and later errors reappear | App and session-persistence rendered/unit tests |
| Preflight/final failure consent and explicit force quit | app-lifecycle, window-close-confirm, renderer-flush, CloseConfirmModal rendered tests |
| Process types and UI copy | `npm run typecheck`; `npm run lint`; i18n resource guards |
| Real Electron interaction | Isolated fixture: injected save rejection → warning dismissal → quit confirmation → Stay → repeat quit → explicit Force quit; 1 passed; screenshots visually reviewed |

Final results: 47/49 files passed directly. The recovery integration fixture was then aligned with the approved identity-preservation policy: 41/41 passed, including consistent historical bindings and a conflicting-binding case that must remain pending. Notebook runtime initially passed 371/372; its sole 1-second queue-wait assertion passed unchanged on isolated rerun (1/1). No timeout or production workaround was added. Node/Web/sandbox typechecks, repository lint and i18n guards passed. Electron build and the isolated interaction journey passed..

The listed checks ran after the final production edit. The subsequent test-only recovery fixture update was followed by its full 41-case suite, Node typecheck and lint; independent review confirmed that this fixture-only update did not invalidate the other consumer results. Earlier sandbox/parallel test attempts were interrupted or failed and are not counted as passes. Independent review found no actionable findings and confirmed the impact mapping and screenshots. Windows/Linux and complete-suite results remain the responsibility of exact-head PR CI. The combined UI journey uses Electron because app exit is unavailable through Web.

## Review focus

Persisted IDs must remain stable across all stores. Dismissing a warning must not clear failed writes. Force quit must remain an explicit choice and retain all other lifecycle guards.

The PR review identified capacity-limit dismissal as an edge case. The final guard restricts dismissal to retryable errors; App and persistence hook suites passed 91/91 after this final UI edit, followed by Web typecheck and lint. Independent review confirmed the fix and its focused impact scope.
