### PR TITLE
fix(literature): preserve save outcomes and search contracts

### DIFF
--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -1,5 +1,5 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
-import { createServer, type Server } from 'node:http'
+import { createServer, request as httpRequest, type Server } from 'node:http'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -411,6 +411,79 @@ describe('AgentMcpHttpHost', () => {
       await client.close()
     }
     expect(saveToInbox).not.toHaveBeenCalled()
+  })
+
+  it('honors cancellation while the original Library request body is still arriving', async () => {
+    host = new AgentMcpHttpHost()
+    const { token } = await host.ensureStarted()
+    const saveToInbox = vi.fn(async () => ({ results: [] }))
+    host.registerLiteratureLibrary('slow-body', {
+      searchLibrary: vi.fn(),
+      readAbstract: vi.fn(),
+      readPdf: vi.fn(),
+      saveToInbox
+    })
+    const url = host.urlFor('library', 'slow-body')
+    const headers = {
+      authorization: `Bearer ${token}`,
+      'content-type': 'application/json',
+      accept: 'application/json, text/event-stream'
+    }
+    const body = JSON.stringify({
+      jsonrpc: '2.0',
+      id: 71,
+      method: 'tools/call',
+      params: {
+        name: 'save_to_inbox',
+        arguments: {
+          candidates: [
+            {
+              item: { itemType: 'journalArticle', title: 'Cancelled before body completion' },
+              source: { provider: 'test', rawMetadata: {} }
+            }
+          ]
+        }
+      }
+    })
+    let finish!: () => void
+    let accepted!: () => void
+    const bodyAccepted = new Promise<void>((resolve) => {
+      accepted = resolve
+    })
+    const pending = new Promise<void>((resolve, reject) => {
+      const request = httpRequest(
+        url,
+        { method: 'POST', headers: { ...headers, expect: '100-continue' } },
+        (response) => {
+          response.resume()
+          response.on('end', resolve)
+        }
+      )
+      request.on('error', reject)
+      request.on('continue', accepted)
+      request.write(body.slice(0, -1))
+      finish = () => request.end(body.slice(-1))
+    })
+    await bodyAccepted
+    // This notification can complete while the earlier POST is waiting for its final byte.
+    const cancelled = await fetch(url, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'notifications/cancelled',
+        params: { requestId: 71 }
+      })
+    })
+    expect(cancelled.status).toBe(202)
+    finish()
+    await pending
+    expect(saveToInbox).not.toHaveBeenCalled()
+    // The same ID is reusable after this POST closes; cancellation must not poison a future call.
+    const repeated = await fetch(url, { method: 'POST', headers, body })
+    expect(repeated.status).toBe(200)
+    await repeated.json()
+    expect(saveToInbox).toHaveBeenCalledOnce()
   })
 
   it('isolates concurrent Library request IDs by route and releases completed or cancelled entries', async () => {

--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -8,6 +8,7 @@ import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { AgentMcpHttpHost } from './mcp-http-host'
+import { literatureItemInputSchema } from '../../shared/literature'
 import { ArtifactRepository } from '../artifacts/repository'
 
 describe('AgentMcpHttpHost', () => {
@@ -342,6 +343,145 @@ describe('AgentMcpHttpHost', () => {
     await client.callTool({ name: 'search_library', arguments: { query: 'retrieval' } })
     expect(searchLibrary).toHaveBeenCalledWith({ query: 'retrieval', scope: 'project', limit: 20 })
     await client.close()
+  })
+
+  it('delivers HTTP cancellation to the active literature lookup before it can save', async () => {
+    host = new AgentMcpHttpHost()
+    const { token } = await host.ensureStarted()
+    let release!: () => void
+    let lookupStarted!: () => void
+    let lookupSignal: AbortSignal | undefined
+    const started = new Promise<void>((resolve) => {
+      lookupStarted = resolve
+    })
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let delivered!: () => void
+    const cancellationDelivered = new Promise<void>((resolve) => {
+      delivered = resolve
+    })
+    const saveToInbox = vi.fn(async () => ({ results: [] }))
+    host.registerLiteratureLibrary('cancel-library', {
+      searchLibrary: vi.fn(),
+      readAbstract: vi.fn(),
+      readPdf: vi.fn(),
+      saveToInbox,
+      resolveSaveReferences: async (_refs, signal) => {
+        lookupSignal = signal
+        lookupStarted()
+        await blocked
+        return [
+          {
+            item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'Paper' }),
+            source: { provider: 'test', rawMetadata: {} }
+          }
+        ]
+      }
+    })
+    const client = new Client({ name: 'cancel-http-test', version: '1' })
+    await client.connect(
+      new StreamableHTTPClientTransport(new URL(host.urlFor('library', 'cancel-library')), {
+        requestInit: { headers: { authorization: `Bearer ${token}` } },
+        fetch: async (input, init) => {
+          const response = await fetch(input, init)
+          if (
+            typeof init?.body === 'string' &&
+            JSON.parse(init.body).method === 'notifications/cancelled'
+          )
+            delivered()
+          return response
+        }
+      })
+    )
+    const controller = new AbortController()
+    const pending = client
+      .callTool({ name: 'save_to_inbox', arguments: { refs: ['doi:10.1234/paper'] } }, undefined, {
+        signal: controller.signal
+      })
+      .catch((error: unknown) => error)
+    try {
+      await started
+      controller.abort()
+      await pending
+      await cancellationDelivered
+      expect(lookupSignal?.aborted).toBe(true)
+    } finally {
+      release()
+      await client.close()
+    }
+    expect(saveToInbox).not.toHaveBeenCalled()
+  })
+
+  it('isolates concurrent Library request IDs by route and releases completed or cancelled entries', async () => {
+    host = new AgentMcpHttpHost()
+    const { token } = await host.ensureStarted()
+    const signals = new Map<string, AbortSignal | undefined>()
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const saves = new Map<string, ReturnType<typeof vi.fn>>()
+    for (const route of ['first', 'second']) {
+      const save = vi.fn(async () => ({ results: [] }))
+      saves.set(route, save)
+      host.registerLiteratureLibrary(route, {
+        searchLibrary: vi.fn(),
+        readAbstract: vi.fn(),
+        readPdf: vi.fn(),
+        saveToInbox: save,
+        resolveSaveReferences: async (_refs, signal) => {
+          signals.set(route, signal)
+          await blocked
+          return [
+            {
+              item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'Paper' }),
+              source: { provider: 'test', rawMetadata: {} }
+            }
+          ]
+        }
+      })
+    }
+    const clients: Client[] = []
+    const connect = async (route: string): Promise<Client> => {
+      const client = new Client({ name: 'route-test', version: '1' })
+      clients.push(client)
+      await client.connect(
+        new StreamableHTTPClientTransport(new URL(host!.urlFor('library', route)), {
+          requestInit: { headers: { authorization: `Bearer ${token}` } }
+        })
+      )
+      return client
+    }
+    const request = { name: 'save_to_inbox', arguments: { refs: ['doi:10.1234/paper'] } }
+    try {
+      const first = await connect('first')
+      const second = await connect('second')
+      const firstResult = first.callTool(request).catch((error: unknown) => error)
+      const secondResult = second.callTool(request)
+      await vi.waitFor(() => expect(signals.size).toBe(2))
+      const duplicate = await connect('first')
+      await expect(duplicate.callTool(request)).rejects.toMatchObject({ code: 409 })
+      await first.notification({ method: 'notifications/cancelled', params: { requestId: 1 } })
+      await vi.waitFor(() => expect(signals.get('first')?.aborted).toBe(true))
+      expect(signals.get('second')?.aborted).toBe(false)
+      release()
+      expect((await secondResult).isError).not.toBe(true)
+      await first.close()
+      await firstResult
+      expect(saves.get('first')).not.toHaveBeenCalled()
+      expect(saves.get('second')).toHaveBeenCalledOnce()
+      // Fresh clients reuse request id 1. Neither completed nor cancelled POSTs may retain it.
+      for (const route of ['first', 'second']) {
+        const reopened = await connect(route)
+        expect((await reopened.callTool(request)).isError).not.toBe(true)
+      }
+      expect(saves.get('first')).toHaveBeenCalledOnce()
+      expect(saves.get('second')).toHaveBeenCalledTimes(2)
+    } finally {
+      release()
+      await Promise.all(clients.map((client) => client.close()))
+    }
   })
 
   it('rejects requests without the bearer token', async () => {

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -96,6 +96,16 @@ class AgentMcpHttpHost {
     }
   >()
 
+  // Keep cancellations only for POSTs already arriving; never retain unknown IDs for future calls.
+  private readonly readingLibraryRequests = new Map<
+    ServerResponse,
+    {
+      routingId: string
+      cancelledIds: Set<string>
+      cancellationBytes: number
+    }
+  >()
+
   constructor(options: { token?: string; host?: string; requestBytes?: number } = {}) {
     this.token = options.token ?? randomUUID()
     this.host = options.host ?? '127.0.0.1'
@@ -194,6 +204,11 @@ class AgentMcpHttpHost {
   // Drops a routing id's registered environments once its session is gone.
   unregister(routingId: string): void {
     this.sessions.delete(routingId)
+    for (const [response, pending] of this.readingLibraryRequests) {
+      if (pending.routingId !== routingId) continue
+      this.readingLibraryRequests.delete(response)
+      response.destroy()
+    }
     for (const [key, active] of this.libraryRequests) {
       if (active.routingId !== routingId) continue
       this.libraryRequests.delete(key)
@@ -204,6 +219,8 @@ class AgentMcpHttpHost {
   // Drops every registered environment (e.g. on runtime disconnect); the server keeps running for reuse.
   clear(): void {
     this.sessions.clear()
+    for (const response of this.readingLibraryRequests.keys()) response.destroy()
+    this.readingLibraryRequests.clear()
     for (const active of this.libraryRequests.values()) active.response.destroy()
     this.libraryRequests.clear()
   }
@@ -302,12 +319,22 @@ class AgentMcpHttpHost {
       void server.close()
     })
 
+    const reading = { routingId, cancelledIds: new Set<string>(), cancellationBytes: 0 }
+    if (kind === 'library' && request.method === 'POST') {
+      this.readingLibraryRequests.set(response, reading)
+      response.once('close', () => this.readingLibraryRequests.delete(response))
+    }
     try {
       await server.connect(transport)
       if (kind === 'library') {
         const receive = transport.onmessage!
         transport.onmessage = (message, extra) => {
+          this.readingLibraryRequests.delete(response)
           if (isJSONRPCRequest(message) && message.method === 'tools/call') {
+            if (reading.cancelledIds.has(JSON.stringify(message.id))) {
+              response.end()
+              return
+            }
             const key = JSON.stringify([routingId, message.id])
             if (this.libraryRequests.has(key)) {
               writeJson(response, 409, { error: 'Duplicate active Literature request id.' })
@@ -321,6 +348,16 @@ class AgentMcpHttpHost {
           } else {
             const cancellation = CancelledNotificationSchema.safeParse(message)
             if (cancellation.success) {
+              const id = JSON.stringify(cancellation.data.params.requestId)
+              for (const [pendingResponse, pending] of this.readingLibraryRequests) {
+                if (pending.routingId !== routingId || pending.cancelledIds.has(id)) continue
+                pending.cancellationBytes += Buffer.byteLength(id)
+                if (pending.cancellationBytes > this.requestBytes) {
+                  // Bound cancellation buffering by the same budget as the incoming body.
+                  this.readingLibraryRequests.delete(pendingResponse)
+                  pendingResponse.destroy()
+                } else pending.cancelledIds.add(id)
+              }
               const key = JSON.stringify([routingId, cancellation.data.params.requestId])
               const active = this.libraryRequests.get(key)
               if (active) {
@@ -340,8 +377,10 @@ class AgentMcpHttpHost {
               emptyValue: undefined
             })
           : undefined
+      if (response.destroyed) return
       await transport.handleRequest(request, response, body)
     } catch (error) {
+      this.readingLibraryRequests.delete(response)
       log.error('MCP host request failed', { kind, error })
 
       if (!response.headersSent) {

--- a/src/main/acp/mcp-http-host.ts
+++ b/src/main/acp/mcp-http-host.ts
@@ -3,6 +3,7 @@ import { createServer, type IncomingMessage, type Server, type ServerResponse } 
 
 import type { McpServer as ModelContextProtocolServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import { CancelledNotificationSchema, isJSONRPCRequest } from '@modelcontextprotocol/sdk/types.js'
 
 import { createArtifactMcpServer, type ArtifactMcpEnvironment } from '../artifacts/mcp-server'
 import { ArtifactRepository } from '../artifacts/repository'
@@ -84,6 +85,16 @@ class AgentMcpHttpHost {
   private startPromise: Promise<HostConnection> | undefined
   private endpoint: string | undefined
   private readonly sessions = new Map<string, SessionEntry>()
+  // HTTP POSTs are stateless, but cancellation must reach the still-running Library POST.
+  // Entries live only until that response closes; request IDs are scoped to the bound route.
+  private readonly libraryRequests = new Map<
+    string,
+    {
+      routingId: string
+      receive: NonNullable<StreamableHTTPServerTransport['onmessage']>
+      response: ServerResponse
+    }
+  >()
 
   constructor(options: { token?: string; host?: string; requestBytes?: number } = {}) {
     this.token = options.token ?? randomUUID()
@@ -125,7 +136,7 @@ class AgentMcpHttpHost {
     this.server = undefined
     this.startPromise = undefined
     this.endpoint = undefined
-    this.sessions.clear()
+    this.clear()
 
     if (!server) return
 
@@ -183,11 +194,18 @@ class AgentMcpHttpHost {
   // Drops a routing id's registered environments once its session is gone.
   unregister(routingId: string): void {
     this.sessions.delete(routingId)
+    for (const [key, active] of this.libraryRequests) {
+      if (active.routingId !== routingId) continue
+      this.libraryRequests.delete(key)
+      active.response.destroy()
+    }
   }
 
   // Drops every registered environment (e.g. on runtime disconnect); the server keeps running for reuse.
   clear(): void {
     this.sessions.clear()
+    for (const active of this.libraryRequests.values()) active.response.destroy()
+    this.libraryRequests.clear()
   }
 
   // Builds the per-session MCP endpoint URL the agent connects to for one kind.
@@ -286,6 +304,36 @@ class AgentMcpHttpHost {
 
     try {
       await server.connect(transport)
+      if (kind === 'library') {
+        const receive = transport.onmessage!
+        transport.onmessage = (message, extra) => {
+          if (isJSONRPCRequest(message) && message.method === 'tools/call') {
+            const key = JSON.stringify([routingId, message.id])
+            if (this.libraryRequests.has(key)) {
+              writeJson(response, 409, { error: 'Duplicate active Literature request id.' })
+              return
+            }
+            const active = { routingId, receive, response }
+            this.libraryRequests.set(key, active)
+            response.once('close', () => {
+              if (this.libraryRequests.get(key) === active) this.libraryRequests.delete(key)
+            })
+          } else {
+            const cancellation = CancelledNotificationSchema.safeParse(message)
+            if (cancellation.success) {
+              const key = JSON.stringify([routingId, cancellation.data.params.requestId])
+              const active = this.libraryRequests.get(key)
+              if (active) {
+                active.receive(message, extra)
+                // Cancelled MCP handlers intentionally send no result. End the original POST
+                // as well so its transport, server, and route entry can be released.
+                active.response.end()
+              }
+            }
+          }
+          receive(message, extra)
+        }
+      }
       const body =
         request.method === 'POST'
           ? await readBoundedJsonBody<unknown>(request, this.requestBytes, {

--- a/src/main/acp/runtime-base-composition.test.ts
+++ b/src/main/acp/runtime-base-composition.test.ts
@@ -193,7 +193,7 @@ describe('ACP Runtime base composition', () => {
     ['codex-response compatibility', codexFramework, false, true],
     ['codex-bridge', codexFramework, false, true]
   ] as const)(
-    'forwards the acquisition cancellation signal with trusted origin for %s',
+    'forwards literature cancellation signals with trusted origin for %s',
     async (_path, framework, nativeMcpEnabled, bridgeMcpAliasesEnabled) => {
       let handler: LiteratureLibraryMcpHandler | undefined
       const host = {
@@ -209,6 +209,9 @@ describe('ACP Runtime base composition', () => {
       const acquirePdf = vi.fn<
         (request: { signal?: AbortSignal }) => Promise<{ status: 'not-found' }>
       >(async () => ({ status: 'not-found' }))
+      const saveToInbox = vi.fn(async () => ({ results: [], cancelled: true }))
+      const resolveSaveReferences = vi.fn(async () => [])
+      const readCandidateFile = vi.fn(async () => '{}')
       const owners = composeAcpRuntimeBaseOwners({
         appVersion: 'test',
         defaultCwd: '/workspace',
@@ -218,7 +221,9 @@ describe('ACP Runtime base composition', () => {
           searchLibrary: vi.fn(),
           readAbstract: vi.fn(),
           readPdf: vi.fn(),
-          saveToInbox: vi.fn()
+          saveToInbox,
+          resolveSaveReferences,
+          readCandidateFile
         }
       })
       const provision = await owners.sessionCapabilities.provision({
@@ -241,6 +246,27 @@ describe('ACP Runtime base composition', () => {
         signal: controller.signal,
         projectId: 'project-1',
         sessionId: 'session-1'
+      })
+      const saved = await handler!.saveToInbox({
+        candidates: [candidate],
+        signal: controller.signal
+      })
+      expect(saved).toEqual({ results: [], cancelled: true })
+      expect(saveToInbox).toHaveBeenCalledWith({
+        candidates: [candidate],
+        signal: controller.signal,
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+      await handler!.resolveSaveReferences!(['doi:10.1234/paper'], controller.signal)
+      expect(resolveSaveReferences).toHaveBeenCalledWith(['doi:10.1234/paper'], controller.signal)
+      await handler!.readCandidateFile!('candidates.json', controller.signal)
+      expect(readCandidateFile).toHaveBeenCalledWith({
+        filename: 'candidates.json',
+        signal: controller.signal,
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        workspaceCwd: '/workspace'
       })
       controller.abort()
       expect(acquirePdf.mock.calls[0][0].signal!.aborted).toBe(true)
@@ -439,7 +465,7 @@ describe('ACP Runtime base composition', () => {
       promptMessageId: 'message-1',
       itemId: 'item-1'
     })
-    expect(resolveSaveReferences).toHaveBeenCalledWith(['pmid:35486828'])
+    expect(resolveSaveReferences).toHaveBeenCalledWith(['pmid:35486828'], undefined)
     expect(formatReferences).toHaveBeenCalledWith({
       projectId: 'project-1',
       itemIds: ['item-1'],

--- a/src/main/acp/runtime-base-composition.ts
+++ b/src/main/acp/runtime-base-composition.ts
@@ -293,18 +293,19 @@ const composeAcpRuntimeBaseOwners = (options: AcpRuntimeOptions) => {
             },
             ...(options.literatureLibrary!.resolveSaveReferences
               ? {
-                  resolveSaveReferences: (references: readonly string[]) =>
-                    options.literatureLibrary!.resolveSaveReferences!(references)
+                  resolveSaveReferences: (references: readonly string[], signal?: AbortSignal) =>
+                    options.literatureLibrary!.resolveSaveReferences!(references, signal)
                 }
               : {}),
             ...(options.literatureLibrary!.readCandidateFile
               ? {
-                  readCandidateFile: (filename: string) =>
+                  readCandidateFile: (filename: string, signal?: AbortSignal) =>
                     options.literatureLibrary!.readCandidateFile!({
                       projectId,
                       sessionId: appSessionId,
                       workspaceCwd,
-                      filename
+                      filename,
+                      signal
                     })
                 }
               : {}),

--- a/src/main/acp/runtime-composition.ts
+++ b/src/main/acp/runtime-composition.ts
@@ -419,9 +419,16 @@ const createAcpRuntime = ({
                         })
                     }
                   : {}),
-                resolveSaveReferences: (references) =>
-                  literatureReferenceResolver.resolve(references),
-                readCandidateFile: async ({ projectId, sessionId, workspaceCwd, filename }) => {
+                resolveSaveReferences: (references, signal) =>
+                  literatureReferenceResolver.resolve(references, signal),
+                readCandidateFile: async ({
+                  projectId,
+                  sessionId,
+                  workspaceCwd,
+                  filename,
+                  signal
+                }) => {
+                  signal?.throwIfAborted()
                   const notebookRoot = getNotebookSessionRoot(dataRoot, projectId, sessionId)
                   const notebookDataDir = join(notebookRoot, 'data')
                   const sourcePath = await resolveAllowedImportFilePath(
@@ -430,9 +437,12 @@ const createAcpRuntime = ({
                     [notebookDataDir, workspaceCwd, notebookRoot]
                   )
                   if ((await stat(sourcePath)).size > MAX_LITERATURE_CANDIDATE_FILE_BYTES) {
-                    throw new Error('Literature candidate file exceeds the 2 MB limit.')
+                    throw Object.assign(
+                      new Error('Literature candidate file exceeds the 2 MB limit.'),
+                      { code: 'CANDIDATE_FILE_TOO_LARGE' }
+                    )
                   }
-                  return readFile(sourcePath, 'utf8')
+                  return readFile(sourcePath, { encoding: 'utf8', signal })
                 },
                 formatReferences: async ({ itemIds, styleId, locale }) => {
                   const items = await literatureCatalog.getMany(itemIds)
@@ -518,26 +528,10 @@ const createAcpRuntime = ({
                   const scope = request.scope ?? 'project'
                   const offset = request.offset ?? 0
                   const limit = request.limit ?? LITERATURE_LIBRARY_SEARCH_DEFAULT_LIMIT
-                  if (scope === 'items') {
-                    const query = request.query?.trim().toLocaleLowerCase()
-                    const selected = (
-                      await literatureCatalog.getMany(request.itemIds ?? [])
-                    ).filter(
-                      ({ item }) =>
-                        !query || JSON.stringify(item).toLocaleLowerCase().includes(query)
-                    )
-                    const items = selected.slice(offset, offset + limit)
-                    const nextOffset = offset + items.length
-                    return {
-                      items,
-                      totalCount: selected.length,
-                      ...(nextOffset < selected.length ? { nextOffset } : {}),
-                      hasMore: nextOffset < selected.length
-                    }
-                  }
                   const page = await literatureCatalog.search({
                     scope: 'library',
                     query: request.query,
+                    ...(scope === 'items' ? { itemIds: [...(request.itemIds ?? [])] } : {}),
                     projectId: scope === 'project' ? request.projectId : undefined,
                     collectionId: scope === 'collection' ? request.collectionId : undefined,
                     offset,
@@ -603,19 +597,32 @@ const createAcpRuntime = ({
                 saveToInbox: async (request) => {
                   const results: LiteratureCatalogReceipt[] = []
                   for (const candidate of request.candidates) {
-                    results.push(
-                      await literatureCatalog.transact({
-                        kind: 'stage-candidate',
-                        candidate: {
-                          ...candidate,
-                          origin: {
-                            kind: 'agent',
-                            projectId: request.projectId,
-                            sessionId: request.sessionId
+                    if (request.signal?.aborted) return { results, cancelled: true }
+                    try {
+                      results.push(
+                        await literatureCatalog.transact({
+                          kind: 'stage-candidate',
+                          candidate: {
+                            ...candidate,
+                            origin: {
+                              kind: 'agent',
+                              projectId: request.projectId,
+                              sessionId: request.sessionId
+                            }
                           }
+                        })
+                      )
+                    } catch {
+                      return {
+                        results,
+                        failure: {
+                          inputIndex: results.length,
+                          code: 'INBOX_SAVE_FAILED',
+                          message:
+                            'Could not save this candidate. Earlier receipts remain valid; later inputs were not attempted.'
                         }
-                      })
-                    )
+                      }
+                    }
                   }
                   return { results }
                 }

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -281,7 +281,8 @@ type AcpRuntimeOptions = {
       sessionId: string
     }) => Promise<import('../literature/agent-pdf-acquisition').AgentPdfAcquisitionResult>
     resolveSaveReferences?: (
-      references: readonly string[]
+      references: readonly string[],
+      signal?: AbortSignal
     ) => Promise<readonly LiteratureLibraryDiscovery[]>
     searchLibrary: (request: {
       projectId: string
@@ -311,6 +312,7 @@ type AcpRuntimeOptions = {
       sessionId: string
       workspaceCwd: string
       filename: string
+      signal?: AbortSignal
     }) => Promise<string>
     formatReferences?: (request: {
       projectId: string
@@ -346,6 +348,7 @@ type AcpRuntimeOptions = {
       projectId: string
       sessionId: string
       candidates: readonly LiteratureLibraryDiscovery[]
+      signal?: AbortSignal
     }) => Promise<LiteratureLibrarySaveResult>
   }>
   sideChatRelays?: Readonly<{

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -923,6 +923,13 @@ class LiteratureCatalog {
         ? Prisma.sql`i."deletedAt" IS NOT NULL`
         : Prisma.sql`i."deletedAt" IS NULL`
     ]
+    if (request.itemIds !== undefined) {
+      predicates.push(
+        request.itemIds.length
+          ? Prisma.sql`i.id IN (${Prisma.join(request.itemIds)})`
+          : Prisma.sql`0 = 1`
+      )
+    }
     const contains = (column: Prisma.Sql, text: string): Prisma.Sql =>
       Prisma.sql`instr(${column}, ${normalizeSearchText(text)}) > 0`
     const creatorMatches = (text: string): Prisma.Sql => Prisma.sql`EXISTS (

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -926,7 +926,7 @@ class LiteratureCatalog {
     if (request.itemIds !== undefined) {
       predicates.push(
         request.itemIds.length
-          ? Prisma.sql`i.id IN (${Prisma.join(request.itemIds)})`
+          ? Prisma.sql`selected.id IN (${Prisma.join(request.itemIds)})`
           : Prisma.sql`0 = 1`
       )
     }
@@ -1002,14 +1002,26 @@ class LiteratureCatalog {
             : request.sortBy === 'created'
               ? Prisma.sql`i."createdAt" ${direction}, i.id ASC`
               : Prisma.sql`i."updatedAt" ${direction}, i.id ASC`
+    // Selected IDs follow getMany's alias contract: filter survivor metadata, return requested IDs.
+    const from =
+      request.itemIds === undefined
+        ? Prisma.sql`"LiteratureItem" i`
+        : Prisma.sql`"LiteratureItem" selected JOIN "LiteratureItem" i
+          ON i.id = COALESCE(selected."mergedIntoItemId", selected.id)`
+    const requestedId = request.itemIds === undefined ? Prisma.sql`i.id` : Prisma.sql`selected.id`
     const ids = await client.$queryRaw<
-      { id: string }[]
-    >(Prisma.sql`SELECT i.id FROM "LiteratureItem" i WHERE ${where} ORDER BY ${orderBy}
+      { id: string; requestedId: string }[]
+    >(Prisma.sql`SELECT i.id, ${requestedId} AS "requestedId" FROM ${from} WHERE ${where} ORDER BY ${orderBy}, ${requestedId} ASC
       ${request.allItemIds ? Prisma.empty : Prisma.sql`LIMIT ${limit} OFFSET ${offset}`}`)
     const itemIds = ids.map(({ id }) => id)
-    if (request.allItemIds) return { entries: [], itemIds, totalCount: itemIds.length }
+    if (request.allItemIds)
+      return {
+        entries: [],
+        itemIds: ids.map(({ requestedId }) => requestedId),
+        totalCount: ids.length
+      }
     const [count] = await client.$queryRaw<{ total: bigint }[]>(
-      Prisma.sql`SELECT COUNT(*) AS total FROM "LiteratureItem" i WHERE ${where}`
+      Prisma.sql`SELECT COUNT(*) AS total FROM ${from} WHERE ${where}`
     )
     const totalCount = Number(count!.total)
     const rows = itemIds.length
@@ -1020,7 +1032,10 @@ class LiteratureCatalog {
       : []
     const byId = new Map(rows.map((row) => [row.id, row]))
     return {
-      entries: itemIds.map((id) => toItemView(byId.get(id)!)),
+      entries: ids.map(({ id, requestedId }) => ({
+        ...toItemView(byId.get(id)!),
+        id: requestedId
+      })),
       totalCount,
       nextOffset: offset + limit < totalCount ? offset + limit : undefined
     }

--- a/src/main/literature/library-mcp-server.test.ts
+++ b/src/main/literature/library-mcp-server.test.ts
@@ -163,7 +163,10 @@ describe('Literature Library MCP server', () => {
       name: 'save_to_inbox',
       arguments: { candidates: [discovery] }
     })
-    expect(saveToInbox).toHaveBeenCalledWith({ candidates: [discovery] })
+    expect(saveToInbox).toHaveBeenCalledWith({
+      candidates: [discovery],
+      signal: expect.any(AbortSignal)
+    })
     expect(saved.structuredContent).toEqual({
       results: [{ kind: 'candidate', id: 'candidate-1', state: 'pending' }]
     })
@@ -226,8 +229,14 @@ describe('Literature Library MCP server', () => {
       arguments: { filename: 'handoff/literature-inbox-payload.json' }
     })
 
-    expect(readCandidateFile).toHaveBeenCalledWith('handoff/literature-inbox-payload.json')
-    expect(saveToInbox).toHaveBeenCalledWith({ candidates: [discovery] })
+    expect(readCandidateFile).toHaveBeenCalledWith(
+      'handoff/literature-inbox-payload.json',
+      expect.any(AbortSignal)
+    )
+    expect(saveToInbox).toHaveBeenCalledWith({
+      candidates: [discovery],
+      signal: expect.any(AbortSignal)
+    })
     expect(saved.structuredContent).toEqual({ results: [] })
 
     await client.close()
@@ -369,8 +378,14 @@ describe('Literature Library MCP server', () => {
       arguments: { refs: ['pmid:35486828', 'doi:10.1000/example'] }
     })
 
-    expect(resolveSaveReferences).toHaveBeenCalledWith(['pmid:35486828', 'doi:10.1000/example'])
-    expect(saveToInbox).toHaveBeenCalledWith({ candidates: [discovery] })
+    expect(resolveSaveReferences).toHaveBeenCalledWith(
+      ['pmid:35486828', 'doi:10.1000/example'],
+      expect.any(AbortSignal)
+    )
+    expect(saveToInbox).toHaveBeenCalledWith({
+      candidates: [discovery],
+      signal: expect.any(AbortSignal)
+    })
     expect(saved.structuredContent).toEqual({ results: [] })
 
     const ambiguous = await client.callTool({

--- a/src/main/literature/library-mcp-server.ts
+++ b/src/main/literature/library-mcp-server.ts
@@ -8,9 +8,12 @@ import {
   literatureSourceInputSchema,
   type LiteratureCitationLocale,
   type LiteratureCitationStyle,
-  type LiteratureCatalogReceipt,
   type LiteratureItemView
 } from '../../shared/literature'
+import {
+  summarizeLiteratureSaveReceipts,
+  type LiteratureLibrarySaveResult
+} from '../../shared/literature-save'
 import { literatureReadPresentation } from './mcp-server'
 import type { AgentPdfAcquisitionResult } from './agent-pdf-acquisition'
 
@@ -56,6 +59,7 @@ type LiteratureLibraryDiscovery = z.infer<typeof literatureDiscoverySchema>
 
 type LiteratureLibrarySaveRequest = Readonly<{
   candidates: readonly LiteratureLibraryDiscovery[]
+  signal?: AbortSignal
 }>
 
 type LiteratureLibrarySearchResult = Readonly<{
@@ -103,6 +107,7 @@ type LiteratureLibrarySearchOutputItem = Readonly<{
   itemType: LiteratureItemView['item']['itemType']
   title: string
   authors: string
+  /** All contributors, including editors and translators. authors contains only authors. */
   creatorCount: number
   issuedText: string
   issuedYear?: number
@@ -120,10 +125,6 @@ type LiteratureLibrarySearchOutputItem = Readonly<{
 
 type LiteratureLibrarySearchOutputResult = Omit<LiteratureLibrarySearchResult, 'items'> &
   Readonly<{ items: readonly LiteratureLibrarySearchOutputItem[] }>
-
-type LiteratureLibrarySaveResult = Readonly<{
-  results: readonly LiteratureCatalogReceipt[]
-}>
 
 type LiteratureLibraryFormatDocumentRequest = Readonly<{
   filename: string
@@ -171,9 +172,10 @@ type LiteratureLibraryMcpHandler = Readonly<{
     request: LiteratureLibraryReadPdfRequest
   ) => Promise<LiteratureLibraryReadPdfResult | undefined>
   resolveSaveReferences?: (
-    references: readonly string[]
+    references: readonly string[],
+    signal?: AbortSignal
   ) => Promise<readonly LiteratureLibraryDiscovery[]>
-  readCandidateFile?: (filename: string) => Promise<string>
+  readCandidateFile?: (filename: string, signal?: AbortSignal) => Promise<string>
   formatReferences?: (
     request: LiteratureLibraryFormatReferencesRequest
   ) => Promise<LiteratureLibraryFormatReferencesResult>
@@ -212,12 +214,6 @@ const presentationContent = (
   text: JSON.stringify({ openScienceLiteraturePresentation: presentation })
 })
 
-const itemTitles = (items: readonly LiteratureItemView[]): string[] =>
-  items
-    .map(({ item }) => item.title.trim())
-    .filter(Boolean)
-    .slice(0, 3)
-
 const compactText = (value: string, limit: number): string =>
   value.length <= limit ? value : `${value.slice(0, Math.max(0, limit - 1))}…`
 
@@ -252,14 +248,21 @@ const compactSearchItem = (
         scheme === 'arxiv'
     )
     .slice(0, 2)
-    .map(({ scheme, value }) => ({ scheme, value: compactText(value, 200) }))
+    .map(({ scheme, value }) => ({ scheme, value }))
 
   return {
     id: view.id,
     metadataRevision: view.metadataRevision,
     itemType: view.item.itemType,
     title: compactText(view.item.title, 400),
-    authors: compactText(view.item.creators.map(creatorName).filter(Boolean).join(', '), 400),
+    authors: compactText(
+      view.item.creators
+        .filter(({ creatorType }) => creatorType === 'author')
+        .map(creatorName)
+        .filter(Boolean)
+        .join(', '),
+      400
+    ),
     creatorCount: view.item.creators.length,
     issuedText: compactText(view.item.issuedText, 100),
     ...(view.item.issuedYear === undefined ? {} : { issuedYear: view.item.issuedYear }),
@@ -280,26 +283,65 @@ const compactSearchItem = (
 }
 
 const compactSearchResult = (
-  result: LiteratureLibrarySearchResult
-): LiteratureLibrarySearchOutputResult => {
+  result: LiteratureLibrarySearchResult,
+  request: LiteratureLibrarySearchRequest
+): {
+  structuredContent: LiteratureLibrarySearchOutputResult
+  content: { type: 'text'; text: string }[]
+} => {
   let abstractLimit = LITERATURE_LIBRARY_SEARCH_ABSTRACT_MAX_CHARACTERS
-  let searchResult = { ...result, items: result.items.map((item) => compactSearchItem(item)) }
-  while (
-    JSON.stringify(searchResult).length > LITERATURE_LIBRARY_SEARCH_OUTPUT_MAX_CHARACTERS &&
-    abstractLimit > LITERATURE_LIBRARY_SEARCH_ABSTRACT_MIN_CHARACTERS
-  ) {
-    const overflow =
-      JSON.stringify(searchResult).length - LITERATURE_LIBRARY_SEARCH_OUTPUT_MAX_CHARACTERS
-    abstractLimit = Math.max(
-      LITERATURE_LIBRARY_SEARCH_ABSTRACT_MIN_CHARACTERS,
-      abstractLimit - Math.ceil(overflow / Math.max(1, result.items.length)) - 16
-    )
-    searchResult = {
-      ...result,
-      items: result.items.map((item) => compactSearchItem(item, abstractLimit))
+  let itemCount = result.items.length
+  while (true) {
+    const items = result.items
+      .slice(0, itemCount)
+      .map((item) => compactSearchItem(item, abstractLimit))
+    const hasMore = itemCount < result.items.length || result.hasMore
+    const nextOffset =
+      itemCount < result.items.length ? (request.offset ?? 0) + itemCount : result.nextOffset
+    const searchResult: LiteratureLibrarySearchOutputResult = {
+      items,
+      totalCount: result.totalCount,
+      hasMore,
+      ...(nextOffset !== undefined ? { nextOffset } : {})
+    }
+    const content = [
+      presentationContent({
+        libraryAction: 'search',
+        libraryScope: request.scope,
+        ...(items.length
+          ? {
+              itemTitles: items
+                .map(({ title }) => title)
+                .filter(Boolean)
+                .slice(0, 3)
+            }
+          : {}),
+        resultCount: items.length,
+        totalCount: result.totalCount,
+        offset: request.offset ?? 0,
+        limit: request.limit,
+        ...(nextOffset !== undefined ? { nextOffset } : {}),
+        hasMore
+      }),
+      { type: 'text' as const, text: JSON.stringify(searchResult) }
+    ]
+    // Include JSON escaping and the presentation block in the emitted text budget.
+    if (JSON.stringify(content).length <= LITERATURE_LIBRARY_SEARCH_OUTPUT_MAX_CHARACTERS) {
+      return { structuredContent: searchResult, content }
+    }
+    if (abstractLimit > LITERATURE_LIBRARY_SEARCH_ABSTRACT_MIN_CHARACTERS) {
+      abstractLimit = Math.max(
+        LITERATURE_LIBRARY_SEARCH_ABSTRACT_MIN_CHARACTERS,
+        Math.floor(abstractLimit / 2)
+      )
+    } else if (itemCount > 1) {
+      itemCount--
+    } else {
+      throw new Error(
+        'SEARCH_RESULT_TOO_LARGE: A record exceeds the search response budget. Narrow the query; exact identifiers have not been truncated.'
+      )
     }
   }
-  return searchResult
 }
 
 const compactBatchAbstract = (
@@ -330,8 +372,10 @@ const resolveSaveCandidates = async (
     candidates?: readonly LiteratureLibraryDiscovery[]
     filename?: string
   },
-  handler: LiteratureLibraryMcpHandler
+  handler: LiteratureLibraryMcpHandler,
+  signal?: AbortSignal
 ): Promise<readonly LiteratureLibraryDiscovery[]> => {
+  signal?.throwIfAborted()
   const inputCount = [request.refs, request.candidates, request.filename].filter(
     (value) => value !== undefined
   ).length
@@ -342,17 +386,35 @@ const resolveSaveCandidates = async (
     if (!handler.resolveSaveReferences) {
       throw new Error('REFERENCE_RESOLUTION_UNAVAILABLE: Identifier lookup is not configured.')
     }
-    return handler.resolveSaveReferences(request.refs)
+    return handler.resolveSaveReferences(request.refs, signal)
   }
   if (request.candidates) return request.candidates
   if (!handler.readCandidateFile) {
     throw new Error('CANDIDATE_FILE_UNAVAILABLE: Candidate file loading is not configured.')
   }
 
+  let content: string
   try {
-    return literatureDiscoveryBatchSchema.parse(
-      JSON.parse(await handler.readCandidateFile(request.filename!))
-    ).candidates
+    content = await handler.readCandidateFile(request.filename!, signal)
+  } catch (error) {
+    signal?.throwIfAborted()
+    const code =
+      typeof error === 'object' && error !== null && 'code' in error ? error.code : undefined
+    if (code === 'CANDIDATE_FILE_TOO_LARGE') {
+      throw new Error('CANDIDATE_FILE_TOO_LARGE: The candidate file exceeds the 2 MB limit.', {
+        cause: error
+      })
+    }
+    throw new Error(
+      code === 'EACCES' || code === 'EPERM'
+        ? 'CANDIDATE_FILE_UNREADABLE: Permission denied. Choose a readable candidate file.'
+        : 'CANDIDATE_FILE_UNREADABLE: Could not read the candidate file. Check that it exists and is accessible in this workspace.',
+      { cause: error }
+    )
+  }
+  signal?.throwIfAborted()
+  try {
+    return literatureDiscoveryBatchSchema.parse(JSON.parse(content)).candidates
   } catch (error) {
     throw new Error('INVALID_CANDIDATE_FILE: The candidate file is not valid Literature JSON.', {
       cause: error
@@ -373,7 +435,7 @@ const createLiteratureLibraryMcpServer = (
     {
       title: 'Search literature library',
       description:
-        "Browse or search the user's Open Science literature metadata library. Results use a compact projection with abstractPreview, abstractLength, and abstractTruncated so a 20-record page stays within the Agent response budget. This does not search external providers or read PDF full text. Omit query to browse records. Scope defaults to project and only returns records linked to the trusted current Project. Use library only when the user explicitly requests their global Library, collection with collectionId for an explicitly selected Collection, or items with the exact itemIds explicitly selected by the user. Each page defaults to 20 records, which is also the maximum. When nextOffset is returned, pass it as offset to continue.",
+        "Browse or search the user's Open Science literature metadata library. Results use a compact projection with abstractPreview, abstractLength, and abstractTruncated so a 20-record page stays within the Agent response budget. authors lists only authors; creatorCount counts all contributors. This does not search external providers or read PDF full text. Omit query to browse records. Scope defaults to project and only returns records linked to the trusted current Project. Use library only when the user explicitly requests their global Library, collection with collectionId for an explicitly selected Collection, or items with the exact itemIds explicitly selected by the user. Each page defaults to 20 records, which is also the maximum. When nextOffset is returned, pass it as offset to continue.",
       inputSchema: {
         query: z.string().trim().min(1).max(2_000).optional(),
         scope: z.enum(LITERATURE_LIBRARY_SCOPES).optional(),
@@ -402,25 +464,7 @@ const createLiteratureLibraryMcpServer = (
         throw new Error('DUPLICATE_ITEM_IDS: Items scope does not accept duplicate itemIds.')
       }
       const result = await handler.searchLibrary({ ...request, scope, limit })
-      const searchResult = compactSearchResult(result)
-      const titles = itemTitles(result.items)
-      return {
-        structuredContent: searchResult,
-        content: [
-          presentationContent({
-            libraryAction: 'search',
-            libraryScope: scope,
-            ...(titles.length > 0 ? { itemTitles: titles } : {}),
-            resultCount: searchResult.items.length,
-            totalCount: result.totalCount,
-            offset: request.offset ?? 0,
-            limit,
-            ...(result.nextOffset !== undefined ? { nextOffset: result.nextOffset } : {}),
-            hasMore: result.hasMore
-          }),
-          { type: 'text' as const, text: JSON.stringify(searchResult) }
-        ]
-      }
+      return compactSearchResult(result, { ...request, scope, limit })
     }
   )
 
@@ -651,7 +695,7 @@ const createLiteratureLibraryMcpServer = (
     {
       title: 'Save literature discoveries',
       description:
-        'Save one to ten literature records discovered by the Agent to the user-level Literature Inbox for review. Open Science supplies the trusted current Project and Session origin; do not include origin fields. Prefer refs with pmid:<id> or doi:<id> so Open Science can retrieve the metadata. Use candidates only for records without a supported identifier. filename remains available for a prepared Notebook batch.',
+        'Save one to ten literature records discovered by the Agent to the user-level Literature Inbox for review. Open Science supplies the trusted current Project and Session origin; do not include origin fields. Each receipt in results corresponds to the completed input prefix; failure.inputIndex is zero-based and later inputs were not attempted. Reused receipts are not newly created rows. Prefer refs with pmid:<id> or doi:<id> so Open Science can retrieve the metadata. Use candidates only for records without a supported identifier. filename remains available for a prepared Notebook batch.',
       inputSchema: {
         refs: z
           .array(z.string().trim().min(1).max(512))
@@ -673,18 +717,21 @@ const createLiteratureLibraryMcpServer = (
           )
       }
     },
-    async (request) => {
-      const candidates = await resolveSaveCandidates(request, handler)
-      const result = await handler.saveToInbox({ candidates })
+    async (request, { signal }) => {
+      const candidates = await resolveSaveCandidates(request, handler, signal)
+      signal.throwIfAborted()
+      const result = await handler.saveToInbox({ candidates, signal })
+      const summary = summarizeLiteratureSaveReceipts(result.results)
       const titles = candidateTitles(candidates)
       return {
+        ...(result.failure || result.cancelled ? { isError: true } : {}),
         structuredContent: result,
         content: [
           presentationContent({
             libraryAction: 'save',
             ...(titles.length > 0 ? { itemTitles: titles } : {}),
             candidateCount: candidates.length,
-            savedCount: result.results.length
+            savedCount: summary.pendingCount
           }),
           { type: 'text' as const, text: JSON.stringify(result) }
         ]
@@ -709,7 +756,8 @@ const createLiteratureLibraryMcpServer = (
         signal.throwIfAborted()
         const candidates = await resolveSaveCandidates(
           { refs: ref ? [ref] : undefined, candidates: candidate ? [candidate] : undefined },
-          handler
+          handler,
+          signal
         )
         if (candidates.length !== 1) throw new Error('Exactly one reference must be resolved.')
         signal.throwIfAborted()

--- a/src/main/literature/library-tool-contracts.test.ts
+++ b/src/main/literature/library-tool-contracts.test.ts
@@ -523,3 +523,55 @@ it('reports the production candidate-file size limit as a read failure, without 
       await rm(root, { recursive: true, force: true })
     }
   }))
+
+it('searches survivor metadata through selected merged aliases and preserves their IDs', async () =>
+  db(async (catalog) => {
+    const survivor = await catalog.transact({ kind: 'create-item', item: item('Climate survivor') })
+    const alias = await catalog.transact({ kind: 'create-item', item: item('Original title') })
+    const reviewed = await catalog.getMany([survivor.id, alias.id])
+    await catalog.transact({
+      kind: 'merge-items',
+      survivorId: survivor.id,
+      duplicateIds: [alias.id],
+      expectedMetadataRevision: reviewed[0].metadataRevision,
+      expectedItems: reviewed.map(({ id, metadataRevision, updatedAt }) => ({
+        id,
+        metadataRevision,
+        updatedAt
+      })),
+      item: reviewed[0].item
+    })
+    const search = production('searchLibrary', catalog)
+    const page = await search({
+      projectId: 'project-1',
+      scope: 'items',
+      itemIds: [alias.id],
+      query: 'Climate'
+    })
+    expect(page.totalCount).toBe(1)
+    expect(page.items).toMatchObject([{ id: alias.id, item: { title: 'Climate survivor' } }])
+    const selected = {
+      projectId: 'project-1',
+      scope: 'items' as const,
+      itemIds: [alias.id, survivor.id],
+      query: 'Climate',
+      limit: 1
+    }
+    const first = await search(selected)
+    const next = await search({ ...selected, offset: first.nextOffset })
+    expect(first.totalCount).toBe(2)
+    expect(new Set([...first.items, ...next.items].map(({ id }) => id))).toEqual(
+      new Set(selected.itemIds)
+    )
+    expect(next.hasMore).toBe(false)
+    expect(
+      (
+        await search({
+          projectId: 'project-1',
+          scope: 'items',
+          itemIds: [alias.id],
+          query: 'Original'
+        })
+      ).items
+    ).toEqual([])
+  }))

--- a/src/main/literature/library-tool-contracts.test.ts
+++ b/src/main/literature/library-tool-contracts.test.ts
@@ -1,0 +1,525 @@
+import { setImmediate } from 'node:timers/promises'
+import { tmpdir } from 'node:os'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type { AcpRuntimeOptions } from '../acp/runtime'
+import { createAcpRuntime, type AcpRuntimeCompositionOptions } from '../acp/runtime-composition'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { expect, it, vi } from 'vitest'
+import type {
+  LiteratureLibraryMcpHandler,
+  LiteratureLibrarySaveResult,
+  LiteratureLibraryDiscovery
+} from './library-mcp-server'
+import { createLiteratureLibraryMcpServer } from './library-mcp-server'
+import { LiteratureCatalog } from './catalog'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import type { LiteratureItemInput, LiteratureItemView } from '../../shared/literature'
+import { literatureItemInputSchema } from '../../shared/literature'
+import { buildLiteratureLibraryToolSummary } from '../../renderer/src/pages/workspace/literature-tool-presentation'
+// Capture the real composition's options at the existing runtime-owner boundary.
+// No provider process, network host, or runtime session is started.
+const capture = vi.hoisted(() => ({ options: undefined as AcpRuntimeOptions | undefined }))
+vi.mock('electron', () => ({
+  app: { getVersion: () => 'test' },
+  BrowserWindow: { getAllWindows: () => [] }
+}))
+vi.mock('../storage-root', () => ({
+  resolveConfigRoot: () => '/unused-test-config',
+  resolveDataRoot: () => '/unused-test-data'
+}))
+vi.mock('../acp/runtime-coordinator', () => ({
+  AcpRuntimeCoordinator: class {
+    constructor(factory: (callbacks: object, grants: object) => unknown) {
+      factory({}, {})
+    }
+  }
+}))
+vi.mock('../acp/runtime-base-composition', () => ({
+  composeAcpRuntimeBaseOwners: (options: AcpRuntimeOptions) => {
+    capture.options = options
+    return {}
+  }
+}))
+vi.mock('../acp/runtime-session-composition', () => ({
+  composeAcpRuntimeSessionOwners: () => ({})
+}))
+vi.mock('../acp/runtime', () => ({ AcpRuntime: class {} }))
+const production = <K extends 'saveToInbox' | 'searchLibrary' | 'readCandidateFile'>(
+  name: K,
+  catalog: LiteratureCatalog
+): NonNullable<AcpRuntimeOptions['literatureLibrary']>[K] => {
+  createAcpRuntime({
+    literatureCatalog: catalog,
+    fixedBackend: {},
+    settingsService: {}
+  } as unknown as AcpRuntimeCompositionOptions)
+  return capture.options!.literatureLibrary![name]
+}
+const item = (title = 'A paper', extra = {}): LiteratureItemInput =>
+  literatureItemInputSchema.parse({ itemType: 'journalArticle', title, ...extra })
+const discovery = (title = 'A paper', extra = {}): LiteratureLibraryDiscovery => ({
+  item: item(title, extra),
+  source: {
+    provider: 'audit',
+    externalId: title,
+    sourceUrl: 'https://example.test/paper',
+    rawMetadata: {}
+  }
+})
+const view = (value: ReturnType<typeof item>, id = 'item-1'): LiteratureItemView => ({
+  id,
+  item: value,
+  metadataRevision: 1,
+  attachments: [],
+  projectIds: [],
+  collectionIds: [],
+  createdAt: 1,
+  updatedAt: 1
+})
+const open = async (
+  handler: Partial<LiteratureLibraryMcpHandler>
+): Promise<{ client: Client; close: () => Promise<void> }> => {
+  const server = createLiteratureLibraryMcpServer({
+    searchLibrary: async () => ({ items: [], totalCount: 0, hasMore: false }),
+    readAbstract: async () => undefined,
+    readPdf: async () => undefined,
+    saveToInbox: async () => ({ results: [] }),
+    ...handler
+  })
+  const client = new Client({ name: 'audit', version: '1' })
+  const [ct, st] = InMemoryTransport.createLinkedPair()
+  await Promise.all([server.connect(st), client.connect(ct)])
+  return {
+    client,
+    close: async () => {
+      await client.close()
+      await server.close()
+    }
+  }
+}
+const db = async (
+  fn: (
+    catalog: LiteratureCatalog,
+    client: ReturnType<typeof createProjectDbClient>
+  ) => Promise<void>
+): Promise<void> => {
+  const root = await mkdtemp(join(tmpdir(), 'literature-tool-contract-'))
+  const client = createProjectDbClient(root)
+  try {
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Research' } })
+    await fn(new LiteratureCatalog(async () => client), client)
+  } finally {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+}
+const bindSave = (catalog: LiteratureCatalog): LiteratureLibraryMcpHandler['saveToInbox'] => {
+  const save = production('saveToInbox', catalog)
+  return (r: Parameters<LiteratureLibraryMcpHandler['saveToInbox']>[0]) =>
+    save({ ...r, projectId: 'project-1', sessionId: 'session-1' })
+}
+const presentation = (result: Awaited<ReturnType<Client['callTool']>>): { savedCount: number } => {
+  const content = result.content as { type: string; text: string }[]
+  return JSON.parse(content[0].text).openScienceLiteraturePresentation as { savedCount: number }
+}
+
+it('retains committed receipts when a later candidate fails', async () =>
+  db(async (catalog, dbClient) => {
+    const real = catalog.transact.bind(catalog)
+    let count = 0
+    vi.spyOn(catalog, 'transact').mockImplementation(async (command) => {
+      if (++count === 2) throw new Error('Injected database unavailable')
+      return real(command)
+    })
+    const api = await open({ saveToInbox: bindSave(catalog) })
+    try {
+      const candidates = [discovery('first'), discovery('second'), discovery('third')]
+      const result = await api.client.callTool({ name: 'save_to_inbox', arguments: { candidates } })
+      expect(await dbClient.literatureInboxCandidate.count()).toBe(1)
+      expect(count).toBe(2)
+      expect(result.structuredContent).toEqual(
+        expect.objectContaining({
+          results: [expect.objectContaining({ kind: 'candidate', state: 'pending' })]
+        })
+      )
+      // A repeat can deduplicate the first candidate but cannot retroactively supply the missing receipt.
+      const retry = await api.client.callTool({ name: 'save_to_inbox', arguments: { candidates } })
+      expect(retry.isError).not.toBe(true)
+      expect(await dbClient.literatureInboxCandidate.count()).toBe(3)
+    } finally {
+      await api.close()
+    }
+  }))
+
+it('does not start saving after cancellation during reference resolution', async () =>
+  db(async (catalog, dbClient) => {
+    let release!: (v: readonly LiteratureLibraryDiscovery[]) => void
+    const saves: Promise<unknown>[] = []
+    const save = bindSave(catalog)
+    const api = await open({
+      resolveSaveReferences: () => new Promise((r) => (release = r)),
+      saveToInbox: (r) => {
+        const saving = save(r)
+        saves.push(saving)
+        return saving
+      }
+    })
+    try {
+      const controller = new AbortController()
+      const pending = api.client
+        .callTool(
+          { name: 'save_to_inbox', arguments: { refs: ['doi:10.1234/example'] } },
+          undefined,
+          { signal: controller.signal }
+        )
+        .then(
+          () => ({ cancelled: false }),
+          () => ({ cancelled: true })
+        )
+      await vi.waitFor(() => expect(release).toBeTypeOf('function'))
+      expect(await dbClient.literatureInboxCandidate.count()).toBe(0)
+      controller.abort()
+      expect(await pending).toEqual({ cancelled: true })
+      await api.client.ping()
+      release([discovery('after cancellation')])
+      await setImmediate()
+      await Promise.all(saves)
+      expect(await dbClient.literatureInboxCandidate.count()).toBe(0)
+    } finally {
+      release?.([discovery('after cancellation')])
+      await api.close()
+    }
+  }))
+
+it('counts repeated candidate receipts once', async () =>
+  db(async (catalog, dbClient) => {
+    const api = await open({ saveToInbox: bindSave(catalog) })
+    try {
+      const repeated = discovery('same pending')
+      const result = await api.client.callTool({
+        name: 'save_to_inbox',
+        arguments: { candidates: [repeated, repeated] }
+      })
+      expect(result.isError).not.toBe(true)
+      expect(await dbClient.literatureInboxCandidate.count()).toBe(1)
+      expect(presentation(result).savedCount).toBe(1)
+      expect((result.structuredContent as LiteratureLibrarySaveResult).results[0].id).toBe(
+        (result.structuredContent as LiteratureLibrarySaveResult).results[1].id
+      )
+    } finally {
+      await api.close()
+    }
+  }))
+
+it('does not count an existing library item as an Inbox save', async () =>
+  db(async (catalog, dbClient) => {
+    const api = await open({ saveToInbox: bindSave(catalog) })
+    try {
+      const existing = discovery('existing', {
+        identifiers: [{ scheme: 'doi', value: '10.1234/existing', isPrimary: true }]
+      })
+      await catalog.transact({ kind: 'create-item', item: existing.item })
+      const reused = await api.client.callTool({
+        name: 'save_to_inbox',
+        arguments: { candidates: [existing] }
+      })
+      expect((reused.structuredContent as LiteratureLibrarySaveResult).results[0]).toMatchObject({
+        kind: 'item',
+        state: 'present'
+      })
+      expect(await dbClient.literatureInboxCandidate.count()).toBe(0)
+      expect(presentation(reused).savedCount).toBe(0)
+      const summary = buildLiteratureLibraryToolSummary('save', { candidates: [existing] }, reused)
+      expect(summary).toMatchObject({ savedCount: 0, action: 'save', libraryScope: 'project' })
+    } finally {
+      await api.close()
+    }
+  }))
+
+it('excludes editors and translators from authors', async () => {
+  const value = item('Edited book', {
+    itemType: 'book',
+    creators: [
+      { nameMode: 'person', givenName: 'Alice', familyName: 'Editor', creatorType: 'editor' },
+      { nameMode: 'organization', literalName: 'Translation Institute', creatorType: 'translator' }
+    ]
+  })
+  const api = await open({
+    searchLibrary: async () => ({ items: [view(value)], totalCount: 1, hasMore: false })
+  })
+  try {
+    const result = await api.client.callTool({ name: 'search_library', arguments: {} })
+    expect(
+      (
+        result.structuredContent as {
+          items: {
+            authors: string
+            creatorCount: number
+            primaryIdentifiers: { value: string }[]
+          }[]
+        }
+      ).items[0]
+    ).toMatchObject({
+      authors: '',
+      creatorCount: 2
+    })
+    expect(JSON.stringify(result.structuredContent)).not.toContain('creatorType')
+  } finally {
+    await api.close()
+  }
+})
+
+it('preserves exact identifier values in search results', async () => {
+  const doi = '10.1234/' + 'segment'.repeat(35)
+  const value = item('Long identifier', {
+    identifiers: [{ scheme: 'doi', value: doi, isPrimary: true }]
+  })
+  expect(value.identifiers[0].value).toBe(doi)
+  const api = await open({
+    searchLibrary: async () => ({ items: [view(value)], totalCount: 1, hasMore: false })
+  })
+  try {
+    const result = await api.client.callTool({ name: 'search_library', arguments: {} })
+    const row = (
+      result.structuredContent as {
+        items: { authors: string; creatorCount: number; primaryIdentifiers: { value: string }[] }[]
+      }
+    ).items[0]
+    expect(row.primaryIdentifiers[0].value).toBe(doi)
+  } finally {
+    await api.close()
+  }
+})
+
+it('bounds all search text blocks for long metadata titles', async () => {
+  const items = Array.from({ length: 3 }, (_, i) =>
+    view(item('Long title ' + String(i) + 'x'.repeat(20000)), 'id-' + i)
+  )
+  const api = await open({ searchLibrary: async () => ({ items, totalCount: 3, hasMore: false }) })
+  try {
+    const result = await api.client.callTool({ name: 'search_library', arguments: {} })
+    expect(JSON.stringify(result.structuredContent).length).toBeLessThan(38000)
+    expect(JSON.stringify(result.content).length).toBeLessThanOrEqual(38000)
+  } finally {
+    await api.close()
+  }
+})
+
+it('distinguishes unreadable files from invalid candidate content', async () => {
+  const save = vi.fn()
+  const api = await open({
+    readCandidateFile: async () => {
+      throw Object.assign(new Error('EACCES: permission denied'), { code: 'EACCES' })
+    },
+    saveToInbox: save
+  })
+  try {
+    const result = await api.client.callTool({
+      name: 'save_to_inbox',
+      arguments: { filename: 'records.json' }
+    })
+    expect(result.isError).toBe(true)
+    expect(JSON.stringify(result.content)).not.toContain('INVALID_CANDIDATE_FILE')
+    expect(save).not.toHaveBeenCalled()
+  } finally {
+    await api.close()
+  }
+})
+
+it('does not search JSON field names in selected-item scope', async () =>
+  db(async (catalog) => {
+    const receipt = await catalog.transact({ kind: 'create-item', item: item('Climate methods') })
+    const search = production('searchLibrary', catalog)
+    const api = await open({
+      searchLibrary: (request) => search({ ...request, projectId: 'project-1' })
+    })
+    try {
+      const result = await api.client.callTool({
+        name: 'search_library',
+        arguments: { scope: 'items', itemIds: [receipt.id], query: 'rights' }
+      })
+      const global = await api.client.callTool({
+        name: 'search_library',
+        arguments: { scope: 'library', query: 'rights' }
+      })
+      expect((global.structuredContent as { totalCount: number }).totalCount).toBe(0)
+      expect((result.structuredContent as { totalCount: number }).totalCount).toBe(0)
+    } finally {
+      await api.close()
+    }
+  }))
+
+it('finishes an in-flight transaction and returns its receipt before stopping the next write', async () =>
+  db(async (catalog, dbClient) => {
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const transact = catalog.transact.bind(catalog)
+    let started!: () => void
+    const entered = new Promise<void>((resolve) => {
+      started = resolve
+    })
+    const spy = vi.spyOn(catalog, 'transact').mockImplementation(async (command) => {
+      started()
+      await blocked
+      return transact(command)
+    })
+    const controller = new AbortController()
+    const save = bindSave(catalog)
+    const pending = save({
+      candidates: [discovery('first'), discovery('second')],
+      signal: controller.signal
+    })
+    await entered
+    controller.abort()
+    release()
+    const result = await pending
+    expect(await dbClient.literatureInboxCandidate.count()).toBe(1)
+    expect(spy).toHaveBeenCalledTimes(1)
+    expect(result).toEqual({
+      results: [expect.objectContaining({ kind: 'candidate', state: 'pending' })],
+      cancelled: true
+    })
+  }))
+
+it('returns bounded complete search records and a continuation that advances', async () => {
+  const identifier = '10.1234/' + 'x'.repeat(12000)
+  const items = Array.from({ length: 4 }, (_, index) =>
+    view(
+      item(`Paper ${index}`, {
+        identifiers: [{ scheme: 'doi', value: identifier + index, isPrimary: true }]
+      }),
+      `item-${index}`
+    )
+  )
+  const api = await open({
+    searchLibrary: async ({ offset = 0 }) => ({
+      items: items.slice(offset),
+      totalCount: 4,
+      hasMore: false
+    })
+  })
+  try {
+    const first = await api.client.callTool({ name: 'search_library', arguments: {} })
+    const page = first.structuredContent as {
+      items: { id: string; primaryIdentifiers: { value: string }[] }[]
+      nextOffset: number
+    }
+    expect(JSON.stringify(first.content).length).toBeLessThanOrEqual(38000)
+    expect(page.items.length).toBeGreaterThan(0)
+    expect(page.items.length).toBeLessThan(4)
+    expect(page.nextOffset).toBe(page.items.length)
+    expect(page.items[0].primaryIdentifiers[0].value).toBe(identifier + '0')
+    const second = await api.client.callTool({
+      name: 'search_library',
+      arguments: { offset: page.nextOffset }
+    })
+    expect(
+      (second.structuredContent as { items: { id: string }[] }).items.map(({ id }) => id)
+    ).toEqual(items.slice(page.nextOffset).map(({ id }) => id))
+  } finally {
+    await api.close()
+  }
+})
+
+it('rejects a single oversized search record without rewriting its identifier', async () => {
+  const api = await open({
+    searchLibrary: async () => ({
+      items: [
+        view(
+          item('Oversized', {
+            identifiers: [{ scheme: 'doi', value: '10.1234/' + 'x'.repeat(40000), isPrimary: true }]
+          })
+        )
+      ],
+      totalCount: 1,
+      hasMore: false
+    })
+  })
+  try {
+    const result = await api.client.callTool({ name: 'search_library', arguments: {} })
+    expect(result.isError).toBe(true)
+    expect(JSON.stringify(result.content)).toContain('SEARCH_RESULT_TOO_LARGE')
+    expect(JSON.stringify(result.content).length).toBeLessThanOrEqual(38000)
+  } finally {
+    await api.close()
+  }
+})
+
+it.each(['{', '{"candidates":[{}]}'])(
+  'still classifies malformed candidate content correctly: %s',
+  async (content) => {
+    const save = vi.fn()
+    const api = await open({ readCandidateFile: async () => content, saveToInbox: save })
+    try {
+      const result = await api.client.callTool({
+        name: 'save_to_inbox',
+        arguments: { filename: 'records.json' }
+      })
+      expect(result.isError).toBe(true)
+      expect(JSON.stringify(result.content)).toContain('INVALID_CANDIDATE_FILE')
+      expect(save).not.toHaveBeenCalled()
+    } finally {
+      await api.close()
+    }
+  }
+)
+
+it('intersects selected IDs with ordinary search and paginates the filtered membership', async () =>
+  db(async (catalog) => {
+    const first = await catalog.transact({ kind: 'create-item', item: item('Climate first') })
+    const second = await catalog.transact({ kind: 'create-item', item: item('Climate second') })
+    await catalog.transact({ kind: 'create-item', item: item('Climate outside selection') })
+    const ids = [first.id, second.id]
+    const search = production('searchLibrary', catalog)
+    const request = {
+      projectId: 'project-1',
+      scope: 'items' as const,
+      itemIds: ids,
+      query: 'Climate',
+      limit: 1
+    }
+    const page = await search(request)
+    expect(page.totalCount).toBe(2)
+    expect(page.nextOffset).toBe(1)
+    const next = await search({ ...request, offset: page.nextOffset })
+    expect(new Set([...page.items, ...next.items].map(({ id }) => id))).toEqual(new Set(ids))
+    expect(next.hasMore).toBe(false)
+    expect(await search({ ...request, itemIds: [] })).toMatchObject({ items: [], totalCount: 0 })
+  }))
+
+it('reports the production candidate-file size limit as a read failure, without disclosing its path', async () =>
+  db(async (catalog) => {
+    const root = await mkdtemp(join(tmpdir(), 'literature-candidate-file-'))
+    const filename = join(root, 'oversized.json')
+    await writeFile(filename, ' '.repeat(2 * 1024 * 1024 + 1))
+    const read = production('readCandidateFile', catalog)!
+    const save = vi.fn()
+    const api = await open({
+      readCandidateFile: (name, signal) =>
+        read({
+          projectId: 'project-1',
+          sessionId: 'session-1',
+          workspaceCwd: root,
+          filename: name,
+          signal
+        }),
+      saveToInbox: save
+    })
+    try {
+      const result = await api.client.callTool({ name: 'save_to_inbox', arguments: { filename } })
+      expect(result.isError).toBe(true)
+      const text = JSON.stringify(result.content)
+      expect(text).toContain('CANDIDATE_FILE_TOO_LARGE')
+      expect(text).not.toContain('INVALID_CANDIDATE_FILE')
+      expect(text).not.toContain(root)
+      expect(save).not.toHaveBeenCalled()
+    } finally {
+      await api.close()
+      await rm(root, { recursive: true, force: true })
+    }
+  }))

--- a/src/main/literature/reference-resolver.test.ts
+++ b/src/main/literature/reference-resolver.test.ts
@@ -96,13 +96,14 @@ describe('LiteratureReferenceResolver', () => {
     expect(String(fetchFn.mock.calls[0]?.[0])).toContain('id=35486828%2C21458665')
   })
 
-  it('normalizes and de-duplicates identifiers before fetching metadata', async () => {
+  it('fetches normalized identifiers once while preserving input positions', async () => {
     const fetchFn = vi.fn(async () => new Response(pubmedResponse))
     const resolver = new LiteratureReferenceResolver(fetchFn as typeof fetch)
 
     const result = await resolver.resolve(['PMID:35486828', 'pmid:35486828'])
 
-    expect(result).toHaveLength(1)
+    expect(result).toHaveLength(2)
+    expect(result[0]).toEqual(result[1])
     expect(fetchFn).toHaveBeenCalledTimes(1)
   })
 
@@ -116,3 +117,31 @@ describe('LiteratureReferenceResolver', () => {
     await expect(resolver.resolve(['pmid:999'])).rejects.toThrow('REFERENCE_NOT_FOUND')
   })
 })
+
+it.each(['doi:10.1234/cancelled', 'pmid:12345'])(
+  'aborts metadata fetch for %s',
+  async (reference) => {
+    const controller = new AbortController()
+    let fetchSignal: AbortSignal | undefined
+    let finish!: (response: Response) => void
+    const fetchFn = vi.fn<typeof fetch>().mockImplementation((_url, options) => {
+      fetchSignal = options?.signal ?? undefined
+      return new Promise((resolve, reject) => {
+        finish = resolve
+        fetchSignal!.addEventListener('abort', () => reject(fetchSignal!.reason), { once: true })
+      })
+    })
+    const reason = new Error('Stopped lookup')
+    const outcome = new LiteratureReferenceResolver(fetchFn)
+      .resolve([reference], controller.signal)
+      .catch((error: unknown) => error)
+    controller.abort(reason)
+    try {
+      expect(fetchSignal?.aborted).toBe(true)
+    } finally {
+      finish(new Response(''))
+      await outcome
+    }
+    expect(await outcome).toBe(reason)
+  }
+)

--- a/src/main/literature/reference-resolver.ts
+++ b/src/main/literature/reference-resolver.ts
@@ -92,21 +92,26 @@ class LiteratureReferenceResolver {
     > = new LiteratureCitationFormatter()
   ) {}
 
-  async resolve(inputs: readonly string[]): Promise<readonly LiteratureReferenceDiscovery[]> {
-    const references = [
-      ...new Map(inputs.map(parseReference).map((ref) => [ref.key, ref])).values()
-    ]
+  async resolve(
+    inputs: readonly string[],
+    signal?: AbortSignal
+  ): Promise<readonly LiteratureReferenceDiscovery[]> {
+    signal?.throwIfAborted()
+    const requested = inputs.map(parseReference)
+    const references = [...new Map(requested.map((ref) => [ref.key, ref])).values()]
     const pmids = references.filter(({ scheme }) => scheme === 'pmid').map(({ value }) => value)
     const discoveries = new Map<string, LiteratureReferenceDiscovery>()
 
     await Promise.all([
-      this.resolvePubmed(pmids, discoveries),
+      this.resolvePubmed(pmids, discoveries, signal),
       ...references
         .filter(({ scheme }) => scheme === 'doi')
-        .map(({ value }) => this.resolveCrossref(value, discoveries))
+        .map(({ value }) => this.resolveCrossref(value, discoveries, signal))
     ])
 
-    return references.map(({ key }) => {
+    signal?.throwIfAborted()
+    // Fetch each identifier once, but keep receipts aligned with every original input.
+    return requested.map(({ key }) => {
       const discovery = discoveries.get(key)
       if (!discovery) throw new Error(`REFERENCE_NOT_FOUND: No metadata was found for ${key}.`)
       return discovery
@@ -115,7 +120,8 @@ class LiteratureReferenceResolver {
 
   private async resolvePubmed(
     pmids: readonly string[],
-    discoveries: Map<string, LiteratureReferenceDiscovery>
+    discoveries: Map<string, LiteratureReferenceDiscovery>,
+    signal?: AbortSignal
   ): Promise<void> {
     if (pmids.length === 0) return
     const params = new URLSearchParams({
@@ -130,7 +136,9 @@ class LiteratureReferenceResolver {
         Accept: 'text/plain',
         'User-Agent': 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
       },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)])
+        : AbortSignal.timeout(REQUEST_TIMEOUT_MS)
     })
     const parsed = await this.formatter.parseReferences(await readResponse(response, 'PubMed'))
     for (const item of parsed.items) {
@@ -152,7 +160,8 @@ class LiteratureReferenceResolver {
 
   private async resolveCrossref(
     doi: string,
-    discoveries: Map<string, LiteratureReferenceDiscovery>
+    discoveries: Map<string, LiteratureReferenceDiscovery>,
+    signal?: AbortSignal
   ): Promise<void> {
     const sourceUrl = `${CROSSREF_BASE}${encodeURIComponent(doi)}`
     const response = await this.fetchFn(sourceUrl, {
@@ -160,7 +169,9 @@ class LiteratureReferenceResolver {
         Accept: 'application/json',
         'User-Agent': 'OpenScience/1.0 (+https://github.com/aipoch/open-science)'
       },
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+      signal: signal
+        ? AbortSignal.any([signal, AbortSignal.timeout(REQUEST_TIMEOUT_MS)])
+        : AbortSignal.timeout(REQUEST_TIMEOUT_MS)
     })
     const message = parseCrossrefResponse(await readResponse(response, 'Crossref'))
     const responseDoi = normalizeIdentifier('doi', message.DOI ?? doi)

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -439,6 +439,8 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('Save to Literature Inbox?')
     expect(html).toContain('Corrective Retrieval Augmented Generation')
     expect(html).toContain('1 reference')
+    expect(html).not.toContain('Pending review:')
+    expect(html).not.toContain('Open Inbox')
     expect(html).not.toContain('open-science-library')
     expect(html).not.toContain('rawMetadata')
     expect(html).not.toContain('provider-secret')

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -1035,7 +1035,7 @@ const PermissionApprovalCard = ({
           ) : null}
         </div>
       ) : literatureSummary ? (
-        <WorkspaceLiteratureToolCard summary={literatureSummary} />
+        <WorkspaceLiteratureToolCard summary={literatureSummary} isApproval />
       ) : isNotebookNetworkApprovalRequest(request) ? (
         <NotebookNetworkApprovalDetail request={request} />
       ) : isSpecialistSwitchRequest(request) ? (

--- a/src/renderer/src/pages/workspace/WorkspaceLiteratureToolCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceLiteratureToolCard.tsx
@@ -10,9 +10,11 @@ import type { LiteratureToolSummary } from './literature-tool-presentation'
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 
 const WorkspaceLiteratureToolCard = ({
-  summary
+  summary,
+  isApproval = false
 }: {
   summary: LiteratureToolSummary
+  isApproval?: boolean
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const isLibrary = summary.libraryScope !== undefined
@@ -103,7 +105,9 @@ const WorkspaceLiteratureToolCard = ({
             </span>
           ) : null}
           {isLibrary &&
-          (summary.action === 'format' || summary.action === 'read') &&
+          (summary.action === 'format' ||
+            summary.action === 'read' ||
+            (isApproval && summary.action === 'save')) &&
           summary.itemCount !== undefined ? (
             <span className="rounded-md bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium tabular-nums text-primary">
               {t('{{count}} references', {

--- a/src/renderer/src/pages/workspace/WorkspaceLiteratureToolCard.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceLiteratureToolCard.tsx
@@ -1,7 +1,9 @@
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V5 */
-import { BookOpenText, ExternalLink, FileText, Inbox, Search } from 'lucide-react'
+import { BookOpenText, FileText, Inbox, Search, TriangleAlert } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
+import { Button } from '@/components/ui/button'
+import { ErrorNotice } from '@/components/error-notice'
 import { useNavigationStore } from '@/stores/navigation-store'
 
 import type { LiteratureToolSummary } from './literature-tool-presentation'
@@ -14,7 +16,7 @@ const WorkspaceLiteratureToolCard = ({
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const isLibrary = summary.libraryScope !== undefined
-  const canOpenInbox = summary.action === 'save' && summary.savedCount !== undefined
+  const canOpenInbox = summary.action === 'save' && (summary.savedCount ?? 0) > 0
   const Icon =
     summary.action === 'save'
       ? Inbox
@@ -36,7 +38,7 @@ const WorkspaceLiteratureToolCard = ({
       ? [summary.styleId?.toUpperCase(), summary.locale].filter(Boolean).join(' · ') ||
         t('Citation')
       : summary.action === 'save'
-        ? t('Inbox')
+        ? t('Literature library')
         : summary.libraryScope === 'project'
           ? t('This project')
           : summary.libraryScope === 'collection'
@@ -90,12 +92,14 @@ const WorkspaceLiteratureToolCard = ({
               {searchRangeLabel}
             </span>
           ) : null}
-          {isLibrary && summary.action === 'save' && summary.itemCount !== undefined ? (
-            <span className="rounded-md bg-bg-200 px-1.5 py-0.5 text-[10px] tabular-nums text-text-200">
-              {t('{{count}} references', {
-                count: summary.savedCount ?? summary.itemCount,
-                defaultValue_one: '{{count}} reference'
-              })}
+          {isLibrary && summary.action === 'save' && summary.savedCount !== undefined ? (
+            <span className="text-[11px] tabular-nums text-text-200">
+              {t('Pending review: {{total}}', { total: summary.savedCount })}
+            </span>
+          ) : null}
+          {summary.existingItemIds && summary.existingItemIds.length > 0 ? (
+            <span className="text-[11px] tabular-nums text-text-200">
+              {t('Already in library: {{total}}', { total: summary.existingItemIds.length })}
             </span>
           ) : null}
           {isLibrary &&
@@ -106,12 +110,6 @@ const WorkspaceLiteratureToolCard = ({
                 count: summary.itemCount,
                 defaultValue_one: '{{count}} reference'
               })}
-            </span>
-          ) : null}
-          {canOpenInbox ? (
-            <span className="inline-flex items-center gap-1 text-[11px] font-medium text-primary">
-              {t('Open')}
-              <ExternalLink className="size-3" aria-hidden="true" />
             </span>
           ) : null}
           {summary.retrievalMode === 'bm25' ? (
@@ -138,6 +136,62 @@ const WorkspaceLiteratureToolCard = ({
           ) : null}
         </div>
       </div>
+
+      {summary.action === 'save' ? (
+        <>
+          {summary.duplicateCount ? (
+            <p className="text-[11px] text-text-300">
+              {t('Repeated inputs: {{total}}', { total: summary.duplicateCount })}
+            </p>
+          ) : null}
+          {summary.otherCount ? (
+            <p className="text-[11px] text-text-300">
+              {t('Other results: {{total}}', { total: summary.otherCount })}
+            </p>
+          ) : null}
+          {summary.notAttemptedCount ? (
+            <p className="text-[11px] text-text-300">
+              {t('Not attempted: {{total}}', { total: summary.notAttemptedCount })}
+            </p>
+          ) : null}
+          {summary.failedInputIndex !== undefined || summary.cancelled ? (
+            <ErrorNotice
+              icon={TriangleAlert}
+              tone="amber"
+              description={
+                summary.cancelled
+                  ? t('Saving stopped. Completed results are kept.')
+                  : t('Could not save reference {{number}}. Earlier results are kept.', {
+                      number: summary.failedInputIndex! + 1
+                    })
+              }
+            />
+          ) : null}
+          {canOpenInbox || summary.existingItemIds?.length ? (
+            <div className="flex flex-wrap gap-2">
+              {canOpenInbox ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => useNavigationStore.getState().openLibrary('user')}
+                >
+                  {t('Open Inbox')}
+                </Button>
+              ) : null}
+              {summary.existingItemIds?.map((id, index) => (
+                <Button
+                  key={id}
+                  variant="outline"
+                  size="sm"
+                  onClick={() => useNavigationStore.getState().openLiteratureItem(id, 'user')}
+                >
+                  {t('Open existing reference {{number}}', { number: index + 1 })}
+                </Button>
+              ))}
+            </div>
+          ) : null}
+        </>
+      ) : null}
 
       {summary.query ? (
         <div className="min-w-0 rounded-md bg-bg-200 px-2.5 py-2">
@@ -198,16 +252,7 @@ const WorkspaceLiteratureToolCard = ({
   const className =
     'flex min-w-0 flex-col gap-2.5 rounded-lg border border-border-200 bg-bg-000 p-3 text-left'
 
-  return canOpenInbox ? (
-    <button
-      type="button"
-      data-testid="literature-tool-card"
-      className={`${className} cursor-pointer transition-colors hover:border-primary/40 hover:bg-bg-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40`}
-      onClick={() => useNavigationStore.getState().openLibrary('user')}
-    >
-      {content}
-    </button>
-  ) : (
+  return (
     <section
       data-testid="literature-tool-card"
       aria-label={isLibrary ? t('Literature library') : t('Reading')}

--- a/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx
@@ -262,47 +262,62 @@ describe('WorkspaceToolDetailsRow', () => {
     expect(container.textContent).not.toContain('private-')
   })
 
-  it('opens the Literature Inbox from a completed save card', async () => {
-    const activity = createActivity({
-      providerToolName: 'mcp__open-science-library__save_to_inbox',
-      rawInput: { candidates: [{ item: { title: 'Paper A' } }] },
-      toolContent: [
-        {
-          type: 'content',
-          content: {
-            type: 'text',
-            text: JSON.stringify({
-              openScienceLiteraturePresentation: {
-                libraryAction: 'save',
-                itemTitles: ['Paper A'],
-                candidateCount: 1,
-                savedCount: 1
-              }
-            })
+  it.each([true, false])(
+    'offers an Inbox action only with a pending receipt (receipt: %s)',
+    async (hasReceipt) => {
+      const activity = createActivity({
+        providerToolName: 'mcp__open-science-library__save_to_inbox',
+        rawInput: { candidates: [{ item: { title: 'Paper A' } }] },
+        toolContent: [
+          {
+            type: 'content',
+            content: {
+              type: 'text',
+              text: JSON.stringify({
+                ...(hasReceipt
+                  ? { results: [{ kind: 'candidate', id: 'pending-1', state: 'pending' }] }
+                  : {}),
+                openScienceLiteraturePresentation: {
+                  libraryAction: 'save',
+                  itemTitles: ['Paper A'],
+                  candidateCount: 1,
+                  savedCount: 1
+                }
+              })
+            }
           }
-        }
-      ]
-    })
+        ]
+      })
 
-    useNavigationStore.setState({ view: 'workspace' })
-    root = createRoot(container)
-    await act(async () => {
-      root.render(
-        <WorkspaceToolDetailsRow
-          activity={activity}
-          details={buildToolActivityDetails(activity)!}
-          isExpanded={true}
-          onToggle={vi.fn()}
-        />
+      useNavigationStore.setState({ view: 'workspace' })
+      root = createRoot(container)
+      await act(async () => {
+        root.render(
+          <WorkspaceToolDetailsRow
+            activity={activity}
+            details={buildToolActivityDetails(activity)!}
+            isExpanded={true}
+            onToggle={vi.fn()}
+          />
+        )
+      })
+
+      const card = container.querySelector('[data-testid="literature-tool-card"]')!
+      const openInbox = Array.from(card.querySelectorAll('button')).find(
+        (button) => button.textContent === 'Open Inbox'
       )
-    })
-
-    const card = container.querySelector('[data-testid="literature-tool-card"]')
-    expect(card?.tagName).toBe('BUTTON')
-    expect(card?.textContent).toContain('Open')
-    act(() => card?.dispatchEvent(new MouseEvent('click', { bubbles: true })))
-    expect(useNavigationStore.getState().view).toBe('library')
-  })
+      if (hasReceipt) {
+        expect(openInbox).toBeDefined()
+        act(() => openInbox!.click())
+        expect(useNavigationStore.getState().view).toBe('library')
+      } else {
+        expect(openInbox).toBeUndefined()
+        expect(card.textContent).not.toContain('Pending review:')
+        act(() => card.dispatchEvent(new MouseEvent('click', { bubbles: true })))
+        expect(useNavigationStore.getState().view).toBe('workspace')
+      }
+    }
+  )
 
   it('presents citation document formatting as a first-party Literature action', async () => {
     const activity = createActivity({

--- a/src/renderer/src/pages/workspace/literature-save-contract.test.tsx
+++ b/src/renderer/src/pages/workspace/literature-save-contract.test.tsx
@@ -1,0 +1,109 @@
+// @vitest-environment jsdom
+import { cleanup, render, fireEvent } from '@testing-library/react'
+import { expect, it, vi } from 'vitest'
+import { WorkspaceLiteratureToolCard } from './WorkspaceLiteratureToolCard'
+import { buildLiteratureLibraryToolSummary } from './literature-tool-presentation'
+import { useNavigationStore } from '../../stores/navigation-store'
+it('does not describe an existing library receipt as an Inbox save', () => {
+  const summary = buildLiteratureLibraryToolSummary(
+    'save',
+    { refs: ['doi:10.1234/existing'] },
+    {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify({
+            openScienceLiteraturePresentation: {
+              libraryAction: 'save',
+              candidateCount: 1,
+              savedCount: 1,
+              itemTitles: ['Existing item']
+            }
+          })
+        },
+        {
+          type: 'text',
+          text: JSON.stringify({ results: [{ kind: 'item', id: 'existing', state: 'present' }] })
+        }
+      ]
+    }
+  )
+  const navigate = vi
+    .spyOn(useNavigationStore.getState(), 'openLiteratureItem')
+    .mockImplementation(() => {})
+  try {
+    const rendered = render(<WorkspaceLiteratureToolCard summary={summary} />)
+    const card = rendered.getByTestId('literature-tool-card')
+    expect(card.textContent).not.toContain('Inbox')
+    expect(card.textContent).toContain('Already in library: 1')
+    fireEvent.click(rendered.getByRole('button', { name: 'Open existing reference 1' }))
+    expect(navigate).toHaveBeenCalledWith('existing', 'user')
+  } finally {
+    cleanup()
+    navigate.mockRestore()
+  }
+})
+
+it('shows mixed outcomes and opens the corresponding destinations', () => {
+  const summary = buildLiteratureLibraryToolSummary(
+    'save',
+    { candidates: [{}, {}, {}, {}, {}] },
+    {
+      results: [
+        { kind: 'candidate', id: 'pending', state: 'pending' },
+        { kind: 'candidate', id: 'pending', state: 'pending' },
+        { kind: 'item', id: 'existing', state: 'present' }
+      ],
+      failure: { inputIndex: 3, code: 'INBOX_SAVE_FAILED', message: 'Failed' }
+    }
+  )
+  const inbox = vi.spyOn(useNavigationStore.getState(), 'openLibrary').mockImplementation(() => {})
+  const existing = vi
+    .spyOn(useNavigationStore.getState(), 'openLiteratureItem')
+    .mockImplementation(() => {})
+  try {
+    const rendered = render(<WorkspaceLiteratureToolCard summary={summary} />)
+    expect(rendered.getByText('Pending review: 1')).toBeDefined()
+    expect(rendered.getByText('Already in library: 1')).toBeDefined()
+    expect(rendered.getByText('Repeated inputs: 1')).toBeDefined()
+    expect(rendered.getByText('Not attempted: 1')).toBeDefined()
+    expect(
+      rendered.getByText('Could not save reference 4. Earlier results are kept.')
+    ).toBeDefined()
+    fireEvent.click(rendered.getByRole('button', { name: 'Open Inbox' }))
+    expect(inbox).toHaveBeenCalledWith('user')
+    fireEvent.click(rendered.getByRole('button', { name: 'Open existing reference 1' }))
+    expect(existing).toHaveBeenCalledWith('existing', 'user')
+  } finally {
+    cleanup()
+    inbox.mockRestore()
+    existing.mockRestore()
+  }
+})
+
+it('does not infer destinations or pending counts from historical summary-only output', () => {
+  const summary = buildLiteratureLibraryToolSummary(
+    'save',
+    { refs: ['doi:10.1234/paper'] },
+    {
+      openScienceLiteraturePresentation: { libraryAction: 'save', candidateCount: 1, savedCount: 1 }
+    }
+  )
+  try {
+    const rendered = render(<WorkspaceLiteratureToolCard summary={summary} />)
+    expect(summary.savedCount).toBeUndefined()
+    expect(rendered.queryAllByRole('button')).toHaveLength(0)
+    expect(rendered.getByTestId('literature-tool-card').textContent).not.toContain('Pending review')
+  } finally {
+    cleanup()
+  }
+})
+
+it('does not label dismissed receipts as pending review', () => {
+  const summary = buildLiteratureLibraryToolSummary(
+    'save',
+    {},
+    { results: [{ kind: 'candidate', id: 'dismissed', state: 'dismissed' }] }
+  )
+  expect(summary).toMatchObject({ savedCount: 0, otherCount: 1, existingItemIds: [] })
+})

--- a/src/renderer/src/pages/workspace/literature-tool-presentation.ts
+++ b/src/renderer/src/pages/workspace/literature-tool-presentation.ts
@@ -1,3 +1,6 @@
+import { literatureCatalogReceiptSchema } from '../../../../shared/literature'
+import { summarizeLiteratureSaveReceipts } from '../../../../shared/literature-save'
+
 type LiteratureToolAction = 'format' | 'read' | 'search' | 'save'
 
 type LiteratureToolSummary = Readonly<{
@@ -20,6 +23,12 @@ type LiteratureToolSummary = Readonly<{
   requestedStart?: number
   requestedEnd?: number
   savedCount?: number
+  existingItemIds?: readonly string[]
+  duplicateCount?: number
+  otherCount?: number
+  failedInputIndex?: number
+  notAttemptedCount?: number
+  cancelled?: boolean
   styleId?: string
   locale?: string
   error?: string
@@ -353,7 +362,35 @@ const buildLiteratureLibraryToolSummary = (
   const candidateCount =
     asNonNegativeInteger(presentation?.candidateCount) ??
     (action === 'save' && Array.isArray(input.candidates) ? input.candidates.length : undefined)
-  const savedCount = asNonNegativeInteger(presentation?.savedCount)
+  // Historical presentation counts may be wrong. Recompute only from actual receipts;
+  // summary-only history remains neutral rather than inventing pending records.
+  const savedResult =
+    action === 'save' ? outputs.find((output) => Array.isArray(output.results)) : undefined
+  const parsedReceipts = savedResult
+    ? literatureCatalogReceiptSchema.array().safeParse(savedResult.results)
+    : undefined
+  const acquired =
+    action === 'save'
+      ? outputs.find((output) => output.status === 'pending-review' && asString(output.candidateId))
+      : undefined
+  const saveSummary = parsedReceipts?.success
+    ? summarizeLiteratureSaveReceipts(parsedReceipts.data)
+    : acquired
+      ? summarizeLiteratureSaveReceipts([
+          { kind: 'candidate', id: acquired.candidateId as string, state: 'pending' }
+        ])
+      : undefined
+  const failedInputIndex = isRecord(savedResult?.failure)
+    ? asNonNegativeInteger(savedResult.failure.inputIndex)
+    : undefined
+  const cancelled = savedResult?.cancelled === true
+  const notAttemptedCount =
+    parsedReceipts?.success && candidateCount !== undefined
+      ? Math.max(
+          0,
+          candidateCount - parsedReceipts.data.length - (failedInputIndex !== undefined ? 1 : 0)
+        )
+      : undefined
   const offset =
     asNonNegativeInteger(presentation?.offset) ??
     asNonNegativeInteger(input.offset) ??
@@ -419,7 +456,17 @@ const buildLiteratureLibraryToolSummary = (
     ...(action === 'search' && offset !== undefined && limit !== undefined
       ? { requestedEnd: offset + limit }
       : {}),
-    ...(savedCount !== undefined ? { savedCount } : {}),
+    ...(saveSummary
+      ? {
+          savedCount: saveSummary.pendingCount,
+          existingItemIds: saveSummary.existingItemIds,
+          duplicateCount: saveSummary.duplicateCount,
+          otherCount: saveSummary.otherCount
+        }
+      : {}),
+    ...(failedInputIndex !== undefined ? { failedInputIndex } : {}),
+    ...(notAttemptedCount !== undefined ? { notAttemptedCount } : {}),
+    ...(cancelled ? { cancelled: true } : {}),
     ...(action === 'format' && asString(input.styleId) ? { styleId: asString(input.styleId) } : {}),
     ...(action === 'format' && asString(input.locale) ? { locale: asString(input.locale) } : {}),
     ...(hasMore !== undefined ? { hasMore } : {})

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts
@@ -552,7 +552,7 @@ describe('workspace tool activity details', () => {
     expect(JSON.stringify(details)).not.toContain('Reference one')
   })
 
-  it('summarizes Library Inbox saves from the small presentation block', () => {
+  it('keeps historical save presentations neutral without original receipts', () => {
     const activity = createActivity({
       providerToolName: 'mcp__open-science-library__save_to_inbox',
       rawInput: {
@@ -592,12 +592,12 @@ describe('workspace tool activity details', () => {
           summary: {
             action: 'save',
             itemTitles: ['Paper A'],
-            itemCount: 1,
-            savedCount: 1
+            itemCount: 1
           }
         }
       ]
     })
+    expect(JSON.stringify(details)).not.toContain('savedCount')
     expect(JSON.stringify(details)).not.toContain('rawMetadata')
   })
 

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4921,6 +4921,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "Das gespeicherte Jahr und Veröffentlichungsdatum stimmen nicht überein. Beim Bearbeiten eines Feldes werden beide abgeglichen.",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Geben Sie ein gültiges Zugriffsdatum ab 1970-01-01 ein oder lassen Sie das Feld leer.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "Die Referenz wurde erstellt, konnte aber nicht mit dem Ziel verknüpft werden. Versuchen Sie es erneut, um die Verknüpfung abzuschließen. Beim Schließen bleibt sie ohne diese Verknüpfung in Ihrer Bibliothek.",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Die Referenz wurde erstellt, aber die folgenden Schritte sind fehlgeschlagen. Versuchen Sie es erneut, um den Vorgang abzuschließen. Beim Schließen bleibt die Referenz in Ihrer Bibliothek."
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Die Referenz wurde erstellt, aber die folgenden Schritte sind fehlgeschlagen. Versuchen Sie es erneut, um den Vorgang abzuschließen. Beim Schließen bleibt die Referenz in Ihrer Bibliothek.",
+    "Add author": "Autor hinzufügen",
+    "Remove author": "Autor entfernen",
+    "Pending review: {{total}}": "Zur Prüfung: {{total}}",
+    "Already in library: {{total}}": "Bereits in der Bibliothek: {{total}}",
+    "Repeated inputs: {{total}}": "Wiederholte Eingaben: {{total}}",
+    "Other results: {{total}}": "Andere Ergebnisse: {{total}}",
+    "Not attempted: {{total}}": "Nicht versucht: {{total}}",
+    "Saving stopped. Completed results are kept.": "Speichern gestoppt. Abgeschlossene Ergebnisse bleiben erhalten.",
+    "Could not save reference {{number}}. Earlier results are kept.": "Quelle {{number}} konnte nicht gespeichert werden. Frühere Ergebnisse bleiben erhalten.",
+    "Open Inbox": "Posteingang öffnen",
+    "Open existing reference {{number}}": "Vorhandene Quelle {{number}} öffnen"
   }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4922,8 +4922,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Geben Sie ein gültiges Zugriffsdatum ab 1970-01-01 ein oder lassen Sie das Feld leer.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "Die Referenz wurde erstellt, konnte aber nicht mit dem Ziel verknüpft werden. Versuchen Sie es erneut, um die Verknüpfung abzuschließen. Beim Schließen bleibt sie ohne diese Verknüpfung in Ihrer Bibliothek.",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Die Referenz wurde erstellt, aber die folgenden Schritte sind fehlgeschlagen. Versuchen Sie es erneut, um den Vorgang abzuschließen. Beim Schließen bleibt die Referenz in Ihrer Bibliothek.",
-    "Add author": "Autor hinzufügen",
-    "Remove author": "Autor entfernen",
     "Pending review: {{total}}": "Zur Prüfung: {{total}}",
     "Already in library: {{total}}": "Bereits in der Bibliothek: {{total}}",
     "Repeated inputs: {{total}}": "Wiederholte Eingaben: {{total}}",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5082,6 +5082,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "El año y la fecha de publicación guardados no coinciden. Al editar cualquiera de los campos, se ajustarán para que coincidan.",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Introduzca una fecha de acceso válida a partir del 1970-01-01, o deje el campo vacío.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "La referencia se creó, pero no se pudo vincular al destino. Vuelva a intentarlo para completar el vínculo. Si cierra, la referencia permanecerá en su biblioteca sin ese vínculo.",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La referencia se creó, pero los pasos posteriores fallaron. Vuelva a intentarlo para terminar. Si cierra, la referencia permanecerá en su biblioteca."
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La referencia se creó, pero los pasos posteriores fallaron. Vuelva a intentarlo para terminar. Si cierra, la referencia permanecerá en su biblioteca.",
+    "Add author": "Añadir autor",
+    "Remove author": "Eliminar autor",
+    "Pending review: {{total}}": "Pendientes de revisión: {{total}}",
+    "Already in library: {{total}}": "Ya en la biblioteca: {{total}}",
+    "Repeated inputs: {{total}}": "Entradas repetidas: {{total}}",
+    "Other results: {{total}}": "Otros resultados: {{total}}",
+    "Not attempted: {{total}}": "Sin intentar: {{total}}",
+    "Saving stopped. Completed results are kept.": "Se detuvo el guardado. Se conservan los resultados completados.",
+    "Could not save reference {{number}}. Earlier results are kept.": "No se pudo guardar la referencia {{number}}. Se conservan los resultados anteriores.",
+    "Open Inbox": "Abrir bandeja de entrada",
+    "Open existing reference {{number}}": "Abrir referencia existente {{number}}"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5083,8 +5083,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Introduzca una fecha de acceso válida a partir del 1970-01-01, o deje el campo vacío.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "La referencia se creó, pero no se pudo vincular al destino. Vuelva a intentarlo para completar el vínculo. Si cierra, la referencia permanecerá en su biblioteca sin ese vínculo.",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La referencia se creó, pero los pasos posteriores fallaron. Vuelva a intentarlo para terminar. Si cierra, la referencia permanecerá en su biblioteca.",
-    "Add author": "Añadir autor",
-    "Remove author": "Eliminar autor",
     "Pending review: {{total}}": "Pendientes de revisión: {{total}}",
     "Already in library: {{total}}": "Ya en la biblioteca: {{total}}",
     "Repeated inputs: {{total}}": "Entradas repetidas: {{total}}",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5082,6 +5082,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "L’année et la date de publication enregistrées ne correspondent pas. Modifier l’un des champs les rendra cohérentes.",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Saisissez une date de consultation valide à partir du 1970-01-01, ou laissez le champ vide.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "La référence a été créée, mais son association à la destination a échoué. Réessayez pour terminer l’association. Si vous fermez, elle restera dans votre bibliothèque sans cette association.",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La référence a été créée, mais les étapes suivantes ont échoué. Réessayez pour terminer. Si vous fermez, la référence restera dans votre bibliothèque."
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La référence a été créée, mais les étapes suivantes ont échoué. Réessayez pour terminer. Si vous fermez, la référence restera dans votre bibliothèque.",
+    "Add author": "Ajouter un auteur",
+    "Remove author": "Supprimer l’auteur",
+    "Pending review: {{total}}": "À examiner : {{total}}",
+    "Already in library: {{total}}": "Déjà dans la bibliothèque : {{total}}",
+    "Repeated inputs: {{total}}": "Entrées répétées : {{total}}",
+    "Other results: {{total}}": "Autres résultats : {{total}}",
+    "Not attempted: {{total}}": "Non tentées : {{total}}",
+    "Saving stopped. Completed results are kept.": "Enregistrement arrêté. Les résultats terminés sont conservés.",
+    "Could not save reference {{number}}. Earlier results are kept.": "Impossible d’enregistrer la référence {{number}}. Les résultats précédents sont conservés.",
+    "Open Inbox": "Ouvrir la boîte de réception",
+    "Open existing reference {{number}}": "Ouvrir la référence existante {{number}}"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5083,8 +5083,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Saisissez une date de consultation valide à partir du 1970-01-01, ou laissez le champ vide.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "La référence a été créée, mais son association à la destination a échoué. Réessayez pour terminer l’association. Si vous fermez, elle restera dans votre bibliothèque sans cette association.",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "La référence a été créée, mais les étapes suivantes ont échoué. Réessayez pour terminer. Si vous fermez, la référence restera dans votre bibliothèque.",
-    "Add author": "Ajouter un auteur",
-    "Remove author": "Supprimer l’auteur",
     "Pending review: {{total}}": "À examiner : {{total}}",
     "Already in library: {{total}}": "Déjà dans la bibliothèque : {{total}}",
     "Repeated inputs: {{total}}": "Entrées répétées : {{total}}",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4769,8 +4769,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "1970-01-01 以降の有効なアクセス日を入力するか、空欄にしてください。",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文献は作成されましたが、保存先への関連付けに失敗しました。再試行して関連付けを完了してください。閉じると文献はライブラリに残りますが、関連付けは行われません。",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献は作成されましたが、後続の処理に失敗しました。再試行して完了してください。閉じても文献はライブラリに残ります。",
-    "Add author": "著者を追加",
-    "Remove author": "著者を削除",
     "Pending review: {{total}}": "確認待ち：{{total}}",
     "Already in library: {{total}}": "ライブラリに登録済み：{{total}}",
     "Repeated inputs: {{total}}": "重複した入力：{{total}}",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4768,6 +4768,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "保存された年と出版日が一致していません。どちらかの欄を編集すると一致するように調整されます。",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "1970-01-01 以降の有効なアクセス日を入力するか、空欄にしてください。",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文献は作成されましたが、保存先への関連付けに失敗しました。再試行して関連付けを完了してください。閉じると文献はライブラリに残りますが、関連付けは行われません。",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献は作成されましたが、後続の処理に失敗しました。再試行して完了してください。閉じても文献はライブラリに残ります。"
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献は作成されましたが、後続の処理に失敗しました。再試行して完了してください。閉じても文献はライブラリに残ります。",
+    "Add author": "著者を追加",
+    "Remove author": "著者を削除",
+    "Pending review: {{total}}": "確認待ち：{{total}}",
+    "Already in library: {{total}}": "ライブラリに登録済み：{{total}}",
+    "Repeated inputs: {{total}}": "重複した入力：{{total}}",
+    "Other results: {{total}}": "その他の結果：{{total}}",
+    "Not attempted: {{total}}": "未実行：{{total}}",
+    "Saving stopped. Completed results are kept.": "保存を停止しました。完了した結果は保持されます。",
+    "Could not save reference {{number}}. Earlier results are kept.": "文献 {{number}} を保存できませんでした。それまでの結果は保持されます。",
+    "Open Inbox": "受信トレイを開く",
+    "Open existing reference {{number}}": "既存の文献 {{number}} を開く"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4766,6 +4766,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "저장된 연도와 출판일이 일치하지 않습니다. 둘 중 하나를 수정하면 일치하도록 조정됩니다.",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "1970-01-01 이후의 유효한 접속일을 입력하거나 비워 두세요.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "문헌이 생성되었지만 대상 위치에 연결하지 못했습니다. 다시 시도하여 연결을 완료하세요. 닫으면 문헌은 라이브러리에 남지만 해당 연결은 생성되지 않습니다.",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "문헌이 생성되었지만 후속 단계가 실패했습니다. 다시 시도하여 완료하세요. 닫아도 문헌은 라이브러리에 남습니다."
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "문헌이 생성되었지만 후속 단계가 실패했습니다. 다시 시도하여 완료하세요. 닫아도 문헌은 라이브러리에 남습니다.",
+    "Add author": "저자 추가",
+    "Remove author": "저자 제거",
+    "Pending review: {{total}}": "검토 대기: {{total}}",
+    "Already in library: {{total}}": "이미 라이브러리에 있음: {{total}}",
+    "Repeated inputs: {{total}}": "중복 입력: {{total}}",
+    "Other results: {{total}}": "기타 결과: {{total}}",
+    "Not attempted: {{total}}": "시도하지 않음: {{total}}",
+    "Saving stopped. Completed results are kept.": "저장이 중지되었습니다. 완료된 결과는 유지됩니다.",
+    "Could not save reference {{number}}. Earlier results are kept.": "문헌 {{number}}을(를) 저장하지 못했습니다. 이전 결과는 유지됩니다.",
+    "Open Inbox": "받은 편지함 열기",
+    "Open existing reference {{number}}": "기존 문헌 {{number}} 열기"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4767,8 +4767,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "1970-01-01 이후의 유효한 접속일을 입력하거나 비워 두세요.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "문헌이 생성되었지만 대상 위치에 연결하지 못했습니다. 다시 시도하여 연결을 완료하세요. 닫으면 문헌은 라이브러리에 남지만 해당 연결은 생성되지 않습니다.",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "문헌이 생성되었지만 후속 단계가 실패했습니다. 다시 시도하여 완료하세요. 닫아도 문헌은 라이브러리에 남습니다.",
-    "Add author": "저자 추가",
-    "Remove author": "저자 제거",
     "Pending review: {{total}}": "검토 대기: {{total}}",
     "Already in library: {{total}}": "이미 라이브러리에 있음: {{total}}",
     "Repeated inputs: {{total}}": "중복 입력: {{total}}",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5214,6 +5214,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "Сохранённые год и дата публикации не совпадают. При изменении любого из полей они будут согласованы.",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Введите допустимую дату доступа не ранее 1970-01-01 или оставьте поле пустым.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "Ссылка создана, но связать её с выбранным местом не удалось. Повторите попытку, чтобы завершить связывание. При закрытии ссылка останется в библиотеке без этой связи.",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Ссылка создана, но последующие шаги завершились ошибкой. Повторите попытку для завершения. При закрытии ссылка останется в библиотеке."
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Ссылка создана, но последующие шаги завершились ошибкой. Повторите попытку для завершения. При закрытии ссылка останется в библиотеке.",
+    "Add author": "Добавить автора",
+    "Remove author": "Удалить автора",
+    "Pending review: {{total}}": "Ожидают проверки: {{total}}",
+    "Already in library: {{total}}": "Уже в библиотеке: {{total}}",
+    "Repeated inputs: {{total}}": "Повторные входные записи: {{total}}",
+    "Other results: {{total}}": "Другие результаты: {{total}}",
+    "Not attempted: {{total}}": "Не обработано: {{total}}",
+    "Saving stopped. Completed results are kept.": "Сохранение остановлено. Завершённые результаты сохранены.",
+    "Could not save reference {{number}}. Earlier results are kept.": "Не удалось сохранить источник {{number}}. Предыдущие результаты сохранены.",
+    "Open Inbox": "Открыть входящие",
+    "Open existing reference {{number}}": "Открыть существующий источник {{number}}"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5215,8 +5215,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "Введите допустимую дату доступа не ранее 1970-01-01 или оставьте поле пустым.",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "Ссылка создана, но связать её с выбранным местом не удалось. Повторите попытку, чтобы завершить связывание. При закрытии ссылка останется в библиотеке без этой связи.",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "Ссылка создана, но последующие шаги завершились ошибкой. Повторите попытку для завершения. При закрытии ссылка останется в библиотеке.",
-    "Add author": "Добавить автора",
-    "Remove author": "Удалить автора",
     "Pending review: {{total}}": "Ожидают проверки: {{total}}",
     "Already in library: {{total}}": "Уже в библиотеке: {{total}}",
     "Repeated inputs: {{total}}": "Повторные входные записи: {{total}}",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4768,6 +4768,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "已保存的年份与出版日期不一致。编辑任一字段将使两者保持一致。",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "请输入不早于 1970-01-01 的有效访问日期，或留空。",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文献已创建，但关联到目标位置失败。请重试以完成关联。关闭后，文献仍保留在文献库中，但不会建立该关联。",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献已创建，但后续步骤失败。请重试以完成。关闭后，文献仍保留在文献库中。"
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献已创建，但后续步骤失败。请重试以完成。关闭后，文献仍保留在文献库中。",
+    "Add author": "添加作者",
+    "Remove author": "移除作者",
+    "Pending review: {{total}}": "待审阅：{{total}}",
+    "Already in library: {{total}}": "文献库中已有：{{total}}",
+    "Repeated inputs: {{total}}": "重复输入：{{total}}",
+    "Other results: {{total}}": "其他结果：{{total}}",
+    "Not attempted: {{total}}": "未尝试：{{total}}",
+    "Saving stopped. Completed results are kept.": "保存已停止。已完成的结果会保留。",
+    "Could not save reference {{number}}. Earlier results are kept.": "无法保存第 {{number}} 条文献。此前的结果会保留。",
+    "Open Inbox": "打开收件箱",
+    "Open existing reference {{number}}": "打开已有文献 {{number}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4769,8 +4769,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "请输入不早于 1970-01-01 的有效访问日期，或留空。",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文献已创建，但关联到目标位置失败。请重试以完成关联。关闭后，文献仍保留在文献库中，但不会建立该关联。",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文献已创建，但后续步骤失败。请重试以完成。关闭后，文献仍保留在文献库中。",
-    "Add author": "添加作者",
-    "Remove author": "移除作者",
     "Pending review: {{total}}": "待审阅：{{total}}",
     "Already in library: {{total}}": "文献库中已有：{{total}}",
     "Repeated inputs: {{total}}": "重复输入：{{total}}",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4768,6 +4768,17 @@
     "The saved year and publication date disagree. Editing either field will reconcile them.": "已儲存的年份與出版日期不一致。編輯任一欄位將使兩者保持一致。",
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "請輸入不早於 1970-01-01 的有效存取日期，或留空。",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文獻已建立，但連結至目標位置失敗。請重試以完成連結。關閉後，文獻仍保留在文獻庫中，但不會建立該連結。",
-    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文獻已建立，但後續步驟失敗。請重試以完成。關閉後，文獻仍保留在文獻庫中。"
+    "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文獻已建立，但後續步驟失敗。請重試以完成。關閉後，文獻仍保留在文獻庫中。",
+    "Add author": "新增作者",
+    "Remove author": "移除作者",
+    "Pending review: {{total}}": "待審閱：{{total}}",
+    "Already in library: {{total}}": "文獻庫中已有：{{total}}",
+    "Repeated inputs: {{total}}": "重複輸入：{{total}}",
+    "Other results: {{total}}": "其他結果：{{total}}",
+    "Not attempted: {{total}}": "未嘗試：{{total}}",
+    "Saving stopped. Completed results are kept.": "儲存已停止。已完成的結果會保留。",
+    "Could not save reference {{number}}. Earlier results are kept.": "無法儲存第 {{number}} 筆文獻。先前的結果會保留。",
+    "Open Inbox": "開啟收件匣",
+    "Open existing reference {{number}}": "開啟已有文獻 {{number}}"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4769,8 +4769,6 @@
     "Enter a valid access date on or after 1970-01-01, or leave it blank.": "請輸入不早於 1970-01-01 的有效存取日期，或留空。",
     "The reference was created, but linking it to the destination failed. Retry to finish linking. Closing leaves it in your library without that link.": "文獻已建立，但連結至目標位置失敗。請重試以完成連結。關閉後，文獻仍保留在文獻庫中，但不會建立該連結。",
     "The reference was created, but the remaining steps failed. Retry to finish. If you close, the reference remains in your library.": "文獻已建立，但後續步驟失敗。請重試以完成。關閉後，文獻仍保留在文獻庫中。",
-    "Add author": "新增作者",
-    "Remove author": "移除作者",
     "Pending review: {{total}}": "待審閱：{{total}}",
     "Already in library: {{total}}": "文獻庫中已有：{{total}}",
     "Repeated inputs: {{total}}": "重複輸入：{{total}}",

--- a/src/shared/literature-save.ts
+++ b/src/shared/literature-save.ts
@@ -1,0 +1,33 @@
+import type { LiteratureCatalogReceipt } from './literature'
+
+export type LiteratureLibrarySaveResult = Readonly<{
+  // Receipts correspond to the completed input prefix, including reused records.
+  results: readonly LiteratureCatalogReceipt[]
+  failure?: Readonly<{ inputIndex: number; code: string; message: string }>
+  cancelled?: boolean
+}>
+
+export const summarizeLiteratureSaveReceipts = (
+  results: readonly LiteratureCatalogReceipt[]
+): {
+  pendingCount: number
+  existingItemIds: string[]
+  duplicateCount: number
+  otherCount: number
+} => {
+  const unique = [
+    ...new Map(results.map((receipt) => [`${receipt.kind}:${receipt.id}`, receipt])).values()
+  ]
+  const pendingCount = unique.filter(
+    ({ kind, state }) => kind === 'candidate' && state === 'pending'
+  ).length
+  const existingItemIds = unique
+    .filter(({ kind, state }) => kind === 'item' && state === 'present')
+    .map(({ id }) => id)
+  return {
+    pendingCount,
+    existingItemIds,
+    duplicateCount: results.length - unique.length,
+    otherCount: unique.length - pendingCount - existingItemIds.length
+  }
+}

--- a/src/shared/literature.ts
+++ b/src/shared/literature.ts
@@ -375,6 +375,7 @@ const literatureCatalogSearchRequestSchema = z
     scope: z.enum(['library', 'inbox', 'collections', 'project-counts', 'duplicates']),
     refreshDuplicates: z.boolean().optional(),
     allItemIds: z.boolean().optional(),
+    itemIds: z.array(nonEmptyTextSchema).max(200).optional(),
     query: optionalTextSchema,
     projectId: optionalTextSchema,
     collectionId: optionalTextSchema,
@@ -391,6 +392,9 @@ const literatureCatalogSearchRequestSchema = z
   .strict()
   .refine((request) => !request.allItemIds || request.scope === 'library', {
     message: 'Complete item membership is only available for the library.'
+  })
+  .refine((request) => request.itemIds === undefined || request.scope === 'library', {
+    message: 'Selected item membership is only available for the library.'
   })
 
 const literatureCatalogSearchPageSchema = z


### PR DESCRIPTION
## Problem

A batch save could commit an initial candidate and then return only an error, hiding the completed work. Cancelling during metadata lookup could still lead to a write. Save cards also counted duplicate receipts and existing library items as Inbox saves. Search previews mixed contributor roles, truncated exact identifiers, searched serialized field names in selected-item scope, and omitted presentation text from their response budget. File-read failures were incorrectly reported as malformed candidate JSON.

## Proposed change

- Keep sequential candidate transactions and return the completed receipt prefix with optional `failure { inputIndex, code, message }` or `cancelled`. Stop before the next write; allow an already-started transaction to finish.
- Propagate cancellation through the MCP handler, trusted runtime wrapper, metadata lookup and file read. The stateless HTTP host forwards Library cancellation notifications to the active request on that same route. Cancellation arriving while a POST body is still being read is retained only for already-arriving same-route requests, with a byte budget, and checked before tool dispatch. These in-memory entries expire with the response; duplicate active IDs fail closed, and route removal/host shutdown closes active responses.
- Derive save counts from unique receipt identities and existing states. Show separate pending-review and existing-library results, repeated inputs, and partial failure. Reuse Inbox and exact-item navigation. Historical raw receipts override inaccurate presentation counts; summary-only history stays neutral and is not rewritten.
- Return only authors in `authors`, retain full identifier values, apply selected IDs through Catalog search while retaining merged aliases and filtering survivor metadata, and budget both emitted search text blocks with advancing pagination. Distinguish unreadable/oversized files from invalid content.

## Scope and non-goals

No database columns, tables, migrations, backfills, entity relationships, or lifecycle enum values change. Added fields are result metadata, an optional read-request ID filter, and cancellation parameters. New tool-result metadata can use the existing conversation persistence path. No durable operation journal, background task system, batch transaction, or historical conversation rewrite is introduced.

The resolver still fetches each normalized identifier once, but preserves duplicate input positions so receipts and failure indices align with the caller's input. A cancelled client may discard the final response: this change prevents further writes but does not promise durable receipt delivery after cancellation or a crash. The full-abstract tool and candidate dismissal lifecycle are unchanged.

## Acceptance criteria and validation

The original behavior regressions failed twice on unchanged production sources with matching assertion causes, then passed after the fixes. Additional real HTTP cancellation tests also failed twice against the original HTTP host. Test-only mocks intercept existing runtime composition boundaries; save/search implementations are not copied and no production test seam was added.

Checks below ran on the final code after the last material production edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| SQLite partial save, cancellation, duplicate/existing receipts, search projection, query membership, file failures | `npx vitest run src/main/literature` | Pass |
| Trusted-origin/signal forwarding for Claude Code, OpenCode, Codex Responses and Codex bridge; HTTP cancellation/isolation/cleanup | `npx vitest run src/main/acp/runtime-composition.test.ts src/main/acp/runtime-base-composition.test.ts src/main/acp/mcp-http-host.test.ts src/main/acp/session-capability-owner.test.ts` | Pass |
| Shared request/receipt contract | `npx vitest run src/shared/literature.test.ts` | Pass |
| Cards, historical output, navigation and actual Library detail destination | `npx vitest run src/renderer/src/pages/workspace/WorkspaceToolDetailsRow.render.test.tsx src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx src/renderer/src/pages/workspace/literature-save-contract.test.tsx src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts src/renderer/src/stores/navigation-store.test.ts src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx` | Pass |
| Eight locale catalogs | `npx vitest run src/renderer/src/i18n/resources.test.ts` | Pass |
| Types and lint | `npm run typecheck:node`, `npm run typecheck:web`, `npm run lint` | Pass |

The final combined targets cover **1,682 tests**. The integration run passed 1,673; eight translation guards loaded before the conflict cleanup and passed on the corrected files, and the 50,000-record concurrency test passed on its standalone rerun. That capacity test has intermittently failed in combined local runs; its passing rerun is not proof of stability. Both process typechecks and lint pass after integration. A later test-only correction updates the existing details-row integration case to exercise the explicit Inbox button with real receipts, and neutral summary-only history. Its renderer consumer set passes **159 tests**, with targeted lint passing; production sources are unchanged. HTTP checks require a loopback listener. Real production cards were rendered with isolated fixtures and checked in ego-browser; the Inbox and exact-item actions were exercised, and screenshots were delivered locally to the maintainer.

The committed `test:affected:explain -- --base b28b9e11 --head HEAD` plan selects the full fallback because the HTTP host is not yet an owned module in the manifest. Per the maintainer's explicit instruction, no full local suite was run and the manifest was not broadened merely for this PR. The complete/platform checks belong to PR CI. Local tests do not claim live model-provider or cross-platform execution. CodeGraph's shared index belongs to another checkout; its structural findings were checked against the current worktree references and consumer tests.

## Review focus

The branch was rebased only to resolve actual merge conflicts. Catalog retains main’s normalized search, task recovery and metadata integrity work, adding parameterized selected-ID/alias filtering. Translation conflicts preserve both additions and main’s removal of obsolete author labels. The module verification was rerun after this integration.

Independent review identified request-registration cancellation and merged-alias regressions. Both were reproduced twice through HTTP/SQLite before correction. CI also exposed an existing approval-card count test; it failed twice locally before restoring its approval-only display. One local 50,000-record concurrency test failed during the first final run, then passed standalone and in the repeated module set; that failure is retained in local evidence. The subsequent macOS journey lane passed. The next portable run exposed an outdated details-row test that expected a whole-card button from summary-only output; it was reproduced locally, then updated to verify both receipt-backed navigation and neutral history. The latest exact-head run remains authoritative.

Review the completed-prefix contract, cancellation forwarding across separate HTTP POSTs and cleanup, exact identifier preservation when shrinking a search page, and neutral handling of incomplete historical tool output. Please assess the final CI plan and independent review before treating the change as fully verified.


### Review clarification: HTTP keep-alive cleanup

The latest static review inferred that `ServerResponse.close` waits for the TCP connection to close. This is inconsistent with [Node's documented response lifecycle](https://nodejs.org/api/http.html#event-close_2): response completion itself emits `close`.

The unchanged production host was independently exercised twice with a real Node HTTP Agent (`keepAlive: true`, `maxSockets: 1`): 20 sequential `tools/call` POSTs reused the same route and JSON-RPC ID. Every response was HTTP 200, calls 2–20 asserted `request.reusedSocket === true`, all 20 asserted one local socket port, and the save handler ran exactly 20 times. No duplicate 409 or retained ID was observed. The temporary verification test is preserved locally; production code and committed tests were restored byte-for-byte. Existing committed HTTP coverage also tests ID reuse after completion/cancellation. No speculative production fix was applied for this unconfirmed finding.


### Final review disposition and CI

All portable shards, Windows core/E2E, macOS build/E2E, Linux isolation, coverage, static checks, CodeQL and PR Gate passed for `95d365b90c800734311ed7bcc25629840125b317`.

A second static review inferred an unhandled write after destroying a response whose body is still arriving. Without production changes, real incomplete HTTP POSTs were tested under route unregister, host clear and cancellation-buffer overflow. All three cases passed twice: the client received the expected ECONNRESET, Vitest reported no unhandled exception/rejection, no save occurred, and re-registering the route served a successful request. The temporary verification is retained locally and the committed test file was restored byte-for-byte. This alleged secondary write failure could not be reproduced; no speculative guard was added.

The concrete cancellation-registration and merged-alias findings were reproduced and corrected. The unchanged production code was independently reviewed as mergeable at `cdaecd72`; the only subsequent commit changes details-row integration tests. Later keep-alive and destroyed-response reports are not treated as confirmed defects because both were tested directly and contradicted their claimed observable outcomes. Local capacity-test intermittency remains disclosed above despite its successful final CI run.
