### PR TITLE
fix(literature): align search and restore capabilities

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -192,19 +192,19 @@ model SessionArtifactRef {
 }
 
 model PermissionGrant {
-  id             String    @id
-  capabilityKind String
-  capabilityKey  String
-  qualifierMode  String    @default("none")
-  qualifierValue String?
-  scopeKind      String
-  projectId      String?
-  sessionId      String?
+  id              String    @id
+  capabilityKind  String
+  capabilityKey   String
+  qualifierMode   String    @default("none")
+  qualifierValue  String?
+  scopeKind       String
+  projectId       String?
+  sessionId       String?
   approvalSummary String?
-  fingerprint    String    @unique
-  revision       Int       @default(1)
-  createdAt      DateTime?
-  project        Project?  @relation(fields: [projectId], references: [id], onDelete: Cascade)
+  fingerprint     String    @unique
+  revision        Int       @default(1)
+  createdAt       DateTime?
+  project         Project?  @relation(fields: [projectId], references: [id], onDelete: Cascade)
 
   @@index([capabilityKind, capabilityKey, qualifierMode, qualifierValue, scopeKind, projectId, sessionId])
   @@index([projectId, sessionId])
@@ -427,7 +427,7 @@ model ContentBlob {
   lastVerificationFailure      String?
   lastVerificationAttemptAt    DateTime?
   literatureAttachmentVersions LiteratureAttachmentVersion[]
-  literatureInboxPdfs           LiteratureInboxPdf[]
+  literatureInboxPdfs          LiteratureInboxPdf[]
 
   @@index([checksum, sizeBytes])
   @@index([state, createdAt])
@@ -436,37 +436,40 @@ model ContentBlob {
 // Mutable bibliographic identity. Item-specific fields that do not belong in the indexed core are
 // retained as validated JSON so Zotero-compatible imports can round-trip without a wide nullable table.
 model LiteratureItem {
-  id                      String                     @id @default(cuid())
-  itemType                String
-  title                   String
-  abstract                String                     @default("")
-  issuedText              String                     @default("")
-  issuedYear              Int?
-  containerTitle          String                     @default("")
-  shortTitle              String                     @default("")
-  language                String                     @default("")
-  rights                  String                     @default("")
-  url                     String                     @default("")
-  accessedAt              DateTime?
-  citationKey             String?
-  extra                   String                     @default("")
-  rating                  Int                        @default(0)
-  personalNote            String                     @default("")
-  typeFieldsJson          String                     @default("{}")
-  metadataRevision        Int                        @default(1)
-  createdAt               DateTime                   @default(now())
-  updatedAt               DateTime                   @updatedAt
-  deletedAt               DateTime?
-  mergedIntoItemId        String?
-  mergedInto              LiteratureItem?            @relation("LiteratureItemMerge", fields: [mergedIntoItemId], references: [id], onDelete: Restrict)
-  mergedItems             LiteratureItem[]           @relation("LiteratureItemMerge")
-  creators                LiteratureItemCreator[]
-  identifiers             LiteratureIdentifier[]
-  sourceRecords           LiteratureSourceRecord[]
-  collections             LiteratureCollectionItem[]
-  projects                ProjectLiterature[]
-  attachments             LiteratureAttachment[]
-  acceptedInboxCandidates LiteratureInboxCandidate[] @relation("AcceptedLiteratureItem")
+  normalizedTitle          String                     @default("")
+  normalizedAbstract       String                     @default("")
+  normalizedContainerTitle String                     @default("")
+  id                       String                     @id @default(cuid())
+  itemType                 String
+  title                    String
+  abstract                 String                     @default("")
+  issuedText               String                     @default("")
+  issuedYear               Int?
+  containerTitle           String                     @default("")
+  shortTitle               String                     @default("")
+  language                 String                     @default("")
+  rights                   String                     @default("")
+  url                      String                     @default("")
+  accessedAt               DateTime?
+  citationKey              String?
+  extra                    String                     @default("")
+  rating                   Int                        @default(0)
+  personalNote             String                     @default("")
+  typeFieldsJson           String                     @default("{}")
+  metadataRevision         Int                        @default(1)
+  createdAt                DateTime                   @default(now())
+  updatedAt                DateTime                   @updatedAt
+  deletedAt                DateTime?
+  mergedIntoItemId         String?
+  mergedInto               LiteratureItem?            @relation("LiteratureItemMerge", fields: [mergedIntoItemId], references: [id], onDelete: Restrict)
+  mergedItems              LiteratureItem[]           @relation("LiteratureItemMerge")
+  creators                 LiteratureItemCreator[]
+  identifiers              LiteratureIdentifier[]
+  sourceRecords            LiteratureSourceRecord[]
+  collections              LiteratureCollectionItem[]
+  projects                 ProjectLiterature[]
+  attachments              LiteratureAttachment[]
+  acceptedInboxCandidates  LiteratureInboxCandidate[] @relation("AcceptedLiteratureItem")
 
   @@index([deletedAt, updatedAt])
   @@index([mergedIntoItemId])
@@ -492,19 +495,19 @@ model LiteratureAttachment {
 }
 
 model LiteratureAttachmentVersion {
-  id            String               @id @default(cuid())
-  attachmentId  String
-  contentBlobId String
-  versionNumber Int
-  filename      String
-  contentType   String
-  sizeBytes     BigInt
+  id             String               @id @default(cuid())
+  attachmentId   String
+  contentBlobId  String
+  versionNumber  Int
+  filename       String
+  contentType    String
+  sizeBytes      BigInt
   provenanceJson String?
-  checksum      String
-  pageCount     Int?
-  createdAt     DateTime             @default(now())
-  attachment    LiteratureAttachment @relation(fields: [attachmentId], references: [id], onDelete: Cascade)
-  contentBlob   ContentBlob          @relation(fields: [contentBlobId], references: [id], onDelete: Restrict)
+  checksum       String
+  pageCount      Int?
+  createdAt      DateTime             @default(now())
+  attachment     LiteratureAttachment @relation(fields: [attachmentId], references: [id], onDelete: Cascade)
+  contentBlob    ContentBlob          @relation(fields: [contentBlobId], references: [id], onDelete: Restrict)
 
   @@unique([attachmentId, versionNumber])
   @@unique([attachmentId, checksum])
@@ -512,15 +515,16 @@ model LiteratureAttachmentVersion {
 }
 
 model LiteratureCreator {
-  id             String                  @id @default(cuid())
-  nameMode       String
-  givenName      String                  @default("")
-  familyName     String                  @default("")
-  literalName    String                  @default("")
-  normalizedName String
-  createdAt      DateTime                @default(now())
-  updatedAt      DateTime                @updatedAt
-  items          LiteratureItemCreator[]
+  normalizedDisplayName String                  @default("")
+  id                    String                  @id @default(cuid())
+  nameMode              String
+  givenName             String                  @default("")
+  familyName            String                  @default("")
+  literalName           String                  @default("")
+  normalizedName        String
+  createdAt             DateTime                @default(now())
+  updatedAt             DateTime                @updatedAt
+  items                 LiteratureItemCreator[]
 
   @@index([normalizedName])
 }
@@ -597,18 +601,18 @@ model LiteratureCandidateDiscovery {
 
 // Agent-acquired PDFs stay in Inbox until their reference is accepted.
 model LiteratureInboxPdf {
-  id            String @id @default(cuid())
-  candidateId   String
-  contentBlobId String
-  filename      String
-  sizeBytes     BigInt
+  id             String                   @id @default(cuid())
+  candidateId    String
+  contentBlobId  String
+  filename       String
+  sizeBytes      BigInt
   provenanceJson String?
-  checksum      String
-  pageCount     Int
-  sourceUrl     String
-  createdAt     DateTime @default(now())
-  candidate     LiteratureInboxCandidate @relation(fields: [candidateId], references: [id], onDelete: Cascade)
-  contentBlob   ContentBlob @relation(fields: [contentBlobId], references: [id], onDelete: Restrict)
+  checksum       String
+  pageCount      Int
+  sourceUrl      String
+  createdAt      DateTime                 @default(now())
+  candidate      LiteratureInboxCandidate @relation(fields: [candidateId], references: [id], onDelete: Cascade)
+  contentBlob    ContentBlob              @relation(fields: [contentBlobId], references: [id], onDelete: Restrict)
 
   @@unique([candidateId, checksum])
   @@index([contentBlobId])
@@ -1150,19 +1154,19 @@ model MemoryEntry {
 // Main-owned delivery facts for terminal background outcomes. This table records only delivery
 // workflow state; Notebook Run and Compute Job records remain the execution authorities.
 model BackgroundResultDelivery {
-  id                    String   @id
+  id                    String    @id
   sourceKind            String
   sourceId              String
   projectId             String
   sessionId             String
   agentFrameId          String?
   state                 String
-  attemptCount          Int      @default(0)
+  attemptCount          Int       @default(0)
   claimToken            String?
   claimExpiresAt        DateTime?
   continuationMessageId String?
-  createdAt             DateTime @default(now())
-  updatedAt             DateTime @updatedAt
+  createdAt             DateTime  @default(now())
+  updatedAt             DateTime  @updatedAt
 
   @@unique([sourceKind, sourceId])
   @@index([sessionId, state, createdAt, id])

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -152,6 +152,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0037_literature_inbox_integrity',
     checksum: 'b491ca823e4c79564cef7cefeeb555d1534c7e5bb676bdd228158fc4c7d4ddca'
+  },
+  {
+    id: '0038_literature_search_text',
+    checksum: '00ae0d9f8f84e7334563a423f0aa9eef90ff33f7e24af91d30e6eb10aad4f1b1'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -105,7 +105,7 @@ const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<v
 
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.slice(-15).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+    expect(MIGRATION_MANIFEST.slice(-16).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
@@ -165,6 +165,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0037_literature_inbox_integrity',
         checksum: 'b491ca823e4c79564cef7cefeeb555d1534c7e5bb676bdd228158fc4c7d4ddca'
+      },
+      {
+        id: '0038_literature_search_text',
+        checksum: '00ae0d9f8f84e7334563a423f0aa9eef90ff33f7e24af91d30e6eb10aad4f1b1'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -205,7 +209,7 @@ describe('packaged database migration ledger smoke', () => {
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
       )
 
       await migrateApplicationDatabase(client)
@@ -243,7 +247,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -279,7 +283,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -379,7 +383,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
@@ -462,7 +466,7 @@ describe('packaged database migration ledger smoke', () => {
            '0027_project_session_defaults',
            '0028_database_numeric_and_null_constraints',
            '0029_compute_host_execution_mode',
-           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity'
+           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0037_literature_inbox_integrity'
+const CURRENT_MIGRATION_ID = '0038_literature_search_text'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -309,7 +309,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -330,6 +330,7 @@ describe('agent memory project scope migration', () => {
       '0034_background_result_delivery',
       '0035_literature_pdf_provenance',
       '0036_content_verification_observation',
+      '0037_literature_inbox_integrity',
       CURRENT_MIGRATION_ID
     )
 
@@ -355,6 +356,7 @@ describe('agent memory project scope migration', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
+        '0037_literature_inbox_integrity',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -221,7 +221,8 @@ describe('application database (integration)', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
 
@@ -1288,7 +1289,8 @@ describe('application database (integration)', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -26,7 +26,7 @@ describe('Compute Job operation migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -46,8 +46,8 @@ describe('Compute Job operation migration', () => {
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 2`
       )
     ).resolves.toEqual([
-      { id: '0037_literature_inbox_integrity' },
-      { id: '0036_content_verification_observation' }
+      { id: '0038_literature_search_text' },
+      { id: '0037_literature_inbox_integrity' }
     ])
   })
 

--- a/src/main/database/compute-job-remote-cleanup-migration.test.ts
+++ b/src/main/database/compute-job-remote-cleanup-migration.test.ts
@@ -79,10 +79,11 @@ describe('Compute Job remote cleanup migration', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0025_managed_file_version_foundation',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -84,10 +84,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0015_session_model_call_usage',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/content-blob-migration.test.ts
+++ b/src/main/database/content-blob-migration.test.ts
@@ -78,7 +78,8 @@ describe('Content blob migration', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(
@@ -159,10 +160,11 @@ describe('Content blob migration', () => {
                 '0034_background_result_delivery',
                 '0035_literature_pdf_provenance',
                 '0036_content_verification_observation',
-                '0037_literature_inbox_integrity'
+                '0037_literature_inbox_integrity',
+                '0038_literature_search_text'
               ],
         from: schema === 'pre-ledger' ? null : '0029_compute_host_execution_mode',
-        to: '0037_literature_inbox_integrity'
+        to: '0038_literature_search_text'
       })
 
       await expect(

--- a/src/main/database/content-verification-observation.test.ts
+++ b/src/main/database/content-verification-observation.test.ts
@@ -28,7 +28,11 @@ it('adds unknown verification observations without changing historical content o
     'a'.repeat(64)
   )
   await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-    applied: ['0036_content_verification_observation', '0037_literature_inbox_integrity']
+    applied: [
+      '0036_content_verification_observation',
+      '0037_literature_inbox_integrity',
+      '0038_literature_search_text'
+    ]
   })
   expect(await client.contentBlob.findUnique({ where: { id: 'old' } })).toMatchObject({
     state: 'available',

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -176,10 +176,11 @@ describe('database JSON constraints migration', () => {
           '0034_background_result_delivery',
           '0035_literature_pdf_provenance',
           '0036_content_verification_observation',
-          '0037_literature_inbox_integrity'
+          '0037_literature_inbox_integrity',
+          '0038_literature_search_text'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0037_literature_inbox_integrity'
+        to: '0038_literature_search_text'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -376,9 +376,10 @@ describe('D02/D04 persisted database boundaries', () => {
           '0034_background_result_delivery',
           '0035_literature_pdf_provenance',
           '0036_content_verification_observation',
-          '0037_literature_inbox_integrity'
+          '0037_literature_inbox_integrity',
+          '0038_literature_search_text'
         ],
-        to: '0037_literature_inbox_integrity'
+        to: '0038_literature_search_text'
       })
       // Literature adds contentBlobId to version rows while preserving their original fields.
       expect(await Promise.all(tables.map(readRows))).toMatchObject(before)

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -129,7 +129,8 @@ describe('database startup logging', () => {
               '0034_background_result_delivery',
               '0035_literature_pdf_provenance',
               '0036_content_verification_observation',
-              '0037_literature_inbox_integrity'
+              '0037_literature_inbox_integrity',
+              '0038_literature_search_text'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -336,6 +336,9 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "ContentBlob_sizeBytes_check" CHECK ("sizeBytes" >= 0)
 );`,
   `CREATE TABLE IF NOT EXISTS "LiteratureItem" (
+    "normalizedTitle" TEXT NOT NULL DEFAULT '',
+    "normalizedAbstract" TEXT NOT NULL DEFAULT '',
+    "normalizedContainerTitle" TEXT NOT NULL DEFAULT '',
     "id" TEXT NOT NULL PRIMARY KEY,
     "itemType" TEXT NOT NULL,
     "title" TEXT NOT NULL,
@@ -391,6 +394,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "LiteratureAttachmentVersion_shape_check" CHECK ("versionNumber" >= 1 AND length(trim("filename")) > 0 AND length(trim("contentType")) > 0 AND "sizeBytes" >= 0 AND length("checksum") = 64 AND "checksum" NOT GLOB '*[^0-9a-f]*' AND ("pageCount" IS NULL OR "pageCount" >= 1))
 );`,
   `CREATE TABLE IF NOT EXISTS "LiteratureCreator" (
+    "normalizedDisplayName" TEXT NOT NULL DEFAULT '',
     "id" TEXT NOT NULL PRIMARY KEY,
     "nameMode" TEXT NOT NULL,
     "givenName" TEXT NOT NULL DEFAULT '',

--- a/src/main/database/literature-inbox-integrity-migration.test.ts
+++ b/src/main/database/literature-inbox-integrity-migration.test.ts
@@ -62,7 +62,7 @@ describe('Literature inbox integrity migration', () => {
       await client.$executeRawUnsafe(
         schema === 'pre-ledger released'
           ? 'DELETE FROM "_open_science_migrations"'
-          : 'DELETE FROM "_open_science_migrations" WHERE id = \'0037_literature_inbox_integrity\''
+          : 'DELETE FROM "_open_science_migrations" WHERE id >= \'0037_literature_inbox_integrity\''
       )
 
       expect(await migrateApplicationDatabase(client)).toMatchObject({

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -459,6 +459,107 @@ describe('application database migrations', () => {
     )
   })
 
+  it('backfills searchable literature text without changing historical metadata', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'literature-search-upgrade-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe('PRAGMA legacy_alter_table = ON')
+    await createDatabaseAtReleasedManifest(
+      client,
+      MIGRATION_MANIFEST.filter(({ id }) => id < '0038_literature_search_text')
+    )
+    await client.$executeRaw`INSERT INTO "LiteratureItem" (id, "itemType", title, abstract, "containerTitle", "metadataRevision", "updatedAt")
+      VALUES ('historical', 'book', 'ÉTUDE', '95% confidence gene_A', 'Биология', 7, 123456789)`
+    await client.$executeRaw`INSERT INTO "LiteratureCreator" (id, "nameMode", "givenName", "familyName", "normalizedName", "updatedAt")
+      VALUES ('historical-author', 'person', 'Jane', 'Smith', 'smith jane', 123456789)`
+    await client.$executeRaw`INSERT INTO "LiteratureItemCreator" ("itemId", "creatorId", "creatorType", ordinal)
+      VALUES ('historical', 'historical-author', 'author', 0)`
+    const batch = Array.from({ length: 501 }, (_, index) => ({
+      id: `batch-${index}`,
+      title: 'Überblick batch'
+    }))
+    await client.$executeRaw`INSERT INTO "LiteratureItem" (id, "itemType", title, "updatedAt")
+      SELECT json_extract(value, '$.id'), 'book', json_extract(value, '$.title'), 123456789 FROM json_each(${JSON.stringify(batch)})`
+    await client.$executeRaw`INSERT INTO "LiteratureCreator" (id, "nameMode", "literalName", "normalizedName", "updatedAt")
+      SELECT json_extract(value, '$.id'), 'organization', 'ÉTUDE Institute', 'étude institute', 123456789 FROM json_each(${JSON.stringify(batch)})`
+    await migrateApplicationDatabase(client)
+    const catalog = new LiteratureCatalog(async () => client!)
+    for (const query of ['étude', '95%', 'gene_A', 'Jane Smith', 'Smith Jane', 'биология'])
+      expect((await catalog.search({ scope: 'library', query })).totalCount).toBe(1)
+    expect(
+      await client.$queryRaw`SELECT title, "normalizedTitle", "normalizedAbstract", "normalizedContainerTitle", "metadataRevision", "updatedAt" FROM "LiteratureItem" WHERE id = 'historical'`
+    ).toEqual([
+      {
+        title: 'ÉTUDE',
+        normalizedTitle: 'étude',
+        normalizedAbstract: '95% confidence gene_a',
+        normalizedContainerTitle: 'биология',
+        metadataRevision: 7,
+        updatedAt: new Date(123456789)
+      }
+    ])
+    expect(
+      (await catalog.search({ scope: 'library', query: 'überblick batch', allItemIds: true }))
+        .totalCount
+    ).toBe(501)
+    expect(
+      await client.literatureCreator.count({ where: { normalizedDisplayName: 'étude institute' } })
+    ).toBe(501)
+    const before = await client.literatureItem.findUniqueOrThrow({ where: { id: 'historical' } })
+    await migrateApplicationDatabase(client)
+    expect(await client.literatureItem.findUniqueOrThrow({ where: { id: 'historical' } })).toEqual(
+      before
+    )
+  })
+
+  it('fills derived literature text when adopting an already current schema', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'literature-search-adoption-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.literatureItem.create({
+      data: { id: 'adopted', itemType: 'book', title: 'ÉTUDE' }
+    })
+    await client.$executeRaw`DELETE FROM "_open_science_migrations" WHERE id = '0038_literature_search_text'`
+    await migrateApplicationDatabase(client)
+    expect(
+      (
+        await new LiteratureCatalog(async () => client!).search({
+          scope: 'library',
+          query: 'étude'
+        })
+      ).totalCount
+    ).toBe(1)
+  })
+
+  it('rolls back a failed literature text backfill and retries the upgrade', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'literature-search-rollback-'))
+    client = createProjectDbClient(storageRoot)
+    await client.$executeRawUnsafe('PRAGMA legacy_alter_table = ON')
+    await createDatabaseAtReleasedManifest(
+      client,
+      MIGRATION_MANIFEST.filter(({ id }) => id < '0038_literature_search_text')
+    )
+    await client.$executeRaw`INSERT INTO "LiteratureItem" (id, "itemType", title, "updatedAt") VALUES ('old', 'book', 'Überblick', 123456789)`
+    await client.$executeRawUnsafe(
+      `CREATE TEMP TRIGGER refuse_search_backfill BEFORE UPDATE ON "LiteratureItem" BEGIN SELECT RAISE(ABORT, 'backfill blocked'); END`
+    )
+    await expect(migrateApplicationDatabase(client)).rejects.toBeDefined()
+    expect(
+      await client.$queryRaw`SELECT id FROM "_open_science_migrations" WHERE id = '0038_literature_search_text'`
+    ).toEqual([])
+    const columns = await client.$queryRaw<{ name: string }[]>`PRAGMA table_info("LiteratureItem")`
+    expect(columns.some(({ name }) => name === 'normalizedTitle')).toBe(false)
+    await client.$executeRawUnsafe('DROP TRIGGER refuse_search_backfill')
+    await migrateApplicationDatabase(client)
+    expect(
+      (
+        await new LiteratureCatalog(async () => client!).search({
+          scope: 'library',
+          query: 'überblick'
+        })
+      ).totalCount
+    ).toBe(1)
+  })
+
   it('creates the final literature uniqueness policy and verifies it on restart', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-explicit-duplicates-'))
     client = createProjectDbClient(storageRoot)
@@ -552,10 +653,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: null,
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -568,8 +670,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0037_literature_inbox_integrity',
-      to: '0037_literature_inbox_integrity'
+      from: '0038_literature_search_text',
+      to: '0038_literature_search_text'
     })
   })
 
@@ -597,10 +699,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0033_compute_job_harvest_retry',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -705,7 +808,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(
@@ -796,7 +900,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -841,7 +946,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -901,10 +1006,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -992,10 +1098,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRaw<
@@ -1118,7 +1225,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0037_literature_inbox_integrity'
+      migrationId: '0038_literature_search_text'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -1135,7 +1242,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual({
       adoptedLegacy: false,
       applied: ['9997_test_suffix'],
-      from: '0037_literature_inbox_integrity',
+      from: '0038_literature_search_text',
       to: '9997_test_suffix'
     })
     await expect(
@@ -1180,6 +1287,7 @@ describe('application database migrations', () => {
       { id: '0035_literature_pdf_provenance' },
       { id: '0036_content_verification_observation' },
       { id: '0037_literature_inbox_integrity' },
+      { id: '0038_literature_search_text' },
       { id: '9997_test_suffix' }
     ])
   })
@@ -1269,10 +1377,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     expect(backupEvents).toEqual([
       {
@@ -1363,7 +1472,8 @@ describe('application database migrations', () => {
       { id: '0034_background_result_delivery' },
       { id: '0035_literature_pdf_provenance' },
       { id: '0036_content_verification_observation' },
-      { id: '0037_literature_inbox_integrity' }
+      { id: '0037_literature_inbox_integrity' },
+      { id: '0038_literature_search_text' }
     ])
   })
 
@@ -1494,6 +1604,7 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
+        '0038_literature_search_text',
         '9997_test_suffix'
       ],
       to: '9997_test_suffix'
@@ -1631,7 +1742,7 @@ describe('application database migrations', () => {
       adoptedLegacy: false,
       applied: MIGRATION_MANIFEST.slice(computePasswordAuthIndex).map(({ id }) => id),
       from: '0009_vision_evidence',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRaw<Array<{ projectId: string }>>`
@@ -1756,7 +1867,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(
@@ -1890,7 +2002,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -1976,7 +2089,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(
@@ -2065,7 +2179,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -2188,7 +2303,8 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     await expect(
@@ -2711,8 +2827,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0036_content_verification_observation.backup',
       'open-science.db.before-0037_literature_inbox_integrity.backup',
+      'open-science.db.before-0038_literature_search_text.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -3018,10 +3134,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ currentVersionId: string | null }>>(
@@ -3080,7 +3197,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -3149,10 +3266,11 @@ describe('application database migrations', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -1,3 +1,7 @@
+import {
+  literatureSearchTextMigration,
+  backfillLiteratureSearchText
+} from './migrations/0038-literature-search-text'
 import { literaturePdfProvenanceMigration } from './migrations/0035-literature-pdf-provenance'
 import {
   literatureInboxIntegrityMigration,
@@ -230,6 +234,11 @@ const checksumMigrationPayload = (
   return hash.digest('hex')
 }
 
+const LITERATURE_SEARCH_TEXT_CHECKSUM = checksumMigrationPayload(
+  literatureSearchTextMigration.id,
+  literatureSearchTextMigration.statements,
+  literatureSearchTextMigration.verifiers
+)
 const BASELINE_CHECKSUM = checksumMigrationPayload(
   BASELINE_ID,
   runtimeSchemaBaselineMigration.statements,
@@ -763,6 +772,12 @@ const MIGRATION_MANIFEST = [
       literatureInboxIntegrityMigration.verifiers,
       literatureInboxIntegrityMigration.operations
     ),
+    backupOnApply: 'required',
+    backupRetention: 'retain'
+  },
+  {
+    ...literatureSearchTextMigration,
+    checksum: LITERATURE_SEARCH_TEXT_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
   }
@@ -1770,94 +1785,106 @@ const applyManifestMigration = async (
   try {
     foreignKeysWereEnabled = disableForeignKeys && (await readForeignKeyState(client)) === 1
     if (foreignKeysWereEnabled) await setForeignKeys(client, false)
-    await client.$transaction(async (transaction) => {
-      const transactionClient = transaction as unknown as PrismaClient
-      // A pre-ledger build may already have emitted the current generated schema. When this
-      // migration's complete verifier contract is already satisfied, adopt its immutable ledger
-      // identity without replaying non-idempotent SQLite ALTER TABLE statements.
-      let contractAlreadySatisfied = false
-      try {
-        await verifyMigrationTarget(transactionClient)
-        contractAlreadySatisfied = true
-      } catch (error) {
-        const failure = classifyDatabaseFailure(error, 'validation', migration.id)
-        // Only a contract mismatch calls for schema changes. A failed read must not cause
-        // non-idempotent ALTER statements to be replayed over an already compatible schema.
-        if (failure.code !== 'database_validation_failed') throw failure
-      }
-      if (
-        contractAlreadySatisfied &&
-        migration.id === managedFileVersionFoundationMigration.id &&
-        migration.checksum === MANAGED_FILE_VERSION_FOUNDATION_CHECKSUM
-      ) {
-        for (const statement of managedFileVersionFoundationCurrentSchemaAdoptionStatements) {
-          await migrationSqlExecutor.execute(transaction, statement)
+    await client.$transaction(
+      async (transaction) => {
+        const transactionClient = transaction as unknown as PrismaClient
+        // A pre-ledger build may already have emitted the current generated schema. When this
+        // migration's complete verifier contract is already satisfied, adopt its immutable ledger
+        // identity without replaying non-idempotent SQLite ALTER TABLE statements.
+        let contractAlreadySatisfied = false
+        try {
+          await verifyMigrationTarget(transactionClient)
+          contractAlreadySatisfied = true
+        } catch (error) {
+          const failure = classifyDatabaseFailure(error, 'validation', migration.id)
+          // Only a contract mismatch calls for schema changes. A failed read must not cause
+          // non-idempotent ALTER statements to be replayed over an already compatible schema.
+          if (failure.code !== 'database_validation_failed') throw failure
         }
-      }
-      if (
-        contractAlreadySatisfied &&
-        migration.id === literatureFoundationMigration.id &&
-        migration.checksum === LITERATURE_FOUNDATION_CHECKSUM
-      ) {
-        for (const statement of literatureContentBlobBackfillStatements) {
-          await migrationSqlExecutor.execute(transaction, statement)
-        }
-      }
-      if (
-        contractAlreadySatisfied &&
-        migration.id === literatureInboxIntegrityMigration.id &&
-        MIGRATION_MANIFEST.some(
-          (entry) => entry.id === migration.id && entry.checksum === migration.checksum
-        )
-      ) {
-        await migrationSqlExecutor.execute(transaction, literatureDiscoveryBackfillStatement)
-      }
-      if (!contractAlreadySatisfied) {
-        if (canVerifyAsCurrentSchema && migration.id === projectPreviewStateOwnerFkMigration.id) {
-          await migrationSqlExecutor.execute(
-            transaction,
-            `DELETE FROM "ProjectPreviewState"
-             WHERE NOT EXISTS (
-               SELECT 1 FROM "Project" WHERE "Project"."id" = "ProjectPreviewState"."projectId"
-             )`
-          )
-        } else {
-          for (const statement of migration.statements) {
+        if (
+          contractAlreadySatisfied &&
+          migration.id === managedFileVersionFoundationMigration.id &&
+          migration.checksum === MANAGED_FILE_VERSION_FOUNDATION_CHECKSUM
+        ) {
+          for (const statement of managedFileVersionFoundationCurrentSchemaAdoptionStatements) {
             await migrationSqlExecutor.execute(transaction, statement)
           }
         }
-        await applySqliteMigrationOperations(transactionClient, adapted.operations)
-      }
-      if (options.repairVisionEvidenceReference && !contractAlreadySatisfied) {
-        // The upstream history created VisionEvidence before this immutable migration. Rebuild it
-        // after UploadVersion so SQLite does not retain the temporary rename as its FK target.
-        await applySqliteMigrationOperations(transactionClient, visionEvidenceMigration.operations)
-      }
-      if (options.repairLiteratureManifestReference) {
-        const manifestTables = await migrationSqlExecutor.query<Array<{ name: string }>>(
-          transactionClient,
-          `SELECT "name" FROM "sqlite_schema"
-           WHERE "type" = 'table' AND "name" = 'ArtifactLiteratureManifest'`
-        )
-        if (manifestTables.length > 0) {
-          const manifestForeignKeys = await migrationSqlExecutor.query<Array<{ table: string }>>(
-            transactionClient,
-            `PRAGMA foreign_key_list("ArtifactLiteratureManifest")`
+        if (
+          contractAlreadySatisfied &&
+          migration.id === literatureFoundationMigration.id &&
+          migration.checksum === LITERATURE_FOUNDATION_CHECKSUM
+        ) {
+          for (const statement of literatureContentBlobBackfillStatements) {
+            await migrationSqlExecutor.execute(transaction, statement)
+          }
+        }
+        if (
+          contractAlreadySatisfied &&
+          migration.id === literatureInboxIntegrityMigration.id &&
+          MIGRATION_MANIFEST.some(
+            (entry) => entry.id === migration.id && entry.checksum === migration.checksum
           )
-          if (manifestForeignKeys.some((foreignKey) => foreignKey.table !== 'ArtifactVersion')) {
-            for (const statement of artifactLiteratureManifestReferenceRepairStatements) {
+        ) {
+          await migrationSqlExecutor.execute(transaction, literatureDiscoveryBackfillStatement)
+        }
+        if (!contractAlreadySatisfied) {
+          if (canVerifyAsCurrentSchema && migration.id === projectPreviewStateOwnerFkMigration.id) {
+            await migrationSqlExecutor.execute(
+              transaction,
+              `DELETE FROM "ProjectPreviewState"
+             WHERE NOT EXISTS (
+               SELECT 1 FROM "Project" WHERE "Project"."id" = "ProjectPreviewState"."projectId"
+             )`
+            )
+          } else {
+            for (const statement of migration.statements) {
               await migrationSqlExecutor.execute(transaction, statement)
             }
           }
+          await applySqliteMigrationOperations(transactionClient, adapted.operations)
         }
-      }
-      try {
-        await verifyMigrationTarget(transactionClient)
-      } catch (error) {
-        throw classifyDatabaseFailure(error, 'validation', migration.id)
-      }
-      await insertLedgerRow(transactionClient, migration)
-    })
+        if (
+          migration.id === literatureSearchTextMigration.id &&
+          migration.checksum === LITERATURE_SEARCH_TEXT_CHECKSUM
+        ) {
+          await backfillLiteratureSearchText(transaction)
+        }
+        if (options.repairVisionEvidenceReference && !contractAlreadySatisfied) {
+          // The upstream history created VisionEvidence before this immutable migration. Rebuild it
+          // after UploadVersion so SQLite does not retain the temporary rename as its FK target.
+          await applySqliteMigrationOperations(
+            transactionClient,
+            visionEvidenceMigration.operations
+          )
+        }
+        if (options.repairLiteratureManifestReference) {
+          const manifestTables = await migrationSqlExecutor.query<Array<{ name: string }>>(
+            transactionClient,
+            `SELECT "name" FROM "sqlite_schema"
+           WHERE "type" = 'table' AND "name" = 'ArtifactLiteratureManifest'`
+          )
+          if (manifestTables.length > 0) {
+            const manifestForeignKeys = await migrationSqlExecutor.query<Array<{ table: string }>>(
+              transactionClient,
+              `PRAGMA foreign_key_list("ArtifactLiteratureManifest")`
+            )
+            if (manifestForeignKeys.some((foreignKey) => foreignKey.table !== 'ArtifactVersion')) {
+              for (const statement of artifactLiteratureManifestReferenceRepairStatements) {
+                await migrationSqlExecutor.execute(transaction, statement)
+              }
+            }
+          }
+        }
+        try {
+          await verifyMigrationTarget(transactionClient)
+        } catch (error) {
+          throw classifyDatabaseFailure(error, 'validation', migration.id)
+        }
+        await insertLedgerRow(transactionClient, migration)
+      },
+      migration.id === literatureSearchTextMigration.id ? { timeout: 120_000 } : undefined
+    )
   } catch (error) {
     migrationFailure = error
   }

--- a/src/main/database/migrations/0038-literature-search-text.ts
+++ b/src/main/database/migrations/0038-literature-search-text.ts
@@ -1,0 +1,86 @@
+import { Prisma } from '@prisma/client'
+import { normalizeLiteratureSearchTextV1 as normalize } from '../../../shared/literature-search-text'
+
+const literatureSearchTextMigration = {
+  id: '0038_literature_search_text',
+  statements: [
+    `-- Backfill v1: NFKC, trim, collapse Unicode whitespace, Unicode lowercase; preserve timestamps and revisions.
+ALTER TABLE "LiteratureItem" ADD COLUMN "normalizedTitle" TEXT NOT NULL DEFAULT ''`,
+    `ALTER TABLE "LiteratureItem" ADD COLUMN "normalizedAbstract" TEXT NOT NULL DEFAULT ''`,
+    `ALTER TABLE "LiteratureItem" ADD COLUMN "normalizedContainerTitle" TEXT NOT NULL DEFAULT ''`,
+    `ALTER TABLE "LiteratureCreator" ADD COLUMN "normalizedDisplayName" TEXT NOT NULL DEFAULT ''`
+  ],
+  operations: [] as const,
+  verifiers: [
+    { kind: 'column-exists', version: 1, table: 'LiteratureItem', column: 'normalizedTitle' },
+    { kind: 'column-exists', version: 1, table: 'LiteratureItem', column: 'normalizedAbstract' },
+    {
+      kind: 'column-exists',
+      version: 1,
+      table: 'LiteratureItem',
+      column: 'normalizedContainerTitle'
+    },
+    {
+      kind: 'column-exists',
+      version: 1,
+      table: 'LiteratureCreator',
+      column: 'normalizedDisplayName'
+    }
+  ] as const
+}
+
+// Run inside the migration transaction, including adoption of a pre-ledger current schema.
+// JSON batches bind data without interpolating user text or exceeding SQLite's parameter limit.
+type ItemText = { id: string; title: string; abstract: string; containerTitle: string }
+type CreatorText = {
+  id: string
+  nameMode: string
+  givenName: string
+  familyName: string
+  literalName: string
+}
+
+const backfillLiteratureSearchText = async (client: Prisma.TransactionClient): Promise<void> => {
+  let cursor: string | undefined
+  for (;;) {
+    const rows: ItemText[] = await client.$queryRaw<ItemText[]>(Prisma.sql`
+      SELECT id, title, abstract, "containerTitle" FROM "LiteratureItem"
+      ${cursor === undefined ? Prisma.empty : Prisma.sql`WHERE id > ${cursor}`} ORDER BY id LIMIT 500`)
+    if (!rows.length) break
+    const values = rows.map((row) => ({
+      id: row.id,
+      title: normalize(row.title),
+      abstract: normalize(row.abstract),
+      containerTitle: normalize(row.containerTitle)
+    }))
+    await client.$executeRaw`UPDATE "LiteratureItem" SET
+      "normalizedTitle" = json_extract(data.value, '$.title'),
+      "normalizedAbstract" = json_extract(data.value, '$.abstract'),
+      "normalizedContainerTitle" = json_extract(data.value, '$.containerTitle')
+      FROM json_each(${JSON.stringify(values)}) AS data WHERE "LiteratureItem".id = json_extract(data.value, '$.id')`
+    cursor = rows.at(-1)!.id
+  }
+  cursor = undefined
+  for (;;) {
+    const rows: CreatorText[] = await client.$queryRaw<CreatorText[]>(Prisma.sql`
+      SELECT id, "nameMode", "givenName", "familyName", "literalName" FROM "LiteratureCreator"
+      ${cursor === undefined ? Prisma.empty : Prisma.sql`WHERE id > ${cursor}`} ORDER BY id LIMIT 500`)
+    if (!rows.length) break
+    const values = rows.map((row) => ({
+      id: row.id,
+      name: normalize(
+        row.nameMode === 'organization' ? row.literalName : `${row.familyName} ${row.givenName}`
+      ),
+      display: normalize(
+        row.nameMode === 'organization' ? row.literalName : `${row.givenName} ${row.familyName}`
+      )
+    }))
+    await client.$executeRaw`UPDATE "LiteratureCreator" SET
+      "normalizedName" = json_extract(data.value, '$.name'),
+      "normalizedDisplayName" = json_extract(data.value, '$.display')
+      FROM json_each(${JSON.stringify(values)}) AS data WHERE "LiteratureCreator".id = json_extract(data.value, '$.id')`
+    cursor = rows.at(-1)!.id
+  }
+}
+
+export { literatureSearchTextMigration, backfillLiteratureSearchText }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -96,10 +96,11 @@ describe('notification attention metadata migration', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0006_database_domain_constraints',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/permission-approval-summary.test.ts
+++ b/src/main/database/permission-approval-summary.test.ts
@@ -22,7 +22,7 @@ it('upgrades historical permissions without inferring descriptions or changing a
     const grant = await registry.remember({ capability, scope: { kind: 'global' } })
     await client.$executeRawUnsafe('ALTER TABLE "PermissionGrant" DROP COLUMN "approvalSummary"')
     await client.$executeRawUnsafe(
-      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')"
+      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')"
     )
     const before = await client.$queryRawUnsafe(
       'SELECT id, capabilityKind, capabilityKey, qualifierMode, qualifierValue, scopeKind, projectId, sessionId, fingerprint, revision, createdAt FROM "PermissionGrant"'
@@ -36,7 +36,8 @@ it('upgrades historical permissions without inferring descriptions or changing a
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     const after = await client.$queryRawUnsafe<Array<Record<string, unknown>>>(

--- a/src/main/database/project-archive-revision.test.ts
+++ b/src/main/database/project-archive-revision.test.ts
@@ -34,7 +34,7 @@ describe('Project archive revision', () => {
     await client.$executeRawUnsafe('DROP TABLE "BackgroundResultDelivery"')
     await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
     await client.$executeRawUnsafe(
-      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity')"
+      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')"
     )
     await expect(
       migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
@@ -46,7 +46,8 @@ describe('Project archive revision', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ]
     })
     expect(

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -74,10 +74,11 @@ describe('Project Session defaults migration', () => {
         '0034_background_result_delivery',
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
-        '0037_literature_inbox_integrity'
+        '0037_literature_inbox_integrity',
+        '0038_literature_search_text'
       ],
       from: '0026_compute_job_remote_cleanup',
-      to: '0037_literature_inbox_integrity'
+      to: '0038_literature_search_text'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(

--- a/src/main/literature/catalog-capacity.test.ts
+++ b/src/main/literature/catalog-capacity.test.ts
@@ -64,7 +64,7 @@ it('allows a small catalog write while a large library search is running', async
         )
       })
     )
-    expect(results.map(({ status }) => status)).toEqual(['fulfilled', 'fulfilled'])
+    expect(results.filter(({ status }) => status === 'rejected')).toEqual([])
     expect(await search).toMatchObject({ totalCount: n })
   } finally {
     await client.$disconnect()

--- a/src/main/literature/catalog-capacity.test.ts
+++ b/src/main/literature/catalog-capacity.test.ts
@@ -1,0 +1,73 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import { createProjectDbClient } from '../projects/prisma-client'
+import { migrateApplicationDatabase } from '../database/migration-service'
+import { LiteratureCatalog } from './catalog'
+import { literatureItemInputSchema } from '../../shared/literature'
+
+it('allows a small catalog write while a large library search is running', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'literature-capacity-'))
+  const client = createProjectDbClient(root)
+  try {
+    await migrateApplicationDatabase(client)
+    const catalog = new LiteratureCatalog(async () => client)
+    const receipt = await catalog.transact({
+      kind: 'create-item',
+      item: literatureItemInputSchema.parse({
+        itemType: 'journalArticle',
+        title: 'Capacity reference',
+        abstract:
+          'A scientific abstract with detailed methods and observations. '.repeat(80) + ' ÉTUDE',
+        creators: [
+          { nameMode: 'person', givenName: 'Jane', familyName: 'Smith', creatorType: 'author' }
+        ]
+      })
+    })
+    if (receipt.kind !== 'item') throw new Error('Expected a reference')
+    const { creators, ...template } = await client.literatureItem.findUniqueOrThrow({
+      where: { id: receipt.id },
+      include: { creators: true }
+    })
+    // Clone a public-command record to seed scale without tying this regression to derived columns.
+    const n = 50000
+    for (let offset = 0; offset < n; offset += 500) {
+      const ids = Array.from({ length: 500 }, (_, i) => `row-${offset + i}`)
+      await client.literatureItem.createMany({ data: ids.map((id) => ({ ...template, id })) })
+      await client.literatureItemCreator.createMany({
+        data: ids.map((itemId) => ({
+          itemId,
+          creatorId: creators[0]!.creatorId,
+          creatorType: 'author',
+          ordinal: 0
+        }))
+      })
+    }
+    await client.literatureItem.delete({ where: { id: receipt.id } })
+    const start = performance.now()
+    const search = catalog.search({ scope: 'library', query: 'ÉTUDE', limit: 25 })
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    const write = catalog.transact({
+      kind: 'create-item',
+      item: literatureItemInputSchema.parse({ itemType: 'book', title: 'Concurrent new reference' })
+    })
+    const results = await Promise.allSettled([search, write])
+    console.info(
+      JSON.stringify({
+        records: n,
+        durationMs: performance.now() - start,
+        outcomes: results.map((result) =>
+          result.status === 'rejected'
+            ? { status: result.status, error: String(result.reason) }
+            : { status: result.status }
+        )
+      })
+    )
+    expect(results.map(({ status }) => status)).toEqual(['fulfilled', 'fulfilled'])
+    expect(await search).toMatchObject({ totalCount: n })
+  } finally {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+}, 120000)

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -84,6 +84,337 @@ describe('LiteratureCatalog', () => {
     return new LiteratureCatalog(async () => client!)
   }
 
+  it.each(['10.2468/exact-reference', '39876543'])(
+    'finds an exact identifier through ordinary search: %s',
+    async (query) => {
+      const catalog = await setup()
+      const created = await catalog.transact({
+        kind: 'create-item',
+        item: literatureItemInputSchema.parse({
+          itemType: 'journalArticle',
+          title: 'Identifier control',
+          issuedYear: 2024,
+          identifiers: [
+            { scheme: 'doi', value: '10.2468/exact-reference' },
+            { scheme: 'pmid', value: '39876543' }
+          ]
+        })
+      })
+      expect((await catalog.get(created.id))!.item.identifiers).toHaveLength(2)
+      expect(
+        (await catalog.search({ scope: 'library', query: 'Identifier control' })).totalCount
+      ).toBe(1)
+      const page = await catalog.search(
+        literatureCatalogSearchRequestSchema.parse({ scope: 'library', query })
+      )
+      expect
+        .soft(page.entries.flatMap((entry) => ('id' in entry ? [entry.id] : [])))
+        .toEqual([created.id])
+      expect.soft(page.totalCount).toBe(1)
+      expect(
+        (await catalog.search({ scope: 'library', query, filter: { yearFrom: 2025 } })).totalCount
+      ).toBe(0)
+    }
+  )
+
+  it.each(['query', 'creator'] as const)(
+    'finds a displayed personal name through %s',
+    async (surface) => {
+      const catalog = await setup()
+      const created = await catalog.transact({
+        kind: 'create-item',
+        item: literatureItemInputSchema.parse({
+          itemType: 'journalArticle',
+          title: 'Personal author control',
+          creators: [
+            { nameMode: 'person', givenName: 'Jane', familyName: 'Smith', creatorType: 'author' }
+          ]
+        })
+      })
+      await catalog.transact({
+        kind: 'create-item',
+        item: literatureItemInputSchema.parse({
+          itemType: 'journalArticle',
+          title: 'Separate authors',
+          creators: [
+            { nameMode: 'person', givenName: 'Jane', familyName: 'Doe', creatorType: 'author' },
+            { nameMode: 'person', givenName: 'John', familyName: 'Smith', creatorType: 'author' }
+          ]
+        })
+      })
+      const search = (text: string): ReturnType<LiteratureCatalog['search']> =>
+        catalog.search(
+          literatureCatalogSearchRequestSchema.parse({
+            scope: 'library',
+            ...(surface === 'query' ? { query: text } : { filter: { creator: text } })
+          })
+        )
+      expect(
+        (await search('Smith Jane')).entries.flatMap((entry) => ('id' in entry ? [entry.id] : []))
+      ).toEqual([created.id])
+      expect(
+        (await search('Jane Smith')).entries.flatMap((entry) => ('id' in entry ? [entry.id] : []))
+      ).toEqual([created.id])
+    }
+  )
+
+  it.each([
+    ['Überblick', 'überblick'],
+    ['Биология', 'биология'],
+    ['ÉTUDE', 'étude']
+  ])('matches Unicode case variants of %s', async (title, query) => {
+    const catalog = await setup()
+    const created = await catalog.transact({
+      kind: 'create-item',
+      item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title })
+    })
+    expect((await catalog.search({ scope: 'library', query: title })).totalCount).toBe(1)
+    const page = await catalog.search(
+      literatureCatalogSearchRequestSchema.parse({ scope: 'library', query })
+    )
+    expect
+      .soft(page.entries.flatMap((entry) => ('id' in entry ? [entry.id] : [])))
+      .toEqual([created.id])
+    expect.soft(page.totalCount).toBe(1)
+  })
+
+  it.each([
+    ['95%', '95% confidence'],
+    ['gene_A', 'gene_A'],
+    ['%', '95% confidence']
+  ])('treats ordinary search input literally: %s', async (query, expectedTitle) => {
+    const catalog = await setup()
+    const ids = new Map<string, string>()
+    for (const title of ['95% confidence', '95X confidence', 'gene_A', 'geneXA']) {
+      const receipt = await catalog.transact({
+        kind: 'create-item',
+        item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title })
+      })
+      ids.set(title, receipt.id)
+    }
+    const request = literatureCatalogSearchRequestSchema.parse({ scope: 'library', query })
+    const page = await catalog.search(request)
+    expect
+      .soft(page.entries.flatMap((entry) => ('id' in entry ? [entry.id] : [])))
+      .toEqual([ids.get(expectedTitle)])
+    expect.soft(page.totalCount).toBe(1)
+    expect
+      .soft((await catalog.search({ ...request, allItemIds: true })).itemIds)
+      .toEqual([ids.get(expectedTitle)])
+  })
+
+  it('keeps a mixed Trash restore atomic and permits restoring its ordinary item alone', async () => {
+    const catalog = await setup()
+    const survivor = await catalog.transact({
+      kind: 'create-item',
+      item: candidate({ doi: '10.2468/retained' }).item
+    })
+    const alias = await catalog.transact({
+      kind: 'create-item',
+      item: candidate({ doi: '10.2468/alias', title: 'Alias' }).item
+    })
+    const ordinary = await catalog.transact({
+      kind: 'create-item',
+      item: candidate({ doi: '10.2468/ordinary', title: 'Ordinary' }).item
+    })
+    const reviewed = (await Promise.all([catalog.get(survivor.id), catalog.get(alias.id)])).map(
+      (view) => view!
+    )
+    await catalog.transact({
+      kind: 'merge-items',
+      survivorId: survivor.id,
+      duplicateIds: [alias.id],
+      expectedMetadataRevision: reviewed[0].metadataRevision,
+      expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+        id,
+        metadataRevision,
+        updatedAt
+      })),
+      item: reviewed[0].item
+    })
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [ordinary.id], state: 'deleted' })
+    const request = literatureCatalogSearchRequestSchema.parse({
+      scope: 'library',
+      lifecycle: 'deleted'
+    })
+    const trash = await catalog.search(request)
+    expect(trash.totalCount).toBe(2)
+    expect(trash.entries.find((entry) => 'id' in entry && entry.id === alias.id)).toMatchObject({
+      mergedIntoItemId: survivor.id
+    })
+    await expect(
+      catalog.transact({
+        kind: 'set-item-lifecycle',
+        itemIds: trash.entries.flatMap((entry) => ('id' in entry ? [entry.id] : [])),
+        state: 'active'
+      })
+    ).rejects.toThrow('One or more Literature Items are unavailable.')
+    expect((await catalog.search(request)).totalCount).toBe(2)
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [ordinary.id], state: 'active' })
+    expect(
+      (await catalog.search(request)).entries.flatMap((entry) => ('id' in entry ? [entry.id] : []))
+    ).toEqual([alias.id])
+    expect((await catalog.get(ordinary.id))!.id).toBe(ordinary.id)
+  })
+
+  it('preserves scope, deduplication and both text conditions for normalized identifiers', async () => {
+    const catalog = await setup()
+    const item = literatureItemInputSchema.parse({
+      itemType: 'book',
+      title: '10.2468/scoped control',
+      issuedYear: 2024,
+      identifiers: [{ scheme: 'doi', value: '10.2468/scoped' }]
+    })
+    const receipt = await catalog.transact({ kind: 'create-item', item })
+    await catalog.transact({
+      kind: 'set-project-items',
+      projectId: 'project-1',
+      itemIds: [receipt.id],
+      included: true,
+      source: 'library'
+    })
+    const request = literatureCatalogSearchRequestSchema.parse({
+      scope: 'library',
+      query: 'https://doi.org/10.2468/SCOPED',
+      projectId: 'project-1',
+      filter: { query: 'control', itemTypes: ['book'], yearFrom: 2024, yearTo: 2024 }
+    })
+    expect
+      .soft(
+        (await catalog.search(request)).entries.flatMap((entry) =>
+          'id' in entry ? [entry.id] : []
+        )
+      )
+      .toEqual([receipt.id])
+    expect.soft((await catalog.search({ ...request, query: '10.2468/scoped' })).totalCount).toBe(1)
+    expect((await catalog.search({ ...request, projectId: 'missing' })).totalCount).toBe(0)
+    expect((await catalog.search({ ...request, filter: { query: 'absent' } })).totalCount).toBe(0)
+    expect(
+      (await catalog.search({ ...request, filter: { itemTypes: ['dataset'] } })).totalCount
+    ).toBe(0)
+  })
+
+  it('normalizes imported and edited text without losing accents or organization phrase order', async () => {
+    const catalog = await setup()
+    const {
+      itemIds: [id]
+    } = await catalog.importItems([
+      literatureItemInputSchema.parse({
+        itemType: 'book',
+        title: 'Imported control',
+        abstract: 'ÉTUDE gene_A',
+        containerTitle: 'Биология',
+        creators: [
+          { nameMode: 'organization', literalName: 'Jane Smith Institute', creatorType: 'author' }
+        ]
+      })
+    ])
+    expect
+      .soft(
+        (
+          await catalog.search({
+            scope: 'library',
+            query: 'étude gene_A',
+            filter: { containerTitle: 'биология' }
+          })
+        ).totalCount
+      )
+      .toBe(1)
+    expect((await catalog.search({ scope: 'library', query: 'etude' })).totalCount).toBe(0)
+    expect(
+      (await catalog.search({ scope: 'library', filter: { creator: 'Smith Jane Institute' } }))
+        .totalCount
+    ).toBe(0)
+    expect(
+      (await catalog.search({ scope: 'library', filter: { creator: 'Jane Smith Institute' } }))
+        .totalCount
+    ).toBe(1)
+    const view = (await catalog.get(id!))!
+    await catalog.transact({
+      kind: 'update-item',
+      itemId: id!,
+      expectedMetadataRevision: view.metadataRevision,
+      item: { ...view.item, title: 'U\u0308berblick', abstract: 'Updated', containerTitle: 'ÉTUDE' }
+    })
+    expect
+      .soft(
+        (
+          await catalog.search({
+            scope: 'library',
+            query: 'überblick',
+            filter: { containerTitle: 'étude' }
+          })
+        ).totalCount
+      )
+      .toBe(1)
+    expect((await catalog.search({ scope: 'library', query: 'étude gene_A' })).totalCount).toBe(0)
+  })
+
+  it('matches numeric publication identifiers without extracting numbers from unrelated prose', async () => {
+    const catalog = await setup()
+    const receipt = await catalog.transact({
+      kind: 'create-item',
+      item: literatureItemInputSchema.parse({
+        itemType: 'book',
+        title: 'Numeric identifier control',
+        identifiers: [
+          { scheme: 'isbn', value: '978-0-306-40615-7' },
+          { scheme: 'issn', value: '2049-3630' }
+        ]
+      })
+    })
+    for (const query of ['9780306406157', '978-0-306-40615-7', '2049-3630']) {
+      expect
+        .soft(
+          (await catalog.search({ scope: 'library', query })).entries.flatMap((entry) =>
+            'id' in entry ? [entry.id] : []
+          )
+        )
+        .toEqual([receipt.id])
+    }
+    expect(
+      (await catalog.search({ scope: 'library', query: 'unrelated 9780306406157 prose' }))
+        .totalCount
+    ).toBe(0)
+  })
+
+  it('keeps filtered pages, counts and all IDs complete beyond a scan batch with tied and null years', async () => {
+    const catalog = await setup()
+    const { itemIds } = await catalog.importItems(
+      Array.from({ length: 503 }, (_, index) =>
+        literatureItemInputSchema.parse({
+          itemType: 'book',
+          title: index % 2 ? 'Control' : 'ÉTUDE',
+          issuedYear: index < 501 ? 2024 : undefined
+        })
+      )
+    )
+    const expected = itemIds.filter((_, index) => index % 2 === 0)
+    for (const sortDirection of ['asc', 'desc'] as const) {
+      const request = literatureCatalogSearchRequestSchema.parse({
+        scope: 'library',
+        query: 'étude',
+        sortBy: 'year',
+        sortDirection,
+        limit: 100
+      })
+      const all = await catalog.search({ ...request, allItemIds: true })
+      expect(all.totalCount).toBe(expected.length)
+      expect(new Set(all.itemIds)).toEqual(new Set(expected))
+      const pages: string[] = []
+      let offset = 0
+      for (;;) {
+        const page = await catalog.search({ ...request, offset })
+        expect(page.totalCount).toBe(expected.length)
+        pages.push(...page.entries.flatMap((entry) => ('id' in entry ? [entry.id] : [])))
+        if (page.nextOffset === undefined) break
+        offset = page.nextOffset
+      }
+      expect(pages).toEqual(all.itemIds)
+      expect((await catalog.search({ ...request, offset: 999 })).entries).toEqual([])
+    }
+  })
+
   it.each(['merge', 'delete', 'batch', 'rollback', 'preview'] as const)(
     'publishes tag assignments only after committed catalog changes: %s',
     async (operation) => {

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -415,6 +415,33 @@ describe('LiteratureCatalog', () => {
     }
   })
 
+  it('does not reinterpret a bare PMID as a different PMCID identity', async () => {
+    const catalog = await setup()
+    const receipts = []
+    for (const scheme of ['pmid', 'pmcid'] as const) {
+      receipts.push(
+        await catalog.transact({
+          kind: 'create-item',
+          item: literatureItemInputSchema.parse({
+            itemType: 'journalArticle',
+            title: `${scheme} control`,
+            identifiers: [{ scheme, value: scheme === 'pmid' ? '39876543' : 'PMC39876543' }]
+          })
+        })
+      )
+    }
+    expect(
+      (await catalog.search({ scope: 'library', query: '39876543' })).entries.flatMap((entry) =>
+        'id' in entry ? [entry.id] : []
+      )
+    ).toEqual([receipts[0].id])
+    expect(
+      (await catalog.search({ scope: 'library', query: 'PMCID: 39876543' })).entries.flatMap(
+        (entry) => ('id' in entry ? [entry.id] : [])
+      )
+    ).toEqual([receipts[1].id])
+  })
+
   it.each(['merge', 'delete', 'batch', 'rollback', 'preview'] as const)(
     'publishes tag assignments only after committed catalog changes: %s',
     async (operation) => {

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -6,6 +6,7 @@ import type { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  createLiteratureIdentifierUrl,
   literatureCatalogSearchRequestSchema,
   literatureCandidateInputSchema,
   literatureItemInputSchema,
@@ -441,6 +442,27 @@ describe('LiteratureCatalog', () => {
       )
     ).toEqual([receipts[1].id])
   })
+
+  it.each(['cond-mat.stat-mech/9901001', 'math.algebra.geometry/9901001'])(
+    'recognizes old-style arXiv forms accepted by the shared link contract: %s',
+    async (value) => {
+      expect(createLiteratureIdentifierUrl('arxiv', value)).toBeDefined()
+      const catalog = await setup()
+      const receipt = await catalog.transact({
+        kind: 'create-item',
+        item: literatureItemInputSchema.parse({
+          itemType: 'preprint',
+          title: 'Archive category control',
+          identifiers: [{ scheme: 'arxiv', value }]
+        })
+      })
+      expect(
+        (await catalog.search({ scope: 'library', query: value })).entries.flatMap((entry) =>
+          'id' in entry ? [entry.id] : []
+        )
+      ).toEqual([receipt.id])
+    }
+  )
 
   it.each(['merge', 'delete', 'batch', 'rollback', 'preview'] as const)(
     'publishes tag assignments only after committed catalog changes: %s',

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -124,7 +124,7 @@ const searchIdentifiers = (
     ['doi', /^10\.\d{4,9}\/\S+$/u],
     ['pmid', /^\d+$/u],
     ['pmcid', /^PMC\d+$/u],
-    ['arxiv', /^(?:\d{4}\.\d{4,5}|[a-z-]+(?:\.[a-z-]+)?\/\d{7})$/iu],
+    ['arxiv', /^(?:\d{4}\.\d{4,5}|[a-z][a-z.-]*\/\d{7})$/iu],
     ['isbn', /^(?:\d{9}[\dX]|\d{13})$/u],
     ['issn', /^\d{7}[\dX]$/u]
   ]

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -3,6 +3,7 @@ import { createHash, randomUUID } from 'node:crypto'
 
 import { Prisma, type PrismaClient } from '@prisma/client'
 import { createLogger } from '../logger'
+import { normalizeLiteratureSearchTextV1 as normalizeSearchText } from '../../shared/literature-search-text'
 import { findLiteratureDuplicateGroups } from './duplicates'
 import { planLiteratureMerge, supplementLiteratureMetadata } from './duplicate-metadata'
 
@@ -40,6 +41,7 @@ import {
 type LiteratureCatalogClient = Pick<
   PrismaClient,
   | '$transaction'
+  | '$queryRaw'
   | 'contentBlob'
   | 'literatureAttachment'
   | 'literatureAttachmentVersion'
@@ -108,14 +110,8 @@ const normalizeIdentifier = (scheme: LiteratureIdentifierScheme, rawValue: strin
 
 const normalizeCreatorName = (creator: LiteratureCreatorInput): string =>
   creator.nameMode === 'organization'
-    ? normalizeSpace(creator.literalName).toLowerCase()
-    : normalizeSpace(`${creator.familyName} ${creator.givenName}`).toLowerCase()
-
-// Search comparison is derived at read time so existing records follow the same rules as new ones.
-const normalizeSearchText = (value: string): string => normalizeSpace(value).toLowerCase()
-// Preserve trailing combining marks when comparing lowercase expansions (for example İ).
-const literalSearchPattern = (value: string): RegExp =>
-  new RegExp(`${normalizeSearchText(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!\\p{M})`, 'u')
+    ? normalizeSearchText(creator.literalName)
+    : normalizeSearchText(`${creator.familyName} ${creator.givenName}`)
 
 const searchIdentifiers = (
   text: string
@@ -137,31 +133,6 @@ const searchIdentifiers = (
     return pattern.test(normalizedValue) ? [{ scheme, normalizedValue }] : []
   })
 }
-
-const searchItemSelect = {
-  id: true,
-  title: true,
-  abstract: true,
-  containerTitle: true,
-  identifiers: { select: { scheme: true, normalizedValue: true } },
-  creators: {
-    select: {
-      creator: { select: { nameMode: true, familyName: true, givenName: true, literalName: true } }
-    }
-  }
-} satisfies Prisma.LiteratureItemSelect
-
-type SearchItem = Prisma.LiteratureItemGetPayload<{ select: typeof searchItemSelect }>
-const matchesCreator = (row: SearchItem, pattern: RegExp): boolean =>
-  row.creators.some(({ creator }) =>
-    (creator.nameMode === 'organization'
-      ? [creator.literalName ?? '']
-      : [
-          `${creator.familyName ?? ''} ${creator.givenName ?? ''}`,
-          `${creator.givenName ?? ''} ${creator.familyName ?? ''}`
-        ]
-    ).some((name) => pattern.test(normalizeSearchText(name)))
-  )
 
 const canonicalJsonValue = (value: unknown): unknown => {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') return value
@@ -522,6 +493,9 @@ const createItem = async (
     data: {
       itemType: item.itemType,
       title: normalizeSpace(item.title),
+      normalizedTitle: normalizeSearchText(item.title),
+      normalizedAbstract: normalizeSearchText(item.abstract),
+      normalizedContainerTitle: normalizeSearchText(item.containerTitle),
       abstract: item.abstract,
       issuedText: item.issuedText,
       issuedYear: item.issuedYear,
@@ -551,6 +525,11 @@ const createItem = async (
     const creators = item.creators.map((creator) => ({
       id: randomUUID(),
       normalizedName: normalizeCreatorName(creator),
+      normalizedDisplayName: normalizeSearchText(
+        creator.nameMode === 'organization'
+          ? creator.literalName
+          : `${creator.givenName} ${creator.familyName}`
+      ),
       ...(creator.nameMode === 'organization'
         ? { nameMode: 'organization', literalName: creator.literalName }
         : { nameMode: 'person', givenName: creator.givenName, familyName: creator.familyName })
@@ -609,6 +588,9 @@ const replaceItemMetadata = async (
     data: {
       itemType: item.itemType,
       title: normalizeSpace(item.title),
+      normalizedTitle: normalizeSearchText(item.title),
+      normalizedAbstract: normalizeSearchText(item.abstract),
+      normalizedContainerTitle: normalizeSearchText(item.containerTitle),
       abstract: item.abstract,
       issuedText: item.issuedText,
       issuedYear: item.issuedYear ?? null,
@@ -645,12 +627,20 @@ const replaceItemMetadata = async (
     const persisted = await transaction.literatureCreator.create({
       data:
         creator.nameMode === 'organization'
-          ? { nameMode: 'organization', literalName: creator.literalName, normalizedName }
+          ? {
+              nameMode: 'organization',
+              literalName: creator.literalName,
+              normalizedName,
+              normalizedDisplayName: normalizedName
+            }
           : {
               nameMode: 'person',
               givenName: creator.givenName,
               familyName: creator.familyName,
-              normalizedName
+              normalizedName,
+              normalizedDisplayName: normalizeSearchText(
+                `${creator.givenName} ${creator.familyName}`
+              )
             },
       select: { id: true }
     })
@@ -915,178 +905,116 @@ class LiteratureCatalog {
         nextOffset: rows.length > limit ? offset + limit : undefined
       }
     }
-    if (
-      request.allItemIds ||
-      request.query?.trim() ||
-      request.filter?.query?.trim() ||
-      request.filter?.creator?.trim() ||
-      request.filter?.containerTitle?.trim()
-    ) {
-      return client.$transaction((transaction) => this.searchLibrary(request, transaction), {
-        timeout: 30_000
-      })
-    }
-    return this.searchLibrary(request, client)
+    return client.$transaction((transaction) => this.searchLibrary(request, transaction), {
+      timeout: 30_000
+    })
   }
 
   private async searchLibrary(
     request: LiteratureCatalogSearchRequest,
-    client: Pick<LiteratureCatalogClient, 'literatureItem' | 'tagAssignment'>
+    client: Pick<LiteratureCatalogClient, 'literatureItem' | '$queryRaw'>
   ): Promise<LiteratureCatalogSearchPage> {
     const offset = Math.max(0, request.offset ?? 0)
     const limit = Math.min(100, Math.max(1, request.limit ?? 50))
-    const query = normalizeSpace(request.query ?? '')
     const filter = request.filter
-    const tagIds = [
-      ...new Set([...(filter?.tagIds ?? []), ...(request.tagId ? [request.tagId] : [])])
+    const predicates: Prisma.Sql[] = [
+      request.lifecycle === 'deleted'
+        ? Prisma.sql`i."deletedAt" IS NOT NULL`
+        : Prisma.sql`i."deletedAt" IS NULL`
     ]
-    let taggedItemIds: string[] | undefined
-    if (tagIds.length > 0) {
-      const assignments = await client.tagAssignment.findMany({
-        where: { resourceType: 'literature.item', tagId: { in: tagIds } },
-        select: { resourceId: true, tagId: true }
-      })
-      const assigned = new Map<string, Set<string>>()
-      for (const assignment of assignments) {
-        const ids = assigned.get(assignment.resourceId) ?? new Set<string>()
-        ids.add(assignment.tagId)
-        assigned.set(assignment.resourceId, ids)
-      }
-      taggedItemIds = [...assigned]
-        .filter(([, ids]) => tagIds.every((tagId) => ids.has(tagId)))
-        .map(([itemId]) => itemId)
+    const contains = (column: Prisma.Sql, text: string): Prisma.Sql =>
+      Prisma.sql`instr(${column}, ${normalizeSearchText(text)}) > 0`
+    const creatorMatches = (text: string): Prisma.Sql => Prisma.sql`EXISTS (
+      SELECT 1 FROM "LiteratureItemCreator" ic JOIN "LiteratureCreator" c ON c.id = ic."creatorId"
+      WHERE ic."itemId" = i.id AND (${contains(Prisma.sql`c."normalizedName"`, text)}
+        OR ${contains(Prisma.sql`c."normalizedDisplayName"`, text)}))`
+    for (const text of [request.query, filter?.query].filter(
+      (value): value is string => !!value?.trim()
+    )) {
+      const alternatives = [
+        contains(Prisma.sql`i."normalizedTitle"`, text),
+        contains(Prisma.sql`i."normalizedAbstract"`, text),
+        contains(Prisma.sql`i."normalizedContainerTitle"`, text),
+        creatorMatches(text)
+      ]
+      const identifiers = searchIdentifiers(normalizeSpace(text))
+      if (identifiers.length)
+        alternatives.push(Prisma.sql`EXISTS (
+        SELECT 1 FROM "LiteratureIdentifier" identifier WHERE identifier."itemId" = i.id AND (
+          ${Prisma.join(
+            identifiers.map(
+              ({ scheme, normalizedValue }) =>
+                Prisma.sql`(identifier.scheme = ${scheme} AND identifier."normalizedValue" = ${normalizedValue})`
+            ),
+            ' OR '
+          )}))`)
+      predicates.push(Prisma.sql`(${Prisma.join(alternatives, ' OR ')})`)
     }
-    const lifecycle = request.lifecycle ?? 'active'
-    const textQueries = [query, normalizeSpace(filter?.query ?? '')].filter(Boolean)
-    const where: Prisma.LiteratureItemWhereInput = {
-      ...(lifecycle === 'deleted' ? { deletedAt: { not: null } } : { deletedAt: null }),
-      ...(taggedItemIds ? { id: { in: taggedItemIds } } : {}),
-      ...(request.projectId || filter?.projectId
-        ? { projects: { some: { projectId: request.projectId ?? filter?.projectId } } }
-        : {}),
-      ...(request.collectionId || filter?.collectionId
-        ? {
-            collections: {
-              some: { collectionId: request.collectionId ?? filter?.collectionId }
-            }
-          }
-        : {}),
-      ...(filter?.itemTypes?.length ? { itemType: { in: filter.itemTypes } } : {}),
-      ...(filter?.yearFrom !== undefined || filter?.yearTo !== undefined
-        ? {
-            issuedYear: {
-              ...(filter.yearFrom !== undefined ? { gte: filter.yearFrom } : {}),
-              ...(filter.yearTo !== undefined ? { lte: filter.yearTo } : {})
-            }
-          }
-        : {}),
-      ...(filter?.hasFullText === undefined
-        ? {}
-        : filter.hasFullText
-          ? { attachments: { some: { versions: { some: {} } } } }
-          : { attachments: { none: { versions: { some: {} } } } })
-    }
-    const sortDirection = request.sortDirection ?? (request.sortBy === 'title' ? 'asc' : 'desc')
-    const orderBy: Prisma.LiteratureItemOrderByWithRelationInput[] =
+    if (filter?.creator?.trim()) predicates.push(creatorMatches(filter.creator))
+    if (filter?.containerTitle?.trim())
+      predicates.push(contains(Prisma.sql`i."normalizedContainerTitle"`, filter.containerTitle))
+    const projectId = request.projectId ?? filter?.projectId
+    if (projectId)
+      predicates.push(
+        Prisma.sql`EXISTS (SELECT 1 FROM "ProjectLiterature" p WHERE p."itemId" = i.id AND p."projectId" = ${projectId})`
+      )
+    const collectionId = request.collectionId ?? filter?.collectionId
+    if (collectionId)
+      predicates.push(
+        Prisma.sql`EXISTS (SELECT 1 FROM "LiteratureCollectionItem" c WHERE c."itemId" = i.id AND c."collectionId" = ${collectionId})`
+      )
+    for (const tagId of new Set([
+      ...(filter?.tagIds ?? []),
+      ...(request.tagId ? [request.tagId] : [])
+    ]))
+      predicates.push(
+        Prisma.sql`EXISTS (SELECT 1 FROM "TagAssignment" t WHERE t."resourceType" = 'literature.item' AND t."resourceId" = i.id AND t."tagId" = ${tagId})`
+      )
+    if (filter?.itemTypes?.length)
+      predicates.push(Prisma.sql`i."itemType" IN (${Prisma.join(filter.itemTypes)})`)
+    if (filter?.yearFrom !== undefined)
+      predicates.push(Prisma.sql`i."issuedYear" >= ${filter.yearFrom}`)
+    if (filter?.yearTo !== undefined)
+      predicates.push(Prisma.sql`i."issuedYear" <= ${filter.yearTo}`)
+    if (filter?.hasFullText !== undefined)
+      predicates.push(Prisma.sql`${filter.hasFullText ? Prisma.empty : Prisma.sql`NOT`} EXISTS (
+      SELECT 1 FROM "LiteratureAttachment" a JOIN "LiteratureAttachmentVersion" v ON v."attachmentId" = a.id WHERE a."itemId" = i.id)`)
+    const where = Prisma.join(predicates, ' AND ')
+    const direction =
+      (request.sortDirection ?? (request.sortBy === 'title' ? 'asc' : 'desc')) === 'asc'
+        ? Prisma.sql`ASC`
+        : Prisma.sql`DESC`
+    const orderBy =
       request.sortBy === 'title'
-        ? [{ title: sortDirection }, { id: 'asc' }]
+        ? Prisma.sql`i.title ${direction}, i.id ASC`
         : request.sortBy === 'year'
-          ? [
-              { issuedYear: { sort: sortDirection, nulls: 'last' } },
-              { title: 'asc' },
-              { id: 'asc' }
-            ]
+          ? Prisma.sql`i."issuedYear" IS NULL ASC, i."issuedYear" ${direction}, i.title ASC, i.id ASC`
           : request.sortBy === 'rating'
-            ? [{ rating: sortDirection }, { title: 'asc' }, { id: 'asc' }]
+            ? Prisma.sql`i.rating ${direction}, i.title ASC, i.id ASC`
             : request.sortBy === 'created'
-              ? [{ createdAt: sortDirection }, { id: 'asc' }]
-              : [{ updatedAt: sortDirection }, { id: 'asc' }]
-    if (textQueries.length || filter?.creator?.trim() || filter?.containerTitle?.trim()) {
-      const queries = textQueries.map((text) => ({
-        pattern: literalSearchPattern(text),
-        identifiers: searchIdentifiers(text)
-      }))
-      const creatorPattern = filter?.creator?.trim()
-        ? literalSearchPattern(filter.creator)
-        : undefined
-      const containerPattern = filter?.containerTitle?.trim()
-        ? literalSearchPattern(filter.containerTitle)
-        : undefined
-      const itemIds: string[] = []
-      let totalCount = 0
-      let cursor: string | undefined
-      // ponytail: linear text scan with bounded row batches; derived search columns if measured library sizes outgrow this path.
-      for (;;) {
-        const rows: SearchItem[] = await client.literatureItem.findMany({
-          where,
-          orderBy,
-          select: searchItemSelect,
-          take: 500,
-          ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {})
+              ? Prisma.sql`i."createdAt" ${direction}, i.id ASC`
+              : Prisma.sql`i."updatedAt" ${direction}, i.id ASC`
+    const ids = await client.$queryRaw<
+      { id: string }[]
+    >(Prisma.sql`SELECT i.id FROM "LiteratureItem" i WHERE ${where} ORDER BY ${orderBy}
+      ${request.allItemIds ? Prisma.empty : Prisma.sql`LIMIT ${limit} OFFSET ${offset}`}`)
+    const itemIds = ids.map(({ id }) => id)
+    if (request.allItemIds) return { entries: [], itemIds, totalCount: itemIds.length }
+    const [count] = await client.$queryRaw<{ total: bigint }[]>(
+      Prisma.sql`SELECT COUNT(*) AS total FROM "LiteratureItem" i WHERE ${where}`
+    )
+    const totalCount = Number(count!.total)
+    const rows = itemIds.length
+      ? await client.literatureItem.findMany({
+          where: { id: { in: itemIds } },
+          include: itemInclude
         })
-        for (const row of rows) {
-          if (creatorPattern && !matchesCreator(row, creatorPattern)) continue
-          if (
-            containerPattern &&
-            !containerPattern.test(normalizeSearchText(row.containerTitle ?? ''))
-          )
-            continue
-          if (
-            !queries.every(
-              ({ pattern, identifiers }) =>
-                [row.title, row.abstract, row.containerTitle].some((value) =>
-                  pattern.test(normalizeSearchText(value ?? ''))
-                ) ||
-                matchesCreator(row, pattern) ||
-                identifiers.some((key) =>
-                  row.identifiers.some(
-                    (id) => id.scheme === key.scheme && id.normalizedValue === key.normalizedValue
-                  )
-                )
-            )
-          )
-            continue
-          if (request.allItemIds || (totalCount >= offset && itemIds.length < limit))
-            itemIds.push(row.id)
-          totalCount += 1
-        }
-        if (rows.length < 500) break
-        cursor = rows.at(-1)!.id
-      }
-      if (request.allItemIds) return { entries: [], itemIds, totalCount }
-      const rows = itemIds.length
-        ? await client.literatureItem.findMany({
-            where: { id: { in: itemIds } },
-            include: itemInclude
-          })
-        : []
-      const byId = new Map(rows.map((row) => [row.id, row]))
-      return {
-        entries: itemIds.map((id) => toItemView(byId.get(id)!)),
-        totalCount,
-        nextOffset: offset + limit < totalCount ? offset + limit : undefined
-      }
-    }
-    if (request.allItemIds) {
-      const rows = await client.literatureItem.findMany({ where, orderBy, select: { id: true } })
-      return { entries: [], itemIds: rows.map(({ id }) => id), totalCount: rows.length }
-    }
-    const [totalCount, rows] = await Promise.all([
-      client.literatureItem.count({ where }),
-      client.literatureItem.findMany({
-        where: {
-          ...where
-        },
-        include: itemInclude,
-        orderBy,
-        skip: offset,
-        take: limit + 1
-      })
-    ])
+      : []
+    const byId = new Map(rows.map((row) => [row.id, row]))
     return {
-      entries: rows.slice(0, limit).map(toItemView),
+      entries: itemIds.map((id) => toItemView(byId.get(id)!)),
       totalCount,
-      nextOffset: rows.length > limit ? offset + limit : undefined
+      nextOffset: offset + limit < totalCount ? offset + limit : undefined
     }
   }
 

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -129,6 +129,8 @@ const searchIdentifiers = (
     ['issn', /^\d{7}[\dX]$/u]
   ]
   return forms.flatMap(([scheme, pattern]) => {
+    // A bare number denotes a PMID, not an implicitly prefixed PMCID.
+    if (scheme === 'pmcid' && /^\d+$/u.test(text)) return []
     // ISBN/ISSN normalization strips arbitrary characters; admit only explicit numeric forms.
     if ((scheme === 'isbn' || scheme === 'issn') && !/^[\dX\s-]+$/iu.test(text)) return []
     const normalizedValue = normalizeIdentifier(scheme, text)

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -111,6 +111,56 @@ const normalizeCreatorName = (creator: LiteratureCreatorInput): string =>
     ? normalizeSpace(creator.literalName).toLowerCase()
     : normalizeSpace(`${creator.familyName} ${creator.givenName}`).toLowerCase()
 
+// Search comparison is derived at read time so existing records follow the same rules as new ones.
+const normalizeSearchText = (value: string): string => normalizeSpace(value).toLowerCase()
+// Preserve trailing combining marks when comparing lowercase expansions (for example İ).
+const literalSearchPattern = (value: string): RegExp =>
+  new RegExp(`${normalizeSearchText(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(?!\\p{M})`, 'u')
+
+const searchIdentifiers = (
+  text: string
+): { scheme: LiteratureIdentifierScheme; normalizedValue: string }[] => {
+  const forms: [LiteratureIdentifierScheme, RegExp][] = [
+    ['doi', /^10\.\d{4,9}\/\S+$/u],
+    ['pmid', /^\d+$/u],
+    ['pmcid', /^PMC\d+$/u],
+    ['arxiv', /^(?:\d{4}\.\d{4,5}|[a-z-]+(?:\.[a-z-]+)?\/\d{7})$/iu],
+    ['isbn', /^(?:\d{9}[\dX]|\d{13})$/u],
+    ['issn', /^\d{7}[\dX]$/u]
+  ]
+  return forms.flatMap(([scheme, pattern]) => {
+    // ISBN/ISSN normalization strips arbitrary characters; admit only explicit numeric forms.
+    if ((scheme === 'isbn' || scheme === 'issn') && !/^[\dX\s-]+$/iu.test(text)) return []
+    const normalizedValue = normalizeIdentifier(scheme, text)
+    return pattern.test(normalizedValue) ? [{ scheme, normalizedValue }] : []
+  })
+}
+
+const searchItemSelect = {
+  id: true,
+  title: true,
+  abstract: true,
+  containerTitle: true,
+  identifiers: { select: { scheme: true, normalizedValue: true } },
+  creators: {
+    select: {
+      creator: { select: { nameMode: true, familyName: true, givenName: true, literalName: true } }
+    }
+  }
+} satisfies Prisma.LiteratureItemSelect
+
+type SearchItem = Prisma.LiteratureItemGetPayload<{ select: typeof searchItemSelect }>
+const matchesCreator = (row: SearchItem, pattern: RegExp): boolean =>
+  row.creators.some(({ creator }) =>
+    (creator.nameMode === 'organization'
+      ? [creator.literalName ?? '']
+      : [
+          `${creator.familyName ?? ''} ${creator.givenName ?? ''}`,
+          `${creator.givenName ?? ''} ${creator.familyName ?? ''}`
+        ]
+    ).some((name) => pattern.test(normalizeSearchText(name)))
+  )
+
 const canonicalJsonValue = (value: unknown): unknown => {
   if (value === null || typeof value === 'string' || typeof value === 'boolean') return value
   if (typeof value === 'number' && Number.isFinite(value)) return value
@@ -863,8 +913,16 @@ class LiteratureCatalog {
         nextOffset: rows.length > limit ? offset + limit : undefined
       }
     }
-    if (request.allItemIds) {
-      return client.$transaction((transaction) => this.searchLibrary(request, transaction))
+    if (
+      request.allItemIds ||
+      request.query?.trim() ||
+      request.filter?.query?.trim() ||
+      request.filter?.creator?.trim() ||
+      request.filter?.containerTitle?.trim()
+    ) {
+      return client.$transaction((transaction) => this.searchLibrary(request, transaction), {
+        timeout: 30_000
+      })
     }
     return this.searchLibrary(request, client)
   }
@@ -911,20 +969,6 @@ class LiteratureCatalog {
             }
           }
         : {}),
-      ...(filter?.creator
-        ? {
-            creators: {
-              some: {
-                creator: {
-                  normalizedName: { contains: normalizeSpace(filter.creator).toLowerCase() }
-                }
-              }
-            }
-          }
-        : {}),
-      ...(filter?.containerTitle
-        ? { containerTitle: { contains: normalizeSpace(filter.containerTitle) } }
-        : {}),
       ...(filter?.itemTypes?.length ? { itemType: { in: filter.itemTypes } } : {}),
       ...(filter?.yearFrom !== undefined || filter?.yearTo !== undefined
         ? {
@@ -938,23 +982,7 @@ class LiteratureCatalog {
         ? {}
         : filter.hasFullText
           ? { attachments: { some: { versions: { some: {} } } } }
-          : { attachments: { none: { versions: { some: {} } } } }),
-      ...(textQueries.length
-        ? {
-            AND: textQueries.map((text) => ({
-              OR: [
-                { title: { contains: text } },
-                { abstract: { contains: text } },
-                { containerTitle: { contains: text } },
-                {
-                  creators: {
-                    some: { creator: { normalizedName: { contains: text.toLowerCase() } } }
-                  }
-                }
-              ]
-            }))
-          }
-        : {})
+          : { attachments: { none: { versions: { some: {} } } } })
     }
     const sortDirection = request.sortDirection ?? (request.sortBy === 'title' ? 'asc' : 'desc')
     const orderBy: Prisma.LiteratureItemOrderByWithRelationInput[] =
@@ -971,6 +999,72 @@ class LiteratureCatalog {
             : request.sortBy === 'created'
               ? [{ createdAt: sortDirection }, { id: 'asc' }]
               : [{ updatedAt: sortDirection }, { id: 'asc' }]
+    if (textQueries.length || filter?.creator?.trim() || filter?.containerTitle?.trim()) {
+      const queries = textQueries.map((text) => ({
+        pattern: literalSearchPattern(text),
+        identifiers: searchIdentifiers(text)
+      }))
+      const creatorPattern = filter?.creator?.trim()
+        ? literalSearchPattern(filter.creator)
+        : undefined
+      const containerPattern = filter?.containerTitle?.trim()
+        ? literalSearchPattern(filter.containerTitle)
+        : undefined
+      const itemIds: string[] = []
+      let totalCount = 0
+      let cursor: string | undefined
+      // ponytail: linear text scan with bounded row batches; derived search columns if measured library sizes outgrow this path.
+      for (;;) {
+        const rows: SearchItem[] = await client.literatureItem.findMany({
+          where,
+          orderBy,
+          select: searchItemSelect,
+          take: 500,
+          ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {})
+        })
+        for (const row of rows) {
+          if (creatorPattern && !matchesCreator(row, creatorPattern)) continue
+          if (
+            containerPattern &&
+            !containerPattern.test(normalizeSearchText(row.containerTitle ?? ''))
+          )
+            continue
+          if (
+            !queries.every(
+              ({ pattern, identifiers }) =>
+                [row.title, row.abstract, row.containerTitle].some((value) =>
+                  pattern.test(normalizeSearchText(value ?? ''))
+                ) ||
+                matchesCreator(row, pattern) ||
+                identifiers.some((key) =>
+                  row.identifiers.some(
+                    (id) => id.scheme === key.scheme && id.normalizedValue === key.normalizedValue
+                  )
+                )
+            )
+          )
+            continue
+          if (request.allItemIds || (totalCount >= offset && itemIds.length < limit))
+            itemIds.push(row.id)
+          totalCount += 1
+        }
+        if (rows.length < 500) break
+        cursor = rows.at(-1)!.id
+      }
+      if (request.allItemIds) return { entries: [], itemIds, totalCount }
+      const rows = itemIds.length
+        ? await client.literatureItem.findMany({
+            where: { id: { in: itemIds } },
+            include: itemInclude
+          })
+        : []
+      const byId = new Map(rows.map((row) => [row.id, row]))
+      return {
+        entries: itemIds.map((id) => toItemView(byId.get(id)!)),
+        totalCount,
+        nextOffset: offset + limit < totalCount ? offset + limit : undefined
+      }
+    }
     if (request.allItemIds) {
       const rows = await client.literatureItem.findMany({ where, orderBy, select: { id: true } })
       return { entries: [], itemIds: rows.map(({ id }) => id), totalCount: rows.length }

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -5502,6 +5502,159 @@ describe('LiteratureLibraryPage', () => {
     }
   })
 
+  it('counts only applied years after an invalid draft is dismissed', async () => {
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }))
+    fireEvent.change(screen.getByLabelText('From year'), { target: { value: '2020' } })
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({
+          scope: 'library',
+          filter: expect.objectContaining({ yearFrom: 2020 })
+        })
+      )
+    )
+    fireEvent.change(screen.getByLabelText('To year'), { target: { value: '2010' } })
+    await waitFor(() =>
+      expect(screen.getByLabelText('To year').getAttribute('aria-invalid')).toBe('true')
+    )
+    fireEvent.keyDown(screen.getByLabelText('To year'), { key: 'Escape' })
+    expect(screen.queryByLabelText('To year')).toBeNull()
+    const requests = search.mock.calls
+      .map(([request]) => request)
+      .filter((request) => request.scope === 'library')
+    expect(requests.at(-1).filter).toMatchObject({ yearFrom: 2020 })
+    expect(requests.at(-1).filter.yearTo).toBeUndefined()
+    expect(screen.getByRole('button', { name: /^Filters/ }).textContent).toBe('Filters1')
+  })
+
+  it.each(['single', 'batch'] as const)(
+    'does not offer enabled %s restoration for merged aliases',
+    async (surface) => {
+      const alias = { ...libraryItem, mergedIntoItemId: 'survivor', deletedAt: 2 }
+      search.mockImplementation((request: { lifecycle?: string; scope: string }) =>
+        Promise.resolve(
+          request.scope === 'library' && request.lifecycle === 'deleted'
+            ? { entries: [alias], totalCount: 1 }
+            : { entries: [] }
+        )
+      )
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'Trash' }))
+      const row = (await screen.findByText(alias.item.title)).closest('tr')!
+      expect(within(row).getByText('Merged duplicate')).not.toBeNull()
+      if (surface === 'single') {
+        await openMenu(within(row).getByRole('button', { name: 'More actions' }))
+        expect(
+          screen.getByRole('menuitem', { name: 'Restore' }).getAttribute('aria-disabled')
+        ).toBe('true')
+      } else {
+        fireEvent.click(screen.getByLabelText('Select all references'))
+        expect(
+          (screen.getByRole('button', { name: 'Restore' }) as HTMLButtonElement).disabled
+        ).toBe(true)
+      }
+      expect(transact).not.toHaveBeenCalled()
+    }
+  )
+
+  it('keeps invalid-only year drafts visible and clearable outside the popover', async () => {
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Filters' }))
+    fireEvent.change(screen.getByLabelText('From year'), { target: { value: '10000' } })
+    await waitFor(() =>
+      expect(screen.getByLabelText('From year').getAttribute('aria-invalid')).toBe('true')
+    )
+    fireEvent.keyDown(screen.getByLabelText('From year'), { key: 'Escape' })
+    expect.soft(screen.queryByText('Enter a valid year range (0–9999).')).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /^Filters/ }))
+    expect(
+      (screen.getByRole('button', { name: 'Clear filters' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }))
+    expect((screen.getByLabelText('From year') as HTMLInputElement).value).toBe('')
+    expect(screen.queryByText('Enter a valid year range (0–9999).')).toBeNull()
+  })
+
+  it('previews recoverable and merged counts across all matching Trash pages', async () => {
+    const entries = Array.from({ length: 26 }, (_, index) => ({
+      ...createLibraryItem(index),
+      deletedAt: 2,
+      ...(index === 25 ? {} : { mergedIntoItemId: 'survivor' })
+    }))
+    search.mockImplementation((request: LiteratureCatalogSearchRequest) => {
+      if (request.scope !== 'library' || request.lifecycle !== 'deleted')
+        return Promise.resolve({ entries: [] })
+      if (request.allItemIds)
+        return Promise.resolve({
+          entries: [],
+          itemIds: entries.map(({ id }) => id),
+          totalCount: 26
+        })
+      const offset = request.offset ?? 0,
+        limit = request.limit ?? 25
+      return Promise.resolve({
+        entries: entries.slice(offset, offset + limit),
+        totalCount: 26,
+        nextOffset: offset + limit < entries.length ? offset + limit : undefined
+      })
+    })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'Trash' }))
+    await screen.findByText('Reference 0')
+    fireEvent.click(screen.getByLabelText('Select all references'))
+    fireEvent.click(screen.getByRole('button', { name: 'Select all matching references 26' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Restore' }))
+    const dialog = await screen.findByRole('alertdialog')
+    expect(
+      within(dialog).getByText('Can restore: 1. Merged duplicates skipped: 25.')
+    ).not.toBeNull()
+    expect(transact).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Restore' }))
+    await waitFor(() =>
+      expect(transact).toHaveBeenCalledWith({
+        kind: 'set-item-lifecycle',
+        itemIds: ['item-25'],
+        state: 'active'
+      })
+    )
+    expect(transact).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([true, false])(
+    'opens a merged alias retained reference with availability %s',
+    async (available) => {
+      const alias = { ...libraryItem, mergedIntoItemId: 'survivor', deletedAt: 2 }
+      search.mockImplementation((request: LiteratureCatalogSearchRequest) =>
+        Promise.resolve(
+          request.scope === 'library' && request.lifecycle === 'deleted'
+            ? { entries: [alias], totalCount: 1 }
+            : { entries: [] }
+        )
+      )
+      get.mockResolvedValue(
+        available
+          ? {
+              ...libraryItem,
+              id: 'survivor',
+              item: { ...libraryItem.item, title: 'Retained reference' }
+            }
+          : undefined
+      )
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'Trash' }))
+      const row = (await screen.findByText(alias.item.title)).closest('tr')!
+      await openMenu(within(row).getByRole('button', { name: 'More actions' }))
+      fireEvent.click(screen.getByRole('menuitem', { name: 'Open retained reference' }))
+      await waitFor(() => expect(get).toHaveBeenCalledWith('survivor'))
+      if (available) await screen.findByText('Retained reference')
+      else await screen.findByText('This reference is no longer in your Library.')
+      expect(transact).not.toHaveBeenCalled()
+    }
+  )
+
   it('applies pending years after closing Filters and restores the drafts when reopened', async () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -447,7 +447,7 @@ describe('LiteratureLibraryPage', () => {
     vi.unstubAllGlobals()
   })
 
-  it('TB-E1 trashes all 26 members despite an update between target reads', async () => {
+  it('trashes all 26 members despite an update between target reads', async () => {
     const { mkdtemp, rm } = await import('node:fs/promises')
     const { tmpdir } = await import('node:os')
     const { join } = await import('node:path')
@@ -457,6 +457,10 @@ describe('LiteratureLibraryPage', () => {
     const { LiteratureCatalog } = await import('../../../../main/literature/catalog')
     const root = await mkdtemp(join(tmpdir(), 'literature-batch-membership-'))
     const client = createProjectDbClient(root)
+    let recordWrite!: (result: Promise<unknown>) => void
+    const written = new Promise<unknown>((resolve) => {
+      recordWrite = resolve
+    })
     try {
       await migrateApplicationDatabase(client)
       const catalog = new LiteratureCatalog(async () => client)
@@ -489,7 +493,16 @@ describe('LiteratureLibraryPage', () => {
         if (resolving && !edited && request.allItemIds) await edit()
         return page
       }
-      transact.mockImplementation((command) => catalog.transact(command))
+      transact.mockImplementation((command) => {
+        const operation = (async () => {
+          const result = await catalog.transact(command)
+          // Model a slow IPC response after the real SQLite write has committed.
+          await new Promise((resolve) => setTimeout(resolve, 1500))
+          return result
+        })()
+        recordWrite(operation)
+        return operation
+      })
       render(<LiteratureLibraryPage />)
       fireEvent.click(screen.getByRole('button', { name: 'All references' }))
       fireEvent.click(await screen.findByLabelText('Select all references'))
@@ -500,12 +513,14 @@ describe('LiteratureLibraryPage', () => {
       )!
       await openMenu(within(toolbar).getByRole('button', { name: 'More actions' }))
       fireEvent.click(screen.getByRole('menuitem', { name: 'Move to Trash' }))
+      await written
       await waitFor(() => expect(screen.queryByText('26 selected')).toBeNull())
       expect(edited).toBe(true)
       const deleted = await client.literatureItem.findMany({ where: { deletedAt: { not: null } } })
       expect(deleted.map(({ id }) => id).sort()).toEqual([...itemIds].sort())
       expect(await client.literatureItem.count({ where: { deletedAt: null } })).toBe(0)
     } finally {
+      await Promise.allSettled(transact.mock.results.map(({ value }) => value))
       cleanup()
       await client.$disconnect()
       await rm(root, { recursive: true, force: true })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -7200,6 +7200,12 @@ describe('LiteratureLibraryPage', () => {
       render(<LiteratureLibraryPage />)
       await screen.findByRole('heading', { name: 'Retrieval research' })
       await openMenu(screen.getByTitle('More actions'))
+      // The project heading appears before its SQLite-backed membership request settles.
+      await waitFor(() =>
+        expect(screen.getByRole('menuitem', { name: 'RIS' }).hasAttribute('data-disabled')).toBe(
+          false
+        )
+      )
       fireEvent.click(screen.getByRole('menuitem', { name: 'RIS' }))
       await waitFor(() => expect(saveBlobFile).toHaveBeenCalledTimes(1), { timeout: 15000 })
       const first = new TextDecoder().decode(

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1285,6 +1285,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const clearSelection = useCallback((): void => selectionStore.clear(), [selectionStore])
   const yearFilter = useLiteratureYearFilter(clearSelection)
   const { from: filterYearFrom, to: filterYearTo } = yearFilter
+  const [filtersOpen, setFiltersOpen] = useState(false)
+  const [restorePreview, setRestorePreview] = useState<{ itemIds: string[]; skipped: number }>()
   const [isBatching, setIsBatching] = useState(false)
   const [batchLookup, setBatchLookup] = useState<{
     mode: BatchLookupMode
@@ -1848,6 +1850,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       setEntriesOffset(0)
       clearSelection()
       setLifecycleFailure(undefined)
+      setRestorePreview(undefined)
       setLinkFailure(undefined)
     }, 0)
     return () => window.clearTimeout(timeout)
@@ -1958,8 +1961,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const activeFilterCount =
     (tagId !== 'all' ? 1 : 0) +
     (filterItemType !== 'all' ? 1 : 0) +
-    (yearFilter.draftFrom ? 1 : 0) +
-    (yearFilter.draftTo ? 1 : 0) +
+    (yearFilter.from ? 1 : 0) +
+    (yearFilter.to ? 1 : 0) +
     (filterHasPdf !== 'all' ? 1 : 0)
 
   const clearFilters = (): void => {
@@ -2758,6 +2761,43 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     const page = await window.api.literature.search({ ...buildEntriesRequest(0), allItemIds: true })
     if (!page.itemIds) throw new Error('Literature membership is unavailable.')
     return page.itemIds.filter((id) => !excludedMatchingIds.has(id))
+  }
+
+  const previewRestoreSelection = async (): Promise<void> => {
+    if (isBatching) return
+    const scopeKey = entriesKey
+    setIsBatching(true)
+    setError(undefined)
+    try {
+      const selectedIds = new Set(await resolveSelectedItemIds())
+      const restorable = new Set<string>()
+      const skipped = new Set<string>()
+      const seenOffsets = new Set<number>()
+      let offset = 0
+      for (;;) {
+        if (seenOffsets.has(offset)) throw new Error('Repeated Literature page.')
+        seenOffsets.add(offset)
+        const page = await window.api.literature.search({
+          ...buildEntriesRequest(offset),
+          limit: 100
+        })
+        if (linkScopeRef.current !== scopeKey) return
+        for (const entry of page.entries.filter(isItem)) {
+          if (!selectedIds.has(entry.id)) continue
+          if (entry.mergedIntoItemId) skipped.add(entry.id)
+          else restorable.add(entry.id)
+        }
+        if (page.nextOffset === undefined) break
+        offset = page.nextOffset
+      }
+      if (restorable.size + skipped.size !== selectedIds.size)
+        throw new Error('Selected Literature membership changed.')
+      setRestorePreview({ itemIds: [...restorable], skipped: skipped.size })
+    } catch {
+      if (linkScopeRef.current === scopeKey) setError(t('Selected references could not be loaded.'))
+    } finally {
+      setIsBatching(false)
+    }
   }
 
   const requestBatchLookup = async (mode: BatchLookupMode): Promise<void> => {
@@ -3874,9 +3914,18 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                               <SelectItem value="rating">{t('Highest rated')}</SelectItem>
                             </SelectContent>
                           </Select>
-                          <Popover>
+                          <Popover open={filtersOpen} onOpenChange={setFiltersOpen}>
                             <PopoverTrigger asChild>
-                              <Button type="button" variant="outline" className="relative">
+                              <Button
+                                type="button"
+                                variant="outline"
+                                className="relative"
+                                aria-describedby={
+                                  yearFilter.invalid && !filtersOpen
+                                    ? 'literature-year-filter-error'
+                                    : undefined
+                                }
+                              >
                                 <SlidersHorizontal className="size-4" aria-hidden="true" />
                                 {t('Filters')}
                                 {activeFilterCount > 0 ? (
@@ -3958,7 +4007,11 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                                   type="button"
                                   variant="outline"
                                   className="w-full"
-                                  disabled={activeFilterCount === 0}
+                                  disabled={
+                                    activeFilterCount === 0 &&
+                                    !yearFilter.draftFrom &&
+                                    !yearFilter.draftTo
+                                  }
                                   onClick={clearFilters}
                                 >
                                   {t('Clear filters')}
@@ -3966,6 +4019,15 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                               </div>
                             </PopoverContent>
                           </Popover>
+                          {yearFilter.invalid && !filtersOpen ? (
+                            <p
+                              id="literature-year-filter-error"
+                              role="status"
+                              className="text-xs text-destructive"
+                            >
+                              {t('Enter a valid year range (0–9999).')}
+                            </p>
+                          ) : null}
                           <LiteratureColumnCustomizer
                             columns={tableColumnOrder}
                             labels={tableColumnLabels}
@@ -4053,8 +4115,16 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                               type="button"
                               variant="outline"
                               size="sm"
-                              disabled={isBatching}
-                              onClick={() => void runLifecycleAction('active')}
+                              disabled={
+                                isBatching ||
+                                (!selection.allMatchingSelected &&
+                                  [...selection.selectedIds].every((id) =>
+                                    items.some(
+                                      (item) => item.id === id && Boolean(item.mergedIntoItemId)
+                                    )
+                                  ))
+                              }
+                              onClick={() => void previewRestoreSelection()}
                             >
                               <RotateCcw className="size-3.5" aria-hidden="true" />
                               {t('Restore')}
@@ -4824,7 +4894,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                                         <>
                                           <DropdownMenuSeparator />
                                           <DropdownMenuItem
-                                            disabled={isBatching}
+                                            disabled={isBatching || Boolean(entry.mergedIntoItemId)}
                                             onSelect={() =>
                                               void setItemsLifecycle([entry.id], 'active')
                                             }
@@ -4832,6 +4902,24 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                                             <RotateCcw className="mr-2 size-4" aria-hidden="true" />
                                             {t('Restore')}
                                           </DropdownMenuItem>
+                                          {entry.mergedIntoItemId ? (
+                                            <DropdownMenuItem
+                                              onSelect={() =>
+                                                useNavigationStore
+                                                  .getState()
+                                                  .openLiteratureItem(
+                                                    entry.mergedIntoItemId!,
+                                                    'user'
+                                                  )
+                                              }
+                                            >
+                                              <BookOpenText
+                                                className="mr-2 size-4"
+                                                aria-hidden="true"
+                                              />
+                                              {t('Open retained reference')}
+                                            </DropdownMenuItem>
+                                          ) : null}
                                         </>
                                       ) : null}
                                       {section !== 'trash' ? (
@@ -5954,6 +6042,49 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                   />
                 ) : null}
                 {t('Delete collection')}
+              </Button>
+            </div>
+          </AlertDialog.Content>
+        </AlertDialog.Portal>
+      </AlertDialog.Root>
+      <AlertDialog.Root
+        open={Boolean(restorePreview)}
+        onOpenChange={(open) => {
+          if (!open && !isBatching) setRestorePreview(undefined)
+        }}
+      >
+        <AlertDialog.Portal>
+          <AlertDialog.Overlay className={dialogOverlayClassName} />
+          <AlertDialog.Content
+            className={dialogPanelClassName('w-[min(440px,calc(100vw-2rem))] p-0')}
+          >
+            <div className={dialogHeaderClassName}>
+              <AlertDialog.Title className={dialogTitleClassName}>{t('Restore')}</AlertDialog.Title>
+            </div>
+            <div className={dialogBodyClassName}>
+              <AlertDialog.Description className={dialogDescriptionClassName}>
+                {t('Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.', {
+                  recoverable: restorePreview?.itemIds.length ?? 0,
+                  skipped: restorePreview?.skipped ?? 0
+                })}
+              </AlertDialog.Description>
+            </div>
+            <div className={dialogFooterClassName}>
+              <AlertDialog.Cancel asChild>
+                <Button type="button" variant="ghost" disabled={isBatching}>
+                  {t('Cancel')}
+                </Button>
+              </AlertDialog.Cancel>
+              <Button
+                type="button"
+                disabled={isBatching || !restorePreview?.itemIds.length}
+                onClick={() => {
+                  const ids = restorePreview?.itemIds
+                  setRestorePreview(undefined)
+                  if (ids?.length) void setItemsLifecycle(ids, 'active')
+                }}
+              >
+                {t('Restore')}
               </Button>
             </div>
           </AlertDialog.Content>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -104,6 +104,8 @@
     "Select no more than {{limit}} references for this task.": "Wählen Sie für diese Aufgabe höchstens {{limit}} Referenzen aus.",
     "This reference changed while you were editing. Your draft has been kept.": "Diese Referenz wurde während der Bearbeitung geändert. Ihr Entwurf wurde beibehalten.",
     "Discard this draft and load the latest saved metadata.": "Diesen Entwurf verwerfen und die zuletzt gespeicherten Metadaten laden.",
+    "Open retained reference": "Beibehaltene Referenz öffnen",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "Wiederherstellbar: {{recoverable}}. Übersprungene zusammengeführte Duplikate: {{skipped}}.",
     "Identifiers (★ primary)": "Identifikatoren (★ primär)",
     "Search again to refresh this older metadata review.": "Suchen Sie erneut, um diese ältere Metadatenprüfung zu aktualisieren.",
     "The reference was saved, but could not be reloaded.": "Die Referenz wurde gespeichert, konnte aber nicht neu geladen werden.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -105,6 +105,8 @@
     "Select no more than {{limit}} references for this task.": "Seleccione como máximo {{limit}} referencias para esta tarea.",
     "This reference changed while you were editing. Your draft has been kept.": "Esta referencia cambió mientras la editaba. Se ha conservado su borrador.",
     "Discard this draft and load the latest saved metadata.": "Descartar este borrador y cargar los últimos metadatos guardados.",
+    "Open retained reference": "Abrir referencia conservada",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "Se pueden restaurar: {{recoverable}}. Duplicados fusionados omitidos: {{skipped}}.",
     "Identifiers (★ primary)": "Identificadores (★ principal)",
     "Search again to refresh this older metadata review.": "Busque de nuevo para actualizar esta revisión anterior de metadatos.",
     "The reference was saved, but could not be reloaded.": "La referencia se guardó, pero no se pudo volver a cargar.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -105,6 +105,8 @@
     "Select no more than {{limit}} references for this task.": "Sélectionnez au maximum {{limit}} références pour cette tâche.",
     "This reference changed while you were editing. Your draft has been kept.": "Cette référence a été modifiée pendant votre saisie. Votre brouillon a été conservé.",
     "Discard this draft and load the latest saved metadata.": "Abandonner ce brouillon et charger les dernières métadonnées enregistrées.",
+    "Open retained reference": "Ouvrir la référence conservée",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "Références pouvant être restaurées : {{recoverable}}. Doublons fusionnés ignorés : {{skipped}}.",
     "Identifiers (★ primary)": "Identifiants (★ principal)",
     "Search again to refresh this older metadata review.": "Relancez la recherche pour actualiser cette ancienne révision des métadonnées.",
     "The reference was saved, but could not be reloaded.": "La référence a été enregistrée, mais n’a pas pu être rechargée.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -103,6 +103,8 @@
     "Select no more than {{limit}} references for this task.": "このタスクでは {{limit}} 件以下の文献を選択してください。",
     "This reference changed while you were editing. Your draft has been kept.": "編集中にこの文献が変更されました。下書きは保持されています。",
     "Discard this draft and load the latest saved metadata.": "この下書きを破棄して、最後に保存されたメタデータを読み込みます。",
+    "Open retained reference": "保持された文献を開く",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "復元可能：{{recoverable}}件。統合済みの重複文献をスキップ：{{skipped}}件。",
     "Identifiers (★ primary)": "識別子（★ 主要）",
     "Search again to refresh this older metadata review.": "再検索して、この古いメタデータの確認内容を更新してください。",
     "The reference was saved, but could not be reloaded.": "文献は保存されましたが、再読み込みできませんでした。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -103,6 +103,8 @@
     "Select no more than {{limit}} references for this task.": "이 작업에는 문헌을 {{limit}}개 이하로 선택하세요.",
     "This reference changed while you were editing. Your draft has been kept.": "편집 중에 이 문헌이 변경되었습니다. 초안은 유지되었습니다.",
     "Discard this draft and load the latest saved metadata.": "이 초안을 버리고 최근 저장된 메타데이터를 불러옵니다.",
+    "Open retained reference": "유지된 문헌 열기",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "복원 가능: {{recoverable}}개. 건너뛴 병합된 중복 문헌: {{skipped}}개.",
     "Identifiers (★ primary)": "식별자(★ 기본)",
     "Search again to refresh this older metadata review.": "다시 검색하여 이전 메타데이터 검토 내용을 새로 고치세요.",
     "The reference was saved, but could not be reloaded.": "참고 문헌은 저장되었지만 다시 불러오지 못했습니다.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -106,6 +106,8 @@
     "Select no more than {{limit}} references for this task.": "Выберите не более {{limit}} источников для этой задачи.",
     "This reference changed while you were editing. Your draft has been kept.": "Эта публикация изменилась во время редактирования. Ваш черновик сохранён.",
     "Discard this draft and load the latest saved metadata.": "Отбросить этот черновик и загрузить последние сохранённые метаданные.",
+    "Open retained reference": "Открыть сохранённую публикацию",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "Можно восстановить: {{recoverable}}. Пропущено объединённых дубликатов: {{skipped}}.",
     "Identifiers (★ primary)": "Идентификаторы (★ основной)",
     "Search again to refresh this older metadata review.": "Повторите поиск, чтобы обновить эти устаревшие данные для проверки.",
     "The reference was saved, but could not be reloaded.": "Источник сохранён, но его не удалось загрузить повторно.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -103,6 +103,8 @@
     "Select no more than {{limit}} references for this task.": "此任务最多支持 {{limit}} 篇文献，请调整选择。",
     "This reference changed while you were editing. Your draft has been kept.": "您编辑期间此文献已更改。您的草稿已保留。",
     "Discard this draft and load the latest saved metadata.": "放弃此草稿并加载最新保存的元数据。",
+    "Open retained reference": "打开保留的文献",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "可恢复：{{recoverable}}。跳过的已合并重复文献：{{skipped}}。",
     "Identifiers (★ primary)": "标识符（★ 主标识）",
     "Search again to refresh this older metadata review.": "请重新搜索以更新这份旧的元数据审阅结果。",
     "The reference was saved, but could not be reloaded.": "文献已保存，但无法重新加载。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -103,6 +103,8 @@
     "Select no more than {{limit}} references for this task.": "此任務最多支援 {{limit}} 篇文獻，請調整選取範圍。",
     "This reference changed while you were editing. Your draft has been kept.": "您編輯期間此文獻已變更。您的草稿已保留。",
     "Discard this draft and load the latest saved metadata.": "捨棄此草稿並載入最新儲存的中繼資料。",
+    "Open retained reference": "開啟保留的文獻",
+    "Can restore: {{recoverable}}. Merged duplicates skipped: {{skipped}}.": "可還原：{{recoverable}}。略過的已合併重複文獻：{{skipped}}。",
     "Identifiers (★ primary)": "識別碼（★ 主要識別碼）",
     "Search again to refresh this older metadata review.": "請重新搜尋以更新這份舊的中繼資料審閱結果。",
     "The reference was saved, but could not be reloaded.": "文獻已儲存，但無法重新載入。",

--- a/src/shared/literature-search-text.ts
+++ b/src/shared/literature-search-text.ts
@@ -1,0 +1,4 @@
+// Version 1 is also used by the immutable literature search migration. Change the persisted
+// normalization only with a new migration so historical and newly written values stay equivalent.
+export const normalizeLiteratureSearchTextV1 = (value: string): string =>
+  value.normalize('NFKC').trim().replace(/\s+/gu, ' ').toLowerCase()


### PR DESCRIPTION
## Problem

Library searches miss exact identifiers, displayed personal names and non-ASCII case variants. Percent and underscore input unexpectedly widen matches, including counts and all-matching selections. Trash exposes Restore for merged aliases even though lifecycle transactions reject them, and invalid year drafts inflate the applied-filter badge.

## Proposed change

- Match recognized identifiers using the existing scheme normalization and exact normalized values. Match literal NFKC/lowercased text, including both personal-name orders within one creator. Keep organization phrases intact.
- Persist three comparison fields on LiteratureItem and one on LiteratureCreator. Use parameter-bound SQLite `instr` and `EXISTS` for matching, with SQL ordering, counts and pagination. Hydrate only the result page. A read transaction keeps IDs, counts and returned records consistent without transferring the corpus to JavaScript.
- Disable alias restoration, link to the retained reference, and preview recoverable/skipped counts for a fixed selection before restoring eligible records. Preserve backend admission and rollback.
- Count committed years and retain an accessible invalid-year warning after the popover closes; allow invalid-only drafts to be cleared.

## Scope and non-goals

**Persistence and historical compatibility:** immutable migration `0038_literature_search_text` adds `LiteratureItem.normalizedTitle`, `normalizedAbstract`, `normalizedContainerTitle` and `LiteratureCreator.normalizedDisplayName`. Existing `normalizedName` retains the family-given/organization form. A versioned shared normalization helper maintains comparison values during create/edit/import/merge and backfills historical rows in bounded batches. Backfill preserves source metadata, revision numbers and modification timestamps, runs during current-schema adoption too, and shares the migration transaction with schema/ledger changes. Existing backup and rollback protection remains. The backfill migration has a 120-second transaction budget; ordinary query timeout is unchanged.

Derived text increases database size, especially for abstracts, and upgrades require a one-time pass over existing metadata. A local 50,000-record SQLite fixture with approximately 4,800-character abstracts upgraded in about 9 seconds including the migration path. The final capacity fixture measured search plus concurrent create at about 0.72 seconds; the same fixture on the prior application-side scan took about 16.7 seconds and rejected the concurrent create because the single connection was occupied. These are local observations, not cross-platform latency guarantees. Arbitrary substring matching remains linear inside SQLite; no ineffective substring B-tree index, external search service or dependency is added.

No new business enums or IPC schemas. New React preview/popover state is transient. Full-text/PDF availability, Inbox/collection-name search, fuzzy names, accent removal and linguistic case folding remain outside this change.

## Acceptance criteria and validation

Real SQLite catalog regressions and real React page tests exercise existing public boundaries. The reported behaviors were reproduced as failing regressions before fixes; existing controls passed. The capacity regression also fails the prior scan because concurrent create cannot acquire the database connection, and passes SQL-side filtering. Its fixture clones a public-command-created record so it does not depend on newly introduced column names. No production test seam was added.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Search/identifiers, same-creator matching, literal Unicode text, import/edit, scope filters, pagination and rollback; module consumers | All `src/main/literature` tests | Passed |
| Alias capabilities, cross-page restore selection, retained-reference navigation, applied years and export consumer | All `src/renderer/src/pages/literature` tests | Passed |
| Shared contracts/CSL, global search and Agent catalog consumers | `literature.test.ts`, `literature-csl.test.ts`, `renderer-contract-catalog.test.ts`, `GlobalSearchDialog.test.tsx`, `runtime-library-evidence.test.ts`, `literature-reference-prompt.test.ts` | Passed |
| Eight translated locales | `src/renderer/src/i18n/resources.test.ts` | Passed |
| Historical backfill, batch boundaries, metadata preservation, adoption, rollback/retry, restart and existing migrations | All `src/main/database` tests | Passed |
| Generated schema and packaged immutable migration ledger | `scripts/generate-database-schema.test.ts`, `scripts/database-migration-ledger-smoke.test.ts`, `npm run db:schema:check` | Passed |

After rebasing onto main `af6d2009`, the literature/consumer command passed 1,612 tests, all 303 database tests passed, and 19 packaged-ledger/schema tests passed. Node/Web/sandbox typechecks, lint and generated-schema verification passed. The released inbox-integrity migration remains unchanged; this PR's unpublished migration is now `0038`.

Main's historical migration fixture was reproduced failing with `database_history_invalid`: removing only its own ledger entry left a later migration in place. The fixture now removes the entire suffix. The Ubuntu batch lifecycle failure was also reproduced twice using a controlled 1.5-second IPC response delay. Its existing real-page test now awaits the actual command before checking cleared selection and all 26 persisted members, retaining the concurrent metadata update and transaction assertions. No production timeout or CI failure policy was weakened.

The complete local suite was intentionally not run at the maintainer's request. Persistence and generated-schema changes require full exact-head PR CI for broad/platform validation. CodeGraph identifies baseline catalog consumers but reports that its index belongs to the primary checkout; this worktree's source and runtime checks establish the new helper/backfill edges. No transport contract or path algorithm changed. Exact-head CI for `be9c9de2` passed all required checks including PR Gate. Its AI review completed with **mergeable** and **no actionable findings**; there are no inline review comments. The unchanged Japanese-language Electron restart scenario also passed five local repetitions and its Windows CI lane without weakening the flaky-test policy.

Real browser verification used the actual React page and a fresh migrated SQLite catalog: alias Restore disabled; mixed recovery previews one eligible and one skipped record and restores only the eligible record; dismissed invalid years retain badge 1 and a visible warning. Three screenshots were inspected and delivered locally. The persistence revision does not alter those screens. Fixtures/evidence/planning artifacts are not committed.

## Review focus

Please review SQL membership and count/page agreement, same-creator matching, identifier recognition guards, complete maintenance of derived text, historical migration atomicity/adoption, and stale-selection failure behavior. Check large-library connection occupancy against the real concurrent-write regression. Do not treat successful execution of a review workflow as an approving review verdict.
