### PR TITLE
fix(literature): preserve duplicate matches and reviewed member scope

### DIFF
--- a/src/main/literature/duplicates.test.ts
+++ b/src/main/literature/duplicates.test.ts
@@ -78,3 +78,47 @@ describe('Literature duplicate detection', () => {
     expect(groups[0].itemIds).toHaveLength(1000)
   })
 })
+
+for (const order of ['abcd', 'cdab', 'badc', 'dcba']) {
+  it(`finds the compatible pair behind crossed identifiers in order ${order}`, () => {
+    const candidates = Object.fromEntries(
+      [
+        ['a', 'x', '1'],
+        ['b', 'y', '2'],
+        ['c', 'x', '2'],
+        ['d', 'x', '2']
+      ].map(([id, value, pmid]) => [
+        id,
+        item(id, {
+          title: '',
+          issuedYear: null,
+          creators: [],
+          identifiers: [
+            { scheme: 'doi', normalizedValue: `10.1234/${value}` },
+            { scheme: 'pmid', normalizedValue: pmid }
+          ]
+        })
+      ])
+    )
+    expect(
+      findLiteratureDuplicateGroups([...order].map((id) => candidates[id])).map((group) =>
+        group.itemIds.sort()
+      )
+    ).toEqual([['c', 'd']])
+  })
+}
+
+it('finds matching metadata after an incompatible candidate occupies its key', () => {
+  expect(
+    findLiteratureDuplicateGroups([
+      item('a', {
+        identifiers: [
+          { scheme: 'doi', normalizedValue: '10.1234/x' },
+          { scheme: 'pmid', normalizedValue: '1' }
+        ]
+      }),
+      item('c', { identifiers: doi('10.1234/y') }),
+      item('d', { identifiers: [{ scheme: 'pmid', normalizedValue: '2' }] })
+    ]).map((group) => group.itemIds)
+  ).toEqual([['c', 'd']])
+})

--- a/src/main/literature/duplicates.ts
+++ b/src/main/literature/duplicates.ts
@@ -18,7 +18,7 @@ const normalize = (value: string): string =>
 
 const identitySchemes = new Set<string>(LITERATURE_IDENTITY_SCHEMES)
 
-// Indexed exact matches keep the scan linear in the number of records and identifiers.
+// Index exact matches by key, retaining incompatible components for later candidates.
 // Deliberately leave fuzzy titles and publication-year differences for manual review.
 export const findLiteratureDuplicateGroups = (
   candidates: DuplicateCandidate[]
@@ -41,7 +41,7 @@ export const findLiteratureDuplicateGroups = (
     }
     return index
   }
-  const keys = new Map<string, number>()
+  const keys = new Map<string, Set<number>>()
   const join = (left: number, right: number): void => {
     left = root(left)
     right = root(right)
@@ -68,9 +68,10 @@ export const findLiteratureDuplicateGroups = (
       )
     }
     for (const key of itemKeys) {
-      const previous = keys.get(key)
-      if (previous !== undefined) join(previous, index)
-      else keys.set(key, index)
+      const representatives = new Set([...(keys.get(key) ?? [])].map(root))
+      for (const previous of representatives) join(previous, index)
+      representatives.add(index)
+      keys.set(key, new Set([...representatives].map(root)))
     }
   })
   const groups = new Map<number, DuplicateCandidate[]>()

--- a/src/renderer/src/pages/literature/LiteratureDuplicateBatch.tsx
+++ b/src/renderer/src/pages/literature/LiteratureDuplicateBatch.tsx
@@ -1,4 +1,4 @@
-import { useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { LoaderCircle } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
@@ -19,18 +19,32 @@ import type {
 export function LiteratureDuplicateBatch({
   groups,
   onBusy,
-  onMerged
+  onMerged,
+  onRefresh = onMerged,
+  onCompleted,
+  result
 }: {
   groups: LiteratureDuplicateGroup[]
   onBusy: (busy: boolean) => void
   onMerged: () => void
+  onRefresh?: () => void
+  onCompleted?: (batch: NonNullable<LiteratureCatalogReceipt['batch']>) => void
+  result?: LiteratureCatalogReceipt['batch']
 }): React.JSX.Element {
   const { t } = useTranslation()
-  const [batch, setBatch] = useState<LiteratureCatalogReceipt['batch']>()
-  const [done, setDone] = useState(false)
+  const [batch, setBatch] = useState<LiteratureCatalogReceipt['batch']>(result)
+  const [done, setDone] = useState(Boolean(result))
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState(false)
   const [strategy, setStrategy] = useState<LiteratureMergeStrategy>('conflict-free')
+  const mounted = useRef(true)
+  useEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+      onBusy(false)
+    }
+  }, [onBusy])
   const previewGroups = useRef<string[][]>([])
   const run = async (mode: 'preview' | 'commit'): Promise<void> => {
     setBusy(true)
@@ -49,14 +63,18 @@ export function LiteratureDuplicateBatch({
           : {}),
         groups: previewGroups.current
       })
+      if (mode === 'commit' && receipt.batch) onCompleted?.(receipt.batch)
+      if (!mounted.current) return
       if (!receipt.batch) throw new Error('Missing duplicate batch result')
       setBatch(receipt.batch)
       setDone(mode === 'commit')
     } catch {
-      setError(true)
+      if (mounted.current) setError(true)
     } finally {
-      setBusy(false)
-      onBusy(false)
+      if (mounted.current) {
+        setBusy(false)
+        onBusy(false)
+      }
       // A lost response can follow committed groups; always invalidate the library after a commit.
       if (mode === 'commit') onMerged()
     }
@@ -78,39 +96,45 @@ export function LiteratureDuplicateBatch({
   }
   return (
     <div className="space-y-3 rounded-lg border border-border-300/80 bg-bg-100 p-4">
-      <Select
-        value={strategy}
-        disabled={busy || done}
-        onValueChange={(value) => {
-          setStrategy(value as LiteratureMergeStrategy)
-          setBatch(undefined)
-          setError(false)
-        }}
-      >
-        <SelectTrigger aria-label={t('Merge strategy')}>
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="conflict-free">{t('Merge conflict-free groups')}</SelectItem>
-          <SelectItem value="most-complete">{t('Keep the most complete reference')}</SelectItem>
-          <SelectItem value="oldest">{t('Keep the earliest added reference')}</SelectItem>
-          <SelectItem value="newest">{t('Keep the most recently updated reference')}</SelectItem>
-        </SelectContent>
-      </Select>
-      <p className="text-sm text-muted-foreground">
-        {strategy === 'conflict-free'
-          ? t(
-              'Only groups with matching identifiers and no conflicting fields are merged. The oldest reference is kept; attachments, tags and destinations are preserved. Groups with more than 20 references need individual review.'
-            )
-          : t(
-              'Keep the chosen reference’s values when fields conflict and fill its empty fields. Attachments, tags and links are preserved. Ambiguous identifiers and groups over 20 references require individual review.'
-            )}
-      </p>
+      {!done ? (
+        <>
+          <Select
+            value={strategy}
+            disabled={busy || done}
+            onValueChange={(value) => {
+              setStrategy(value as LiteratureMergeStrategy)
+              setBatch(undefined)
+              setError(false)
+            }}
+          >
+            <SelectTrigger aria-label={t('Merge strategy')}>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="conflict-free">{t('Merge conflict-free groups')}</SelectItem>
+              <SelectItem value="most-complete">{t('Keep the most complete reference')}</SelectItem>
+              <SelectItem value="oldest">{t('Keep the earliest added reference')}</SelectItem>
+              <SelectItem value="newest">
+                {t('Keep the most recently updated reference')}
+              </SelectItem>
+            </SelectContent>
+          </Select>
+          <p className="text-sm text-muted-foreground">
+            {strategy === 'conflict-free'
+              ? t(
+                  'Only groups with matching identifiers and no conflicting fields are merged. The oldest reference is kept; attachments, tags and destinations are preserved. Groups with more than 20 references need individual review.'
+                )
+              : t(
+                  'Keep the chosen reference’s values when fields conflict and fill its empty fields. Attachments, tags and links are preserved. Ambiguous identifiers and groups over 20 references require individual review.'
+                )}
+          </p>
+        </>
+      ) : null}
       {error ? (
         <LiteratureErrorNotice
           tone="amber"
           title={t('Duplicate processing failed. Refresh the list before trying again.')}
-          primaryButton={{ label: t('Refresh'), onClick: onMerged }}
+          primaryButton={{ label: t('Refresh'), onClick: onRefresh }}
         />
       ) : null}
       {batch?.groups && !done ? (

--- a/src/renderer/src/pages/literature/LiteratureDuplicateMembers.tsx
+++ b/src/renderer/src/pages/literature/LiteratureDuplicateMembers.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { LiteratureErrorNotice } from './LiteratureErrorNotice'
+import type { LiteratureDuplicateGroup, LiteratureItemView } from '../../../../shared/literature'
+
+const PAGE_SIZE = 50
+
+export function LiteratureDuplicateMembers({
+  group,
+  busy,
+  onReview,
+  onClose
+}: {
+  group: LiteratureDuplicateGroup
+  busy: boolean
+  onReview: (itemIds: string[]) => void
+  onClose: () => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  const [offset, setOffset] = useState(0)
+  const [retry, setRetry] = useState(0)
+  const [selected, setSelected] = useState<string[]>([])
+  const [page, setPage] = useState<{ key: string; items: LiteratureItemView[]; error: boolean }>()
+  const requestKey = `${offset}:${retry}`
+  const pending = page?.key !== requestKey
+  useEffect(() => {
+    let cancelled = false
+    const ids = group.itemIds.slice(offset, offset + PAGE_SIZE)
+    void Promise.all(ids.map((id) => window.api.literature.get(id))).then(
+      (items) => {
+        if (cancelled) return
+        const available = items.filter((item, index): item is LiteratureItemView =>
+          Boolean(item && !item.deletedAt && item.id === ids[index])
+        )
+        setPage({ key: requestKey, items: available, error: available.length !== ids.length })
+      },
+      () => {
+        if (!cancelled) setPage({ key: requestKey, items: [], error: true })
+      }
+    )
+    return () => {
+      cancelled = true
+    }
+  }, [group.itemIds, offset, requestKey])
+
+  return (
+    <section
+      className="w-full space-y-3 border-t border-border-300/80 pt-4"
+      aria-label={t('Select 2–20 references to compare.')}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-sm text-muted-foreground">{t('Select 2–20 references to compare.')}</p>
+        <Button variant="ghost" disabled={busy} onClick={onClose}>
+          {t('Close')}
+        </Button>
+      </div>
+      {pending ? (
+        <p role="status">{t('Loading…')}</p>
+      ) : page?.error ? (
+        <LiteratureErrorNotice
+          tone="amber"
+          title={t('Literature could not be loaded.')}
+          primaryButton={{ label: t('Retry'), onClick: () => setRetry((value) => value + 1) }}
+        />
+      ) : (
+        <ul className="max-h-80 divide-y divide-border-300/80 overflow-y-auto">
+          {page?.items.map(({ id, item }) => (
+            <li key={id}>
+              <label className="flex cursor-pointer items-start gap-3 py-3">
+                <input
+                  type="checkbox"
+                  className="mt-1 size-4 shrink-0 accent-primary"
+                  checked={selected.includes(id)}
+                  disabled={busy || (selected.length >= 20 && !selected.includes(id))}
+                  onChange={(event) =>
+                    setSelected((ids) =>
+                      event.target.checked ? [...ids, id] : ids.filter((value) => value !== id)
+                    )
+                  }
+                />
+                <span className="min-w-0 text-sm">
+                  <span className="block font-medium break-words">{item.title}</span>
+                  <span className="block break-words text-xs text-muted-foreground">
+                    {[
+                      item.issuedYear,
+                      ...(item.identifiers ?? []).map(
+                        ({ scheme, value }) => `${scheme.toUpperCase()}: ${value}`
+                      )
+                    ]
+                      .filter(Boolean)
+                      .join(' · ')}
+                  </span>
+                </span>
+              </label>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="flex flex-wrap items-center justify-between gap-3 text-sm">
+        <span>
+          {t('Page {{current}} of {{total}}', {
+            current: Math.floor(offset / PAGE_SIZE) + 1,
+            total: Math.ceil(group.itemIds.length / PAGE_SIZE)
+          })}
+        </span>
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            disabled={busy || offset === 0}
+            onClick={() => setOffset(offset - PAGE_SIZE)}
+          >
+            {t('Previous page')}
+          </Button>
+          <Button
+            variant="outline"
+            disabled={busy || offset + PAGE_SIZE >= group.itemIds.length}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            {t('Next page')}
+          </Button>
+        </div>
+      </div>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <span className="text-sm tabular-nums">
+          {t('Selected: {{selected}} / 20', { selected: selected.length })}
+        </span>
+        <Button
+          disabled={busy || pending || page?.error || selected.length < 2}
+          onClick={() => onReview(selected)}
+        >
+          {t('Compare selected references')}
+        </Button>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/src/pages/literature/LiteratureDuplicatesView.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureDuplicatesView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 import { LiteratureDuplicatesView } from './LiteratureDuplicatesView'
 
@@ -43,4 +44,240 @@ it('shows a partially selected page and limits Select groups on this page to vis
   expect(selectPage.indeterminate).toBe(false)
   fireEvent.click(selectPage)
   expect(groupCheckboxes.every((checkbox) => !checkbox.checked)).toBe(true)
+})
+
+const duplicateGroup = (
+  itemIds = ['1', '2']
+): import('../../../../shared/literature').LiteratureDuplicateGroup => ({
+  id: 'group',
+  title: 'Shared paper',
+  itemIds,
+  match: 'identifier' as const
+})
+const previewReceipt = {
+  kind: 'item',
+  id: '1',
+  batch: {
+    eligible: 1,
+    reduced: 1,
+    review: 0,
+    succeeded: 0,
+    skipped: 0,
+    failed: 0,
+    groups: [
+      {
+        survivorId: '1',
+        survivorTitle: 'Reviewed survivor',
+        conflicts: false,
+        items: ['1', '2'].map((id) => ({ id, metadataRevision: 1, updatedAt: 1 }))
+      }
+    ]
+  }
+}
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Preserve each mock's inferred callable signature.
+function setupDuplicates(itemIds = ['1', '2']) {
+  const search = vi.fn(async () => ({ totalCount: 1, entries: [duplicateGroup(itemIds)] }))
+  const transact = vi.fn(async () => previewReceipt)
+  const get = vi.fn(async (id: string) => ({
+    id,
+    item: { title: `Reference ${id}` },
+    deletedAt: null
+  }))
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { literature: { search, transact, get } }
+  })
+  const props = {
+    active: true,
+    revision: 0,
+    onCount: vi.fn(),
+    onReview: vi.fn(),
+    onMerged: vi.fn()
+  }
+  return { search, transact, get, props }
+}
+async function selectAndPreview(): Promise<void> {
+  fireEvent.click(await screen.findByRole('checkbox', { name: /Select duplicate group:/ }))
+  fireEvent.click(screen.getByRole('button', { name: 'Preview batch merge' }))
+  await screen.findByText('Keep reference: Reviewed survivor')
+}
+
+it('invalidates the reviewed batch when refreshed group membership changes', async () => {
+  const { search, transact, props } = setupDuplicates()
+  const view = render(<LiteratureDuplicatesView {...props} />)
+  await selectAndPreview()
+  search.mockResolvedValue({ totalCount: 1, entries: [duplicateGroup(['1', '2', '3'])] })
+  view.rerender(<LiteratureDuplicatesView {...props} revision={1} />)
+  await screen.findByText(/3 references/)
+  const commit = screen.queryByRole<HTMLButtonElement>('button', {
+    name: 'Merge conflict-free groups'
+  })
+  if (commit && !commit.disabled) fireEvent.click(commit)
+  expect(transact.mock.calls).toHaveLength(1)
+  expect(screen.queryByText('Keep reference: Reviewed survivor')).toBeNull()
+})
+
+it('prevents submitting an old preview while the refreshed list is unresolved', async () => {
+  const { search, transact, props } = setupDuplicates()
+  const view = render(<LiteratureDuplicatesView {...props} />)
+  await selectAndPreview()
+  search.mockImplementationOnce(() => new Promise(() => {}))
+  view.rerender(<LiteratureDuplicatesView {...props} revision={1} />)
+  await waitFor(() => expect(search).toHaveBeenCalledTimes(2))
+  const commit = screen.queryByRole<HTMLButtonElement>('button', {
+    name: 'Merge conflict-free groups'
+  })
+  if (commit && !commit.disabled) fireEvent.click(commit)
+  expect(transact.mock.calls).toHaveLength(1)
+})
+
+it('allows previewing again after the failure notice refresh completes', async () => {
+  const { search, transact, props } = setupDuplicates()
+  transact.mockRejectedValueOnce(new Error('Temporary failure'))
+  function Parent(): React.JSX.Element {
+    const [revision, setRevision] = useState(0)
+    return (
+      <LiteratureDuplicatesView
+        {...props}
+        revision={revision}
+        onMerged={() => setRevision((value) => value + 1)}
+      />
+    )
+  }
+  render(<Parent />)
+  fireEvent.click(await screen.findByRole('checkbox', { name: /Select duplicate group:/ }))
+  fireEvent.click(screen.getByRole('button', { name: 'Preview batch merge' }))
+  const notice = await screen.findByText(
+    'Duplicate processing failed. Refresh the list before trying again.'
+  )
+  const refreshButtons = screen.getAllByRole('button', { name: 'Refresh' })
+  expect(refreshButtons).toHaveLength(2)
+  expect(notice).toBeTruthy()
+  fireEvent.click(refreshButtons[1])
+  await waitFor(() => expect(search).toHaveBeenCalledTimes(2))
+  const checkbox = await screen.findByRole<HTMLInputElement>('checkbox', {
+    name: /Select duplicate group:/
+  })
+  if (!checkbox.checked) fireEvent.click(checkbox)
+  const preview = screen.getByRole<HTMLButtonElement>('button', { name: 'Preview batch merge' })
+  expect(preview.disabled).toBe(false)
+  fireEvent.click(preview)
+  await screen.findByText('Keep reference: Reviewed survivor')
+})
+
+it('offers the entire oversized group for selection before handing a subset to merge review', async () => {
+  const { get, transact, props } = setupDuplicates(
+    Array.from({ length: 21 }, (_, i) => String(i + 1))
+  )
+  render(<LiteratureDuplicatesView {...props} />)
+  fireEvent.click(await screen.findByRole('button', { name: 'Review duplicates' }))
+  await waitFor(() => expect(get).toHaveBeenCalled())
+  // Opening the group must not silently choose its first 20 members for the user.
+  expect(props.onReview).not.toHaveBeenCalled()
+  expect(transact).not.toHaveBeenCalled()
+  await screen.findByText('Reference 21')
+})
+
+it('compares an explicitly selected subset across member pages without merging', async () => {
+  const { get, transact, props } = setupDuplicates(
+    Array.from({ length: 51 }, (_, i) => String(i + 1))
+  )
+  render(<LiteratureDuplicatesView {...props} />)
+  fireEvent.click(await screen.findByRole('button', { name: 'Review duplicates' }))
+  const members = within(
+    await screen.findByRole('region', { name: 'Select 2–20 references to compare.' })
+  )
+  fireEvent.click(await members.findByRole('checkbox', { name: 'Reference 1' }))
+  expect(get).toHaveBeenCalledTimes(50)
+  fireEvent.click(members.getByRole('button', { name: 'Next page' }))
+  fireEvent.click(await members.findByRole('checkbox', { name: 'Reference 51' }))
+  expect(get).toHaveBeenCalledTimes(51)
+  fireEvent.click(members.getByRole('button', { name: 'Compare selected references' }))
+  await waitFor(() =>
+    expect(props.onReview).toHaveBeenCalledWith([
+      expect.objectContaining({ id: '1' }),
+      expect.objectContaining({ id: '51' })
+    ])
+  )
+  expect(get.mock.calls.slice(-2)).toEqual([['1'], ['51']])
+  expect(transact).not.toHaveBeenCalled()
+})
+
+it('limits member selection to 20 and lets the user replace an unwanted member', async () => {
+  const { props } = setupDuplicates(Array.from({ length: 21 }, (_, i) => String(i + 1)))
+  render(<LiteratureDuplicatesView {...props} />)
+  fireEvent.click(await screen.findByRole('button', { name: 'Review duplicates' }))
+  const members = within(
+    await screen.findByRole('region', { name: 'Select 2–20 references to compare.' })
+  )
+  const first = await members.findByRole<HTMLInputElement>('checkbox', { name: 'Reference 1' })
+  const compare = members.getByRole<HTMLButtonElement>('button', {
+    name: 'Compare selected references'
+  })
+  expect(compare.disabled).toBe(true)
+  for (let i = 1; i <= 20; i++)
+    fireEvent.click(members.getByRole('checkbox', { name: `Reference ${i}` }))
+  const last = members.getByRole<HTMLInputElement>('checkbox', { name: 'Reference 21' })
+  expect(last.disabled).toBe(true)
+  fireEvent.click(first)
+  expect(last.disabled).toBe(false)
+  fireEvent.click(last)
+  fireEvent.click(compare)
+  await waitFor(() => expect(props.onReview).toHaveBeenCalledTimes(1))
+  expect(props.onReview.mock.calls[0][0].map(({ id }: { id: string }) => id)).toEqual(
+    Array.from({ length: 20 }, (_, i) => String(i + 2))
+  )
+})
+
+it('retries a failed member page without discarding selections on other pages', async () => {
+  const { get, props } = setupDuplicates(Array.from({ length: 51 }, (_, i) => String(i + 1)))
+  render(<LiteratureDuplicatesView {...props} />)
+  fireEvent.click(await screen.findByRole('button', { name: 'Review duplicates' }))
+  const members = within(
+    await screen.findByRole('region', { name: 'Select 2–20 references to compare.' })
+  )
+  fireEvent.click(await members.findByRole('checkbox', { name: 'Reference 1' }))
+  get.mockRejectedValueOnce(new Error('Temporary read failure'))
+  fireEvent.click(members.getByRole('button', { name: 'Next page' }))
+  fireEvent.click(await members.findByRole('button', { name: 'Retry' }))
+  fireEvent.click(await members.findByRole('checkbox', { name: 'Reference 51' }))
+  fireEvent.click(members.getByRole('button', { name: 'Compare selected references' }))
+  await waitFor(() => expect(props.onReview).toHaveBeenCalledTimes(1))
+  expect(props.onReview.mock.calls[0][0].map(({ id }: { id: string }) => id)).toEqual(['1', '51'])
+})
+
+it('ignores a discarded preview response without clearing a newer preview busy state', async () => {
+  const { search, transact, props } = setupDuplicates()
+  let oldPreview!: (receipt: typeof previewReceipt) => void
+  let newPreview!: (receipt: typeof previewReceipt) => void
+  transact.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        oldPreview = resolve
+      })
+  )
+  const view = render(<LiteratureDuplicatesView {...props} />)
+  fireEvent.click(await screen.findByRole('checkbox', { name: /Select duplicate group:/ }))
+  fireEvent.click(screen.getByRole('button', { name: 'Preview batch merge' }))
+  view.rerender(<LiteratureDuplicatesView {...props} revision={1} />)
+  await waitFor(() => expect(search).toHaveBeenCalledTimes(2))
+  const preview = await screen.findByRole<HTMLButtonElement>('button', {
+    name: 'Preview batch merge'
+  })
+  expect(preview.disabled).toBe(false)
+  transact.mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        newPreview = resolve
+      })
+  )
+  fireEvent.click(preview)
+  oldPreview(previewReceipt)
+  await waitFor(() =>
+    expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Refresh' }).disabled).toBe(true)
+  )
+  expect(screen.queryByText('Keep reference: Reviewed survivor')).toBeNull()
+  newPreview(previewReceipt)
+  await screen.findByText('Keep reference: Reviewed survivor')
+  expect(screen.getByRole<HTMLButtonElement>('button', { name: 'Refresh' }).disabled).toBe(false)
 })

--- a/src/renderer/src/pages/literature/LiteratureDuplicatesView.tsx
+++ b/src/renderer/src/pages/literature/LiteratureDuplicatesView.tsx
@@ -3,8 +3,13 @@ import { Copy, LoaderCircle, RotateCcw } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { LiteratureErrorNotice } from './LiteratureErrorNotice'
+import { LiteratureDuplicateMembers } from './LiteratureDuplicateMembers'
 import { LiteratureDuplicateBatch } from './LiteratureDuplicateBatch'
-import type { LiteratureDuplicateGroup, LiteratureItemView } from '../../../../shared/literature'
+import type {
+  LiteratureCatalogReceipt,
+  LiteratureDuplicateGroup,
+  LiteratureItemView
+} from '../../../../shared/literature'
 
 export type LiteratureDuplicateCountHandle = { setCount: (count: number | undefined) => void }
 
@@ -59,7 +64,23 @@ export const LiteratureDuplicatesView = ({
   const reviewRequest = useRef(0)
   const [selected, setSelected] = useState<string[]>([])
   const [batchBusy, setBatchBusy] = useState(false)
+  const [completed, setCompleted] = useState<{
+    selection: string
+    groups: LiteratureDuplicateGroup[]
+    batch: NonNullable<LiteratureCatalogReceipt['batch']>
+  }>()
+  const completedResult = completed?.selection === JSON.stringify(selected) ? completed : undefined
+  const selectGroups: typeof setSelected = (value) => {
+    setCompleted(undefined)
+    setSelected(value)
+  }
   const refreshed = useRef(0)
+  const [expanded, setExpanded] = useState<{ id: string; requestKey: string }>()
+  const refreshList = (): void => {
+    selectGroups([])
+    setCompleted(undefined)
+    setRefresh((value) => value + 1)
+  }
 
   useEffect(() => {
     let cancelled = false
@@ -116,7 +137,7 @@ export const LiteratureDuplicatesView = ({
       reviewRequest.current += 1
       window.clearTimeout(timer)
     }
-  }, [active])
+  }, [requestKey])
 
   const review = async (group: LiteratureDuplicateGroup): Promise<void> => {
     const request = ++reviewRequest.current
@@ -154,10 +175,7 @@ export const LiteratureDuplicatesView = ({
         <Button
           variant="outline"
           disabled={pending || Boolean(reviewing) || batchBusy}
-          onClick={() => {
-            setSelected([])
-            setRefresh((value) => value + 1)
-          }}
+          onClick={refreshList}
         >
           <RotateCcw className="size-4" aria-hidden="true" />
           {t('Refresh')}
@@ -186,18 +204,38 @@ export const LiteratureDuplicatesView = ({
               checked={groups.every((group) => selected.includes(group.id))}
               disabled={batchBusy}
               onChange={(event) =>
-                setSelected(event.target.checked ? groups.map((group) => group.id) : [])
+                selectGroups(event.target.checked ? groups.map((group) => group.id) : [])
               }
             />
             {t('Select groups on this page')}
           </label>
         ) : null}
-        {selected.length > 0 ? (
+        {completedResult || (!pending && !error && selected.length > 0) ? (
           <LiteratureDuplicateBatch
-            key={selected.join(':')}
-            groups={groups.filter((group) => selected.includes(group.id))}
+            key={
+              completedResult
+                ? 'completed'
+                : JSON.stringify([
+                    requestKey,
+                    groups
+                      .filter((group) => selected.includes(group.id))
+                      .map((group) => group.itemIds)
+                  ])
+            }
+            groups={
+              completedResult?.groups ?? groups.filter((group) => selected.includes(group.id))
+            }
+            result={completedResult?.batch}
+            onCompleted={(batch) =>
+              setCompleted({
+                selection: JSON.stringify(selected),
+                groups: groups.filter((group) => selected.includes(group.id)),
+                batch
+              })
+            }
             onBusy={setBatchBusy}
             onMerged={onMerged}
+            onRefresh={refreshList}
           />
         ) : null}
         {pending ? (
@@ -228,7 +266,7 @@ export const LiteratureDuplicatesView = ({
                     checked={selected.includes(group.id)}
                     disabled={batchBusy || Boolean(reviewing)}
                     onChange={(event) =>
-                      setSelected((ids) =>
+                      selectGroups((ids) =>
                         event.target.checked
                           ? [...ids, group.id]
                           : ids.filter((id) => id !== group.id)
@@ -256,7 +294,10 @@ export const LiteratureDuplicatesView = ({
                   <Button
                     variant="outline"
                     disabled={Boolean(reviewing) || batchBusy}
-                    onClick={() => void review(group)}
+                    onClick={() => {
+                      if (group.itemIds.length > 20) setExpanded({ id: group.id, requestKey })
+                      else void review(group)
+                    }}
                   >
                     {reviewing === group.id ? (
                       <LoaderCircle
@@ -266,6 +307,15 @@ export const LiteratureDuplicatesView = ({
                     ) : null}
                     {t('Review duplicates')}
                   </Button>
+                  {expanded?.id === group.id && expanded.requestKey === requestKey ? (
+                    <LiteratureDuplicateMembers
+                      key={JSON.stringify([requestKey, group.itemIds])}
+                      group={group}
+                      busy={Boolean(reviewing) || batchBusy}
+                      onReview={(itemIds) => void review({ ...group, itemIds })}
+                      onClose={() => setExpanded(undefined)}
+                    />
+                  ) : null}
                 </div>
               ))}
             </div>
@@ -284,7 +334,7 @@ export const LiteratureDuplicatesView = ({
                 variant="outline"
                 disabled={offset === 0 || Boolean(reviewing) || batchBusy}
                 onClick={() => {
-                  setSelected([])
+                  selectGroups([])
                   setOffset(Math.max(0, offset - 20))
                 }}
               >
@@ -294,7 +344,7 @@ export const LiteratureDuplicatesView = ({
                 variant="outline"
                 disabled={nextOffset === undefined || Boolean(reviewing) || batchBusy}
                 onClick={() => {
-                  setSelected([])
+                  selectGroups([])
                   setOffset(nextOffset ?? offset)
                 }}
               >

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4871,6 +4871,9 @@
     "Snapshot unavailable": "Snapshot nicht verfügbar",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "Dieser ältere Datensatz bestätigt keine bereitgestellten Belege und enthält nicht alle Korpus-Snapshots.",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "Die Belegzahlen beschreiben Inhalte, die dem Agenten bereitgestellt wurden, keine abgeschlossene Lektüre. Kandidatenzahlen werden vom Agenten angegeben und mit den Suchergebnissen abgeglichen. Die folgenden Suchzahlen gelten jeweils für einzelne Ergebnisseiten.",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "Gespeicherte Referenzmetadaten. Anhänge stammen aus dem aktuellen Bibliothekseintrag."
+    "Saved reference metadata. Attachments reflect the current Library entry.": "Gespeicherte Referenzmetadaten. Anhänge stammen aus dem aktuellen Bibliothekseintrag.",
+    "Select 2–20 references to compare.": "Wählen Sie 2–20 Literaturangaben zum Vergleichen aus.",
+    "Selected: {{selected}} / 20": "Ausgewählt: {{selected}} / 20",
+    "Compare selected references": "Ausgewählte Literaturangaben vergleichen"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5032,6 +5032,9 @@
     "Snapshot unavailable": "Instantánea no disponible",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "Este registro anterior no verifica las evidencias devueltas ni conserva todas las instantáneas del corpus.",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "Los recuentos de evidencias describen el contenido devuelto al Agente, no una lectura completada. El Agente declara el número de candidatos, que se comprueba con los registros recuperados. Los recuentos siguientes corresponden a cada página de resultados.",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "Metadatos guardados de la referencia. Los adjuntos corresponden a la entrada actual de la biblioteca."
+    "Saved reference metadata. Attachments reflect the current Library entry.": "Metadatos guardados de la referencia. Los adjuntos corresponden a la entrada actual de la biblioteca.",
+    "Select 2–20 references to compare.": "Seleccione entre 2 y 20 referencias para comparar.",
+    "Selected: {{selected}} / 20": "Seleccionadas: {{selected}} / 20",
+    "Compare selected references": "Comparar referencias seleccionadas"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5032,6 +5032,9 @@
     "Snapshot unavailable": "Instantané indisponible",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "Cet ancien enregistrement ne vérifie pas les éléments fournis et ne conserve pas tous les instantanés du corpus.",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "Les nombres décrivent le contenu fourni à l’Agent, pas une lecture achevée. Le nombre de candidats est déclaré par l’Agent et vérifié par rapport aux résultats récupérés. Les nombres ci-dessous correspondent à chaque page de résultats.",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "Métadonnées de la référence enregistrées. Les pièces jointes proviennent de la notice actuelle de la bibliothèque."
+    "Saved reference metadata. Attachments reflect the current Library entry.": "Métadonnées de la référence enregistrées. Les pièces jointes proviennent de la notice actuelle de la bibliothèque.",
+    "Select 2–20 references to compare.": "Sélectionnez 2 à 20 références à comparer.",
+    "Selected: {{selected}} / 20": "Sélectionnées : {{selected}} / 20",
+    "Compare selected references": "Comparer les références sélectionnées"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4718,6 +4718,9 @@
     "Snapshot unavailable": "スナップショットなし",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "この古い記録では、返された根拠の確認や全資料のスナップショットの保存は行われていません。",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "根拠の件数はエージェントに返された内容を示し、読了を意味しません。候補数はエージェントが申告し、検索記録に照らして検証されます。以下の検索件数は、各応答の結果ページごとの値です。",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "保存された文献メタデータです。添付ファイルは現在のライブラリ項目のものです。"
+    "Saved reference metadata. Attachments reflect the current Library entry.": "保存された文献メタデータです。添付ファイルは現在のライブラリ項目のものです。",
+    "Select 2–20 references to compare.": "比較する文献を2～20件選択してください。",
+    "Selected: {{selected}} / 20": "選択済み：{{selected}} / 20",
+    "Compare selected references": "選択した文献を比較"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4716,6 +4716,9 @@
     "Snapshot unavailable": "스냅샷 없음",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "이 이전 기록은 반환된 근거를 검증하거나 전체 자료의 스냅샷을 보존하지 않습니다.",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "근거 수는 에이전트에 반환된 내용을 나타내며 읽기 완료를 의미하지 않습니다. 후보 수는 에이전트가 보고하며 검색 기록을 기준으로 검증됩니다. 아래 검색 수는 각 응답의 결과 페이지별 수치입니다.",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "저장된 문헌 메타데이터입니다. 첨부 파일은 현재 라이브러리 항목의 파일입니다."
+    "Saved reference metadata. Attachments reflect the current Library entry.": "저장된 문헌 메타데이터입니다. 첨부 파일은 현재 라이브러리 항목의 파일입니다.",
+    "Select 2–20 references to compare.": "비교할 문헌을 2~20개 선택하세요.",
+    "Selected: {{selected}} / 20": "선택됨: {{selected}} / 20",
+    "Compare selected references": "선택한 문헌 비교"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5164,6 +5164,9 @@
     "Snapshot unavailable": "Снимок недоступен",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "Эта старая запись не подтверждает предоставленные материалы и не содержит снимков всех источников корпуса.",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "Числа отражают содержимое, переданное Агенту, а не завершённое чтение. Число кандидатов указано Агентом и проверено по найденным записям. Числа поиска ниже относятся к отдельным страницам результатов.",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "Сохранённые метаданные источника. Вложения относятся к текущей записи библиотеки."
+    "Saved reference metadata. Attachments reflect the current Library entry.": "Сохранённые метаданные источника. Вложения относятся к текущей записи библиотеки.",
+    "Select 2–20 references to compare.": "Выберите от 2 до 20 источников для сравнения.",
+    "Selected: {{selected}} / 20": "Выбрано: {{selected}} / 20",
+    "Compare selected references": "Сравнить выбранные источники"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4718,6 +4718,9 @@
     "Snapshot unavailable": "快照不可用",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "此旧记录未核实返回的证据，也未保存全部语料快照。",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "证据数量表示返回给智能体的内容，不代表已完成阅读。候选数量由智能体申报，并根据检索记录校验。下方检索数量分别对应各次返回的结果页。",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "已保存的文献元数据。附件来自当前文献库条目。"
+    "Saved reference metadata. Attachments reflect the current Library entry.": "已保存的文献元数据。附件来自当前文献库条目。",
+    "Select 2–20 references to compare.": "选择 2–20 篇文献进行比较。",
+    "Selected: {{selected}} / 20": "已选择：{{selected}} / 20",
+    "Compare selected references": "比较所选文献"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4718,6 +4718,9 @@
     "Snapshot unavailable": "快照無法使用",
     "This older record does not verify delivered evidence or preserve every corpus snapshot.": "此舊記錄未核實傳回的證據，也未儲存全部語料快照。",
     "Evidence counts describe content returned to the Agent, not completed reading. Candidates are Agent-reported and checked against retrieved records. Search counts below describe individual result pages.": "證據數量表示傳回給智能體的內容，不代表已完成閱讀。候選數量由智能體申報，並根據檢索記錄驗證。下方檢索數量分別對應各次傳回的結果頁。",
-    "Saved reference metadata. Attachments reflect the current Library entry.": "已儲存的文獻中繼資料。附件來自目前文獻庫項目。"
+    "Saved reference metadata. Attachments reflect the current Library entry.": "已儲存的文獻中繼資料。附件來自目前文獻庫項目。",
+    "Select 2–20 references to compare.": "選取 2–20 篇文獻進行比較。",
+    "Selected: {{selected}} / 20": "已選取：{{selected}} / 20",
+    "Compare selected references": "比較所選文獻"
   }
 }


### PR DESCRIPTION
## Problem

Crossed identifiers can occupy duplicate-match keys and hide a later compatible pair. A refreshed duplicate group can retain an older executable batch preview, and the failure notice's Refresh does not restore retry. Oversized groups repeatedly open only their first 20 references.

## Proposed change

- Retain incompatible representatives per match key while preserving identifier conflict checks and compacting joined roots.
- Invalidate executable previews during list refresh and when membership changes. Discard late preview responses, release their busy state, and retain completed batch results as read-only receipts.
- Route failure recovery through the full list refresh, clearing selection and requiring a fresh preview rather than replaying a write.
- Add a paged member list for oversized groups: select 2–20 references across 50-member pages, then reread exactly that subset for the existing comparison panel. Translate new copy in all eight locales.

## Scope and non-goals

No schema, persisted field, migration, public enum, IPC shape, or historical-data adapter changes. New state is transient: scan representatives, member paging/selection/loading, and completed batch receipt. Existing merge writes and item revision checks remain authoritative. No automatic historical repair, fuzzy matching or canonical partition of all ambiguous records. Highly conflicted individual keys can require quadratic comparisons; ordinary identical groups compact to one representative.

## Acceptance criteria and validation

Regressions use the production grouping function and mounted real components through the existing API boundary; no production test seam. The unchanged-source baseline was run twice with identical results (15 tests: 8 pass, 7 expected failures). Expanded regression coverage was also run against the original production files (19 tests: 8 pass, 11 expected failures), then repairs restored. Passing controls cover pair-first scan order and existing conflict rejection.

Final checks ran after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Candidate grouping, conflict preservation, catalog scan/merge persistence | `npx vitest run src/main/literature/duplicates.test.ts src/main/literature/duplicate-metadata.test.ts src/main/literature/catalog.test.ts` | Passed in combined run |
| Preview invalidation, loading, failure recovery, late response, cross-page subset and 20-item cap | `npx vitest run src/renderer/src/pages/literature/LiteratureDuplicatesView.test.tsx src/renderer/src/pages/literature/LiteratureDuplicateBatch.test.tsx` | Passed in combined run |
| Parent completion receipts, merge review and shared limits | `npx vitest run src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx src/renderer/src/pages/literature/LiteratureMergeReview.render.test.tsx src/renderer/src/pages/literature/literature-merge.test.ts src/shared/literature.test.ts` | Passed in combined run |
| All translated catalogs | `npx vitest run src/renderer/src/i18n/resources.test.ts` | Passed in combined run |
| Affected processes | `npm run typecheck:node` (including sandbox), `npm run typecheck:web` | Passed |
| Source conventions | `npm run lint`, `git diff --check` | Passed |

Combined targeted result: **1,057/1,057 passed**. Browser verification used real components with labeled controlled fixtures: reference 21 is reachable without writes; selecting references 1 and 51 hands exactly those IDs to comparison with zero transactions; error Refresh clears the failure and re-enables preview after reselection. Screenshots retained locally.

`npm run test:affected:explain -- --base a5df2aa75e8e458ae9f65ac64b33fb15683b2221 --head HEAD` selects full fallback because literature has no registered module owner. At maintainer request, no full local suite was run; PR CI is authoritative for full/platform checks. The root CodeGraph index belongs to another working tree, so current changed-file imports and behavior tests supplement its baseline consumer map. No transport contract changed; native platform packaging and dual-Electron-window operation were not exercised locally. These results are not a claim of completed independent review; PR review and CI remain pending.

## Review focus

Conflict-safe representative retention; executable preview lifetime versus completed receipts; late async cleanup; member paging/selection and exact subset handoff. Confirm final check coverage and full/platform CI before merge.

Rebased only to resolve reported conflicts. Conflicts were limited to appended locale entries; both sides were preserved. Production logic and regression test source are byte-for-byte unchanged from the initially reviewed commit. All listed checks were rerun on a14387e4 after resolution.
