### PR TITLE
fix(compute-host): save edited skeleton details against the empty stored document

### DIFF
--- a/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx
@@ -1391,6 +1391,38 @@ it('keeps the draft and reloads a merge base after a details conflict', async ()
   expect(saveDetails).toHaveBeenLastCalledWith('ssh:biowulf', 'my draft', 'other writer')
 })
 
+it('saves edits to auto-generated details against the empty stored document', async () => {
+  stubDetailsGet('## Resources\ncpus: 128', true)
+  const saveDetails = vi.fn().mockResolvedValue(undefined)
+  useComputeStore.setState({ hosts: [host({ detailsDoc: '' })], saveDetails })
+  await act(async () => root.render(<ComputeHostDetail providerId="ssh:biowulf" />))
+  const section = Array.from(
+    container.querySelectorAll<HTMLElement>('[data-slot="settings-section"]')
+  ).find((section) => section.querySelector('h3')?.textContent === 'Details')!
+  const click = async (text: string): Promise<void> => {
+    await act(async () =>
+      Array.from(section.querySelectorAll('button'))
+        .find((button) => button.textContent?.trim() === text)!
+        .click()
+    )
+  }
+  await click('Edit')
+  const draft = section.querySelector('textarea')!
+  act(() => {
+    Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, 'value')!.set!.call(
+      draft,
+      '## Resources\ncpus: 128\n\n## Usage Policy\nUse direct SSH.'
+    )
+    draft.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+  await click('Save')
+  expect(saveDetails).toHaveBeenCalledWith(
+    'ssh:biowulf',
+    '## Resources\ncpus: 128\n\n## Usage Policy\nUse direct SSH.',
+    ''
+  )
+})
+
 // Exercise live app-language changes while Intl retains the host's default locale.
 it('updates metadata dates with the interface language on an unchanged host', async () => {
   const timestamp = '2026-09-02T12:00:00.000Z'

--- a/src/renderer/src/pages/settings/ComputeHostDetail.tsx
+++ b/src/renderer/src/pages/settings/ComputeHostDetail.tsx
@@ -303,7 +303,7 @@ export function ComputeHostDetail({
     setDetailsSaving(true)
     setDetailsError(undefined)
     try {
-      await saveDetails(providerId, detailsDoc, originalDoc)
+      await saveDetails(providerId, detailsDoc, isSkeleton ? '' : originalDoc)
       setDetailsConflict(false)
       setMergeBase(undefined)
       setOriginalDoc(detailsDoc)


### PR DESCRIPTION
Closes #2358

## What

Editing the **Details** of a compute host right after a successful probe failed with:

```
replaceDetails: old_text does not match the current details document for "ssh:..."
```

When the host has no stored details, `detailsGet` returns a probe-generated skeleton (`isSkeleton: true`) and the editor uses it as both the draft and `originalDoc`. On save, that skeleton text was sent as `old_text`, but the stored `detailsDoc` is still `''`, so the compare-and-set guard in `replaceDetails` rejected every first edit of auto-generated details.

## Fix

`handleDetailsSave` now sends `''` as `old_text` when the loaded document is a skeleton — the same thing `reloadDetailsForMerge` already does (`setOriginalDoc(skeleton ? '' : doc)`). One-line change in `ComputeHostDetail.tsx`.

## Tests

Added a render test that loads a skeleton details doc, edits it, saves, and asserts `saveDetails` is called with `oldText === ''`.

- Without the fix: `expected "" ... received "## Resources\ncpus: 128"` (test fails)
- With the fix: passes

```
npx vitest run src/renderer/src/pages/settings/ComputeHostDetail.render.test.tsx src/renderer/src/pages/settings/compute-i18n.render.test.tsx
 Test Files  2 passed (2)
      Tests  57 passed (57)
npx eslint <both files>      → clean
npx prettier --check <both>  → clean
```

I could not run the full `npm run typecheck:web` locally (tsc runs out of memory on my box); the change only reuses the existing `isSkeleton` state so I expect CI to cover it.
