### PR TITLE
fix(literature): isolate detail requests and recover saved metadata

### DIFF
--- a/src/renderer/src/pages/literature/LiteratureDetailController.ts
+++ b/src/renderer/src/pages/literature/LiteratureDetailController.ts
@@ -2,6 +2,7 @@ import type { LiteratureItemView } from '../../../../shared/literature'
 
 export type LiteratureDetailSnapshot = Readonly<{
   item?: LiteratureItemView
+  generation: number
   open: boolean
 }>
 
@@ -14,7 +15,7 @@ export type LiteratureDetailController = Readonly<{
 }>
 
 const createLiteratureDetailController = (): LiteratureDetailController => {
-  let snapshot: LiteratureDetailSnapshot = { open: false }
+  let snapshot: LiteratureDetailSnapshot = { open: false, generation: 0 }
   const listeners = new Set<() => void>()
   const publish = (next: LiteratureDetailSnapshot): void => {
     snapshot = next
@@ -28,12 +29,12 @@ const createLiteratureDetailController = (): LiteratureDetailController => {
       return () => listeners.delete(listener)
     },
     close: () => {
-      if (!snapshot.open && !snapshot.item) return
-      publish({ open: false })
+      publish({ open: false, generation: snapshot.generation + 1 })
     },
-    open: (item) => publish({ item, open: true }),
+    open: (item) => publish({ item, open: true, generation: snapshot.generation + 1 }),
     replace: (item) => {
-      if (snapshot.item?.id !== item.id) return
+      if (snapshot.item?.id !== item.id || item.metadataRevision < snapshot.item.metadataRevision)
+        return
       publish({ ...snapshot, item })
     }
   }

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -7264,5 +7264,178 @@ describe('LiteratureLibraryPage', () => {
       await act(async () => pending.resolve(reply))
       expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
     })
+    it('publishes an inline save to a detail opened during its readback', async () => {
+      await showLibrary()
+      const pending = deferred<LiteratureItemView>()
+      get.mockReturnValueOnce(pending.promise)
+      fireEvent.click(
+        screen.getByRole('combobox', { name: `Reference type: ${libraryItem.item.title}` })
+      )
+      fireEvent.click(screen.getByRole('option', { name: 'Preprint' }))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await act(async () =>
+        pending.resolve({
+          ...libraryItem,
+          metadataRevision: 2,
+          item: { ...libraryItem.item, itemType: 'preprint' }
+        })
+      )
+      expect(within(screen.getByRole('dialog')).queryAllByText('Preprint').length).toBeGreaterThan(
+        0
+      )
+      await editDetail()
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() =>
+        expect(transact).toHaveBeenLastCalledWith(
+          expect.objectContaining({ expectedMetadataRevision: 2 })
+        )
+      )
+    })
+
+    it.each(['view', 'edit'] as const)(
+      'publishes a pending background read to a subsequently opened %s detail',
+      async (mode) => {
+        const summary = {
+          id: 'opening-job',
+          mode: 'metadata' as const,
+          phase: 'apply' as const,
+          state: 'running' as const,
+          total: 1,
+          checked: 1,
+          ready: 0,
+          done: 0,
+          failed: 0,
+          createdAt: 1,
+          updatedAt: 1,
+          completedItemIds: [] as string[]
+        }
+        vi.mocked(window.api.literature.jobs).mockResolvedValue({ jobs: [], summaries: [summary] })
+        await showLibrary()
+        await screen.findByRole('button', { name: 'Background tasks' })
+        const pending = deferred<LiteratureItemView>()
+        get.mockReturnValueOnce(pending.promise)
+        vi.mocked(window.api.literature.jobs).mockResolvedValue({
+          jobs: [],
+          summaries: [
+            { ...summary, state: 'completed', done: 1, completedItemIds: [libraryItem.id] }
+          ]
+        })
+        await act(async () => window.dispatchEvent(new Event('literature-jobs-changed')))
+        await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        if (mode === 'edit') {
+          await editDetail()
+          fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Keep my draft' } })
+        }
+        await act(async () => pending.resolve(version(2, 'Fresh background title')))
+        expect(
+          document.querySelector('[data-slot="literature-table-scroll"]')!.textContent
+        ).toContain('Fresh background title')
+        if (mode === 'view') {
+          expect(
+            within(screen.getByRole('dialog')).getByRole('heading', { level: 2 }).textContent
+          ).toBe('Fresh background title')
+        } else {
+          expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Keep my draft')
+          expect(
+            within(screen.getByRole('dialog')).queryByText(
+              'This reference changed while you were editing. Your draft has been kept.'
+            )
+          ).not.toBeNull()
+          expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
+            true
+          )
+        }
+      }
+    )
+
+    it('reloads a completed PDF import into a reopened newer detail', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      stageLocalFile.mockResolvedValue({
+        id: 'upload-1',
+        sessionId: '.pending',
+        name: 'paper.pdf',
+        originalName: 'paper.pdf',
+        path: '/managed/paper.pdf',
+        mimeType: 'application/pdf',
+        size: 8
+      })
+      const pending = deferred<{ item: LiteratureItemView }>()
+      importPdf.mockReturnValueOnce(pending.promise)
+      fireEvent.change(screen.getByLabelText('Add PDF'), {
+        target: { files: [new File(['%PDF-1.7'], 'paper.pdf', { type: 'application/pdf' })] }
+      })
+      await waitFor(() => expect(importPdf).toHaveBeenCalledTimes(1))
+      closeDetail()
+      const latest = version(3, 'Latest metadata before attachment')
+      get.mockResolvedValueOnce(latest)
+      act(() => useNavigationStore.getState().openLiteratureItem(libraryItem.id, 'user'))
+      await screen.findByRole('heading', { name: latest.item.title })
+      const withPdf = createLibraryItemWithPdf()
+      get.mockResolvedValue({ ...latest, attachments: withPdf.attachments })
+      await act(async () => pending.resolve({ item: withPdf }))
+      await waitFor(() =>
+        expect(
+          within(screen.getByRole('dialog')).queryByRole('button', { name: 'Preview paper.pdf' })
+        ).not.toBeNull()
+      )
+      expect(
+        within(screen.getByRole('dialog')).getByRole('heading', { level: 2 }).textContent
+      ).toBe(latest.item.title)
+      expect(importPdf).toHaveBeenCalledTimes(1)
+      expect(get).toHaveBeenCalledTimes(2)
+    })
+    it.each(['save', 'completion'] as const)(
+      'publishes an earlier %s without replacing the reopened editor draft',
+      async (operation) => {
+        await showLibrary()
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        const updated = version(2, 'Committed before reopening')
+        const pending = deferred<LiteratureItemView>()
+        if (operation === 'save') {
+          await editDetail()
+          get.mockReturnValueOnce(pending.promise)
+          fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+          await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+        } else {
+          await openMenu(screen.getByRole('button', { name: 'More actions' }))
+          fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+          fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+          await screen.findByRole('button', { name: 'Apply metadata' })
+          completeMetadata.mockImplementationOnce(async () => ({
+            mode: 'commit',
+            provider: 'crossref',
+            sourceUrl: 'https://example.test',
+            item: await pending.promise,
+            filled: [],
+            conflicts: []
+          }))
+          fireEvent.click(screen.getByRole('button', { name: 'Apply metadata' }))
+          await waitFor(() =>
+            expect(completeMetadata).toHaveBeenLastCalledWith(
+              expect.objectContaining({ mode: 'commit' })
+            )
+          )
+        }
+        closeDetail()
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        await editDetail()
+        fireEvent.change(screen.getByLabelText('Title'), {
+          target: { value: 'Keep this newer draft' }
+        })
+        await act(async () => pending.resolve(updated))
+        expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe(
+          'Keep this newer draft'
+        )
+        expect(
+          within(screen.getByRole('dialog')).queryByText(
+            'This reference changed while you were editing. Your draft has been kept.'
+          )
+        ).not.toBeNull()
+        expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
+      }
+    )
   })
 })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -7350,6 +7350,108 @@ describe('LiteratureLibraryPage', () => {
       }
     )
 
+    it.each(['pending', 'visible'] as const)(
+      'invalidates a %s metadata preview when the background publishes a newer revision',
+      async (previewState) => {
+        const summary = {
+          id: 'preview-update-job',
+          mode: 'metadata' as const,
+          phase: 'apply' as const,
+          state: 'running' as const,
+          total: 1,
+          checked: 1,
+          ready: 0,
+          done: 0,
+          failed: 0,
+          createdAt: 1,
+          updatedAt: 1,
+          completedItemIds: [] as string[]
+        }
+        vi.mocked(window.api.literature.jobs).mockResolvedValue({ jobs: [], summaries: [summary] })
+        await showLibrary()
+        await screen.findByRole('button', { name: 'Background tasks' })
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        await openMenu(screen.getByRole('button', { name: 'More actions' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+        const reply = await completeMetadata.getMockImplementation()!({ mode: 'preview' })
+        const pending = deferred<typeof reply>()
+        completeMetadata.mockReturnValueOnce(pending.promise)
+        fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+        await waitFor(() => expect(completeMetadata).toHaveBeenCalledTimes(1))
+        if (previewState === 'visible') {
+          await act(async () => pending.resolve(reply))
+          expect(screen.getByRole('button', { name: 'Apply metadata' })).not.toBeNull()
+        }
+        get.mockResolvedValue(version(2, 'Background revision two'))
+        vi.mocked(window.api.literature.jobs).mockResolvedValue({
+          jobs: [],
+          summaries: [
+            { ...summary, state: 'completed', done: 1, completedItemIds: [libraryItem.id] }
+          ]
+        })
+        await act(async () => window.dispatchEvent(new Event('literature-jobs-changed')))
+        await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+        if (previewState === 'pending') await act(async () => pending.resolve(reply))
+        expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
+        expect(screen.queryByText('Journal of Retrieval')).toBeNull()
+        expect(screen.getByRole('button', { name: 'Search' })).toHaveProperty('disabled', false)
+        expect(completeMetadata).toHaveBeenCalledTimes(1)
+        completeMetadata.mockResolvedValueOnce({
+          ...reply,
+          item: version(2, 'Background revision two'),
+          reviewToken: 'fresh-review'
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+        fireEvent.click(await screen.findByRole('button', { name: 'Apply metadata' }))
+        await waitFor(() =>
+          expect(completeMetadata).toHaveBeenLastCalledWith(
+            expect.objectContaining({
+              mode: 'commit',
+              expectedMetadataRevision: 2,
+              reviewToken: 'fresh-review'
+            })
+          )
+        )
+      }
+    )
+
+    it('keeps a metadata preview when background attachments change at the same revision', async () => {
+      const summary = {
+        id: 'attachment-preview-job',
+        mode: 'full-text' as const,
+        phase: 'apply' as const,
+        state: 'running' as const,
+        total: 1,
+        checked: 1,
+        ready: 0,
+        done: 0,
+        failed: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        completedItemIds: [] as string[]
+      }
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({ jobs: [], summaries: [summary] })
+      await showLibrary()
+      await screen.findByRole('button', { name: 'Background tasks' })
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+      await screen.findByRole('button', { name: 'Apply metadata' })
+      get.mockResolvedValue(createLibraryItemWithPdf())
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({
+        jobs: [],
+        summaries: [{ ...summary, state: 'completed', done: 1, completedItemIds: [libraryItem.id] }]
+      })
+      await act(async () => window.dispatchEvent(new Event('literature-jobs-changed')))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+      expect(screen.getByRole('button', { name: 'Apply metadata' })).toHaveProperty(
+        'disabled',
+        false
+      )
+      expect(screen.getByText('Journal of Retrieval')).not.toBeNull()
+    })
+
     it('publishes successful background reads when another completed item cannot be read', async () => {
       const summary = {
         id: 'partial-read-job',

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -7350,6 +7350,52 @@ describe('LiteratureLibraryPage', () => {
       }
     )
 
+    it('publishes successful background reads when another completed item cannot be read', async () => {
+      const summary = {
+        id: 'partial-read-job',
+        mode: 'metadata' as const,
+        phase: 'apply' as const,
+        state: 'running' as const,
+        total: 2,
+        checked: 2,
+        ready: 0,
+        done: 0,
+        failed: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        completedItemIds: [] as string[]
+      }
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({ jobs: [], summaries: [summary] })
+      await showLibrary()
+      await screen.findByRole('button', { name: 'Background tasks' })
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      get.mockImplementation(async (id: string) => {
+        if (id === libraryItem.id) return version(2, 'Successful background update')
+        throw new Error('The other reference cannot be read')
+      })
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({
+        jobs: [],
+        summaries: [
+          {
+            ...summary,
+            state: 'completed',
+            done: 2,
+            completedItemIds: [libraryItem.id, 'unavailable-item']
+          }
+        ]
+      })
+      await act(async () => window.dispatchEvent(new Event('literature-jobs-changed')))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+      expect(
+        within(screen.getByRole('dialog')).getByRole('heading', { level: 2 }).textContent
+      ).toBe('Successful background update')
+      expect(
+        document.querySelector('[data-slot="literature-table-scroll"]')!.textContent
+      ).toContain('Successful background update')
+      closeDetail()
+      expect(screen.queryByText('Literature could not be loaded.')).not.toBeNull()
+    })
+
     it('reloads a completed PDF import into a reopened newer detail', async () => {
       await showLibrary()
       await openReferenceDetail(screen.getByText(libraryItem.item.title))

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -6893,4 +6893,376 @@ describe('LiteratureLibraryPage', () => {
       await rm(root, { recursive: true, force: true })
     }
   }, 120000)
+  describe('detail request and snapshot consistency', () => {
+    const deferred = <T,>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+      let resolve!: (value: T) => void
+      const promise = new Promise<T>((done) => {
+        resolve = done
+      })
+      return { promise, resolve }
+    }
+    const version = (revision: number, title: string): LiteratureItemView => ({
+      ...libraryItem,
+      metadataRevision: revision,
+      item: { ...libraryItem.item, title }
+    })
+    const showLibrary = async (): Promise<void> => {
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => ({
+        entries: request.scope === 'library' ? [libraryItem] : []
+      }))
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await screen.findByText(libraryItem.item.title)
+    }
+    const editDetail = async (): Promise<void> => {
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Edit metadata' }))
+    }
+    const closeDetail = (): void => {
+      fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
+    }
+
+    it('keeps a reopened reference newer than an earlier save readback', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      const oldRead = deferred<LiteratureItemView>()
+      get.mockReturnValueOnce(oldRead.promise)
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Saved version two' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+      closeDetail()
+      get.mockResolvedValueOnce(version(3, 'Latest version three'))
+      act(() => useNavigationStore.getState().openLiteratureItem(libraryItem.id, 'user'))
+      await screen.findByRole('heading', { name: 'Latest version three' })
+      await act(async () => oldRead.resolve(version(2, 'Saved version two')))
+      expect(
+        within(screen.getByRole('dialog')).getByRole('heading', { level: 2 }).textContent
+      ).toBe('Latest version three')
+      await editDetail()
+      get.mockResolvedValue(version(4, 'Latest version three'))
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() =>
+        expect(transact).toHaveBeenLastCalledWith(
+          expect.objectContaining({
+            expectedMetadataRevision: 3
+          })
+        )
+      )
+    })
+
+    it('does not restore an old preview after reopening metadata lookup', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+      const reply = await completeMetadata.getMockImplementation()!({ mode: 'preview' })
+      const pending = deferred<typeof reply>()
+      completeMetadata.mockReturnValueOnce(pending.promise)
+      const callsBefore = completeMetadata.mock.calls.length
+      fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Search' }))
+      await waitFor(() => expect(completeMetadata).toHaveBeenCalledTimes(callsBefore + 1))
+      closeDetail()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+      expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
+      await act(async () => pending.resolve(reply))
+      const staleApply = screen.queryByRole('button', { name: 'Apply metadata' })
+      if (staleApply) {
+        fireEvent.click(staleApply)
+        await act(async () => {})
+      }
+      expect(completeMetadata).toHaveBeenCalledTimes(callsBefore + 1)
+      expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
+    })
+
+    it('hides a completed preview when its identifier is edited', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+      fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Search' }))
+      await screen.findByRole('button', { name: 'Apply metadata' })
+      fireEvent.change(screen.getByRole('textbox', { name: 'DOI' }), {
+        target: { value: '10.1234/new-identifier' }
+      })
+      expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
+    })
+
+    it('recovers a committed detail save by reading without a second transaction', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      let actualRevision = 1
+      transact.mockImplementation(async (command) => {
+        if (command.expectedMetadataRevision !== actualRevision) throw new Error('Metadata changed')
+        actualRevision += 1
+        return { kind: 'item', id: libraryItem.id, state: 'present' }
+      })
+      get.mockRejectedValueOnce(new Error('Read temporarily unavailable'))
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Committed draft' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => {
+        expect(actualRevision).toBe(2)
+        expect(get).toHaveBeenCalledTimes(1)
+        expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Committed draft')
+        expect(screen.getByRole('alert')).not.toBeNull()
+      })
+      get.mockResolvedValue(version(2, 'Committed draft'))
+      // Prefer the dedicated recovery action when present; the existing UI offers only Save.
+      fireEvent.click(
+        screen.queryByRole('button', { name: /retry|reload/i }) ??
+          screen.getByRole('button', { name: 'Save' })
+      )
+      await act(async () => {})
+      expect(transact).toHaveBeenCalledTimes(1)
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+      expect(await screen.findByRole('heading', { name: 'Committed draft' })).not.toBeNull()
+    })
+
+    it('publishes background metadata completion to the open detail', async () => {
+      const summary = {
+        id: 'detail-background-job',
+        mode: 'metadata' as const,
+        phase: 'apply' as const,
+        state: 'running' as const,
+        total: 1,
+        checked: 1,
+        ready: 0,
+        done: 0,
+        failed: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        completedItemIds: [] as string[]
+      }
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({ jobs: [], summaries: [summary] })
+      await showLibrary()
+      await screen.findByRole('button', { name: 'Background tasks' })
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      get.mockResolvedValue(version(2, 'Background updated title'))
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({
+        jobs: [],
+        summaries: [{ ...summary, state: 'completed', done: 1, completedItemIds: [libraryItem.id] }]
+      })
+      await act(async () => window.dispatchEvent(new Event('literature-jobs-changed')))
+      await waitFor(() =>
+        expect(
+          document.querySelector('[data-slot="literature-table-scroll"]')!.textContent
+        ).toContain('Background updated title')
+      )
+      expect(
+        within(screen.getByRole('dialog')).getByRole('heading', { level: 2 }).textContent
+      ).toBe('Background updated title')
+      await editDetail()
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() =>
+        expect(transact).toHaveBeenCalledWith(
+          expect.objectContaining({
+            expectedMetadataRevision: 2
+          })
+        )
+      )
+    })
+
+    it('honors a row opened after a pending linked reference request', async () => {
+      const second = { ...version(1, 'Manually selected reference'), id: 'item-2' }
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => ({
+        entries: request.scope === 'library' ? [libraryItem, second] : []
+      }))
+      const pending = deferred<LiteratureItemView>()
+      get.mockReturnValueOnce(pending.promise)
+      useNavigationStore.getState().openLiteratureItem(libraryItem.id, 'user')
+      render(<LiteratureLibraryPage />)
+      await waitFor(() => expect(get).toHaveBeenCalledWith(libraryItem.id))
+      await openReferenceDetail(await screen.findByText(second.item.title))
+      expect(screen.getByRole('heading', { name: second.item.title })).not.toBeNull()
+      await act(async () => pending.resolve(libraryItem))
+      expect(
+        within(screen.getByRole('dialog')).getByRole('heading', { level: 2 }).textContent
+      ).toBe(second.item.title)
+    })
+
+    it('retains a detail save when returning to the cached library page', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      const updated = version(2, 'Saved cache title')
+      get.mockResolvedValue(updated)
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: updated.item.title } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await screen.findByRole('heading', { name: updated.item.title })
+      closeDetail()
+      expect(screen.getByText(updated.item.title)).not.toBeNull()
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => ({
+        entries: request.scope === 'library' ? [updated] : []
+      }))
+      const listReads = (): number =>
+        search.mock.calls.filter(([request]) => request.scope === 'library' && request.limit !== 1)
+          .length
+      const before = listReads()
+      fireEvent.click(screen.getByRole('button', { name: 'Inbox' }))
+      await act(async () => {})
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await act(async () => {})
+      // The original bug restores a cached old title without an authoritative list read.
+      expect(
+        document.querySelector('[data-slot="literature-table-scroll"]')!.textContent,
+        `Main library requests before/after returning: ${before}/${listReads()}`
+      ).toContain(updated.item.title)
+    })
+    it('keeps a newer editor and its draft when an earlier save finishes', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      const pending = deferred<LiteratureItemView>()
+      get.mockReturnValueOnce(pending.promise)
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+      closeDetail()
+      get.mockResolvedValueOnce(version(3, 'Newest title'))
+      act(() => useNavigationStore.getState().openLiteratureItem(libraryItem.id, 'user'))
+      await screen.findByRole('heading', { name: 'Newest title' })
+      await editDetail()
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'New opening draft' } })
+      await act(async () => pending.resolve(version(2, 'Old response')))
+      expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('New opening draft')
+      expect(screen.queryByRole('alert')).toBeNull()
+    })
+
+    it('keeps retrying only the read after an acknowledged save', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      get.mockRejectedValue(new Error('Read unavailable'))
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Acknowledged title' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await screen.findByText('The reference was saved, but could not be reloaded.')
+      expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
+        true
+      )
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+      await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+      await waitFor(() =>
+        expect((screen.getByRole('button', { name: 'Retry' }) as HTMLButtonElement).disabled).toBe(
+          false
+        )
+      )
+      expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Acknowledged title')
+      expect(transact).toHaveBeenCalledTimes(1)
+      get.mockResolvedValue(version(2, 'Acknowledged title'))
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+      await screen.findByRole('heading', { name: 'Acknowledged title' })
+      expect(transact).toHaveBeenCalledTimes(1)
+    })
+
+    it('preserves a conflicting draft until the latest version is explicitly loaded', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      const latest = version(2, 'Other writer title')
+      transact.mockRejectedValueOnce(
+        new Error('Literature metadata revision conflict: expected 1, actual 2')
+      )
+      get.mockResolvedValue(latest)
+      fireEvent.change(screen.getByLabelText('Title'), {
+        target: { value: 'My conflicting draft' }
+      })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await screen.findByText(
+        'This reference changed while you were editing. Your draft has been kept.'
+      )
+      expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe(
+        'My conflicting draft'
+      )
+      expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
+        true
+      )
+      expect(transact).toHaveBeenCalledTimes(1)
+      fireEvent.click(screen.getByRole('button', { name: 'Load latest version' }))
+      expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe(latest.item.title)
+      expect(transact).toHaveBeenCalledTimes(1)
+      get.mockResolvedValue(version(3, 'Reviewed draft'))
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Reviewed draft' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await waitFor(() =>
+        expect(transact).toHaveBeenLastCalledWith(
+          expect.objectContaining({ expectedMetadataRevision: 2 })
+        )
+      )
+    })
+
+    it('keeps an editable draft when a transaction fails without committing', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      transact.mockRejectedValueOnce(new Error('Write unavailable'))
+      get.mockResolvedValue(libraryItem)
+      fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Unsaved draft' } })
+      fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+      await screen.findByText('Literature could not be updated.')
+      await waitFor(() =>
+        expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
+          false
+        )
+      )
+      expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Unsaved draft')
+      expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+    })
+
+    it('keeps the draft when background metadata arrives during editing', async () => {
+      const summary = {
+        id: 'edit-job',
+        mode: 'metadata' as const,
+        phase: 'apply' as const,
+        state: 'running' as const,
+        total: 1,
+        checked: 1,
+        ready: 0,
+        done: 0,
+        failed: 0,
+        createdAt: 1,
+        updatedAt: 1,
+        completedItemIds: [] as string[]
+      }
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({ jobs: [], summaries: [summary] })
+      await showLibrary()
+      await screen.findByRole('button', { name: 'Background tasks' })
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      const title = screen.getByLabelText('Title')
+      fireEvent.change(title, { target: { value: 'Work in progress' } })
+      get.mockResolvedValue(version(2, 'Background result'))
+      vi.mocked(window.api.literature.jobs).mockResolvedValue({
+        jobs: [],
+        summaries: [{ ...summary, state: 'completed', done: 1, completedItemIds: [libraryItem.id] }]
+      })
+      await act(async () => window.dispatchEvent(new Event('literature-jobs-changed')))
+      await screen.findByText(
+        'This reference changed while you were editing. Your draft has been kept.'
+      )
+      expect(screen.getByLabelText('Title')).toBe(title)
+      expect((title as HTMLInputElement).value).toBe('Work in progress')
+      expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
+        true
+      )
+      expect(transact).not.toHaveBeenCalled()
+    })
+
+    it('rejects a preview after leaving and reentering lookup without closing detail', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+      const reply = await completeMetadata.getMockImplementation()!({ mode: 'preview' })
+      const pending = deferred<typeof reply>()
+      completeMetadata.mockReturnValueOnce(pending.promise)
+      fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Back' }))
+      await openMenu(screen.getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+      await act(async () => pending.resolve(reply))
+      expect(screen.queryByRole('button', { name: 'Apply metadata' })).toBeNull()
+    })
+  })
 })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1811,14 +1811,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const receiveBackgroundItems = useCallback(
     (itemIds: string[]): void => {
       setDuplicatesRevision((value) => value + 1)
-      const generation = detailController.getSnapshot().generation
       void Promise.all(itemIds.map((id) => window.api.literature.get(id))).then(
         (results) => {
           const updated = results.filter((item): item is LiteratureItemView => Boolean(item))
           void refreshItems(itemIds, updated)
-          if (detailController.getSnapshot().generation === generation) {
-            updated.forEach((item) => detailController.replace(item))
-          }
+          // Data publication follows item identity/revision, not the opening that started the read.
+          updated.forEach((item) => detailController.replace(item))
         },
         () => setError(t('Literature could not be loaded.'))
       )
@@ -2282,8 +2280,10 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         itemId: current.id,
         attachment: staged
       })
-      if (detailController.getSnapshot().generation === generation)
-        detailController.replace(receipt.item)
+      // An attachment receipt may predate metadata edits in a reopened detail. Re-read rather
+      // than using metadataRevision as an attachment version or rolling metadata backwards.
+      const updated = await window.api.literature.get(current.id).catch(() => undefined)
+      detailController.replace(updated ?? receipt.item)
       await loadEntries(true)
     } catch (error) {
       if (detailController.getSnapshot().generation === generation)
@@ -2411,7 +2411,6 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       (item.rating ?? 0) === (entry.item.rating ?? 0)
     )
       return
-    const generation = detailController.getSnapshot().generation
     let persisted = false
     try {
       await window.api.literature.transact({
@@ -2426,8 +2425,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
           const updated = await window.api.literature.get(entry.id)
           if (!updated) throw new Error('Literature Item is unavailable after updating.')
           await refreshItems([updated.id], [updated])
-          if (detailController.getSnapshot().generation === generation)
-            detailController.replace(updated)
+          detailController.replace(updated)
           setError(undefined)
           return updated
         } catch (error) {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -60,6 +60,7 @@ import { useTranslation } from 'react-i18next'
 import { FileDropOverlay } from '@/components/FileDropOverlay'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { ActionToast } from '@/components/ActionToast'
+import { ErrorNotice } from '@/components/error-notice'
 import { LiteratureErrorNotice } from './LiteratureErrorNotice'
 import { Button } from '@/components/ui/button'
 import { ScrollArea } from '@/components/ui/scroll-area'
@@ -1310,12 +1311,6 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const [detailController] = useState(createLiteratureDetailController)
   const selectedItem = detailController.getSnapshot().item
   const selectedItemId = selectedItem?.id
-  const updateMetadataItem = useCallback((updated: LiteratureItemView): void => {
-    setItems((entries) => entries.map((entry) => (entry.id === updated.id ? updated : entry)))
-    setDuplicatesRevision((value) => value + 1)
-  }, [])
-  const metadata = useLiteratureMetadata(detailController, updateMetadataItem)
-  const { changeMode: changeDetailMode } = metadata
   const [isCreatingItem, setIsCreatingItem] = useState(false)
   const [isSavingNewItem, setIsSavingNewItem] = useState(false)
   const [createItemError, setCreateItemError] = useState<string>()
@@ -1405,21 +1400,10 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       0
     )
 
-  const closeSelectedItemDetail = useCallback((): void => {
-    detailTagMenuOpenRef.current = false
-    detailSelectOpenRef.current = false
-    childLayerDismissGuardUntilRef.current = 0
-    detailController.close()
-    startTransition(() => {
-      setPdfError(undefined)
-      changeDetailMode('view')
-      setProjectLinkError(undefined)
-      setCollectionLinkError(undefined)
-    })
-  }, [changeDetailMode, detailController])
-
+  const detailInteractionRef = useRef(0)
   const openSelectedItemDetail = useCallback(
     (item: LiteratureItemView): void => {
+      detailInteractionRef.current += 1
       detailController.open(item)
     },
     [detailController]
@@ -1505,6 +1489,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   useEffect(() => {
     if (!pendingLiteratureItemId) return
     const itemId = pendingLiteratureItemId
+    const interaction = ++detailInteractionRef.current
     let active = true
     queueMicrotask(() => {
       if (!active) return
@@ -1518,12 +1503,20 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       void window.api.literature.get(itemId).then(
         (item) => {
           if (!active) return
+          if (detailInteractionRef.current !== interaction) {
+            consumeLiteratureItem(itemId)
+            return
+          }
           if (item) openSelectedItemDetail(item)
           else setLinkedItemError(t('This reference is no longer in your Library.'))
           consumeLiteratureItem(itemId)
         },
         () => {
           if (!active) return
+          if (detailInteractionRef.current !== interaction) {
+            consumeLiteratureItem(itemId)
+            return
+          }
           setLinkedItemError(undefined)
           setError(t('Literature could not be loaded.'))
           consumeLiteratureItem(itemId)
@@ -1765,6 +1758,32 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     onEmptyPage: setEntriesOffset,
     onError: receiveEntriesError
   })
+  const updateMetadataItem = (updated: LiteratureItemView): void => {
+    const current = detailController.getSnapshot().item
+    const latest =
+      current?.id === updated.id && current.metadataRevision > updated.metadataRevision
+        ? current
+        : updated
+    void refreshItems([updated.id], [latest])
+    setDuplicatesRevision((value) => value + 1)
+  }
+  const metadata = useLiteratureMetadata(detailController, updateMetadataItem)
+  const { changeMode: changeDetailMode } = metadata
+
+  const closeSelectedItemDetail = useCallback((): void => {
+    detailInteractionRef.current += 1
+    detailTagMenuOpenRef.current = false
+    detailSelectOpenRef.current = false
+    childLayerDismissGuardUntilRef.current = 0
+    detailController.close()
+    startTransition(() => {
+      setPdfError(undefined)
+      changeDetailMode('view')
+      setProjectLinkError(undefined)
+      setCollectionLinkError(undefined)
+    })
+  }, [changeDetailMode, detailController])
+
   const appliedTagRevision = useRef(tagRevision)
   useEffect(() => {
     if (appliedTagRevision.current === tagRevision) return
@@ -1792,9 +1811,19 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const receiveBackgroundItems = useCallback(
     (itemIds: string[]): void => {
       setDuplicatesRevision((value) => value + 1)
-      void refreshItems(itemIds)
+      const generation = detailController.getSnapshot().generation
+      void Promise.all(itemIds.map((id) => window.api.literature.get(id))).then(
+        (results) => {
+          const updated = results.filter((item): item is LiteratureItemView => Boolean(item))
+          void refreshItems(itemIds, updated)
+          if (detailController.getSnapshot().generation === generation) {
+            updated.forEach((item) => detailController.replace(item))
+          }
+        },
+        () => setError(t('Literature could not be loaded.'))
+      )
     },
-    [refreshItems]
+    [detailController, refreshItems, t]
   )
 
   useEffect(() => {
@@ -2237,7 +2266,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }
 
   const addPdf = async (file: File): Promise<void> => {
-    const current = detailController.getSnapshot().item
+    const { item: current, generation } = detailController.getSnapshot()
     if (!current || isAddingPdf) return
     setIsAddingPdf(true)
     setPdfError(undefined)
@@ -2253,10 +2282,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         itemId: current.id,
         attachment: staged
       })
-      detailController.replace(receipt.item)
+      if (detailController.getSnapshot().generation === generation)
+        detailController.replace(receipt.item)
       await loadEntries(true)
     } catch (error) {
-      setPdfError(pdfImportErrorMessage(error, t))
+      if (detailController.getSnapshot().generation === generation)
+        setPdfError(pdfImportErrorMessage(error, t))
     } finally {
       if (staged)
         await window.api.uploads.deleteUpload({ path: staged.path }).catch(() => undefined)
@@ -2380,6 +2411,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       (item.rating ?? 0) === (entry.item.rating ?? 0)
     )
       return
+    const generation = detailController.getSnapshot().generation
     let persisted = false
     try {
       await window.api.literature.transact({
@@ -2394,7 +2426,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
           const updated = await window.api.literature.get(entry.id)
           if (!updated) throw new Error('Literature Item is unavailable after updating.')
           await refreshItems([updated.id], [updated])
-          detailController.replace(updated)
+          if (detailController.getSnapshot().generation === generation)
+            detailController.replace(updated)
           setError(undefined)
           return updated
         } catch (error) {
@@ -5084,7 +5117,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       </Dialog.Root>
 
       <LiteratureDetailBoundary controller={detailController}>
-        {({ item: selectedItem, open }) => (
+        {({ item: selectedItem, open, generation }) => (
           // The portaled file preview owns focus while open. A lower modal's scroll lock would
           // reject its wheel/touch events because the preview is outside the detail content.
           <Dialog.Root open={open} modal={!previewItem}>
@@ -5288,25 +5321,61 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                         requestAnimationFrame(() => pdfInputRef.current?.click())
                       }}
                       onAdded={(updated) => {
-                        detailController.replace(updated)
                         updateMetadataItem(updated)
-                        if (detailController.getSnapshot().item?.id === updated.id)
+                        if (detailController.getSnapshot().generation === generation) {
+                          detailController.replace(updated)
                           changeDetailMode('view')
+                        }
                         void loadEntries(true)
                       }}
                     />
                   ) : metadata.mode === 'edit' ? (
-                    <LiteratureMetadataEditor
-                      key={`${selectedItem.id}:${selectedItem.metadataRevision}`}
-                      item={selectedItem.item}
-                      saving={metadata.saving}
-                      error={metadata.error}
-                      className="min-h-0 flex-1 max-h-none"
-                      onCancel={() => {
-                        changeDetailMode('view')
-                      }}
-                      onSave={(item) => void metadata.save(item)}
-                    />
+                    <>
+                      {metadata.awaitingReload || metadata.externallyUpdated() ? (
+                        <ErrorNotice
+                          className="mx-5 mt-4 w-auto shrink-0"
+                          role="alert"
+                          tone="amber"
+                          description={
+                            metadata.awaitingReload
+                              ? t('The reference was saved, but could not be reloaded.')
+                              : t(
+                                  'This reference changed while you were editing. Your draft has been kept.'
+                                )
+                          }
+                          primaryButton={
+                            metadata.awaitingReload
+                              ? {
+                                  label: t('Retry'),
+                                  loading: metadata.saving,
+                                  onClick: () => void metadata.reloadSaved()
+                                }
+                              : {
+                                  label: t('Load latest version'),
+                                  disabled: metadata.saving,
+                                  description: t(
+                                    'Discard this draft and load the latest saved metadata.'
+                                  ),
+                                  onClick: metadata.loadLatest
+                                }
+                          }
+                        />
+                      ) : null}
+                      <LiteratureMetadataEditor
+                        key={`${selectedItem.id}:${metadata.editBase?.metadataRevision}`}
+                        item={metadata.editBase?.item ?? selectedItem.item}
+                        saving={metadata.saving || metadata.awaitingReload}
+                        saveDisabled={metadata.externallyUpdated()}
+                        error={
+                          metadata.awaitingReload || metadata.externallyUpdated()
+                            ? undefined
+                            : metadata.error
+                        }
+                        className="min-h-0 flex-1 max-h-none"
+                        onCancel={() => changeDetailMode('view')}
+                        onSave={(item) => void metadata.save(item)}
+                      />
+                    </>
                   ) : metadata.mode === 'complete' ? (
                     <div className="min-h-0 flex-1 overflow-y-auto px-5 py-5 text-sm">
                       <LiteratureMetadataLookup

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1811,14 +1811,17 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const receiveBackgroundItems = useCallback(
     (itemIds: string[]): void => {
       setDuplicatesRevision((value) => value + 1)
-      void Promise.all(itemIds.map((id) => window.api.literature.get(id))).then(
+      void Promise.allSettled(itemIds.map((id) => window.api.literature.get(id))).then(
         (results) => {
-          const updated = results.filter((item): item is LiteratureItemView => Boolean(item))
+          const updated = results.flatMap((result) =>
+            result.status === 'fulfilled' && result.value ? [result.value] : []
+          )
           void refreshItems(itemIds, updated)
           // Data publication follows item identity/revision, not the opening that started the read.
           updated.forEach((item) => detailController.replace(item))
-        },
-        () => setError(t('Literature could not be loaded.'))
+          if (results.some((result) => result.status === 'rejected'))
+            setError(t('Literature could not be loaded.'))
+        }
       )
     },
     [detailController, refreshItems, t]

--- a/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
@@ -20,6 +20,7 @@ import {
 type LiteratureMetadataEditorProps = Readonly<{
   item: LiteratureItemInput
   saving: boolean
+  saveDisabled?: boolean
   error?: string
   className?: string
   beforeFields?: React.ReactNode
@@ -52,6 +53,7 @@ const ADVANCED_FIELD_KEYS = [
 const LiteratureMetadataEditor = ({
   item,
   saving,
+  saveDisabled = false,
   error,
   className,
   beforeFields,
@@ -124,7 +126,7 @@ const LiteratureMetadataEditor = ({
   }
 
   const submit = (): void => {
-    if (saving) return
+    if (saving || saveDisabled) return
     const creators = draft.creators.filter((creator) =>
       creator.nameMode === 'organization'
         ? creator.literalName.trim()
@@ -416,7 +418,11 @@ const LiteratureMetadataEditor = ({
         <Button type="button" variant="outline" disabled={saving} onClick={onCancel}>
           {t('Cancel')}
         </Button>
-        <Button type="button" disabled={saving || !draft.title.trim()} onClick={submit}>
+        <Button
+          type="button"
+          disabled={saving || saveDisabled || !draft.title.trim()}
+          onClick={submit}
+        >
           {t('Save')}
         </Button>
       </div>

--- a/src/renderer/src/pages/literature/useLiteratureMetadata.ts
+++ b/src/renderer/src/pages/literature/useLiteratureMetadata.ts
@@ -104,10 +104,8 @@ const useLiteratureMetadata = (
       const updated = await window.api.literature.get(current.item.id)
       if (!updated) throw new Error('Literature Item is unavailable after updating.')
       onItemChange(updated)
-      if (active()) {
-        controller.replace(updated)
-        changeMode('view')
-      }
+      controller.replace(updated)
+      if (active()) changeMode('view')
     } catch {
       if (active()) setError(t('The reference was saved, but could not be reloaded.'))
     } finally {
@@ -138,10 +136,8 @@ const useLiteratureMetadata = (
       const updated = await window.api.literature.get(current.id)
       if (!updated) throw new Error('Literature Item is unavailable after updating.')
       onItemChange(updated)
-      if (active()) {
-        controller.replace(updated)
-        changeMode('view')
-      }
+      controller.replace(updated)
+      if (active()) changeMode('view')
     } catch {
       if (active()) {
         setAwaitingReload(persisted)
@@ -157,7 +153,7 @@ const useLiteratureMetadata = (
           const latest = await window.api.literature.get(current.id)
           if (latest) {
             onItemChange(latest)
-            if (active()) controller.replace(latest)
+            controller.replace(latest)
           }
         } catch {
           /* Keep the draft and original error when the follow-up read also fails. */
@@ -202,7 +198,7 @@ const useLiteratureMetadata = (
         if (result.mode === 'preview') setOverwriteFields(new Set())
       }
       if (result.mode === 'commit') {
-        if (active()) controller.replace(result.item)
+        controller.replace(result.item)
         onItemChange(result.item)
       }
     } catch {

--- a/src/renderer/src/pages/literature/useLiteratureMetadata.ts
+++ b/src/renderer/src/pages/literature/useLiteratureMetadata.ts
@@ -73,19 +73,21 @@ const useLiteratureMetadata = (
   )
 
   useLayoutEffect(() => {
-    let generation = controller.getSnapshot().generation
+    let previous = controller.getSnapshot()
     const unsubscribe = controller.subscribe(() => {
-      const next = controller.getSnapshot().generation
-      if (next === generation) return
-      generation = next
-      changeMode('view')
+      const next = controller.getSnapshot()
+      const openingChanged = next.generation !== previous.generation
+      const revisionChanged = next.item?.metadataRevision !== previous.item?.metadataRevision
+      previous = next
+      if (openingChanged) changeMode('view')
+      else if (revisionChanged) resetCompletion()
     })
     return () => {
       unsubscribe()
       requestRef.current += 1
       completionRequestRef.current += 1
     }
-  }, [controller, changeMode])
+  }, [controller, changeMode, resetCompletion])
 
   const externallyUpdated = (): boolean =>
     Boolean(
@@ -176,6 +178,7 @@ const useLiteratureMetadata = (
     const active = (): boolean =>
       controller.getSnapshot().generation === generation &&
       controller.getSnapshot().item?.id === current.id &&
+      controller.getSnapshot().item?.metadataRevision === current.metadataRevision &&
       completionRequestRef.current === request
     identifierRef.current = identifier
     setCompleting(true)
@@ -193,13 +196,22 @@ const useLiteratureMetadata = (
               overwriteFields: [...overwriteFields]
             }
       )
-      if (active()) {
-        setCompletion(result)
-        if (result.mode === 'preview') setOverwriteFields(new Set())
-      }
       if (result.mode === 'commit') {
+        const showResult = active()
+        // Publishing the saved revision invalidates its preview; retain the successful receipt.
         controller.replace(result.item)
         onItemChange(result.item)
+        const published = controller.getSnapshot()
+        if (
+          showResult &&
+          published.generation === generation &&
+          published.item?.id === current.id &&
+          published.item.metadataRevision === result.item.metadataRevision
+        )
+          setCompletion(result)
+      } else if (active()) {
+        setCompletion(result)
+        setOverwriteFields(new Set())
       }
     } catch {
       if (active())

--- a/src/renderer/src/pages/literature/useLiteratureMetadata.ts
+++ b/src/renderer/src/pages/literature/useLiteratureMetadata.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react'
+import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import type {
@@ -19,6 +19,11 @@ const useLiteratureMetadata = (
   mode: DetailMode
   changeMode: (mode: DetailMode) => void
   saving: boolean
+  editBase?: LiteratureItemView
+  awaitingReload: boolean
+  externallyUpdated: () => boolean
+  reloadSaved: () => Promise<void>
+  loadLatest: () => void
   error?: string
   completion?: LiteratureMetadataCompletionResult
   completing: boolean
@@ -30,6 +35,10 @@ const useLiteratureMetadata = (
   complete: (mode: 'commit' | 'preview', identifier?: LiteratureMetadataIdentifier) => Promise<void>
 } => {
   const { t } = useTranslation()
+  const [editBase, setEditBase] = useState<LiteratureItemView>()
+  const [awaitingReload, setAwaitingReload] = useState(false)
+  const requestRef = useRef(0)
+  const completionRequestRef = useRef(0)
   const [mode, setMode] = useState<DetailMode>('view')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string>()
@@ -42,6 +51,8 @@ const useLiteratureMetadata = (
   const identifierRef = useRef<LiteratureMetadataIdentifier>(undefined)
 
   const resetCompletion = useCallback((): void => {
+    completionRequestRef.current += 1
+    setCompleting(false)
     setCompletion(undefined)
     setCompletionError(undefined)
     setOverwriteFields((current) => (current.size === 0 ? current : new Set()))
@@ -50,18 +61,72 @@ const useLiteratureMetadata = (
 
   const changeMode = useCallback(
     (next: DetailMode): void => {
+      requestRef.current += 1
+      setSaving(false)
+      setAwaitingReload(false)
+      setEditBase(next === 'edit' ? controller.getSnapshot().item : undefined)
       setError(undefined)
       if (next === 'complete' || next === 'view') resetCompletion()
       setMode(next)
     },
-    [resetCompletion]
+    [controller, resetCompletion]
   )
 
+  useLayoutEffect(() => {
+    let generation = controller.getSnapshot().generation
+    const unsubscribe = controller.subscribe(() => {
+      const next = controller.getSnapshot().generation
+      if (next === generation) return
+      generation = next
+      changeMode('view')
+    })
+    return () => {
+      unsubscribe()
+      requestRef.current += 1
+      completionRequestRef.current += 1
+    }
+  }, [controller, changeMode])
+
+  const externallyUpdated = (): boolean =>
+    Boolean(
+      editBase &&
+      (controller.getSnapshot().item?.metadataRevision ?? -1) > editBase.metadataRevision
+    )
+
+  const reloadSaved = async (): Promise<void> => {
+    const current = controller.getSnapshot()
+    if (!current.item || saving) return
+    const request = ++requestRef.current
+    const active = (): boolean =>
+      controller.getSnapshot().generation === current.generation && requestRef.current === request
+    setSaving(true)
+    try {
+      const updated = await window.api.literature.get(current.item.id)
+      if (!updated) throw new Error('Literature Item is unavailable after updating.')
+      onItemChange(updated)
+      if (active()) {
+        controller.replace(updated)
+        changeMode('view')
+      }
+    } catch {
+      if (active()) setError(t('The reference was saved, but could not be reloaded.'))
+    } finally {
+      if (active()) setSaving(false)
+    }
+  }
+
   const save = async (item: LiteratureItemInput): Promise<void> => {
-    const current = controller.getSnapshot().item
-    if (!current || saving) return
+    const current = editBase
+    if (!current || saving || awaitingReload || externallyUpdated()) return
+    const generation = controller.getSnapshot().generation
+    const request = ++requestRef.current
+    const active = (): boolean =>
+      controller.getSnapshot().generation === generation &&
+      controller.getSnapshot().item?.id === current.id &&
+      requestRef.current === request
     setSaving(true)
     setError(undefined)
+    let persisted = false
     try {
       await window.api.literature.transact({
         kind: 'update-item',
@@ -69,17 +134,37 @@ const useLiteratureMetadata = (
         expectedMetadataRevision: current.metadataRevision,
         item
       })
+      persisted = true
       const updated = await window.api.literature.get(current.id)
       if (!updated) throw new Error('Literature Item is unavailable after updating.')
-      controller.replace(updated)
       onItemChange(updated)
-      if (controller.getSnapshot().item?.id === current.id) setMode('view')
+      if (active()) {
+        controller.replace(updated)
+        changeMode('view')
+      }
     } catch {
-      if (controller.getSnapshot().item?.id === current.id) {
-        setError(t('Literature could not be updated.'))
+      if (active()) {
+        setAwaitingReload(persisted)
+        setError(
+          persisted
+            ? t('The reference was saved, but could not be reloaded.')
+            : t('Literature could not be updated.')
+        )
+      }
+      if (!persisted) {
+        // Read the conflicting version without rebasing the user's whole draft onto it.
+        try {
+          const latest = await window.api.literature.get(current.id)
+          if (latest) {
+            onItemChange(latest)
+            if (active()) controller.replace(latest)
+          }
+        } catch {
+          /* Keep the draft and original error when the follow-up read also fails. */
+        }
       }
     } finally {
-      setSaving(false)
+      if (active()) setSaving(false)
     }
   }
 
@@ -90,6 +175,12 @@ const useLiteratureMetadata = (
     const current = controller.getSnapshot().item
     const identifier = nextIdentifier ?? identifierRef.current
     if (!current || !identifier?.value || completing) return
+    const generation = controller.getSnapshot().generation
+    const request = ++completionRequestRef.current
+    const active = (): boolean =>
+      controller.getSnapshot().generation === generation &&
+      controller.getSnapshot().item?.id === current.id &&
+      completionRequestRef.current === request
     identifierRef.current = identifier
     setCompleting(true)
     setCompletionError(undefined)
@@ -106,23 +197,32 @@ const useLiteratureMetadata = (
               overwriteFields: [...overwriteFields]
             }
       )
-      if (controller.getSnapshot().item?.id === current.id) {
+      if (active()) {
         setCompletion(result)
         if (result.mode === 'preview') setOverwriteFields(new Set())
       }
       if (result.mode === 'commit') {
-        controller.replace(result.item)
+        if (active()) controller.replace(result.item)
         onItemChange(result.item)
       }
     } catch {
-      setCompletionError({ itemId: current.id, message: t('Metadata could not be completed.') })
+      if (active())
+        setCompletionError({ itemId: current.id, message: t('Metadata could not be completed.') })
     } finally {
-      setCompleting(false)
+      if (active()) setCompleting(false)
     }
   }
 
   return {
     mode,
+    editBase,
+    awaitingReload,
+    externallyUpdated,
+    reloadSaved,
+    loadLatest: () => {
+      setEditBase(controller.getSnapshot().item)
+      setError(undefined)
+    },
     changeMode,
     saving,
     error,

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -102,6 +102,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "Wählen Sie für diese Aufgabe höchstens {{limit}} Referenzen aus.",
+    "This reference changed while you were editing. Your draft has been kept.": "Diese Referenz wurde während der Bearbeitung geändert. Ihr Entwurf wurde beibehalten.",
+    "Discard this draft and load the latest saved metadata.": "Diesen Entwurf verwerfen und die zuletzt gespeicherten Metadaten laden.",
     "Identifiers (★ primary)": "Identifikatoren (★ primär)",
     "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
     "The reference was saved, but could not be reloaded.": "Die Referenz wurde gespeichert, konnte aber nicht neu geladen werden.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -103,6 +103,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "Seleccione como máximo {{limit}} referencias para esta tarea.",
+    "This reference changed while you were editing. Your draft has been kept.": "Esta referencia cambió mientras la editaba. Se ha conservado su borrador.",
+    "Discard this draft and load the latest saved metadata.": "Descartar este borrador y cargar los últimos metadatos guardados.",
     "Identifiers (★ primary)": "Identificadores (★ principal)",
     "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
     "The reference was saved, but could not be reloaded.": "La referencia se guardó, pero no se pudo volver a cargar.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -103,6 +103,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "Sélectionnez au maximum {{limit}} références pour cette tâche.",
+    "This reference changed while you were editing. Your draft has been kept.": "Cette référence a été modifiée pendant votre saisie. Votre brouillon a été conservé.",
+    "Discard this draft and load the latest saved metadata.": "Abandonner ce brouillon et charger les dernières métadonnées enregistrées.",
     "Identifiers (★ primary)": "Identifiants (★ principal)",
     "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
     "The reference was saved, but could not be reloaded.": "La référence a été enregistrée, mais n’a pas pu être rechargée.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -101,6 +101,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "このタスクでは {{limit}} 件以下の文献を選択してください。",
+    "This reference changed while you were editing. Your draft has been kept.": "編集中にこの文献が変更されました。下書きは保持されています。",
+    "Discard this draft and load the latest saved metadata.": "この下書きを破棄して、最後に保存されたメタデータを読み込みます。",
     "Identifiers (★ primary)": "識別子（★ 主要）",
     "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
     "The reference was saved, but could not be reloaded.": "文献は保存されましたが、再読み込みできませんでした。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -101,6 +101,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "이 작업에는 문헌을 {{limit}}개 이하로 선택하세요.",
+    "This reference changed while you were editing. Your draft has been kept.": "편집 중에 이 문헌이 변경되었습니다. 초안은 유지되었습니다.",
+    "Discard this draft and load the latest saved metadata.": "이 초안을 버리고 최근 저장된 메타데이터를 불러옵니다.",
     "Identifiers (★ primary)": "식별자(★ 기본)",
     "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
     "The reference was saved, but could not be reloaded.": "참고 문헌은 저장되었지만 다시 불러오지 못했습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -104,6 +104,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "Выберите не более {{limit}} источников для этой задачи.",
+    "This reference changed while you were editing. Your draft has been kept.": "Эта публикация изменилась во время редактирования. Ваш черновик сохранён.",
+    "Discard this draft and load the latest saved metadata.": "Отбросить этот черновик и загрузить последние сохранённые метаданные.",
     "Identifiers (★ primary)": "Идентификаторы (★ основной)",
     "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
     "The reference was saved, but could not be reloaded.": "Источник сохранён, но его не удалось загрузить повторно.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -101,6 +101,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "此任务最多支持 {{limit}} 篇文献，请调整选择。",
+    "This reference changed while you were editing. Your draft has been kept.": "您编辑期间此文献已更改。您的草稿已保留。",
+    "Discard this draft and load the latest saved metadata.": "放弃此草稿并加载最新保存的元数据。",
     "Identifiers (★ primary)": "标识符（★ 主标识）",
     "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
     "The reference was saved, but could not be reloaded.": "文献已保存，但无法重新加载。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -101,6 +101,8 @@
   },
   "renderer": {
     "Select no more than {{limit}} references for this task.": "此任務最多支援 {{limit}} 篇文獻，請調整選取範圍。",
+    "This reference changed while you were editing. Your draft has been kept.": "您編輯期間此文獻已變更。您的草稿已保留。",
+    "Discard this draft and load the latest saved metadata.": "捨棄此草稿並載入最新儲存的中繼資料。",
     "Identifiers (★ primary)": "識別碼（★ 主要識別碼）",
     "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
     "The reference was saved, but could not be reloaded.": "文獻已儲存，但無法重新載入。",


### PR DESCRIPTION
## Problem

A delayed detail save or metadata lookup can update a later opening of the same reference. Link loading can also replace a reference the user selected more recently. Detail saves leave the page cache stale, background completion leaves the detail stale, and a committed save whose readback fails offers another write against the obsolete revision.

## Proposed change

Track detail opening generations and navigation intent, reject obsolete UI callbacks and older metadata snapshots, and route detail saves through the existing page cache. Publish fetched background results to the current detail, including references outside the displayed page. Keep relationship operations on their existing semantic update paths. Authoritative inline/background/save/completion data updates follow item identity and revision across openings; modes, errors and previews remain scoped to the originating operation. Successful PDF imports re-read the current item before publishing attachments. Background reads publish successful results even if another completed item cannot be read, retaining the existing error and Retry surface. Metadata revision changes clear obsolete previews and pending lookup results while retaining the identifier input for a fresh search; same-revision attachment updates preserve previews. Successful completion receipts remain visible.

Retain the editing snapshot and draft when metadata changes externally. Saving stays blocked until the user explicitly chooses to discard the draft and load the latest metadata. Distinguish a committed save from a failed readback: keep the submitted fields and offer read-only Retry instead of another transaction. Add translated recovery copy in all eight locales and use the existing ErrorNotice surface.

## Scope and non-goals

Renderer state and existing catalog API usage only. Added generation, request and recovery bookkeeping is memory-only. No database, persisted enum, data relationship, migration, historical compatibility layer, persistent draft or automatic merge. Existing optimistic revision checks remain authoritative.

## Acceptance criteria and validation

- Mounted-page regressions control the existing API boundary; the original six failure scenarios failed twice on untouched production code before repair. The expanded final tests were replayed twice with base production files: the same 11 regressions failed and two controls passed. Six additional review regressions for valid late data publication and one partial-background-read regression failed twice before repair and now pass. Two preview/revision regressions also failed twice before repair; an attachment-only update control verifies preview preservation. These are renderer integration tests, not a two-window end-to-end claim.
- Detail lifecycle, draft retention, navigation, read-only recovery, background publication, cache reentry and editor/import/full-text consumers -> `npx vitest run src/renderer/src/pages/literature src/renderer/src/i18n/resources.test.ts --maxWorkers=1` -> 1,103 passed.
- Renderer interfaces -> `npm run typecheck:web` -> passed.
- Source conventions -> `npm run lint` -> passed.
- Existing real SQLite optimistic revision contract -> targeted `catalog.test.ts` test `updates citation metadata atomically with optimistic revision checks` -> passed.
- Controlled browser verification with real page components: saved-but-unloaded Retry restores the detail; background updates retain the draft; loading latest replaces the draft only after the explicit action. Screenshots were inspected, including notice bounds inside the dialog and a revision change clearing the preview while keeping the identifier and Search usable.

The final renderer/i18n suite, typecheck and lint run after the last material edit. An earlier parallel module run failed two existing pagination/reading cases; both passed in the focused rerun and the full sequential module rerun without changing their tests.

The local impact explainer reports an unknown module owner for the literature controller and therefore selects a full fallback. Per maintainer instruction, no full local suite was run: the explicit local set includes all literature renderer consumers and the i18n guard; PR CI remains authoritative for full/platform coverage. No main/preload runtime or persisted contract changed. Actual multi-window and packaged cross-platform behavior were not exercised locally.

## Review focus

Please check that stale writes still update the cache without changing a newer opening, recovery never resubmits an acknowledged transaction, background refresh preserves an editor's original draft/revision, and same-revision relationship updates remain accepted.

Rebased onto main at b5a3df4c. The PDF import conflict keeps main's specific error copy and this PR's generation guard. Local Prisma Client was regenerated to match main; no schema change is part of this PR. The first module run had a timeout in an existing project export test; its focused rerun and the final sequential module run passed without changing code or tests.

Latest rebase: main c9e66afd. Additive locale conflicts retain both main and PR entries. Final module/i18n count is 1,103 passed; web typecheck and lint passed. Functional patches are unchanged.
