### PR TITLE
fix(literature): preserve reference selection and replay identity

### DIFF
--- a/src/main/acp/literature-reference-prompt.test.ts
+++ b/src/main/acp/literature-reference-prompt.test.ts
@@ -1,8 +1,33 @@
 import { describe, expect, it } from 'vitest'
 
+import { sanitizeMessageParts } from '../../shared/session-persistence'
+import {
+  docFromMessageParts,
+  docToMessageParts,
+  docArtifactCount
+} from '../../renderer/src/pages/workspace/composer/composer-doc'
+
 import { buildLiteratureReferencePrompt } from './literature-reference-prompt'
 
 describe('buildLiteratureReferencePrompt', () => {
+  it.each([5, 6, 10])(
+    'preserves exact retrieval identities for %i composer Collections',
+    (count) => {
+      const scopes = Array.from({ length: count }, (_, index) => ({
+        type: 'literature-scope' as const,
+        scope: 'collection' as const,
+        collectionId: `collection-exact-${index + 1}`,
+        name: `Study set ${index + 1}`
+      }))
+      const doc = docFromMessageParts(scopes)
+      expect(docArtifactCount(doc)).toBe(count)
+      const parts = sanitizeMessageParts(docToMessageParts(doc))
+      expect(parts).toEqual(scopes)
+      const prompt = buildLiteratureReferencePrompt(parts)
+      for (const scope of scopes) expect(prompt).toContain(JSON.stringify(scope.collectionId))
+    }
+  )
+
   it('serializes an immutable metadata snapshot without local file paths', () => {
     const prompt = buildLiteratureReferencePrompt([
       {

--- a/src/main/acp/literature-reference-prompt.ts
+++ b/src/main/acp/literature-reference-prompt.ts
@@ -1,3 +1,4 @@
+import { MAX_COMPOSER_ATTACHMENTS } from '../../shared/uploads'
 import type {
   LiteratureReference,
   LiteratureScopeReference,
@@ -11,7 +12,7 @@ const referencesFromParts = (parts: readonly MessagePart[] | undefined): Literat
     if (part.type !== 'literature' || seen.has(part.itemId)) continue
     seen.add(part.itemId)
     references.push(part)
-    if (references.length === 10) break
+    if (references.length === MAX_COMPOSER_ATTACHMENTS) break
   }
   return references
 }
@@ -25,7 +26,7 @@ const scopesFromParts = (parts: readonly MessagePart[] | undefined): LiteratureS
     if (seen.has(identity)) continue
     seen.add(identity)
     scopes.push(part)
-    if (scopes.length === 5) break
+    if (scopes.length === MAX_COMPOSER_ATTACHMENTS) break
   }
   return scopes
 }

--- a/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
+++ b/src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts
@@ -8309,6 +8309,131 @@ describe('resuming an interrupted session on demand', () => {
     ).toHaveLength(2)
   })
 
+  it.each(['claude-code', 'opencode', 'codex-response', 'codex-bridge'] as const)(
+    'sends frozen historical Literature identities during %s application replay',
+    async (target) => {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: 'Compare @Study set with @Repeated title',
+        cwd: '/workspace/project',
+        projectId: 'default-project',
+        parts: [
+          {
+            type: 'literature-scope',
+            scope: 'collection',
+            collectionId: 'frozen-collection',
+            name: 'Study set'
+          },
+          {
+            type: 'literature',
+            itemId: 'frozen-item',
+            metadataRevision: 7,
+            item: {
+              itemType: 'journalArticle',
+              title: 'Repeated title',
+              abstract: 'Frozen evidence abstract',
+              issuedText: '2025',
+              containerTitle: '',
+              shortTitle: '',
+              language: '',
+              rights: '',
+              url: '',
+              extra: '',
+              typeFields: {},
+              creators: [],
+              identifiers: [{ scheme: 'doi', value: '10.1234/history', isPrimary: true }]
+            }
+          }
+        ]
+      })
+      useSessionStore.getState().finishRun('session-1')
+      const runtime = {
+        state: createSnapshot([]),
+        createSession: vi.fn(),
+        resumeSession: vi.fn().mockResolvedValue({
+          sessionId: 'session-1',
+          cwd: '/workspace/project',
+          contextReset: true
+        }),
+        resetSessionContext: vi.fn(),
+        sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+      }
+      await sendWorkspaceMessage(runtime, {
+        sessionId: 'session-1',
+        text: 'Continue using these references',
+        cwd: '/workspace/project',
+        projectId: 'default-project',
+        historyReplayDescriptor: { target }
+      })
+      await flushRuntimeTasks()
+      const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+      for (const value of [
+        'frozen-collection',
+        'frozen-item',
+        '10.1234/history',
+        'Frozen evidence abstract'
+      ])
+        expect(preamble).toContain(value)
+      expect(preamble).toMatch(/metadataRevision[^0-9]*7/)
+      expect(preamble).not.toContain('Continue using these references')
+    }
+  )
+
+  it('replays Literature scopes from the active Branch without leaking the replaced Branch', async () => {
+    for (const id of ['shared-scope', 'replaced-scope']) {
+      useSessionStore.getState().appendUserMessage({
+        sessionId: 'session-1',
+        content: `Use @${id}`,
+        cwd: '/workspace/project',
+        projectId: 'default-project',
+        parts: [{ type: 'literature-scope', scope: 'collection', collectionId: id, name: id }]
+      })
+      useSessionStore.getState().finishRun('session-1')
+    }
+    const second = useSessionStore.getState().sessions[0].messages.at(-1)!
+    const runtime = {
+      state: createSnapshot(['session-1']),
+      createSession: vi.fn(),
+      resumeSession: vi.fn(),
+      resetSessionContext: vi.fn().mockResolvedValue({ contextReset: true }),
+      sendPrompt: vi.fn().mockResolvedValue(createSnapshot(['session-1']))
+    }
+    await resendEditedWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      messageId: second.id,
+      text: 'Use @active-scope',
+      parts: [
+        {
+          type: 'literature-scope',
+          scope: 'collection',
+          collectionId: 'active-scope',
+          name: 'active-scope'
+        }
+      ]
+    })
+    await flushRuntimeTasks()
+    useSessionStore.getState().finishRun('session-1')
+    runtime.state = createSnapshot([])
+    runtime.resumeSession.mockResolvedValue({
+      sessionId: 'session-1',
+      cwd: '/workspace/project',
+      contextReset: true
+    })
+    runtime.sendPrompt.mockClear()
+    await sendWorkspaceMessage(runtime, {
+      sessionId: 'session-1',
+      text: 'Continue',
+      cwd: '/workspace/project',
+      projectId: 'default-project'
+    })
+    await flushRuntimeTasks()
+    const preamble = runtime.sendPrompt.mock.calls[0]?.[5]
+    expect(preamble).toContain('"collectionId":"shared-scope"')
+    expect(preamble).toContain('"collectionId":"active-scope"')
+    expect(preamble).not.toContain('replaced-scope')
+    expect(useSessionStore.getState().sessions[0].conversationGraph?.branches.length).toBe(2)
+  })
+
   it('replays a history preamble when a resume resets agent context', async () => {
     // A completed prior turn that should be replayed to the freshly-adopted agent.
     useSessionStore.getState().appendUserMessage({

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -198,6 +198,124 @@ const renderPopup = async ({
 }
 
 describe('ArtifactMentionPopup', () => {
+  it.each(['click', 'Enter'])(
+    'rejects prior-project Literature suggestions via %s while the next search is pending',
+    async (selection) => {
+      const onSelect = vi.fn()
+      window.api.literature.search = vi.fn().mockImplementation((request) => {
+        if (request.scope === 'collections') return Promise.resolve({ entries: [] })
+        if (request.projectId === 'project-b') return new Promise(() => undefined)
+        return Promise.resolve({ entries: [libraryPdf] })
+      })
+      await renderPopup({ query: 'Corrective', onSelect })
+      await vi.waitFor(() =>
+        expect(options().some((row) => row.textContent?.includes('Corrective'))).toBe(true)
+      )
+      await act(async () => useNavigationStore.setState({ activeProjectId: 'project-b' }))
+      if (selection === 'click')
+        act(() =>
+          options()
+            .find((row) => row.textContent?.includes('Corrective'))
+            ?.click()
+        )
+      else pressKey('Enter')
+      expect(onSelect).not.toHaveBeenCalled()
+      expect(options().some((row) => row.textContent?.includes('Corrective'))).toBe(false)
+    }
+  )
+
+  it('reports failed Collection suggestions instead of an empty result', async () => {
+    window.api.projectFiles.listFiles = vi.fn().mockResolvedValue({ items: [], totalCount: 0 })
+    window.api.literature.search = vi.fn().mockImplementation(async (request) => {
+      if (request.scope === 'collections') throw new Error('Collection search unavailable')
+      return { entries: [] }
+    })
+    await renderPopup({ query: 'Unique' })
+    await vi.waitFor(() => expect(window.api.literature.search).toHaveBeenCalled())
+    await flushSelection()
+    expect(document.body.querySelector('[role="alert"]')).not.toBeNull()
+    expect(document.body.textContent).not.toContain('No artifacts yet')
+  })
+
+  it('reports failed Literature suggestions alongside healthy project files', async () => {
+    window.api.literature.search = vi.fn().mockImplementation(async (request) => {
+      if (request.scope === 'collections') return { entries: [] }
+      throw new Error('Literature search unavailable')
+    })
+    await renderPopup({ query: 'seq' })
+    await vi.waitFor(() => expect(window.api.literature.search).toHaveBeenCalled())
+    await flushSelection()
+    expect(options().some((row) => row.textContent?.includes('sequence.csv'))).toBe(true)
+    expect(document.body.querySelector('[role="alert"]')?.textContent ?? '').toContain(
+      'Literature could not be loaded.'
+    )
+  })
+
+  it('retries only the failed source while keeping healthy options available', async () => {
+    let fail = true
+    window.api.literature.search = vi.fn().mockImplementation(async (request) => {
+      if (request.scope === 'collections') {
+        if (fail) throw new Error('Collection search unavailable')
+        return {
+          entries: [
+            {
+              id: 'collection-retry',
+              name: 'Corrective collection',
+              description: '',
+              itemCount: 1,
+              createdAt: 1,
+              updatedAt: 1
+            }
+          ]
+        }
+      }
+      return { entries: [libraryPdf] }
+    })
+    await renderPopup({ query: 'Corrective' })
+    await vi.waitFor(() =>
+      expect(document.body.querySelector('[role="alert"]')?.textContent).toContain(
+        'Collections could not be loaded.'
+      )
+    )
+    expect(options().some((row) => row.textContent?.includes('Corrective Retrieval'))).toBe(true)
+    const count = vi
+      .mocked(window.api.literature.search)
+      .mock.calls.filter(([request]) => request.scope !== 'collections').length
+    fail = false
+    act(() => document.body.querySelector<HTMLButtonElement>('[role="alert"] button')?.click())
+    expect(document.body.querySelector('[role="alert"]')).toBeNull()
+    expect(options().some((row) => row.textContent?.includes('Corrective Retrieval'))).toBe(true)
+    await vi.waitFor(() =>
+      expect(options().some((row) => row.textContent?.includes('Corrective collection'))).toBe(true)
+    )
+    expect(
+      vi
+        .mocked(window.api.literature.search)
+        .mock.calls.filter(([request]) => request.scope !== 'collections')
+    ).toHaveLength(count)
+  })
+
+  it('accepts fresh next-project results after rejecting the previous project', async () => {
+    const onSelect = vi.fn()
+    window.api.literature.search = vi.fn().mockImplementation(async (request) => ({
+      entries:
+        request.scope === 'collections'
+          ? []
+          : [{ ...libraryPdf, id: request.projectId === 'project-b' ? 'item-b' : 'item-a' }]
+    }))
+    await renderPopup({ query: 'Corrective', onSelect })
+    await vi.waitFor(() =>
+      expect(options().some((row) => row.textContent?.includes('Corrective'))).toBe(true)
+    )
+    await act(async () => useNavigationStore.setState({ activeProjectId: 'project-b' }))
+    expect(options().some((row) => row.textContent?.includes('Corrective'))).toBe(false)
+    await vi.waitFor(() =>
+      expect(options().some((row) => row.textContent?.includes('Corrective'))).toBe(true)
+    )
+    pressKey('Enter')
+    expect(onSelect).toHaveBeenCalledWith(expect.objectContaining({ itemId: 'item-b' }))
+  })
+
   it('owns Enter while project files are still loading', () => {
     window.api.projectFiles.listFiles = vi.fn(
       () => new Promise(() => undefined)

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -65,6 +65,13 @@ type ArtifactRow = {
   positions?: number[]
 }
 
+type LiteratureResult = {
+  projectId?: string
+  query: string
+  rows: ArtifactRow[]
+  state: 'loading' | 'loaded' | 'error'
+}
+
 // Catalog keys for the section headers, ordered as they render.
 const SECTION_UPLOADS_KEY = 'User uploads'
 const SECTION_ARTIFACTS_KEY = 'Other artifacts'
@@ -88,13 +95,21 @@ export const ArtifactMentionPopup = ({
   const [projectFiles, setProjectFiles] = useState<{
     projectId?: string
     files: ProjectFileItem[]
-    state: 'loaded' | 'error'
-  }>({ files: [], state: 'loaded' })
-  const [library, setLibrary] = useState<{
-    query: string
-    rows: ArtifactRow[]
     state: 'loading' | 'loaded' | 'error'
-  }>({ query: '', rows: [], state: 'loading' })
+  }>({ files: [], state: 'loaded' })
+  const [library, setLibrary] = useState<LiteratureResult>({
+    query: '',
+    rows: [],
+    state: 'loading'
+  })
+  const [collections, setCollections] = useState<LiteratureResult>({
+    query: '',
+    rows: [],
+    state: 'loading'
+  })
+  const [fileRetry, setFileRetry] = useState(0)
+  const [libraryRetry, setLibraryRetry] = useState(0)
+  const [collectionRetry, setCollectionRetry] = useState(0)
 
   useEffect(() => {
     let cancelled = false
@@ -111,43 +126,33 @@ export const ArtifactMentionPopup = ({
     return () => {
       cancelled = true
     }
-  }, [activeProjectId])
+  }, [activeProjectId, fileRetry])
 
   useEffect(() => {
     let cancelled = false
     const timeout = window.setTimeout(() => {
-      void Promise.all([
-        query.trim()
-          ? searchLiteratureCollectionMentionOptions(query).catch(() => [])
-          : Promise.resolve([]),
-        searchLiteratureMentionOptions(query, { projectId: activeProjectId })
-      ]).then(
-        ([collections, options]) => {
+      void searchLiteratureMentionOptions(query, { projectId: activeProjectId }).then(
+        (options) => {
           if (cancelled) return
           setLibrary({
+            projectId: activeProjectId,
             query,
             state: 'loaded',
-            rows: [
-              ...collections.map((option) => ({
-                id: option.reference.scope === 'collection' ? option.reference.collectionId : '',
-                name: option.name,
-                picked: option.reference,
-                tag: 'collection-scope' as const
-              })),
-              ...options.map((option) => ({
-                id: option.reference.itemId,
-                name: option.name,
-                picked: option.reference,
-                source: 'literature' as const,
-                tag: 'library' as const,
-                iconName: option.iconName,
-                description: option.description
-              }))
-            ]
+            rows: options.map((option) => ({
+              id: option.reference.itemId,
+              projectId: activeProjectId,
+              name: option.name,
+              picked: option.reference,
+              source: 'literature',
+              tag: 'library',
+              iconName: option.iconName,
+              description: option.description
+            }))
           })
         },
         () => {
-          if (!cancelled) setLibrary({ query, rows: [], state: 'error' })
+          if (!cancelled)
+            setLibrary({ projectId: activeProjectId, query, rows: [], state: 'error' })
         }
       )
     }, 120)
@@ -155,9 +160,47 @@ export const ArtifactMentionPopup = ({
       cancelled = true
       window.clearTimeout(timeout)
     }
-  }, [activeProjectId, query])
+  }, [activeProjectId, query, libraryRetry])
 
-  const libraryState = library.query === query ? library.state : 'loading'
+  useEffect(() => {
+    let cancelled = false
+    const timeout = window.setTimeout(() => {
+      void (
+        query.trim() ? searchLiteratureCollectionMentionOptions(query) : Promise.resolve([])
+      ).then(
+        (options) => {
+          if (cancelled) return
+          setCollections({
+            projectId: activeProjectId,
+            query,
+            state: 'loaded',
+            rows: options.map((option) => ({
+              id: option.reference.scope === 'collection' ? option.reference.collectionId : '',
+              projectId: activeProjectId,
+              name: option.name,
+              picked: option.reference,
+              tag: 'collection-scope'
+            }))
+          })
+        },
+        () => {
+          if (!cancelled)
+            setCollections({ projectId: activeProjectId, query, rows: [], state: 'error' })
+        }
+      )
+    }, 120)
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeout)
+    }
+  }, [activeProjectId, query, collectionRetry])
+
+  const libraryState =
+    library.query === query && library.projectId === activeProjectId ? library.state : 'loading'
+  const collectionState =
+    collections.query === query && collections.projectId === activeProjectId
+      ? collections.state
+      : 'loading'
 
   // ManagedFile supplies a logical file identity. The consumer resolves its current DB head when the
   // turn starts; only an explicit history action may attach an immutable Version id.
@@ -180,6 +223,7 @@ export const ArtifactMentionPopup = ({
       ? [
           {
             id: 'library',
+            projectId: activeProjectId,
             name: t('Library'),
             description: t('References linked to this project.'),
             picked: { type: 'literature-scope', scope: 'project' },
@@ -187,8 +231,13 @@ export const ArtifactMentionPopup = ({
           }
         ]
       : []
-    return [...projectRows, ...libraryScopeRows, ...(library.query === query ? library.rows : [])]
-  }, [activeProjectId, library, projectFiles, query, t])
+    return [
+      ...projectRows,
+      ...libraryScopeRows,
+      ...(collectionState === 'loaded' ? collections.rows : []),
+      ...(libraryState === 'loaded' ? library.rows : [])
+    ]
+  }, [activeProjectId, library, libraryState, collections, collectionState, projectFiles, query, t])
   const loadState =
     !activeProjectId || projectFiles.projectId === activeProjectId ? projectFiles.state : 'loading'
 
@@ -246,6 +295,8 @@ export const ArtifactMentionPopup = ({
 
   const selectRow = useCallback(
     async (row: ArtifactRow): Promise<void> => {
+      if (row.projectId !== useNavigationStore.getState().activeProjectId || !matches.includes(row))
+        return
       const revision = ++selectionRevisionRef.current
       if (
         (row.tag === 'library' || row.tag === 'library-scope' || row.tag === 'collection-scope') &&
@@ -296,7 +347,7 @@ export const ArtifactMentionPopup = ({
         setSelectionError(t('Could not resolve file version.'))
       }
     },
-    [onSelect, t]
+    [matches, onSelect, t]
   )
 
   useLayoutEffect(
@@ -310,6 +361,12 @@ export const ArtifactMentionPopup = ({
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.isComposing || composingRef?.current) return
+      if (
+        event.target instanceof Element &&
+        event.target.closest('button') &&
+        event.key !== 'Escape'
+      )
+        return
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         if (matches.length > 0) setActiveIndex((safeIndex + 1) % matches.length)
@@ -430,35 +487,77 @@ export const ArtifactMentionPopup = ({
   }
 
   return (
-    <div className="absolute bottom-full left-0 mb-1 z-50 bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
+    <div className="absolute bottom-full left-0 mb-1 z-50 flex flex-col bg-bg-000 border-0.5 border-border-200 rounded-xl shadow-[0_4px_16px_hsl(var(--always-black)/10%)] p-1.5 min-w-[320px] max-w-[440px] max-h-[min(45vh,18rem)] overflow-hidden">
       {selectionError ? (
         <div role="alert" className="px-2 py-1.5 text-sm text-danger-000">
           {selectionError}
         </div>
       ) : null}
-      {matches.length === 0 ? (
+      {[
+        {
+          state: loadState,
+          label: t('Could not load project files'),
+          retry: () => {
+            setProjectFiles({ projectId: activeProjectId, files: [], state: 'loading' })
+            setFileRetry((value) => value + 1)
+          }
+        },
+        {
+          state: libraryState,
+          label: t('Literature could not be loaded.'),
+          retry: () => {
+            setLibrary({ projectId: activeProjectId, query, rows: [], state: 'loading' })
+            setLibraryRetry((value) => value + 1)
+          }
+        },
+        {
+          state: collectionState,
+          label: t('Collections could not be loaded.'),
+          retry: () => {
+            setCollections({ projectId: activeProjectId, query, rows: [], state: 'loading' })
+            setCollectionRetry((value) => value + 1)
+          }
+        }
+      ]
+        .filter(({ state }) => state === 'error')
+        .map(({ label, retry }) => (
+          <div
+            key={label}
+            role="alert"
+            aria-live="assertive"
+            aria-atomic="true"
+            className="flex shrink-0 items-center justify-between gap-3 px-2 py-1.5 text-sm text-text-300"
+          >
+            <span>{label}</span>
+            <button
+              type="button"
+              className="shrink-0 text-primary underline"
+              onMouseDown={(event) => event.preventDefault()}
+              onClick={retry}
+            >
+              {t('Retry')}
+            </button>
+          </div>
+        ))}
+      {matches.length === 0 && ![loadState, libraryState, collectionState].includes('error') ? (
         <div
-          role={loadState === 'error' || libraryState === 'error' ? 'alert' : 'status'}
-          aria-live={loadState === 'error' || libraryState === 'error' ? 'assertive' : 'polite'}
+          role="status"
+          aria-live="polite"
           aria-atomic="true"
           className="px-2 py-1.5 text-sm text-text-300"
         >
           {loadState === 'loading'
             ? t('Loading project files…')
-            : loadState === 'error'
-              ? t('Could not load project files')
-              : libraryState === 'loading'
-                ? t('Loading…')
-                : libraryState === 'error'
-                  ? t('Literature could not be loaded.')
-                  : t('No artifacts yet')}
+            : libraryState === 'loading' || collectionState === 'loading'
+              ? t('Loading…')
+              : t('No artifacts yet')}
         </div>
       ) : null}
       <ul
         id={resolvedListboxId}
         role="listbox"
         aria-label={t('Artifact suggestions')}
-        className="overflow-y-auto max-h-[min(45vh,18rem)]"
+        className="min-h-0 overflow-y-auto max-h-[min(45vh,18rem)]"
       >
         {uploadMatches.length > 0 ? (
           <>
@@ -512,7 +611,7 @@ export const ArtifactMentionPopup = ({
           </>
         ) : null}
       </ul>
-      <div className="mt-1 -mx-1.5 -mb-1.5 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
+      <div className="shrink-0 mt-1 -mx-1.5 -mb-1.5 px-3.5 pt-1.5 pb-2 border-t border-border-300 flex items-center gap-3 text-[11px] text-text-400 select-none">
         <span>
           <span className="text-text-300">↑↓</span> {t('navigate')}
         </span>

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -315,6 +315,60 @@ const flushProjectFiles = async (): Promise<void> => {
 }
 
 describe('ComposerEditor mention input safety', () => {
+  it('does not insert a prior-project reference into an identical unsaved project draft', async () => {
+    window.api.literature = {
+      ...window.api.literature,
+      search: vi.fn().mockImplementation((request) => {
+        if (request.scope === 'collections') return Promise.resolve({ entries: [] })
+        if (request.projectId === 'project-b') return new Promise(() => undefined)
+        return Promise.resolve({
+          entries: [
+            {
+              id: 'project-a-only-item',
+              metadataRevision: 7,
+              attachments: [],
+              projectIds: ['default'],
+              collectionIds: [],
+              createdAt: 1,
+              updatedAt: 1,
+              item: {
+                itemType: 'journalArticle',
+                title: 'UniquePaper',
+                abstract: '',
+                issuedText: '',
+                containerTitle: '',
+                shortTitle: '',
+                language: '',
+                rights: '',
+                url: '',
+                extra: '',
+                typeFields: {},
+                creators: [],
+                identifiers: []
+              }
+            }
+          ]
+        })
+      })
+    }
+    const doc: ComposerDoc = { nodes: [{ type: 'text', text: '@Unique' }] }
+    renderEditor({ doc })
+    await typeQuery('@Unique')
+    await vi.waitFor(() =>
+      expect(document.body.querySelector('[role="option"]')?.textContent).toContain('UniquePaper')
+    )
+    await act(async () => useNavigationStore.setState({ activeProjectId: 'project-b' }))
+    renderEditor({ doc: { nodes: [{ type: 'text', text: '@Unique' }] } })
+    act(() => document.body.querySelector<HTMLElement>('[role="option"]')?.click())
+    expect(useNavigationStore.getState().activeProjectId).toBe('project-b')
+    expect(
+      domToDoc(editor()).nodes.some(
+        (node) => node.type === 'literature' && node.itemId === 'project-a-only-item'
+      )
+    ).toBe(false)
+    expect(document.body.querySelector('[role="listbox"]')).toBeNull()
+  })
+
   const typeQuery = async (text: string): Promise<void> => {
     act(() => {
       editor().textContent = text

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -493,6 +493,7 @@ export const ComposerEditor = ({
     trigger: '#',
     disabled: disabled || docSessionCount(doc) >= MAX_COMPOSER_SESSION_MENTIONS
   })
+  const activeProjectId = useNavigationStore((state) => state.activeProjectId)
   const mentionPopupOpen = mention.active || artifactMention.active || sessionMention.active
   const undoCaretRef = useRef<ComposerCaretPosition | undefined>(undefined)
 
@@ -507,6 +508,8 @@ export const ComposerEditor = ({
     cancelSessionMention()
   }, [
     mentionPreviewContext?.sessionId,
+    mentionPreviewContext?.projectId,
+    activeProjectId,
     cancelSkillMention,
     cancelArtifactMention,
     cancelSessionMention

--- a/src/renderer/src/pages/workspace/composer/composer-doc.ts
+++ b/src/renderer/src/pages/workspace/composer/composer-doc.ts
@@ -2,6 +2,8 @@
 // chips, and artifact chips. These functions are DOM-free except domToDoc/applyDocToDom, which
 // bridge the model to the contenteditable editor.
 
+import { MAX_COMPOSER_ATTACHMENTS } from '../../../../../shared/uploads'
+
 import { getExtensionPreservingFileNameParts } from '../extension-preserving-file-name'
 
 import type { FileReference } from '../../../../../shared/artifacts'
@@ -47,7 +49,7 @@ export type ComposerNode =
 export type ComposerDoc = { nodes: ComposerNode[] }
 
 // Max artifact `@` mentions per message, mirroring the composer upload attachment cap.
-export const MAX_COMPOSER_ARTIFACT_MENTIONS = 10
+export const MAX_COMPOSER_ARTIFACT_MENTIONS = MAX_COMPOSER_ATTACHMENTS
 export const MAX_COMPOSER_SESSION_MENTIONS = MAX_SESSION_REFERENCES_PER_MESSAGE
 
 export const LONG_PASTE_CHARACTER_THRESHOLD = 10_000

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -76,9 +76,18 @@ const speakerPrefixFor = (message: HistoryMessage): string => `**${speakerFor(me
 // These are the selected historical snapshots, never fresh Library lookups or current instructions.
 const historicalReferences = (message: HistoryMessage, compact = false): string => {
   if (message.role !== 'user') return ''
+  const seen = new Set<string>()
   const references = (message.parts ?? []).flatMap<Record<string, unknown>>((part) => {
+    if (part.type !== 'literature-scope' && part.type !== 'literature') return []
+    const identity =
+      part.type === 'literature'
+        ? `item:${part.itemId}`
+        : part.scope === 'collection'
+          ? `collection:${part.collectionId}`
+          : part.scope
+    if (seen.has(identity)) return []
+    seen.add(identity)
     if (part.type === 'literature-scope') return [part]
-    if (part.type !== 'literature') return []
     const { type, itemId, metadataRevision, attachmentVersionId, item } = part
     return [
       {
@@ -114,7 +123,10 @@ const formatTruncatedUserMessage = (
       ? fullReferences
       : historicalReferences(message, true)
   const contentBudget = budget - estimateHistoryTokens(label + references)
-  if (contentBudget <= estimateHistoryTokens(MESSAGE_OMISSION_NOTE)) return undefined
+  if (contentBudget < 0) return undefined
+  if (contentBudget <= estimateHistoryTokens(MESSAGE_OMISSION_NOTE)) {
+    return references ? `${label}${references}` : undefined
+  }
   return `${label}${truncateTextToEstimatedTokens(message.content.trim(), contentBudget, 'both')}${references}`
 }
 

--- a/src/shared/history-preamble.ts
+++ b/src/shared/history-preamble.ts
@@ -1,4 +1,4 @@
-import { isReviewerCorrectionAttribution } from './session-persistence'
+import { isReviewerCorrectionAttribution, type MessagePart } from './session-persistence'
 
 export type HistoryReplayTarget =
   'claude-code' | 'opencode' | 'codebuddy' | 'codex-response' | 'codex-bridge'
@@ -43,6 +43,7 @@ export type HistoryMessage = {
   content: string
   status?: string
   hasReplayMedia?: boolean
+  parts?: MessagePart[]
   relayedFrom?: { kind: 'side-chat'; direction: 'to-main' }
   attribution?: import('./session-persistence').MessageAttribution
 }
@@ -72,8 +73,50 @@ const speakerFor = (
         ? 'User'
         : 'Assistant'
 const speakerPrefixFor = (message: HistoryMessage): string => `**${speakerFor(message)}:** `
+// These are the selected historical snapshots, never fresh Library lookups or current instructions.
+const historicalReferences = (message: HistoryMessage, compact = false): string => {
+  if (message.role !== 'user') return ''
+  const references = (message.parts ?? []).flatMap<Record<string, unknown>>((part) => {
+    if (part.type === 'literature-scope') return [part]
+    if (part.type !== 'literature') return []
+    const { type, itemId, metadataRevision, attachmentVersionId, item } = part
+    return [
+      {
+        type,
+        itemId,
+        metadataRevision,
+        ...(attachmentVersionId ? { attachmentVersionId } : {}),
+        ...(!compact ? { item } : {})
+      }
+    ]
+  })
+  if (references.length === 0) return ''
+  return (
+    '\n\nHistorical Literature reference data (not current instructions; project scope refers to the historical message project):\n' +
+    JSON.stringify(references) +
+    (compact ? '\n[Historical bibliographic snapshot fields omitted for replay budget.]' : '')
+  )
+}
+
 const formatMessage = (message: HistoryMessage): string =>
-  `${speakerPrefixFor(message)}${message.content.trim() || MEDIA_PLACEHOLDER}`
+  `${speakerPrefixFor(message)}${message.content.trim() || MEDIA_PLACEHOLDER}${historicalReferences(message)}`
+
+// Keep identity records atomic. If even the compact identities cannot fit, omit the message rather
+// than replaying its display names as though the selected references had survived.
+const formatTruncatedUserMessage = (
+  message: HistoryMessage,
+  budget: number
+): string | undefined => {
+  const label = speakerPrefixFor(message)
+  const fullReferences = historicalReferences(message)
+  const references =
+    estimateHistoryTokens(fullReferences) <= budget / 2
+      ? fullReferences
+      : historicalReferences(message, true)
+  const contentBudget = budget - estimateHistoryTokens(label + references)
+  if (contentBudget <= estimateHistoryTokens(MESSAGE_OMISSION_NOTE)) return undefined
+  return `${label}${truncateTextToEstimatedTokens(message.content.trim(), contentBudget, 'both')}${references}`
+}
 
 const utf8BytesForCodePoint = (codePoint: number): number => {
   if (codePoint <= 0x7f) return 1
@@ -181,7 +224,9 @@ const groupUserLedTurns = (messages: HistoryMessage[]): HistoryTurn[] => {
     .filter(
       (message) =>
         message.status !== 'error' &&
-        (message.content.trim().length > 0 || message.hasReplayMedia === true)
+        (message.content.trim().length > 0 ||
+          message.hasReplayMedia === true ||
+          historicalReferences(message).length > 0)
     )
   const turns: HistoryTurn[] = []
 
@@ -205,8 +250,7 @@ const fullTurn = (turn: HistoryTurn): ProjectedTurn => ({
 })
 
 const estimateFormattedMessageTokens = (message: HistoryMessage): number =>
-  estimateHistoryTokens(speakerPrefixFor(message)) +
-  estimateHistoryTokens(message.content.trim() || MEDIA_PLACEHOLDER)
+  estimateHistoryTokens(formatMessage(message))
 
 const estimateFullTurnTokens = (turn: HistoryTurn): number =>
   turn.messages.reduce(
@@ -224,14 +268,9 @@ const projectTurn = (turn: HistoryTurn, budget: number): ProjectedTurn | undefin
   const selectedMessageIndexes = [user.index]
 
   if (fullUserCost > budget) {
-    const label = speakerPrefixFor(user)
-    const contentBudget = budget - estimateHistoryTokens(label)
-    if (contentBudget <= estimateHistoryTokens(MESSAGE_OMISSION_NOTE)) return undefined
-    return {
-      index: turn.index,
-      text: `${label}${truncateTextToEstimatedTokens(user.content.trim(), contentBudget, 'both')}`,
-      selectedMessageIndexes
-    }
+    const text = formatTruncatedUserMessage(user, budget)
+    if (!text) return undefined
+    return { index: turn.index, text, selectedMessageIndexes }
   }
 
   let lead = formatMessage(user)
@@ -303,7 +342,9 @@ const fitTurnForPacket = (
   while (low <= high) {
     const middle = Math.floor((low + high) / 2)
     const projection = projectTurn(turn, middle)
-    if (projection && estimateHistoryTokens(render(projection)) <= budget) {
+    if (!projection) {
+      low = middle + 1
+    } else if (estimateHistoryTokens(render(projection)) <= budget) {
       best = projection
       low = middle + 1
     } else {

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4466,6 +4466,7 @@
     "Literature could not be created.": "Die Literaturangabe konnte nicht erstellt werden.",
     "Literature could not be deleted permanently.": "Die Literaturangabe konnte nicht endgültig gelöscht werden.",
     "Literature could not be loaded.": "Die Literaturangaben konnten nicht geladen werden.",
+    "Collections could not be loaded.": "Sammlungen konnten nicht geladen werden.",
     "This reference is no longer in your Library.": "Diese Literaturangabe befindet sich nicht mehr in Ihrer Bibliothek.",
     "Literature could not be merged.": "Die Literaturangaben konnten nicht zusammengeführt werden.",
     "Literature could not be updated.": "Die Literaturangabe konnte nicht aktualisiert werden.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -1624,6 +1624,7 @@
     "Inbox": "Bandeja de entrada",
     "Inbox is clear": "La bandeja de entrada está vacía",
     "Literature could not be loaded.": "No se pudieron cargar las referencias.",
+    "Collections could not be loaded.": "No se pudieron cargar las colecciones.",
     "This reference is no longer in your Library.": "Esta referencia ya no está en su Biblioteca.",
     "Literature could not be updated.": "No se pudieron actualizar las referencias.",
     "Literature library": "Biblioteca de referencias",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -1623,6 +1623,7 @@
     "Inbox": "Boîte de réception",
     "Inbox is clear": "La boîte de réception est vide",
     "Literature could not be loaded.": "Les références n’ont pas pu être chargées.",
+    "Collections could not be loaded.": "Impossible de charger les collections.",
     "This reference is no longer in your Library.": "Cette référence ne figure plus dans votre bibliothèque.",
     "Literature could not be updated.": "Les références n’ont pas pu être mises à jour.",
     "Literature library": "Bibliothèque de références",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -1555,6 +1555,7 @@
     "Inbox": "受信トレイ",
     "Inbox is clear": "受信トレイは空です",
     "Literature could not be loaded.": "文献を読み込めませんでした。",
+    "Collections could not be loaded.": "コレクションを読み込めませんでした。",
     "This reference is no longer in your Library.": "この文献はライブラリに存在しません。",
     "Literature could not be updated.": "文献を更新できませんでした。",
     "Literature library": "文献ライブラリ",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -1571,6 +1571,7 @@
     "Inbox": "받은 편지함",
     "Inbox is clear": "받은 편지함이 비어 있습니다",
     "Literature could not be loaded.": "문헌을 불러올 수 없습니다.",
+    "Collections could not be loaded.": "컬렉션을 불러오지 못했습니다.",
     "This reference is no longer in your Library.": "이 참고 문헌은 더 이상 라이브러리에 없습니다.",
     "Literature could not be updated.": "문헌을 업데이트할 수 없습니다.",
     "Literature library": "문헌 라이브러리",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -1622,6 +1622,7 @@
     "Inbox": "Входящие",
     "Inbox is clear": "Входящих нет",
     "Literature could not be loaded.": "Не удалось загрузить источники.",
+    "Collections could not be loaded.": "Не удалось загрузить коллекции.",
     "This reference is no longer in your Library.": "Этой ссылки больше нет в вашей библиотеке.",
     "Literature could not be updated.": "Не удалось обновить источники.",
     "Literature library": "Библиотека источников",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -1642,6 +1642,7 @@
     "Inbox": "收件箱",
     "Inbox is clear": "收件箱已清空",
     "Literature could not be loaded.": "无法加载文献。",
+    "Collections could not be loaded.": "无法加载集合。",
     "This reference is no longer in your Library.": "这篇文献已不在您的文献库中。",
     "Literature could not be updated.": "无法更新文献。",
     "Literature library": "文献库",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -1640,6 +1640,7 @@
     "Inbox": "收件匣",
     "Inbox is clear": "收件匣已清空",
     "Literature could not be loaded.": "無法載入文獻。",
+    "Collections could not be loaded.": "無法載入集合。",
     "This reference is no longer in your Library.": "這篇文獻已不在您的文獻庫中。",
     "Literature could not be updated.": "無法更新文獻。",
     "Literature library": "文獻庫",

--- a/src/shared/session-history-replay.test.ts
+++ b/src/shared/session-history-replay.test.ts
@@ -16,7 +16,90 @@ const upload = (id: string, versionId: string, name: string): PersistedUploadedA
   size: 100
 })
 
+const referenceMessage = (content: string): PersistedChatMessage => ({
+  id: 'reference-budget',
+  role: 'user',
+  content,
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1,
+  updatedAt: 1,
+  parts: [
+    {
+      type: 'literature',
+      itemId: 'stable-item',
+      metadataRevision: 7,
+      item: {
+        itemType: 'journalArticle',
+        title: 'Frozen title',
+        abstract: 'Large frozen abstract '.repeat(1000),
+        issuedText: '',
+        containerTitle: '',
+        shortTitle: '',
+        language: '',
+        rights: '',
+        url: '',
+        extra: '',
+        typeFields: {},
+        creators: [],
+        identifiers: []
+      }
+    }
+  ]
+})
+
 describe('buildSessionHistoryReplay', () => {
+  it.each(['', 'Long message text '.repeat(1000)])(
+    'keeps fitting compact identities without reserving a text omission marker (%#)',
+    (content) => {
+      const message = referenceMessage(content)
+      const roomy = buildSessionHistoryReplay([message], { target: 'codex-bridge', budget: 1000 })!
+      const identityOnly = roomy.historyPreamble.replace(
+        /\*\*User:\*\* [\s\S]*?(?=\n\nHistorical Literature)/,
+        '**User:** '
+      )
+      const budget = estimateHistoryTokens(identityOnly) + 1
+      const replay = buildSessionHistoryReplay([message], { target: 'codex-bridge', budget })
+      expect(replay).toBeDefined()
+      expect(replay?.historyPreamble).toContain('"itemId":"stable-item"')
+      expect(replay?.historyPreamble).toContain('"metadataRevision":7')
+      expect(estimateHistoryTokens(replay!.historyPreamble)).toBeLessThanOrEqual(budget)
+      expect(
+        buildSessionHistoryReplay([message], { target: 'codex-bridge', budget: 100 })
+      ).toBeUndefined()
+    }
+  )
+
+  it('deduplicates historical references by stable identity while preserving first snapshots and order', () => {
+    const message = referenceMessage('Use these references')
+    const item = message.parts![0]
+    const collection = {
+      type: 'literature-scope' as const,
+      scope: 'collection' as const,
+      collectionId: 'stable-collection',
+      name: 'Original collection'
+    }
+    const project = { type: 'literature-scope' as const, scope: 'project' as const }
+    message.parts = [item, collection, project]
+    const expected = buildSessionHistoryReplay([message], { target: 'codex-bridge', budget: 1000 })
+    expect(expected).toBeDefined()
+    message.parts.push(
+      ...Array.from({ length: 7 }, () => [
+        { ...item, metadataRevision: 8 },
+        { ...collection, name: 'Later name' },
+        project
+      ]).flat()
+    )
+    const repeated = buildSessionHistoryReplay([message], { target: 'codex-bridge', budget: 1000 })
+    expect(repeated).toEqual(expected)
+    const full = buildSessionHistoryReplay([message], { target: 'codex-bridge', budget: 1000000 })!
+    expect(full.historyPreamble.match(/"itemId":"stable-item"/g)).toHaveLength(1)
+    expect(full.historyPreamble.match(/"collectionId":"stable-collection"/g)).toHaveLength(1)
+    expect(full.historyPreamble.match(/"scope":"project"/g)).toHaveLength(1)
+    expect(full.historyPreamble).not.toContain('Later name')
+    expect(full.historyPreamble).not.toContain('"metadataRevision":8')
+  })
+
   it.each(['claude-code', 'opencode', 'codebuddy', 'codex-response', 'codex-bridge'] as const)(
     'replays frozen Literature and Collection identities for %s',
     (target) => {

--- a/src/shared/session-history-replay.test.ts
+++ b/src/shared/session-history-replay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
+import { estimateHistoryTokens } from './history-preamble'
 import type { PersistedChatMessage } from './session-persistence'
 import { buildSessionHistoryReplay } from './session-history-replay'
 import type { PersistedUploadedAttachment } from './uploads'
@@ -16,6 +17,123 @@ const upload = (id: string, versionId: string, name: string): PersistedUploadedA
 })
 
 describe('buildSessionHistoryReplay', () => {
+  it.each(['claude-code', 'opencode', 'codebuddy', 'codex-response', 'codex-bridge'] as const)(
+    'replays frozen Literature and Collection identities for %s',
+    (target) => {
+      const message: PersistedChatMessage = {
+        id: 'history-reference-message',
+        role: 'user',
+        content: 'Compare @Study set with @Repeated title',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1,
+        parts: [
+          {
+            type: 'literature-scope',
+            scope: 'collection',
+            collectionId: 'original-collection-id',
+            name: 'Study set'
+          },
+          {
+            type: 'literature',
+            itemId: 'original-item-id',
+            metadataRevision: 7,
+            item: {
+              itemType: 'journalArticle',
+              title: 'Repeated title',
+              abstract: 'Frozen original abstract',
+              issuedText: '2025',
+              issuedYear: 2025,
+              containerTitle: 'Journal',
+              shortTitle: '',
+              language: 'en',
+              rights: '',
+              url: '',
+              extra: '',
+              typeFields: {},
+              creators: [],
+              identifiers: [{ scheme: 'doi', value: '10.1234/frozen', isPrimary: true }]
+            }
+          }
+        ]
+      }
+      const replay = buildSessionHistoryReplay([message], { target, budget: 10000 })
+      expect(replay?.historyPreamble).toContain(message.content)
+      for (const value of [
+        'original-collection-id',
+        'original-item-id',
+        '10.1234/frozen',
+        'Frozen original abstract'
+      ]) {
+        expect(replay?.historyPreamble).toContain(value)
+      }
+      expect(replay?.historyPreamble).toMatch(/metadataRevision[^0-9]*7/)
+      expect(replay?.historyPreamble).toContain('not current instructions')
+      const original = structuredClone(message)
+      for (const budget of [800, 1000, 2000]) {
+        const verbose = structuredClone(message)
+        const reference = verbose.parts?.find((part) => part.type === 'literature')
+        if (reference?.type === 'literature') reference.item.abstract = 'Frozen摘要 '.repeat(10000)
+        const bounded = buildSessionHistoryReplay([verbose], { target, budget })
+        expect(bounded).toBeDefined()
+        expect(estimateHistoryTokens(bounded!.historyPreamble)).toBeLessThanOrEqual(budget)
+        expect(bounded?.historyPreamble).toContain('original-collection-id')
+        expect(bounded?.historyPreamble).toContain('original-item-id')
+        expect(bounded?.historyPreamble).toMatch(/metadataRevision[^0-9]*7/)
+        expect(bounded?.historyPreamble).toContain('omitted for replay budget')
+        expect(bounded?.historyPreamble).not.toContain('Frozen摘要')
+      }
+      expect(message).toEqual(original)
+    }
+  )
+
+  it('keeps content-only legacy messages readable without guessing reference identities', () => {
+    const replay = buildSessionHistoryReplay(
+      [
+        {
+          id: 'legacy',
+          role: 'user',
+          content: 'Compare @Study set',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1
+        }
+      ],
+      { target: 'codex-bridge' }
+    )
+    expect(replay?.historyPreamble).toContain('Compare @Study set')
+    expect(replay?.historyPreamble).not.toContain('collectionId')
+  })
+
+  it('does not leak reference data from a turn omitted by the shared replay budget', () => {
+    const messages: PersistedChatMessage[] = Array.from({ length: 5 }, (_, index) => ({
+      id: `message-${index}`,
+      role: 'user',
+      content: index === 2 ? 'large middle '.repeat(500) : `Turn ${index}`,
+      status: 'complete',
+      eventIds: [],
+      createdAt: index,
+      updatedAt: index,
+      parts:
+        index === 2
+          ? [
+              {
+                type: 'literature-scope',
+                scope: 'collection',
+                collectionId: 'omitted-collection',
+                name: 'Hidden scope'
+              }
+            ]
+          : []
+    }))
+    const replay = buildSessionHistoryReplay(messages, { target: 'codex-bridge', budget: 1000 })
+    expect(replay?.historyPreamble).toContain('Turn 0')
+    expect(replay?.historyPreamble).toContain('Turn 4')
+    expect(replay?.historyPreamble).not.toContain('omitted-collection')
+  })
+
   it('does not replay Reading PDFs while preserving ordinary PDF attachments', () => {
     const readingPdf = upload('reading-upload', 'reading-version', 'reading.pdf')
     const ordinaryPdf = upload('ordinary-upload', 'ordinary-version', 'ordinary.pdf')


### PR DESCRIPTION
## Problem

Switching between unsaved project drafts with the same mention query can leave the previous project's Literature candidates selectable. Messages may contain up to ten references, but prompt preparation silently discards Collection identities after the fifth. Application history replay preserves mention names while losing their frozen reference identity and metadata. Partial suggestion failures can also appear as empty or complete results.

## Proposed change

- Bind Literature and Collection results to project and query; invalidate mention menus when draft project identity changes.
- Reuse the existing ten-reference budget for Collection scope prompts.
- Include existing historical reference parts in the shared replay projection and budget. Keep identities atomic, preserve fitting compact identities even when body text cannot fit, and deduplicate by stable identity while retaining the first snapshot; explicitly omit verbose snapshot fields when necessary. Historical metadata remains data, not current instructions.
- Keep independent file, Literature and Collection outcomes, with source-specific errors and in-place retry alongside healthy results. Include all eight translations.

## Scope and non-goals

No database migration, new persisted fields, new MessagePart variants, new state enum values, or Collection membership expansion. Result ownership and retry state are transient. Content-only legacy history stays text-only without guessing IDs. Native provider context continuation and subscription lifecycles are unchanged. The fix does not restrict legitimate cross-project use of the user-level library.

## Acceptance criteria and validation

Before production changes, the same 11 regressions failed in two runs against the default-branch baseline; the five-Collection control and 100 other cases passed. Four additional real-send replay cases also failed twice against the original history implementation with the expected missing collection ID. Fixed versions pass.

After the final review fixes and rebase onto `a5df2aa7`, all 469 selected popup/editor, scope-prompt, history-replay, actual-send, prompt-preparation, and continuation cases passed on `deabfeba`. `npm run typecheck` (both processes) and `npm run lint` also passed on this head. The two added budget regressions first failed for the reported reasons before their production fixes; empty-content and insufficient-budget controls are covered.

The broader owner/consumer evidence below covers the unchanged portions of the patch; the relevant UI and replay checks were rerun after the final edits:

| Behavior | Project-owned check (`npx vitest run` with these paths) | Result |
| --- | --- | --- |
| Project ownership, real editor insertion, retry and serialization | `src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx`, `ComposerEditor.interaction.test.tsx`, `composer-doc.test.ts` in the same directory | Pass; final UI rerun 102/102 |
| Exact Collection IDs and main prompt preparation | `src/main/acp/literature-reference-prompt.test.ts`, `src/main/acp/prompt-preparation-owner.test.ts`, `src/main/acp/prompt-content-owner.test.ts` | Pass |
| Frozen snapshots, budget, actual send, active Branch and native continuation controls | `src/shared/session-history-replay.test.ts`, `src/renderer/src/lib/acp/history-preamble.test.ts`, `src/renderer/src/lib/acp/useWorkspaceAgentRuntime.test.ts` | Pass; final replay subset 13/13 |
| Main continuation consumers | `src/main/acp/durable-continuation-context-owner.test.ts`, `src/main/acp/interrupted-turn-continuation.test.ts` | 29/29 |
| Other replay consumers | `src/main/reviewer/orchestrator.test.ts`, `src/main/reviewer/orchestrator-prompt.test.ts`, `src/main/side-chat/ipc.test.ts`, `src/renderer/src/lib/acp/workspace-runtime-session-branch-owner.test.ts`, `src/renderer/src/lib/acp/workspace-runtime-save-as-skill-owner.test.tsx`, `src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx` | Pass |
| Translations | `src/renderer/src/i18n/resources.test.ts` | All 804 cases pass across the suite run and isolated semantic-scan rerun |
| Process types and lint | `npm run typecheck:node`; `npx tsc --noEmit -p tsconfig.web.json --composite false`; `npm run lint`; `git diff --check` | Pass |

Across the owner and consumer sets, 1,566 distinct tests passed after targeted reruns. The reviewer suite required execution outside the sandbox for its loopback server; the semantic i18n scan passed in isolation after a resource-contention timeout, without changing its threshold. A first filtered scan selected no tests and is not counted as evidence.

The impact explain tool reports an unknown Literature module owner and falls back to full. Per maintainer request, local validation uses explicit owner/consumer boundaries instead of the complete portable suite; exact-head PR CI remains authoritative for full and platform checks. Live providers and OS packaging were not exercised locally. The four execution targets are covered at shared replay and real application send boundaries; CodeBuddy also has shared replay coverage.

Browser verification used the real popup and ComposerEditor with controlled API responses: independent retries recover healthy options, and switching identical unsaved drafts closes the menu without inserting the prior-project item. Before/after screenshots were captured for the maintainer; fixtures and images are local-only.

## Review focus

Atomic reference identities under replay budget pressure, active-Branch isolation, stale-selection rejection, and independent retry behavior. Independent exact-head review and required CI must complete before merge.
