### PR TITLE
fix(literature): preserve task recovery and metadata outcomes

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -470,6 +470,7 @@ model LiteratureItem {
   projects                 ProjectLiterature[]
   attachments              LiteratureAttachment[]
   acceptedInboxCandidates  LiteratureInboxCandidate[] @relation("AcceptedLiteratureItem")
+  metadataCommitReceipts LiteratureMetadataCommitReceipt[]
 
   @@index([deletedAt, updatedAt])
   @@index([mergedIntoItemId])
@@ -1171,4 +1172,16 @@ model BackgroundResultDelivery {
   @@unique([sourceKind, sourceId])
   @@index([sessionId, state, createdAt, id])
   @@index([sourceKind, state, createdAt, id])
+}
+
+// Immutable proof of a metadata application. Retain while the reference exists, including soft
+// deletion/merge; removing a JSON task must not invalidate checkpoints that can still replay.
+model LiteratureMetadataCommitReceipt {
+  operationId                String         @id
+  itemId                     String
+  expectedMetadataRevision   Int
+  committedMetadataRevision  Int
+  item                       LiteratureItem @relation(fields: [itemId], references: [id], onDelete: Cascade)
+
+  @@index([itemId])
 }

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -156,6 +156,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0038_literature_search_text',
     checksum: '00ae0d9f8f84e7334563a423f0aa9eef90ff33f7e24af91d30e6eb10aad4f1b1'
+  },
+  {
+    id: '0039_literature_metadata_commit_receipt',
+    checksum: 'd173f039c39c6a7de3460f861f5e34b306106fdcf014f654b435acf1e933e0b1'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -159,7 +159,7 @@ const EXPECTED_MIGRATION_LEDGER = [
   },
   {
     id: '0039_literature_metadata_commit_receipt',
-    checksum: 'd173f039c39c6a7de3460f861f5e34b306106fdcf014f654b435acf1e933e0b1'
+    checksum: '2d78a9270e8d861a9c8613106143888ea8a029878d5e553098c3729a42d95ffb'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -79,6 +79,7 @@ const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<v
   await client.$executeRawUnsafe('ALTER TABLE "PermissionGrant" DROP COLUMN "approvalSummary"')
   await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
   for (const table of [
+    'LiteratureMetadataCommitReceipt',
     'ArtifactLiteratureManifest',
     'ProjectLiterature',
     'LiteratureCollectionItem',
@@ -169,6 +170,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0038_literature_search_text',
         checksum: '00ae0d9f8f84e7334563a423f0aa9eef90ff33f7e24af91d30e6eb10aad4f1b1'
+      },
+      {
+        id: '0039_literature_metadata_commit_receipt',
+        checksum: 'd173f039c39c6a7de3460f861f5e34b306106fdcf014f654b435acf1e933e0b1'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -209,7 +214,7 @@ describe('packaged database migration ledger smoke', () => {
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
       )
 
       await migrateApplicationDatabase(client)
@@ -247,7 +252,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -283,7 +288,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -383,7 +388,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
@@ -466,7 +471,7 @@ describe('packaged database migration ledger smoke', () => {
            '0027_project_session_defaults',
            '0028_database_numeric_and_null_constraints',
            '0029_compute_host_execution_mode',
-           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text'
+           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0039_literature_metadata_commit_receipt'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -106,7 +106,7 @@ const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<v
 
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.slice(-16).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+    expect(MIGRATION_MANIFEST.slice(-17).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
@@ -173,7 +173,7 @@ describe('packaged database migration ledger smoke', () => {
       },
       {
         id: '0039_literature_metadata_commit_receipt',
-        checksum: 'd173f039c39c6a7de3460f861f5e34b306106fdcf014f654b435acf1e933e0b1'
+        checksum: '2d78a9270e8d861a9c8613106143888ea8a029878d5e553098c3729a42d95ffb'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -471,7 +471,7 @@ describe('packaged database migration ledger smoke', () => {
            '0027_project_session_defaults',
            '0028_database_numeric_and_null_constraints',
            '0029_compute_host_execution_mode',
-           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0039_literature_metadata_commit_receipt'
+           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0038_literature_search_text'
+const CURRENT_MIGRATION_ID = '0039_literature_metadata_commit_receipt'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -308,6 +308,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "producerRunId"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
       `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -310,7 +310,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -332,6 +332,7 @@ describe('agent memory project scope migration', () => {
       '0035_literature_pdf_provenance',
       '0036_content_verification_observation',
       '0037_literature_inbox_integrity',
+      '0038_literature_search_text',
       CURRENT_MIGRATION_ID
     )
 
@@ -358,6 +359,7 @@ describe('agent memory project scope migration', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
+        '0038_literature_search_text',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -222,7 +222,8 @@ describe('application database (integration)', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
 
@@ -1290,7 +1291,8 @@ describe('application database (integration)', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -25,8 +25,9 @@ describe('Compute Job operation migration', () => {
     await client.$executeRawUnsafe(`DROP TABLE "ComputeJobOperation"`)
     await client.$executeRawUnsafe('ALTER TABLE "ComputeJob" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -46,8 +47,8 @@ describe('Compute Job operation migration', () => {
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 2`
       )
     ).resolves.toEqual([
-      { id: '0038_literature_search_text' },
-      { id: '0037_literature_inbox_integrity' }
+      { id: '0039_literature_metadata_commit_receipt' },
+      { id: '0038_literature_search_text' }
     ])
   })
 

--- a/src/main/database/compute-job-remote-cleanup-migration.test.ts
+++ b/src/main/database/compute-job-remote-cleanup-migration.test.ts
@@ -80,10 +80,11 @@ describe('Compute Job remote cleanup migration', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0025_managed_file_version_foundation',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -85,10 +85,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0015_session_model_call_usage',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/content-blob-migration.test.ts
+++ b/src/main/database/content-blob-migration.test.ts
@@ -33,6 +33,7 @@ const createDatabaseBeforeLiteratureFoundation = async (client: PrismaClient): P
   await client.$executeRawUnsafe('ALTER TABLE "UploadVersion" DROP COLUMN "contentBlobId"')
   await client.$executeRawUnsafe('ALTER TABLE "ArtifactVersion" DROP COLUMN "contentBlobId"')
   await client.$executeRawUnsafe('DROP TABLE "ContentBlob"')
+  await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
   await client.$executeRawUnsafe(
     `DELETE FROM "_open_science_migrations"
      WHERE "id" >= '0030_literature_foundation'`
@@ -65,6 +66,7 @@ describe('Content blob migration', () => {
         id
       )
     }
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
       `DELETE FROM "_open_science_migrations" WHERE "id" >= '0030_literature_foundation'`
     )
@@ -79,7 +81,8 @@ describe('Content blob migration', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(
@@ -98,6 +101,7 @@ describe('Content blob migration', () => {
         await createDatabaseBeforeLiteratureFoundation(client)
       } else {
         await migrateApplicationDatabase(client)
+        await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
         await client.$executeRawUnsafe(
           schema === 'pre-ledger'
             ? 'DELETE FROM "_open_science_migrations"'
@@ -161,10 +165,11 @@ describe('Content blob migration', () => {
                 '0035_literature_pdf_provenance',
                 '0036_content_verification_observation',
                 '0037_literature_inbox_integrity',
-                '0038_literature_search_text'
+                '0038_literature_search_text',
+                '0039_literature_metadata_commit_receipt'
               ],
         from: schema === 'pre-ledger' ? null : '0029_compute_host_execution_mode',
-        to: '0038_literature_search_text'
+        to: '0039_literature_metadata_commit_receipt'
       })
 
       await expect(
@@ -236,6 +241,7 @@ describe('Content blob migration', () => {
       const before = await readContent()
       // The fixture rewinds the ledger after changing data; discard its earlier recovery snapshot.
       await rm(`${databasePath}.before-0030_literature_foundation.backup`, { force: true })
+      await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
       await client.$executeRawUnsafe(
         `DELETE FROM "_open_science_migrations" WHERE "id" >= '0030_literature_foundation'`
       )

--- a/src/main/database/content-verification-observation.test.ts
+++ b/src/main/database/content-verification-observation.test.ts
@@ -20,6 +20,7 @@ it('adds unknown verification observations without changing historical content o
   await client.$executeRawUnsafe(
     'ALTER TABLE "ContentBlob" DROP COLUMN "lastVerificationAttemptAt"'
   )
+  await client.$executeRawUnsafe('DROP TABLE "LiteratureMetadataCommitReceipt"')
   await client.$executeRawUnsafe(
     `DELETE FROM "_open_science_migrations" WHERE "id" >= '0036_content_verification_observation'`
   )
@@ -28,11 +29,7 @@ it('adds unknown verification observations without changing historical content o
     'a'.repeat(64)
   )
   await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-    applied: [
-      '0036_content_verification_observation',
-      '0037_literature_inbox_integrity',
-      '0038_literature_search_text'
-    ]
+    applied: ['0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt']
   })
   expect(await client.contentBlob.findUnique({ where: { id: 'old' } })).toMatchObject({
     state: 'available',

--- a/src/main/database/content-verification-observation.test.ts
+++ b/src/main/database/content-verification-observation.test.ts
@@ -29,7 +29,12 @@ it('adds unknown verification observations without changing historical content o
     'a'.repeat(64)
   )
   await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-    applied: ['0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt']
+    applied: [
+      '0036_content_verification_observation',
+      '0037_literature_inbox_integrity',
+      '0038_literature_search_text',
+      '0039_literature_metadata_commit_receipt'
+    ]
   })
   expect(await client.contentBlob.findUnique({ where: { id: 'old' } })).toMatchObject({
     state: 'available',

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -177,10 +177,11 @@ describe('database JSON constraints migration', () => {
           '0035_literature_pdf_provenance',
           '0036_content_verification_observation',
           '0037_literature_inbox_integrity',
-          '0038_literature_search_text'
+          '0038_literature_search_text',
+          '0039_literature_metadata_commit_receipt'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0038_literature_search_text'
+        to: '0039_literature_metadata_commit_receipt'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -377,9 +377,10 @@ describe('D02/D04 persisted database boundaries', () => {
           '0035_literature_pdf_provenance',
           '0036_content_verification_observation',
           '0037_literature_inbox_integrity',
-          '0038_literature_search_text'
+          '0038_literature_search_text',
+          '0039_literature_metadata_commit_receipt'
         ],
-        to: '0038_literature_search_text'
+        to: '0039_literature_metadata_commit_receipt'
       })
       // Literature adds contentBlobId to version rows while preserving their original fields.
       expect(await Promise.all(tables.map(readRows))).toMatchObject(before)

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -130,7 +130,8 @@ describe('database startup logging', () => {
               '0035_literature_pdf_provenance',
               '0036_content_verification_observation',
               '0037_literature_inbox_integrity',
-              '0038_literature_search_text'
+              '0038_literature_search_text',
+              '0039_literature_metadata_commit_receipt'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -972,6 +972,13 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "BackgroundResultDelivery_attemptCount_check" CHECK ("attemptCount" >= 0),
     CONSTRAINT "BackgroundResultDelivery_claimLifecycle_check" CHECK ((("state" IN ('claimed', 'dispatching') AND "claimToken" IS NOT NULL AND length(trim("claimToken")) > 0 AND "claimExpiresAt" IS NOT NULL) OR ("state" NOT IN ('claimed', 'dispatching') AND "claimToken" IS NULL AND "claimExpiresAt" IS NULL))),
     CONSTRAINT "BackgroundResultDelivery_continuation_check" CHECK (("continuationMessageId" IS NULL OR length(trim("continuationMessageId")) > 0) AND ("state" <> 'dispatching' OR "continuationMessageId" IS NOT NULL) AND ("state" <> 'waiting-result' OR "continuationMessageId" IS NULL))
+);`,
+  `CREATE TABLE IF NOT EXISTS "LiteratureMetadataCommitReceipt" (
+    "operationId" TEXT NOT NULL PRIMARY KEY,
+    "itemId" TEXT NOT NULL,
+    "expectedMetadataRevision" INTEGER NOT NULL,
+    "committedMetadataRevision" INTEGER NOT NULL,
+    CONSTRAINT "LiteratureMetadataCommitReceipt_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "LiteratureItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
 );`
 ] as const
 
@@ -1106,6 +1113,7 @@ const RUNTIME_SCHEMA_INDEX_DDLS = [
   `CREATE INDEX IF NOT EXISTS "BackgroundResultDelivery_sessionId_state_createdAt_id_idx" ON "BackgroundResultDelivery"("sessionId", "state", "createdAt", "id");`,
   `CREATE INDEX IF NOT EXISTS "BackgroundResultDelivery_sourceKind_state_createdAt_id_idx" ON "BackgroundResultDelivery"("sourceKind", "state", "createdAt", "id");`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "BackgroundResultDelivery_sourceKind_sourceId_key" ON "BackgroundResultDelivery"("sourceKind", "sourceId");`,
+  `CREATE INDEX IF NOT EXISTS "LiteratureMetadataCommitReceipt_itemId_idx" ON "LiteratureMetadataCommitReceipt"("itemId");`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "MemoryEntry_global_contentKey_key" ON "MemoryEntry"("contentKey") WHERE "projectId" IS NULL`,
   `CREATE UNIQUE INDEX IF NOT EXISTS "LiteratureCollection_root_nameKey_key" ON "LiteratureCollection"("nameKey") WHERE "parentId" IS NULL`,
   `CREATE INDEX IF NOT EXISTS "BackgroundResultDelivery_project_visible_idx" ON "BackgroundResultDelivery"("projectId", "updatedAt" DESC, "id") WHERE "state" IN ('waiting-result', 'pending', 'claimed', 'dispatching', 'needs-attention')`,
@@ -1175,7 +1183,8 @@ const RUNTIME_SCHEMA_TABLES = [
   'MemorySettings',
   'MemoryCategory',
   'MemoryEntry',
-  'BackgroundResultDelivery'
+  'BackgroundResultDelivery',
+  'LiteratureMetadataCommitReceipt'
 ] as const
 
 export {

--- a/src/main/database/literature-inbox-integrity-migration.test.ts
+++ b/src/main/database/literature-inbox-integrity-migration.test.ts
@@ -59,6 +59,7 @@ describe('Literature inbox integrity migration', () => {
       } else {
         await client.literatureCandidateDiscovery.deleteMany()
       }
+      await client.$executeRawUnsafe('DROP TABLE "LiteratureMetadataCommitReceipt"')
       await client.$executeRawUnsafe(
         schema === 'pre-ledger released'
           ? 'DELETE FROM "_open_science_migrations"'
@@ -66,7 +67,10 @@ describe('Literature inbox integrity migration', () => {
       )
 
       expect(await migrateApplicationDatabase(client)).toMatchObject({
-        applied: expect.arrayContaining(['0037_literature_inbox_integrity'])
+        applied: expect.arrayContaining([
+          '0037_literature_inbox_integrity',
+          '0039_literature_metadata_commit_receipt'
+        ])
       })
       expect(await client.literatureSourceRecord.findMany()).toEqual(sources)
       expect(

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -316,6 +316,42 @@ describe('application database migrations', () => {
     if (storageRoot) await rm(storageRoot, { force: true, recursive: true })
   })
 
+  it('adds empty metadata commit receipts without inventing proof for historical references', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'literature-receipt-upgrade-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.literatureItem.create({
+      data: {
+        id: 'historical-reference',
+        itemType: 'journalArticle',
+        title: 'Historical paper',
+        containerTitle: 'Already populated',
+        metadataRevision: 7
+      }
+    })
+    const before = await client.literatureItem.findMany()
+    await client.$executeRawUnsafe('DROP TABLE "LiteratureMetadataCommitReceipt"')
+    await client.$executeRawUnsafe(
+      `DELETE FROM "_open_science_migrations" WHERE id = '0039_literature_metadata_commit_receipt'`
+    )
+    const ledger = await client.$queryRawUnsafe(
+      'SELECT * FROM "_open_science_migrations" ORDER BY id'
+    )
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
+      from: '0037_literature_inbox_integrity',
+      to: '0039_literature_metadata_commit_receipt',
+      applied: ['0039_literature_metadata_commit_receipt']
+    })
+    expect(await client.literatureMetadataCommitReceipt.count()).toBe(0)
+    expect(await client.literatureItem.findMany()).toEqual(before)
+    expect(
+      await client.$queryRawUnsafe(
+        `SELECT * FROM "_open_science_migrations" WHERE id <> '0039_literature_metadata_commit_receipt' ORDER BY id`
+      )
+    ).toEqual(ledger)
+    await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+  })
+
   it('upgrades existing attachment and pending Inbox PDF rows without inventing provenance', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'literature-provenance-upgrade-'))
     client = createProjectDbClient(storageRoot)
@@ -332,6 +368,7 @@ describe('application database migrations', () => {
     await client.$executeRawUnsafe(
       'ALTER TABLE "ContentBlob" DROP COLUMN "lastVerificationAttemptAt"'
     )
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
       `DELETE FROM "_open_science_migrations" WHERE "id" >= '0035_literature_pdf_provenance'`
     )
@@ -654,10 +691,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: null,
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -670,8 +708,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0038_literature_search_text',
-      to: '0038_literature_search_text'
+      from: '0039_literature_metadata_commit_receipt',
+      to: '0039_literature_metadata_commit_receipt'
     })
   })
 
@@ -689,6 +727,7 @@ describe('application database migrations', () => {
     client = createProjectDbClient(storageRoot)
     await migrateApplicationDatabase(client)
     await client.$executeRawUnsafe('DROP TABLE "BackgroundResultDelivery"')
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
       `DELETE FROM "_open_science_migrations" WHERE "id" >= '0034_background_result_delivery'`
     )
@@ -700,10 +739,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0033_compute_job_harvest_retry',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -809,7 +849,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(
@@ -901,7 +942,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -946,7 +988,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -1007,10 +1049,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -1099,10 +1142,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRaw<
@@ -1225,7 +1269,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0038_literature_search_text'
+      migrationId: '0039_literature_metadata_commit_receipt'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -1242,7 +1286,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual({
       adoptedLegacy: false,
       applied: ['9997_test_suffix'],
-      from: '0038_literature_search_text',
+      from: '0039_literature_metadata_commit_receipt',
       to: '9997_test_suffix'
     })
     await expect(
@@ -1288,6 +1332,7 @@ describe('application database migrations', () => {
       { id: '0036_content_verification_observation' },
       { id: '0037_literature_inbox_integrity' },
       { id: '0038_literature_search_text' },
+      { id: '0039_literature_metadata_commit_receipt' },
       { id: '9997_test_suffix' }
     ])
   })
@@ -1378,10 +1423,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     expect(backupEvents).toEqual([
       {
@@ -1473,7 +1519,8 @@ describe('application database migrations', () => {
       { id: '0035_literature_pdf_provenance' },
       { id: '0036_content_verification_observation' },
       { id: '0037_literature_inbox_integrity' },
-      { id: '0038_literature_search_text' }
+      { id: '0038_literature_search_text' },
+      { id: '0039_literature_metadata_commit_receipt' }
     ])
   })
 
@@ -1605,6 +1652,7 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt',
         '9997_test_suffix'
       ],
       to: '9997_test_suffix'
@@ -1742,7 +1790,7 @@ describe('application database migrations', () => {
       adoptedLegacy: false,
       applied: MIGRATION_MANIFEST.slice(computePasswordAuthIndex).map(({ id }) => id),
       from: '0009_vision_evidence',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRaw<Array<{ projectId: string }>>`
@@ -1868,7 +1916,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(
@@ -2003,7 +2052,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -2090,7 +2140,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(
@@ -2180,7 +2231,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -2304,7 +2356,8 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     await expect(
@@ -2828,7 +2881,7 @@ describe('application database migrations', () => {
       )
     ).resolves.toEqual([
       'open-science.db.before-0037_literature_inbox_integrity.backup',
-      'open-science.db.before-0038_literature_search_text.backup',
+      'open-science.db.before-0039_literature_metadata_commit_receipt.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -3135,10 +3188,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ currentVersionId: string | null }>>(
@@ -3197,7 +3251,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -3267,10 +3321,11 @@ describe('application database migrations', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -338,7 +338,7 @@ describe('application database migrations', () => {
       'SELECT * FROM "_open_science_migrations" ORDER BY id'
     )
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
-      from: '0037_literature_inbox_integrity',
+      from: '0038_literature_search_text',
       to: '0039_literature_metadata_commit_receipt',
       applied: ['0039_literature_metadata_commit_receipt']
     })
@@ -555,7 +555,7 @@ describe('application database migrations', () => {
     await client.literatureItem.create({
       data: { id: 'adopted', itemType: 'book', title: 'ÉTUDE' }
     })
-    await client.$executeRaw`DELETE FROM "_open_science_migrations" WHERE id = '0038_literature_search_text'`
+    await client.$executeRaw`DELETE FROM "_open_science_migrations" WHERE id >= '0038_literature_search_text'`
     await migrateApplicationDatabase(client)
     expect(
       (
@@ -2880,7 +2880,7 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0037_literature_inbox_integrity.backup',
+      'open-science.db.before-0038_literature_search_text.backup',
       'open-science.db.before-0039_literature_metadata_commit_receipt.backup',
       unknownBackupName
     ])

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -2,6 +2,7 @@ import {
   literatureSearchTextMigration,
   backfillLiteratureSearchText
 } from './migrations/0038-literature-search-text'
+import { literatureMetadataCommitReceiptMigration } from './migrations/0039-literature-metadata-commit-receipt'
 import { literaturePdfProvenanceMigration } from './migrations/0035-literature-pdf-provenance'
 import {
   literatureInboxIntegrityMigration,
@@ -780,6 +781,17 @@ const MIGRATION_MANIFEST = [
     checksum: LITERATURE_SEARCH_TEXT_CHECKSUM,
     backupOnApply: 'required',
     backupRetention: 'retain'
+  },
+  {
+    ...literatureMetadataCommitReceiptMigration,
+    checksum: checksumMigrationPayload(
+      literatureMetadataCommitReceiptMigration.id,
+      literatureMetadataCommitReceiptMigration.statements,
+      literatureMetadataCommitReceiptMigration.verifiers,
+      literatureMetadataCommitReceiptMigration.operations
+    ),
+    backupOnApply: 'required',
+    backupRetention: 'retain'
   }
 ] as const satisfies readonly MigrationManifestEntry[]
 // schema-locality: begin frozen-0001-repairs
@@ -1200,6 +1212,7 @@ const verifyCurrentApplicationSchema = async (client: PrismaClient): Promise<voi
   await runMigrationVerifiers(client, backgroundResultDeliveryMigration.verifiers)
   await runMigrationVerifiers(client, literaturePdfProvenanceMigration.verifiers)
   await runMigrationVerifiers(client, contentVerificationObservationMigration.verifiers)
+  await runMigrationVerifiers(client, literatureMetadataCommitReceiptMigration.verifiers)
 }
 
 const readLedger = async (client: PrismaClient): Promise<LedgerRow[]> => {

--- a/src/main/database/migrations/0039-literature-metadata-commit-receipt.ts
+++ b/src/main/database/migrations/0039-literature-metadata-commit-receipt.ts
@@ -1,0 +1,39 @@
+/* Immutable 0039 migration snapshot. Do not regenerate after release. */
+const literatureMetadataCommitReceiptMigration = {
+  id: '0039_literature_metadata_commit_receipt',
+  statements: [
+    `CREATE TABLE "LiteratureMetadataCommitReceipt" (
+      "operationId" TEXT NOT NULL PRIMARY KEY,
+      "itemId" TEXT NOT NULL,
+      "expectedMetadataRevision" INTEGER NOT NULL,
+      "committedMetadataRevision" INTEGER NOT NULL,
+      CONSTRAINT "LiteratureMetadataCommitReceipt_itemId_fkey" FOREIGN KEY ("itemId") REFERENCES "LiteratureItem" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+    )`,
+    'CREATE INDEX "LiteratureMetadataCommitReceipt_itemId_idx" ON "LiteratureMetadataCommitReceipt"("itemId")'
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'table-exists', version: 1, table: 'LiteratureMetadataCommitReceipt' },
+    {
+      kind: 'foreign-key-exists',
+      version: 2,
+      table: 'LiteratureMetadataCommitReceipt',
+      column: 'itemId',
+      referencedTable: 'LiteratureItem',
+      referencedColumn: 'id',
+      onDelete: 'CASCADE',
+      onUpdate: 'CASCADE'
+    },
+    {
+      kind: 'indexes-exist',
+      version: 1,
+      indexes: [
+        {
+          name: 'LiteratureMetadataCommitReceipt_itemId_idx',
+          sql: 'CREATE INDEX "LiteratureMetadataCommitReceipt_itemId_idx" ON "LiteratureMetadataCommitReceipt"("itemId")'
+        }
+      ]
+    }
+  ] as const
+}
+export { literatureMetadataCommitReceiptMigration }

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -97,10 +97,11 @@ describe('notification attention metadata migration', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0006_database_domain_constraints',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/permission-approval-summary.test.ts
+++ b/src/main/database/permission-approval-summary.test.ts
@@ -21,8 +21,9 @@ it('upgrades historical permissions without inferring descriptions or changing a
     )!
     const grant = await registry.remember({ capability, scope: { kind: 'global' } })
     await client.$executeRawUnsafe('ALTER TABLE "PermissionGrant" DROP COLUMN "approvalSummary"')
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')"
+      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')"
     )
     const before = await client.$queryRawUnsafe(
       'SELECT id, capabilityKind, capabilityKey, qualifierMode, qualifierValue, scopeKind, projectId, sessionId, fingerprint, revision, createdAt FROM "PermissionGrant"'
@@ -37,7 +38,8 @@ it('upgrades historical permissions without inferring descriptions or changing a
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     const after = await client.$queryRawUnsafe<Array<Record<string, unknown>>>(

--- a/src/main/database/project-archive-revision.test.ts
+++ b/src/main/database/project-archive-revision.test.ts
@@ -33,8 +33,9 @@ describe('Project archive revision', () => {
     // Reconstruct the immediately preceding released schema and ledger, including real row data.
     await client.$executeRawUnsafe('DROP TABLE "BackgroundResultDelivery"')
     await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
+    await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text')"
+      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')"
     )
     await expect(
       migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
@@ -47,7 +48,8 @@ describe('Project archive revision', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ]
     })
     expect(

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -75,10 +75,11 @@ describe('Project Session defaults migration', () => {
         '0035_literature_pdf_provenance',
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
-        '0038_literature_search_text'
+        '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt'
       ],
       from: '0026_compute_job_remote_cleanup',
-      to: '0038_literature_search_text'
+      to: '0039_literature_metadata_commit_receipt'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(

--- a/src/main/literature/batch-jobs.test.ts
+++ b/src/main/literature/batch-jobs.test.ts
@@ -65,7 +65,12 @@ async function setup(): Promise<{
     catalog: { get: async (id: string) => item(id) },
     metadata: {
       complete: metadata,
-      applyReviewed: vi.fn(async (review: LiteratureMetadataCompletionResult) => review)
+      applyReviewed: vi.fn(async (review: LiteratureMetadataCompletionResult) => {
+        const current = await options.catalog.get(review.item.id)
+        if (current.metadataRevision !== review.item.metadataRevision)
+          throw new Error('Reference changed')
+        return review
+      })
     },
     fullText: { run: fullText },
     onError: vi.fn(),
@@ -445,7 +450,7 @@ it('offers identifier-only metadata additions as a ready batch row', async () =>
   current.item.identifiers = [{ scheme: 'pmid', value: '12345678', isPrimary: true }]
   const applyMetadata = vi.fn(async (input) => ({ ...current, item: input.item }))
   const enricher = new LiteratureMetadataEnricher(
-    { get: async () => current, applyMetadata },
+    { getMetadataCommitReceipt: async () => null, get: async () => current, applyMetadata },
     vi.fn(
       async () =>
         new Response(
@@ -722,6 +727,7 @@ it('keeps unsearched references resumable after applying a paused partial search
     failed: 0
   })
   expect(await state(jobs, jobId)).toMatchObject({ state: 'paused', phase: 'search' })
+  expect((await state(jobs, jobId)).rows[1].checked).toBe(true)
   await jobs.run({ action: 'resume', jobId })
   await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
   expect(metadata).toHaveBeenCalledTimes(2)
@@ -840,4 +846,31 @@ it('recognizes its committed metadata after replaying the pre-commit checkpoint'
     completedItemIds: [created.id]
   })
   expect(fetchMetadata).toHaveBeenCalledOnce()
+})
+
+it('restores a historically completed partial search without repeating completed metadata', async () => {
+  const { jobs, options, path, metadata } = await setup()
+  const jobId = randomUUID()
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  await jobs.close()
+  const checkpoint = join(`${path}.d`, `${jobId}.json`)
+  const stored = JSON.parse(await readFile(checkpoint, 'utf8'))
+  stored.state = 'completed'
+  stored.phase = 'apply'
+  stored.phaseItemIds = ['a']
+  stored.rows[0].status = 'done'
+  stored.rows.push({ id: 'b', status: 'pending', checked: true })
+  await writeFile(checkpoint, JSON.stringify(stored))
+  const reopened = new LiteratureBatchJobs(options)
+  cleanup.push(() => reopened.close())
+  expect(await state(reopened, jobId)).toMatchObject({
+    state: 'paused',
+    phase: 'search',
+    phaseItemIds: undefined
+  })
+  metadata.mockClear()
+  await reopened.run({ action: 'resume', jobId })
+  await vi.waitFor(async () => expect((await state(reopened, jobId)).state).toBe('review'))
+  expect(metadata).toHaveBeenCalledExactlyOnceWith({ mode: 'preview', itemId: 'b' })
 })

--- a/src/main/literature/batch-jobs.test.ts
+++ b/src/main/literature/batch-jobs.test.ts
@@ -688,3 +688,156 @@ it('finishes an attachment from its committed receipt while item refresh is unav
   await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('completed'))
   expect((await state(jobs, jobId)).rows[0].status).toBe('done')
 })
+
+it('keeps unsearched references resumable after applying a paused partial search', async () => {
+  const { jobs, metadata, options } = await setup()
+  let release!: () => void
+  metadata.mockImplementationOnce(async () => {
+    await new Promise<void>((resolve) => {
+      release = resolve
+    })
+    return preview('a')
+  })
+  const jobId = randomUUID()
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a', 'b'], requestId: jobId })
+  await vi.waitFor(() => expect(release).toBeTypeOf('function'))
+  try {
+    await jobs.run({ action: 'pause', jobId })
+  } finally {
+    release()
+  }
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('paused'))
+  expect((await state(jobs, jobId)).rows.map(({ status }) => status)).toEqual(['ready', 'pending'])
+  await jobs.run({ action: 'apply', jobId, selections: [{ itemId: 'a' }] })
+  await vi.waitFor(async () => {
+    expect(['paused', 'completed']).toContain((await state(jobs, jobId)).state)
+  })
+  expect(options.metadata.applyReviewed).toHaveBeenCalledOnce()
+  expect((await state(jobs, jobId)).rows.map(({ status }) => status)).toEqual(['done', 'pending'])
+  expect((await jobs.run({ action: 'list' })).summaries?.[0]).toMatchObject({
+    total: 2,
+    checked: 1,
+    done: 1,
+    ready: 0,
+    failed: 0
+  })
+  expect(await state(jobs, jobId)).toMatchObject({ state: 'paused', phase: 'search' })
+  await jobs.run({ action: 'resume', jobId })
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  expect(metadata).toHaveBeenCalledTimes(2)
+  expect(metadata).toHaveBeenLastCalledWith({ mode: 'preview', itemId: 'b' })
+  expect((await state(jobs, jobId)).rows.map(({ status }) => status)).toEqual(['done', 'ready'])
+})
+
+it('reloads repaired checkpoints on the same service without dropping any indexed task', async () => {
+  const { rename } = await import('node:fs/promises')
+  const { jobs, options, path } = await setup()
+  const first = randomUUID(),
+    second = randomUUID()
+  for (const jobId of [first, second]) {
+    await jobs.run({ action: 'create', mode: 'metadata', itemIds: ['a'], requestId: jobId })
+    await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  }
+  await jobs.close()
+  const indexBefore = await readFile(path, 'utf8')
+  const checkpoint = join(`${path}.d`, `${first}.json`)
+  await rename(checkpoint, `${checkpoint}.saved`)
+  const reopened = new LiteratureBatchJobs(options)
+  cleanup.push(() => reopened.close())
+  try {
+    const blocked = await Promise.allSettled([
+      reopened.run({ action: 'list' }),
+      reopened.run({ action: 'get', jobId: second }),
+      reopened.run({ action: 'remove', jobId: second })
+    ])
+    expect(blocked.map((result) => result.status)).toEqual(['rejected', 'rejected', 'rejected'])
+    for (const result of blocked)
+      if (result.status === 'rejected') expect(result.reason.message).toContain('checkpoint')
+    expect(await readFile(path, 'utf8')).toBe(indexBefore)
+  } finally {
+    await rename(`${checkpoint}.saved`, checkpoint)
+  }
+  // Control: the original bytes are healthy and load in another instance.
+  const fresh = new LiteratureBatchJobs(options)
+  expect((await fresh.run({ action: 'list' })).summaries?.map(({ id }) => id)).toEqual([
+    second,
+    first
+  ])
+  await fresh.close()
+  await expect(reopened.run({ action: 'list' })).resolves.toMatchObject({
+    summaries: [{ id: second }, { id: first }]
+  })
+  expect((await state(reopened, second)).state).toBe('review')
+  await reopened.run({ action: 'remove', jobId: second })
+  expect((await reopened.run({ action: 'list' })).summaries?.map(({ id }) => id)).toEqual([first])
+})
+
+it('recognizes its committed metadata after replaying the pre-commit checkpoint', async () => {
+  const { LiteratureCatalog } = await import('./catalog')
+  const { LiteratureMetadataEnricher } = await import('./metadata-enricher')
+  const { createProjectDbClient } = await import('../projects/prisma-client')
+  const { migrateApplicationDatabase } = await import('../database/migration-service')
+  const { jobs: initial, options, path } = await setup()
+  await initial.close()
+  const root = await mkdtemp(join(tmpdir(), 'literature-task-commit-'))
+  cleanup.push(() => rm(root, { recursive: true, force: true }))
+  const client = createProjectDbClient(root)
+  cleanup.push(() => client.$disconnect())
+  await migrateApplicationDatabase(client)
+  const catalog = new LiteratureCatalog(async () => client)
+  const created = await catalog.transact({ kind: 'create-item', item: item('a').item })
+  const original = (await catalog.get(created.id))!
+  const fetchMetadata = vi.fn(
+    async () =>
+      new Response(
+        JSON.stringify({
+          message: {
+            DOI: '10.1234/example',
+            'container-title': ['Committed journal']
+          }
+        })
+      )
+  )
+  const enricher = new LiteratureMetadataEnricher(catalog, fetchMetadata)
+  const jobId = randomUUID()
+  const checkpoint = join(`${path}.d`, `${jobId}.json`)
+  let beforeCommit = ''
+  const serviceOptions = { ...options, catalog, metadata: enricher }
+  const jobs = new LiteratureBatchJobs({
+    ...serviceOptions,
+    metadata: {
+      complete: (request) => enricher.complete(request),
+      applyReviewed: async (review) => {
+        // The service has durably accepted apply, but has not yet committed catalog data.
+        beforeCommit = await readFile(checkpoint, 'utf8')
+        return enricher.applyReviewed(review)
+      }
+    }
+  })
+  cleanup.push(() => jobs.close())
+  await jobs.run({ action: 'create', mode: 'metadata', itemIds: [created.id], requestId: jobId })
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('review'))
+  await jobs.run({ action: 'apply', jobId, selections: [{ itemId: created.id }] })
+  await vi.waitFor(async () => expect((await state(jobs, jobId)).state).toBe('completed'))
+  await jobs.close()
+  const committed = (await catalog.get(created.id))!
+  expect(committed.item.containerTitle).toBe('Committed journal')
+  expect(committed.metadataRevision).toBeGreaterThan(original.metadataRevision)
+  expect(JSON.parse(beforeCommit)).toMatchObject({ state: 'running', phase: 'apply' })
+  // Reconstruct only the crash window: catalog commit survived, task completion did not.
+  await writeFile(checkpoint, beforeCommit)
+  const reopened = new LiteratureBatchJobs(serviceOptions)
+  cleanup.push(() => reopened.close())
+  expect((await state(reopened, jobId)).state).toBe('paused')
+  await reopened.run({ action: 'resume', jobId })
+  await vi.waitFor(async () => expect((await state(reopened, jobId)).state).toBe('completed'))
+  expect((await catalog.get(created.id))!.metadataRevision).toBe(committed.metadataRevision)
+  expect((await catalog.get(created.id))!.item.containerTitle).toBe('Committed journal')
+  expect.soft((await state(reopened, jobId)).rows[0]).toMatchObject({ status: 'done' })
+  expect.soft((await reopened.run({ action: 'list' })).summaries?.[0]).toMatchObject({
+    done: 1,
+    failed: 0,
+    completedItemIds: [created.id]
+  })
+  expect(fetchMetadata).toHaveBeenCalledOnce()
+})

--- a/src/main/literature/batch-jobs.ts
+++ b/src/main/literature/batch-jobs.ts
@@ -88,12 +88,21 @@ export class LiteratureBatchJobs {
           if (row.status === 'searching') row.status = 'pending'
           if (row.status === 'saving') row.status = 'ready'
         }
+        if (job.state === 'completed' && job.rows.some(({ status }) => status === 'pending')) {
+          job.state = 'paused'
+          job.phase = 'search'
+          job.phaseItemIds = undefined
+          job.updatedAt = Math.max(Date.now(), job.updatedAt + 1)
+        }
       }
       if (stored.status === 'found' && stored.value.version === 1) {
         for (const job of this.jobs) await this.save(job)
         await this.saveIndex()
       }
-    })())
+    })().catch((error: unknown) => {
+      this.loaded = undefined
+      throw error
+    }))
   }
 
   private jobPath(id: string): string {
@@ -165,7 +174,7 @@ export class LiteratureBatchJobs {
         const settled = this.jobs.findLastIndex(
           (job) =>
             job.state === 'completed' &&
-            job.rows.every(({ status }) => status !== 'ready' && status !== 'error')
+            job.rows.every(({ status }) => status === 'done' || status === 'skipped')
         )
         if (settled < 0) throw new Error('Remove completed Literature tasks before adding more.')
         prunedId = nextJobs.splice(settled, 1)[0]?.id
@@ -245,6 +254,7 @@ export class LiteratureBatchJobs {
             throw new Error('Review the current task results before applying.')
         }
         for (const row of job.rows) {
+          if (row.status !== 'ready') continue
           const selected = request.selections.find(({ itemId }) => itemId === row.id)
           row.checked = Boolean(selected)
           if (selected?.candidateId) row.candidateId = selected.candidateId
@@ -377,6 +387,12 @@ export class LiteratureBatchJobs {
               job.rows.some(({ status }) => status === 'ready' || status === 'error')
             ? 'review'
             : 'completed'
+      // Applying a selection does not finish a search the user paused.
+      if (job.state === 'completed' && job.rows.some(({ status }) => status === 'pending')) {
+        job.phase = 'search'
+        job.phaseItemIds = undefined
+        job.state = 'paused'
+      }
       job.updatedAt = Math.max(Date.now(), job.updatedAt + 1)
       this.currentJobId = undefined
       await this.save(job)
@@ -435,7 +451,7 @@ export class LiteratureBatchJobs {
       !current ||
       current.id !== row.id ||
       current.deletedAt ||
-      current.metadataRevision !== row.item?.metadataRevision
+      (job.mode === 'full-text' && current.metadataRevision !== row.item?.metadataRevision)
     )
       throw new Error('Reference changed')
     if (job.mode === 'metadata') {

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -2807,4 +2807,115 @@ describe('LiteratureCatalog', () => {
       client!.literatureItem.count({ where: { id: { in: items.map(({ id }) => id) } } })
     ).resolves.toBe(0)
   })
+
+  it('retains metadata commit proof across edits and soft deletion, and removes it with the reference', async () => {
+    const catalog = await setup()
+    const created = await catalog.transact({ kind: 'create-item', item: candidate().item })
+    const before = (await catalog.get(created.id))!
+    const input = {
+      operationId: 'review-operation',
+      itemId: before.id,
+      expectedMetadataRevision: before.metadataRevision,
+      item: { ...before.item, containerTitle: 'Committed journal' },
+      source: candidate().source
+    }
+    const committed = await catalog.applyMetadata(input)
+    expect(await catalog.getMetadataCommitReceipt(input.operationId)).toEqual({
+      operationId: input.operationId,
+      itemId: before.id,
+      expectedMetadataRevision: before.metadataRevision,
+      committedMetadataRevision: committed.metadataRevision
+    })
+    await catalog.transact({
+      kind: 'update-item',
+      itemId: before.id,
+      expectedMetadataRevision: committed.metadataRevision,
+      item: { ...committed.item, title: 'Later edit' }
+    })
+    const later = (await catalog.get(before.id))!
+    expect(await catalog.applyMetadata(input)).toEqual(later)
+    await expect(
+      catalog.applyMetadata({ ...input, operationId: 'different-operation' })
+    ).rejects.toThrow('revision conflict')
+    expect(await catalog.getMetadataCommitReceipt('different-operation')).toBeNull()
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [before.id], state: 'deleted' })
+    expect(await catalog.getMetadataCommitReceipt(input.operationId)).not.toBeNull()
+    await catalog.transact({ kind: 'delete-items-permanently', itemIds: [before.id] })
+    expect(await catalog.getMetadataCommitReceipt(input.operationId)).toBeNull()
+  })
+
+  it('rolls back metadata when its commit receipt cannot be written', async () => {
+    const catalog = await setup()
+    const created = await catalog.transact({ kind: 'create-item', item: candidate().item })
+    const before = (await catalog.get(created.id))!
+    const failing = client!.$extends({
+      query: {
+        literatureMetadataCommitReceipt: {
+          async create() {
+            throw new Error('Receipt storage unavailable')
+          }
+        }
+      }
+    })
+    const failingCatalog = new LiteratureCatalog(async () => failing as unknown as PrismaClient)
+    await expect(
+      failingCatalog.applyMetadata({
+        operationId: 'interrupted',
+        itemId: before.id,
+        expectedMetadataRevision: before.metadataRevision,
+        item: { ...before.item, containerTitle: 'Must roll back' },
+        source: candidate().source
+      })
+    ).rejects.toThrow('Receipt storage unavailable')
+    expect(await catalog.get(before.id)).toEqual(before)
+    expect(await catalog.getMetadataCommitReceipt('interrupted')).toBeNull()
+    expect(await client!.literatureSourceRecord.count()).toBe(0)
+  })
+
+  it('keeps commit receipts bound to their original reference when references merge', async () => {
+    const catalog = await setup()
+    const first = await catalog.transact({ kind: 'create-item', item: candidate().item })
+    const second = await catalog.transact({
+      kind: 'create-item',
+      item: candidate({ doi: '10.1234/other' }).item
+    })
+    const before = (await catalog.get(first.id))!
+    await catalog.applyMetadata({
+      operationId: 'original-reference-operation',
+      itemId: first.id,
+      expectedMetadataRevision: before.metadataRevision,
+      item: before.item,
+      source: candidate().source
+    })
+    const originalReceipt = await catalog.getMetadataCommitReceipt('original-reference-operation')
+    const reviewed = (await Promise.all([catalog.get(first.id), catalog.get(second.id)])).map(
+      (item) => item!
+    )
+    await catalog.transact({
+      kind: 'merge-items',
+      survivorId: second.id,
+      duplicateIds: [first.id],
+      item: reviewed[1].item,
+      expectedMetadataRevision: reviewed[1].metadataRevision,
+      expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+        id,
+        metadataRevision,
+        updatedAt
+      }))
+    })
+    expect(await catalog.getMetadataCommitReceipt('original-reference-operation')).toEqual(
+      originalReceipt
+    )
+    const survivor = (await catalog.get(second.id))!
+    await expect(
+      catalog.applyMetadata({
+        operationId: 'original-reference-operation',
+        itemId: second.id,
+        expectedMetadataRevision: survivor.metadataRevision,
+        item: survivor.item,
+        source: candidate().source
+      })
+    ).rejects.toThrow('operation identity')
+    expect(await catalog.get(second.id)).toEqual(survivor)
+  })
 })

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -78,6 +78,7 @@ type AttachLiteratureContentInput = Readonly<{
 type AttachedLiteratureContent = Readonly<{ attachmentId: string; versionId: string }>
 
 type ApplyLiteratureMetadataInput = Readonly<{
+  operationId?: string
   itemId: string
   expectedMetadataRevision: number
   item: LiteratureItemInput
@@ -1066,6 +1067,18 @@ class LiteratureCatalog {
     })
   }
 
+  async getMetadataCommitReceipt(operationId: string): Promise<{
+    operationId: string
+    itemId: string
+    expectedMetadataRevision: number
+    committedMetadataRevision: number
+  } | null> {
+    const client = await this.getClient()
+    return client.$transaction((transaction) =>
+      transaction.literatureMetadataCommitReceipt.findUnique({ where: { operationId } })
+    )
+  }
+
   async applyMetadata(input: ApplyLiteratureMetadataInput): Promise<LiteratureItemView> {
     await this.updateItem(
       {
@@ -1074,7 +1087,8 @@ class LiteratureCatalog {
         expectedMetadataRevision: input.expectedMetadataRevision,
         item: input.item
       },
-      input.source
+      input.source,
+      input.operationId
     )
     const updated = await this.get(input.itemId)
     if (!updated) throw new Error('Literature Item is unavailable.')
@@ -1450,7 +1464,8 @@ class LiteratureCatalog {
 
   private async updateItem(
     command: Extract<LiteratureCatalogCommand, { kind: 'update-item' }>,
-    source?: LiteratureSourceInput
+    source?: LiteratureSourceInput,
+    operationId?: string
   ): Promise<LiteratureCatalogReceipt> {
     const itemId = normalizeSpace(command.itemId)
     const item = literatureItemInputSchema.parse(command.item)
@@ -1458,8 +1473,35 @@ class LiteratureCatalog {
 
     return client
       .$transaction(async (transaction): Promise<LiteratureCatalogReceipt> => {
+        if (operationId) {
+          const receipt = await transaction.literatureMetadataCommitReceipt.findUnique({
+            where: { operationId }
+          })
+          if (receipt) {
+            if (
+              receipt.itemId !== itemId ||
+              receipt.expectedMetadataRevision !== command.expectedMetadataRevision
+            )
+              throw new Error('Metadata operation identity does not match the reviewed reference.')
+            return { kind: 'item', id: itemId, state: 'present' }
+          }
+        }
         await replaceItemMetadata(transaction, itemId, command.expectedMetadataRevision, item)
         if (source) await this.attachSource(transaction, { source, itemId })
+        if (operationId) {
+          const committed = await transaction.literatureItem.findUniqueOrThrow({
+            where: { id: itemId },
+            select: { metadataRevision: true }
+          })
+          await transaction.literatureMetadataCommitReceipt.create({
+            data: {
+              operationId,
+              itemId,
+              expectedMetadataRevision: command.expectedMetadataRevision,
+              committedMetadataRevision: committed.metadataRevision
+            }
+          })
+        }
         return { kind: 'item', id: itemId, state: 'present' }
       })
       .finally(() => duplicateGroups.delete(client))

--- a/src/main/literature/metadata-enricher.test.ts
+++ b/src/main/literature/metadata-enricher.test.ts
@@ -73,7 +73,11 @@ describe('LiteratureMetadataEnricher', () => {
   it('previews citation metadata without mutating the catalog', async () => {
     const applyMetadata = vi.fn()
     const enricher = new LiteratureMetadataEnricher(
-      { get: vi.fn().mockResolvedValue(view), applyMetadata },
+      {
+        getMetadataCommitReceipt: async () => null,
+        get: vi.fn().mockResolvedValue(view),
+        applyMetadata
+      },
       vi.fn().mockResolvedValue(
         new Response(JSON.stringify(crossrefResponse), {
           status: 200,
@@ -116,6 +120,7 @@ describe('LiteratureMetadataEnricher', () => {
     const applyMetadata = vi.fn()
     const enricher = new LiteratureMetadataEnricher(
       {
+        getMetadataCommitReceipt: async () => null,
         get: vi.fn().mockResolvedValue({
           ...view,
           item: { ...item, identifiers: [] }
@@ -157,6 +162,7 @@ describe('LiteratureMetadataEnricher', () => {
   it('keeps existing values and reports Crossref conflicts', async () => {
     const enricher = new LiteratureMetadataEnricher(
       {
+        getMetadataCommitReceipt: async () => null,
         get: vi.fn().mockResolvedValue({
           ...view,
           item: { ...item, containerTitle: 'User Journal', typeFields: { volume: '9' } }
@@ -182,7 +188,11 @@ describe('LiteratureMetadataEnricher', () => {
     const updated = { ...view, metadataRevision: 3 }
     const applyMetadata = vi.fn().mockResolvedValue(updated)
     const enricher = new LiteratureMetadataEnricher(
-      { get: vi.fn().mockResolvedValue(view), applyMetadata },
+      {
+        getMetadataCommitReceipt: async () => null,
+        get: vi.fn().mockResolvedValue(view),
+        applyMetadata
+      },
       vi.fn().mockResolvedValue(new Response(JSON.stringify(crossrefResponse), { status: 200 }))
     )
 
@@ -216,6 +226,7 @@ describe('LiteratureMetadataEnricher', () => {
       )
     const enricher = new LiteratureMetadataEnricher(
       {
+        getMetadataCommitReceipt: async () => null,
         get: vi.fn().mockResolvedValue({
           ...view,
           item: { ...item, containerTitle: 'User Journal', typeFields: { volume: '9' } }
@@ -246,7 +257,10 @@ describe('LiteratureMetadataEnricher', () => {
     const fetch = vi
       .fn()
       .mockImplementation(async () => new Response(JSON.stringify(crossrefResponse)))
-    const enricher = new LiteratureMetadataEnricher({ get, applyMetadata }, fetch)
+    const enricher = new LiteratureMetadataEnricher(
+      { getMetadataCommitReceipt: async () => null, get, applyMetadata },
+      fetch
+    )
     const review = await enricher.complete({ mode: 'preview', itemId: view.id })
     fetch.mockRejectedValue(new Error('Provider unavailable after review'))
     await enricher.complete({
@@ -277,7 +291,11 @@ const regressionEnricher = (
     item: input.item
   }))
   const enricher = new LiteratureMetadataEnricher(
-    { get: vi.fn().mockResolvedValue({ ...view, item: current }), applyMetadata },
+    {
+      getMetadataCommitReceipt: async () => null,
+      get: vi.fn().mockResolvedValue({ ...view, item: current }),
+      applyMetadata
+    },
     vi.fn().mockResolvedValue(response)
   )
   return { enricher, applyMetadata }

--- a/src/main/literature/metadata-enricher.ts
+++ b/src/main/literature/metadata-enricher.ts
@@ -13,7 +13,7 @@ import {
 } from '../../shared/literature'
 import { normalizeIdentifier, type LiteratureCatalog } from './catalog'
 
-type MetadataCatalog = Pick<LiteratureCatalog, 'applyMetadata' | 'get'>
+type MetadataCatalog = Pick<LiteratureCatalog, 'applyMetadata' | 'get' | 'getMetadataCommitReceipt'>
 type FetchFn = typeof fetch
 
 const CROSSREF_BASE = 'https://api.crossref.org/works/'
@@ -484,6 +484,28 @@ class LiteratureMetadataEnricher {
     overwriteFields: readonly LiteratureMetadataField[] = []
   ): Promise<LiteratureMetadataCompletionResult> {
     const current = await this.catalog.get(review.item.id)
+    const operationId = review.reviewToken
+      ? `${review.reviewToken}:${JSON.stringify([...new Set(overwriteFields)].sort())}`
+      : undefined
+    const receipt = operationId ? await this.catalog.getMetadataCommitReceipt(operationId) : null
+    if (
+      receipt &&
+      current &&
+      current.id === review.item.id &&
+      !current.deletedAt &&
+      receipt.itemId === review.item.id &&
+      receipt.expectedMetadataRevision === review.item.metadataRevision &&
+      current.metadataRevision >= receipt.committedMetadataRevision
+    ) {
+      return {
+        mode: 'commit',
+        provider: review.provider,
+        sourceUrl: review.sourceUrl,
+        item: current,
+        filled: review.filled,
+        conflicts: review.conflicts
+      }
+    }
     if (
       !current ||
       current.id !== review.item.id ||
@@ -516,6 +538,7 @@ class LiteratureMetadataEnricher {
       }
     }
     const persistedItem = await this.catalog.applyMetadata({
+      operationId,
       itemId: current.id,
       expectedMetadataRevision: review.item.metadataRevision,
       item: merged.item,

--- a/src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx
@@ -177,3 +177,20 @@ it('updates metadata dates with the interface language on an unchanged host', as
     })
   }
 })
+
+it('keeps unsearched references discoverable after a partial application is marked completed', async () => {
+  await show([
+    {
+      ...job,
+      state: 'completed',
+      phase: 'apply',
+      total: 2,
+      checked: 1,
+      ready: 0,
+      done: 1,
+      failed: 0,
+      completedItemIds: ['a']
+    }
+  ])
+  expect(screen.queryByRole('button', { name: 'Background tasks' })).not.toBeNull()
+})

--- a/src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBackgroundTasks.test.tsx
@@ -21,7 +21,14 @@ it('refreshes the library when a background job completes after its dialog close
   request.mockResolvedValue({
     jobs: [],
     summaries: [
-      { ...job, state: 'completed', done: 3, ready: 0, completedItemIds: ['a', 'b', 'c'] }
+      {
+        ...job,
+        state: 'completed',
+        checked: 3,
+        done: 3,
+        ready: 0,
+        completedItemIds: ['a', 'b', 'c']
+      }
     ]
   })
   await act(async () => {

--- a/src/renderer/src/pages/literature/LiteratureBackgroundTasks.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBackgroundTasks.tsx
@@ -101,7 +101,9 @@ export function LiteratureBackgroundTasks({
     review: t('Awaiting review'),
     completed: t('Completed')
   }
-  const pending = jobs.filter((job) => job.state !== 'completed' || job.failed > 0 || job.ready > 0)
+  const pending = jobs.filter(
+    (job) => job.state !== 'completed' || job.failed > 0 || job.ready > 0 || job.checked < job.total
+  )
   const running = pending.filter((job) => job.state === 'running' || job.state === 'pausing')
   const allPaused = pending.every((job) => job.state === 'paused')
   const checked = running.reduce(
@@ -207,6 +209,9 @@ export function LiteratureBackgroundTasks({
                         : job.mode === 'metadata'
                           ? t('Metadata updated: {{done}}', { done: job.done })
                           : t('PDFs added: {{done}}', { done: job.done })}
+                      {job.total > job.checked
+                        ? ` · ${t('Pending')}: ${job.total - job.checked}`
+                        : null}
                       {job.failed > 0 ? ` · ${t('Failed')}: ${job.failed}` : null}
                     </p>
                     <p className="text-xs text-muted-foreground">

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
@@ -304,3 +304,37 @@ it('retires a failed apply request when the user changes the selection', async (
   expect(jobs.mock.calls.filter(([request]) => request.action === 'apply')).toHaveLength(1)
   expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
 })
+
+it('adopts another window saved deselection when this window has no pending draft', async () => {
+  job.state = 'review'
+  job.rows[0]!.status = 'ready'
+  job.rows.push({
+    id: 'second',
+    item: { ...item, id: 'second', item: { ...item.item, title: 'Second paper' } },
+    checked: true,
+    status: 'ready'
+  })
+  open(id)
+  await flush()
+  expect(
+    (screen.getByRole('checkbox', { name: 'Select reference: First paper' }) as HTMLInputElement)
+      .checked
+  ).toBe(true)
+  job.rows[0]!.checked = false
+  job.updatedAt += 1
+  fireEvent(window, new Event('literature-job-refresh'))
+  await act(async () => {})
+  expect
+    .soft(
+      (screen.getByRole('checkbox', { name: 'Select reference: First paper' }) as HTMLInputElement)
+        .checked
+    )
+    .toBe(false)
+  fireEvent.click(screen.getByRole('button', { name: /Apply metadata/ }))
+  await act(async () => {})
+  expect(jobs).toHaveBeenLastCalledWith({
+    action: 'apply',
+    jobId: id,
+    selections: [{ itemId: 'second', candidateId: undefined }]
+  })
+})

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.test.tsx
@@ -31,7 +31,17 @@ const flush = async (): Promise<void> => {
 beforeEach(() => {
   vi.useFakeTimers()
   vi.clearAllMocks()
-  jobs.mockImplementation(async () => ({ jobs: [structuredClone(job)] }))
+  jobs.mockImplementation(async (request) => {
+    if (request.action === 'review') {
+      for (const selection of request.selections)
+        Object.assign(
+          job.rows.find(({ id }) => id === selection.itemId)!,
+          selection
+        )
+      job.updatedAt += 1
+    }
+    return { jobs: [structuredClone(job)] }
+  })
   job = {
     id,
     mode: 'metadata',
@@ -287,6 +297,10 @@ it('retires a failed apply request when the user changes the selection', async (
   job.rows[0]!.status = 'ready'
   jobs.mockImplementation(async (request) => {
     if (request.action === 'apply') throw new Error('checkpoint unavailable')
+    if (request.action === 'review') {
+      Object.assign(job.rows[0]!, request.selections[0])
+      job.updatedAt += 1
+    }
     return { jobs: [structuredClone(job)] }
   })
   open(id)
@@ -337,4 +351,64 @@ it('adopts another window saved deselection when this window has no pending draf
     jobId: id,
     selections: [{ itemId: 'second', candidateId: undefined }]
   })
+})
+
+it('adopts another window saved candidate when there is no local draft', async () => {
+  job.state = 'review'
+  job.mode = 'full-text'
+  job.rows[0] = {
+    ...job.rows[0]!,
+    status: 'ready',
+    candidateId: 'first-source',
+    candidates: [
+      {
+        id: 'first-source',
+        provider: 'pmc',
+        source: 'PMC',
+        url: 'https://first.example/paper.pdf'
+      },
+      {
+        id: 'second-source',
+        provider: 'pmc',
+        source: 'PMC',
+        url: 'https://second.example/paper.pdf'
+      }
+    ]
+  }
+  open(id, 'full-text')
+  await flush()
+  job.updatedAt += 1
+  job.rows[0].candidateId = 'second-source'
+  fireEvent(window, new Event('literature-job-refresh'))
+  await act(async () => {})
+  fireEvent.click(screen.getByRole('button', { name: 'Add attachment (1)' }))
+  await act(async () => {})
+  expect(jobs).toHaveBeenLastCalledWith({
+    action: 'apply',
+    jobId: id,
+    selections: [{ itemId: item.id, candidateId: 'second-source' }]
+  })
+})
+
+it('retires failed apply selections when another window saves a different review', async () => {
+  job.state = 'review'
+  job.rows[0]!.status = 'ready'
+  jobs.mockImplementation(async (request) => {
+    if (request.action === 'apply') throw new Error('checkpoint unavailable')
+    return { jobs: [structuredClone(job)] }
+  })
+  open(id)
+  await flush()
+  fireEvent.click(screen.getByRole('button', { name: 'Apply metadata (1)' }))
+  await act(async () => {})
+  expect(screen.getByRole('alert')).toBeTruthy()
+  job.rows[0]!.checked = false
+  job.updatedAt += 1
+  fireEvent(window, new Event('literature-job-refresh'))
+  await act(async () => {})
+  expect((screen.getByRole('checkbox') as HTMLInputElement).checked).toBe(false)
+  const retry = screen.queryByRole('button', { name: 'Retry' })
+  if (retry) fireEvent.click(retry)
+  await act(async () => {})
+  expect(jobs.mock.calls.filter(([request]) => request.action === 'apply')).toHaveLength(1)
 })

--- a/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteratureBatchLookupDialog.tsx
@@ -72,6 +72,21 @@ export const LiteratureBatchLookupDialog = ({
   const receive = (value: Job): void => {
     const prior = jobRef.current
     if (prior && value.updatedAt < prior.updatedAt) return
+    const failed = failedCommand.current
+    if (
+      failed?.action === 'apply' &&
+      failed.selections.some((selection) => {
+        if (pendingDrafts.current.has(selection.itemId)) return false
+        const row = value.rows.find(({ id }) => id === selection.itemId)
+        return (
+          !row ||
+          row.status !== 'ready' ||
+          !row.checked ||
+          row.candidateId !== selection.candidateId
+        )
+      })
+    )
+      failedCommand.current = undefined
     const changedRows = prior
       ? value.rows
           .filter((row, index) => row.status === 'done' && prior.rows[index]?.status !== 'done')
@@ -85,7 +100,10 @@ export const LiteratureBatchLookupDialog = ({
       const byId = new Map(current.map((row) => [row.id, row]))
       return value.rows.map((row) => {
         const local = byId.get(row.id)
-        return local && local.status === 'ready' && row.status === 'ready'
+        return pendingDrafts.current.has(row.id) &&
+          local &&
+          local.status === 'ready' &&
+          row.status === 'ready'
           ? {
               ...row,
               checked: local.checked,
@@ -159,7 +177,7 @@ export const LiteratureBatchLookupDialog = ({
       const currentJob = jobRef.current
       const selections = [...pendingDrafts.current.values()]
       if (!currentJob || selections.length === 0) return
-      await window.api.literature.jobs({
+      const result = await window.api.literature.jobs({
         action: 'review',
         jobId: currentJob.id,
         selections
@@ -168,6 +186,7 @@ export const LiteratureBatchLookupDialog = ({
         if (pendingDrafts.current.get(selection.itemId) === selection)
           pendingDrafts.current.delete(selection.itemId)
       }
+      if (result.jobs[0]) receive(result.jobs[0])
     }
     // Retain failed selections so Retry and later commands can persist them again.
     draftWrites.current = draftWrites.current.then(write, write)
@@ -313,6 +332,11 @@ export const LiteratureBatchLookupDialog = ({
                   }
                 }}
               />
+            ) : null}
+            {rows.length > checked ? (
+              <p>
+                {t('Pending')}: {rows.length - checked}
+              </p>
             ) : null}
             <div className="flex flex-wrap justify-between gap-2 tabular-nums">
               <span>


### PR DESCRIPTION
## Problem

Applying ready results from a paused Literature search could mark the whole task completed and hide its remaining references. A repaired checkpoint could remain unreadable until restart, and a clean review window could retain another window's obsolete selections. Replaying a task after metadata committed but before its completion checkpoint was saved could report that successful operation as failed.

## Proposed change

- Return partial applications to the existing search/paused state, preserve pending selections, and keep unfinished work discoverable and ineligible for completed-task pruning. Show the pending count derived from existing summary fields.
- Retry rejected initialization on the next request while retaining concurrent-load deduplication and the all-task recovery barrier.
- Overlay local review choices only for pending drafts, receive acknowledged review snapshots, and retire failed apply requests when newer saved choices invalidate them.
- Write metadata commit receipts in the same SQLite transaction as reference metadata and source provenance. Reconcile matching receipts before treating an old revision as a conflict; unrelated operations retain revision protection.

## Persistence and compatibility

Adds `LiteratureMetadataCommitReceipt` with four columns: `operationId`, `itemId`, `expectedMetadataRevision`, and `committedMetadataRevision`. Operation identity uses the existing review token and normalized overwrite selection. The additive `0039` migration follows the Prisma-owned schema and generated runtime target; existing reference columns, task JSON members, and task/row enum values are unchanged.

Receipts stay bound to the original reference across edits, soft deletion, and merge. Permanent reference deletion cascades them; removing a JSON task does not erase replay evidence. Migration creates an empty receipt table and does not infer historical successes. Previously completed checkpoints with pending rows load as search/paused. Older previews without operation identity keep conservative revision checking. Older app versions cannot be assumed to open a database with the newer migration ledger; no downgrade migration is provided.

The broad-looking database test diff updates current-tail expectations and historical suffix fixtures for the additive migration; released migration payloads are unchanged.

## Acceptance criteria and validation

Regressions were added before fixes. The original five failures were reproduced twice; the expanded seven-case reproduction ran twice with original production files restored, with identical failure names/reasons. A separate failed-apply/remote-deselection test demonstrated two apply requests before its fix and one afterward. The fixed production files were restored byte-for-byte after those baseline checks.

Final checks after rebasing onto `7f5d71573fd7e179009e75245cda11eb8b1815c2`: 1978 focused tests passed after all conflict resolutions. Typecheck, lint and generated-schema checks passed. Main's released `0038` search-text migration and normalized search fields are preserved; this PR's unpublished receipt migration is now `0039`. Packaged ledger checksums and historical suffix fixtures match that ordering.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Task pause/apply/recovery, checkpoint repair, metadata catalog/enricher, rollback, receipt identity/lifecycle, renderer selections/entry, schema upgrades and persistence | Focused Vitest run of `scripts/database-migration-ledger-smoke.test.ts`, `src/main/database`, `src/main/literature`, `src/shared/literature.test.ts`, `src/shared/literature-jobs.test.ts`, `src/renderer/src/pages/literature`, and `src/main/storage/durable-json-file.test.ts` | 1055 passed |
| IPC/application adapters, preload and renderer contracts, eight locale catalogs | `src/shared/renderer-contract-catalog.test.ts`, `src/main/application-command-composition.test.ts`, `src/main/application-command-electron-adapter.test.ts`, `src/preload/index.test.ts`, `src/renderer/src/i18n/resources.test.ts` in the focused Vitest run | 923 passed |
| Main/renderer/sandbox types | `npm run typecheck` | passed |
| Linted source | `npm run lint` | passed |
| Generated DB target | `npm run db:schema:check` | passed |
| Patch whitespace | `git diff --check` | passed |

No full local test suite was run, per maintainer instruction. Database tests cover the generated Prisma target and migration suffix; adapter/consumer tests cover the dynamic task contract. PR CI is the authority for full portable, operating-system, packaging and independent-review checks.

## Review focus

Metadata receipt writes must roll back with metadata/provenance, unrelated revisions must still conflict, and dirty drafts must survive failed saves. The receipt rollback probe uses a test-only Prisma extension at the existing dependency boundary, with real SQLite transactions; no production test seam was added.

UI verification used actual React components with controlled task snapshots: apply one reference, retain Pending: 1 and Resume, close the dialog, reopen from Background tasks, then resume. ego-browser verified the flow; its screenshot capture timed out, so existing Playwright captured and visually verified the same fixture. This is not two-window Electron E2E. Crash recovery restores authentic pre-commit checkpoint bytes after a real SQLite commit, rather than a process-kill/power-loss test. Live metadata providers and cross-platform packaging remain CI/manual coverage.
