### PR TITLE
fix(literature): preserve note drafts and synchronize tag updates

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1771,7 +1771,10 @@ const createApplicationModules = async (
     new MemoryRepository(() => getProjectDbClient(configRoot)),
     applicationEvents
   )
-  const literatureCatalog = new LiteratureCatalog(() => getProjectDbClient(configRoot))
+  const literatureCatalog = new LiteratureCatalog(
+    () => getProjectDbClient(configRoot),
+    () => tagService.notifyAssignmentsChanged()
+  )
   const literatureCitationStyles = new LiteratureCitationStyleLibrary(
     join(resolveDataRoot(), 'literature', 'citation-styles')
   )

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -17,6 +17,9 @@ import { migrateApplicationDatabase } from '../database/migration-service'
 import { createProjectDbClient } from '../projects/prisma-client'
 import { LiteratureCatalog, normalizeIdentifier } from './catalog'
 import { LiteratureCitationFormatter } from './citation-formatter'
+import { TagRepository } from '../tags/repository'
+import { TagResourceCatalog } from '../tags/resource-catalog'
+import { TagService } from '../tags/service'
 
 describe('Literature identifier normalization', () => {
   it('removes text joined to the end of a DOI before provider lookup', () => {
@@ -80,6 +83,101 @@ describe('LiteratureCatalog', () => {
     await client.project.create({ data: { id: 'project-1', name: 'Research' } })
     return new LiteratureCatalog(async () => client!)
   }
+
+  it.each(['merge', 'delete', 'batch', 'rollback', 'preview'] as const)(
+    'publishes tag assignments only after committed catalog changes: %s',
+    async (operation) => {
+      await setup()
+      const catalog = new LiteratureCatalog(
+        async () => client!,
+        () => tags.notifyAssignmentsChanged()
+      )
+      const survivor = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      const duplicate = await catalog.transact({
+        kind: 'create-item',
+        item: candidate().item,
+        duplicatePolicy: 'separate'
+      })
+      const publish = vi.fn()
+      const tags = new TagService(
+        new TagRepository(async () => client!),
+        new TagResourceCatalog({
+          listSkills: async () => [],
+          listConnectors: async () => ({ connectors: [], customServers: [] }),
+          listSpecialists: async () => [],
+          listLiteratureItems: async () => client!.literatureItem.findMany({ select: { id: true } })
+        }),
+        { publish }
+      )
+      await tags.snapshot()
+      const before = await tags.setAssignment({
+        tagId: 'tag-favorite',
+        resourceType: 'literature.item',
+        resourceId: duplicate.id,
+        assigned: true
+      })
+      publish.mockClear()
+      const reviewed = (
+        await Promise.all([catalog.get(survivor.id), catalog.get(duplicate.id)])
+      ).map((item) => item!)
+      if (operation === 'delete') {
+        await catalog.transact({
+          kind: 'set-item-lifecycle',
+          itemIds: [duplicate.id],
+          state: 'deleted'
+        })
+        await catalog.transact({ kind: 'delete-items-permanently', itemIds: [duplicate.id] })
+      } else if (operation === 'batch' || operation === 'preview') {
+        await catalog.transact({
+          kind: 'merge-duplicates',
+          mode: operation === 'preview' ? 'preview' : 'commit',
+          groups: [
+            [survivor.id, duplicate.id],
+            ['missing-a', 'missing-b']
+          ],
+          strategy: 'oldest',
+          expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+            id,
+            metadataRevision,
+            updatedAt
+          }))
+        })
+      } else {
+        const merging = catalog.transact({
+          kind: 'merge-items',
+          survivorId: survivor.id,
+          duplicateIds: [duplicate.id],
+          expectedMetadataRevision: operation === 'rollback' ? 999 : reviewed[0].metadataRevision,
+          expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+            id,
+            metadataRevision,
+            updatedAt
+          })),
+          item: reviewed[0].item
+        })
+        if (operation === 'rollback') await expect(merging).rejects.toThrow()
+        else await merging
+      }
+      const assignments = await client!.tagAssignment.findMany({
+        where: { resourceType: 'literature.item' }
+      })
+      const expectedIds =
+        operation === 'delete'
+          ? []
+          : [operation === 'rollback' || operation === 'preview' ? duplicate.id : survivor.id]
+      expect(assignments.map(({ resourceId }) => resourceId)).toEqual(expectedIds)
+      const after = await tags.snapshot()
+      expect(after.assignments.map(({ resourceId }) => resourceId)).toEqual(expectedIds)
+      if (operation === 'rollback' || operation === 'preview') {
+        expect(after.revision).toBe(before.revision)
+        expect(publish).not.toHaveBeenCalled()
+        return
+      }
+      expect.soft(after.revision).toBe(before.revision + 1)
+      expect.soft(publish).toHaveBeenCalledTimes(1)
+      expect.soft(publish).toHaveBeenCalledWith('tags:changed', { revision: after.revision })
+    }
+  )
 
   it.each([
     ['deleted', 'missing'],

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -1,6 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 
 import { Prisma, type PrismaClient } from '@prisma/client'
+import { createLogger } from '../logger'
 import { findLiteratureDuplicateGroups } from './duplicates'
 import { planLiteratureMerge, supplementLiteratureMetadata } from './duplicate-metadata'
 
@@ -43,6 +44,8 @@ type LiteratureCatalogClient = Pick<
   | 'projectLiterature'
   | 'tagAssignment'
 >
+
+const log = createLogger('literature-catalog')
 
 type LiteratureCatalogClientProvider = () => Promise<LiteratureCatalogClient>
 const duplicateGroups = new WeakMap<
@@ -634,7 +637,19 @@ const acceptInboxCandidate = async (
 }
 
 class LiteratureCatalog {
-  constructor(private readonly getClient: LiteratureCatalogClientProvider) {}
+  constructor(
+    private readonly getClient: LiteratureCatalogClientProvider,
+    private readonly onTagAssignmentsChanged?: () => Promise<void>
+  ) {}
+
+  private async publishTagAssignmentsChanged(): Promise<void> {
+    try {
+      await this.onTagAssignmentsChanged?.()
+    } catch (error) {
+      // Delivery cannot roll back an already committed catalog transaction.
+      log.warn('Could not publish committed tag assignment changes', { error })
+    }
+  }
 
   async search(request: LiteratureCatalogSearchRequest): Promise<LiteratureCatalogSearchPage> {
     const client = await this.getClient()
@@ -1610,7 +1625,8 @@ class LiteratureCatalog {
   ): Promise<LiteratureCatalogReceipt> {
     const itemIds = [...new Set(command.itemIds)]
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
+    let tagsChanged = false
+    const receipt = await client.$transaction<LiteratureCatalogReceipt>(async (transaction) => {
       const requestedItems = await transaction.literatureItem.findMany({
         where: { id: { in: itemIds } },
         select: { id: true, deletedAt: true }
@@ -1635,9 +1651,10 @@ class LiteratureCatalog {
       await transaction.literatureInboxCandidate.deleteMany({
         where: { acceptedItemId: { in: deletionIds } }
       })
-      await transaction.tagAssignment.deleteMany({
+      const removedTags = await transaction.tagAssignment.deleteMany({
         where: { resourceType: 'literature.item', resourceId: { in: deletionIds } }
       })
+      tagsChanged = removedTags.count > 0
       await transaction.literatureItem.updateMany({
         where: { id: { in: deletionIds } },
         data: { mergedIntoItemId: null }
@@ -1652,6 +1669,8 @@ class LiteratureCatalog {
       }
       return { kind: 'item', id: itemIds[0]!, state: 'deleted-permanently' }
     })
+    if (tagsChanged) await this.publishTagAssignmentsChanged()
+    return receipt
   }
 
   private async moveCollectionItems(
@@ -1697,7 +1716,11 @@ class LiteratureCatalog {
     command: Extract<LiteratureCatalogCommand, { kind: 'merge-items' }>
   ): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    return client.$transaction((transaction) => this.mergeItemsInTransaction(transaction, command))
+    const result = await client.$transaction((transaction) =>
+      this.mergeItemsInTransaction(transaction, command)
+    )
+    if (result.tagsChanged) await this.publishTagAssignmentsChanged()
+    return result.receipt
   }
 
   private async mergeDuplicates(
@@ -1730,6 +1753,7 @@ class LiteratureCatalog {
       }
       ids.forEach((id) => seen.add(id))
       try {
+        let tagsChanged = false
         const merged = await client.$transaction(async (transaction) => {
           const rows = await transaction.literatureItem.findMany({
             where: { id: { in: ids }, deletedAt: null, mergedIntoItemId: null },
@@ -1772,7 +1796,7 @@ class LiteratureCatalog {
             updatedAt
           }))
           if (command.mode === 'commit') {
-            await this.mergeItemsInTransaction(transaction, {
+            const result = await this.mergeItemsInTransaction(transaction, {
               kind: 'merge-items',
               survivorId: plan.survivor.id,
               duplicateIds: rows.filter((row) => row.id !== plan.survivor.id).map((row) => row.id),
@@ -1780,6 +1804,7 @@ class LiteratureCatalog {
               expectedItems: items,
               item: plan.item
             })
+            tagsChanged = result.tagsChanged
           }
           return {
             survivorId: plan.survivor.id,
@@ -1790,6 +1815,7 @@ class LiteratureCatalog {
         })
         if (merged) {
           // Publish the result only after the transaction commits successfully.
+          if (tagsChanged) await this.publishTagAssignmentsChanged()
           batch.groups!.push(merged)
           detail.status = command.mode === 'commit' ? 'merged' : 'ready'
           batch.eligible += 1
@@ -1811,7 +1837,7 @@ class LiteratureCatalog {
   private async mergeItemsInTransaction(
     transaction: Prisma.TransactionClient,
     command: Extract<LiteratureCatalogCommand, { kind: 'merge-items' }>
-  ): Promise<LiteratureCatalogReceipt> {
+  ): Promise<{ receipt: LiteratureCatalogReceipt; tagsChanged: boolean }> {
     const duplicateIds = [...new Set(command.duplicateIds)].filter(
       (itemId) => itemId !== command.survivorId
     )
@@ -1940,7 +1966,10 @@ class LiteratureCatalog {
       },
       data: { deletedAt: new Date(), mergedIntoItemId: command.survivorId }
     })
-    return { kind: 'item', id: command.survivorId, state: 'merged' }
+    return {
+      receipt: { kind: 'item', id: command.survivorId, state: 'merged' },
+      tagsChanged: assignments.length > 0
+    }
   }
 
   private async attachSource(

--- a/src/main/tags/service.test.ts
+++ b/src/main/tags/service.test.ts
@@ -269,4 +269,37 @@ describe('TagService', () => {
     expect(events.publish).toHaveBeenNthCalledWith(1, 'tags:changed', { revision: 1 })
     expect(events.publish).toHaveBeenNthCalledWith(2, 'tags:changed', { revision: 2 })
   })
+  it('queues committed assignment notifications with snapshots and ordinary mutations', async () => {
+    let release!: () => void
+    const repository = {
+      reorder: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = resolve
+          })
+      ),
+      snapshot: vi.fn(async (revision: number) => snapshot(revision)),
+      pruneStaleAssignments: vi.fn().mockResolvedValue(0)
+    }
+    const events = { publish: vi.fn() }
+    const resources = { snapshot: vi.fn().mockResolvedValue({}) }
+    const service = new TagService(
+      repository as unknown as TagRepository,
+      resources as unknown as TagResourceCatalog,
+      events
+    )
+    const mutation = service.reorder({ tagIds: [] })
+    await Promise.resolve()
+    const notification = service.notifyAssignmentsChanged()
+    const read = service.snapshot()
+    expect(events.publish).not.toHaveBeenCalled()
+    release()
+    await mutation
+    await notification
+    expect(await read).toEqual(snapshot(2))
+    expect(events.publish.mock.calls).toEqual([
+      ['tags:changed', { revision: 1 }],
+      ['tags:changed', { revision: 2 }]
+    ])
+  })
 })

--- a/src/main/tags/service.ts
+++ b/src/main/tags/service.ts
@@ -36,6 +36,16 @@ class TagService {
     return result
   }
 
+  // Catalog transactions own their relationship writes; join the same publication queue after commit.
+  notifyAssignmentsChanged(): Promise<void> {
+    const result = this.mutationQueue.then(() => {
+      this.revision += 1
+      this.events.publish('tags:changed', { revision: this.revision })
+    })
+    this.mutationQueue = result.catch(() => undefined)
+    return result
+  }
+
   snapshot(): Promise<TagSnapshot> {
     const result = this.mutationQueue.then(async () => {
       const pending = [...this.pendingResourceDeletions.values()]

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -3556,12 +3556,13 @@ describe('LiteratureLibraryPage', () => {
   })
 
   it.each([
-    { filtered: true, remains: false },
-    { filtered: false, remains: true },
-    { filtered: true, remains: true }
+    { filtered: true, remains: false, retry: false },
+    { filtered: false, remains: true, retry: false },
+    { filtered: true, remains: true, retry: false },
+    { filtered: true, remains: true, retry: true }
   ])(
-    'refreshes a Favorites result after a tag event with filtered=$filtered and remains=$remains',
-    async ({ filtered, remains }) => {
+    'refreshes a Favorites result after a tag event with filtered=$filtered, remains=$remains and retry=$retry',
+    async ({ filtered, remains, retry }) => {
       window.localStorage.setItem(
         'open-science:literature-table-preferences',
         JSON.stringify({ visible: ['notes'] })
@@ -3572,12 +3573,17 @@ describe('LiteratureLibraryPage', () => {
         return () => undefined
       })
       let assigned = true
-      search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
-        Promise.resolve({
+      let failRefresh = false
+      search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+        if (request.scope === 'library' && request.tagId && failRefresh) {
+          failRefresh = false
+          return Promise.reject(new Error('Tag-filter refresh unavailable'))
+        }
+        return Promise.resolve({
           entries: request.scope === 'library' && (!request.tagId || assigned) ? [libraryItem] : [],
           totalCount: request.scope === 'library' && (!request.tagId || assigned) ? 1 : 0
         })
-      )
+      })
       render(<LiteratureLibraryPage />)
       fireEvent.click(screen.getByRole('button', { name: 'All references' }))
       await screen.findByText(libraryItem.item.title)
@@ -3599,6 +3605,7 @@ describe('LiteratureLibraryPage', () => {
       }) as HTMLInputElement
       fireEvent.change(input, { target: { value: 'Draft during tag refresh' } })
       assigned = remains
+      failRefresh = retry
       vi.mocked(window.api.tags.snapshot).mockResolvedValue({
         revision: 2,
         tags: useTagStore.getState().tags,
@@ -3608,6 +3615,16 @@ describe('LiteratureLibraryPage', () => {
         emitChanged({ revision: 2 })
       })
       await waitFor(() => expect(useTagStore.getState().revision).toBe(2))
+      if (retry) {
+        await screen.findByText('Literature could not be loaded.')
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        expect(screen.getByRole('textbox', { name: `Note for ${libraryItem.item.title}` })).toBe(
+          input
+        )
+        await waitFor(() =>
+          expect(screen.queryByText('Literature could not be loaded.')).toBeNull()
+        )
+      }
       if (remains) {
         expect(screen.getByRole('textbox', { name: `Note for ${libraryItem.item.title}` })).toBe(
           input

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -199,6 +199,10 @@ describe('LiteratureLibraryPage', () => {
   const saveBlobFile = vi.fn()
 
   beforeEach(() => {
+    // Failed assertions must not leak unused one-shot IPC replies into another scenario.
+    search.mockReset()
+    get.mockReset()
+    transact.mockReset().mockResolvedValue({ kind: 'item', id: 'item-1', state: 'present' })
     window.localStorage.clear()
     window.sessionStorage.clear()
     useNavigationStore.setState({
@@ -3307,6 +3311,297 @@ describe('LiteratureLibraryPage', () => {
     expect(screen.queryByLabelText('Title')).toBeNull()
     expect(screen.getByRole('heading', { name: 'Collections' })).not.toBeNull()
   })
+
+  it('retains an unsaved note after persistence rejects so it can be retried', async () => {
+    window.localStorage.setItem(
+      'open-science:literature-table-preferences',
+      JSON.stringify({ visible: ['rating', 'notes'] })
+    )
+    const saved = { ...libraryItem, item: { ...libraryItem.item, personalNote: 'Old saved note' } }
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve({ entries: request.scope === 'library' ? [saved] : [] })
+    )
+    transact.mockRejectedValueOnce(new Error('persistence unavailable'))
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const input = await screen.findByRole('textbox', { name: `Note for ${saved.item.title}` })
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'Important new unsaved analysis' } })
+    fireEvent.blur(input)
+    await screen.findByText('Literature could not be updated.')
+    expect(transact).toHaveBeenCalledWith(
+      expect.objectContaining({
+        expectedMetadataRevision: 1,
+        item: expect.objectContaining({ personalNote: 'Important new unsaved analysis' })
+      })
+    )
+    expect(
+      (screen.getByRole('textbox', { name: `Note for ${saved.item.title}` }) as HTMLInputElement)
+        .value
+    ).toBe('Important new unsaved analysis')
+  })
+
+  it('distinguishes a committed note from a failed readback and retains its text', async () => {
+    window.localStorage.setItem(
+      'open-science:literature-table-preferences',
+      JSON.stringify({ visible: ['notes'] })
+    )
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve({ entries: request.scope === 'library' ? [libraryItem] : [] })
+    )
+    get.mockRejectedValueOnce(new Error('read unavailable'))
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const input = (await screen.findByRole('textbox', {
+      name: `Note for ${libraryItem.item.title}`
+    })) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Committed analysis' } })
+    fireEvent.blur(input)
+    await screen.findByText('The reference was saved, but could not be reloaded.')
+    expect(input.value).toBe('Committed analysis')
+    expect(transact).toHaveBeenCalledTimes(1)
+  })
+
+  it('retries a failed note without losing text and adopts the next clean snapshot', async () => {
+    window.localStorage.setItem(
+      'open-science:literature-table-preferences',
+      JSON.stringify({ visible: ['rating', 'notes'] })
+    )
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve({ entries: request.scope === 'library' ? [libraryItem] : [] })
+    )
+    transact.mockRejectedValueOnce(new Error('offline'))
+    get
+      .mockResolvedValueOnce({
+        ...libraryItem,
+        metadataRevision: 2,
+        item: { ...libraryItem.item, personalNote: 'Retry this draft' }
+      })
+      .mockResolvedValueOnce({
+        ...libraryItem,
+        metadataRevision: 3,
+        item: { ...libraryItem.item, personalNote: 'New saved note', rating: 4 }
+      })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const input = (await screen.findByRole('textbox', {
+      name: `Note for ${libraryItem.item.title}`
+    })) as HTMLInputElement
+    fireEvent.change(input, { target: { value: 'Retry this draft' } })
+    fireEvent.blur(input)
+    await screen.findByText(
+      'Your note draft is preserved. Retry saving or press Escape to discard.'
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+    await waitFor(() =>
+      expect(
+        screen.queryByText('Your note draft is preserved. Retry saving or press Escape to discard.')
+      ).toBeNull()
+    )
+    expect(input.value).toBe('Retry this draft')
+    expect(transact.mock.calls[1][0]).toEqual(transact.mock.calls[0][0])
+    fireEvent.click(screen.getByRole('button', { name: 'Set rating to 4' }))
+    await waitFor(() => expect(input.value).toBe('New saved note'))
+  })
+
+  it('preserves a note being edited when a pending rating save completes', async () => {
+    window.localStorage.setItem(
+      'open-science:literature-table-preferences',
+      JSON.stringify({ visible: ['rating', 'notes'] })
+    )
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve({ entries: request.scope === 'library' ? [libraryItem] : [] })
+    )
+    let finish!: () => void
+    transact.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = () => resolve({ kind: 'item', id: libraryItem.id })
+        })
+    )
+    get.mockResolvedValue({
+      ...libraryItem,
+      metadataRevision: 2,
+      item: { ...libraryItem.item, rating: 4 }
+    })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const input = await screen.findByRole('textbox', { name: `Note for ${libraryItem.item.title}` })
+    fireEvent.click(screen.getByRole('button', { name: 'Set rating to 4' }))
+    fireEvent.focus(input)
+    fireEvent.change(input, { target: { value: 'Draft typed while rating saves' } })
+    await act(async () => {
+      finish()
+    })
+    expect(get).toHaveBeenCalledWith(libraryItem.id)
+    expect(transact).toHaveBeenCalledTimes(1)
+    const current = screen.getByRole('textbox', { name: `Note for ${libraryItem.item.title}` })
+    expect((current as HTMLInputElement).value).toBe('Draft typed while rating saves')
+    expect(current).toBe(input)
+    transact.mockRejectedValueOnce(new Error('Literature Item changed.'))
+    fireEvent.blur(current)
+    await screen.findByText('Literature could not be updated.')
+    expect(transact).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        expectedMetadataRevision: 1,
+        item: expect.objectContaining({ personalNote: 'Draft typed while rating saves' })
+      })
+    )
+    expect((current as HTMLInputElement).value).toBe('Draft typed while rating saves')
+    act(() => current.focus())
+    fireEvent.keyDown(current, { key: 'Escape' })
+    expect((current as HTMLInputElement).value).toBe('')
+    expect(transact).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps a saved rating and queries its new order when returning to a cached sort', async () => {
+    const first = {
+      ...createLibraryItem(1),
+      item: { ...libraryItem.item, title: 'First ranked', rating: 4 }
+    }
+    let second = {
+      ...createLibraryItem(2),
+      item: { ...libraryItem.item, title: 'Second ranked', rating: 1 }
+    }
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+      Promise.resolve({
+        entries:
+          request.scope === 'library'
+            ? request.sortBy === 'rating' && second.item.rating === 5
+              ? [second, first]
+              : [first, second]
+            : [],
+        totalCount: request.scope === 'library' ? 2 : 0
+      })
+    )
+    transact.mockImplementationOnce(async () => {
+      second = {
+        ...second,
+        metadataRevision: second.metadataRevision + 1,
+        item: { ...second.item, rating: 5 }
+      }
+      return { kind: 'item', id: second.id }
+    })
+    get.mockImplementation(async (id: string) => (id === second.id ? second : first))
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await screen.findByText('Second ranked')
+    fireEvent.click(screen.getByLabelText('Sort references'))
+    fireEvent.click(screen.getByRole('option', { name: 'Highest rated' }))
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'library', sortBy: 'rating' })
+      )
+    )
+    fireEvent.click(
+      within(screen.getByText('Second ranked').closest('tr')!).getByRole('button', {
+        name: 'Set rating to 5'
+      })
+    )
+    await waitFor(() => expect(get).toHaveBeenCalledWith(second.id))
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(
+      within(screen.getByText('Second ranked').closest('tr')!)
+        .getByRole('button', { name: 'Set rating to 5' })
+        .querySelector('svg')
+        ?.getAttribute('class')
+    ).toContain('fill-amber-400')
+    fireEvent.click(screen.getByLabelText('Sort references'))
+    fireEvent.click(screen.getByRole('option', { name: 'Recently updated' }))
+    await screen.findByText('Second ranked')
+    fireEvent.click(screen.getByLabelText('Sort references'))
+    fireEvent.click(screen.getByRole('option', { name: 'Highest rated' }))
+    await screen.findByText('Second ranked')
+    expect(
+      within(screen.getByText('Second ranked').closest('tr')!)
+        .getByRole('button', { name: 'Set rating to 5' })
+        .querySelector('svg')
+        ?.getAttribute('class')
+    ).toContain('fill-amber-400')
+    expect(
+      screen.getAllByRole('row').filter((row) => row.textContent?.includes('ranked'))[0].textContent
+    ).toContain('Second ranked')
+  })
+
+  it.each([
+    { filtered: true, remains: false },
+    { filtered: false, remains: true },
+    { filtered: true, remains: true }
+  ])(
+    'refreshes a Favorites result after a tag event with filtered=$filtered and remains=$remains',
+    async ({ filtered, remains }) => {
+      window.localStorage.setItem(
+        'open-science:literature-table-preferences',
+        JSON.stringify({ visible: ['notes'] })
+      )
+      let emitChanged!: (event: { revision: number }) => void
+      vi.mocked(window.api.tags.onChanged).mockImplementation((listener) => {
+        emitChanged = listener
+        return () => undefined
+      })
+      let assigned = true
+      search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+        Promise.resolve({
+          entries: request.scope === 'library' && (!request.tagId || assigned) ? [libraryItem] : [],
+          totalCount: request.scope === 'library' && (!request.tagId || assigned) ? 1 : 0
+        })
+      )
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await screen.findByText(libraryItem.item.title)
+      if (filtered) {
+        fireEvent.click(screen.getByRole('button', { name: 'Filters' }))
+        fireEvent.click(screen.getByLabelText('Filter by Tag'))
+        fireEvent.click(screen.getByRole('option', { name: 'Favorites' }))
+        await waitFor(() =>
+          expect(search).toHaveBeenCalledWith(
+            expect.objectContaining({ scope: 'library', tagId: 'tag-favorite' })
+          )
+        )
+      }
+      const previousQueries = search.mock.calls.filter(
+        ([request]) => request.scope === 'library' && request.limit !== 1
+      ).length
+      const input = screen.getByRole('textbox', {
+        name: `Note for ${libraryItem.item.title}`
+      }) as HTMLInputElement
+      fireEvent.change(input, { target: { value: 'Draft during tag refresh' } })
+      assigned = remains
+      vi.mocked(window.api.tags.snapshot).mockResolvedValue({
+        revision: 2,
+        tags: useTagStore.getState().tags,
+        assignments: remains ? useTagStore.getState().assignments : []
+      })
+      await act(async () => {
+        emitChanged({ revision: 2 })
+      })
+      await waitFor(() => expect(useTagStore.getState().revision).toBe(2))
+      if (remains) {
+        expect(screen.getByRole('textbox', { name: `Note for ${libraryItem.item.title}` })).toBe(
+          input
+        )
+        expect(input.value).toBe('Draft during tag refresh')
+      }
+      if (!filtered) {
+        expect(screen.getByText(libraryItem.item.title)).not.toBeNull()
+        expect(
+          search.mock.calls.filter(
+            ([request]) => request.scope === 'library' && request.limit !== 1
+          )
+        ).toHaveLength(previousQueries)
+        return
+      }
+      if (!remains)
+        await waitFor(() => expect(screen.queryByText(libraryItem.item.title)).toBeNull())
+      expect(
+        search.mock.calls.filter(([request]) => request.scope === 'library' && request.limit !== 1)
+          .length
+      ).toBeGreaterThan(previousQueries)
+    }
+  )
 
   it('edits rating and notes directly in optional table columns', async () => {
     window.localStorage.setItem(

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -3341,26 +3341,59 @@ describe('LiteratureLibraryPage', () => {
     ).toBe('Important new unsaved analysis')
   })
 
-  it('distinguishes a committed note from a failed readback and retains its text', async () => {
-    window.localStorage.setItem(
-      'open-science:literature-table-preferences',
-      JSON.stringify({ visible: ['notes'] })
-    )
-    search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
-      Promise.resolve({ entries: request.scope === 'library' ? [libraryItem] : [] })
-    )
-    get.mockRejectedValueOnce(new Error('read unavailable'))
-    render(<LiteratureLibraryPage />)
-    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
-    const input = (await screen.findByRole('textbox', {
-      name: `Note for ${libraryItem.item.title}`
-    })) as HTMLInputElement
-    fireEvent.change(input, { target: { value: 'Committed analysis' } })
-    fireEvent.blur(input)
-    await screen.findByText('The reference was saved, but could not be reloaded.')
-    expect(input.value).toBe('Committed analysis')
-    expect(transact).toHaveBeenCalledTimes(1)
-  })
+  it.each([false, true])(
+    'reloads a committed note without repeating the write (edited during recovery: %s)',
+    async (edited) => {
+      window.localStorage.setItem(
+        'open-science:literature-table-preferences',
+        JSON.stringify({ visible: ['notes'] })
+      )
+      search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+        Promise.resolve({ entries: request.scope === 'library' ? [libraryItem] : [] })
+      )
+      get
+        .mockRejectedValueOnce(new Error('read unavailable'))
+        .mockRejectedValueOnce(new Error('still unavailable'))
+        .mockResolvedValue({
+          ...libraryItem,
+          metadataRevision: 2,
+          item: { ...libraryItem.item, personalNote: 'Committed analysis' }
+        })
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      const input = (await screen.findByRole('textbox', {
+        name: `Note for ${libraryItem.item.title}`
+      })) as HTMLInputElement
+      fireEvent.change(input, { target: { value: 'Committed analysis' } })
+      fireEvent.blur(input)
+      await screen.findByText('The reference was saved, but could not be reloaded.')
+      expect(input.value).toBe('Committed analysis')
+      expect(transact).toHaveBeenCalledTimes(1)
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+      await waitFor(() =>
+        expect(screen.getByRole('button', { name: 'Retry' }).hasAttribute('disabled')).toBe(false)
+      )
+      expect(input.value).toBe('Committed analysis')
+      expect(transact).toHaveBeenCalledTimes(1)
+      if (edited) fireEvent.change(input, { target: { value: 'Further analysis' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(3))
+      expect(transact).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(input.getAttribute('aria-invalid')).toBeNull())
+      expect(input.value).toBe(edited ? 'Further analysis' : 'Committed analysis')
+      if (edited) {
+        fireEvent.blur(input)
+        await waitFor(() => expect(transact).toHaveBeenCalledTimes(2))
+        expect(transact.mock.calls[1][0]).toEqual(
+          expect.objectContaining({
+            expectedMetadataRevision: 2,
+            item: expect.objectContaining({ personalNote: 'Further analysis' })
+          })
+        )
+      }
+    }
+  )
 
   it('retries a failed note without losing text and adopts the next clean snapshot', async () => {
     window.localStorage.setItem(

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -3389,15 +3389,11 @@ describe('LiteratureLibraryPage', () => {
     })) as HTMLInputElement
     fireEvent.change(input, { target: { value: 'Retry this draft' } })
     fireEvent.blur(input)
-    await screen.findByText(
-      'Your note draft is preserved. Retry saving or press Escape to discard.'
-    )
+    await screen.findByText('Draft preserved. Escape to discard.')
     fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
     await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
     await waitFor(() =>
-      expect(
-        screen.queryByText('Your note draft is preserved. Retry saving or press Escape to discard.')
-      ).toBeNull()
+      expect(screen.queryByText('Draft preserved. Escape to discard.')).toBeNull()
     )
     expect(input.value).toBe('Retry this draft')
     expect(transact.mock.calls[1][0]).toEqual(transact.mock.calls[0][0])

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -919,13 +919,20 @@ function LiteratureNoteControl({
   onCommit
 }: Readonly<{
   entry: LiteratureItemView
-  onCommit: (base: LiteratureItemView, note: string) => Promise<void>
+  onCommit: (
+    base: LiteratureItemView,
+    note: string,
+    onPersisted: (reload: () => Promise<LiteratureItemView>) => void
+  ) => Promise<void>
 }>): React.JSX.Element {
   const { t } = useTranslation()
   const [edit, setEdit] = useState<{ base: LiteratureItemView; draft: string }>()
   const [isSaving, setIsSaving] = useState(false)
   const [failed, setFailed] = useState(false)
   const savingRef = useRef(false)
+  const recoveryRef = useRef<
+    { note: string; reload: () => Promise<LiteratureItemView> } | undefined
+  >(undefined)
   const cancelNextBlurRef = useRef(false)
   const dirty = edit !== undefined && edit.draft !== (edit.base.item.personalNote ?? '')
   // A dirty draft keeps its original full item and revision, including across rating refreshes.
@@ -939,7 +946,7 @@ function LiteratureNoteControl({
     }
     if (savingRef.current) return
     const note = draft.trim()
-    if (note === (base.item.personalNote ?? '')) {
+    if (!recoveryRef.current && note === (base.item.personalNote ?? '')) {
       setEdit(undefined)
       setFailed(false)
       return
@@ -947,8 +954,26 @@ function LiteratureNoteControl({
     savingRef.current = true
     setIsSaving(true)
     try {
-      await onCommit(base, note)
-      setEdit(undefined)
+      const recovery = recoveryRef.current
+      if (recovery) {
+        const updated = await recovery.reload()
+        // New typing during recovery remains a draft. Only rebase it when the saved note
+        // still matches our acknowledged write; otherwise retain conflict protection.
+        setEdit(
+          note === recovery.note
+            ? undefined
+            : {
+                base: (updated.item.personalNote ?? '') === recovery.note ? updated : base,
+                draft
+              }
+        )
+      } else {
+        await onCommit(base, note, (reload) => {
+          recoveryRef.current = { note, reload }
+        })
+        setEdit(undefined)
+      }
+      recoveryRef.current = undefined
       setFailed(false)
     } catch {
       setFailed(true)
@@ -2126,7 +2151,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
 
   const persistInlineItem = async (
     entry: LiteratureItemView,
-    patch: Partial<Pick<LiteratureItemInput, 'itemType' | 'personalNote' | 'rating'>>
+    patch: Partial<Pick<LiteratureItemInput, 'itemType' | 'personalNote' | 'rating'>>,
+    onPersisted?: (reload: () => Promise<LiteratureItemView>) => void
   ): Promise<void> => {
     const item = { ...entry.item, ...patch }
     if (
@@ -2144,11 +2170,21 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         item
       })
       persisted = true
-      const updated = await window.api.literature.get(entry.id)
-      if (!updated) throw new Error('Literature Item is unavailable after updating.')
-      await refreshItems([updated.id], [updated])
-      detailController.replace(updated)
-      setError(undefined)
+      const reload = async (): Promise<LiteratureItemView> => {
+        try {
+          const updated = await window.api.literature.get(entry.id)
+          if (!updated) throw new Error('Literature Item is unavailable after updating.')
+          await refreshItems([updated.id], [updated])
+          detailController.replace(updated)
+          setError(undefined)
+          return updated
+        } catch (error) {
+          setError(t('The reference was saved, but could not be reloaded.'))
+          throw error
+        }
+      }
+      onPersisted?.(reload)
+      await reload()
     } catch (error) {
       setError(
         persisted
@@ -4252,8 +4288,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                                         <LiteratureNoteControl
                                           key={entry.id}
                                           entry={entry}
-                                          onCommit={(base, personalNote) =>
-                                            persistInlineItem(base, { personalNote })
+                                          onCommit={(base, personalNote, onPersisted) =>
+                                            persistInlineItem(base, { personalNote }, onPersisted)
                                           }
                                         />
                                       </td>

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -915,56 +915,92 @@ function LiteratureTypeControl({
 }
 
 function LiteratureNoteControl({
-  value,
-  title,
+  entry,
   onCommit
 }: Readonly<{
-  value: string
-  title: string
-  onCommit: (note: string) => Promise<void>
+  entry: LiteratureItemView
+  onCommit: (base: LiteratureItemView, note: string) => Promise<void>
 }>): React.JSX.Element {
   const { t } = useTranslation()
-  const [draft, setDraft] = useState(value)
+  const [edit, setEdit] = useState<{ base: LiteratureItemView; draft: string }>()
   const [isSaving, setIsSaving] = useState(false)
+  const [failed, setFailed] = useState(false)
+  const savingRef = useRef(false)
   const cancelNextBlurRef = useRef(false)
+  const dirty = edit !== undefined && edit.draft !== (edit.base.item.personalNote ?? '')
+  // A dirty draft keeps its original full item and revision, including across rating refreshes.
+  const base = dirty ? edit.base : entry
+  const draft = dirty ? edit.draft : (entry.item.personalNote ?? '')
 
   const commitNote = async (): Promise<void> => {
     if (cancelNextBlurRef.current) {
       cancelNextBlurRef.current = false
       return
     }
+    if (savingRef.current) return
     const note = draft.trim()
-    setDraft(note)
-    if (isSaving || note === value) return
+    if (note === (base.item.personalNote ?? '')) {
+      setEdit(undefined)
+      setFailed(false)
+      return
+    }
+    savingRef.current = true
     setIsSaving(true)
     try {
-      await onCommit(note)
+      await onCommit(base, note)
+      setEdit(undefined)
+      setFailed(false)
     } catch {
-      setDraft(value)
+      setFailed(true)
     } finally {
+      savingRef.current = false
       setIsSaving(false)
     }
   }
 
   return (
-    <Input
-      value={draft}
-      readOnly={isSaving}
-      aria-label={t('Note for {{title}}', { title })}
-      aria-busy={isSaving}
-      placeholder={t('Add a note…')}
-      className="h-8 border-transparent bg-transparent px-2 text-xs placeholder:text-muted-foreground/70 hover:border-border hover:bg-bg-100 focus-visible:border-border focus-visible:bg-bg-000"
-      onChange={(event) => setDraft(event.currentTarget.value)}
-      onKeyDown={(event) => {
-        if (event.key === 'Enter') event.currentTarget.blur()
-        if (event.key === 'Escape') {
-          cancelNextBlurRef.current = true
-          setDraft(value)
-          event.currentTarget.blur()
-        }
-      }}
-      onBlur={() => void commitNote()}
-    />
+    <div>
+      <Input
+        value={draft}
+        readOnly={isSaving}
+        aria-label={t('Note for {{title}}', { title: entry.item.title })}
+        aria-busy={isSaving}
+        aria-invalid={failed || undefined}
+        placeholder={t('Add a note…')}
+        className="h-8 border-transparent bg-transparent px-2 text-xs placeholder:text-muted-foreground/70 hover:border-border hover:bg-bg-100 focus-visible:border-border focus-visible:bg-bg-000"
+        onFocus={() => {
+          if (!dirty) setEdit({ base: entry, draft: entry.item.personalNote ?? '' })
+        }}
+        onChange={(event) => setEdit({ base, draft: event.currentTarget.value })}
+        onKeyDown={(event) => {
+          if (isSaving || event.nativeEvent.isComposing) return
+          if (event.key === 'Enter') event.currentTarget.blur()
+          if (event.key === 'Escape') {
+            cancelNextBlurRef.current = true
+            setEdit(undefined)
+            setFailed(false)
+            event.currentTarget.blur()
+          }
+        }}
+        onBlur={() => void commitNote()}
+      />
+      {failed ? (
+        <div className="px-2 text-xs text-status-warning-foreground">
+          <p role="alert">
+            {t('Your note draft is preserved. Retry saving or press Escape to discard.')}
+          </p>
+          <button
+            type="button"
+            className="underline"
+            disabled={isSaving}
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => void commitNote()}
+          >
+            {t('Retry')}
+          </button>
+        </div>
+      ) : null}
+    </div>
   )
 }
 
@@ -1177,6 +1213,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const loadProjects = useProjectStore((state) => state.loadProjects)
   const loadTags = useTagStore((state) => state.load)
   const listenTags = useTagStore((state) => state.listen)
+  const tagRevision = useTagStore((state) => state.revision)
   const [section, setSection] = useState<LibrarySection>('inbox')
   const [duplicatesOpen, setDuplicatesOpen] = useState(false)
   const [shouldCueLiteratureReview, setShouldCueLiteratureReview] = useState(
@@ -1616,6 +1653,20 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     onEmptyPage: setEntriesOffset,
     onError: receiveEntriesError
   })
+  const appliedTagRevision = useRef(tagRevision)
+  useEffect(() => {
+    if (appliedTagRevision.current === tagRevision) return
+    appliedTagRevision.current = tagRevision
+    if (tagId !== 'all') {
+      clearSelection()
+      // Keep surviving keyed editors mounted during an authoritative background refresh.
+      void reloadEntries(true, true)
+    } else {
+      // Previously visited filtered scopes must not resurrect old assignment membership.
+      void refreshItems([])
+    }
+  }, [clearSelection, refreshItems, reloadEntries, tagId, tagRevision])
+
   const loadEntries = useCallback(
     (force = false): Promise<void> => {
       if (force) {
@@ -2084,6 +2135,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       (item.rating ?? 0) === (entry.item.rating ?? 0)
     )
       return
+    let persisted = false
     try {
       await window.api.literature.transact({
         kind: 'update-item',
@@ -2091,13 +2143,18 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         expectedMetadataRevision: entry.metadataRevision,
         item
       })
+      persisted = true
       const updated = await window.api.literature.get(entry.id)
       if (!updated) throw new Error('Literature Item is unavailable after updating.')
-      setItems((current) => current.map((item) => (item.id === updated.id ? updated : item)))
+      await refreshItems([updated.id], [updated])
       detailController.replace(updated)
       setError(undefined)
     } catch (error) {
-      setError(t('Literature could not be updated.'))
+      setError(
+        persisted
+          ? t('The reference was saved, but could not be reloaded.')
+          : t('Literature could not be updated.')
+      )
       throw error
     }
   }
@@ -4193,11 +4250,10 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                                     return (
                                       <td key={column} className="px-2 py-2 align-middle">
                                         <LiteratureNoteControl
-                                          key={`${entry.id}:${entry.metadataRevision}:note`}
-                                          value={entry.item.personalNote ?? ''}
-                                          title={entry.item.title}
-                                          onCommit={(personalNote) =>
-                                            persistInlineItem(entry, { personalNote })
+                                          key={entry.id}
+                                          entry={entry}
+                                          onCommit={(base, personalNote) =>
+                                            persistInlineItem(base, { personalNote })
                                           }
                                         />
                                       </td>

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1693,12 +1693,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }, [clearSelection, refreshItems, reloadEntries, tagId, tagRevision])
 
   const loadEntries = useCallback(
-    (force = false): Promise<void> => {
+    (force = false, preservePage = false): Promise<void> => {
       if (force) {
         setDuplicatesRevision((value) => value + 1)
         setLibraryCountRevision((value) => value + 1)
       }
-      return reloadEntries(force)
+      return reloadEntries(force, preservePage)
     },
     [reloadEntries]
   )
@@ -3880,7 +3880,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                         disabled: isBatching,
                         onClick: () => {
                           void Promise.all([
-                            loadEntries(true),
+                            loadEntries(true, true),
                             loadCollections(),
                             loadProjectCounts()
                           ]).catch(() => setError(t('Literature could not be loaded.')))

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -985,13 +985,13 @@ function LiteratureNoteControl({
         onBlur={() => void commitNote()}
       />
       {failed ? (
-        <div className="px-2 text-xs text-status-warning-foreground">
-          <p role="alert">
-            {t('Your note draft is preserved. Retry saving or press Escape to discard.')}
+        <div className="flex items-center gap-2 px-2 text-xs text-status-warning-foreground">
+          <p role="alert" className="truncate" title={t('Draft preserved. Escape to discard.')}>
+            {t('Draft preserved. Escape to discard.')}
           </p>
           <button
             type="button"
-            className="underline"
+            className="shrink-0 underline"
             disabled={isSaving}
             onMouseDown={(event) => event.preventDefault()}
             onClick={() => void commitNote()}

--- a/src/renderer/src/pages/literature/useLiteratureEntries.test.tsx
+++ b/src/renderer/src/pages/literature/useLiteratureEntries.test.tsx
@@ -259,4 +259,105 @@ describe('useLiteratureEntries', () => {
       true
     )
   })
+  it('requeries a page whose in-flight search predates an inline update', async () => {
+    const item: LiteratureItemView = {
+      id: 'a',
+      item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'Saved' }),
+      attachments: [],
+      collectionIds: [],
+      projectIds: [],
+      metadataRevision: 2,
+      createdAt: 1,
+      updatedAt: 2
+    }
+    let finish!: (page: LiteratureCatalogSearchPage) => void
+    search
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve
+          })
+      )
+      .mockResolvedValueOnce({ entries: [item], totalCount: 1 })
+    const { result, onPage } = setup()
+    await act(() => result.current.refreshItems([item.id], [item]))
+    await act(async () => {
+      finish({ entries: [{ ...item, metadataRevision: 1 }], totalCount: 1 })
+    })
+    expect(search).toHaveBeenCalledTimes(2)
+    expect(onPage).toHaveBeenCalledTimes(1)
+    expect(onPage.mock.calls[0][0].entries[0].metadataRevision).toBe(2)
+  })
+
+  it('keeps a newer inline revision when an older background read completes', async () => {
+    const original: LiteratureItemView = {
+      id: 'a',
+      item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'Saved' }),
+      attachments: [],
+      collectionIds: [],
+      projectIds: [],
+      metadataRevision: 1,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    search.mockResolvedValue({ entries: [original], totalCount: 1 })
+    let finish!: (item: LiteratureItemView) => void
+    window.api.literature.get = vi.fn(
+      () =>
+        new Promise<LiteratureItemView>((resolve) => {
+          finish = resolve
+        })
+    )
+    const { result, onPage } = setup()
+    await act(async () => {})
+    let pending!: Promise<void>
+    act(() => {
+      pending = result.current.refreshItems(['a'])
+    })
+    await act(() => result.current.refreshItems(['a'], [{ ...original, metadataRevision: 3 }]))
+    await act(async () => {
+      finish({ ...original, metadataRevision: 2 })
+      await pending
+    })
+    expect(onPage.mock.lastCall?.[0].entries[0].metadataRevision).toBe(3)
+  })
+  it('retains the displayed page during a failed background refresh and retries its dirty cache', async () => {
+    const item: LiteratureItemView = {
+      id: 'a',
+      item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'Saved' }),
+      attachments: [],
+      collectionIds: [],
+      projectIds: [],
+      metadataRevision: 1,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    search.mockResolvedValue({ entries: [item], totalCount: 1 })
+    const { result, onPage, onError, rerender } = setup()
+    await act(async () => {})
+    let reject!: (error: Error) => void
+    search.mockImplementationOnce(
+      () =>
+        new Promise((_, fail) => {
+          reject = fail
+        })
+    )
+    let pending!: Promise<void>
+    act(() => {
+      pending = result.current.reload(true, true)
+    })
+    expect(result.current.loading).toBe(false)
+    await act(async () => {
+      reject(new Error('offline'))
+      await pending
+    })
+    expect(result.current.failed).toBe(false)
+    expect(onError).toHaveBeenLastCalledWith(true)
+    expect(onPage).toHaveBeenCalledTimes(1)
+    rerender({ enabled: true, scopeKey: 'other', request: { ...request, query: 'other' } })
+    await act(async () => {})
+    rerender({ enabled: true, scopeKey: 'library', request })
+    await act(async () => {})
+    expect(search).toHaveBeenCalledTimes(4)
+  })
 })

--- a/src/renderer/src/pages/literature/useLiteratureEntries.ts
+++ b/src/renderer/src/pages/literature/useLiteratureEntries.ts
@@ -2,7 +2,8 @@ import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 
 import type {
   LiteratureCatalogSearchPage,
-  LiteratureCatalogSearchRequest
+  LiteratureCatalogSearchRequest,
+  LiteratureItemView
 } from '../../../../shared/literature'
 
 const PAGE_CACHE_SIZE = 12
@@ -33,13 +34,14 @@ const useLiteratureEntries = ({
   loading: boolean
   failed: boolean
   pageTransitionLoading: boolean
-  reload: (force?: boolean) => Promise<void>
-  refreshItems: (itemIds: string[]) => Promise<void>
+  reload: (force?: boolean, preservePage?: boolean) => Promise<void>
+  refreshItems: (itemIds: string[], updatedItems?: LiteratureItemView[]) => Promise<void>
 } => {
   const [loading, setLoading] = useState(true)
   const [loadedKey, setLoadedKey] = useState<string>()
   const [failedKey, setFailedKey] = useState<string>()
   const generationRef = useRef(0)
+  const dataRevisionRef = useRef(0)
   const cacheRef = useRef(new Map<string, LiteratureCatalogSearchPage>())
   const dirtyKeys = useRef(new Set<string>())
   const [cachedKeys, setCachedKeys] = useState<ReadonlySet<string>>(() => new Set())
@@ -51,17 +53,26 @@ const useLiteratureEntries = ({
   const pageKey = `${scopeKey}:${request.offset ?? 0}`
 
   const reload = useCallback(
-    async (force = false): Promise<void> => {
+    async (force = false, preservePage = false): Promise<void> => {
+      const retained =
+        preservePage && appliedPageRef.current?.key === pageKey ? appliedPageRef.current : undefined
       if (force) {
         cacheRef.current.clear()
         dirtyKeys.current.clear()
-        setCachedKeys(new Set())
-        appliedPageRef.current = undefined
-        setLoadedKey(undefined)
+        if (retained) {
+          cacheRef.current.set(pageKey, retained.page)
+          dirtyKeys.current.add(pageKey)
+        }
+        setCachedKeys(new Set(cacheRef.current.keys()))
+        if (!retained) {
+          appliedPageRef.current = undefined
+          setLoadedKey(undefined)
+        }
         setFailedKey(undefined)
       }
       if (!enabled) return
       const generation = ++generationRef.current
+      let dataRevision = dataRevisionRef.current
       const cached =
         force || dirtyKeys.current.has(pageKey) ? undefined : cacheRef.current.get(pageKey)
       setFailedKey(undefined)
@@ -76,7 +87,11 @@ const useLiteratureEntries = ({
       }
       if (!cached) setLoading(true)
       try {
-        const page = cached ?? (await window.api.literature.search(request))
+        let page = cached ?? (await window.api.literature.search(request))
+        while (generation === generationRef.current && dataRevision !== dataRevisionRef.current) {
+          dataRevision = dataRevisionRef.current
+          page = await window.api.literature.search(request)
+        }
         if (generation !== generationRef.current) return
         if (page.entries.length === 0 && (request.offset ?? 0) > 0) {
           onEmptyPage(Math.max(0, (request.offset ?? 0) - (request.limit ?? 50)))
@@ -96,7 +111,7 @@ const useLiteratureEntries = ({
         setLoadedKey(pageKey)
       } catch {
         if (generation === generationRef.current) {
-          setFailedKey(pageKey)
+          if (!retained) setFailedKey(pageKey)
           onError(true)
         }
       } finally {
@@ -107,7 +122,8 @@ const useLiteratureEntries = ({
   )
 
   const refreshItems = useCallback(
-    async (itemIds: string[]): Promise<void> => {
+    async (itemIds: string[], updatedItems?: LiteratureItemView[]): Promise<void> => {
+      dataRevisionRef.current += 1
       const displayed = appliedPageRef.current
       const ids = new Set(itemIds)
       // Invalidate other scopes, but keep the current page and its order while it is being read.
@@ -122,7 +138,8 @@ const useLiteratureEntries = ({
         'metadataRevision' in entry && ids.has(entry.id) ? [entry.id] : []
       )
       try {
-        const updated = await Promise.all(visible.map((id) => window.api.literature.get(id)))
+        const updated =
+          updatedItems ?? (await Promise.all(visible.map((id) => window.api.literature.get(id))))
         if (generation !== generationRef.current || appliedPageRef.current?.key !== pageKey) return
         const replacements = new Map(
           updated.flatMap((entry) => (entry ? [[entry.id, entry] as const] : []))
@@ -131,7 +148,10 @@ const useLiteratureEntries = ({
         const page = {
           ...current,
           entries: current.entries.map((entry) =>
-            'metadataRevision' in entry ? (replacements.get(entry.id) ?? entry) : entry
+            'metadataRevision' in entry &&
+            (replacements.get(entry.id)?.metadataRevision ?? -1) >= entry.metadataRevision
+              ? replacements.get(entry.id)!
+              : entry
           )
         }
         cacheRef.current.set(pageKey, page)

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -103,6 +103,8 @@
   "renderer": {
     "Identifiers (★ primary)": "Identifikatoren (★ primär)",
     "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
+    "The reference was saved, but could not be reloaded.": "Die Referenz wurde gespeichert, konnte aber nicht neu geladen werden.",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "Ihr Notizentwurf bleibt erhalten. Speichern Sie erneut oder drücken Sie Escape, um ihn zu verwerfen.",
     "Not answered": "Nicht beantwortet",
     "Automatic contrast": "Automatischer Kontrast",
     "Display range": "Anzeigebereich",

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -104,7 +104,7 @@
     "Identifiers (★ primary)": "Identifikatoren (★ primär)",
     "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
     "The reference was saved, but could not be reloaded.": "Die Referenz wurde gespeichert, konnte aber nicht neu geladen werden.",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "Ihr Notizentwurf bleibt erhalten. Speichern Sie erneut oder drücken Sie Escape, um ihn zu verwerfen.",
+    "Draft preserved. Escape to discard.": "Entwurf erhalten. Escape zum Verwerfen.",
     "Not answered": "Nicht beantwortet",
     "Automatic contrast": "Automatischer Kontrast",
     "Display range": "Anzeigebereich",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -104,6 +104,8 @@
   "renderer": {
     "Identifiers (★ primary)": "Identificadores (★ principal)",
     "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
+    "The reference was saved, but could not be reloaded.": "La referencia se guardó, pero no se pudo volver a cargar.",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "El borrador de la nota se conserva. Vuelva a intentar guardarlo o pulse Escape para descartarlo.",
     "Not answered": "Sin responder",
     "Automatic contrast": "Contraste automático",
     "Display range": "Rango de visualización",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -105,7 +105,7 @@
     "Identifiers (★ primary)": "Identificadores (★ principal)",
     "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
     "The reference was saved, but could not be reloaded.": "La referencia se guardó, pero no se pudo volver a cargar.",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "El borrador de la nota se conserva. Vuelva a intentar guardarlo o pulse Escape para descartarlo.",
+    "Draft preserved. Escape to discard.": "Borrador conservado. Escape para descartar.",
     "Not answered": "Sin responder",
     "Automatic contrast": "Contraste automático",
     "Display range": "Rango de visualización",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -104,6 +104,8 @@
   "renderer": {
     "Identifiers (★ primary)": "Identifiants (★ principal)",
     "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
+    "The reference was saved, but could not be reloaded.": "La référence a été enregistrée, mais n’a pas pu être rechargée.",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "Votre brouillon de note est conservé. Réessayez de l’enregistrer ou appuyez sur Échap pour l’abandonner.",
     "Not answered": "Sans réponse",
     "Automatic contrast": "Contraste automatique",
     "Display range": "Plage d’affichage",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -105,7 +105,7 @@
     "Identifiers (★ primary)": "Identifiants (★ principal)",
     "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
     "The reference was saved, but could not be reloaded.": "La référence a été enregistrée, mais n’a pas pu être rechargée.",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "Votre brouillon de note est conservé. Réessayez de l’enregistrer ou appuyez sur Échap pour l’abandonner.",
+    "Draft preserved. Escape to discard.": "Brouillon conservé. Échap pour abandonner.",
     "Not answered": "Sans réponse",
     "Automatic contrast": "Contraste automatique",
     "Display range": "Plage d’affichage",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -102,6 +102,8 @@
   "renderer": {
     "Identifiers (★ primary)": "識別子（★ 主要）",
     "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
+    "The reference was saved, but could not be reloaded.": "文献は保存されましたが、再読み込みできませんでした。",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "メモの下書きは保持されています。保存を再試行するか、Escape キーで破棄してください。",
     "Not answered": "未回答",
     "Automatic contrast": "自動コントラスト",
     "Display range": "表示範囲",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -103,7 +103,7 @@
     "Identifiers (★ primary)": "識別子（★ 主要）",
     "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
     "The reference was saved, but could not be reloaded.": "文献は保存されましたが、再読み込みできませんでした。",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "メモの下書きは保持されています。保存を再試行するか、Escape キーで破棄してください。",
+    "Draft preserved. Escape to discard.": "下書きを保持しました。Escape で破棄。",
     "Not answered": "未回答",
     "Automatic contrast": "自動コントラスト",
     "Display range": "表示範囲",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -102,6 +102,8 @@
   "renderer": {
     "Identifiers (★ primary)": "식별자(★ 기본)",
     "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
+    "The reference was saved, but could not be reloaded.": "참고 문헌은 저장되었지만 다시 불러오지 못했습니다.",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "메모 초안이 보존되었습니다. 저장을 다시 시도하거나 Escape 키를 눌러 취소하세요.",
     "Not answered": "미응답",
     "Automatic contrast": "자동 대비",
     "Display range": "표시 범위",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -103,7 +103,7 @@
     "Identifiers (★ primary)": "식별자(★ 기본)",
     "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
     "The reference was saved, but could not be reloaded.": "참고 문헌은 저장되었지만 다시 불러오지 못했습니다.",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "메모 초안이 보존되었습니다. 저장을 다시 시도하거나 Escape 키를 눌러 취소하세요.",
+    "Draft preserved. Escape to discard.": "초안이 보존되었습니다. Escape로 취소.",
     "Not answered": "미응답",
     "Automatic contrast": "자동 대비",
     "Display range": "표시 범위",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -106,7 +106,7 @@
     "Identifiers (★ primary)": "Идентификаторы (★ основной)",
     "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
     "The reference was saved, but could not be reloaded.": "Источник сохранён, но его не удалось загрузить повторно.",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "Черновик заметки сохранён в редакторе. Повторите сохранение или нажмите Escape, чтобы отменить изменения.",
+    "Draft preserved. Escape to discard.": "Черновик сохранён. Escape — отменить.",
     "Not answered": "Нет ответа",
     "Automatic contrast": "Автоматическая контрастность",
     "Display range": "Диапазон отображения",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -105,6 +105,8 @@
   "renderer": {
     "Identifiers (★ primary)": "Идентификаторы (★ основной)",
     "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
+    "The reference was saved, but could not be reloaded.": "Источник сохранён, но его не удалось загрузить повторно.",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "Черновик заметки сохранён в редакторе. Повторите сохранение или нажмите Escape, чтобы отменить изменения.",
     "Not answered": "Нет ответа",
     "Automatic contrast": "Автоматическая контрастность",
     "Display range": "Диапазон отображения",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -102,6 +102,8 @@
   "renderer": {
     "Identifiers (★ primary)": "标识符（★ 主标识）",
     "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
+    "The reference was saved, but could not be reloaded.": "文献已保存，但无法重新加载。",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "笔记草稿已保留。请重试保存，或按 Escape 放弃修改。",
     "Not answered": "未填写",
     "Automatic contrast": "自动对比度",
     "Display range": "显示范围",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -103,7 +103,7 @@
     "Identifiers (★ primary)": "标识符（★ 主标识）",
     "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
     "The reference was saved, but could not be reloaded.": "文献已保存，但无法重新加载。",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "笔记草稿已保留。请重试保存，或按 Escape 放弃修改。",
+    "Draft preserved. Escape to discard.": "草稿已保留，按 Escape 放弃。",
     "Not answered": "未填写",
     "Automatic contrast": "自动对比度",
     "Display range": "显示范围",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -102,6 +102,8 @@
   "renderer": {
     "Identifiers (★ primary)": "識別碼（★ 主要識別碼）",
     "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
+    "The reference was saved, but could not be reloaded.": "文獻已儲存，但無法重新載入。",
+    "Your note draft is preserved. Retry saving or press Escape to discard.": "筆記草稿已保留。請重試儲存，或按 Escape 放棄修改。",
     "Not answered": "未填寫",
     "Automatic contrast": "自動對比度",
     "Display range": "顯示範圍",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -103,7 +103,7 @@
     "Identifiers (★ primary)": "識別碼（★ 主要識別碼）",
     "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
     "The reference was saved, but could not be reloaded.": "文獻已儲存，但無法重新載入。",
-    "Your note draft is preserved. Retry saving or press Escape to discard.": "筆記草稿已保留。請重試儲存，或按 Escape 放棄修改。",
+    "Draft preserved. Escape to discard.": "草稿已保留，按 Escape 捨棄。",
     "Not answered": "未填寫",
     "Automatic contrast": "自動對比度",
     "Display range": "顯示範圍",


### PR DESCRIPTION
## Problem

Inline note failures replace the user's draft, and a concurrent rating refresh remounts the note editor. Successful inline updates also leave stale cached pages behind. Tag assignment snapshots do not refresh filtered literature results, while catalog merge/deletion transactions change tag relationships without publishing the tag service's revision event.

## Proposed change

- Preserve note drafts and their original item/revision, with compact two-row retry feedback and explicit Escape discard. Adopt incoming notes only when the editor is clean. Distinguish a successful write from a failed readback; retry acknowledged writes by reloading only, retaining any further typing and preserving concurrency checks.
- Reuse the page-cache owner for inline updates, reject stale reads, and invalidate obsolete sort/filter snapshots. Background tag-filter refresh keeps surviving editors mounted and reconciles selection/counts/pagination; unfiltered views do not reload for badge changes.
- Notify the existing TagService queue after committed single merges, batch groups and permanent deletions that changed assignments. Keep relationship writes in their existing transaction; previews and rollbacks remain silent.

## Scope and non-goals

No database schema, persisted enum, IPC payload, historical migration or new dependency. Additional state is renderer memory only. Existing data remains compatible; previously lost unsaved drafts cannot be reconstructed. No persistent draft storage, automatic conflict merge or replacement cache/event framework.

## Acceptance criteria and validation

The tests exercise mounted production React controls through the existing IPC boundary and real SQLite catalog/tag services. Two isolated runs against unchanged production source each produced the same 9 expected failures and 3 passing controls. Tests reset one-shot IPC mocks so intentional failures cannot contaminate subsequent scenarios.

Rebased onto `a7350344` and verified the final two-row note feedback. The module run passed 1,430 of 1,434 tests under concurrent local load; the two affected test files were then rerun with one worker and all 930 tests passed, including all four earlier failures. No production changes or relaxed assertions were needed for that rerun. Both typechecks and lint passed. The previous commit’s complete PR Gate also passed.

| Behavior / boundary | Check | Result |
| --- | --- | --- |
| Draft failure/retry, captured revision, rating cache, tag-filter membership and mounted-editor lifecycle | Literature renderer owner tests and useLiteratureEntries tests | Passed |
| Transactional tag migration/deletion, batch/preview/rollback events and tag queue ordering | Literature catalog and tag service/repository tests | Passed |
| Cache consumers, manifest/content access, application events, shared command/renderer contracts, translations | Owner and consumer set below | 1,434 tests covered; all passed across the module run and isolated recheck |
| Main and renderer contracts | `npm run typecheck:node` (including sandbox types), `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Visible note recovery and successful retry | ego-browser with the production page/CSS and a controlled local persistence fixture | Draft retained; retry removed the error |

<details><summary>Owner/consumer test command</summary>

```sh
npx vitest run src/main/literature src/renderer/src/pages/literature src/main/tags src/renderer/src/stores/tag-store.test.ts src/renderer/src/i18n/resources.test.ts src/main/application-events.test.ts src/shared/literature.test.ts src/shared/tags.test.ts src/main/storage/content-repository.test.ts src/main/artifacts/literature-manifest.test.ts src/main/runtime-state-ownership.architecture.test.ts src/shared/application-command-contract.test.ts src/shared/renderer-contract-catalog.test.ts --maxWorkers=2 --testTimeout=60000
```

</details>

The explain plan selects the full CI fallback because `src/main/ipc.ts` has no declared module owner. Per maintainer instruction, the complete suite was not run locally; PR CI remains authoritative for full/platform checks. Local coverage includes the mutating Catalog's composition boundary and the read-only manifest consumer. No path, native packaging or migration changes require new local platform fixtures. Cross-window delivery is covered through the shared event/service/store boundaries; the browser screenshot uses controlled persistence, not a live multi-window database session.

The acknowledged-write recovery follow-up passed 142 mounted-page/cache tests, renderer typecheck and lint. Before the fix, its mounted-page regression failed because Retry issued a second write. Repeated readback failures and editing during recovery are covered; browser verification confirmed successful recovery with the existing two-row feedback.

## Review focus

Preserving the draft's original revision, background-refresh stale-response handling, and publishing tag changes only after commit through the shared service owner.
