### PR TITLE
fix(literature): preserve export round trips and complete membership

### DIFF
--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -179,6 +179,52 @@ describe('LiteratureCatalog', () => {
     }
   )
 
+  it('reads all matching member IDs independently of page limits and later title changes', async () => {
+    const catalog = await setup()
+    const { itemIds } = await catalog.importItems(
+      Array.from({ length: 101 }, (_, index) =>
+        literatureItemInputSchema.parse({
+          itemType: 'book',
+          title: `Paper ${String(index).padStart(3, '0')}`
+        })
+      )
+    )
+    await catalog.transact({
+      kind: 'set-project-items',
+      projectId: 'project-1',
+      itemIds,
+      included: true,
+      source: 'library'
+    })
+    const page = await catalog.search({
+      scope: 'library',
+      projectId: 'project-1',
+      sortBy: 'title',
+      allItemIds: true,
+      limit: 1,
+      offset: 100
+    })
+    expect(page).toEqual({ entries: [], itemIds, totalCount: 101 })
+    const view = (await catalog.get(itemIds[100]!))!
+    await catalog.transact({
+      kind: 'update-item',
+      itemId: view.id,
+      expectedMetadataRevision: view.metadataRevision,
+      item: { ...view.item, title: 'A moved reference' }
+    })
+    expect(page.itemIds).toEqual(itemIds)
+    const filtered = await catalog.search({
+      scope: 'library',
+      projectId: 'project-1',
+      filter: { query: 'A moved' },
+      allItemIds: true
+    })
+    expect(filtered.itemIds).toEqual([view.id])
+    expect(
+      (await catalog.search({ scope: 'library', projectId: 'missing', allItemIds: true })).itemIds
+    ).toEqual([])
+  })
+
   it.each([
     ['deleted', 'missing'],
     ['active', 'missing'],

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -776,6 +776,19 @@ class LiteratureCatalog {
         nextOffset: rows.length > limit ? offset + limit : undefined
       }
     }
+    if (request.allItemIds) {
+      return client.$transaction((transaction) => this.searchLibrary(request, transaction))
+    }
+    return this.searchLibrary(request, client)
+  }
+
+  private async searchLibrary(
+    request: LiteratureCatalogSearchRequest,
+    client: Pick<LiteratureCatalogClient, 'literatureItem' | 'tagAssignment'>
+  ): Promise<LiteratureCatalogSearchPage> {
+    const offset = Math.max(0, request.offset ?? 0)
+    const limit = Math.min(100, Math.max(1, request.limit ?? 50))
+    const query = normalizeSpace(request.query ?? '')
     const filter = request.filter
     const tagIds = [
       ...new Set([...(filter?.tagIds ?? []), ...(request.tagId ? [request.tagId] : [])])
@@ -871,6 +884,10 @@ class LiteratureCatalog {
             : request.sortBy === 'created'
               ? [{ createdAt: sortDirection }, { id: 'asc' }]
               : [{ updatedAt: sortDirection }, { id: 'asc' }]
+    if (request.allItemIds) {
+      const rows = await client.literatureItem.findMany({ where, orderBy, select: { id: true } })
+      return { entries: [], itemIds: rows.map(({ id }) => id), totalCount: rows.length }
+    }
     const [totalCount, rows] = await Promise.all([
       client.literatureItem.count({ where }),
       client.literatureItem.findMany({

--- a/src/main/literature/citation-exchange.ts
+++ b/src/main/literature/citation-exchange.ts
@@ -1,0 +1,78 @@
+import type { CslItem, CslName } from '../../shared/literature-csl'
+
+// citeme-engine-wasm 0.3.8 exposes BibTeX month and day components as zero-based values.
+// Keep the correction at this format boundary; RIS and CSL dates are one-based.
+export const normalizeBibtexEntry = (entry: Record<string, unknown>): Record<string, unknown> => {
+  const issued = entry.issued as { 'date-parts'?: unknown } | undefined
+  const parts = issued?.['date-parts']
+  const date = Array.isArray(parts) && Array.isArray(parts[0]) ? parts[0] : undefined
+  const custom = entry.custom as { eprint?: { id?: unknown; type?: unknown } } | undefined
+  return {
+    ...entry,
+    ...(date && typeof date[1] === 'number'
+      ? {
+          issued: {
+            'date-parts': [
+              date.map((part, index) =>
+                (index === 1 || index === 2) && typeof part === 'number' ? part + 1 : part
+              )
+            ]
+          }
+        }
+      : {}),
+    ...(custom?.eprint?.type === 'arxiv' && typeof custom.eprint.id === 'string'
+      ? { arXiv: custom.eprint.id }
+      : {})
+  }
+}
+
+const lineValue = (value: string): string => value.replace(/[\r\n]+/gu, ' ').trim()
+const nameText = (name: CslName): string =>
+  name.literal ?? `${name.family ?? ''}, ${name.given ?? ''}`
+
+// BOOK A3/editor, A4/translator and ET/edition follow Zotero's RIS mappings.
+// Labeled N1 notes preserve identifiers without misusing DOI or accession-number tags.
+// These notes are readable by other tools; structured recovery is our explicit adapter contract.
+export const exportRisFields = (item: CslItem): string => {
+  const fields: [string, string][] = []
+  for (const key of ['PMID', 'PMCID', 'arXiv'] as const) {
+    if (item[key]) fields.push(['N1', `${key}: ${item[key]}`])
+  }
+  for (const name of item.editor ?? [])
+    fields.push([item.type === 'book' ? 'A3' : 'A2', nameText(name)])
+  for (const name of item.translator ?? []) fields.push(['A4', nameText(name)])
+  if (item.edition) fields.push(['ET', item.edition])
+  return fields.map(([tag, value]) => `${tag}  - ${lineValue(value)}\n`).join('')
+}
+
+export const importRisFields = (
+  input: string,
+  entry: Record<string, unknown>
+): Record<string, unknown> => {
+  const result = { ...entry }
+  const editors: CslName[] = []
+  const translators: CslName[] = []
+  for (const line of input.split(/\r?\n/u)) {
+    const match = /^[ \t]*([A-Z0-9]{2})[ \t]+-[ \t]*(.*)$/u.exec(line)
+    if (!match) continue
+    const [, tag, raw] = match
+    if (tag === 'ER') break
+    const value = raw!.trim()
+    if (!value) continue
+    if (tag === 'N1') {
+      const identifier = /^(PMID|PMCID|arXiv):\s*(\S+)$/u.exec(value)
+      if (identifier) result[identifier[1]!] = identifier[2]
+    } else if (tag === 'ET') result.edition = value
+    else if (tag === 'A4' || tag === 'ED' || tag === (entry.type === 'book' ? 'A3' : 'A2')) {
+      const comma = value.indexOf(',')
+      const name =
+        comma < 0
+          ? { literal: value }
+          : { family: value.slice(0, comma).trim(), given: value.slice(comma + 1).trim() }
+      ;(tag === 'A4' ? translators : editors).push(name)
+    }
+  }
+  if (editors.length) result.editor = editors
+  if (translators.length) result.translator = translators
+  return result
+}

--- a/src/main/literature/citation-exchange.ts
+++ b/src/main/literature/citation-exchange.ts
@@ -26,6 +26,8 @@ export const normalizeBibtexEntry = (entry: Record<string, unknown>): Record<str
   }
 }
 
+const literalNamePrefix = 'Open Science literal creator: '
+
 const lineValue = (value: string): string => value.replace(/[\r\n]+/gu, ' ').trim()
 const nameText = (name: CslName): string =>
   name.literal ?? `${name.family ?? ''}, ${name.given ?? ''}`
@@ -38,9 +40,17 @@ export const exportRisFields = (item: CslItem): string => {
   for (const key of ['PMID', 'PMCID', 'arXiv'] as const) {
     if (item[key]) fields.push(['N1', `${key}: ${item[key]}`])
   }
-  for (const name of item.editor ?? [])
-    fields.push([item.type === 'book' ? 'A3' : 'A2', nameText(name)])
-  for (const name of item.translator ?? []) fields.push(['A4', nameText(name)])
+  for (const [tag, names] of [
+    [item.type === 'book' ? 'A3' : 'A2', item.editor ?? []],
+    ['A4', item.translator ?? []]
+  ] as const) {
+    names.forEach((name, index) => {
+      fields.push([tag, nameText(name)])
+      if (name.literal) {
+        fields.push(['N1', `${literalNamePrefix}${JSON.stringify([tag, index, name.literal])}`])
+      }
+    })
+  }
   if (item.edition) fields.push(['ET', item.edition])
   return fields.map(([tag, value]) => `${tag}  - ${lineValue(value)}\n`).join('')
 }
@@ -52,6 +62,9 @@ export const importRisFields = (
   const result = { ...entry }
   const editors: CslName[] = []
   const translators: CslName[] = []
+  const rawNames = new Map<CslName, string>()
+  const literalNames: { tag: string; index: number; literal: string }[] = []
+  const editorTag = entry.type === 'book' ? 'A3' : 'A2'
   for (const line of input.split(/\r?\n/u)) {
     const match = /^[ \t]*([A-Z0-9]{2})[ \t]+-[ \t]*(.*)$/u.exec(line)
     if (!match) continue
@@ -62,15 +75,40 @@ export const importRisFields = (
     if (tag === 'N1') {
       const identifier = /^(PMID|PMCID|arXiv):\s*(\S+)$/u.exec(value)
       if (identifier) result[identifier[1]!] = identifier[2]
+      if (value.startsWith(literalNamePrefix)) {
+        try {
+          const marker: unknown = JSON.parse(value.slice(literalNamePrefix.length))
+          if (
+            Array.isArray(marker) &&
+            marker.length === 3 &&
+            typeof marker[0] === 'string' &&
+            Number.isInteger(marker[1]) &&
+            marker[1] >= 0 &&
+            typeof marker[2] === 'string'
+          ) {
+            literalNames.push({ tag: marker[0], index: marker[1], literal: marker[2] })
+          }
+        } catch {
+          // Unrecognized notes never override the ordinary RIS creator fields.
+        }
+      }
     } else if (tag === 'ET') result.edition = value
-    else if (tag === 'A4' || tag === 'ED' || tag === (entry.type === 'book' ? 'A3' : 'A2')) {
+    else if (tag === 'A4' || tag === 'ED' || tag === editorTag) {
       const comma = value.indexOf(',')
       const name =
         comma < 0
           ? { literal: value }
           : { family: value.slice(0, comma).trim(), given: value.slice(comma + 1).trim() }
+      rawNames.set(name, value)
       ;(tag === 'A4' ? translators : editors).push(name)
     }
+  }
+  for (const { tag, index, literal } of literalNames) {
+    const names = tag === 'A4' ? translators : tag === editorTag ? editors : undefined
+    const name = names?.[index]
+    // Only restore mode when the marker still describes this exact visible field. A third-party
+    // edit or reordered creator list must not be overwritten by a stale note.
+    if (names && name && rawNames.get(name) === lineValue(literal)) names[index] = { literal }
   }
   if (editors.length) result.editor = editors
   if (translators.length) result.translator = translators

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -17,6 +17,7 @@ import {
   type LiteratureRecordImportFormat
 } from '../../shared/literature'
 import { fromCslItem, toCslItem } from '../../shared/literature-csl'
+import { exportRisFields, importRisFields, normalizeBibtexEntry } from './citation-exchange'
 import {
   citationResourceDirectory,
   type LiteratureCitationStyleLibrary
@@ -319,7 +320,14 @@ class LiteratureCitationFormatter {
   ): Promise<string> {
     const engine = await this.engine()
     if (format === 'ris') {
-      return engine.exportRis(JSON.stringify(references.map(({ id, item }) => toCslItem(id, item))))
+      return references
+        .map(({ id, item }) => {
+          const csl = toCslItem(id, item)
+          return engine
+            .exportRis(JSON.stringify([csl]))
+            .replace(/^ER {2}-.*$/mu, () => `${exportRisFields(csl)}ER  - `)
+        })
+        .join('\n')
     }
     // The engine silently renames duplicate IDs in a batch. Export records independently so the
     // complete-output owner (Library export or LaTeX bundle) can reject collisions without renaming.
@@ -328,8 +336,14 @@ class LiteratureCitationFormatter {
         const fallback = /^[A-Za-z0-9][A-Za-z0-9_:.+-]{0,127}$/u.test(id)
           ? id
           : `os${createHash('sha256').update(id).digest('hex').slice(0, 12)}`
+        const csl = toCslItem(citationKey(fallback, item), item)
         return engine
-          .exportBibtex(JSON.stringify(toCslItem(citationKey(fallback, item), item)))
+          .exportBibtex(
+            JSON.stringify({
+              ...csl,
+              ...(csl.arXiv ? { custom: { eprint: { id: csl.arXiv, type: 'arxiv' } } } : {})
+            })
+          )
           .trim()
       })
       .join('\n\n')
@@ -339,16 +353,31 @@ class LiteratureCitationFormatter {
     const nbib = parseNbib(input)
     if (nbib) return nbib
     const engine = await this.engine()
-    const parsed = parseResultSchema.parse(
+    let parsed = parseResultSchema.parse(
       JSON.parse(engine.parseAuto(input, LITERATURE_RECORD_IMPORT_MAX_RECORDS)) as unknown
     )
     if (parsed.format !== 'bibtex' && parsed.format !== 'ris') {
       throw new Error('Selected file must contain BibTeX or RIS references.')
     }
+    const format = parsed.format
+    if (format === 'ris') {
+      // Parse each source record independently so rejected records cannot shift supplemental fields.
+      const records = input
+        .split(/(?=^[ \t]*TY[ \t]+-)/mu)
+        .filter((record) => /^[ \t]*TY[ \t]+-/mu.test(record))
+      const entries: Record<string, unknown>[] = []
+      const recordErrors: CitationImportError[] = []
+      for (const record of records.slice(0, LITERATURE_RECORD_IMPORT_MAX_RECORDS)) {
+        const result = parseResultSchema.parse(JSON.parse(engine.parseAuto(record, 1)))
+        recordErrors.push(...result.errors)
+        for (const entry of result.entries) entries.push(importRisFields(record, entry))
+      }
+      parsed = { ...parsed, entries, errors: recordErrors }
+    }
     const errors = [...parsed.errors]
     const items = parsed.entries.flatMap((entry) => {
       try {
-        return [fromCslItem(entry)]
+        return [fromCslItem(format === 'bibtex' ? normalizeBibtexEntry(entry) : entry)]
       } catch (error) {
         errors.push({
           preview: String(entry.title ?? entry.id ?? '').slice(0, 160),
@@ -358,7 +387,7 @@ class LiteratureCitationFormatter {
       }
     })
     return {
-      format: parsed.format,
+      format,
       items,
       errors,
       truncated: parsed.truncated,

--- a/src/main/literature/export-roundtrip.test.ts
+++ b/src/main/literature/export-roundtrip.test.ts
@@ -187,4 +187,41 @@ describe('Literature export round trips', () => {
       { nameMode: 'person', creatorType: 'translator', givenName: 'Li', familyName: 'Translator' }
     ])
   })
+  it('preserves comma-containing organization editors and translators in RIS', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const creators = [
+      {
+        nameMode: 'organization' as const,
+        literalName: 'Department, University',
+        creatorType: 'editor' as const
+      },
+      {
+        nameMode: 'person' as const,
+        familyName: 'Editor',
+        givenName: 'Ada',
+        creatorType: 'editor' as const
+      },
+      {
+        nameMode: 'organization' as const,
+        literalName: 'Translation,$&Group',
+        creatorType: 'translator' as const
+      }
+    ]
+    const content = await formatter.exportReferences(
+      [{ id: 'book', item: { ...reference, itemType: 'book', creators } }],
+      'ris'
+    )
+    const parsed = await formatter.parseReferences(content)
+    expect(parsed.errors).toEqual([])
+    expect(parsed.items[0]?.creators).toEqual(creators)
+    const edited = await formatter.parseReferences(
+      content.replace('A3  - Department, University', 'A3  - Updated, Person')
+    )
+    expect(edited.items[0]?.creators[0]).toEqual({
+      nameMode: 'person',
+      familyName: 'Updated',
+      givenName: 'Person',
+      creatorType: 'editor'
+    })
+  })
 })

--- a/src/main/literature/export-roundtrip.test.ts
+++ b/src/main/literature/export-roundtrip.test.ts
@@ -1,0 +1,190 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { literatureItemInputSchema } from '../../shared/literature'
+import { migrateApplicationDatabase } from '../database/migration-service'
+import { createProjectDbClient } from '../projects/prisma-client'
+import { LiteratureCatalog } from './catalog'
+import { LiteratureCitationFormatter } from './citation-formatter'
+
+const reference = literatureItemInputSchema.parse({
+  itemType: 'journalArticle',
+  title: 'Round trip paper',
+  issuedYear: 2024,
+  containerTitle: 'Journal',
+  creators: [{ creatorType: 'author', nameMode: 'person', givenName: 'Ada', familyName: 'Author' }]
+})
+
+describe('Literature export round trips', () => {
+  it.each(['bibtex', 'ris'] as const)(
+    'preserves all twelve publication months in %s',
+    async (format) => {
+      const formatter = new LiteratureCitationFormatter()
+      const months = [
+        'jan',
+        'feb',
+        'mar',
+        'apr',
+        'may',
+        'jun',
+        'jul',
+        'aug',
+        'sep',
+        'oct',
+        'nov',
+        'dec'
+      ]
+      for (let month = 1; month <= 12; month++) {
+        const item = { ...reference, issuedText: `2024-${String(month).padStart(2, '0')}-12` }
+        const content = await formatter.exportReferences([{ id: 'dated', item }], format)
+        if (format === 'bibtex') expect(content).toContain(`month = ${months[month - 1]}`)
+        const parsed = await formatter.parseReferences(content)
+        expect(parsed.errors).toEqual([])
+        expect(parsed.items).toHaveLength(1)
+        expect
+          .soft(parsed.items[0]?.issuedText)
+          .toBe(`2024-${month}${format === 'ris' ? '-12' : ''}`)
+      }
+    }
+  )
+
+  it.each(['bibtex', 'ris'] as const)(
+    'preserves supported stable identifiers in %s',
+    async (format) => {
+      const formatter = new LiteratureCitationFormatter()
+      const identifiers = [
+        { scheme: 'doi' as const, value: '10.1234/control', isPrimary: true },
+        { scheme: 'pmid' as const, value: '12345678', isPrimary: false },
+        { scheme: 'pmcid' as const, value: 'PMC123456', isPrimary: false },
+        { scheme: 'arxiv' as const, value: '2401.15884', isPrimary: false }
+      ]
+      const content = await formatter.exportReferences(
+        [{ id: 'identified', item: { ...reference, identifiers } }],
+        format
+      )
+      const parsed = await formatter.parseReferences(content)
+      expect(parsed.errors).toEqual([])
+      expect(parsed.items[0]?.identifiers).toContainEqual(identifiers[0])
+      for (const identifier of identifiers) {
+        expect.soft(content).toContain(identifier.value)
+        expect
+          .soft(parsed.items[0]?.identifiers)
+          .toContainEqual(
+            expect.objectContaining({ scheme: identifier.scheme, value: identifier.value })
+          )
+      }
+    }
+  )
+
+  it.each(['bibtex', 'ris'] as const)('preserves book edition in %s', async (format) => {
+    const formatter = new LiteratureCitationFormatter()
+    const item = {
+      ...reference,
+      itemType: 'book' as const,
+      typeFields: { edition: '2', publisher: 'Audit Press' }
+    }
+    const parsed = await formatter.parseReferences(
+      await formatter.exportReferences([{ id: 'book', item }], format)
+    )
+    expect(parsed.errors).toEqual([])
+    expect(parsed.items[0]?.typeFields.publisher).toBe('Audit Press')
+    expect(parsed.items[0]?.typeFields.edition).toBe('2')
+  })
+
+  it('preserves book editors and translators in RIS', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const creators = [
+      {
+        nameMode: 'person' as const,
+        givenName: 'Ada',
+        familyName: 'Editor',
+        creatorType: 'editor' as const
+      },
+      {
+        nameMode: 'person' as const,
+        givenName: 'Li',
+        familyName: 'Translator',
+        creatorType: 'translator' as const
+      }
+    ]
+    const item = { ...reference, itemType: 'book' as const, creators }
+    const content = await formatter.exportReferences([{ id: 'book', item }], 'ris')
+    const parsed = await formatter.parseReferences(content)
+    expect(parsed.errors).toEqual([])
+    expect.soft(content).toContain('Editor')
+    expect.soft(content).toContain('Translator')
+    expect.soft(parsed.items[0]?.creators).toEqual(creators)
+  })
+
+  it.each(['bibtex', 'ris'] as const)(
+    'reuses the existing PMID-only record after %s export',
+    async (format) => {
+      const root = await mkdtemp(join(tmpdir(), 'literature-export-identity-'))
+      const client = createProjectDbClient(root)
+      try {
+        await migrateApplicationDatabase(client)
+        const catalog = new LiteratureCatalog(async () => client)
+        const formatter = new LiteratureCitationFormatter()
+        for (const scheme of ['doi', 'pmid'] as const) {
+          const item = {
+            ...reference,
+            title: `${scheme} paper`,
+            identifiers: [
+              { scheme, value: scheme === 'doi' ? '10.1234/control' : '12345678', isPrimary: true }
+            ]
+          }
+          const original = await catalog.transact({ kind: 'create-item', item })
+          const content = await formatter.exportReferences([{ id: original.id, item }], format)
+          const parsed = await formatter.parseReferences(content)
+          expect(parsed.errors).toEqual([])
+          const preview = await catalog.inspectImportItems(parsed.items, parsed.errors)
+          expect.soft(preview[0]?.existingItemId).toBe(original.id)
+          const receipt = await catalog.importItems(parsed.items)
+          expect.soft(receipt).toEqual({ createdCount: 0, reusedCount: 1, itemIds: [original.id] })
+        }
+      } finally {
+        await client.$disconnect()
+        await rm(root, { recursive: true, force: true })
+      }
+    },
+    120000
+  )
+  it('keeps BibLaTeX full-date components one-based', async () => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      '@article{x,title={Dated paper},date={2024-03-12}}'
+    )
+    expect(parsed.errors).toEqual([])
+    expect(parsed.items[0]?.issuedText).toBe('2024-3-12')
+  })
+
+  it('keeps RIS supplemental fields with their own records across a rejected entry', async () => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'TY  - BOOK\nTI  - First\nN1  - PMID: 11111111\nA3  - Editor, Ada\nET  - 2\nER  -\n' +
+        'TY  - BOOK\nN1  - PMID: 22222222\nET  - 9\nER  -\n' +
+        'TY  - BOOK\nTI  - Last\nN1  - PMID: 33333333\nA4  - Translator, Li\nET  - 3\nER  -'
+    )
+    expect(parsed.errors).toHaveLength(1)
+    expect(
+      parsed.items.map(({ title, identifiers, typeFields }) => ({
+        title,
+        identifiers,
+        edition: typeFields.edition
+      }))
+    ).toEqual([
+      {
+        title: 'First',
+        identifiers: [{ scheme: 'pmid', value: '11111111', isPrimary: false }],
+        edition: '2'
+      },
+      {
+        title: 'Last',
+        identifiers: [{ scheme: 'pmid', value: '33333333', isPrimary: false }],
+        edition: '3'
+      }
+    ])
+    expect(parsed.items[1]?.creators).toEqual([
+      { nameMode: 'person', creatorType: 'translator', givenName: 'Li', familyName: 'Translator' }
+    ])
+  })
+})

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -359,7 +359,24 @@ describe('LiteratureLibraryPage', () => {
         literature: {
           lookupMetadata: vi.fn(async () => libraryItem.item),
           jobs: vi.fn(async () => ({ jobs: [], summaries: [] })),
-          search,
+          search: async (request: LiteratureCatalogSearchRequest) => {
+            const page = await search(request)
+            if (!request.allItemIds || page.itemIds) return page
+            // Legacy fixtures describe their in-memory member set as pages. Adapt only the
+            // fixture data; production and real-catalog cases return one ID snapshot.
+            const entries = [...page.entries]
+            let nextOffset = page.nextOffset
+            while (nextOffset !== undefined) {
+              const next = await search({ ...request, offset: nextOffset })
+              entries.push(...next.entries)
+              nextOffset = next.nextOffset
+            }
+            return {
+              entries: [],
+              itemIds: entries.map((entry) => entry.id),
+              totalCount: entries.length
+            }
+          },
           transact,
           get,
           completeMetadata,
@@ -4722,7 +4739,7 @@ describe('LiteratureLibraryPage', () => {
         scope: 'library',
         projectId: 'project-1',
         sortBy: 'title',
-        limit: 100
+        allItemIds: true
       })
     )
     expect(saveBlobFile).toHaveBeenCalledWith(
@@ -4768,7 +4785,7 @@ describe('LiteratureLibraryPage', () => {
         scope: 'library',
         collectionId: collection.id,
         sortBy: 'title',
-        limit: 100
+        allItemIds: true
       })
     )
     expect(saveBlobFile).toHaveBeenCalledWith(
@@ -5965,4 +5982,124 @@ describe('LiteratureLibraryPage', () => {
     expect((await screen.findByRole('alert')).textContent).toBe('PDF could not be added.')
     expect(transact).toHaveBeenCalledTimes(1)
   })
+  it('reports a failed membership read without saving an incomplete project export', async () => {
+    search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => {
+      if (request.allItemIds) throw new Error('Membership read failed')
+      return { entries: request.scope === 'library' ? [libraryItem] : [] }
+    })
+    useNavigationStore.setState({ pendingLiteratureProjectId: 'project-1' })
+    render(<LiteratureLibraryPage />)
+    await screen.findByRole('heading', { name: 'Retrieval research' })
+    await openMenu(screen.getByTitle('More actions'))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'RIS' }))
+    await screen.findByText('References could not be exported.')
+    expect(formatReferences).not.toHaveBeenCalled()
+    expect(saveBlobFile).not.toHaveBeenCalled()
+  })
+
+  it('exports every project member when a title moves during pagination', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { createProjectDbClient } = await import('../../../../main/projects/prisma-client')
+    const { migrateApplicationDatabase } =
+      await import('../../../../main/database/migration-service')
+    const { LiteratureCatalog } = await import('../../../../main/literature/catalog')
+    const { LiteratureCitationFormatter } =
+      await import('../../../../main/literature/citation-formatter')
+    const root = await mkdtemp(join(tmpdir(), 'literature-export-pagination-'))
+    const client = createProjectDbClient(root)
+    try {
+      await migrateApplicationDatabase(client)
+      await client.project.create({ data: { id: 'project-1', name: 'Retrieval research' } })
+      const catalog = new LiteratureCatalog(async () => client)
+      const formatter = new LiteratureCitationFormatter()
+      const { itemIds: ids } = await catalog.importItems(
+        Array.from({ length: 101 }, (_, index) => ({
+          ...libraryItem.item,
+          title: `Paper ${String(index + 1).padStart(3, '0')}`,
+          identifiers: []
+        }))
+      )
+      await catalog.transact({
+        kind: 'set-project-items',
+        projectId: 'project-1',
+        itemIds: ids,
+        included: true,
+        source: 'library'
+      })
+      let moveOnSecondPage = true
+      const seenPages: { offset?: number; ids: string[]; totalCount?: number }[] = []
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => {
+        if (request.scope !== 'library' || request.projectId !== 'project-1') return { entries: [] }
+        if (request.sortBy === 'title' && request.offset === 100 && moveOnSecondPage) {
+          moveOnSecondPage = false
+          const view = (await catalog.get(ids[100]!))!
+          await catalog.transact({
+            kind: 'update-item',
+            itemId: view.id,
+            expectedMetadataRevision: view.metadataRevision,
+            item: { ...view.item, title: 'A moved reference' }
+          })
+        }
+        const page = await catalog.search(request)
+        if (request.allItemIds && moveOnSecondPage) {
+          moveOnSecondPage = false
+          const view = (await catalog.get(ids[100]!))!
+          await catalog.transact({
+            kind: 'update-item',
+            itemId: view.id,
+            expectedMetadataRevision: view.metadataRevision,
+            item: { ...view.item, title: 'A moved reference' }
+          })
+        }
+        if (request.sortBy === 'title')
+          seenPages.push({
+            offset: request.offset,
+            ids: page.entries.map((e) => ('id' in e ? e.id : '')),
+            totalCount: page.totalCount
+          })
+        return page
+      })
+      formatReferences.mockImplementation(async ({ itemIds }: { itemIds: string[] }) => {
+        const refs = (await catalog.getMany(itemIds)).map(({ id, item }) => ({ id, item }))
+        return {
+          references: [],
+          exports: {
+            bibtex: await formatter.exportReferences(refs, 'bibtex'),
+            ris: await formatter.exportReferences(refs, 'ris')
+          }
+        }
+      })
+      useNavigationStore.setState({ pendingLiteratureProjectId: 'project-1' })
+      render(<LiteratureLibraryPage />)
+      await screen.findByRole('heading', { name: 'Retrieval research' })
+      await openMenu(screen.getByTitle('More actions'))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'RIS' }))
+      await waitFor(() => expect(saveBlobFile).toHaveBeenCalledTimes(1), { timeout: 15000 })
+      const first = new TextDecoder().decode(
+        (saveBlobFile.mock.calls[0]![0] as { data: ArrayBuffer }).data
+      )
+      expect.soft(first.match(/^TY {2}-/gm)).toHaveLength(101)
+      expect.soft(first).toContain('A moved reference')
+      expect(seenPages.every((p) => p.totalCount === 101)).toBe(true)
+      expect.soft(formatReferences.mock.calls[0]![0].itemIds).toContain(ids[100])
+      expect(screen.queryByText('References could not be exported.')).toBeNull()
+      await waitFor(() =>
+        expect(screen.getByTitle('More actions').hasAttribute('disabled')).toBe(false)
+      )
+      await openMenu(screen.getByTitle('More actions'))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'RIS' }))
+      await waitFor(() => expect(saveBlobFile).toHaveBeenCalledTimes(2), { timeout: 15000 })
+      const control = new TextDecoder().decode(
+        (saveBlobFile.mock.calls[1]![0] as { data: ArrayBuffer }).data
+      )
+      expect(control.match(/^TY {2}-/gm)).toHaveLength(101)
+      expect(control).toContain('A moved reference')
+    } finally {
+      cleanup()
+      await client.$disconnect()
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 120000)
 })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -2520,22 +2520,9 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const resolveSelectedItemIds = async (): Promise<string[]> => {
     const { allMatchingSelected, excludedMatchingIds, selectedIds } = selectionStore.getSnapshot()
     if (!allMatchingSelected) return [...selectedIds]
-    const itemIds: string[] = []
-    const seenOffsets = new Set<number>()
-    let offset = 0
-    while (!seenOffsets.has(offset)) {
-      seenOffsets.add(offset)
-      const page = await window.api.literature.search(buildEntriesRequest(offset))
-      itemIds.push(
-        ...page.entries
-          .filter(isItem)
-          .map(({ id }) => id)
-          .filter((id) => !excludedMatchingIds.has(id))
-      )
-      if (page.nextOffset === undefined) break
-      offset = page.nextOffset
-    }
-    return [...new Set(itemIds)]
+    const page = await window.api.literature.search({ ...buildEntriesRequest(0), allItemIds: true })
+    if (!page.itemIds) throw new Error('Literature membership is unavailable.')
+    return page.itemIds.filter((id) => !excludedMatchingIds.has(id))
   }
 
   const requestBatchLookup = async (mode: BatchLookupMode): Promise<void> => {
@@ -2941,11 +2928,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
 
   const exportCurrentScope = async (format: 'bibtex' | 'ris'): Promise<boolean> => {
     if (!selectedProject && !selectedCollection) return false
-    const itemIds: string[] = []
-    let offset = 0
-    const seenOffsets = new Set<number>()
-    while (!seenOffsets.has(offset)) {
-      seenOffsets.add(offset)
+    try {
       const page = await window.api.literature.search({
         scope: 'library',
         ...(selectedProject ? { projectId: selectedProject.id } : {}),
@@ -2953,18 +2936,18 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         lifecycle: 'active',
         sortBy: 'title',
         sortDirection: 'asc',
-        offset,
-        limit: 100
+        allItemIds: true
       })
-      itemIds.push(...page.entries.filter(isItem).map(({ id }) => id))
-      if (page.nextOffset === undefined) break
-      offset = page.nextOffset
+      if (!page.itemIds) throw new Error('Literature membership is unavailable.')
+      return await exportReferenceIds(
+        page.itemIds,
+        format,
+        `${selectedProject?.name ?? selectedCollection?.name ?? 'references'}-references`
+      )
+    } catch (error) {
+      setError(t('References could not be exported.'))
+      throw error
     }
-    return exportReferenceIds(
-      [...new Set(itemIds)],
-      format,
-      `${selectedProject?.name ?? selectedCollection?.name ?? 'references'}-references`
-    )
   }
 
   const mergeSelectedItems = async (): Promise<void> => {

--- a/src/shared/literature-csl.test.ts
+++ b/src/shared/literature-csl.test.ts
@@ -113,6 +113,7 @@ describe('toCslItem', () => {
       accessed: { 'date-parts': [[2026, 8, 31]] },
       'container-title': 'Research Journal',
       DOI: '10.0000/example',
+      PMID: '1234',
       volume: '12',
       issue: '3',
       page: '44–58',
@@ -158,6 +159,19 @@ describe('toCslItem', () => {
 })
 
 describe('fromCslItem', () => {
+  it.each([
+    [2024, 0],
+    [2024, 13],
+    [2024, 2, 0],
+    [2023, 2, 29],
+    [2024, 4, 31],
+    [2024, 'bad', 12]
+  ])('rejects invalid positional date parts %j', (...parts) => {
+    expect(() => fromCslItem({ title: 'Invalid date', issued: { 'date-parts': [parts] } })).toThrow(
+      'Invalid bibliographic date'
+    )
+  })
+
   it('maps imported CSL metadata into the Literature model', () => {
     expect(
       fromCslItem({

--- a/src/shared/literature-csl.test.ts
+++ b/src/shared/literature-csl.test.ts
@@ -159,6 +159,11 @@ describe('toCslItem', () => {
 })
 
 describe('fromCslItem', () => {
+  it('accepts model-valid year zero through the CSL projection', () => {
+    const projected = toCslItem('year-zero', item({ issuedYear: 0 }))
+    expect(fromCslItem(projected).issuedYear).toBe(0)
+  })
+
   it.each([
     [2024, 0],
     [2024, 13],

--- a/src/shared/literature-csl.ts
+++ b/src/shared/literature-csl.ts
@@ -219,7 +219,7 @@ const dateParts = (value: unknown): readonly number[] | undefined => {
     date.length < 1 ||
     date.length > 3 ||
     !date.every((part) => typeof part === 'number' && Number.isInteger(part)) ||
-    year < 1 ||
+    year < 0 ||
     (month !== undefined && (month < 1 || month > 12)) ||
     (day !== undefined && (day < 1 || day > days[month - 1]!))
   )

--- a/src/shared/literature-csl.ts
+++ b/src/shared/literature-csl.ts
@@ -73,6 +73,9 @@ type CslItem = Readonly<{
   abstract?: string
   language?: string
   URL?: string
+  PMID?: string
+  PMCID?: string
+  arXiv?: string
   DOI?: string
   ISBN?: string
   ISSN?: string
@@ -135,7 +138,7 @@ const accessedDate = (accessedAt: number | undefined): CslDate | undefined => {
 
 const identifierFor = (
   item: LiteratureItemInput,
-  scheme: 'doi' | 'isbn' | 'issn'
+  scheme: 'doi' | 'isbn' | 'issn' | 'pmid' | 'pmcid' | 'arxiv'
 ): string | undefined => {
   const identifier = preferredLiteratureIdentifier(item.identifiers, scheme)
   return identifier
@@ -154,6 +157,9 @@ const toCslItem = (id: string, item: LiteratureItemInput): CslItem => {
   const translator = creatorsFor(item.creators, 'translator')
   const accessed = accessedDate(item.accessedAt)
   const issued = issuedDate(item)
+  const PMID = identifierFor(item, 'pmid')
+  const PMCID = identifierFor(item, 'pmcid')
+  const arXiv = identifierFor(item, 'arxiv')
   const DOI = identifierFor(item, 'doi')
   const ISBN = identifierFor(item, 'isbn')
   const ISSN = identifierFor(item, 'issn')
@@ -178,6 +184,9 @@ const toCslItem = (id: string, item: LiteratureItemInput): CslItem => {
     ...(item.abstract ? { abstract: item.abstract } : {}),
     ...(item.language ? { language: item.language } : {}),
     ...(item.url ? { URL: item.url } : {}),
+    ...(PMID ? { PMID } : {}),
+    ...(PMCID ? { PMCID } : {}),
+    ...(arXiv ? { arXiv } : {}),
     ...(DOI ? { DOI } : {}),
     ...(ISBN ? { ISBN } : {}),
     ...(ISSN ? { ISSN } : {}),
@@ -202,10 +211,20 @@ const dateParts = (value: unknown): readonly number[] | undefined => {
   if (!value || typeof value !== 'object') return undefined
   const parts = (value as { 'date-parts'?: unknown })['date-parts']
   if (!Array.isArray(parts) || !Array.isArray(parts[0])) return undefined
-  const normalized = parts[0].filter(
-    (part): part is number => typeof part === 'number' && Number.isInteger(part) && part >= 0
+  const date = parts[0]
+  const [year, month, day] = date
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  if (
+    date.length < 1 ||
+    date.length > 3 ||
+    !date.every((part) => typeof part === 'number' && Number.isInteger(part)) ||
+    year < 1 ||
+    (month !== undefined && (month < 1 || month > 12)) ||
+    (day !== undefined && (day < 1 || day > days[month - 1]!))
   )
-  return normalized.length > 0 ? normalized : undefined
+    throw new Error('Invalid bibliographic date.')
+  return date
 }
 
 const creatorsFromCsl = (

--- a/src/shared/literature.ts
+++ b/src/shared/literature.ts
@@ -347,6 +347,7 @@ const literatureCatalogSearchRequestSchema = z
   .object({
     scope: z.enum(['library', 'inbox', 'collections', 'project-counts', 'duplicates']),
     refreshDuplicates: z.boolean().optional(),
+    allItemIds: z.boolean().optional(),
     query: optionalTextSchema,
     projectId: optionalTextSchema,
     collectionId: optionalTextSchema,
@@ -361,6 +362,9 @@ const literatureCatalogSearchRequestSchema = z
     limit: z.number().int().positive().max(100).optional()
   })
   .strict()
+  .refine((request) => !request.allItemIds || request.scope === 'library', {
+    message: 'Complete item membership is only available for the library.'
+  })
 
 const literatureCatalogSearchPageSchema = z
   .object({
@@ -373,6 +377,7 @@ const literatureCatalogSearchPageSchema = z
         literatureDuplicateGroupSchema
       ])
     ),
+    itemIds: z.array(nonEmptyTextSchema).optional(),
     totalCount: z.number().int().nonnegative().optional(),
     nextOffset: z.number().int().nonnegative().optional()
   })


### PR DESCRIPTION
## Problem

Exporting and reimporting references changes BibTeX publication months, drops PubMed/PMC/arXiv identity, and loses RIS book editors, translators and editions. Concurrent title changes during project export can also silently omit members while the total count stays unchanged.

## Proposed change

Keep the pinned citation engine and supplement its format boundaries: normalize its zero-based BibTeX publication date components, validate positional dates, project PMID/PMCID and native arXiv eprint metadata, and preserve RIS responsibilities, edition and labeled identifier notes. App-defined literal-creator notes preserve organization names containing commas without overriding subsequently edited visible fields; year zero remains compatible with the existing model. Parse RIS supplements per source record so rejected entries cannot shift fields to another reference.

Extend the existing literature search contract with an optional complete-ID query. Resolve filters and IDs inside one database transaction, then reuse those IDs for project/collection export and all-matching selection. Existing formatting rejects unavailable IDs; failed member reads now use the existing export error surface.

## Scope and non-goals

No dependency, database schema, lifecycle enum, persistent snapshot, or historical data rewrite. Existing literature fields and save/import mechanisms remain the storage owners. The optional `allItemIds`/`itemIds` fields are transient query data. Historical bad dates, lost identifiers and existing duplicates are not automatically repaired. RIS identifier notes preserve the values and round-trip within this application; other tools may retain them only as notes. Membership is fixed, not a long-lived snapshot of every metadata value. Traditional BibTeX day precision is separate from the month correction.

## Acceptance criteria and validation

- Real WASM twelve-month round trips, identifiers, RIS book metadata and real SQLite PMID reuse: `src/main/literature/export-roundtrip.test.ts`.
- Invalid date positions: `src/shared/literature-csl.test.ts`.
- Complete ID selection, filters and post-read changes: `src/main/literature/catalog.test.ts`.
- Real Library + migrated SQLite + WASM: concurrent rename still saves all 101 RIS records; member-query failure saves nothing. Existing project, collection and all-matching consumers remain covered by `LiteratureLibraryPage.render.test.tsx`.
- Focused owner/contract/consumer validation covers `src/main/literature`, `src/shared/literature.test.ts`, `src/shared/literature-csl.test.ts`, `src/shared/renderer-contract-catalog.test.ts`, `src/renderer/src/pages/literature`, and `src/main/acp/literature-reference-prompt.test.ts`.
- After rebasing onto current main, all 586 focused owner/contract/consumer tests passed, along with full typecheck and lint. The only conflict joined two independently added catalog test blocks; range-diff confirms no implementation change from conflict resolution.
- Independent review follow-up: both reported boundary cases failed in two unchanged-source runs and now pass, including personal/organization role controls and stale-marker handling. All 66 affected formatter/CSL/document/LaTeX tests, full typecheck and lint pass after this follow-up.
- Both process typechecks, repository lint, changed-file formatting and diff checks passed. The checks ran after the last material edit.
- Unchanged-source replay twice: the same 17 behavior assertion failures and 2 passing controls; restored code passes all 20 focused regressions. No setup errors or timeouts counted.
- Browser verification used the actual Library component, temporary SQLite and real WASM: 101 saved records including the renamed member; subsequent injected query failure displays the existing error and does not save another file.

Per maintainer instruction, no complete local test suite ran. The impact manifest does not declare a Literature owner, so required full/platform CI remains authoritative. Document/LaTeX, catalog and renderer consumers are included locally; provider translation, subscriptions, OS paths, packaging and database migrations are unchanged.

## Review focus

Format-specific normalization must not shift RIS/accessed dates; identifier notes must stay associated with their source RIS record; complete-ID queries must retain filter semantics and exclusions. No generic replacement citation parser, title-based merging or persistent export state is introduced.
