### PR TITLE
fix(literature): tolerate preference failures and validate batch capacity

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -3878,15 +3878,28 @@ describe('notebook runtime service', () => {
       }
     )
 
-    it.each(['linux', 'win32'] as const)(
-      'recovers a lost background Shell receipt and idempotently cancels running work on %s',
-      async (platform) => {
+    it.each([
+      { platform: 'linux', dispatchDelayMs: 0 },
+      { platform: 'win32', dispatchDelayMs: 0 },
+      { platform: 'linux', dispatchDelayMs: 1500 }
+    ] as const)(
+      'recovers a lost background Shell receipt and idempotently cancels running work on $platform after $dispatchDelayMs ms dispatch delay',
+      async ({ platform, dispatchDelayMs }) => {
         const root = await createStorageRoot()
+        const executionStarted = createDeferred<void>()
+        const dispatchAllowed = createDeferred<void>()
+        const repository = new NotebookRunRepository(root)
+        const transitionRun = repository.transitionRun.bind(repository)
+        vi.spyOn(repository, 'transitionRun').mockImplementation(async (request) => {
+          if (dispatchDelayMs && request.run.status === 'running') await dispatchAllowed.promise
+          return transitionRun(request)
+        })
         let executions = 0
         const execute = vi.fn<NotebookShellProcess['execute']>(
           (request) =>
             new Promise((resolve) => {
               executions += 1
+              executionStarted.resolve()
               request.signal?.addEventListener(
                 'abort',
                 () =>
@@ -3904,7 +3917,7 @@ describe('notebook runtime service', () => {
           configRoot: root,
           dataRoot: root,
           projectId: 'default-project',
-          repository: new NotebookRunRepository(root),
+          repository,
           shellProcess: { execute },
           backgroundExecutionEnabled: true,
           platform
@@ -3920,10 +3933,26 @@ describe('notebook runtime service', () => {
         const first = await service.executeShellBackground(request)
         const recovered = await service.executeShellBackground(request)
 
-        expect(recovered.runId).toBe(first.runId)
-        await vi.waitFor(() => expect(executions).toBe(1))
-        await service.cancelBackgroundRun({ ...request, runId: first.runId })
-        expect(executions).toBe(1)
+        // Admission can precede dispatch by more than waitFor's one-second default.
+        const releaseDispatch = setTimeout(() => dispatchAllowed.resolve(), dispatchDelayMs)
+        try {
+          expect(recovered.runId).toBe(first.runId)
+          await executionStarted.promise
+          expect(executions).toBe(1)
+          await expect(
+            service.cancelBackgroundRun({ ...request, runId: first.runId })
+          ).resolves.toMatchObject({ run: { status: 'cancelled' } })
+          await expect(
+            service.cancelBackgroundRun({ ...request, runId: first.runId })
+          ).resolves.toMatchObject({ run: { status: 'cancelled' } })
+          expect(executions).toBe(1)
+        } finally {
+          clearTimeout(releaseDispatch)
+          dispatchAllowed.resolve()
+          await executionStarted.promise
+          await service.cancelBackgroundRun({ ...request, runId: first.runId })
+          await service.waitForBackgroundRun(first.runId)
+        }
       }
     )
 

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -2,6 +2,7 @@
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { literatureJobRequestSchema } from '../../../../shared/literature-jobs'
 import {
   LITERATURE_IMPORT_IDENTITY_CONFLICT,
   literatureCatalogCommandSchema
@@ -445,6 +446,198 @@ describe('LiteratureLibraryPage', () => {
     transact.mockReset().mockResolvedValue({ kind: 'item', id: 'item-1', state: 'present' })
     vi.unstubAllGlobals()
   })
+
+  it('TB-E1 trashes all 26 members despite an update between target reads', async () => {
+    const { mkdtemp, rm } = await import('node:fs/promises')
+    const { tmpdir } = await import('node:os')
+    const { join } = await import('node:path')
+    const { createProjectDbClient } = await import('../../../../main/projects/prisma-client')
+    const { migrateApplicationDatabase } =
+      await import('../../../../main/database/migration-service')
+    const { LiteratureCatalog } = await import('../../../../main/literature/catalog')
+    const root = await mkdtemp(join(tmpdir(), 'literature-batch-membership-'))
+    const client = createProjectDbClient(root)
+    try {
+      await migrateApplicationDatabase(client)
+      const catalog = new LiteratureCatalog(async () => client)
+      const { itemIds } = await catalog.importItems(
+        Array.from({ length: 26 }, (_, index) => ({
+          ...libraryItem.item,
+          title: `Member ${index}`,
+          identifiers: []
+        }))
+      )
+      const initial = await catalog.search({ scope: 'library', sortBy: 'updated', limit: 100 })
+      const lastId = (initial.entries[25] as LiteratureItemView).id
+      let resolving = false
+      let edited = false
+      const edit = async (): Promise<void> => {
+        edited = true
+        const view = (await catalog.get(lastId))!
+        await catalog.transact({
+          kind: 'update-item',
+          itemId: lastId,
+          expectedMetadataRevision: view.metadataRevision,
+          item: { ...view.item, abstract: 'Concurrent metadata edit' }
+        })
+      }
+      // Use the actual catalog API, bypassing the legacy fixture pagination adapter.
+      window.api.literature.search = async (request) => {
+        if (resolving && !edited && request.scope === 'library' && request.offset === 25)
+          await edit()
+        const page = await catalog.search(request)
+        if (resolving && !edited && request.allItemIds) await edit()
+        return page
+      }
+      transact.mockImplementation((command) => catalog.transact(command))
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      fireEvent.click(await screen.findByLabelText('Select all references'))
+      fireEvent.click(screen.getByRole('button', { name: 'Select all matching references 26' }))
+      resolving = true
+      const toolbar = document.querySelector<HTMLElement>(
+        '[data-slot="literature-selection-toolbar"]'
+      )!
+      await openMenu(within(toolbar).getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Move to Trash' }))
+      await waitFor(() => expect(screen.queryByText('26 selected')).toBeNull())
+      expect(edited).toBe(true)
+      const deleted = await client.literatureItem.findMany({ where: { deletedAt: { not: null } } })
+      expect(deleted.map(({ id }) => id).sort()).toEqual([...itemIds].sort())
+      expect(await client.literatureItem.count({ where: { deletedAt: null } })).toBe(0)
+    } finally {
+      cleanup()
+      await client.$disconnect()
+      await rm(root, { recursive: true, force: true })
+    }
+  }, 120000)
+
+  it('TB-01 keeps the real page usable when preference writes fail', async () => {
+    search.mockImplementation(async ({ scope }) =>
+      scope === 'library' ? { entries: [libraryItem], totalCount: 1 } : { entries: [] }
+    )
+    const original = window.localStorage.setItem.bind(window.localStorage)
+    const write = vi
+      .spyOn(window.localStorage, 'setItem')
+      .mockImplementation(function (key, value) {
+        if (key === 'open-science:literature-table-preferences')
+          throw new DOMException('Injected preference quota', 'QuotaExceededError')
+        original(key, value)
+      })
+    try {
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await screen.findByText(libraryItem.item.title)
+      fireEvent.click(screen.getByRole('button', { name: 'Customize' }))
+      fireEvent.click(await screen.findByRole('checkbox', { name: 'Notes' }))
+      expect(screen.getByRole('columnheader', { name: 'Notes' })).not.toBeNull()
+      const attempts = write.mock.calls.length
+      await act(async () => {})
+      expect(write.mock.calls.length).toBe(attempts)
+    } finally {
+      write.mockRestore()
+    }
+  })
+
+  it.each([true, false])(
+    'TB-03 preserves external columns when storage event delivered: %s',
+    async (deliverEvent) => {
+      localStorage.setItem(
+        'open-science:literature-table-preferences',
+        JSON.stringify({ order: [], visible: ['year'] })
+      )
+      search.mockImplementation(async ({ scope }) =>
+        scope === 'library' ? { entries: [libraryItem], totalCount: 1 } : { entries: [] }
+      )
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await screen.findByText(libraryItem.item.title)
+      const key = 'open-science:literature-table-preferences'
+      const stored = JSON.parse(localStorage.getItem(key)!)
+      const value = JSON.stringify({ ...stored, visible: [...stored.visible, 'abstract'] })
+      act(() => {
+        localStorage.setItem(key, value)
+        const event = new StorageEvent('storage', { key, newValue: value })
+        Object.defineProperty(event, 'storageArea', { value: window.localStorage })
+        if (deliverEvent) window.dispatchEvent(event)
+      })
+      if (deliverEvent)
+        expect.soft(screen.queryByRole('columnheader', { name: 'Abstract' })).not.toBeNull()
+      fireEvent.click(screen.getByRole('button', { name: 'Customize' }))
+      fireEvent.click(await screen.findByRole('checkbox', { name: 'Notes' }))
+      expect(JSON.parse(localStorage.getItem(key)!).visible).toEqual(
+        expect.arrayContaining(['abstract', 'notes'])
+      )
+    }
+  )
+
+  it('TB-04 exposes mixed selection for the visible page', async () => {
+    search.mockImplementation(async ({ scope }) =>
+      scope === 'library'
+        ? { entries: [createLibraryItem(1), createLibraryItem(2)], totalCount: 2 }
+        : { entries: [] }
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const all = (await screen.findByLabelText('Select all references')) as HTMLInputElement
+    const rows = screen.getAllByRole('checkbox').filter((input) => input !== all)
+    fireEvent.click(rows[0]!)
+    expect(screen.getByText('1 selected')).not.toBeNull()
+    expect(all.checked).toBe(false)
+    expect(all.indeterminate).toBe(true)
+    fireEvent.click(all)
+    expect(all.checked).toBe(true)
+    expect(all.indeterminate).toBe(false)
+    fireEvent.click(all)
+    expect(all.checked).toBe(false)
+    expect(all.indeterminate).toBe(false)
+  })
+
+  it.each(
+    ['Complete metadata', 'Find full-text PDF'].flatMap((action) =>
+      [1000, 1001].map((count) => ({ action, count }))
+    )
+  )(
+    'TB-02 $action validates $count matching references before creating a job',
+    async ({ action, count }) => {
+      const items = Array.from({ length: count }, (_, index) => createLibraryItem(index))
+      search.mockImplementation(async (request) => {
+        if (request.scope !== 'library') return { entries: [] }
+        if (request.allItemIds)
+          return { entries: [], itemIds: items.map(({ id }) => id), totalCount: count }
+        return { entries: items.slice(0, 25), totalCount: count, nextOffset: 25 }
+      })
+      const jobs = vi.mocked(window.api.literature.jobs)
+      jobs.mockImplementation(async (request) => {
+        literatureJobRequestSchema.parse(request)
+        return { jobs: [], summaries: [] }
+      })
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      fireEvent.click(await screen.findByLabelText('Select all references'))
+      fireEvent.click(
+        screen.getByRole('button', { name: new RegExp('^Select all matching references') })
+      )
+      const toolbar = document.querySelector<HTMLElement>(
+        '[data-slot="literature-selection-toolbar"]'
+      )!
+      await openMenu(within(toolbar).getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: action }))
+      await act(async () => {})
+      if (count > 1000) {
+        expect(
+          screen.queryByText('Select no more than 1000 references for this task.')
+        ).not.toBeNull()
+        expect(jobs.mock.calls.filter(([r]) => r.action === 'create')).toHaveLength(0)
+        expect(screen.queryByRole('dialog')).toBeNull()
+      } else {
+        expect(jobs.mock.calls.filter(([r]) => r.action === 'create')).toHaveLength(1)
+        const request = jobs.mock.calls.find(([r]) => r.action === 'create')![0]
+        expect(literatureJobRequestSchema.safeParse(request).success).toBe(true)
+        expect(request.action === 'create' && request.itemIds.length).toBe(1000)
+      }
+    }
+  )
 
   it('shows the load error after the initial Inbox request settles', async () => {
     search.mockImplementation((request: LiteratureCatalogSearchRequest) =>

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1,5 +1,6 @@
 import type { TFunction } from 'i18next'
 import { LiteratureAttachments } from './LiteratureAttachments'
+import { LITERATURE_JOB_MAX_ITEMS } from '../../../../shared/literature-jobs'
 import {
   LITERATURE_COLLECTION_NAME_CONFLICT,
   LITERATURE_IMPORT_IDENTITY_CONFLICT
@@ -413,18 +414,21 @@ const LiteratureSelectPageCheckbox = ({
   label: string
   store: LiteratureSelectionStore
 }>): React.JSX.Element => {
-  const allSelected = useSyncExternalStore(
+  const selectedCount = useSyncExternalStore(
     store.subscribe,
     () => {
       const snapshot = store.getSnapshot()
-      return (
-        itemIds.length > 0 && itemIds.every((itemId) => isLiteratureItemSelected(snapshot, itemId))
-      )
+      return itemIds.filter((itemId) => isLiteratureItemSelected(snapshot, itemId)).length
     },
-    () => false
+    () => 0
   )
+  const allSelected = itemIds.length > 0 && selectedCount === itemIds.length
+  const mixed = selectedCount > 0 && !allSelected
   return (
     <input
+      ref={(input) => {
+        if (input) input.indeterminate = mixed
+      }}
       type="checkbox"
       checked={allSelected}
       disabled={disabled}
@@ -1435,12 +1439,59 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     }
   }, [])
 
+  const previousTablePreferences = useRef(initialTablePreferences)
   useEffect(() => {
-    window.localStorage.setItem(
-      LITERATURE_TABLE_PREFERENCES_KEY,
-      JSON.stringify({ order: tableColumnOrder, visible: [...visibleTableColumns] })
+    const previous = previousTablePreferences.current
+    const local = { order: tableColumnOrder, visible: [...visibleTableColumns] }
+    // External updates have already been adopted; do not echo them to other windows.
+    if (
+      local.order === previous.order &&
+      local.visible.length === previous.visible.length &&
+      local.visible.every((column) => previous.visible.includes(column))
     )
+      return
+    const latest = loadLiteratureTablePreferences()
+    const visible = new Set(latest.visible)
+    for (const column of literatureTableColumns) {
+      if (visibleTableColumns.has(column) !== previous.visible.includes(column)) {
+        if (visibleTableColumns.has(column)) visible.add(column)
+        else visible.delete(column)
+      }
+    }
+    const merged = {
+      order: tableColumnOrder === previous.order ? latest.order : tableColumnOrder,
+      visible: [...visible]
+    }
+    try {
+      window.localStorage.setItem(LITERATURE_TABLE_PREFERENCES_KEY, JSON.stringify(merged))
+    } catch {
+      // Non-critical preferences remain usable in memory; retry only on another edit.
+      return
+    }
+    previousTablePreferences.current = merged
+    if (merged.order !== tableColumnOrder) setTableColumnOrder(merged.order)
+    if (
+      merged.visible.length !== local.visible.length ||
+      merged.visible.some((column) => !visibleTableColumns.has(column))
+    )
+      setVisibleTableColumns(visible)
   }, [tableColumnOrder, visibleTableColumns])
+
+  useEffect(() => {
+    const onStorage = (event: StorageEvent): void => {
+      if (
+        event.storageArea !== window.localStorage ||
+        (event.key !== null && event.key !== LITERATURE_TABLE_PREFERENCES_KEY)
+      )
+        return
+      const preferences = loadLiteratureTablePreferences()
+      previousTablePreferences.current = preferences
+      setTableColumnOrder(preferences.order)
+      setVisibleTableColumns(new Set(preferences.visible))
+    }
+    window.addEventListener('storage', onStorage)
+    return () => window.removeEventListener('storage', onStorage)
+  }, [])
 
   useEffect(() => {
     if (!projectsLoaded) void loadProjects()
@@ -2659,6 +2710,14 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     setError(undefined)
     try {
       const itemIds = await resolveSelectedItemIds()
+      if (itemIds.length > LITERATURE_JOB_MAX_ITEMS) {
+        setError(
+          t('Select no more than {{limit}} references for this task.', {
+            limit: LITERATURE_JOB_MAX_ITEMS
+          })
+        )
+        return
+      }
       if (itemIds.length) setBatchLookup({ mode, itemIds })
     } catch {
       setError(t('Selected references could not be loaded.'))

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -101,6 +101,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "Wählen Sie für diese Aufgabe höchstens {{limit}} Referenzen aus.",
     "Identifiers (★ primary)": "Identifikatoren (★ primär)",
     "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
     "The reference was saved, but could not be reloaded.": "Die Referenz wurde gespeichert, konnte aber nicht neu geladen werden.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "Seleccione como máximo {{limit}} referencias para esta tarea.",
     "Identifiers (★ primary)": "Identificadores (★ principal)",
     "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
     "The reference was saved, but could not be reloaded.": "La referencia se guardó, pero no se pudo volver a cargar.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "Sélectionnez au maximum {{limit}} références pour cette tâche.",
     "Identifiers (★ primary)": "Identifiants (★ principal)",
     "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
     "The reference was saved, but could not be reloaded.": "La référence a été enregistrée, mais n’a pas pu être rechargée.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "このタスクでは {{limit}} 件以下の文献を選択してください。",
     "Identifiers (★ primary)": "識別子（★ 主要）",
     "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
     "The reference was saved, but could not be reloaded.": "文献は保存されましたが、再読み込みできませんでした。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "이 작업에는 문헌을 {{limit}}개 이하로 선택하세요.",
     "Identifiers (★ primary)": "식별자(★ 기본)",
     "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
     "The reference was saved, but could not be reloaded.": "참고 문헌은 저장되었지만 다시 불러오지 못했습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -103,6 +103,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "Выберите не более {{limit}} источников для этой задачи.",
     "Identifiers (★ primary)": "Идентификаторы (★ основной)",
     "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
     "The reference was saved, but could not be reloaded.": "Источник сохранён, но его не удалось загрузить повторно.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "此任务最多支持 {{limit}} 篇文献，请调整选择。",
     "Identifiers (★ primary)": "标识符（★ 主标识）",
     "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
     "The reference was saved, but could not be reloaded.": "文献已保存，但无法重新加载。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "Select no more than {{limit}} references for this task.": "此任務最多支援 {{limit}} 篇文獻，請調整選取範圍。",
     "Identifiers (★ primary)": "識別碼（★ 主要識別碼）",
     "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
     "The reference was saved, but could not be reloaded.": "文獻已儲存，但無法重新載入。",

--- a/src/shared/literature-jobs.ts
+++ b/src/shared/literature-jobs.ts
@@ -7,6 +7,8 @@ import {
 } from './literature'
 import { defineApplicationCommandContract, validationCodec } from './application-command-contract'
 
+export const LITERATURE_JOB_MAX_ITEMS = 1000
+
 const id = z.string().trim().min(1).max(512)
 export const literatureJobRowSchema = z
   .object({
@@ -26,9 +28,9 @@ export const literatureJobSchema = z
     id,
     mode: z.enum(['metadata', 'full-text']),
     phase: z.enum(['search', 'apply']),
-    phaseItemIds: z.array(id).max(1000).optional(),
+    phaseItemIds: z.array(id).max(LITERATURE_JOB_MAX_ITEMS).optional(),
     state: z.enum(['queued', 'running', 'pausing', 'paused', 'review', 'completed']),
-    rows: z.array(literatureJobRowSchema).min(1).max(1000),
+    rows: z.array(literatureJobRowSchema).min(1).max(LITERATURE_JOB_MAX_ITEMS),
     createdAt: z.number().finite(),
     updatedAt: z.number().finite(),
     progress: z.object({ itemId: id, value: literatureFullTextProgressSchema }).optional()
@@ -40,7 +42,7 @@ export const literatureJobRequestSchema = z.discriminatedUnion('action', [
     .object({
       action: z.literal('create'),
       mode: z.enum(['metadata', 'full-text']),
-      itemIds: z.array(id).min(1).max(1000),
+      itemIds: z.array(id).min(1).max(LITERATURE_JOB_MAX_ITEMS),
       requestId: z.string().uuid()
     })
     .strict(),
@@ -58,7 +60,7 @@ export const literatureJobRequestSchema = z.discriminatedUnion('action', [
       selections: z
         .array(z.object({ itemId: id, checked: z.boolean(), candidateId: id.optional() }).strict())
         .min(1)
-        .max(1000)
+        .max(LITERATURE_JOB_MAX_ITEMS)
     })
     .strict(),
   z
@@ -68,7 +70,7 @@ export const literatureJobRequestSchema = z.discriminatedUnion('action', [
       selections: z
         .array(z.object({ itemId: id, candidateId: id.optional() }).strict())
         .min(1)
-        .max(1000)
+        .max(LITERATURE_JOB_MAX_ITEMS)
     })
     .strict()
 ])


### PR DESCRIPTION
Literature table preferences can currently throw during page mount when storage writes fail, and another window's column changes can be overwritten by a stale local snapshot. Bulk lookup also accepts selections that exceed the task API's 1,000-reference limit, while partial page selection has no mixed checkbox state.

This change:
- Keeps preferences usable in memory after a failed write, skips unnecessary mount writes, and retries only after another edit.
- Adopts external storage changes without echoing them and merges independent column visibility edits against the latest stored preferences. This remains lightweight preference synchronization, without atomic concurrent-write guarantees.
- Rejects oversized metadata/full-text selections before creating a task, preserves selection, and displays a translated limit message in all eight locales. Exactly 1,000 references remain supported; nothing is silently truncated.
- Sets the native page checkbox's indeterminate state from visible page members.
- Adds a real SQLite regression for moving all 26 selected references to Trash despite a concurrent metadata update. The existing membership snapshot fix already handles this; no additional production change is needed for that case.

No database migration, data-model change, or dependency is introduced.

Validation:
- Nine real-page regression/boundary cases. Reported failures were reproduced before fixing; the historical offset resolver repeatedly processed only 25 of 26 records, while the current snapshot resolver processes all 26.
- After rebasing: 20 test files / 1,072 tests passed across literature renderer tests, i18n guards, shared literature contracts, and duplicate catalog tests. Low-concurrency rerun used a 60-second test timeout; the SQLite regression uses the existing database test convention of 120 seconds after a loaded-machine timeout.
- Web typecheck, changed-file ESLint, and diff whitespace checks passed.
- Earlier full suite: 27,719 passed, 11 failed in unchanged Office preview (8) and Micromamba sandbox (3) tests. Full suite is not claimed green.
