### PR TITLE
fix(literature): preserve reading candidates and selected sources

### DIFF
--- a/src/main/literature/attachment-authority.ts
+++ b/src/main/literature/attachment-authority.ts
@@ -21,6 +21,8 @@ type LiteratureAttachmentAuthorityOptions = Readonly<{
   content: Pick<ContentRepository, 'verify'>
 }>
 
+class LiteratureAttachmentUnavailableError extends Error {}
+
 class LiteratureAttachmentAuthority {
   constructor(private readonly options: LiteratureAttachmentAuthorityOptions) {}
 
@@ -39,7 +41,7 @@ class LiteratureAttachmentAuthority {
 
     const verification = await this.options.content.verify(version.contentBlobId)
     if (verification.state !== 'available') {
-      throw new Error(
+      throw new LiteratureAttachmentUnavailableError(
         `Literature attachment content is unavailable: ${versionId} (${verification.reason})`
       )
     }
@@ -50,7 +52,9 @@ class LiteratureAttachmentAuthority {
       content.storageKey !== version.contentBlob.storageKey ||
       (content.contentType !== undefined && content.contentType !== version.contentType)
     ) {
-      throw new Error('Literature Attachment Version does not match its Content Blob authority.')
+      throw new LiteratureAttachmentUnavailableError(
+        'Literature Attachment Version does not match its Content Blob authority.'
+      )
     }
 
     return {
@@ -69,5 +73,5 @@ class LiteratureAttachmentAuthority {
   }
 }
 
-export { LiteratureAttachmentAuthority }
+export { LiteratureAttachmentAuthority, LiteratureAttachmentUnavailableError }
 export type { LiteratureAttachmentAuthorityOptions, ResolvedLiteratureAttachmentVersion }

--- a/src/main/session-persistence/pdf-context-owner.test.ts
+++ b/src/main/session-persistence/pdf-context-owner.test.ts
@@ -3,7 +3,10 @@ import { LiteratureAttachmentAuthority } from '../literature/attachment-authorit
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import type { NotebookRunInputFile } from '../../shared/notebook'
-import type { SessionRuntimeContext } from '../../shared/session-persistence'
+import {
+  sessionApplicationCommandContracts,
+  type SessionRuntimeContext
+} from '../../shared/session-persistence'
 import { ImmutableInputAuthority } from '../immutable-input-authority'
 import { SessionPdfSourceResolver } from '../literature/session-pdf-source-resolver'
 import { inspectPdfPageCount, MAX_AUTO_EXTRACT_PDF_BYTES } from '../uploads/attachment-media'
@@ -140,7 +143,11 @@ describe('SessionPdfContextOwner', () => {
         sourceKind: 'literature-attachment-version' as const,
         sourceVersionId
       }))
-      const result = owner.filterCandidates({ projectId: 'project-1', sources })
+      const result = owner
+        .filterCandidates({ projectId: 'project-1', sources })
+        .then((result) =>
+          sessionApplicationCommandContracts.filterPdfContextCandidates.result.parse(result)
+        )
       if (failure === 'database' || failure === 'storage') {
         await expect(result).rejects.toThrow(
           failure === 'database' ? 'database read failed' : 'storage offline'
@@ -154,6 +161,21 @@ describe('SessionPdfContextOwner', () => {
       }
     }
   )
+
+  it('bounds and validates unavailable sources at the candidate result boundary', () => {
+    const parse = sessionApplicationCommandContracts.filterPdfContextCandidates.result.parse
+    const source = { sourceKind: 'literature-attachment-version', sourceVersionId: 'missing' }
+    const result = { sources: [], pendingAttachmentIds: [] }
+    expect(parse(result)).toEqual(result)
+    expect(parse({ ...result, unavailableSources: Array(100).fill(source) })).toHaveProperty(
+      'unavailableSources.length',
+      100
+    )
+    expect(() => parse({ ...result, unavailableSources: Array(101).fill(source) })).toThrow()
+    expect(() =>
+      parse({ ...result, unavailableSources: [{ ...source, sourceVersionId: '' }] })
+    ).toThrow()
+  })
 
   it('filters PDF context candidates to multi-page immutable Versions', async () => {
     const harness = setup()

--- a/src/main/session-persistence/pdf-context-owner.test.ts
+++ b/src/main/session-persistence/pdf-context-owner.test.ts
@@ -1,3 +1,5 @@
+import type { PrismaClient } from '@prisma/client'
+import { LiteratureAttachmentAuthority } from '../literature/attachment-authority'
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
 import type { NotebookRunInputFile } from '../../shared/notebook'
@@ -86,6 +88,73 @@ const setup = (resolved: NotebookRunInputFile | null = input): SessionPdfContext
 }
 
 describe('SessionPdfContextOwner', () => {
+  it.each(['missing', 'checksum-mismatch', 'authority-mismatch', 'database', 'storage'])(
+    'LR-02 isolates attachment failure but preserves service errors (%s)',
+    async (failure) => {
+      const findUnique = vi.fn(async ({ where: { id } }) => {
+        if (failure === 'database') throw new Error('database read failed')
+        return {
+          id,
+          attachmentId: id,
+          versionNumber: 1,
+          contentBlobId: id,
+          filename: `${id}.pdf`,
+          contentType: 'application/pdf',
+          sizeBytes: 42n,
+          checksum: id,
+          pageCount: 2,
+          attachment: { itemId: id, item: { deletedAt: null } },
+          contentBlob: { storageKey: id }
+        }
+      })
+      const verify = vi.fn(async (id: string) => {
+        if (failure === 'storage') throw new Error('storage offline')
+        if (id === 'bad' && (failure === 'missing' || failure === 'checksum-mismatch')) {
+          return { state: 'unavailable', reason: failure } as const
+        }
+        return {
+          state: 'available' as const,
+          content: {
+            id,
+            path: `/managed/${id}.pdf`,
+            storageKey: id,
+            checksum: id === 'bad' ? 'wrong-checksum' : id,
+            sizeBytes: 42n,
+            contentType: 'application/pdf'
+          }
+        }
+      })
+      const literature = new LiteratureAttachmentAuthority({
+        getClient: async () =>
+          ({ literatureAttachmentVersion: { findUnique } }) as unknown as PrismaClient,
+        content: { verify }
+      })
+      const owner = new SessionPdfContextOwner({
+        sources: new SessionPdfSourceResolver({
+          literature,
+          inputs: { resolveVersion: vi.fn(), openContent: vi.fn() }
+        }),
+        sessions: { readSessionRuntimeContext: vi.fn(), patchSessionRuntimeContext: vi.fn() }
+      })
+      const sources = ['bad', 'good'].map((sourceVersionId) => ({
+        sourceKind: 'literature-attachment-version' as const,
+        sourceVersionId
+      }))
+      const result = owner.filterCandidates({ projectId: 'project-1', sources })
+      if (failure === 'database' || failure === 'storage') {
+        await expect(result).rejects.toThrow(
+          failure === 'database' ? 'database read failed' : 'storage offline'
+        )
+      } else {
+        await expect(result).resolves.toMatchObject({
+          sources: [sources[1]],
+          unavailableSources: [sources[0]]
+        })
+        expect(findUnique).toHaveBeenCalledTimes(2)
+      }
+    }
+  )
+
   it('filters PDF context candidates to multi-page immutable Versions', async () => {
     const harness = setup()
     harness.resolveVersion.mockImplementation(async ({ inputFileVersionId }) =>
@@ -128,7 +197,10 @@ describe('SessionPdfContextOwner', () => {
           sourceVersionId: 'multi-page'
         }
       ],
-      pendingAttachmentIds: []
+      pendingAttachmentIds: [],
+      unavailableSources: [
+        { sourceKind: 'artifact-version', sourceFileId: 'missing', sourceVersionId: 'missing' }
+      ]
     })
   })
 

--- a/src/main/session-persistence/pdf-context-owner.ts
+++ b/src/main/session-persistence/pdf-context-owner.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto'
+import { LiteratureAttachmentUnavailableError } from '../literature/attachment-authority'
 
 import {
   type FilterSessionPdfContextCandidatesRequest,
@@ -48,19 +49,31 @@ class SessionPdfContextOwner {
   ): Promise<FilterSessionPdfContextCandidatesResult> {
     const sources: SessionPdfContextSource[] = []
     const pendingAttachmentIds: string[] = []
+    const unavailableSources: SessionPdfContextSource[] = []
     const seen = new Set<string>()
     for (const source of request.sources) {
       const identity = `${source.sourceKind}:${source.sourceVersionId}`
       if (seen.has(identity)) continue
       seen.add(identity)
-      const input = await this.options.sources.resolveVersion({
-        projectId: request.projectId,
-        sourceKind: source.sourceKind,
-        sourceVersionId: source.sourceVersionId,
-        expectedSourceFileId: source.sourceFileId
-      })
+      let input: ResolvedSessionPdfVersion | undefined
+      try {
+        input = await this.options.sources.resolveVersion({
+          projectId: request.projectId,
+          sourceKind: source.sourceKind,
+          sourceVersionId: source.sourceVersionId,
+          expectedSourceFileId: source.sourceFileId
+        })
+      } catch (error) {
+        // Only an identified attachment integrity failure is local to this candidate.
+        // Database and storage service failures must retain the picker's retry surface.
+        if (!(error instanceof LiteratureAttachmentUnavailableError)) throw error
+        log.warn('PDF context candidate resolution failed', errorLogFields(error))
+      }
+      if (!input) {
+        unavailableSources.push(source)
+        continue
+      }
       if (
-        !input ||
         !isPdf(input.filename, input.contentType) ||
         input.sizeBytes > MAX_AUTO_EXTRACT_PDF_BYTES
       ) {
@@ -69,6 +82,7 @@ class SessionPdfContextOwner {
       try {
         if ((await this.pageCount(input)) > 1) sources.push(source)
       } catch (error) {
+        unavailableSources.push(source)
         log.warn('PDF context candidate inspection failed', {
           sourceKind: source.sourceKind,
           ...errorLogFields(error)
@@ -95,7 +109,11 @@ class SessionPdfContextOwner {
       eligibleCount: sources.length,
       pendingEligibleCount: pendingAttachmentIds.length
     })
-    return { sources, pendingAttachmentIds }
+    return {
+      sources,
+      pendingAttachmentIds,
+      ...(unavailableSources.length ? { unavailableSources } : {})
+    }
   }
 
   async link(request: LinkSessionPdfContextRequest): Promise<SessionRuntimeContext> {

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -3658,6 +3658,78 @@ describe('workspace agent message sending', () => {
     ).toBe(false)
   })
 
+  it.each(['new', 'existing', 'new-partial', 'existing-partial'] as const)(
+    'LR-05 blocks an unavailable selected literature version (%s)',
+    async (kind) => {
+      if (kind.startsWith('existing')) {
+        useSessionStore.getState().appendUserMessage({
+          sessionId: 'transport-session-1',
+          content: 'Existing prompt',
+          cwd: '/workspace/project',
+          projectId: 'project-1'
+        })
+        useSessionStore.getState().finishRun('transport-session-1')
+      }
+      const linkPdfContext = vi.fn()
+      vi.stubGlobal('window', {
+        api: {
+          sessions: {
+            filterPdfContextCandidates: vi.fn().mockResolvedValue({
+              sources: kind.endsWith('partial')
+                ? [
+                    {
+                      sourceKind: 'literature-attachment-version',
+                      sourceVersionId: 'healthy-version'
+                    }
+                  ]
+                : [],
+              pendingAttachmentIds: []
+            }),
+            linkPdfContext,
+            saveSession: vi.fn(async (session: PersistedChatSession) => session)
+          }
+        }
+      })
+      const runtime = {
+        state: createSnapshot(kind.startsWith('existing') ? ['transport-session-1'] : []),
+        createSession: vi
+          .fn()
+          .mockResolvedValue({ sessionId: 'transport-session-1', cwd: '/workspace/project' }),
+        resumeSession: vi.fn(),
+        resetSessionContext: vi.fn(),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['transport-session-1']))
+      }
+      const before = useSessionStore.getState().sessions
+      const result = await sendWorkspaceMessage(
+        runtime,
+        {
+          ...(kind.startsWith('existing') ? { sessionId: 'transport-session-1' } : {}),
+          text: 'Read the selected paper',
+          cwd: '/workspace/project',
+          projectId: 'project-1',
+          pendingPdfContextVersions: [
+            { sourceKind: 'literature-attachment-version', sourceVersionId: 'deleted-version' },
+            ...(kind.endsWith('partial')
+              ? [
+                  {
+                    sourceKind: 'literature-attachment-version' as const,
+                    sourceVersionId: 'healthy-version'
+                  }
+                ]
+              : [])
+          ]
+        },
+        { awaitPendingPreparation: true }
+      ).catch((error) => error)
+      expect(runtime.sendPrompt).not.toHaveBeenCalled()
+      expect(linkPdfContext).not.toHaveBeenCalled()
+      expect(runtime.createSession).not.toHaveBeenCalled()
+      expect(result).toBeInstanceOf(Error)
+      expect(result.message).toContain('deleted-version')
+      expect(useSessionStore.getState().sessions).toEqual(before)
+    }
+  )
+
   it('keeps an ineligible follow-up PDF as an ordinary attachment', async () => {
     useSessionStore.getState().appendUserMessage({
       sessionId: 'transport-session-1',

--- a/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
+++ b/src/renderer/src/lib/acp/workspace-runtime-command-owner.ts
@@ -1,3 +1,4 @@
+import { i18next } from '../../i18n'
 import type { AcpMessageImage, AcpRuntimeEvent } from '../../../../shared/acp'
 import type { FileReference } from '../../../../shared/artifacts'
 import * as annotationProtocol from '../../../../shared/annotations'
@@ -495,6 +496,23 @@ const filterPendingPdfContext = async (
     sources: uniqueVersions,
     ...(pendingAttachments.length > 0 ? { pendingAttachments } : {})
   })
+  const missingLiterature = (request.pendingPdfContextVersions ?? []).filter(
+    (source) =>
+      source.sourceKind === 'literature-attachment-version' &&
+      !eligible.sources.some(
+        (available) =>
+          available.sourceKind === source.sourceKind &&
+          available.sourceVersionId === source.sourceVersionId
+      )
+  )
+  if (missingLiterature.length) {
+    throw new Error(
+      i18next.t(
+        'Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.',
+        { versions: missingLiterature.map(({ sourceVersionId }) => sourceVersionId).join(', ') }
+      )
+    )
+  }
   return {
     attachmentIds: [...eligible.pendingAttachmentIds],
     versions: [...eligible.sources]
@@ -740,6 +758,20 @@ const sendWorkspaceMessage = async (
           toRuntimeUploadedAttachment(upload, replaySession?.projectId)
         )
   if (!content && effectiveAttachments.length === 0 && annotations.length === 0) return undefined
+
+  // Validate explicit library choices before adding a message or creating a pending Session,
+  // so the composer's existing rejection path preserves the draft and selection.
+  const selectedLiterature = input.pendingPdfContextVersions?.filter(
+    ({ sourceKind }) => sourceKind === 'literature-attachment-version'
+  )
+  if (selectedLiterature?.length) {
+    await filterPendingPdfContext({
+      projectId: input.projectId ?? replaySession?.projectId,
+      attachments: [],
+      pendingPdfContextVersions: selectedLiterature
+    })
+    if (lifecycle.isCurrent?.() === false) return undefined
+  }
 
   if (input.branchSourceSessionId) {
     const pending = useSessionStore.getState().branchInNewSession({

--- a/src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx
+++ b/src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx
@@ -13,6 +13,128 @@ afterEach(() => {
 })
 
 describe('ReadingContextPicker', () => {
+  const paper = {
+    id: 'item-101',
+    item: { title: 'older.pdf', creators: [] },
+    attachments: [
+      {
+        kind: 'supplementary',
+        versions: [
+          {
+            id: 'version-101',
+            filename: 'supplement.pdf',
+            contentType: 'application/pdf',
+            sizeBytes: 42,
+            pageCount: 2,
+            versionNumber: 1,
+            createdAt: 1
+          }
+        ]
+      }
+    ]
+  }
+  const openPicker = (): void => {
+    render(
+      <ReadingContextPicker
+        projectId="project-1"
+        linkedSources={[]}
+        atLimit={false}
+        onSelect={vi.fn()}
+      >
+        <button type="button">Reading</button>
+      </ReadingContextPicker>
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Reading' }))
+  }
+  const installApi = (search = vi.fn().mockResolvedValue({ entries: [paper] })): void => {
+    vi.stubGlobal('api', {
+      literature: { search },
+      projectFiles: { listFiles: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }) },
+      sessions: {
+        filterPdfContextCandidates: vi.fn(async ({ sources }) => ({
+          sources,
+          pendingAttachmentIds: []
+        }))
+      }
+    })
+  }
+
+  it('LR-01 finds a supplementary PDF after 100 metadata-only project records', async () => {
+    const search = vi.fn(async ({ offset = 0 }) =>
+      offset === 0
+        ? {
+            entries: Array.from({ length: 100 }, (_, id) => ({
+              ...paper,
+              id: `metadata-${id}`,
+              attachments: []
+            })),
+            totalCount: 101,
+            nextOffset: 100
+          }
+        : { entries: [paper], totalCount: 101 }
+    )
+    installApi(search)
+    openPicker()
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search PDFs' }), {
+      target: { value: paper.item.title }
+    })
+    expect(await screen.findByRole('option', { name: paper.item.title })).not.toBeNull()
+    expect(search).toHaveBeenLastCalledWith({
+      scope: 'library',
+      projectId: 'project-1',
+      limit: 100,
+      offset: 100
+    })
+  })
+
+  it('LR-02 shows healthy candidates with a partial-failure warning and retry', async () => {
+    installApi()
+    const filter = vi.mocked(window.api.sessions.filterPdfContextCandidates)
+    filter.mockResolvedValueOnce({
+      sources: [{ sourceKind: 'literature-attachment-version', sourceVersionId: 'version-101' }],
+      pendingAttachmentIds: [],
+      unavailableSources: [{ sourceKind: 'literature-attachment-version', sourceVersionId: 'bad' }]
+    })
+    openPicker()
+    expect(await screen.findByRole('option', { name: paper.item.title })).not.toBeNull()
+    expect(screen.getByRole('alert').textContent).toContain('Some PDFs are unavailable')
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await screen.findByRole('option', { name: paper.item.title })
+    expect(screen.queryByRole('alert')).toBeNull()
+  })
+
+  it('LR-03 reports a literature database failure and retries project discovery', async () => {
+    const search = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('database read failed'))
+      .mockResolvedValueOnce({ entries: [paper] })
+    installApi(search)
+    openPicker()
+    expect(await screen.findByRole('alert')).not.toBeNull()
+    expect(screen.queryByText('No multi-page PDFs available')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    expect(await screen.findByRole('option', { name: paper.item.title })).not.toBeNull()
+  })
+
+  it.each(['Project', 'Library'])(
+    'LR-04 keeps results when clicking the active %s tab',
+    async (tab) => {
+      const search = vi.fn().mockResolvedValue({ entries: [paper] })
+      installApi(search)
+      openPicker()
+      await screen.findByRole('option', { name: paper.item.title })
+      if (tab === 'Library') {
+        fireEvent.click(screen.getByRole('button', { name: tab }))
+        await screen.findByRole('option', { name: paper.item.title })
+      }
+      const calls = search.mock.calls.length
+      fireEvent.click(screen.getByRole('button', { name: tab }))
+      expect(await screen.findByRole('option', { name: paper.item.title })).not.toBeNull()
+      expect(screen.queryByText('Checking PDFs…')).toBeNull()
+      expect(search).toHaveBeenCalledTimes(calls)
+    }
+  )
+
   it('hides stale project PDFs and prevents selection while the next project loads', async () => {
     const file = (projectId: string): ProjectFileItem => ({
       id: projectId,
@@ -36,6 +158,7 @@ describe('ReadingContextPicker', () => {
     const listFiles = vi.fn().mockResolvedValueOnce(first).mockReturnValueOnce(loadingSecond)
     vi.stubGlobal('api', {
       projectFiles: { listFiles },
+      literature: { search: vi.fn().mockResolvedValue({ entries: [] }) },
       sessions: { filterPdfContextCandidates: vi.fn(async ({ sources }) => ({ sources })) }
     })
     const selectFirst = vi.fn().mockResolvedValue(undefined)
@@ -87,6 +210,7 @@ describe('ReadingContextPicker', () => {
       .mockResolvedValueOnce({ items: [], totalCount: 0 })
     vi.stubGlobal('api', {
       projectFiles: { listFiles },
+      literature: { search: vi.fn().mockResolvedValue({ entries: [] }) },
       sessions: { filterPdfContextCandidates: vi.fn() }
     })
 
@@ -165,6 +289,7 @@ describe('ReadingContextPicker', () => {
     })
     vi.stubGlobal('api', {
       projectFiles: { listFiles },
+      literature: { search: vi.fn().mockResolvedValue({ entries: [] }) },
       sessions: { filterPdfContextCandidates }
     })
     const onSelect = vi.fn().mockResolvedValue(undefined)

--- a/src/renderer/src/pages/workspace/ReadingContextPicker.tsx
+++ b/src/renderer/src/pages/workspace/ReadingContextPicker.tsx
@@ -47,7 +47,7 @@ const isPdfCandidate = (file: ProjectFileItem): boolean =>
 const inspectCandidates = async (
   projectId: string,
   candidates: readonly EligiblePdf[]
-): Promise<EligiblePdf[]> => {
+): Promise<{ items: EligiblePdf[]; unavailableCount: number }> => {
   const byKey = new Map<string, EligiblePdf>()
   for (const candidate of candidates) {
     if (!byKey.has(sourceKey(candidate.source))) byKey.set(sourceKey(candidate.source), candidate)
@@ -55,21 +55,28 @@ const inspectCandidates = async (
 
   const uniqueCandidates = [...byKey.values()]
   const eligible = new Set<string>()
+  let unavailableCount = 0
   for (let offset = 0; offset < uniqueCandidates.length; offset += 100) {
     const page = uniqueCandidates.slice(offset, offset + 100)
     const result = await window.api.sessions.filterPdfContextCandidates({
       projectId,
       sources: page.map(({ source }) => source)
     })
+    unavailableCount += result.unavailableSources?.length ?? 0
     for (const source of result.sources) eligible.add(sourceKey(source))
   }
-  return uniqueCandidates.filter(({ source }) => eligible.has(sourceKey(source)))
+  return {
+    items: uniqueCandidates.filter(({ source }) => eligible.has(sourceKey(source))),
+    unavailableCount
+  }
 }
 
-const loadProjectPdfs = async (projectId: string): Promise<EligiblePdf[]> => {
+const loadProjectPdfs = async (
+  projectId: string
+): Promise<{ items: EligiblePdf[]; unavailableCount: number }> => {
   const [files, literature] = await Promise.all([
     loadAllProjectFiles(projectId),
-    searchLiteraturePdfOptions('', { projectId }).catch(() => [])
+    searchLiteraturePdfOptions('', { projectId })
   ])
   const candidates = [
     ...files.flatMap((file): EligiblePdf[] => {
@@ -86,7 +93,10 @@ const loadProjectPdfs = async (projectId: string): Promise<EligiblePdf[]> => {
   return inspectCandidates(projectId, candidates)
 }
 
-const loadLibraryPdfs = async (projectId: string, query: string): Promise<EligiblePdf[]> => {
+const loadLibraryPdfs = async (
+  projectId: string,
+  query: string
+): Promise<{ items: EligiblePdf[]; unavailableCount: number }> => {
   const options = await searchLiteraturePdfOptions(query)
   return inspectCandidates(
     projectId,
@@ -115,6 +125,7 @@ export const ReadingContextPicker = ({
   const [result, setResult] = useState<{
     projectId?: string
     items: EligiblePdf[]
+    unavailableCount?: number
     status: 'idle' | 'loading' | 'loaded' | 'error'
   }>({ items: [], status: 'idle' })
   const sourceQuery = source === 'library' ? query : ''
@@ -129,8 +140,8 @@ export const ReadingContextPicker = ({
             ? loadProjectPdfs(projectId)
             : loadLibraryPdfs(projectId, sourceQuery)
         ).then(
-          (items) => {
-            if (!cancelled) setResult({ projectId, items, status: 'loaded' })
+          (loaded) => {
+            if (!cancelled) setResult({ projectId, ...loaded, status: 'loaded' })
           },
           () => {
             if (!cancelled) setResult({ projectId, items: [], status: 'error' })
@@ -203,6 +214,7 @@ export const ReadingContextPicker = ({
                   type="button"
                   aria-pressed={source === candidateSource}
                   onClick={() => {
+                    if (candidateSource === source) return
                     setSource(candidateSource)
                     setResult({ items: [], status: 'loading' })
                   }}
@@ -227,6 +239,22 @@ export const ReadingContextPicker = ({
               />
             </label>
           </>
+        ) : null}
+        {isCurrentProject && result.status === 'loaded' && !!result.unavailableCount ? (
+          <div role="alert" className="px-2 py-2">
+            <ErrorNotice
+              icon={AlertTriangle}
+              tone="amber"
+              title={t('Some PDFs are unavailable. Available PDFs are listed below.')}
+              primaryButton={{
+                label: t('Retry'),
+                onClick: () => {
+                  setResult({ items: [], status: 'loading' })
+                  setLoadRevision((revision) => revision + 1)
+                }
+              }}
+            />
+          </div>
         ) : null}
         {atLimit ? (
           <p className="px-2 py-2 text-sm text-text-300">

--- a/src/renderer/src/pages/workspace/literature-pdf-options.ts
+++ b/src/renderer/src/pages/workspace/literature-pdf-options.ts
@@ -94,17 +94,24 @@ export const searchLiteraturePdfOptions = async (
   query: string,
   { projectId }: { projectId?: string } = {}
 ): Promise<LiteraturePdfOption[]> => {
-  const page = await window.api.literature.search({
-    scope: 'library',
-    ...(query.trim() ? { query: query.trim() } : {}),
-    ...(projectId ? { projectId } : {}),
-    limit: 100
-  })
-  return page.entries.flatMap((entry) => {
-    if (!isItem(entry)) return []
-    const option = literatureItemToPdfOption(entry)
-    return option ? [option] : []
-  })
+  const options: LiteraturePdfOption[] = []
+  let offset: number | undefined
+  do {
+    const page = await window.api.literature.search({
+      scope: 'library',
+      ...(query.trim() ? { query: query.trim() } : {}),
+      ...(projectId ? { projectId } : {}),
+      ...(offset !== undefined ? { offset } : {}),
+      limit: 100
+    })
+    for (const entry of page.entries) {
+      if (!isItem(entry)) continue
+      const option = literatureItemToPdfOption(entry)
+      if (option) options.push(option)
+    }
+    offset = page.nextOffset
+  } while (offset !== undefined)
+  return options
 }
 
 export const literatureItemToMentionOption = (

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -105,6 +105,8 @@
     "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
     "The reference was saved, but could not be reloaded.": "Die Referenz wurde gespeichert, konnte aber nicht neu geladen werden.",
     "Draft preserved. Escape to discard.": "Entwurf erhalten. Escape zum Verwerfen.",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "Einige PDFs sind nicht verfügbar. Verfügbare PDFs werden unten aufgeführt.",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "Ausgewählte Literaturversionen sind nicht verfügbar: {{versions}}. Entfernen Sie diese oder wählen Sie sie vor dem Senden erneut aus.",
     "Not answered": "Nicht beantwortet",
     "Automatic contrast": "Automatischer Kontrast",
     "Display range": "Anzeigebereich",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -106,6 +106,8 @@
     "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
     "The reference was saved, but could not be reloaded.": "La referencia se guardó, pero no se pudo volver a cargar.",
     "Draft preserved. Escape to discard.": "Borrador conservado. Escape para descartar.",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "Algunos PDF no están disponibles. Los PDF disponibles se muestran a continuación.",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "Las versiones de bibliografía seleccionadas no están disponibles: {{versions}}. Elimínelas o vuelva a seleccionarlas antes de enviar.",
     "Not answered": "Sin responder",
     "Automatic contrast": "Contraste automático",
     "Display range": "Rango de visualización",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -106,6 +106,8 @@
     "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
     "The reference was saved, but could not be reloaded.": "La référence a été enregistrée, mais n’a pas pu être rechargée.",
     "Draft preserved. Escape to discard.": "Brouillon conservé. Échap pour abandonner.",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "Certains PDF sont indisponibles. Les PDF disponibles sont affichés ci-dessous.",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "Les versions des références sélectionnées sont indisponibles : {{versions}}. Retirez-les ou sélectionnez-les à nouveau avant l’envoi.",
     "Not answered": "Sans réponse",
     "Automatic contrast": "Contraste automatique",
     "Display range": "Plage d’affichage",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -104,6 +104,8 @@
     "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
     "The reference was saved, but could not be reloaded.": "文献は保存されましたが、再読み込みできませんでした。",
     "Draft preserved. Escape to discard.": "下書きを保持しました。Escape で破棄。",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "一部の PDF は利用できません。利用可能な PDF を以下に表示しています。",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "選択した文献のバージョンは利用できません：{{versions}}。削除するか、選択し直してから送信してください。",
     "Not answered": "未回答",
     "Automatic contrast": "自動コントラスト",
     "Display range": "表示範囲",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -104,6 +104,8 @@
     "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
     "The reference was saved, but could not be reloaded.": "참고 문헌은 저장되었지만 다시 불러오지 못했습니다.",
     "Draft preserved. Escape to discard.": "초안이 보존되었습니다. Escape로 취소.",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "일부 PDF를 사용할 수 없습니다. 사용 가능한 PDF가 아래에 표시됩니다.",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "선택한 문헌 버전을 사용할 수 없습니다: {{versions}}. 제거하거나 다시 선택한 후 전송하세요.",
     "Not answered": "미응답",
     "Automatic contrast": "자동 대비",
     "Display range": "표시 범위",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -107,6 +107,8 @@
     "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
     "The reference was saved, but could not be reloaded.": "Источник сохранён, но его не удалось загрузить повторно.",
     "Draft preserved. Escape to discard.": "Черновик сохранён. Escape — отменить.",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "Некоторые PDF недоступны. Доступные PDF перечислены ниже.",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "Выбранные версии литературы недоступны: {{versions}}. Удалите их или выберите заново перед отправкой.",
     "Not answered": "Нет ответа",
     "Automatic contrast": "Автоматическая контрастность",
     "Display range": "Диапазон отображения",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -104,6 +104,8 @@
     "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
     "The reference was saved, but could not be reloaded.": "文献已保存，但无法重新加载。",
     "Draft preserved. Escape to discard.": "草稿已保留，按 Escape 放弃。",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "部分 PDF 不可用。下方列出了可用的 PDF。",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "所选文献版本不可用：{{versions}}。请移除或重新选择后再发送。",
     "Not answered": "未填写",
     "Automatic contrast": "自动对比度",
     "Display range": "显示范围",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -104,6 +104,8 @@
     "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
     "The reference was saved, but could not be reloaded.": "文獻已儲存，但無法重新載入。",
     "Draft preserved. Escape to discard.": "草稿已保留，按 Escape 捨棄。",
+    "Some PDFs are unavailable. Available PDFs are listed below.": "部分 PDF 無法使用。下方列出了可用的 PDF。",
+    "Selected literature versions are unavailable: {{versions}}. Remove or reselect them before sending.": "所選文獻版本無法使用：{{versions}}。請移除或重新選擇後再傳送。",
     "Not answered": "未填寫",
     "Automatic contrast": "自動對比度",
     "Display range": "顯示範圍",

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -196,6 +196,7 @@ export type FilterSessionPdfContextCandidatesRequest = Readonly<{
 export type FilterSessionPdfContextCandidatesResult = Readonly<{
   sources: readonly SessionPdfContextSource[]
   pendingAttachmentIds: readonly string[]
+  unavailableSources?: readonly SessionPdfContextSource[]
 }>
 
 export type LinkSessionPdfContextRequest = Readonly<{

--- a/src/shared/session-persistence.ts
+++ b/src/shared/session-persistence.ts
@@ -4897,7 +4897,8 @@ export const filterSessionPdfContextCandidatesRequestSchema = z
 export const filterSessionPdfContextCandidatesResultSchema = z
   .object({
     sources: z.array(sessionPdfContextSourceSchema).max(100),
-    pendingAttachmentIds: z.array(z.string().min(1)).max(3)
+    pendingAttachmentIds: z.array(z.string().min(1)).max(3),
+    unavailableSources: z.array(sessionPdfContextSourceSchema).max(100).optional()
   })
   .strict()
 


### PR DESCRIPTION
## Problem

Reading-context discovery could omit PDFs after the first 100 literature records, discard all healthy candidates after one corrupt attachment, hide project literature query failures, or get stuck after clicking the active source tab. A literature version deleted after selection could also be silently dropped while a new or existing conversation still sent the prompt without the selected reading context.

## Proposed change

- **LR-01:** follow the existing `nextOffset` pagination contract when collecting literature PDFs, including supplementary PDFs.
- **LR-02:** isolate identified literature attachment integrity failures and report unavailable sources alongside healthy candidates. Database and storage service exceptions still reach the retryable overall error surface; checksum and authority verification remain mandatory.
- **LR-03:** preserve project literature query failures through the existing `ErrorNotice` and Retry flow.
- **LR-04:** ignore clicks on the active Project/Library tab.
- **LR-05:** reject a send if any explicitly selected pending literature version is unavailable. Validate before mutating conversation state and reuse the same validation at preparation for new and existing conversations; preserve the draft and identify unavailable version IDs.

## Scope and non-goals

No database migration, persisted model change, dependency, or new state machine. The candidate-check response gains the optional diagnostic `unavailableSources` field, and the picker shows partial failures with Retry. Both new messages are translated into all eight locales. Existing ordinary-attachment behavior for single-page/oversized uploads is preserved.

The pagination implementation reads all matching record pages; very large libraries may therefore require more discovery requests. No new paging UI or cache is introduced.

## Acceptance criteria and validation

Regression tests use the real React picker, the real literature attachment authority/source resolver/context owner chain, and the public send command for both new and existing conversations. No test-only production seam was added. On unchanged `main` (`418f4a61`), the expanded regression selection produced **12 expected failures and 2 passing service-failure controls**. Core failures were reproduced repeatedly before and after the fixes were prepared.

Checks below exercised the final material changes; the final picker presentation was rechecked separately and included in the subsequent full suite.

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| Pagination, partial-failure notice, project query retry, active-tab behavior | `npx vitest run src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx --maxWorkers=1` | 9 passed |
| Attachment isolation, service failures, send admission and existing upload behavior | `npx vitest run src/renderer/src/pages/workspace/ReadingContextPicker.test.tsx src/main/session-persistence/pdf-context-owner.test.ts src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts --maxWorkers=1` | 304 passed |
| All translated renderer copy | `npx vitest run src/renderer/src/i18n/resources.test.ts --maxWorkers=1` | 804 passed |
| Main, renderer and sandbox package types | `npm run typecheck` | Passed |
| Repository lint | `npm run lint` | Incomplete: interrupted after over 20 minutes under concurrent validation load; no diagnostic result |
| Changed-file lint | `npx eslint` on the changed TypeScript/TSX files | Passed |
| Full fallback, including interface/adapter and consumer tests | `npm test -- --maxWorkers=2` | 27,533 passed, 10 failed, 250 skipped |

The full run required execution outside the agent sandbox for macOS sandbox/local-process tests. It is **not a full green verification**:

- Two `LiteratureLibraryPage.render.test.tsx` cases exceeded the default 15-second timeout: returning from Duplicates and paginated Reading candidates. Both passed in an isolated rerun with `--testTimeout=60000`; the unchanged baseline also passed these two cases.
- Eight `office-behavior-regressions.test.ts` cases failed. An isolated OF01 rerun still left the blank XLSX preview in `pending` instead of `ready`. Office preview behavior is outside this change and remains unresolved.

All runtime areas are covered by typechecks; the full suite was included because the change crosses the renderer, main owner and shared IPC result contract. Cross-platform/Electron packaged-app checks were not run locally. CI and independent review remain necessary before merge.

## Review focus

Confirm that attachment-local failures cannot hide service-wide failures, all explicitly selected literature versions must survive send validation, and pagination retains the existing eligible attachment range.
