### PR TITLE
fix(updater): explain Windows installer handoff failures

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -245,7 +245,8 @@ FunctionEnd
   # Checking only after uninstalling can reject the update with the old executable already gone.
   # A stale locked uninstaller must not turn a silent install into a false success or offer the unsafe
   # Ignore choice. OPEN_EXISTING keeps this check non-destructive; Retry lets the user release a
-  # transient lock, while silent installs take the Cancel path and return a failure code.
+  # transient lock. Unattended installs stay silent; a user-requested restart must explain failure
+  # even though electron-updater starts NSIS with /S and exits before observing the result.
   Function ensureExistingUninstallerIsWritable
     IfFileExists "$INSTDIR\${UNINSTALL_FILENAME}" ensureExistingUninstallerIsWritable_retry ensureExistingUninstallerIsWritable_done
 
@@ -258,9 +259,25 @@ FunctionEnd
       Return
 
     ensureExistingUninstallerIsWritable_failed:
-      DetailPrint `Cannot replace the existing uninstaller: "$INSTDIR\${UNINSTALL_FILENAME}".`
-      IfSilent ensureExistingUninstallerIsWritable_cancel
-      MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION "$(uninstallFailed)$\r$\n$INSTDIR\${UNINSTALL_FILENAME}" IDRETRY ensureExistingUninstallerIsWritable_retry
+      DetailPrint `Cannot replace the existing uninstaller: "$INSTDIR\${UNINSTALL_FILENAME}". Windows error: $R1.`
+      ${if} ${Silent}
+        # --updated + --force-run is the existing Restart to update handoff, including old clients.
+        # Plain /S and non-relaunching update jobs must not wait for someone to dismiss a dialog.
+        ${ifNot} ${isUpdated}
+          Goto ensureExistingUninstallerIsWritable_cancel
+        ${endif}
+        ${ifNot} ${isForceRun}
+          Goto ensureExistingUninstallerIsWritable_cancel
+        ${endif}
+      ${endif}
+      ${if} $R1 == 5
+        MessageBox MB_OK|MB_ICONEXCLAMATION|MB_SETFOREGROUND "Open Science could not finish updating.$\r$\n$\r$\nWindows denied access to:$\r$\n$INSTDIR\${UNINSTALL_FILENAME}$\r$\n$\r$\nClose this notice, then run the official Open Science installer as administrator to update this installation.$\r$\n$\r$\nWindows error: $R1"
+      ${elseif} $R1 == 32
+      ${orIf} $R1 == 33
+        MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION|MB_SETFOREGROUND "Open Science could not finish updating.$\r$\n$\r$\nAnother process is using:$\r$\n$INSTDIR\${UNINSTALL_FILENAME}$\r$\n$\r$\nClose the process using this file, then choose Retry. Choose Cancel to stop this update.$\r$\n$\r$\nWindows error: $R1" IDRETRY ensureExistingUninstallerIsWritable_retry
+      ${else}
+        MessageBox MB_RETRYCANCEL|MB_ICONEXCLAMATION|MB_SETFOREGROUND "Open Science could not finish updating.$\r$\n$\r$\nWindows could not replace:$\r$\n$INSTDIR\${UNINSTALL_FILENAME}$\r$\n$\r$\nChoose Retry to try again, or Cancel to stop this update. If the problem continues, report the file path and Windows error below.$\r$\n$\r$\nWindows error: $R1" IDRETRY ensureExistingUninstallerIsWritable_retry
+      ${endif}
 
     ensureExistingUninstallerIsWritable_cancel:
       # customInit may already have moved nested user data outside the old installation.

--- a/scripts/fixtures/windows-update-notice/NoticeRegression.cs
+++ b/scripts/fixtures/windows-update-notice/NoticeRegression.cs
@@ -1,0 +1,149 @@
+// An opt-in native installer test, not an application helper. Observes real Win32 dialogs
+// belonging only to the child installer. No UI or updater behavior is mocked.
+using System;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Security.Principal;
+using System.Text;
+using System.Threading;
+using Microsoft.Win32;
+
+class NoticeRegression {
+  const string Name = "open-science-update-notice-test";
+  const string Guid = "11f7eae6-e7e3-4c1c-931f-2a9b1df095ea";
+  delegate bool WindowCallback(IntPtr window, IntPtr parameter);
+  [DllImport("user32.dll")] static extern bool EnumWindows(WindowCallback callback, IntPtr parameter);
+  [DllImport("user32.dll")] static extern bool EnumChildWindows(IntPtr parent, WindowCallback callback, IntPtr parameter);
+  [DllImport("user32.dll")] static extern uint GetWindowThreadProcessId(IntPtr window, out uint pid);
+  [DllImport("user32.dll")] static extern bool IsWindowVisible(IntPtr window);
+  [DllImport("user32.dll", CharSet = CharSet.Unicode)] static extern int GetWindowText(IntPtr window, StringBuilder text, int count);
+  [DllImport("user32.dll")] static extern IntPtr GetDlgItem(IntPtr window, int id);
+  [DllImport("user32.dll")] static extern bool PostMessage(IntPtr window, uint message, IntPtr wParam, IntPtr lParam);
+
+  static void Require(bool value, string message) { if (!value) throw new Exception(message); }
+  static Process Start(string file, string arguments) {
+    return Process.Start(new ProcessStartInfo(file, arguments) { UseShellExecute = false, CreateNoWindow = true });
+  }
+  static int Finish(Process process) {
+    Require(process.WaitForExit(30000), "Installer did not finish within 30 seconds.");
+    return process.ExitCode;
+  }
+  static int Run(string file, string arguments) { using (var process = Start(file, arguments)) return Finish(process); }
+  static IntPtr Dialog(Process process) {
+    IntPtr found = IntPtr.Zero;
+    EnumWindows((window, _) => {
+      uint pid; GetWindowThreadProcessId(window, out pid);
+      if (pid == process.Id && IsWindowVisible(window) &&
+          (GetDlgItem(window, 1) != IntPtr.Zero || GetDlgItem(window, 2) != IntPtr.Zero)) found = window;
+      return true;
+    }, IntPtr.Zero);
+    return found;
+  }
+  static string Text(IntPtr dialog) {
+    var result = new StringBuilder();
+    EnumChildWindows(dialog, (window, _) => {
+      var text = new StringBuilder(4096);
+      GetWindowText(window, text, text.Capacity);
+      result.AppendLine(text.ToString());
+      return true;
+    }, IntPtr.Zero);
+    return result.ToString();
+  }
+  static IntPtr WaitForNotice(Process process) {
+    var timer = Stopwatch.StartNew();
+    while (timer.ElapsedMilliseconds < 10000) {
+      var dialog = Dialog(process);
+      if (dialog != IntPtr.Zero) return dialog;
+      if (process.HasExited) throw new Exception("Installer exited with code " + process.ExitCode + " without showing an update failure notice; the user can only reopen the old version.");
+      Thread.Sleep(30);
+    }
+    throw new Exception("No update failure notice appeared within 10 seconds.");
+  }
+  static void Click(IntPtr dialog, int id) {
+    Require(GetDlgItem(dialog, id) != IntPtr.Zero, "Expected notice button " + id + " was absent.");
+    Require(PostMessage(dialog, 0x0111, new IntPtr(id), IntPtr.Zero), "Could not invoke notice button.");
+  }
+
+  static int Main(string[] args) {
+    string install = null, uninstaller = null, originalAcl = null;
+    FileStream held = null;
+    Process updater = null;
+    try {
+      var fixture = Path.GetFullPath(args[0]);
+      var scenario = args[1];
+      foreach (var hive in new[] { Registry.CurrentUser, Registry.LocalMachine }) {
+        using (var key = hive.OpenSubKey("Software\\" + Guid)) Require(key == null, "Previous test registration exists; inspect it before running.");
+      }
+      install = Path.Combine(fixture, "installed");
+      Require(!Directory.Exists(install) || Directory.GetFileSystemEntries(install).Length == 0, "Test install directory must be empty.");
+      Directory.CreateDirectory(install);
+      var previous = Path.Combine(fixture, "0.25.1", "dist", "notice-fixture-installer.exe");
+      var current = Path.Combine(fixture, "0.26.0", "dist", "notice-fixture-installer.exe");
+      Require(Run(previous, "/S /D=" + install) == 0, "Fixture install failed.");
+      var executable = Path.Combine(install, Name + ".exe");
+      uninstaller = Path.Combine(install, "Uninstall " + Name + ".exe");
+      Require(Run(executable, "") == 25, "Previous version was not launchable.");
+      bool denied = scenario.StartsWith("denied");
+      bool silent = scenario.EndsWith("silent");
+      bool retry = scenario == "locked-retry";
+      if (denied) {
+        var original = File.GetAccessControl(uninstaller);
+        foreach (FileSystemAccessRule rule in original.GetAccessRules(true, false, typeof(SecurityIdentifier)))
+          Require(rule.IsInherited, "Fixture must have an inherited DACL for safe restoration.");
+        Require(!original.AreAccessRulesProtected, "Fixture DACL must not be protected.");
+        originalAcl = original.GetSecurityDescriptorSddlForm(AccessControlSections.Access);
+        var acl = new FileSecurity();
+        acl.SetAccessRuleProtection(true, false);
+        foreach (var sid in new[] { "S-1-5-18", "S-1-5-32-544" })
+          acl.AddAccessRule(new FileSystemAccessRule(new SecurityIdentifier(sid), FileSystemRights.FullControl, AccessControlType.Allow));
+        acl.AddAccessRule(new FileSystemAccessRule(new SecurityIdentifier("S-1-5-32-545"), FileSystemRights.ReadAndExecute, AccessControlType.Allow));
+        File.SetAccessControl(uninstaller, acl);
+        bool refused = false;
+        try { using (File.Open(uninstaller, FileMode.Open, FileAccess.Write, FileShare.Read)) {} }
+        catch (UnauthorizedAccessException) { refused = true; }
+        Require(refused, "Permission fixture needs a non-elevated process; write probe unexpectedly succeeded.");
+      } else {
+        held = File.Open(uninstaller, FileMode.Open, FileAccess.Read, FileShare.Read);
+      }
+      updater = Start(current, "/S --updated " + (silent ? "" : "--force-run ") + "/D=" + install);
+      if (silent) {
+        Require(Finish(updater) == 2, "Unattended update must fail silently with exit 2.");
+      } else {
+        var dialog = WaitForNotice(updater);
+        var text = Text(dialog);
+        Console.WriteLine(text);
+        Require(text.Contains(uninstaller), "Notice omitted the affected file.");
+        Require(text.Contains(denied ? "Windows error: 5" : "Windows error: 32"), "Notice omitted the actual Windows error.");
+        Require(text.Contains(denied ? "administrator" : "Retry"), "Notice did not explain recovery.");
+        // Local screenshot mode leaves the real dialog available for Computer Use.
+        if (args.Length > 2 && args[2] == "--inspect") {
+          Console.WriteLine("NOTICE_READY_FOR_SCREENSHOT");
+          Require(updater.WaitForExit(180000), "Screenshot inspection timed out.");
+        } else if (retry) {
+          held.Dispose(); held = null;
+          Click(dialog, 4);
+        } else Click(dialog, 2); // Windows gives a single OK button IDCANCEL, as well as Cancel.
+        Require(Finish(updater) == (retry ? 0 : 2), "Unexpected installer result after notice action.");
+      }
+      Require(Run(executable, "") == (retry ? 26 : 25), "Notice action left the wrong app version.");
+      Console.WriteLine("PASS: " + scenario);
+      return 0;
+    } catch (Exception error) {
+      Console.Error.WriteLine(error.Message);
+      return 1;
+    } finally {
+      if (updater != null) { if (!updater.HasExited) { updater.Kill(); updater.WaitForExit(); } updater.Dispose(); }
+      if (held != null) held.Dispose();
+      if (originalAcl != null) {
+        Require(Run("icacls.exe", "\"" + uninstaller + "\" /reset") == 0, "Could not restore fixture DACL.");
+        Require(File.GetAccessControl(uninstaller).GetSecurityDescriptorSddlForm(AccessControlSections.Access) == originalAcl, "Fixture DACL was not restored exactly.");
+      }
+      if (uninstaller != null && File.Exists(uninstaller)) {
+        Require(Run(uninstaller, "/S /currentuser _?=" + install) == 0, "Fixture uninstall failed.");
+        File.Delete(uninstaller);
+      }
+    }
+  }
+}

--- a/scripts/fixtures/windows-update-notice/README.md
+++ b/scripts/fixtures/windows-update-notice/README.md
@@ -1,0 +1,53 @@
+# Windows update failure notice regression
+
+This opt-in test runs real NSIS installers through the same `/S --updated --force-run`
+boundary as electron-updater's Restart action. It observes the native failure dialog,
+installer exit code, and launchable version. There is no production test seam.
+
+Run on a Windows desktop with a **non-elevated** token, the existing repository
+dependencies, .NET Framework's `csc.exe`, and electron-builder's cached NSIS tools.
+Do not run two copies concurrently: the fixture has one dedicated product GUID.
+Portable Vitest runs skip these tests; a skip is not native certification.
+
+From the repository/worktree root, using PowerShell:
+
+```powershell
+# Point these at your existing electron-builder cache directories.
+$env:ELECTRON_BUILDER_NSIS_DIR = '<cached nsis directory>'
+$env:ELECTRON_BUILDER_NSIS_RESOURCES_DIR = '<cached nsis-resources directory>'
+$env:OPEN_SCIENCE_MAKENSIS = "$env:ELECTRON_BUILDER_NSIS_DIR/makensis.exe"
+node scripts/fixtures/windows-update-notice/build.mjs .scratch/notice-fixture
+$env:OPEN_SCIENCE_UPDATE_NOTICE_FIXTURE = (Get-Item .scratch/notice-fixture).FullName
+node node_modules/vitest/vitest.mjs run scripts/windows-update-notice.test.ts --maxWorkers=1
+```
+
+Rebuild after any installer-hook change. The builder uses the released `v0.25.1`
+hook for the previous installer and the working tree hook for the target installer;
+the tag must exist locally. Tiny native payloads return 25 and 26 respectively.
+Runtime cleanup scripts are successful stubs, so the fixture cannot manage real
+application resources. Install/profile/temp paths live under the supplied fixture
+directory; the product name and registry GUID are distinct from Open Science.
+
+The runner refuses an existing fixture registration or nonempty install directory.
+For the permission scenario it changes only the fixture uninstaller's DACL, proves
+write access is denied, then restores and verifies its exact original DACL in
+`finally`. The lock scenario holds that same file with read-only sharing. Normal
+completion and assertion failures uninstall the fixture. If the runner is forcibly
+terminated, inspect the fixture registration and files before running again; do not
+remove any real Open Science installation or change its permissions.
+
+| Scenario                           | Expected public behavior                                                             |
+| ---------------------------------- | ------------------------------------------------------------------------------------ |
+| Access denied, interactive restart | Error 5 and administrator recovery notice; dismiss → exit 2, previous app launchable |
+| File occupied, interactive restart | Error 32 and Retry/Cancel notice; Cancel → exit 2, previous app launchable           |
+| File released before Retry         | Retry → exit 0, new app launchable                                                   |
+| Access denied, unattended update   | No blocking notice; exit 2, previous app launchable                                  |
+| File occupied, unattended update   | No blocking notice; exit 2, previous app launchable                                  |
+
+With the unmodified hook, the three interactive cases fail because the installer
+exits 2 without displaying a notice, leaving the old app launchable. The unattended
+cases already pass. This reproduces a sufficient cause of the reported silent
+failure, not proof of a specific reporter's ACL or antivirus state.
+
+This fixture covers the installer boundary, not Electron relaunch, all NSIS error
+codes, full package contents, antivirus products, or elevated/manual recovery.

--- a/scripts/fixtures/windows-update-notice/build.mjs
+++ b/scripts/fixtures/windows-update-notice/build.mjs
@@ -1,0 +1,80 @@
+// Build tiny real NSIS installers with the released/current product hooks and isolated identity.
+// Uses the existing electron-builder installation and its normal NSIS cache; never publishes.
+import { execFileSync } from 'node:child_process'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join, resolve } from 'node:path'
+import { build, Platform, Arch } from 'electron-builder'
+
+const root = resolve(process.argv[2])
+const compiler = process.env.OPEN_SCIENCE_MAKENSIS
+if (!compiler) throw new Error('Set OPEN_SCIENCE_MAKENSIS to the cached makensis.exe.')
+const name = 'open-science-update-notice-test'
+const guid = '11f7eae6-e7e3-4c1c-931f-2a9b1df095ea'
+for (const [version, code, hook] of [
+  [
+    '0.25.1',
+    25,
+    execFileSync('git', ['show', 'v0.25.1:build/installer.nsh'], { encoding: 'utf8' })
+  ],
+  ['0.26.0', 26, await readFile('build/installer.nsh', 'utf8')]
+]) {
+  const projectDir = join(root, version)
+  const packed = join(projectDir, 'packed')
+  await mkdir(join(packed, 'resources'), { recursive: true })
+  await writeFile(
+    join(projectDir, 'package.json'),
+    JSON.stringify({
+      name,
+      version,
+      description: 'Isolated Windows update notice test',
+      author: 'Open Science'
+    })
+  )
+  await writeFile(
+    join(projectDir, 'payload.nsi'),
+    [
+      'Unicode true',
+      'RequestExecutionLevel user',
+      'SilentInstall silent',
+      `OutFile "${join(packed, `${name}.exe`)}"`,
+      'Section',
+      `SetErrorLevel ${code}`,
+      'SectionEnd'
+    ].join('\n')
+  )
+  execFileSync(compiler, ['/V2', join(projectDir, 'payload.nsi')], { windowsHide: true })
+  for (const script of [
+    'windows-runtime-cache-uninstall.ps1',
+    'windows-notebook-sandbox-uninstall.ps1'
+  ]) {
+    await writeFile(join(packed, 'resources', script), 'exit 0\r\n')
+  }
+  await writeFile(join(projectDir, 'installer.nsh'), hook)
+  await build({
+    projectDir,
+    prepackaged: packed,
+    targets: Platform.WINDOWS.createTarget('nsis', Arch.x64),
+    publish: 'never',
+    config: {
+      appId: `com.aipoch.test.${name}`,
+      productName: name,
+      electronVersion: '39.8.10',
+      npmRebuild: false,
+      directories: { output: join(projectDir, 'dist') },
+      win: { executableName: name, signAndEditExecutable: false },
+      nsis: {
+        guid,
+        oneClick: false,
+        perMachine: false,
+        allowElevation: false,
+        allowToChangeInstallationDirectory: true,
+        createDesktopShortcut: false,
+        createStartMenuShortcut: false,
+        runAfterFinish: false,
+        packElevateHelper: false,
+        include: join(projectDir, 'installer.nsh'),
+        artifactName: 'notice-fixture-installer.exe'
+      }
+    }
+  })
+}

--- a/scripts/windows-update-notice.test.ts
+++ b/scripts/windows-update-notice.test.ts
@@ -1,0 +1,60 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, readFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+
+import { beforeAll, describe, expect, it } from 'vitest'
+
+// Requires the real versioned NSIS fixture built by fixtures/windows-update-notice/build.mjs.
+// Opt in on a Windows desktop at medium integrity. Portable CI does not certify native dialogs.
+const fixture = process.env.OPEN_SCIENCE_UPDATE_NOTICE_FIXTURE
+describe.skipIf(process.platform !== 'win32' || !fixture)('Windows update failure notice', () => {
+  const root = resolve(fixture ?? '.')
+  const runner = join(root, 'notice-regression.exe')
+  const env = { ...process.env }
+  beforeAll(() => {
+    expect(
+      readFileSync(join(root, '0.26.0/installer.nsh'), 'utf8'),
+      'Rebuild the native fixture after changing build/installer.nsh.'
+    ).toBe(readFileSync('build/installer.nsh', 'utf8'))
+    for (const [key, directory] of Object.entries({
+      TEMP: 'temp',
+      TMP: 'temp',
+      APPDATA: 'profile/roaming',
+      LOCALAPPDATA: 'profile/local'
+    })) {
+      env[key] = join(root, directory)
+      mkdirSync(env[key]!, { recursive: true })
+    }
+    const compiler = join(process.env.WINDIR!, 'Microsoft.NET/Framework64/v4.0.30319/csc.exe')
+    const result = spawnSync(
+      compiler,
+      [
+        '/nologo',
+        `/out:${runner}`,
+        resolve('scripts/fixtures/windows-update-notice/NoticeRegression.cs')
+      ],
+      {
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: 30000
+      }
+    )
+    expect(result.error).toBeUndefined()
+    expect(result.status, result.stdout + result.stderr).toBe(0)
+  })
+  it.each(['denied', 'locked', 'locked-retry', 'denied-silent', 'locked-silent'])(
+    '%s: explains interactive failure and preserves safe installer behavior',
+    (scenario) => {
+      const result = spawnSync(runner, [root, scenario], {
+        env,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: 90000
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.status, result.stdout + result.stderr).toBe(0)
+      expect(result.stdout).toContain(`PASS: ${scenario}`)
+    },
+    95000
+  )
+})


### PR DESCRIPTION
## Problem

On Windows, Restart hands the update to NSIS and exits before the installer's result
is observable by the app. If the existing uninstaller is not writable, NSIS silently
exits 2 and leaves the old version launchable. Users receive no explanation or
recovery action. A real NSIS fixture reproduces both access denial and file sharing
violations; this does not prove the original reporter's ACL or antivirus state.

## Proposed change

For the existing interactive `/S --updated --force-run` handoff, show the affected
file and Windows error. Access denial explains manual administrator installation;
file occupation offers Retry/Cancel. Keep the write preflight, old-app/data
preservation, and unattended silent behavior. Do not elevate automatically.

## Scope and non-goals

Only the native installer failure interaction changes. No renderer, architecture,
data model, fields, enum states, persisted format or migration changes. Existing
0.25.1 handoff flags work with a future target installer; this does not modify the
already released 0.26.0 installer. Antivirus attribution, full Electron relaunch,
and automatic elevation are outside this fix.

## Acceptance criteria and validation

All checks below ran after the last material edit:

- Native permission/lock/cancel/retry/unattended behavior ->
  `OPEN_SCIENCE_UPDATE_NOTICE_FIXTURE=<built fixture> node node_modules/vitest/vitest.mjs run scripts/windows-update-notice.test.ts --maxWorkers=1`
  -> 5 passed. Actual native dialogs were inspected and captured locally.
- Updater handoff, Windows installer/certification and packaging contracts ->
  `node node_modules/vitest/vitest.mjs run src/main/update/electron-updater-strategy.test.ts scripts/windows-updater-certification.test.ts scripts/windows-installer-smoke.test.ts scripts/electron-builder-config.test.ts --maxWorkers=1`
  -> 107 passed; combined final run: 112 passed in 5 files.
- Regression provenance: before the hook change, 3 interactive cases failed
  specifically because NSIS exited 2 without a notice and retained the old version;
  2 unattended cases passed. The access-denied failure was repeated before fixing.
- `rtk npm run lint` -> passed (final cached rerun after the last material edit).

The native test uses isolated product identity/install/profile paths and cleans up
its fixture installation; no production test seam. See the fixture README for
prerequisites and reproduction. Ordinary portable CI skips this opt-in desktop
suite, which is not native certification. Existing portable contract tests run in
CI. No runtime TypeScript/configuration changed, so runtime process typechecks and
renderer tests are not in the impact set. No full local npm test was run, as
requested. Direct Vitest was used because the shared dependency tree's unrelated
Prisma-client pretest guard is stale; this was not counted as regression evidence.

Uncovered risks: actual reporter ACL/security-product state, full Electron relaunch,
uncommon Windows errors and elevated manual recovery on a complete installation.
Independent reviews of the final diff: Standards — no findings; Spec — no findings. The final check mapping covers the changed installer boundary and existing updater/packaging consumers.

## Review focus

Confirm interactive Restart can explain failure without blocking unattended update
jobs, and the existing write-access/data-preservation safeguards remain intact.
