### PR TITLE
fix(literature): validate and recover imported citation styles

### DIFF
--- a/src/main/literature/citation-formatter.test.ts
+++ b/src/main/literature/citation-formatter.test.ts
@@ -232,7 +232,7 @@ describe('LiteratureCitationFormatter', () => {
       await expect(
         formatter.parseReferences('@article{example, title={A useful paper}, year={2024}}')
       ).resolves.toMatchObject({ items: [expect.objectContaining({ title: 'A useful paper' })] })
-      expect((await styles.list()).some(({ id }) => id === `custom:${digest}`)).toBe(true)
+      expect((await styles.list()).some(({ id }) => id === `custom:${digest}`)).toBe(false)
       await styles.delete(`custom:${digest}`)
       expect((await styles.list()).some(({ id }) => id === `custom:${digest}`)).toBe(false)
     } finally {

--- a/src/main/literature/citation-style-library.test.ts
+++ b/src/main/literature/citation-style-library.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -8,6 +8,8 @@ vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
   return { ...actual, readFile: vi.fn(actual.readFile) }
 })
+
+import { LiteratureCitationFormatter } from './citation-formatter'
 
 import { LiteratureCitationStyleLibrary } from './citation-style-library'
 
@@ -114,4 +116,102 @@ describe('LiteratureCitationStyleLibrary', () => {
 
     expect((await library.list()).filter(({ source }) => source === 'custom')).toEqual([])
   })
+})
+
+const macroStyle = (): string =>
+  independentStyle()
+    .replace(
+      '</info>',
+      '</info><macro name="journal-format"><text value="REQUIRED JOURNAL FORMAT"/></macro>'
+    )
+    .replaceAll('<text variable="title"/>', '<text macro="journal-format"/>')
+
+it('CS-01 rejects undefined macro references instead of accepting generic fallback output', async () => {
+  const { library } = await createLibrary()
+  const valid = macroStyle()
+  const styleId = await library.import(valid)
+  expect(await new LiteratureCitationFormatter(library).formatStyleExample(styleId)).toEqual({
+    inText: 'REQUIRED JOURNAL FORMAT',
+    reference: 'REQUIRED JOURNAL FORMAT'
+  })
+  await expect(
+    library.import(valid.replace('name="journal-format"', 'name="renamed-format"'))
+  ).rejects.toThrow(/undefined macro/i)
+  expect((await library.list()).filter(({ source }) => source === 'custom')).toHaveLength(1)
+})
+
+it('CS-01 rejects a citation-only style with an application-support explanation', async () => {
+  const { library } = await createLibrary()
+  const content = independentStyle().replace(/<bibliography>.*?<\/bibliography>/u, '')
+  await expect(library.import(content)).rejects.toThrow(/bibliography/i)
+  expect((await library.list()).filter(({ source }) => source === 'custom')).toEqual([])
+})
+
+it.each([
+  ['truncated XML', '<style>truncated'],
+  [
+    'valid replacement',
+    independentStyle('Changed style').replaceAll(
+      '<text variable="title"/>',
+      '<text value="CHANGED OUTPUT"/>'
+    )
+  ]
+])('CS-02 restores the original bytes by reimporting over %s', async (_kind, damaged) => {
+  const { library, stylesDirectory } = await createLibrary()
+  const original = macroStyle()
+  const styleId = await library.import(original)
+  const path = join(stylesDirectory, `${styleId.slice(7)}.csl`)
+  await writeFile(path, damaged)
+  expect(await library.import(original)).toBe(styleId)
+  expect(await readFile(path, 'utf8')).toBe(original)
+  expect((await library.list()).find(({ id }) => id === styleId)?.title).toBe(
+    'A compact journal style'
+  )
+  expect(await new LiteratureCitationFormatter(library).formatStyleExample(styleId)).toEqual({
+    inText: 'REQUIRED JOURNAL FORMAT',
+    reference: 'REQUIRED JOURNAL FORMAT'
+  })
+})
+
+it('CS-02 excludes valid replacement content under the original digest from listing and formatting', async () => {
+  const { library, stylesDirectory } = await createLibrary()
+  const styleId = await library.import(macroStyle())
+  await writeFile(
+    join(stylesDirectory, `${styleId.slice(7)}.csl`),
+    independentStyle('Changed style')
+  )
+  expect((await library.list()).some(({ id }) => id === styleId)).toBe(false)
+  await expect(
+    new LiteratureCitationFormatter(library).formatStyleExample(styleId)
+  ).rejects.toThrow()
+})
+
+it('CS-05 imports CDATA metadata just like ordinary XML text', async () => {
+  const { library } = await createLibrary()
+  const styleId = await library.import(independentStyle('<![CDATA[A compact journal style]]>'))
+  expect((await library.list()).find(({ id }) => id === styleId)?.title).toBe(
+    'A compact journal style'
+  )
+  expect(await new LiteratureCitationFormatter(library).formatStyleExample(styleId)).toMatchObject({
+    reference: 'Genome Editing in Human Cells'
+  })
+})
+
+it('CS-02 checks and restores stored bytes even when UTF-8 decoding masks corruption', async () => {
+  const { library, stylesDirectory } = await createLibrary()
+  const content = independentStyle('A \uFFFD journal style')
+  const styleId = await library.import(content)
+  const path = join(stylesDirectory, `${styleId.slice(7)}.csl`)
+  const original = Buffer.from(content, 'utf8')
+  const offset = original.indexOf(Buffer.from('\uFFFD'))
+  const damaged = Buffer.concat([
+    original.subarray(0, offset),
+    Buffer.from([0xff]),
+    original.subarray(offset + 3)
+  ])
+  expect(damaged.toString('utf8')).toBe(content)
+  await writeFile(path, damaged)
+  expect.soft((await library.list()).some(({ id }) => id === styleId)).toBe(false)
+  expect(await library.import(content)).toBe(styleId)
+  expect(await readFile(path)).toEqual(original)
 })

--- a/src/main/literature/citation-style-library.ts
+++ b/src/main/literature/citation-style-library.ts
@@ -1,6 +1,6 @@
-import { createHash } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { existsSync } from 'node:fs'
-import { mkdir, readFile, readdir, unlink, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rename, rm, unlink, writeFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -50,6 +50,10 @@ const parseCitationStyle = (
   let infoDepth = -1
   let rootSeen = false
   let dependent = false
+  let citation = false
+  let bibliography = false
+  const macros = new Set<string>()
+  const macroReferences = new Set<string>()
   let capture: 'id' | 'rights' | 'summary' | 'title' | undefined
   const captured = { id: '', rights: '', summary: '', title: '' }
   const parser = new SaxesParser({ xmlns: true })
@@ -76,6 +80,18 @@ const parseCitationStyle = (
       rootSeen = true
       return
     }
+    if (tag.uri !== CSL_NAMESPACE) return
+    const attributes = Object.values(tag.attributes).filter((attribute) => attribute.prefix === '')
+    const macroReference = attributes.find((attribute) => attribute.local === 'macro')?.value
+    if (macroReference !== undefined) macroReferences.add(macroReference)
+    if (depth === 2) {
+      if (tag.local === 'citation') citation = true
+      if (tag.local === 'bibliography') bibliography = true
+      if (tag.local === 'macro') {
+        const name = attributes.find((attribute) => attribute.local === 'name')?.value
+        if (name !== undefined) macros.add(name)
+      }
+    }
     if (tag.local === 'info' && depth === 2) {
       infoDepth = depth
       return
@@ -97,9 +113,11 @@ const parseCitationStyle = (
       capture = tag.local
     }
   })
-  parser.on('text', (text) => {
+  const captureText = (text: string): void => {
     if (capture) captured[capture] += text
-  })
+  }
+  parser.on('text', captureText)
+  parser.on('cdata', captureText)
   parser.on('closetag', () => {
     if (capture && depth === infoDepth + 1) capture = undefined
     if (depth === infoDepth) infoDepth = -1
@@ -121,6 +139,15 @@ const parseCitationStyle = (
   }
   if (dependent) {
     throw new Error('Dependent CSL styles are not supported yet. Import an independent style.')
+  }
+
+  for (const name of macroReferences) {
+    if (!macros.has(name)) throw new Error(`The CSL style references an undefined macro: ${name}`)
+  }
+  if (!citation || !bibliography) {
+    throw new Error(
+      'Open Science requires CSL styles with both citation and bibliography sections.'
+    )
   }
 
   return {
@@ -174,11 +201,9 @@ class LiteratureCitationStyleLibrary {
         .map(async (entry) => {
           const digest = entry.name.slice(0, -4)
           try {
-            return parseCitationStyle(
-              await readFile(join(this.customDirectory, entry.name), 'utf8'),
-              `custom:${digest}`,
-              'custom'
-            )
+            const content = await readFile(join(this.customDirectory, entry.name))
+            if (createHash('sha256').update(content).digest('hex') !== digest) return undefined
+            return parseCitationStyle(content.toString('utf8'), `custom:${digest}`, 'custom')
           } catch {
             return undefined
           }
@@ -217,13 +242,20 @@ class LiteratureCitationStyleLibrary {
       engine.free()
     }
     await mkdir(this.customDirectory, { recursive: true })
-    await writeFile(this.customPath(styleId), content, {
-      encoding: 'utf8',
-      flag: 'wx',
-      mode: 0o600
-    }).catch((error: NodeJS.ErrnoException) => {
-      if (error.code !== 'EEXIST') throw error
+    const path = this.customPath(styleId)
+    const existing = await readFile(path).catch((error: NodeJS.ErrnoException) => {
+      if (error.code !== 'ENOENT') throw error
+      return undefined
     })
+    if (existing?.equals(Buffer.from(content, 'utf8'))) return styleId
+    // Publish complete bytes, including when reimport repairs a damaged content-addressed file.
+    const temporaryPath = `${path}.${randomUUID()}.tmp`
+    try {
+      await writeFile(temporaryPath, content, { encoding: 'utf8', flag: 'wx', mode: 0o600 })
+      await rename(temporaryPath, path)
+    } finally {
+      await rm(temporaryPath, { force: true })
+    }
     return styleId
   }
 

--- a/src/renderer/src/pages/literature/CitationStylesView.test.tsx
+++ b/src/renderer/src/pages/literature/CitationStylesView.test.tsx
@@ -1,5 +1,6 @@
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { useState } from 'react'
 import { afterEach, expect, it, vi } from 'vitest'
 
 import type { LiteratureCitationStyleView } from '../../../../shared/literature'
@@ -188,6 +189,90 @@ it('imports, previews, and removes a custom CSL through the style manager', asyn
     view.rerender(<CitationStylesView {...props} styles={[]} />)
     expect(screen.queryByText('Test journal')).toBeNull()
     expect(screen.getByText('No imported styles')).not.toBeNull()
+  } finally {
+    window.api = previousApi
+  }
+})
+
+const styleA: LiteratureCitationStyleView = {
+  id: 'custom:' + 'a'.repeat(64),
+  title: 'Style A',
+  source: 'custom'
+}
+const styleB: LiteratureCitationStyleView = {
+  id: 'custom:' + 'b'.repeat(64),
+  title: 'Style B',
+  source: 'custom'
+}
+const StatefulStyleManager = ({
+  initial
+}: {
+  initial?: LiteratureCitationStyleView[]
+}): React.JSX.Element => {
+  const [styles, setStyles] = useState(initial)
+  return <CitationStylesView styles={styles} onStylesChange={setStyles} onBack={() => {}} />
+}
+const importFile = (): void => {
+  const file = new File(['CSL'], 'journal.csl', { type: 'application/xml' })
+  Object.defineProperty(file, 'text', { value: async () => 'CSL' })
+  fireEvent.change(screen.getByLabelText('Import CSL'), { target: { files: [file] } })
+}
+
+it('CS-03 shows an imported style while the initial list is still pending and ignores its late result', async () => {
+  const previousApi = window.api
+  let finishList!: (value: unknown) => void
+  const citationStyles = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishList = resolve
+        })
+    )
+    .mockResolvedValue({ styles: [styleB], changedStyleId: styleB.id })
+  window.api = { literature: { citationStyles } } as unknown as Window['api']
+  try {
+    render(<StatefulStyleManager />)
+    expect(screen.getByText('Loading citation styles…')).not.toBeNull()
+    await act(async () => importFile())
+    expect(citationStyles).toHaveBeenCalledWith({ kind: 'import', content: 'CSL' })
+    expect(screen.queryByText('Loading citation styles…')).toBeNull()
+    expect(screen.getByRole('button', { name: 'Preview: Style B' })).not.toBeNull()
+    await act(async () => finishList({ styles: [] }))
+    expect(screen.getByRole('button', { name: 'Preview: Style B' })).not.toBeNull()
+  } finally {
+    window.api = previousApi
+  }
+})
+
+it('CS-04 prevents an import snapshot from restoring a deleted style', async () => {
+  const previousApi = window.api
+  let finishImport!: (value: unknown) => void
+  const citationStyles = vi.fn().mockImplementation((request) =>
+    request.kind === 'import'
+      ? new Promise((resolve) => {
+          finishImport = resolve
+        })
+      : Promise.resolve({ styles: [styleB], changedStyleId: styleA.id })
+  )
+  window.api = { literature: { citationStyles } } as unknown as Window['api']
+  try {
+    render(<StatefulStyleManager initial={[styleA]} />)
+    await act(async () => importFile())
+    await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Delete Style A' })))
+    const deletedDuringImport = citationStyles.mock.calls.some(
+      ([request]) => request.kind === 'delete'
+    )
+    if (deletedDuringImport)
+      expect(screen.queryByRole('button', { name: 'Preview: Style A' })).toBeNull()
+    await act(async () => finishImport({ styles: [styleA, styleB], changedStyleId: styleB.id }))
+    // With a serialized UI, retry the delete once import finishes.
+    if (!deletedDuringImport) {
+      await act(async () => fireEvent.click(screen.getByRole('button', { name: 'Delete Style A' })))
+    }
+    expect(citationStyles).toHaveBeenCalledWith({ kind: 'delete', styleId: styleA.id })
+    expect(screen.queryByRole('button', { name: 'Preview: Style A' })).toBeNull()
+    expect(screen.getByRole('button', { name: 'Preview: Style B' })).not.toBeNull()
   } finally {
     window.api = previousApi
   }

--- a/src/renderer/src/pages/literature/CitationStylesView.tsx
+++ b/src/renderer/src/pages/literature/CitationStylesView.tsx
@@ -34,6 +34,7 @@ const CitationStylesView = ({
   const [loading, setLoading] = useState(styles === undefined)
   const [importing, setImporting] = useState(false)
   const [deletingId, setDeletingId] = useState<string>()
+  const mutating = importing || deletingId !== undefined
   const [previewStates, setPreviewStates] = useState<Record<string, CitationStylePreviewState>>({})
   const [error, setError] = useState<string>()
   const previewRequestsRef = useRef(new Set<string>())
@@ -172,6 +173,7 @@ const CitationStylesView = ({
   )
 
   const importStyle = async (file: File): Promise<void> => {
+    if (mutating) return
     setError(undefined)
     if (!file.name.toLowerCase().endsWith('.csl')) {
       setError(t('Choose a .csl file.'))
@@ -196,6 +198,7 @@ const CitationStylesView = ({
   }
 
   const deleteStyle = async (styleId: string): Promise<void> => {
+    if (mutating) return
     setError(undefined)
     setDeletingId(styleId)
     try {
@@ -363,7 +366,7 @@ const CitationStylesView = ({
             type="button"
             variant="ghost"
             size="icon-sm"
-            disabled={deletingId !== undefined}
+            disabled={mutating}
             aria-label={t('Delete {{style}}', { style: style.title })}
             title={t('Delete')}
             onClick={() => void deleteStyle(style.id)}
@@ -403,6 +406,7 @@ const CitationStylesView = ({
             <input
               ref={inputRef}
               type="file"
+              disabled={mutating}
               accept=".csl,application/xml,text/xml"
               className="sr-only"
               aria-label={t('Import CSL')}
@@ -412,7 +416,7 @@ const CitationStylesView = ({
                 if (file) void importStyle(file)
               }}
             />
-            <Button type="button" disabled={importing} onClick={() => inputRef.current?.click()}>
+            <Button type="button" disabled={mutating} onClick={() => inputRef.current?.click()}>
               {importing ? (
                 <LoaderCircle
                   className="size-4 animate-spin motion-reduce:animate-none"
@@ -435,7 +439,7 @@ const CitationStylesView = ({
           </p>
         ) : null}
 
-        {loading ? (
+        {loading && styles === undefined ? (
           <div role="status" className="mt-8 flex items-center gap-2 text-sm text-muted-foreground">
             <LoaderCircle
               className="size-4 animate-spin motion-reduce:animate-none"


### PR DESCRIPTION
## Summary

Imported citation styles can be accepted without the formatting behavior Open Science requires, damaged stored files cannot be repaired by reimporting, and overlapping style-manager requests can leave the UI loading indefinitely or restore deleted rows.

- Validate macro references and require citation and bibliography sections before accepting a style. Capture CDATA metadata through the existing text handler. These are focused support checks, not a full CSL semantic validator.
- Verify stored styles against their content-addressed IDs using raw bytes. Preserve identical imports and repair mismatched files by publishing validated original content through a same-directory temporary file and rename.
- Show available styles even if the initial list request remains pending, and make import/delete mutually exclusive using existing component state.

No new dependencies, persistent fields, database/schema changes, or IPC revisions. The interaction changes are precise import errors, working reimport recovery, and temporarily disabled conflicting mutation controls.

## Regression evidence

Added nine regression cases through the existing library and component boundaries, without new production test seams. Backend tests use the installed citeme-engine-wasm and real temporary files; component tests render the actual view with controlled API response ordering.

The initial eight cases failed consistently in two runs before the fixes. The raw-byte corruption case then failed twice before its correction. All pass after their respective fixes. A baseline formatter probe also confirmed generic fallback output for missing macros, an empty bibliography for a citation-only style, and changed output under an old ID after file replacement.

## Validation

- Literature module, style-manager component, and i18n guards: 26 files / 1,092 tests passed before the additional byte-corruption case; the final full run includes that new case, and the final style-library suite passed all 12 tests.
- Type checking, changed-file ESLint, and `git diff --check` passed. Node type checking was repeated after the byte-level correction.
- Full `npm test -- --maxWorkers=8` completed: 27,596 passed, 18 failed, 251 skipped. This is not an all-green full-suite result:
  - Seven failures in literature-list rendering and Web download tests passed when rerun with one worker; the matching baseline checks also passed.
  - Eight Office-preview failures reproduced on the unchanged base commit (`547e1896`).
  - Three package-cache sandbox integration tests failed because the production sandbox denied executing Micromamba from the worktree dependency path.
- The earlier settings/runtime test failures caused by the agent execution sandbox disappeared outside that sandbox: all 405 tests passed.

The filesystem reproductions deliberately corrupt temporary files; they do not demonstrate normal writes causing corruption. The UI races are tested at the React/API boundary, not by scheduling full Electron IPC traffic.
