### PR TITLE
fix(literature): preserve manual entry and metadata integrity

### DIFF
--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -4003,6 +4003,156 @@ describe('LiteratureLibraryPage', () => {
     ).toHaveLength(2)
   })
 
+  it.each([
+    ['readback', 'reuse'],
+    ['project link', 'reuse'],
+    ['collection link', 'reuse'],
+    ['readback', 'separate']
+  ] as const)(
+    'resumes acknowledged manual creation after failed %s with %s policy',
+    async (boundary, policy) => {
+      const { mkdtemp, rm } = await import('node:fs/promises')
+      const { tmpdir } = await import('node:os')
+      const { join } = await import('node:path')
+      const { createProjectDbClient } = await import('../../../../main/projects/prisma-client')
+      const { migrateApplicationDatabase } =
+        await import('../../../../main/database/migration-service')
+      const { LiteratureCatalog } = await import('../../../../main/literature/catalog')
+      const root = await mkdtemp(join(tmpdir(), 'literature-manual-retry-'))
+      const client = createProjectDbClient(root)
+      try {
+        await migrateApplicationDatabase(client)
+        await client.project.create({ data: { id: 'project-1', name: 'Retrieval research' } })
+        const catalog = new LiteratureCatalog(async () => client)
+        const collection = await catalog.transact({
+          kind: 'create-collection',
+          name: 'Manual destination'
+        })
+        window.api.literature.search = (request) => catalog.search(request)
+        let fail = true
+        let committedId: string | undefined
+        transact.mockImplementation(async (command) => {
+          if (
+            fail &&
+            ((boundary === 'project link' && command.kind === 'set-project-item') ||
+              (boundary === 'collection link' && command.kind === 'set-collection-item'))
+          ) {
+            fail = false
+            throw new Error('Temporary destination failure')
+          }
+          const receipt = await catalog.transact(command)
+          if (command.kind === 'create-item') committedId ??= receipt.id
+          return receipt
+        })
+        get.mockImplementation(async (id: string) => {
+          if (fail && boundary === 'readback' && committedId) {
+            fail = false
+            throw new Error('Temporary read failure')
+          }
+          return catalog.get(id)
+        })
+        if (boundary === 'project link')
+          useNavigationStore.setState({ pendingLiteratureProjectId: 'project-1' })
+        render(<LiteratureLibraryPage />)
+        if (boundary === 'project link')
+          await screen.findByRole('heading', { name: 'Retrieval research' })
+        else if (boundary === 'collection link')
+          fireEvent.click(await screen.findByRole('button', { name: 'Manual destination' }))
+        else fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+        await openMenu(screen.getByRole('button', { name: 'Add' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Add reference' }))
+        if (policy === 'separate') {
+          await openMenu(screen.getByRole('combobox', { name: 'When identifiers match' }))
+          fireEvent.click(screen.getByRole('option', { name: 'Keep as separate reference' }))
+        }
+        fireEvent.change(screen.getByLabelText('Title'), {
+          target: { value: 'No identifier manual reference' }
+        })
+        fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+        await within(screen.getByRole('dialog')).findByRole('alert')
+        expect(await client.literatureItem.count()).toBe(1)
+        expect((await catalog.get(committedId!))?.item.identifiers).toEqual([])
+        const dialog = screen.getByRole('dialog')
+        fireEvent.click(
+          within(dialog).queryByRole('button', { name: /retry/i }) ??
+            within(dialog).getByRole('button', { name: 'Save' })
+        )
+        await screen.findByRole('heading', { name: 'No identifier manual reference' })
+        expect
+          .soft(await client.literatureItem.findMany({ select: { id: true, title: true } }))
+          .toEqual([{ id: committedId, title: 'No identifier manual reference' }])
+        expect
+          .soft(transact.mock.calls.filter(([command]) => command.kind === 'create-item'))
+          .toHaveLength(1)
+        const saved = (await catalog.get(committedId!))!
+        if (boundary === 'project link') expect(saved.projectIds).toEqual(['project-1'])
+        if (boundary === 'collection link') expect(saved.collectionIds).toEqual([collection.id])
+      } finally {
+        cleanup()
+        await client.$disconnect()
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it('locks acknowledged metadata and retries only readback after a successful project link', async () => {
+    useNavigationStore.setState({ pendingLiteratureProjectId: 'project-1' })
+    get
+      .mockRejectedValueOnce(new Error('Read unavailable'))
+      .mockRejectedValueOnce(new Error('Still unavailable'))
+      .mockResolvedValue({
+        ...libraryItem,
+        projectIds: ['project-1'],
+        item: { ...libraryItem.item, title: 'Saved metadata' }
+      })
+    render(<LiteratureLibraryPage />)
+    await screen.findByRole('heading', { name: 'Retrieval research' })
+    await openMenu(screen.getByRole('button', { name: 'Add' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add reference' }))
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Saved metadata' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByRole('alert')
+    expect(screen.getByLabelText('Title').matches(':disabled')).toBe(true)
+    expect(screen.getByRole('alert').textContent).toMatch(/created.*retry/i)
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(2))
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Retry' }).matches(':disabled')).toBe(false)
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await screen.findByRole('heading', { name: 'Saved metadata' })
+    expect(transact.mock.calls.map(([command]) => command.kind)).toEqual([
+      'create-item',
+      'set-project-item'
+    ])
+  })
+
+  it('permits a fresh creation intent after closing an acknowledged recovery', async () => {
+    get
+      .mockRejectedValueOnce(new Error('Read unavailable'))
+      .mockResolvedValue({ ...libraryItem, item: { ...libraryItem.item, title: 'Second intent' } })
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await openMenu(screen.getByRole('button', { name: 'Add' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add reference' }))
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'First intent' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByRole('alert')
+    expect(screen.getByRole('alert').textContent).toMatch(/remains.*library/i)
+    fireEvent.click(screen.getAllByRole('button', { name: 'Close' })[0])
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    await openMenu(screen.getByRole('button', { name: 'Add' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Add reference' }))
+    fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Second intent' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    await screen.findByRole('heading', { name: 'Second intent' })
+    expect(
+      transact.mock.calls
+        .filter(([command]) => command.kind === 'create-item')
+        .map(([command]) => command.item.title)
+    ).toEqual(['First intent', 'Second intent'])
+  })
+
   it('links a manually created reference to the current Project', async () => {
     const createdItem: LiteratureItemView = {
       ...libraryItem,

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1315,6 +1315,19 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const [isCreatingItem, setIsCreatingItem] = useState(false)
   const [isSavingNewItem, setIsSavingNewItem] = useState(false)
   const [createItemError, setCreateItemError] = useState<string>()
+  const [createdItemId, setCreatedItemId] = useState<string>()
+  const creatingItemRef = useRef(false)
+  const pendingCreationRef = useRef<{
+    id: string
+    destination?: Extract<
+      LiteratureCatalogCommand,
+      { kind: 'set-project-item' | 'set-collection-item' }
+    >
+    projectId?: string
+    collectionId?: string
+    file?: File
+    pdfItem?: LiteratureItemView
+  }>(undefined)
   const [pendingImportPdf, setPendingImportPdf] = useState<File>()
   const [pendingImportDraft, setPendingImportDraft] = useState<LiteratureItemInput>()
   const [isReadingImportMetadata, setIsReadingImportMetadata] = useState(false)
@@ -2536,80 +2549,95 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     }
   }
 
-  const createManualItem = async (item: LiteratureItemInput): Promise<void> => {
-    if (isSavingNewItem) return
+  const createManualItem = async (item?: LiteratureItemInput): Promise<void> => {
+    if (creatingItemRef.current || (!pendingCreationRef.current && !item)) return
+    creatingItemRef.current = true
     setIsSavingNewItem(true)
     setCreateItemError(undefined)
-    const file = pendingImportPdf
     const transferId = crypto.randomUUID()
     let staged: Awaited<ReturnType<typeof stageComposerFile>> | undefined
-    let createdItemId: string | undefined
     try {
-      const receipt = await window.api.literature.transact({
-        kind: 'create-item',
-        item,
-        ...(duplicatePolicy === 'reuse' ? {} : { duplicatePolicy })
-      })
-      createdItemId = receipt.id
-      if (projectId) {
-        await window.api.literature.transact({
-          kind: 'set-project-item',
+      if (!pendingCreationRef.current) {
+        const receipt = await window.api.literature.transact({
+          kind: 'create-item',
+          item: item!,
+          ...(duplicatePolicy === 'reuse' ? {} : { duplicatePolicy })
+        })
+        // This receipt belongs to this dialog's creation intent, including its original destination.
+        pendingCreationRef.current = {
+          id: receipt.id,
           projectId,
-          itemId: receipt.id,
-          included: true,
-          source: 'library'
-        })
-      } else if (collectionId) {
-        await window.api.literature.transact({
-          kind: 'set-collection-item',
           collectionId,
-          itemId: receipt.id,
-          included: true
-        })
+          file: pendingImportPdf,
+          destination: projectId
+            ? {
+                kind: 'set-project-item',
+                projectId,
+                itemId: receipt.id,
+                included: true,
+                source: 'library'
+              }
+            : collectionId
+              ? { kind: 'set-collection-item', collectionId, itemId: receipt.id, included: true }
+              : undefined
+        }
+        setCreatedItemId(receipt.id)
       }
-      const created = file
-        ? await (async (): Promise<LiteratureItemView> => {
-            staged = await stageComposerFile(file, window.api.uploads, {
-              transferId,
-              name: file.name
-            })
-            await window.api.uploads.claimLocalFile?.({ transferId })
-            return (
-              await window.api.literature.importPdf({ itemId: receipt.id, attachment: staged })
-            ).item
-          })()
-        : await window.api.literature.get(receipt.id)
+      const pending = pendingCreationRef.current
+      if (pending.destination) {
+        await window.api.literature.transact(pending.destination)
+        pending.destination = undefined
+      }
+      if (pending.file && !pending.pdfItem) {
+        staged = await stageComposerFile(pending.file, window.api.uploads, {
+          transferId,
+          name: pending.file.name
+        })
+        await window.api.uploads.claimLocalFile?.({ transferId })
+        pending.pdfItem = (
+          await window.api.literature.importPdf({ itemId: pending.id, attachment: staged })
+        ).item
+      }
+      const created = pending.pdfItem ?? (await window.api.literature.get(pending.id))
       if (!created) throw new Error('Literature Item is unavailable after creating.')
       setItems((entries) =>
         entries.some((entry) => entry.id === created.id)
           ? entries.map((entry) => (entry.id === created.id ? created : entry))
           : [created, ...entries]
       )
-      if (collectionId) await loadCollections()
-      if (projectId) await loadProjectCounts()
-      setIsCreatingItem(false)
-      setPendingImportPdf(undefined)
-      setPendingImportDraft(undefined)
+      if (pending.collectionId) await loadCollections()
+      if (pending.projectId) await loadProjectCounts()
+      closeItemEditor()
       openSelectedItemDetail(created)
     } catch (error) {
-      if (file && createdItemId) {
-        const created = await window.api.literature.get(createdItemId).catch(() => undefined)
-        if (created) {
-          setIsCreatingItem(false)
-          setPendingImportPdf(undefined)
-          setPendingImportDraft(undefined)
-          openSelectedItemDetail(created)
-          setPdfError(pdfImportErrorMessage(error, t))
-        } else {
-          setCreateItemError(t('Literature could not be created.'))
-        }
+      const pending = pendingCreationRef.current
+      // Retain the existing PDF-error detail recovery only once destination linking has completed.
+      const created =
+        pending?.file && !pending.destination && !pending.pdfItem
+          ? await window.api.literature.get(pending.id).catch(() => undefined)
+          : undefined
+      if (created) {
+        closeItemEditor()
+        openSelectedItemDetail(created)
+        setPdfError(pdfImportErrorMessage(error, t))
       } else {
-        setCreateItemError(t('Literature could not be created.'))
+        setCreateItemError(
+          pending
+            ? pending.destination
+              ? t(
+                  'The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.'
+                )
+              : t(
+                  'The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.'
+                )
+            : t('Literature could not be created.')
+        )
       }
     } finally {
       if (staged)
         await window.api.uploads.deleteUpload({ path: staged.path }).catch(() => undefined)
-      if (createdItemId) void loadEntries(true)
+      void loadEntries(true)
+      creatingItemRef.current = false
       setIsSavingNewItem(false)
     }
   }
@@ -2639,6 +2667,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }
 
   const closeItemEditor = (): void => {
+    pendingCreationRef.current = undefined
+    setCreatedItemId(undefined)
     setDuplicatePolicy('reuse')
     importMetadataGenerationRef.current += 1
     setIsCreatingItem(false)
@@ -5032,7 +5062,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                   <LiteratureDuplicatePolicyField
                     value={duplicatePolicy}
                     onChange={setDuplicatePolicy}
-                    disabled={isSavingNewItem}
+                    disabled={isSavingNewItem || Boolean(createdItemId)}
                   />
                 }
                 key={pendingImportPdf?.name ?? 'manual-reference'}
@@ -5044,6 +5074,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                 }
                 saving={isSavingNewItem}
                 error={createItemError}
+                onRetry={createdItemId ? () => void createManualItem() : undefined}
                 onCancel={closeItemEditor}
                 onSave={(item) => void createManualItem(item)}
               />

--- a/src/renderer/src/pages/literature/LiteratureMetadataEditor.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataEditor.test.tsx
@@ -1,7 +1,8 @@
 // @vitest-environment jsdom
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { literatureItemInputSchema } from '../../../../shared/literature'
+import { literatureItemInputSchema, type LiteratureItemInput } from '../../../../shared/literature'
+import { toCslItem } from '../../../../shared/literature-csl'
 import { LiteratureMetadataEditor } from './LiteratureMetadataEditor'
 
 afterEach(cleanup)
@@ -28,9 +29,373 @@ describe('LiteratureMetadataEditor', () => {
     rerender(<LiteratureMetadataEditor {...props} saving={false} error="Save failed" />)
     expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('Draft title')
     expect(screen.getByRole('alert').textContent).toBe('Save failed')
-    expect(screen.getByRole('button', { name: 'Add author' }).matches(':disabled')).toBe(false)
+    expect(screen.getByRole('button', { name: /Add (creator|author)/ }).matches(':disabled')).toBe(
+      false
+    )
     expect(screen.getByRole('combobox', { name: 'Reference type' }).matches(':disabled')).toBe(
       false
     )
   })
+})
+
+const editableItem = (): LiteratureItemInput =>
+  literatureItemInputSchema.parse({
+    itemType: 'book',
+    title: 'Manual metadata',
+    issuedYear: 2024,
+    issuedText: '2024-03-12',
+    shortTitle: 'Short',
+    language: 'fr',
+    rights: 'CC BY',
+    citationKey: 'manual2024',
+    accessedAt: Date.UTC(2026, 8, 8),
+    extra: 'Original provider notes',
+    typeFields: { custom: { nested: ['preserve'] } },
+    creators: [
+      { nameMode: 'person', givenName: 'Ada', familyName: 'Lovelace', creatorType: 'editor' },
+      { nameMode: 'organization', literalName: 'Research Council', creatorType: 'author' },
+      {
+        nameMode: 'person',
+        givenName: 'Other',
+        familyName: 'Contributor',
+        creatorType: 'illustrator'
+      }
+    ]
+  })
+
+it.each(['2024.9', '2e3', '10000', '-1'])(
+  'blocks invalid year text before submitting: %s',
+  (value) => {
+    const onSave = vi.fn()
+    render(
+      <LiteratureMetadataEditor
+        item={editableItem()}
+        saving={false}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+    const year = screen.getByLabelText('Year')
+    fireEvent.change(year, { target: { value } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSave).not.toHaveBeenCalled()
+    expect(year.getAttribute('aria-invalid')).toBe('true')
+    expect(screen.getByRole('alert').textContent).toMatch(/year|9999/i)
+  }
+)
+
+it('keeps publication filtering and citation dates consistent after editing the year', async () => {
+  const { mkdtemp, rm } = await import('node:fs/promises')
+  const { tmpdir } = await import('node:os')
+  const { join } = await import('node:path')
+  const { createProjectDbClient } = await import('../../../../main/projects/prisma-client')
+  const { migrateApplicationDatabase } = await import('../../../../main/database/migration-service')
+  const { LiteratureCatalog } = await import('../../../../main/literature/catalog')
+  const root = await mkdtemp(join(tmpdir(), 'literature-manual-date-'))
+  const client = createProjectDbClient(root)
+  try {
+    await migrateApplicationDatabase(client)
+    const catalog = new LiteratureCatalog(async () => client)
+    const receipt = await catalog.transact({ kind: 'create-item', item: editableItem() })
+    const original = (await catalog.get(receipt.id))!
+    const onSave = vi.fn()
+    render(
+      <LiteratureMetadataEditor
+        item={original.item}
+        saving={false}
+        onSave={onSave}
+        onCancel={vi.fn()}
+      />
+    )
+    fireEvent.change(screen.getByLabelText('Year'), { target: { value: '2025' } })
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+    expect(onSave).toHaveBeenCalledOnce()
+    await catalog.transact({
+      kind: 'update-item',
+      itemId: original.id,
+      expectedMetadataRevision: original.metadataRevision,
+      item: onSave.mock.calls[0][0]
+    })
+    const saved = (await catalog.get(original.id))!
+    expect(saved.item.issuedYear).toBe(2025)
+    const currentYear = await catalog.search({
+      scope: 'library',
+      filter: { yearFrom: 2025, yearTo: 2025 }
+    })
+    const oldYear = await catalog.search({
+      scope: 'library',
+      filter: { yearFrom: 2024, yearTo: 2024 }
+    })
+    expect(currentYear.entries.map((entry) => ('id' in entry ? entry.id : undefined))).toEqual([
+      saved.id
+    ])
+    expect(oldYear.entries).toEqual([])
+    expect(toCslItem(saved.id, saved.item).issued?.['date-parts'][0][0]).toBe(saved.item.issuedYear)
+  } finally {
+    cleanup()
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+it('shows existing creator roles and offers creator name modes', () => {
+  render(
+    <LiteratureMetadataEditor
+      item={editableItem()}
+      saving={false}
+      onSave={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+  expect(screen.queryAllByRole('combobox', { name: /role/i })).toHaveLength(3)
+  expect(screen.getByText('Editor')).not.toBeNull()
+  expect(screen.getByText(/illustrator/i)).not.toBeNull()
+  expect(screen.getAllByRole('combobox', { name: /name type|name mode/i })).toHaveLength(3)
+})
+
+it.each([
+  'Short title',
+  'Language',
+  'Rights',
+  'Date accessed',
+  'Citation key',
+  'Extra',
+  'Publication date'
+])('provides a manual metadata control for %s', (label) => {
+  render(
+    <LiteratureMetadataEditor
+      item={editableItem()}
+      saving={false}
+      onSave={vi.fn()}
+      onCancel={vi.fn()}
+    />
+  )
+  const advanced = screen.getByRole('button', { name: 'Advanced settings' })
+  if (advanced.getAttribute('aria-expanded') === 'false') fireEvent.click(advanced)
+  expect(screen.queryByLabelText(label)).not.toBeNull()
+})
+
+it('preserves stored roles, literal names, and unedited extended metadata', () => {
+  const item = editableItem()
+  const onSave = vi.fn()
+  render(<LiteratureMetadataEditor item={item} saving={false} onSave={onSave} onCancel={vi.fn()} />)
+  fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'Edited title' } })
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+  expect(onSave).toHaveBeenCalledWith({ ...item, title: 'Edited title' })
+  const csl = toCslItem('manual', onSave.mock.calls[0][0])
+  expect(csl.editor).toEqual([{ given: 'Ada', family: 'Lovelace' }])
+  expect(csl.author).toEqual([{ literal: 'Research Council' }])
+  expect(csl).toMatchObject({
+    language: 'fr',
+    'title-short': 'Short',
+    accessed: { 'date-parts': [[2026, 9, 8]] }
+  })
+})
+
+const mountEditor = (overrides: Partial<LiteratureItemInput> = {}): ReturnType<typeof vi.fn> => {
+  const onSave = vi.fn()
+  render(
+    <LiteratureMetadataEditor
+      item={{ ...editableItem(), ...overrides }}
+      saving={false}
+      onSave={onSave}
+      onCancel={vi.fn()}
+    />
+  )
+  return onSave
+}
+const change = (label: string, value: string): void => {
+  fireEvent.change(screen.getByLabelText(label), { target: { value } })
+}
+const save = (): void => {
+  fireEvent.click(screen.getByRole('button', { name: 'Save' }))
+}
+const advanced = (): void => {
+  const button = screen.getByRole('button', { name: 'Advanced settings' })
+  if (button.getAttribute('aria-expanded') === 'false') fireEvent.click(button)
+}
+const choose = (trigger: HTMLElement, value: string): void => {
+  fireEvent.keyDown(trigger, { key: 'Enter' })
+  fireEvent.click(screen.getByRole('option', { name: value }))
+}
+
+it.each(['', '0', '9999'])('accepts an unknown or boundary year: %s', (year) => {
+  const onSave = mountEditor({ issuedText: '', issuedYear: undefined })
+  change('Year', year)
+  save()
+  expect(onSave).toHaveBeenCalledOnce()
+  expect(literatureItemInputSchema.parse(onSave.mock.calls[0][0]).issuedYear).toBe(
+    year ? Number(year) : undefined
+  )
+})
+
+it.each(['Year', 'Publication date'])(
+  'clears both publication values when clearing %s',
+  (field) => {
+    const onSave = mountEditor()
+    change(field, '')
+    save()
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ issuedYear: undefined, issuedText: '' })
+    )
+  }
+)
+
+it('requires correction of a leap day after changing to a non-leap year', () => {
+  const onSave = mountEditor({ issuedText: '2024-02-29' })
+  change('Year', '2025')
+  save()
+  expect(onSave).not.toHaveBeenCalled()
+  expect(document.activeElement).toBe(screen.getByLabelText('Publication date'))
+  change('Publication date', '2025-02-28')
+  save()
+  expect(onSave).toHaveBeenCalledWith(
+    expect.objectContaining({ issuedText: '2025-02-28', issuedYear: 2025 })
+  )
+})
+
+it.each(['2025', '2025-04', '2025-04-30'])(
+  'derives the year from a publication date: %s',
+  (date) => {
+    const onSave = mountEditor()
+    change('Publication date', date)
+    save()
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ issuedText: date, issuedYear: 2025 })
+    )
+  }
+)
+
+it.each(['2025-02-29', '2024-13', '2025-04-31', '2025junk'])(
+  'rejects a malformed publication date: %s',
+  (date) => {
+    const onSave = mountEditor()
+    change('Publication date', date)
+    save()
+    expect(onSave).not.toHaveBeenCalled()
+    expect(screen.getByLabelText('Publication date').getAttribute('aria-invalid')).toBe('true')
+  }
+)
+
+it.each(['Spring 2024', '2023-03-12'])('preserves an untouched legacy date: %s', (issuedText) => {
+  const onSave = mountEditor({ issuedText })
+  change('Title', 'Unrelated edit')
+  save()
+  expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ issuedText, issuedYear: 2024 }))
+})
+
+it('requires an explicit decision before replacing opaque historical date text', () => {
+  const onSave = mountEditor({ issuedText: 'Spring 2024' })
+  change('Year', '2025')
+  save()
+  expect(onSave).not.toHaveBeenCalled()
+  expect((screen.getByLabelText('Publication date') as HTMLInputElement).value).toBe('Spring 2024')
+  change('Publication date', '2025')
+  save()
+  expect(onSave).toHaveBeenCalledWith(
+    expect.objectContaining({ issuedText: '2025', issuedYear: 2025 })
+  )
+})
+
+it('edits extended metadata and projects the selected accessed day in UTC', () => {
+  const onSave = mountEditor()
+  advanced()
+  change('Short title', 'New short title')
+  change('Language', 'de')
+  change('Rights', 'CC0')
+  change('Citation key', 'newKey')
+  change('Extra', 'New extra\nSecond line')
+  change('Date accessed', '2026-09-09')
+  save()
+  const item = literatureItemInputSchema.parse(onSave.mock.calls[0][0])
+  expect(item).toMatchObject({
+    shortTitle: 'New short title',
+    language: 'de',
+    rights: 'CC0',
+    citationKey: 'newKey',
+    extra: 'New extra\nSecond line',
+    accessedAt: Date.UTC(2026, 8, 9),
+    typeFields: { custom: { nested: ['preserve'] } }
+  })
+  expect(toCslItem('manual', item).accessed).toEqual({ 'date-parts': [[2026, 9, 9]] })
+})
+
+it('retains an untouched access timestamp and permits clearing it', () => {
+  const accessedAt = Date.UTC(2026, 8, 8, 23, 45)
+  const onSave = mountEditor({ accessedAt })
+  save()
+  expect(onSave.mock.calls[0][0].accessedAt).toBe(accessedAt)
+  advanced()
+  change('Date accessed', '')
+  save()
+  expect(onSave.mock.calls[1][0].accessedAt).toBeUndefined()
+})
+
+it('blocks access dates outside the existing timestamp contract', () => {
+  const onSave = mountEditor()
+  advanced()
+  change('Date accessed', '1969-12-31')
+  save()
+  expect(onSave).not.toHaveBeenCalled()
+  expect(document.activeElement).toBe(screen.getByLabelText('Date accessed'))
+})
+
+it('creates editors and organization translators while restoring inactive names', () => {
+  const onSave = mountEditor({ creators: [] })
+  fireEvent.click(screen.getByRole('button', { name: /Add (creator|author)/ }))
+  choose(screen.getByRole('combobox', { name: 'Creator role' }), 'Editor')
+  change('Given name', 'Ada')
+  change('Family name', 'Lovelace')
+  choose(screen.getByRole('combobox', { name: 'Name type' }), 'Organization')
+  change('Organization', 'Research Council')
+  choose(screen.getByRole('combobox', { name: 'Name type' }), 'Person')
+  expect((screen.getByLabelText('Given name') as HTMLInputElement).value).toBe('Ada')
+  save()
+  expect(toCslItem('manual', onSave.mock.calls[0][0]).editor).toEqual([
+    { given: 'Ada', family: 'Lovelace' }
+  ])
+  choose(screen.getByRole('combobox', { name: 'Name type' }), 'Organization')
+  expect((screen.getByLabelText('Organization') as HTMLInputElement).value).toBe('Research Council')
+  choose(screen.getByRole('combobox', { name: 'Creator role' }), 'Translator')
+  save()
+  const saved = literatureItemInputSchema.parse(onSave.mock.calls[1][0])
+  expect(saved.creators).toEqual([
+    { nameMode: 'organization', literalName: 'Research Council', creatorType: 'translator' }
+  ])
+  expect(toCslItem('manual', saved).translator).toEqual([{ literal: 'Research Council' }])
+})
+
+it('keeps creator order and inactive names attached to the correct row after deletion', () => {
+  const onSave = mountEditor()
+  choose(screen.getAllByRole('combobox', { name: 'Name type' })[1], 'Person')
+  fireEvent.change(screen.getAllByLabelText('Given name')[1], { target: { value: 'Remember me' } })
+  fireEvent.click(screen.getAllByRole('button', { name: /Remove (creator|author)/ })[0])
+  choose(screen.getAllByRole('combobox', { name: 'Name type' })[0], 'Organization')
+  expect((screen.getByLabelText('Organization') as HTMLInputElement).value).toBe('Research Council')
+  save()
+  expect(onSave.mock.calls[0][0].creators).toEqual(editableItem().creators.slice(1))
+})
+
+it('renders an arbitrary stored role without treating it as an object property', () => {
+  const onSave = mountEditor({
+    creators: [{ nameMode: 'organization', literalName: 'Archive', creatorType: 'constructor' }]
+  })
+  expect(screen.getByRole('combobox', { name: 'Creator role' }).textContent).toContain(
+    'constructor'
+  )
+  save()
+  expect(onSave.mock.calls[0][0].creators[0].creatorType).toBe('constructor')
+})
+
+it('does not treat an incomplete native access-date input as an intentional clear', () => {
+  const onSave = mountEditor()
+  advanced()
+  const input = screen.getByLabelText('Date accessed') as HTMLInputElement
+  fireEvent.change(input, { target: { value: '' } })
+  // jsdom cannot type into native date segments; Chromium exposes partial input as badInput
+  // with an empty value. Keep the probe at that public browser validity boundary.
+  Object.defineProperty(input, 'validity', { configurable: true, value: { badInput: true } })
+  save()
+  expect(onSave).not.toHaveBeenCalled()
+  expect(document.activeElement).toBe(input)
 })

--- a/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataEditor.tsx
@@ -1,5 +1,5 @@
 import { ChevronDown, Plus, Trash2 } from 'lucide-react'
-import { useState } from 'react'
+import { useId, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { Button } from '@/components/ui/button'
@@ -24,16 +24,49 @@ type LiteratureMetadataEditorProps = Readonly<{
   error?: string
   className?: string
   beforeFields?: React.ReactNode
+  onRetry?: () => void
   onCancel: () => void
   onSave: (item: LiteratureItemInput) => void
 }>
 
-const emptyAuthor = (): LiteratureCreatorInput => ({
+type CreatorDraft = {
+  nameMode: LiteratureCreatorInput['nameMode']
+  creatorType: string
+  givenName: string
+  familyName: string
+  literalName: string
+}
+
+const emptyCreator = (): CreatorDraft => ({
   nameMode: 'person',
   givenName: '',
   familyName: '',
+  literalName: '',
   creatorType: 'author'
 })
+
+// Match the calendar dates consumed by CSL, while retaining untouched legacy free text.
+const publicationDateParts = (text: string): number[] | undefined => {
+  const match = /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/u.exec(text.trim())
+  if (!match) return undefined
+  const parts = match
+    .slice(1)
+    .filter((part) => part !== undefined)
+    .map(Number)
+  const [year, month, day] = parts
+  const leap = year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0)
+  const days = [31, leap ? 29 : 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31]
+  return (month !== undefined && (year === 0 || month < 1 || month > 12)) ||
+    (day !== undefined && (day < 1 || day > days[month - 1]))
+    ? undefined
+    : parts
+}
+
+const accessDateText = (timestamp: number | undefined): string => {
+  if (timestamp === undefined) return ''
+  const date = new Date(timestamp)
+  return Number.isFinite(date.getTime()) ? date.toISOString().split('T')[0] : ''
+}
 
 const emptyIdentifier = (): LiteratureIdentifierInput => ({
   scheme: 'doi',
@@ -57,10 +90,13 @@ const LiteratureMetadataEditor = ({
   error,
   className,
   beforeFields,
+  onRetry,
   onCancel,
   onSave
 }: LiteratureMetadataEditorProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const id = useId()
+  const locked = saving || Boolean(onRetry)
   const itemTypeLabels: Record<LiteratureItemType, string> = {
     journalArticle: t('Journal article'),
     review: t('Review'),
@@ -76,12 +112,62 @@ const LiteratureMetadataEditor = ({
     webpage: t('Web page'),
     document: t('Document')
   }
-  const [draft, setDraft] = useState<LiteratureItemInput>(() => ({
+  const [draft, setDraft] = useState<
+    Omit<LiteratureItemInput, 'creators'> & { creators: CreatorDraft[] }
+  >(() => ({
     ...item,
-    creators: item.creators.map((creator) => ({ ...creator })),
+    creators: item.creators.map((creator) => ({ ...emptyCreator(), ...creator })),
     identifiers: normalizeLiteratureIdentifierPreferences(item.identifiers),
     typeFields: { ...item.typeFields }
   }))
+  const [year, setYear] = useState(String(item.issuedYear ?? ''))
+  const [publicationDate, setPublicationDate] = useState(item.issuedText)
+  const [accessDate, setAccessDate] = useState(() => accessDateText(item.accessedAt))
+  const [invalidField, setInvalidField] = useState<'year' | 'publication' | 'access'>()
+  const yearRef = useRef<HTMLInputElement>(null)
+  const publicationRef = useRef<HTMLInputElement>(null)
+  const accessRef = useRef<HTMLInputElement>(null)
+  const originalDate = publicationDateParts(item.issuedText)
+  const datesChanged = year !== String(item.issuedYear ?? '') || publicationDate !== item.issuedText
+  const legacyDateConflict =
+    !datesChanged &&
+    originalDate &&
+    item.issuedYear !== undefined &&
+    originalDate[0] !== item.issuedYear
+  const creatorRoleLabels = new Map([
+    ['author', t('Author')],
+    ['editor', t('Editor')],
+    ['translator', t('Translator')]
+  ])
+  const creatorRoles = [
+    ...new Set([
+      'author',
+      'editor',
+      'translator',
+      ...item.creators.map(({ creatorType }) => creatorType)
+    ])
+  ]
+
+  const updateYear = (value: string): void => {
+    setYear(value)
+    setInvalidField(undefined)
+    if (value !== '' && !/^\d{1,4}$/u.test(value)) return
+    setPublicationDate((current) => {
+      // Opaque historical text requires an explicit decision at Publication date.
+      if (current && !/^(\d{4})(?:-\d{1,2}(?:-\d{1,2})?)?$/u.test(current.trim())) return current
+      return value === '' ? '' : value.padStart(4, '0') + current.trim().slice(4)
+    })
+  }
+  const updatePublicationDate = (value: string): void => {
+    setPublicationDate(value)
+    setInvalidField(undefined)
+    if (!value.trim()) setYear('')
+    else {
+      const parts = publicationDateParts(value)
+      if (parts) setYear(String(parts[0]))
+    }
+  }
+
   const [advancedOpen, setAdvancedOpen] = useState(() =>
     ADVANCED_FIELD_KEYS.some((key) => {
       const value = item.typeFields[key]
@@ -89,7 +175,7 @@ const LiteratureMetadataEditor = ({
     })
   )
 
-  const updateCreator = (index: number, creator: LiteratureCreatorInput): void => {
+  const updateCreator = (index: number, creator: CreatorDraft): void => {
     setDraft((current) => ({
       ...current,
       creators: current.creators.map((entry, entryIndex) =>
@@ -126,288 +212,463 @@ const LiteratureMetadataEditor = ({
   }
 
   const submit = (): void => {
-    if (saving || saveDisabled) return
-    const creators = draft.creators.filter((creator) =>
+    if (locked || saveDisabled || !draft.title.trim()) return
+    if (year && !/^\d{1,4}$/u.test(year)) {
+      setInvalidField('year')
+      yearRef.current?.focus()
+      return
+    }
+    const issuedYear = year === '' ? undefined : Number(year)
+    const parts = publicationDateParts(publicationDate)
+    if (datesChanged && publicationDate.trim() && (!parts || parts[0] !== issuedYear)) {
+      setInvalidField('publication')
+      publicationRef.current?.focus()
+      return
+    }
+    if (accessRef.current?.validity.badInput) {
+      setInvalidField('access')
+      accessRef.current.focus()
+      return
+    }
+    let accessedAt = item.accessedAt
+    if (accessDate !== accessDateText(item.accessedAt)) {
+      accessedAt = accessDate ? Date.parse(`${accessDate}T00:00:00Z`) : undefined
+      if (
+        accessedAt !== undefined &&
+        (!Number.isFinite(accessedAt) ||
+          accessedAt < 0 ||
+          accessDateText(accessedAt) !== accessDate)
+      ) {
+        setInvalidField('access')
+        accessRef.current?.focus()
+        return
+      }
+    }
+    const creators = draft.creators.flatMap<LiteratureCreatorInput>((creator) =>
       creator.nameMode === 'organization'
         ? creator.literalName.trim()
+          ? [
+              {
+                nameMode: 'organization',
+                creatorType: creator.creatorType,
+                literalName: creator.literalName
+              }
+            ]
+          : []
         : creator.givenName.trim() || creator.familyName.trim()
+          ? [
+              {
+                nameMode: 'person',
+                creatorType: creator.creatorType,
+                givenName: creator.givenName,
+                familyName: creator.familyName
+              }
+            ]
+          : []
     )
     const identifiers = draft.identifiers.filter(({ value }) => value.trim())
-    onSave({ ...draft, title: draft.title.trim(), creators, identifiers })
+    onSave({
+      ...draft,
+      title: draft.title.trim(),
+      creators,
+      identifiers,
+      issuedYear,
+      issuedText: datesChanged ? publicationDate.trim() : item.issuedText,
+      accessedAt
+    })
   }
 
   return (
-    <fieldset
-      disabled={saving}
-      className={cn('min-w-0 max-h-[70vh] space-y-5 overflow-y-auto p-5 text-sm', className)}
-    >
-      {beforeFields}
-      <div className="block space-y-1.5">
-        <label htmlFor="literature-reference-type" className="font-medium">
-          {t('Reference type')}
-        </label>
-        <Select
-          disabled={saving}
-          value={draft.itemType}
-          onValueChange={(value) =>
-            setDraft((current) => ({
-              ...current,
-              itemType: value as LiteratureItemType
-            }))
-          }
-        >
-          <SelectTrigger id="literature-reference-type" className="h-8">
-            <span className="truncate">{itemTypeLabels[draft.itemType]}</span>
-          </SelectTrigger>
-          <SelectContent>
-            {LITERATURE_ITEM_TYPES.map((itemType) => (
-              <SelectItem key={itemType} value={itemType}>
-                {itemTypeLabels[itemType]}
-              </SelectItem>
-            ))}
-          </SelectContent>
-        </Select>
-      </div>
-
-      <label className="block space-y-1.5">
-        <span className="font-medium">{t('Title')}</span>
-        <Input
-          value={draft.title}
-          onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))}
-          autoFocus
-        />
-      </label>
-
-      <div className="grid gap-4 sm:grid-cols-2">
-        <label className="block space-y-1.5">
-          <span className="font-medium">{t('Year')}</span>
-          <Input
-            type="number"
-            min={0}
-            max={9999}
-            value={draft.issuedYear ?? ''}
-            onChange={(event) => {
-              const value = event.target.value
-              const parsedYear = Number.parseInt(value, 10)
+    <div className={cn('min-w-0 max-h-[70vh] space-y-5 overflow-y-auto p-5 text-sm', className)}>
+      <fieldset disabled={locked} className="min-w-0 space-y-5">
+        {beforeFields}
+        <div className="block space-y-1.5">
+          <label htmlFor="literature-reference-type" className="font-medium">
+            {t('Reference type')}
+          </label>
+          <Select
+            disabled={locked}
+            value={draft.itemType}
+            onValueChange={(value) =>
               setDraft((current) => ({
                 ...current,
-                issuedYear: value && Number.isInteger(parsedYear) ? parsedYear : undefined
-              }))
-            }}
-          />
-        </label>
-        <label className="block space-y-1.5">
-          <span className="font-medium">{t('Publication')}</span>
-          <Input
-            value={draft.containerTitle}
-            onChange={(event) =>
-              setDraft((current) => ({ ...current, containerTitle: event.target.value }))
-            }
-          />
-        </label>
-      </div>
-
-      <div>
-        <button
-          type="button"
-          className="flex items-center gap-1.5 font-medium"
-          aria-expanded={advancedOpen}
-          aria-controls="literature-advanced-fields"
-          onClick={() => setAdvancedOpen((open) => !open)}
-        >
-          <ChevronDown
-            className={`size-4 transition-transform ${advancedOpen ? 'rotate-180' : ''}`}
-            aria-hidden="true"
-          />
-          {t('Advanced settings')}
-        </button>
-        {advancedOpen ? (
-          <div id="literature-advanced-fields" className="mt-4 grid gap-4 sm:grid-cols-2">
-            {[
-              ['volume', t('Volume')],
-              ['issue', t('Issue')],
-              ['pages', t('Pages')],
-              ['publisher', t('Publisher')],
-              ['publisherPlace', t('Place')],
-              ['edition', t('Edition')]
-            ].map(([key, label]) => (
-              <label key={key} className="block space-y-1.5">
-                <span className="font-medium">{label}</span>
-                <Input
-                  value={typeField(key)}
-                  onChange={(event) => updateTypeField(key, event.target.value)}
-                />
-              </label>
-            ))}
-          </div>
-        ) : null}
-      </div>
-
-      <section className="space-y-2">
-        <div className="flex items-center justify-between gap-3">
-          <h3 className="font-medium">{t('Authors')}</h3>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() =>
-              setDraft((current) => ({
-                ...current,
-                creators: [...current.creators, emptyAuthor()]
+                itemType: value as LiteratureItemType
               }))
             }
           >
-            <Plus className="size-3.5" aria-hidden="true" />
-            {t('Add author')}
-          </Button>
+            <SelectTrigger id="literature-reference-type" className="h-8">
+              <span className="truncate">{itemTypeLabels[draft.itemType]}</span>
+            </SelectTrigger>
+            <SelectContent>
+              {LITERATURE_ITEM_TYPES.map((itemType) => (
+                <SelectItem key={itemType} value={itemType}>
+                  {itemTypeLabels[itemType]}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
         </div>
-        <div className="space-y-2">
-          {draft.creators.map((creator, index) => (
-            <div key={index} className="flex items-center gap-2">
-              {creator.nameMode === 'organization' ? (
+
+        <label className="block space-y-1.5">
+          <span className="font-medium">{t('Title')}</span>
+          <Input
+            value={draft.title}
+            onChange={(event) => setDraft((current) => ({ ...current, title: event.target.value }))}
+            autoFocus
+          />
+        </label>
+
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="block space-y-1.5">
+            <span className="font-medium">{t('Year')}</span>
+            <Input
+              ref={yearRef}
+              aria-label={t('Year')}
+              inputMode="numeric"
+              value={year}
+              aria-invalid={invalidField === 'year'}
+              aria-describedby={invalidField === 'year' ? `${id}-year-error` : undefined}
+              onChange={(event) => updateYear(event.target.value)}
+            />
+            {invalidField === 'year' ? (
+              <span id={`${id}-year-error`} role="alert" className="block text-destructive">
+                {t('Enter a whole year from 0 to 9999, or leave it blank.')}
+              </span>
+            ) : null}
+          </label>
+          <label className="block space-y-1.5">
+            <span className="font-medium">{t('Publication date')}</span>
+            <Input
+              ref={publicationRef}
+              aria-label={t('Publication date')}
+              value={publicationDate}
+              placeholder={t('YYYY-MM-DD')}
+              aria-invalid={invalidField === 'publication'}
+              aria-describedby={`${id}-date-help${invalidField === 'publication' ? ` ${id}-date-error` : ''}`}
+              onChange={(event) => updatePublicationDate(event.target.value)}
+            />
+            {invalidField === 'publication' ? (
+              <span id={`${id}-date-error`} role="alert" className="block text-destructive">
+                {t('Enter a valid publication date matching the year, or clear both fields.')}
+              </span>
+            ) : null}
+          </label>
+        </div>
+        <p id={`${id}-date-help`} className="text-xs text-muted-foreground">
+          {t(
+            'Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.'
+          )}
+        </p>
+        {legacyDateConflict ? (
+          <p className="text-xs text-status-warning-foreground">
+            {t(
+              'The saved year and publication date disagree. Editing either field will reconcile them.'
+            )}
+          </p>
+        ) : null}
+        <div>
+          <label className="block space-y-1.5">
+            <span className="font-medium">{t('Publication')}</span>
+            <Input
+              value={draft.containerTitle}
+              onChange={(event) =>
+                setDraft((current) => ({ ...current, containerTitle: event.target.value }))
+              }
+            />
+          </label>
+        </div>
+
+        <div>
+          <button
+            type="button"
+            className="flex items-center gap-1.5 font-medium"
+            aria-expanded={advancedOpen}
+            aria-controls="literature-advanced-fields"
+            onClick={() => setAdvancedOpen((open) => !open)}
+          >
+            <ChevronDown
+              className={`size-4 transition-transform ${advancedOpen ? 'rotate-180' : ''}`}
+              aria-hidden="true"
+            />
+            {t('Advanced settings')}
+          </button>
+          {advancedOpen ? (
+            <div id="literature-advanced-fields" className="mt-4 grid gap-4 sm:grid-cols-2">
+              {[
+                ['volume', t('Volume')],
+                ['issue', t('Issue')],
+                ['pages', t('Pages')],
+                ['publisher', t('Publisher')],
+                ['publisherPlace', t('Place')],
+                ['edition', t('Edition')]
+              ].map(([key, label]) => (
+                <label key={key} className="block space-y-1.5">
+                  <span className="font-medium">{label}</span>
+                  <Input
+                    value={typeField(key)}
+                    onChange={(event) => updateTypeField(key, event.target.value)}
+                  />
+                </label>
+              ))}
+              {(
+                [
+                  ['shortTitle', t('Short title')],
+                  ['language', t('Language')],
+                  ['citationKey', t('Citation key')],
+                  ['rights', t('Rights')]
+                ] as const
+              ).map(([key, label]) => (
+                <label key={key} className="block space-y-1.5">
+                  <span className="font-medium">{label}</span>
+                  <Input
+                    value={draft[key] ?? ''}
+                    onChange={(event) =>
+                      setDraft((current) => ({ ...current, [key]: event.target.value }))
+                    }
+                  />
+                </label>
+              ))}
+              <label className="block space-y-1.5">
+                <span className="font-medium">{t('Date accessed')}</span>
                 <Input
-                  aria-label={t('Organization')}
-                  value={creator.literalName}
+                  ref={accessRef}
+                  aria-label={t('Date accessed')}
+                  type="date"
+                  min="1970-01-01"
+                  value={accessDate}
+                  aria-invalid={invalidField === 'access'}
+                  aria-describedby={invalidField === 'access' ? `${id}-access-error` : undefined}
+                  onChange={(event) => {
+                    setAccessDate(event.target.value)
+                    setInvalidField(undefined)
+                  }}
+                />
+                {invalidField === 'access' ? (
+                  <span id={`${id}-access-error`} role="alert" className="block text-destructive">
+                    {t('Enter a valid access date on or after 1970-01-01, or leave it blank.')}
+                  </span>
+                ) : null}
+              </label>
+              <label className="block space-y-1.5 sm:col-span-2">
+                <span className="font-medium">{t('Extra')}</span>
+                <Textarea
+                  value={draft.extra}
+                  rows={3}
                   onChange={(event) =>
-                    updateCreator(index, { ...creator, literalName: event.target.value })
+                    setDraft((current) => ({ ...current, extra: event.target.value }))
                   }
                 />
-              ) : (
-                <>
-                  <Input
-                    aria-label={t('Given name')}
-                    placeholder={t('Given name')}
-                    value={creator.givenName}
-                    onChange={(event) =>
-                      updateCreator(index, { ...creator, givenName: event.target.value })
-                    }
-                  />
-                  <Input
-                    aria-label={t('Family name')}
-                    placeholder={t('Family name')}
-                    value={creator.familyName}
-                    onChange={(event) =>
-                      updateCreator(index, { ...creator, familyName: event.target.value })
-                    }
-                  />
-                </>
-              )}
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={t('Remove author')}
-                onClick={() =>
-                  setDraft((current) => ({
-                    ...current,
-                    creators: current.creators.filter((_, entryIndex) => entryIndex !== index)
-                  }))
-                }
-              >
-                <Trash2 className="size-3.5" aria-hidden="true" />
-              </Button>
-            </div>
-          ))}
-        </div>
-      </section>
-
-      <section className="space-y-2">
-        <div className="flex items-center justify-between gap-3">
-          <h3 className="font-medium">{t('Identifiers')}</h3>
-          <Button
-            type="button"
-            variant="ghost"
-            size="sm"
-            onClick={() =>
-              setDraft((current) => ({
-                ...current,
-                identifiers: [...current.identifiers, emptyIdentifier()]
-              }))
-            }
-          >
-            <Plus className="size-3.5" aria-hidden="true" />
-            {t('Add identifier')}
-          </Button>
-        </div>
-        <div className="space-y-2">
-          {draft.identifiers.map((identifier, index) => (
-            <div key={index} className="flex items-center gap-2">
-              <Select
-                disabled={saving}
-                value={identifier.scheme}
-                onValueChange={(value) =>
-                  updateIdentifier(index, {
-                    ...identifier,
-                    scheme: value as LiteratureIdentifierInput['scheme']
-                  })
-                }
-              >
-                <SelectTrigger aria-label={t('Type')} className="h-8 w-24 text-xs">
-                  <span className="truncate">{identifier.scheme.toUpperCase()}</span>
-                </SelectTrigger>
-                <SelectContent>
-                  {LITERATURE_IDENTIFIER_SCHEMES.map((scheme) => (
-                    <SelectItem key={scheme} value={scheme}>
-                      {scheme.toUpperCase()}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <Input
-                aria-label={identifier.scheme.toUpperCase()}
-                className="h-8"
-                value={identifier.value}
-                onChange={(event) =>
-                  updateIdentifier(index, { ...identifier, value: event.target.value })
-                }
-              />
-              <label className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
-                <input
-                  type="radio"
-                  name={`primary-literature-identifier-${identifier.scheme}`}
-                  checked={identifier.isPrimary}
-                  onChange={() => updateIdentifier(index, { ...identifier, isPrimary: true })}
-                />
-                {t('Preferred for {{scheme}}', { scheme: identifier.scheme.toUpperCase() })}
               </label>
-              <Button
-                type="button"
-                variant="ghost"
-                size="icon-sm"
-                aria-label={t('Remove identifier')}
-                onClick={() =>
-                  setDraft((current) => ({
-                    ...current,
-                    identifiers: current.identifiers.filter((_, entryIndex) => entryIndex !== index)
-                  }))
-                }
-              >
-                <Trash2 className="size-3.5" aria-hidden="true" />
-              </Button>
             </div>
-          ))}
+          ) : null}
         </div>
-      </section>
 
-      <label className="block space-y-1.5">
-        <span className="font-medium">{t('URL')}</span>
-        <Input
-          value={draft.url}
-          onChange={(event) => setDraft((current) => ({ ...current, url: event.target.value }))}
-        />
-      </label>
+        <section className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="font-medium">{t('Creators')}</h3>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                setDraft((current) => ({
+                  ...current,
+                  creators: [...current.creators, emptyCreator()]
+                }))
+              }
+            >
+              <Plus className="size-3.5" aria-hidden="true" />
+              {t('Add creator')}
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {draft.creators.map((creator, index) => (
+              <div key={index} className="space-y-2">
+                <div className="flex items-center gap-2">
+                  <Select
+                    disabled={locked}
+                    value={creator.creatorType}
+                    onValueChange={(creatorType) =>
+                      updateCreator(index, { ...creator, creatorType })
+                    }
+                  >
+                    <SelectTrigger aria-label={t('Creator role')} className="h-8 flex-1">
+                      <span>
+                        {creatorRoleLabels.get(creator.creatorType) ?? creator.creatorType}
+                      </span>
+                    </SelectTrigger>
+                    <SelectContent>
+                      {creatorRoles.map((role) => (
+                        <SelectItem key={role} value={role}>
+                          {creatorRoleLabels.get(role) ?? role}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <Select
+                    disabled={locked}
+                    value={creator.nameMode}
+                    onValueChange={(nameMode: CreatorDraft['nameMode']) =>
+                      updateCreator(index, { ...creator, nameMode })
+                    }
+                  >
+                    <SelectTrigger aria-label={t('Name type')} className="h-8 flex-1">
+                      <span>{creator.nameMode === 'person' ? t('Person') : t('Organization')}</span>
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="person">{t('Person')}</SelectItem>
+                      <SelectItem value="organization">{t('Organization')}</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                <div className="flex items-center gap-2">
+                  {creator.nameMode === 'organization' ? (
+                    <Input
+                      aria-label={t('Organization')}
+                      value={creator.literalName}
+                      onChange={(event) =>
+                        updateCreator(index, { ...creator, literalName: event.target.value })
+                      }
+                    />
+                  ) : (
+                    <>
+                      <Input
+                        aria-label={t('Given name')}
+                        placeholder={t('Given name')}
+                        value={creator.givenName}
+                        onChange={(event) =>
+                          updateCreator(index, { ...creator, givenName: event.target.value })
+                        }
+                      />
+                      <Input
+                        aria-label={t('Family name')}
+                        placeholder={t('Family name')}
+                        value={creator.familyName}
+                        onChange={(event) =>
+                          updateCreator(index, { ...creator, familyName: event.target.value })
+                        }
+                      />
+                    </>
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label={t('Remove creator')}
+                    onClick={() =>
+                      setDraft((current) => ({
+                        ...current,
+                        creators: current.creators.filter((_, entryIndex) => entryIndex !== index)
+                      }))
+                    }
+                  >
+                    <Trash2 className="size-3.5" aria-hidden="true" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
 
-      <label className="block space-y-1.5">
-        <span className="font-medium">{t('Abstract')}</span>
-        <Textarea
-          value={draft.abstract}
-          rows={6}
-          onChange={(event) =>
-            setDraft((current) => ({ ...current, abstract: event.target.value }))
-          }
-        />
-      </label>
+        <section className="space-y-2">
+          <div className="flex items-center justify-between gap-3">
+            <h3 className="font-medium">{t('Identifiers')}</h3>
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() =>
+                setDraft((current) => ({
+                  ...current,
+                  identifiers: [...current.identifiers, emptyIdentifier()]
+                }))
+              }
+            >
+              <Plus className="size-3.5" aria-hidden="true" />
+              {t('Add identifier')}
+            </Button>
+          </div>
+          <div className="space-y-2">
+            {draft.identifiers.map((identifier, index) => (
+              <div key={index} className="flex items-center gap-2">
+                <Select
+                  disabled={locked}
+                  value={identifier.scheme}
+                  onValueChange={(value) =>
+                    updateIdentifier(index, {
+                      ...identifier,
+                      scheme: value as LiteratureIdentifierInput['scheme']
+                    })
+                  }
+                >
+                  <SelectTrigger aria-label={t('Type')} className="h-8 w-24 text-xs">
+                    <span className="truncate">{identifier.scheme.toUpperCase()}</span>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {LITERATURE_IDENTIFIER_SCHEMES.map((scheme) => (
+                      <SelectItem key={scheme} value={scheme}>
+                        {scheme.toUpperCase()}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <Input
+                  aria-label={identifier.scheme.toUpperCase()}
+                  className="h-8"
+                  value={identifier.value}
+                  onChange={(event) =>
+                    updateIdentifier(index, { ...identifier, value: event.target.value })
+                  }
+                />
+                <label className="flex shrink-0 items-center gap-1 text-xs text-muted-foreground">
+                  <input
+                    type="radio"
+                    name={`primary-literature-identifier-${identifier.scheme}`}
+                    checked={identifier.isPrimary}
+                    onChange={() => updateIdentifier(index, { ...identifier, isPrimary: true })}
+                  />
+                  {t('Preferred for {{scheme}}', { scheme: identifier.scheme.toUpperCase() })}
+                </label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon-sm"
+                  aria-label={t('Remove identifier')}
+                  onClick={() =>
+                    setDraft((current) => ({
+                      ...current,
+                      identifiers: current.identifiers.filter(
+                        (_, entryIndex) => entryIndex !== index
+                      )
+                    }))
+                  }
+                >
+                  <Trash2 className="size-3.5" aria-hidden="true" />
+                </Button>
+              </div>
+            ))}
+          </div>
+        </section>
 
+        <label className="block space-y-1.5">
+          <span className="font-medium">{t('URL')}</span>
+          <Input
+            value={draft.url}
+            onChange={(event) => setDraft((current) => ({ ...current, url: event.target.value }))}
+          />
+        </label>
+
+        <label className="block space-y-1.5">
+          <span className="font-medium">{t('Abstract')}</span>
+          <Textarea
+            value={draft.abstract}
+            rows={6}
+            onChange={(event) =>
+              setDraft((current) => ({ ...current, abstract: event.target.value }))
+            }
+          />
+        </label>
+      </fieldset>
       {error ? (
         <p role="alert" className="text-sm text-danger-000">
           {error}
@@ -416,17 +677,17 @@ const LiteratureMetadataEditor = ({
 
       <div className="flex justify-end gap-2 border-t border-border-300/80 pt-4">
         <Button type="button" variant="outline" disabled={saving} onClick={onCancel}>
-          {t('Cancel')}
+          {onRetry ? t('Close') : t('Cancel')}
         </Button>
         <Button
           type="button"
-          disabled={saving || saveDisabled || !draft.title.trim()}
-          onClick={submit}
+          disabled={saving || (!onRetry && (saveDisabled || !draft.title.trim()))}
+          onClick={onRetry ?? submit}
         >
-          {t('Save')}
+          {onRetry ? t('Retry') : t('Save')}
         </Button>
       </div>
-    </fieldset>
+    </div>
   )
 }
 

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4378,7 +4378,6 @@
     "Accept": "Übernehmen",
     "Actions": "Aktionen",
     "Add PDF": "PDF hinzufügen",
-    "Add author": "Autor hinzufügen",
     "Add identifier": "Identifikator hinzufügen",
     "Add reference": "Literaturangabe hinzufügen",
     "All references": "Alle Literaturangaben",
@@ -4528,7 +4527,6 @@
     "Reference file could not be read.": "Die Literaturdatei konnte nicht gelesen werden.",
     "Reference type": "Literaturart",
     "References could not be exported.": "Die Literaturangaben konnten nicht exportiert werden.",
-    "Remove author": "Autor entfernen",
     "Remove identifier": "Identifikator entfernen",
     "Report": "Bericht",
     "Restore references or delete them permanently.": "Stellen Sie Literaturangaben wieder her oder löschen Sie sie endgültig.",
@@ -4907,6 +4905,20 @@
     "Dismissed": "Ignoriert",
     "No dismissed references": "Keine ignorierten Referenzen",
     "Dismissed references can be restored here.": "Ignorierte Referenzen können hier wiederhergestellt werden.",
-    "Accepting will link to: {{projects}}": "Beim Annehmen wird mit folgenden Projekten verknüpft: {{projects}}"
+    "Accepting will link to: {{projects}}": "Beim Annehmen wird mit folgenden Projekten verknüpft: {{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "Mitwirkende",
+    "Add creator": "Mitwirkende hinzufügen",
+    "Remove creator": "Mitwirkende entfernen",
+    "Creator role": "Rolle",
+    "Name type": "Namenstyp",
+    "Person": "Person",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "Geben Sie ein ganzzahliges Jahr von 0 bis 9999 ein oder lassen Sie das Feld leer.",
+    "Enter a valid publication date matching the year, or clear both fields.": "Geben Sie ein gültiges, zum Jahr passendes Veröffentlichungsdatum ein oder leeren Sie beide Felder.",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "Verwenden Sie YYYY, YYYY-MM oder YYYY-MM-DD. Jahr und Datum bleiben synchron; das Leeren eines Feldes leert beide.",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "Das gespeicherte Jahr und Veröffentlichungsdatum stimmen nicht überein. Beim Bearbeiten eines Feldes werden beide abgeglichen.",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Geben Sie ein gültiges Zugriffsdatum ab 1970-01-01 ein oder lassen Sie das Feld leer.",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "Die Referenz wurde erstellt, konnte aber nicht mit dem Ziel verknüpft werden. Versuchen Sie es erneut, um die Verknüpfung abzuschließen. Beim Schließen bleibt sie ohne diese Verknüpfung in Ihrer Bibliothek.",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Die Referenz wurde erstellt, aber die folgenden Schritte sind fehlgeschlagen. Versuchen Sie es erneut, um den Vorgang abzuschließen. Beim Schließen bleibt die Referenz in Ihrer Bibliothek."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4723,11 +4723,9 @@
     "Year": "Año",
     "Publication": "Publicación",
     "Authors": "Autores",
-    "Add author": "Añadir autor",
     "Given name": "Nombre",
     "Family name": "Apellidos",
     "Organization": "Organización",
-    "Remove author": "Eliminar autor",
     "Add identifier": "Añadir identificador",
     "Remove identifier": "Eliminar identificador",
     "URL": "URL",
@@ -5068,6 +5066,20 @@
     "Dismissed": "Ignoradas",
     "No dismissed references": "No hay referencias ignoradas",
     "Dismissed references can be restored here.": "Las referencias ignoradas se pueden restaurar aquí.",
-    "Accepting will link to: {{projects}}": "Al aceptar, se vinculará a: {{projects}}"
+    "Accepting will link to: {{projects}}": "Al aceptar, se vinculará a: {{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "Colaboradores",
+    "Add creator": "Añadir colaborador",
+    "Remove creator": "Eliminar colaborador",
+    "Creator role": "Función del colaborador",
+    "Name type": "Tipo de nombre",
+    "Person": "Persona",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "Introduzca un año entero entre 0 y 9999, o deje el campo vacío.",
+    "Enter a valid publication date matching the year, or clear both fields.": "Introduzca una fecha de publicación válida que coincida con el año, o vacíe ambos campos.",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "Utilice YYYY, YYYY-MM o YYYY-MM-DD. El año y la fecha se mantienen sincronizados; vaciar uno borra ambos.",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "El año y la fecha de publicación guardados no coinciden. Al editar cualquiera de los campos, se ajustarán para que coincidan.",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Introduzca una fecha de acceso válida a partir del 1970-01-01, o deje el campo vacío.",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "La referencia se creó, pero no se pudo vincular al destino. Vuelva a intentarlo para completar el vínculo. Si cierra, la referencia permanecerá en su biblioteca sin ese vínculo.",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La referencia se creó, pero los pasos posteriores fallaron. Vuelva a intentarlo para terminar. Si cierra, la referencia permanecerá en su biblioteca."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4723,11 +4723,9 @@
     "Year": "Année",
     "Publication": "Publication",
     "Authors": "Auteurs",
-    "Add author": "Ajouter un auteur",
     "Given name": "Prénom",
     "Family name": "Nom",
     "Organization": "Organisation",
-    "Remove author": "Supprimer l’auteur",
     "Add identifier": "Ajouter un identifiant",
     "Remove identifier": "Supprimer l’identifiant",
     "URL": "URL",
@@ -5068,6 +5066,20 @@
     "Dismissed": "Ignorées",
     "No dismissed references": "Aucune référence ignorée",
     "Dismissed references can be restored here.": "Les références ignorées peuvent être restaurées ici.",
-    "Accepting will link to: {{projects}}": "Accepter associera la référence à : {{projects}}"
+    "Accepting will link to: {{projects}}": "Accepter associera la référence à : {{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "Contributeurs",
+    "Add creator": "Ajouter un contributeur",
+    "Remove creator": "Supprimer le contributeur",
+    "Creator role": "Rôle du contributeur",
+    "Name type": "Type de nom",
+    "Person": "Personne",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "Saisissez une année entière de 0 à 9999, ou laissez le champ vide.",
+    "Enter a valid publication date matching the year, or clear both fields.": "Saisissez une date de publication valide correspondant à l’année, ou videz les deux champs.",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "Utilisez YYYY, YYYY-MM ou YYYY-MM-DD. L’année et la date restent synchronisées ; vider un champ vide les deux.",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "L’année et la date de publication enregistrées ne correspondent pas. Modifier l’un des champs les rendra cohérentes.",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Saisissez une date de consultation valide à partir du 1970-01-01, ou laissez le champ vide.",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "La référence a été créée, mais son association à la destination a échoué. Réessayez pour terminer l’association. Si vous fermez, elle restera dans votre bibliothèque sans cette association.",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La référence a été créée, mais les étapes suivantes ont échoué. Réessayez pour terminer. Si vous fermez, la référence restera dans votre bibliothèque."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4417,11 +4417,9 @@
     "Year": "年",
     "Publication": "掲載誌",
     "Authors": "著者",
-    "Add author": "著者を追加",
     "Given name": "名",
     "Family name": "姓",
     "Organization": "組織",
-    "Remove author": "著者を削除",
     "Add identifier": "識別子を追加",
     "Remove identifier": "識別子を削除",
     "URL": "URL",
@@ -4754,6 +4752,20 @@
     "Dismissed": "無視済み",
     "No dismissed references": "無視した文献はありません",
     "Dismissed references can be restored here.": "無視した文献はここで復元できます。",
-    "Accepting will link to: {{projects}}": "承認すると次のプロジェクトに関連付けられます：{{projects}}"
+    "Accepting will link to: {{projects}}": "承認すると次のプロジェクトに関連付けられます：{{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "著作者",
+    "Add creator": "著作者を追加",
+    "Remove creator": "著作者を削除",
+    "Creator role": "著作者の役割",
+    "Name type": "名前の種類",
+    "Person": "個人",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "0〜9999 の整数の年を入力するか、空欄にしてください。",
+    "Enter a valid publication date matching the year, or clear both fields.": "年と一致する有効な出版日を入力するか、両方の欄を空にしてください。",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "YYYY、YYYY-MM、YYYY-MM-DD 形式を使用します。年と日付は連動し、どちらかを消去すると両方が消去されます。",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "保存された年と出版日が一致していません。どちらかの欄を編集すると一致するように調整されます。",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "1970-01-01 以降の有効なアクセス日を入力するか、空欄にしてください。",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文献は作成されましたが、保存先への関連付けに失敗しました。再試行して関連付けを完了してください。閉じると文献はライブラリに残りますが、関連付けは行われません。",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献は作成されましたが、後続の処理に失敗しました。再試行して完了してください。閉じても文献はライブラリに残ります。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4415,11 +4415,9 @@
     "Year": "연도",
     "Publication": "출판물",
     "Authors": "저자",
-    "Add author": "저자 추가",
     "Given name": "이름",
     "Family name": "성",
     "Organization": "기관",
-    "Remove author": "저자 제거",
     "Add identifier": "식별자 추가",
     "Remove identifier": "식별자 제거",
     "URL": "URL",
@@ -4752,6 +4750,20 @@
     "Dismissed": "무시됨",
     "No dismissed references": "무시한 문헌이 없습니다",
     "Dismissed references can be restored here.": "무시한 문헌은 여기서 복원할 수 있습니다.",
-    "Accepting will link to: {{projects}}": "수락하면 다음 프로젝트에 연결됩니다: {{projects}}"
+    "Accepting will link to: {{projects}}": "수락하면 다음 프로젝트에 연결됩니다: {{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "기여자",
+    "Add creator": "기여자 추가",
+    "Remove creator": "기여자 제거",
+    "Creator role": "기여자 역할",
+    "Name type": "이름 유형",
+    "Person": "개인",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "0~9999 사이의 정수 연도를 입력하거나 비워 두세요.",
+    "Enter a valid publication date matching the year, or clear both fields.": "연도와 일치하는 유효한 출판일을 입력하거나 두 필드를 모두 비우세요.",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "YYYY, YYYY-MM 또는 YYYY-MM-DD 형식을 사용하세요. 연도와 날짜는 동기화되며, 하나를 지우면 둘 다 지워집니다.",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "저장된 연도와 출판일이 일치하지 않습니다. 둘 중 하나를 수정하면 일치하도록 조정됩니다.",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "1970-01-01 이후의 유효한 접속일을 입력하거나 비워 두세요.",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "문헌이 생성되었지만 대상 위치에 연결하지 못했습니다. 다시 시도하여 연결을 완료하세요. 닫으면 문헌은 라이브러리에 남지만 해당 연결은 생성되지 않습니다.",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "문헌이 생성되었지만 후속 단계가 실패했습니다. 다시 시도하여 완료하세요. 닫아도 문헌은 라이브러리에 남습니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4851,11 +4851,9 @@
     "Year": "Год",
     "Publication": "Издание",
     "Authors": "Авторы",
-    "Add author": "Добавить автора",
     "Given name": "Имя",
     "Family name": "Фамилия",
     "Organization": "Организация",
-    "Remove author": "Удалить автора",
     "Add identifier": "Добавить идентификатор",
     "Remove identifier": "Удалить идентификатор",
     "URL": "URL",
@@ -5200,6 +5198,20 @@
     "Dismissed": "Отклонённые",
     "No dismissed references": "Нет отклонённых публикаций",
     "Dismissed references can be restored here.": "Отклонённые публикации можно восстановить здесь.",
-    "Accepting will link to: {{projects}}": "При принятии публикация будет связана с проектами: {{projects}}"
+    "Accepting will link to: {{projects}}": "При принятии публикация будет связана с проектами: {{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "Создатели",
+    "Add creator": "Добавить создателя",
+    "Remove creator": "Удалить создателя",
+    "Creator role": "Роль создателя",
+    "Name type": "Тип имени",
+    "Person": "Человек",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "Введите целый год от 0 до 9999 или оставьте поле пустым.",
+    "Enter a valid publication date matching the year, or clear both fields.": "Введите допустимую дату публикации, соответствующую году, или очистите оба поля.",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "Используйте YYYY, YYYY-MM или YYYY-MM-DD. Год и дата синхронизируются; очистка одного поля очищает оба.",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "Сохранённые год и дата публикации не совпадают. При изменении любого из полей они будут согласованы.",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Введите допустимую дату доступа не ранее 1970-01-01 или оставьте поле пустым.",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "Ссылка создана, но связать её с выбранным местом не удалось. Повторите попытку, чтобы завершить связывание. При закрытии ссылка останется в библиотеке без этой связи.",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Ссылка создана, но последующие шаги завершились ошибкой. Повторите попытку для завершения. При закрытии ссылка останется в библиотеке."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4418,11 +4418,9 @@
     "Year": "年份",
     "Publication": "出版物",
     "Authors": "作者",
-    "Add author": "添加作者",
     "Given name": "名",
     "Family name": "姓",
     "Organization": "机构",
-    "Remove author": "移除作者",
     "Add identifier": "添加标识符",
     "Remove identifier": "移除标识符",
     "URL": "URL",
@@ -4754,6 +4752,20 @@
     "Dismissed": "已忽略",
     "No dismissed references": "没有已忽略的文献",
     "Dismissed references can be restored here.": "可以在此恢复已忽略的文献。",
-    "Accepting will link to: {{projects}}": "接受后将关联到：{{projects}}"
+    "Accepting will link to: {{projects}}": "接受后将关联到：{{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "创作者",
+    "Add creator": "添加创作者",
+    "Remove creator": "移除创作者",
+    "Creator role": "创作者角色",
+    "Name type": "姓名类型",
+    "Person": "个人",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "请输入 0 到 9999 之间的整数年份，或留空。",
+    "Enter a valid publication date matching the year, or clear both fields.": "请输入与年份一致的有效出版日期，或清空这两个字段。",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "使用 YYYY、YYYY-MM 或 YYYY-MM-DD 格式。年份与日期保持同步；清空其中一个会同时清空两者。",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "已保存的年份与出版日期不一致。编辑任一字段将使两者保持一致。",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "请输入不早于 1970-01-01 的有效访问日期，或留空。",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文献已创建，但关联到目标位置失败。请重试以完成关联。关闭后，文献仍保留在文献库中，但不会建立该关联。",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献已创建，但后续步骤失败。请重试以完成。关闭后，文献仍保留在文献库中。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4418,11 +4418,9 @@
     "Year": "年份",
     "Publication": "出版物",
     "Authors": "作者",
-    "Add author": "新增作者",
     "Given name": "名",
     "Family name": "姓",
     "Organization": "機構",
-    "Remove author": "移除作者",
     "Add identifier": "新增識別碼",
     "Remove identifier": "移除識別碼",
     "URL": "URL",
@@ -4754,6 +4752,20 @@
     "Dismissed": "已忽略",
     "No dismissed references": "沒有已忽略的文獻",
     "Dismissed references can be restored here.": "可以在此還原已忽略的文獻。",
-    "Accepting will link to: {{projects}}": "接受後將關聯至：{{projects}}"
+    "Accepting will link to: {{projects}}": "接受後將關聯至：{{projects}}",
+    "YYYY-MM-DD": "YYYY-MM-DD",
+    "Creators": "創作者",
+    "Add creator": "新增創作者",
+    "Remove creator": "移除創作者",
+    "Creator role": "創作者角色",
+    "Name type": "姓名類型",
+    "Person": "個人",
+    "Enter a whole year from 0 to 9999, or leave it blank.": "請輸入 0 到 9999 之間的整數年份，或留空。",
+    "Enter a valid publication date matching the year, or clear both fields.": "請輸入與年份一致的有效出版日期，或清空這兩個欄位。",
+    "Use YYYY, YYYY-MM, or YYYY-MM-DD. Year and date stay in sync; clearing either clears both.": "使用 YYYY、YYYY-MM 或 YYYY-MM-DD 格式。年份與日期保持同步；清空其中一個會同時清空兩者。",
+    "The saved year and publication date disagree. Editing either field will reconcile them.": "已儲存的年份與出版日期不一致。編輯任一欄位將使兩者保持一致。",
+    "Enter a valid access date on or after 1970-01-01, or leave it blank.": "請輸入不早於 1970-01-01 的有效存取日期，或留空。",
+    "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文獻已建立，但連結至目標位置失敗。請重試以完成連結。關閉後，文獻仍保留在文獻庫中，但不會建立該連結。",
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文獻已建立，但後續步驟失敗。請重試以完成。關閉後，文獻仍保留在文獻庫中。"
   }
 }


### PR DESCRIPTION
## Problem

After manual reference creation committed, a failed read or destination link left Save available and repeated the creation on retry, producing duplicate records and leaving the original unlinked. Year input also truncated fractions and scientific notation, and editing the year could leave a conflicting publication date used by citations. Existing creator roles, organization names, and several supported metadata fields lacked editing controls.

## Proposed change

Retain the acknowledged item ID and unfinished operations in the current create dialog. Recovery locks submitted metadata and offers Retry/Close; retries resume the existing reference without replaying creation or completed links. Preserve the existing PDF failure recovery.

Validate complete year input before saving and coordinate publication year/date, including leap-day validation. Expose creator roles and person/organization selectors with reversible name drafts, and add short title, language, citation key, access date, rights, and Extra controls. Translate new copy in all eight locales.

## Scope and non-goals

No database columns, migrations, persisted enums, IPC commands, or dependencies change. All new recovery and input state is renderer memory. Recovery ends on dialog close/restart; an explicit new Add reference starts a new intent. This does not solve an unacknowledged commit or perform automatic duplicate cleanup.

Untouched historical date pairs, free-text dates, unknown creator roles, nested custom fields, and access timestamps are preserved. Editing a date requires a coherent pair; impossible leap days require user correction. Explicit access-date edits use a UTC calendar day in the existing timestamp field. No global schema tightening or historical data migration is introduced.

## Acceptance criteria and validation

The same expanded regressions were run twice against the unfixed production files: 30 editor failures with 7 passing controls, plus 6 creation-recovery failures in each run. The page tests use real Catalog transactions and temporary migrated SQLite databases, injecting failures only at reads or destination links. Additional arbitrary-role and native partial-date regressions failed before their respective fixes.

Checks below ran after the last material edit:

| Behavior | Check | Result |
| --- | --- | --- |
| Creation recovery, metadata/date/creator editing, Catalog persistence, PDF/import consumers, CSL projection, and all eight locales | `npx vitest run src/renderer/src/pages/literature src/main/literature src/shared/literature.test.ts src/shared/literature-csl.test.ts src/renderer/src/i18n/resources.test.ts` | 1553 passed |
| Node, sandbox, and renderer type contracts | `npm run typecheck` | passed |
| Linted source | `npm run lint` | passed |
| Patch whitespace | `git diff --check` | passed |

Browser verification mounted the actual Library component with an isolated API fixture: invalid year input emitted no create request; corrected dates and creator/advanced metadata reached the save payload; Retry after an acknowledged create/read failure opened the existing detail with one create request. Updated forms and recovery UI were visually inspected and captured locally. SQLite behavior is independently covered by the automated tests.

The local Test Impact Set includes the existing metadata editor consumers and the Catalog/CSL boundaries. CodeGraph supplied the baseline consumer map but warned that its index was for the parent checkout; actual worktree imports, typechecks, and mounted consumers were checked directly. The committed-diff `test:affected:explain` plan selects the full fallback because the literature paths have no module owner in the current manifest. Per maintainer instruction, local verification used the explicit owner/consumer commands above instead of full `npm test`; CI owns the full fallback. PR CI remains authoritative for full portable/platform verification and independent review; packaging and live providers were not exercised locally.

## Review focus

Acknowledged-operation ownership and clearing on a new dialog intent; no replay of completed links/PDF receipts; legacy-date preservation versus explicitly edited date coordination; reversible creator drafts and serialization of only the selected name mode.
