### PR TITLE
fix(literature)!: synchronize clients and reject stale collection edits

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -1,4 +1,4 @@
-import { expect, test as base } from '@playwright/test'
+import { expect, test as base, type TestInfo } from '@playwright/test'
 import { spawn } from 'node:child_process'
 import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -340,7 +340,7 @@ class ElectronAppHarness implements ElectronApp {
     private readonly windowMode: E2eWindowMode
   ) {}
 
-  static async create(windowMode: E2eWindowMode): Promise<ElectronAppHarness> {
+  static async create(windowMode: E2eWindowMode, testInfo: TestInfo): Promise<ElectronAppHarness> {
     const testRoot = await mkdtemp(join(tmpdir(), 'open-science-electron-e2e-'))
     const harness = new ElectronAppHarness(
       testRoot,
@@ -361,6 +361,10 @@ class ElectronAppHarness implements ElectronApp {
       await harness.launch()
       return harness
     } catch (error) {
+      await harness
+        .captureMainLog('startup-failure.log')
+        .then((path) => testInfo.attach('main-process-log', { path, contentType: 'text/plain' }))
+        .catch(() => undefined)
       await harness.dispose().catch(() => undefined)
       throw error
     }
@@ -936,12 +940,12 @@ class ElectronAppHarness implements ElectronApp {
       this.resourceProfiler !== undefined
     )
     await this.resourceProfiler?.attach(this.application)
+    this.mainLogDirectory = await this.application.evaluate(({ app }) => app.getPath('logs'))
     this.currentPage = await openMainWindow(
       this.application,
       this.rendererFailures,
       this.windowMode
     )
-    this.mainLogDirectory = await this.application.evaluate(({ app }) => app.getPath('logs'))
   }
 
   private get runningApplication(): ElectronApplication {
@@ -1028,7 +1032,7 @@ const test = base.extend<{ app: ElectronApp; windowMode: E2eWindowMode }>({
   windowMode: ['hidden', { option: true }],
   // Playwright fixture callbacks require an object pattern even when no base fixture is needed.
   app: async ({ windowMode }, install, testInfo) => {
-    const app = await ElectronAppHarness.create(windowMode)
+    const app = await ElectronAppHarness.create(windowMode, testInfo)
 
     try {
       await install(app)

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -1,4 +1,4 @@
-import { expect, test as base, type TestInfo } from '@playwright/test'
+import { expect, test as base } from '@playwright/test'
 import { spawn } from 'node:child_process'
 import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -340,7 +340,7 @@ class ElectronAppHarness implements ElectronApp {
     private readonly windowMode: E2eWindowMode
   ) {}
 
-  static async create(windowMode: E2eWindowMode, testInfo: TestInfo): Promise<ElectronAppHarness> {
+  static async create(windowMode: E2eWindowMode): Promise<ElectronAppHarness> {
     const testRoot = await mkdtemp(join(tmpdir(), 'open-science-electron-e2e-'))
     const harness = new ElectronAppHarness(
       testRoot,
@@ -361,10 +361,6 @@ class ElectronAppHarness implements ElectronApp {
       await harness.launch()
       return harness
     } catch (error) {
-      await harness
-        .captureMainLog('startup-failure.log')
-        .then((path) => testInfo.attach('main-process-log', { path, contentType: 'text/plain' }))
-        .catch(() => undefined)
       await harness.dispose().catch(() => undefined)
       throw error
     }
@@ -940,12 +936,12 @@ class ElectronAppHarness implements ElectronApp {
       this.resourceProfiler !== undefined
     )
     await this.resourceProfiler?.attach(this.application)
-    this.mainLogDirectory = await this.application.evaluate(({ app }) => app.getPath('logs'))
     this.currentPage = await openMainWindow(
       this.application,
       this.rendererFailures,
       this.windowMode
     )
+    this.mainLogDirectory = await this.application.evaluate(({ app }) => app.getPath('logs'))
   }
 
   private get runningApplication(): ElectronApplication {
@@ -1032,7 +1028,7 @@ const test = base.extend<{ app: ElectronApp; windowMode: E2eWindowMode }>({
   windowMode: ['hidden', { option: true }],
   // Playwright fixture callbacks require an object pattern even when no base fixture is needed.
   app: async ({ windowMode }, install, testInfo) => {
-    const app = await ElectronAppHarness.create(windowMode, testInfo)
+    const app = await ElectronAppHarness.create(windowMode)
 
     try {
       await install(app)

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -2,6 +2,7 @@ import { expect, test as base } from '@playwright/test'
 import { spawn } from 'node:child_process'
 import { chmod, copyFile, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+import { fileURLToPath } from 'node:url'
 import { delimiter, isAbsolute, join, relative, resolve, sep } from 'node:path'
 import { _electron as electron, type ElectronApplication, type Page } from 'playwright'
 import {
@@ -115,6 +116,8 @@ const closeElectronApplicationForCleanup = async (
 
 type ElectronApp = {
   readonly page: Page
+  openAdditionalRenderer: () => Promise<Page>
+  authenticatedWebUrl: () => Promise<string>
   allowRendererConsoleError: (text: string) => void
   captureMainLog: (name: string) => Promise<string>
   armDelegatedHandoffCleanupSabotage: (childName: string) => Promise<void>
@@ -547,6 +550,62 @@ class ElectronAppHarness implements ElectronApp {
       })
       await bridge.api.compute.bookmarksSet('ssh:a11y-fixture', ['/scratch/fixture/pinned'])
     })
+  }
+
+  async openAdditionalRenderer(): Promise<Page> {
+    const next = this.runningApplication.waitForEvent('window')
+    await this.runningApplication.evaluate(
+      ({ BrowserWindow }, preload) => {
+        const source = BrowserWindow.getAllWindows().find((window) =>
+          window.webContents.getURL().includes('index.html')
+        )!
+        const window = new BrowserWindow({
+          show: false,
+          webPreferences: {
+            preload,
+            contextIsolation: true,
+            nodeIntegration: false,
+            sandbox: true
+          }
+        })
+        void window.loadURL(source.webContents.getURL())
+      },
+      fileURLToPath(new URL('../preload/index.js', this.page.url()))
+    )
+    const page = await next
+    await page.waitForFunction(() => Boolean(window.api?.databaseStartup))
+    await waitForRendererReady(page)
+    return page
+  }
+
+  async authenticatedWebUrl(): Promise<string> {
+    const target = electronLaunchTarget(this.roots.userDataRoot)
+    const child = spawn(
+      target.executablePath ?? ((await import('electron')).default as unknown as string),
+      [...target.args, '--serve=0'],
+      { env: launchEnvironment(this.roots.storageRoot), stdio: 'ignore' }
+    )
+    await new Promise<void>((resolve, reject) => {
+      child.once('error', reject)
+      child.once('exit', () => resolve())
+    })
+    let port: number | undefined
+    await expect
+      .poll(async () => {
+        try {
+          port = (
+            JSON.parse(
+              await readFile(join(this.roots.storageRoot, 'web-service.json'), 'utf8')
+            ) as { port: number }
+          ).port
+        } catch {
+          return false
+        }
+        return Boolean(port)
+      })
+      .toBe(true)
+    const token = (await readFile(join(this.roots.storageRoot, 'web-token'), 'utf8')).trim()
+    return `http://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`
   }
 
   async completeOnboarding(): Promise<Page> {

--- a/e2e/literature-client-sync.spec.ts
+++ b/e2e/literature-client-sync.spec.ts
@@ -1,0 +1,104 @@
+import { expect } from '@playwright/test'
+import type { Page } from 'playwright'
+import { test } from './fixtures/electron-app'
+import { literatureCandidateInputSchema, literatureItemInputSchema } from '../src/shared/literature'
+
+const library = async (page: Page): Promise<void> => {
+  await page.getByRole('button', { name: 'Library', exact: true }).click()
+  await page.getByRole('button', { name: 'All references', exact: true }).click()
+}
+
+test('synchronizes ordinary writes across two Electron renderers and a Web client', async ({
+  app,
+  browser
+}) => {
+  test.setTimeout(180_000)
+  const first = await app.completeOnboarding()
+  const second = await app.openAdditionalRenderer()
+  const web = await browser.newPage()
+  try {
+    await web.goto(await app.authenticatedWebUrl())
+    for (const page of [first, second, web]) await library(page)
+    const item = literatureItemInputSchema.parse({
+      itemType: 'journalArticle',
+      title: 'Created in desktop'
+    })
+    const created = await first.evaluate(
+      (item) => window.api.literature.transact({ kind: 'create-item', item }),
+      item
+    )
+    for (const page of [second, web])
+      await expect(page.getByText(item.title, { exact: true })).toBeVisible()
+    const saved = await web.evaluate(async (id) => {
+      const current = (await window.api.literature.get(id))!
+      await window.api.literature.transact({
+        kind: 'update-item',
+        itemId: id,
+        expectedMetadataRevision: current.metadataRevision,
+        item: { ...current.item, title: 'Edited in Web' }
+      })
+      return id
+    }, created.id)
+    for (const page of [first, second])
+      await expect(page.getByText('Edited in Web', { exact: true })).toBeVisible()
+    const collection = await second.evaluate(() =>
+      window.api.literature.transact({ kind: 'create-collection', name: 'Shared collection' })
+    )
+    for (const page of [first, web])
+      await expect(
+        page.getByRole('button', { name: 'Shared collection', exact: true })
+      ).toBeVisible()
+    await web.evaluate(
+      ({ collectionId, itemId }) =>
+        window.api.literature.transact({
+          kind: 'set-collection-item',
+          collectionId,
+          itemId,
+          included: true
+        }),
+      { collectionId: collection.id, itemId: saved }
+    )
+    await first.getByRole('button', { name: 'Shared collection', exact: true }).click()
+    await expect(first.getByText('Edited in Web', { exact: true })).toBeVisible()
+    const candidate = literatureCandidateInputSchema.parse({
+      item: { itemType: 'journalArticle', title: 'Accepted from Inbox' },
+      source: { provider: 'manual', rawMetadata: {} },
+      origin: { kind: 'user' }
+    })
+    const staged = await first.evaluate(
+      (candidate) => window.api.literature.transact({ kind: 'stage-candidate', candidate }),
+      candidate
+    )
+    await second.evaluate(
+      (candidateId) => window.api.literature.transact({ kind: 'accept-candidate', candidateId }),
+      staged.id
+    )
+    await expect(web.getByText('Accepted from Inbox', { exact: true })).toBeVisible()
+    await second.evaluate(
+      (id) =>
+        window.api.literature.transact({
+          kind: 'set-item-lifecycle',
+          itemIds: [id],
+          state: 'deleted'
+        }),
+      created.id
+    )
+    await expect(first.getByText('Edited in Web', { exact: true })).toHaveCount(0)
+    await expect(web.getByText('Edited in Web', { exact: true })).toHaveCount(0)
+    // Suspend the real Web transport, commit while disconnected, then let replay/recovery restore it.
+    await web.context().setOffline(true)
+    const missed = await first.evaluate(
+      (item) =>
+        window.api.literature.transact({
+          kind: 'create-item',
+          item: { ...item, title: 'Committed while Web was offline' }
+        }),
+      item
+    )
+    expect(missed.id).toBeTruthy()
+    await web.context().setOffline(false)
+    await expect(web.getByText('Committed while Web was offline', { exact: true })).toBeVisible()
+  } finally {
+    await web.close()
+  }
+})

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -639,6 +639,7 @@ model LiteratureSourceRecord {
 }
 
 model LiteratureCollection {
+  revision    Int                        @default(1)
   id          String                     @id @default(cuid())
   name        String
   nameKey     String

--- a/scripts/database-migration-ledger-smoke.mjs
+++ b/scripts/database-migration-ledger-smoke.mjs
@@ -160,6 +160,10 @@ const EXPECTED_MIGRATION_LEDGER = [
   {
     id: '0039_literature_metadata_commit_receipt',
     checksum: '2d78a9270e8d861a9c8613106143888ea8a029878d5e553098c3729a42d95ffb'
+  },
+  {
+    id: '0040_literature_collection_revision',
+    checksum: 'ba19650afd09b7a52d317ad51361b0e68b4e105c6a55cdc88d0e9c04760e3bfa'
   }
 ]
 const LEGACY_PROJECT_ID = 'package-smoke-legacy-project'

--- a/scripts/database-migration-ledger-smoke.test.ts
+++ b/scripts/database-migration-ledger-smoke.test.ts
@@ -106,7 +106,7 @@ const removeArchiveAndLiteratureSchema = async (client: PrismaClient): Promise<v
 
 describe('packaged database migration ledger smoke', () => {
   it('pins every packaged application migration identity and checksum', () => {
-    expect(MIGRATION_MANIFEST.slice(-17).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
+    expect(MIGRATION_MANIFEST.slice(-18).map(({ id, checksum }) => ({ id, checksum }))).toEqual([
       {
         id: '0023_compute_job_operation',
         checksum: 'c625e336996c7dd1eba64da8ccd306104ccd68cf219e60ee2c3889749f86b079'
@@ -174,6 +174,10 @@ describe('packaged database migration ledger smoke', () => {
       {
         id: '0039_literature_metadata_commit_receipt',
         checksum: '2d78a9270e8d861a9c8613106143888ea8a029878d5e553098c3729a42d95ffb'
+      },
+      {
+        id: '0040_literature_collection_revision',
+        checksum: 'ba19650afd09b7a52d317ad51361b0e68b4e105c6a55cdc88d0e9c04760e3bfa'
       }
     ])
     expect(() => assertApplicationMigrationLedger(MIGRATION_MANIFEST)).not.toThrow()
@@ -214,7 +218,7 @@ describe('packaged database migration ledger smoke', () => {
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')`
       )
 
       await migrateApplicationDatabase(client)
@@ -252,7 +256,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await rebuildComputeJobWithoutAnalysisConstraints(client, false)
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')`
       )
       await client.$executeRawUnsafe(`INSERT INTO "ComputeJob" (
         "id", "providerId", "shape", "sessionId", "projectId", "status", "intent",
@@ -288,7 +292,7 @@ describe('packaged database migration ledger smoke', () => {
       await migrateApplicationDatabase(client)
       await client.$executeRawUnsafe('DROP INDEX "MemoryEntry_global_contentKey_key"')
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')`
       )
       await client.memoryEntry.createMany({
         data: [
@@ -388,7 +392,7 @@ describe('packaged database migration ledger smoke', () => {
         'ALTER TABLE "SessionAuxiliaryTurnUsage" DROP COLUMN "providerId"'
       )
       await client.$executeRawUnsafe(
-        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
+        `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0019_session_usage_attribution', '0020_compute_job_analysis_state', '0021_compute_job_analysis_constraints', '0022_memory_global_content_unique', '0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)
       await removeArchiveAndLiteratureSchema(client)
@@ -471,7 +475,7 @@ describe('packaged database migration ledger smoke', () => {
            '0027_project_session_defaults',
            '0028_database_numeric_and_null_constraints',
            '0029_compute_host_execution_mode',
-           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt'
+           '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision'
          )`
       )
       await rebuildComputeJobWithoutAnalysisConstraints(client, true)

--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -1,3 +1,4 @@
+import type { LiteratureChangedEvent } from '../shared/literature'
 import type {
   AcpAgentRuntimeUpdate,
   AcpPermissionRequest,
@@ -72,6 +73,7 @@ export type ApplicationEventMap = {
   'sessions:flush-request': SessionPersistenceFlushRequest
   'project-files:changed': ProjectFilesChangedEvent
   'permissions:changed': PermissionGrantsChangedEvent
+  'literature:changed': LiteratureChangedEvent
   'tags:changed': TagsChangedEvent
   'memory:changed': MemoryChangedEvent
   'connectors:approval-request': ConnectorApprovalRequest

--- a/src/main/database/agent-memory-project-scope-migration.test.ts
+++ b/src/main/database/agent-memory-project-scope-migration.test.ts
@@ -17,7 +17,7 @@ const COMPUTE_ANALYSIS_CONSTRAINTS_MIGRATION_ID = '0021_compute_job_analysis_con
 const MEMORY_GLOBAL_CONTENT_UNIQUE_MIGRATION_ID = '0022_memory_global_content_unique'
 const COMPUTE_JOB_OPERATION_MIGRATION_ID = '0023_compute_job_operation'
 const COMPUTE_JOB_FILE_EVIDENCE_MIGRATION_ID = '0024_compute_job_file_evidence'
-const CURRENT_MIGRATION_ID = '0039_literature_metadata_commit_receipt'
+const CURRENT_MIGRATION_ID = '0040_literature_collection_revision'
 const MEMORY_AUXILIARY_SCHEMA_NAMES = [
   'MemoryEntryFts',
   'MemoryEntry_fts_insert',
@@ -310,7 +310,7 @@ describe('agent memory project scope migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       CURRENT_AGENT_MEMORY_MIGRATION_ID,
       SESSION_AUXILIARY_USAGE_MIGRATION_ID,
       SESSION_USAGE_ATTRIBUTION_MIGRATION_ID,
@@ -333,6 +333,7 @@ describe('agent memory project scope migration', () => {
       '0036_content_verification_observation',
       '0037_literature_inbox_integrity',
       '0038_literature_search_text',
+      '0039_literature_metadata_commit_receipt',
       CURRENT_MIGRATION_ID
     )
 
@@ -360,6 +361,7 @@ describe('agent memory project scope migration', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
+        '0039_literature_metadata_commit_receipt',
         CURRENT_MIGRATION_ID
       ],
       to: CURRENT_MIGRATION_ID

--- a/src/main/database/application-database.integration.test.ts
+++ b/src/main/database/application-database.integration.test.ts
@@ -223,7 +223,8 @@ describe('application database (integration)', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
 
@@ -1292,7 +1293,8 @@ describe('application database (integration)', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
 

--- a/src/main/database/compute-job-operation-migration.test.ts
+++ b/src/main/database/compute-job-operation-migration.test.ts
@@ -27,7 +27,7 @@ describe('Compute Job operation migration', () => {
     await client.$executeRawUnsafe('ALTER TABLE "ComputeHost" DROP COLUMN "executionMode"')
     await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')`
+      `DELETE FROM "_open_science_migrations" WHERE "id" IN ('0023_compute_job_operation', '0024_compute_job_file_evidence', '0025_managed_file_version_foundation', '0026_compute_job_remote_cleanup', '0027_project_session_defaults', '0028_database_numeric_and_null_constraints', '0029_compute_host_execution_mode', '0030_literature_foundation', '0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')`
     )
     const [{ sql: computeJobSqlBefore }] = await client.$queryRawUnsafe<Array<{ sql: string }>>(
       `SELECT "sql" FROM "sqlite_schema" WHERE "type" = 'table' AND "name" = 'ComputeJob'`
@@ -47,8 +47,8 @@ describe('Compute Job operation migration', () => {
         `SELECT "id" FROM "_open_science_migrations" ORDER BY "id" DESC LIMIT 2`
       )
     ).resolves.toEqual([
-      { id: '0039_literature_metadata_commit_receipt' },
-      { id: '0038_literature_search_text' }
+      { id: '0040_literature_collection_revision' },
+      { id: '0039_literature_metadata_commit_receipt' }
     ])
   })
 

--- a/src/main/database/compute-job-remote-cleanup-migration.test.ts
+++ b/src/main/database/compute-job-remote-cleanup-migration.test.ts
@@ -81,10 +81,11 @@ describe('Compute Job remote cleanup migration', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0025_managed_file_version_foundation',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ remoteCleanupDisposition: string }>>(

--- a/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
+++ b/src/main/database/compute-job-sensitive-data-encryption-migration.test.ts
@@ -86,10 +86,11 @@ describe('Compute Job sensitive data encryption migration', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0015_session_model_call_usage',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       access(`${databasePath}.before-0016_compute_job_sensitive_data_encryption.backup`)

--- a/src/main/database/content-blob-migration.test.ts
+++ b/src/main/database/content-blob-migration.test.ts
@@ -82,7 +82,8 @@ describe('Content blob migration', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(
@@ -166,10 +167,11 @@ describe('Content blob migration', () => {
                 '0036_content_verification_observation',
                 '0037_literature_inbox_integrity',
                 '0038_literature_search_text',
-                '0039_literature_metadata_commit_receipt'
+                '0039_literature_metadata_commit_receipt',
+                '0040_literature_collection_revision'
               ],
         from: schema === 'pre-ledger' ? null : '0029_compute_host_execution_mode',
-        to: '0039_literature_metadata_commit_receipt'
+        to: '0040_literature_collection_revision'
       })
 
       await expect(

--- a/src/main/database/content-verification-observation.test.ts
+++ b/src/main/database/content-verification-observation.test.ts
@@ -33,7 +33,8 @@ it('adds unknown verification observations without changing historical content o
       '0036_content_verification_observation',
       '0037_literature_inbox_integrity',
       '0038_literature_search_text',
-      '0039_literature_metadata_commit_receipt'
+      '0039_literature_metadata_commit_receipt',
+      '0040_literature_collection_revision'
     ]
   })
   expect(await client.contentBlob.findUnique({ where: { id: 'old' } })).toMatchObject({

--- a/src/main/database/database-json-constraints-migration.test.ts
+++ b/src/main/database/database-json-constraints-migration.test.ts
@@ -178,10 +178,11 @@ describe('database JSON constraints migration', () => {
           '0036_content_verification_observation',
           '0037_literature_inbox_integrity',
           '0038_literature_search_text',
-          '0039_literature_metadata_commit_receipt'
+          '0039_literature_metadata_commit_receipt',
+          '0040_literature_collection_revision'
         ],
         from: '0007_notification_attention_metadata',
-        to: '0039_literature_metadata_commit_receipt'
+        to: '0040_literature_collection_revision'
       })
       await expect(access(`${databasePath}.before-${MIGRATION_ID}.backup`)).resolves.toBeUndefined()
       await expect(

--- a/src/main/database/database-null-and-version-bounds.test.ts
+++ b/src/main/database/database-null-and-version-bounds.test.ts
@@ -378,9 +378,10 @@ describe('D02/D04 persisted database boundaries', () => {
           '0036_content_verification_observation',
           '0037_literature_inbox_integrity',
           '0038_literature_search_text',
-          '0039_literature_metadata_commit_receipt'
+          '0039_literature_metadata_commit_receipt',
+          '0040_literature_collection_revision'
         ],
-        to: '0039_literature_metadata_commit_receipt'
+        to: '0040_literature_collection_revision'
       })
       // Literature adds contentBlobId to version rows while preserving their original fields.
       expect(await Promise.all(tables.map(readRows))).toMatchObject(before)

--- a/src/main/database/database-startup-logging.test.ts
+++ b/src/main/database/database-startup-logging.test.ts
@@ -131,7 +131,8 @@ describe('database startup logging', () => {
               '0036_content_verification_observation',
               '0037_literature_inbox_integrity',
               '0038_literature_search_text',
-              '0039_literature_metadata_commit_receipt'
+              '0039_literature_metadata_commit_receipt',
+              '0040_literature_collection_revision'
             ],
             adoptedLegacy: true
           })

--- a/src/main/database/generated/runtime-schema.ts
+++ b/src/main/database/generated/runtime-schema.ts
@@ -487,6 +487,7 @@ const RUNTIME_SCHEMA_TABLE_DDLS = [
     CONSTRAINT "LiteratureSourceRecord_shape_check" CHECK ((("itemId" IS NOT NULL AND "inboxCandidateId" IS NULL) OR ("itemId" IS NULL AND "inboxCandidateId" IS NOT NULL)) AND length(trim("provider")) > 0 AND ("externalId" IS NULL OR length(trim("externalId")) > 0) AND ("sourceUrl" IS NULL OR length(trim("sourceUrl")) > 0) AND length(trim("metadataChecksum")) > 0 AND json_valid("rawMetadataJson") AND json_type("rawMetadataJson") = 'object')
 );`,
   `CREATE TABLE IF NOT EXISTS "LiteratureCollection" (
+    "revision" INTEGER NOT NULL DEFAULT 1,
     "id" TEXT NOT NULL PRIMARY KEY,
     "name" TEXT NOT NULL,
     "nameKey" TEXT NOT NULL,

--- a/src/main/database/literature-collection-revision.test.ts
+++ b/src/main/database/literature-collection-revision.test.ts
@@ -1,0 +1,41 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, expect, it } from 'vitest'
+import { createProjectDbClient } from '../projects/prisma-client'
+import { migrateApplicationDatabase } from './migration-service'
+
+let root: string | undefined
+let client: ReturnType<typeof createProjectDbClient> | undefined
+afterEach(async () => {
+  await client?.$disconnect()
+  if (root) await rm(root, { recursive: true, force: true })
+})
+it('backfills collection revisions without changing existing values or hierarchy', async () => {
+  root = await mkdtemp(join(tmpdir(), 'collection-revision-'))
+  client = createProjectDbClient(root)
+  await migrateApplicationDatabase(client)
+  await client.literatureCollection.create({
+    data: { id: 'parent', name: 'Parent', nameKey: 'parent', description: 'Saved description' }
+  })
+  await client.literatureCollection.create({
+    data: { id: 'child', name: 'Child', nameKey: 'child', parentId: 'parent' }
+  })
+  const sql =
+    'SELECT "id", "name", "description", "parentId", "createdAt", "updatedAt" FROM "LiteratureCollection" ORDER BY "id"'
+  const before = await client.$queryRawUnsafe(sql)
+  await client.$executeRawUnsafe('ALTER TABLE "LiteratureCollection" DROP COLUMN "revision"')
+  await client.$executeRawUnsafe(
+    'DELETE FROM "_open_science_migrations" WHERE id = \'0040_literature_collection_revision\''
+  )
+  await expect(
+    migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
+  ).resolves.toMatchObject({ applied: ['0040_literature_collection_revision'] })
+  expect(await client.$queryRawUnsafe(sql)).toEqual(before)
+  expect(await client.literatureCollection.findMany({ select: { revision: true } })).toEqual([
+    { revision: 1 },
+    { revision: 1 }
+  ])
+  await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
+  expect(await client.$queryRawUnsafe('PRAGMA foreign_key_check')).toEqual([])
+})

--- a/src/main/database/literature-inbox-integrity-migration.test.ts
+++ b/src/main/database/literature-inbox-integrity-migration.test.ts
@@ -69,7 +69,7 @@ describe('Literature inbox integrity migration', () => {
       expect(await migrateApplicationDatabase(client)).toMatchObject({
         applied: expect.arrayContaining([
           '0037_literature_inbox_integrity',
-          '0039_literature_metadata_commit_receipt'
+          '0040_literature_collection_revision'
         ])
       })
       expect(await client.literatureSourceRecord.findMany()).toEqual(sources)

--- a/src/main/database/migration-service.test.ts
+++ b/src/main/database/migration-service.test.ts
@@ -332,21 +332,21 @@ describe('application database migrations', () => {
     const before = await client.literatureItem.findMany()
     await client.$executeRawUnsafe('DROP TABLE "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      `DELETE FROM "_open_science_migrations" WHERE id = '0039_literature_metadata_commit_receipt'`
+      `DELETE FROM "_open_science_migrations" WHERE id IN ('0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')`
     )
     const ledger = await client.$queryRawUnsafe(
       'SELECT * FROM "_open_science_migrations" ORDER BY id'
     )
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       from: '0038_literature_search_text',
-      to: '0039_literature_metadata_commit_receipt',
-      applied: ['0039_literature_metadata_commit_receipt']
+      to: '0040_literature_collection_revision',
+      applied: ['0039_literature_metadata_commit_receipt', '0040_literature_collection_revision']
     })
     expect(await client.literatureMetadataCommitReceipt.count()).toBe(0)
     expect(await client.literatureItem.findMany()).toEqual(before)
     expect(
       await client.$queryRawUnsafe(
-        `SELECT * FROM "_open_science_migrations" WHERE id <> '0039_literature_metadata_commit_receipt' ORDER BY id`
+        `SELECT * FROM "_open_science_migrations" WHERE id NOT IN ('0039_literature_metadata_commit_receipt', '0040_literature_collection_revision') ORDER BY id`
       )
     ).toEqual(ledger)
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -692,10 +692,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: null,
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     expect(compatibility).toEqual([{ sqliteVersion: expect.stringMatching(/^\d+\.\d+\.\d+$/) }])
     await expect(
@@ -708,8 +709,8 @@ describe('application database migrations', () => {
     await expect(migrateApplicationDatabase(client)).resolves.toEqual({
       adoptedLegacy: false,
       applied: [],
-      from: '0039_literature_metadata_commit_receipt',
-      to: '0039_literature_metadata_commit_receipt'
+      from: '0040_literature_collection_revision',
+      to: '0040_literature_collection_revision'
     })
   })
 
@@ -740,10 +741,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0033_compute_job_harvest_retry',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRaw<Array<{ name: string }>>`
@@ -850,7 +852,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(
@@ -943,7 +946,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -988,7 +992,7 @@ describe('application database migrations', () => {
 
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({
       applied: expect.arrayContaining(['0010_compute_password_auth']),
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$executeRawUnsafe(
@@ -1050,10 +1054,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -1143,10 +1148,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0005_project_preview_state_owner_fk',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRaw<
@@ -1269,7 +1275,7 @@ describe('application database migrations', () => {
       })
     ).rejects.toMatchObject({
       code: 'database_validation_failed',
-      migrationId: '0039_literature_metadata_commit_receipt'
+      migrationId: '0040_literature_collection_revision'
     })
     expect(retired).toEqual([])
     await expect(access(backupPath)).resolves.toBeUndefined()
@@ -1286,7 +1292,7 @@ describe('application database migrations', () => {
     ).resolves.toEqual({
       adoptedLegacy: false,
       applied: ['9997_test_suffix'],
-      from: '0039_literature_metadata_commit_receipt',
+      from: '0040_literature_collection_revision',
       to: '9997_test_suffix'
     })
     await expect(
@@ -1333,6 +1339,7 @@ describe('application database migrations', () => {
       { id: '0037_literature_inbox_integrity' },
       { id: '0038_literature_search_text' },
       { id: '0039_literature_metadata_commit_receipt' },
+      { id: '0040_literature_collection_revision' },
       { id: '9997_test_suffix' }
     ])
   })
@@ -1424,10 +1431,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0001_runtime_schema_baseline',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     expect(backupEvents).toEqual([
       {
@@ -1520,7 +1528,8 @@ describe('application database migrations', () => {
       { id: '0036_content_verification_observation' },
       { id: '0037_literature_inbox_integrity' },
       { id: '0038_literature_search_text' },
-      { id: '0039_literature_metadata_commit_receipt' }
+      { id: '0039_literature_metadata_commit_receipt' },
+      { id: '0040_literature_collection_revision' }
     ])
   })
 
@@ -1653,6 +1662,7 @@ describe('application database migrations', () => {
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
         '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision',
         '9997_test_suffix'
       ],
       to: '9997_test_suffix'
@@ -1790,7 +1800,7 @@ describe('application database migrations', () => {
       adoptedLegacy: false,
       applied: MIGRATION_MANIFEST.slice(computePasswordAuthIndex).map(({ id }) => id),
       from: '0009_vision_evidence',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRaw<Array<{ projectId: string }>>`
@@ -1917,7 +1927,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(
@@ -2053,7 +2064,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(migrateApplicationDatabase(client)).resolves.toMatchObject({ applied: [] })
@@ -2141,7 +2153,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(
@@ -2232,7 +2245,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
@@ -2357,7 +2371,8 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     await expect(
@@ -2880,8 +2895,8 @@ describe('application database migrations', () => {
         entries.filter((entry) => entry.endsWith('.backup')).sort()
       )
     ).resolves.toEqual([
-      'open-science.db.before-0038_literature_search_text.backup',
       'open-science.db.before-0039_literature_metadata_commit_receipt.backup',
+      'open-science.db.before-0040_literature_collection_revision.backup',
       unknownBackupName
     ])
     expect(retired).toHaveLength(MIGRATION_MANIFEST.length - 2)
@@ -3189,10 +3204,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ currentVersionId: string | null }>>(
@@ -3251,7 +3267,7 @@ describe('application database migrations', () => {
         MIGRATION_MANIFEST.findIndex(({ id }) => id === '0009_vision_evidence')
       ).map(({ id }) => id),
       from: '0008_database_json_constraints',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(verifyCurrentApplicationSchema(client)).resolves.toBeUndefined()
   })
@@ -3322,10 +3338,11 @@ describe('application database migrations', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0024_compute_job_file_evidence',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRaw<Array<{ uploadVersionId: string }>>`

--- a/src/main/database/migration-service.ts
+++ b/src/main/database/migration-service.ts
@@ -1,3 +1,4 @@
+import { literatureCollectionRevisionMigration } from './migrations/0040-literature-collection-revision'
 import {
   literatureSearchTextMigration,
   backfillLiteratureSearchText
@@ -792,6 +793,17 @@ const MIGRATION_MANIFEST = [
     ),
     backupOnApply: 'required',
     backupRetention: 'retain'
+  },
+  {
+    ...literatureCollectionRevisionMigration,
+    checksum: checksumMigrationPayload(
+      literatureCollectionRevisionMigration.id,
+      literatureCollectionRevisionMigration.statements,
+      literatureCollectionRevisionMigration.verifiers,
+      literatureCollectionRevisionMigration.operations
+    ),
+    backupOnApply: 'required',
+    backupRetention: 'retain'
   }
 ] as const satisfies readonly MigrationManifestEntry[]
 // schema-locality: begin frozen-0001-repairs
@@ -1213,6 +1225,7 @@ const verifyCurrentApplicationSchema = async (client: PrismaClient): Promise<voi
   await runMigrationVerifiers(client, literaturePdfProvenanceMigration.verifiers)
   await runMigrationVerifiers(client, contentVerificationObservationMigration.verifiers)
   await runMigrationVerifiers(client, literatureMetadataCommitReceiptMigration.verifiers)
+  await runMigrationVerifiers(client, literatureCollectionRevisionMigration.verifiers)
 }
 
 const readLedger = async (client: PrismaClient): Promise<LedgerRow[]> => {

--- a/src/main/database/migrations/0040-literature-collection-revision.ts
+++ b/src/main/database/migrations/0040-literature-collection-revision.ts
@@ -1,5 +1,5 @@
 /* Immutable collection edit concurrency migration. */
-export const literatureCollectionRevisionMigration = {
+const literatureCollectionRevisionMigration = {
   id: '0040_literature_collection_revision',
   statements: [
     'ALTER TABLE "LiteratureCollection" ADD COLUMN "revision" INTEGER NOT NULL DEFAULT 1'
@@ -9,3 +9,5 @@ export const literatureCollectionRevisionMigration = {
     { kind: 'column-exists', version: 1, table: 'LiteratureCollection', column: 'revision' }
   ] as const
 }
+
+export { literatureCollectionRevisionMigration }

--- a/src/main/database/migrations/0040-literature-collection-revision.ts
+++ b/src/main/database/migrations/0040-literature-collection-revision.ts
@@ -1,0 +1,11 @@
+/* Immutable collection edit concurrency migration. */
+export const literatureCollectionRevisionMigration = {
+  id: '0040_literature_collection_revision',
+  statements: [
+    'ALTER TABLE "LiteratureCollection" ADD COLUMN "revision" INTEGER NOT NULL DEFAULT 1'
+  ] as const,
+  operations: [] as const,
+  verifiers: [
+    { kind: 'column-exists', version: 1, table: 'LiteratureCollection', column: 'revision' }
+  ] as const
+}

--- a/src/main/database/notification-attention-metadata-migration.test.ts
+++ b/src/main/database/notification-attention-metadata-migration.test.ts
@@ -98,10 +98,11 @@ describe('notification attention metadata migration', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0006_database_domain_constraints',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       access(`${databasePath}.before-0007_notification_attention_metadata.backup`)

--- a/src/main/database/permission-approval-summary.test.ts
+++ b/src/main/database/permission-approval-summary.test.ts
@@ -23,7 +23,7 @@ it('upgrades historical permissions without inferring descriptions or changing a
     await client.$executeRawUnsafe('ALTER TABLE "PermissionGrant" DROP COLUMN "approvalSummary"')
     await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')"
+      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')"
     )
     const before = await client.$queryRawUnsafe(
       'SELECT id, capabilityKind, capabilityKey, qualifierMode, qualifierValue, scopeKind, projectId, sessionId, fingerprint, revision, createdAt FROM "PermissionGrant"'
@@ -39,7 +39,8 @@ it('upgrades historical permissions without inferring descriptions or changing a
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     const after = await client.$queryRawUnsafe<Array<Record<string, unknown>>>(

--- a/src/main/database/project-archive-revision.test.ts
+++ b/src/main/database/project-archive-revision.test.ts
@@ -35,7 +35,7 @@ describe('Project archive revision', () => {
     await client.$executeRawUnsafe('ALTER TABLE "Project" DROP COLUMN "archiveRevision"')
     await client.$executeRawUnsafe('DROP TABLE IF EXISTS "LiteratureMetadataCommitReceipt"')
     await client.$executeRawUnsafe(
-      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt')"
+      "DELETE FROM \"_open_science_migrations\" WHERE id IN ('0031_project_archive_revision', '0032_permission_approval_summary', '0033_compute_job_harvest_retry', '0034_background_result_delivery', '0035_literature_pdf_provenance', '0036_content_verification_observation', '0037_literature_inbox_integrity', '0038_literature_search_text', '0039_literature_metadata_commit_receipt', '0040_literature_collection_revision')"
     )
     await expect(
       migrateApplicationDatabase(client, { databasePath: join(root, 'open-science.db') })
@@ -49,7 +49,8 @@ describe('Project archive revision', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ]
     })
     expect(

--- a/src/main/database/project-session-defaults-migration.test.ts
+++ b/src/main/database/project-session-defaults-migration.test.ts
@@ -76,10 +76,11 @@ describe('Project Session defaults migration', () => {
         '0036_content_verification_observation',
         '0037_literature_inbox_integrity',
         '0038_literature_search_text',
-        '0039_literature_metadata_commit_receipt'
+        '0039_literature_metadata_commit_receipt',
+        '0040_literature_collection_revision'
       ],
       from: '0026_compute_job_remote_cleanup',
-      to: '0039_literature_metadata_commit_receipt'
+      to: '0040_literature_collection_revision'
     })
     await expect(
       client.$queryRawUnsafe<Array<{ sessionDefaults: string }>>(

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1777,7 +1777,8 @@ const createApplicationModules = async (
     () => getProjectDbClient(configRoot),
     () => tagService.notifyAssignmentsChanged(),
     contentRepository,
-    (remove) => sessionPersistenceCoordinator.withLiteratureAttachmentRemoval(remove)
+    (remove) => sessionPersistenceCoordinator.withLiteratureAttachmentRemoval(remove),
+    (event) => applicationEvents.publish('literature:changed', event)
   )
   const literatureCitationStyles = new LiteratureCitationStyleLibrary(
     join(resolveDataRoot(), 'literature', 'citation-styles')

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -8,6 +8,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   createLiteratureIdentifierUrl,
   literatureCatalogSearchRequestSchema,
+  literatureCatalogCommandSchema,
+  type LiteratureCollectionView,
   literatureCandidateInputSchema,
   literatureItemInputSchema,
   type LiteratureCandidateInput
@@ -2650,6 +2652,199 @@ describe('LiteratureCatalog', () => {
     })
   })
 
+  it('publishes committed literature writes, excluding no-ops, previews and rollbacks', async () => {
+    await setup()
+    const events = vi.fn()
+    const catalog = new LiteratureCatalog(
+      async () => client!,
+      undefined,
+      undefined,
+      undefined,
+      events
+    )
+    const created = await catalog.transact({ kind: 'create-item', item: candidate().item })
+    expect(events).toHaveBeenLastCalledWith({
+      revision: 1,
+      itemIds: [created.id],
+      collectionIds: undefined
+    })
+    expect((await catalog.get(created.id))!.item.title).toBe(candidate().item.title)
+    events.mockClear()
+    await catalog.importItems([])
+    await catalog.inspectImportItems([candidate().item], [])
+    await expect(
+      catalog.transact({
+        kind: 'set-item-lifecycle',
+        itemIds: [created.id, 'missing'],
+        state: 'deleted'
+      })
+    ).rejects.toThrow()
+    await expect(
+      catalog.transact({
+        kind: 'update-item',
+        itemId: created.id,
+        expectedMetadataRevision: 999,
+        item: candidate().item
+      })
+    ).rejects.toThrow()
+    expect(events).not.toHaveBeenCalled()
+    expect(await catalog.get(created.id)).toBeDefined()
+    const collection = await catalog.transact({ kind: 'create-collection', name: 'Shared' })
+    const linking = {
+      kind: 'set-collection-item' as const,
+      collectionId: collection.id,
+      itemId: created.id,
+      included: true
+    }
+    await catalog.transact(linking)
+    expect(events).toHaveBeenLastCalledWith(
+      expect.objectContaining({ itemIds: [created.id], collectionIds: [collection.id] })
+    )
+    events.mockClear()
+    await catalog.transact(linking)
+    expect(events).not.toHaveBeenCalled()
+    const input = { ...candidate().item, title: 'Saved despite failed delivery' }
+    events.mockImplementation(() => {
+      throw new Error('Disconnected renderer')
+    })
+    await expect(
+      catalog.transact({
+        kind: 'update-item',
+        itemId: created.id,
+        expectedMetadataRevision: 1,
+        item: input
+      })
+    ).resolves.toMatchObject({ id: created.id })
+    expect((await catalog.get(created.id))!.item.title).toBe(input.title)
+  })
+
+  it('rejects stale collection edits after promotion, deletion and request retry', async () => {
+    const catalog = await setup()
+    const parent = await catalog.transact({ kind: 'create-collection', name: 'Parent' })
+    const child = await catalog.transact({
+      kind: 'create-collection',
+      name: 'Child',
+      parentId: parent.id
+    })
+    const command = {
+      kind: 'update-collection' as const,
+      collectionId: child.id,
+      expectedRevision: 1,
+      name: 'Changed',
+      description: ''
+    }
+    await catalog.transact({ kind: 'delete-collection', collectionId: parent.id })
+    await expect(catalog.transact(command)).rejects.toThrow(
+      'literature_collection_revision_conflict'
+    )
+    await catalog.transact({ ...command, expectedRevision: 2 })
+    await expect(catalog.transact({ ...command, expectedRevision: 2 })).rejects.toThrow(
+      'literature_collection_revision_conflict'
+    )
+    await catalog.transact({ kind: 'delete-collection', collectionId: child.id })
+    const recreated = await catalog.transact({ kind: 'create-collection', name: 'Changed' })
+    expect(recreated.id).not.toBe(child.id)
+    await expect(catalog.transact({ ...command, expectedRevision: 3 })).rejects.toThrow(
+      'literature_collection_revision_conflict'
+    )
+  })
+
+  it.each(['name', 'description'] as const)(
+    'does not silently overwrite a prior collection edit when a stale editor changes %s',
+    async (field) => {
+      const first = await setup()
+      const second = new LiteratureCatalog(async () => client!)
+      const created = await first.transact({
+        kind: 'create-collection',
+        name: 'Original',
+        description: 'Original description'
+      })
+      const read = async (catalog: LiteratureCatalog): Promise<LiteratureCollectionView> =>
+        (await catalog.search({ scope: 'collections' })).entries.find(
+          (entry) => 'id' in entry && entry.id === created.id
+        ) as LiteratureCollectionView
+      const snapshotA = await read(first)
+      const snapshotB = await read(second)
+      expect(snapshotB).toEqual(snapshotA)
+      await first.transact(
+        literatureCatalogCommandSchema.parse({
+          kind: 'update-collection',
+          expectedRevision: 1,
+          collectionId: created.id,
+          name: 'Renamed by A',
+          description: snapshotA.description
+        })
+      )
+      expect((await read(first)).name).toBe('Renamed by A')
+      const [saveB] = await Promise.allSettled([
+        second.transact(
+          literatureCatalogCommandSchema.parse({
+            kind: 'update-collection',
+            expectedRevision: snapshotA.revision,
+            collectionId: created.id,
+            name: field === 'name' ? 'Renamed by B' : snapshotB.name,
+            description: field === 'description' ? 'Description from B' : snapshotB.description
+          })
+        )
+      ])
+      const final = await read(first)
+      // A visible conflict or an explicit disjoint-field merge are both safe policies.
+      expect.soft(saveB.status).toBe('rejected')
+      expect(final.name).toBe('Renamed by A')
+      expect(final.description).toBe(
+        saveB.status === 'fulfilled' && field === 'description'
+          ? 'Description from B'
+          : snapshotA.description
+      )
+    }
+  )
+
+  it('reads new attachments and relationships without a metadata or parent timestamp change', async () => {
+    const catalog = await setup()
+    const created = await catalog.transact({ kind: 'create-item', item: candidate().item })
+    const before = (await catalog.get(created.id))!
+    const collection = await catalog.transact({ kind: 'create-collection', name: 'Related' })
+    await catalog.transact({
+      kind: 'set-collection-item',
+      collectionId: collection.id,
+      itemId: created.id,
+      included: true
+    })
+    await catalog.transact({
+      kind: 'set-project-item',
+      projectId: 'project-1',
+      itemId: created.id,
+      included: true,
+      source: 'user'
+    })
+    const checksum = 'a'.repeat(64)
+    await client!.contentBlob.create({
+      data: {
+        id: 'relation-blob',
+        checksum,
+        storageKey: 'content/relation-blob',
+        sizeBytes: 128n,
+        contentType: 'application/pdf',
+        state: 'available',
+        verifiedAt: new Date()
+      }
+    })
+    await catalog.attachContent({
+      itemId: created.id,
+      contentBlobId: 'relation-blob',
+      filename: 'new.pdf',
+      contentType: 'application/pdf',
+      sizeBytes: 128,
+      checksum
+    })
+    const after = (await catalog.get(created.id))!
+    expect(after.attachments).toHaveLength(1)
+    expect(after.collectionIds).toEqual([collection.id])
+    expect(after.projectIds).toEqual(['project-1'])
+    expect(after.metadataRevision).toBe(before.metadataRevision)
+    expect(after.updatedAt).toBe(before.updatedAt)
+  })
+
   it('enforces sibling Collection names while allowing the same name under different parents', async () => {
     const catalog = await setup()
     const root = await catalog.transact({ kind: 'create-collection', name: ' Review   queue ' })
@@ -2671,6 +2866,7 @@ describe('LiteratureCatalog', () => {
     await expect(
       catalog.transact({
         kind: 'update-collection',
+        expectedRevision: 1,
         collectionId: other.id,
         name: 'Review queue',
         description: ''
@@ -2679,6 +2875,7 @@ describe('LiteratureCatalog', () => {
     await expect(
       catalog.transact({
         kind: 'update-collection',
+        expectedRevision: 1,
         collectionId: child.id,
         name: 'REVIEW QUEUE',
         description: 'Updated'
@@ -2719,6 +2916,7 @@ describe('LiteratureCatalog', () => {
     })
     await catalog.transact({
       kind: 'update-collection',
+      expectedRevision: 1,
       collectionId: child.id,
       name: 'Child review',
       description: ''
@@ -2762,6 +2960,7 @@ describe('LiteratureCatalog', () => {
 
     await catalog.transact({
       kind: 'update-collection',
+      expectedRevision: 1,
       collectionId: collection.id,
       name: 'Included studies',
       description: 'Final synthesis set.'

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -2579,20 +2579,13 @@ describe('LiteratureCatalog', () => {
     const catalog = await setup()
     const source = await catalog.transact({ kind: 'create-collection', name: 'Source' })
     const target = await catalog.transact({ kind: 'create-collection', name: 'Target' })
-    const ids: string[] = []
-    for (let index = 0; index < 201; index++) {
-      const item = await catalog.transact({
-        kind: 'create-item',
-        item: candidate({ doi: `10.1234/batch-${index}`, title: `Reference ${index}` }).item
-      })
-      ids.push(item.id)
-      await catalog.transact({
-        kind: 'set-collection-item',
-        collectionId: source.id,
-        itemId: item.id,
-        included: true
-      })
-    }
+    const { itemIds: ids } = await catalog.importItems(
+      Array.from(
+        { length: 201 },
+        (_, index) => candidate({ doi: `10.1234/batch-${index}`, title: `Reference ${index}` }).item
+      ),
+      source.id
+    )
     await catalog.transact({
       kind: 'move-collection-items',
       sourceCollectionId: source.id,

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -1440,7 +1440,20 @@ class LiteratureCatalog {
       select: { contentBlobId: true }
     })
     if (!version) throw new Error('Literature Attachment is unavailable.')
-    const verification = await this.content.verify(version.contentBlobId, { retry: true })
+    const verification = await this.content
+      .verify(version.contentBlobId, { retry: true })
+      .catch((error: unknown) => {
+        // Content verification persists permission-denied observations before rethrowing the OS error.
+        if (
+          typeof error === 'object' &&
+          error !== null &&
+          'code' in error &&
+          (error.code === 'EACCES' || error.code === 'EPERM')
+        ) {
+          this.publishChanged({ itemIds: [command.itemId] })
+        }
+        throw error
+      })
     // Verification persists its observation before returning, including an unavailable result.
     // This invalidates that committed observation; it is not a successful verification notice.
     this.publishChanged({ itemIds: [command.itemId] })

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -18,6 +18,7 @@ import {
   LITERATURE_IDENTITY_SCHEMES,
   LITERATURE_IMPORT_IDENTITY_CONFLICT,
   LITERATURE_COLLECTION_NAME_CONFLICT,
+  LITERATURE_COLLECTION_REVISION_CONFLICT,
   literatureCandidateInputSchema,
   literaturePdfProvenanceSchema,
   type LiteraturePdfProvenance,
@@ -26,6 +27,7 @@ import {
   normalizeLiteratureIdentifierValue,
   normalizeLiteratureIdentifierPreferences,
   type LiteratureCatalogCommand,
+  type LiteratureChangedEvent,
   type LiteratureDuplicatePolicy,
   type LiteratureCollectionView,
   type LiteratureCatalogReceipt,
@@ -779,8 +781,46 @@ class LiteratureCatalog {
       remove((attachmentIds) => {
         // Metadata-only clients may delete metadata, but cannot bypass attachment authority.
         if (attachmentIds.length) throw new Error('Literature attachment removal is unavailable.')
-      })
+      }),
+    private readonly onChanged?: (event: LiteratureChangedEvent) => void
   ) {}
+
+  private revision = 0
+
+  private publishChanged(change: Omit<LiteratureChangedEvent, 'revision'>): void {
+    try {
+      this.onChanged?.({ ...change, revision: ++this.revision })
+    } catch (error) {
+      log.warn('Could not publish committed literature changes', { error })
+    }
+  }
+
+  // Observe writes on the transaction's own SQLite connection. Read-only previews and empty
+  // upserts do not emit; rollback cannot reach publication. Delivery cannot undo the commit.
+  private async commit<T>(
+    client: LiteratureCatalogClient,
+    operation: (transaction: Prisma.TransactionClient) => Promise<T>,
+    changes:
+      | Omit<LiteratureChangedEvent, 'revision'>
+      | ((result: T) => Omit<LiteratureChangedEvent, 'revision'>),
+    options?: { timeout: number }
+  ): Promise<T> {
+    if (!this.onChanged) return client.$transaction(operation, options)
+    const committed = await client.$transaction(async (transaction) => {
+      const count = async (): Promise<bigint> =>
+        (
+          await transaction.$queryRawUnsafe<{ count: bigint }[]>('SELECT total_changes() AS count')
+        )[0]!.count
+      const before = await count()
+      const result = await operation(transaction)
+      return { result, changed: (await count()) !== before }
+    }, options)
+    if (committed.changed) {
+      duplicateGroups.delete(client)
+      this.publishChanged(typeof changes === 'function' ? changes(committed.result) : changes)
+    }
+    return committed.result
+  }
 
   private async publishTagAssignmentsChanged(): Promise<void> {
     try {
@@ -870,6 +910,7 @@ class LiteratureCatalog {
       return {
         entries: rows.slice(0, limit).map((row): LiteratureCollectionView => ({
           id: row.id,
+          revision: row.revision,
           name: row.name,
           description: row.description,
           parentId: row.parentId ?? undefined,
@@ -1232,88 +1273,92 @@ class LiteratureCatalog {
     }
 
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
-      const [item, blob] = await Promise.all([
-        transaction.literatureItem.findFirst({
-          where: { id: itemId, deletedAt: null },
-          select: { id: true, metadataRevision: true }
-        }),
-        transaction.contentBlob.findUnique({ where: { id: input.contentBlobId } })
-      ])
-      if (!item) throw new Error('Literature Item is unavailable.')
-      if (
-        input.expectedMetadataRevision !== undefined &&
-        item.metadataRevision !== input.expectedMetadataRevision
-      ) {
-        throw new Error('Literature Item changed before the PDF could be attached.')
-      }
-      if (
-        !blob ||
-        blob.state !== 'available' ||
-        blob.checksum !== input.checksum ||
-        blob.sizeBytes !== BigInt(input.sizeBytes) ||
-        (blob.contentType !== null && blob.contentType !== contentType)
-      ) {
-        throw new Error('Literature attachment bytes do not match the content authority.')
-      }
+    return this.commit(
+      client,
+      async (transaction) => {
+        const [item, blob] = await Promise.all([
+          transaction.literatureItem.findFirst({
+            where: { id: itemId, deletedAt: null },
+            select: { id: true, metadataRevision: true }
+          }),
+          transaction.contentBlob.findUnique({ where: { id: input.contentBlobId } })
+        ])
+        if (!item) throw new Error('Literature Item is unavailable.')
+        if (
+          input.expectedMetadataRevision !== undefined &&
+          item.metadataRevision !== input.expectedMetadataRevision
+        ) {
+          throw new Error('Literature Item changed before the PDF could be attached.')
+        }
+        if (
+          !blob ||
+          blob.state !== 'available' ||
+          blob.checksum !== input.checksum ||
+          blob.sizeBytes !== BigInt(input.sizeBytes) ||
+          (blob.contentType !== null && blob.contentType !== contentType)
+        ) {
+          throw new Error('Literature attachment bytes do not match the content authority.')
+        }
 
-      if (!input.attachmentId) {
-        const existingItemVersion = await transaction.literatureAttachmentVersion.findFirst({
-          where: { checksum: input.checksum, attachment: { itemId } },
-          select: { id: true, attachmentId: true }
-        })
-        if (existingItemVersion) {
-          return {
-            attachmentId: existingItemVersion.attachmentId,
-            versionId: existingItemVersion.id
+        if (!input.attachmentId) {
+          const existingItemVersion = await transaction.literatureAttachmentVersion.findFirst({
+            where: { checksum: input.checksum, attachment: { itemId } },
+            select: { id: true, attachmentId: true }
+          })
+          if (existingItemVersion) {
+            return {
+              attachmentId: existingItemVersion.attachmentId,
+              versionId: existingItemVersion.id
+            }
           }
         }
-      }
 
-      const attachment = input.attachmentId
-        ? await transaction.literatureAttachment.findFirst({
-            where: { id: input.attachmentId, itemId },
-            select: { id: true }
-          })
-        : await transaction.literatureAttachment.create({
-            data: {
-              itemId,
-              kind,
-              title: input.title?.trim() ?? '',
-              sortOrder: await transaction.literatureAttachment.count({ where: { itemId } })
-            },
-            select: { id: true }
-          })
-      if (!attachment) throw new Error('Literature Attachment is unavailable.')
+        const attachment = input.attachmentId
+          ? await transaction.literatureAttachment.findFirst({
+              where: { id: input.attachmentId, itemId },
+              select: { id: true }
+            })
+          : await transaction.literatureAttachment.create({
+              data: {
+                itemId,
+                kind,
+                title: input.title?.trim() ?? '',
+                sortOrder: await transaction.literatureAttachment.count({ where: { itemId } })
+              },
+              select: { id: true }
+            })
+        if (!attachment) throw new Error('Literature Attachment is unavailable.')
 
-      const existing = await transaction.literatureAttachmentVersion.findUnique({
-        where: {
-          attachmentId_checksum: { attachmentId: attachment.id, checksum: input.checksum }
-        },
-        select: { id: true }
-      })
-      if (existing) return { attachmentId: attachment.id, versionId: existing.id }
-      const latest = await transaction.literatureAttachmentVersion.findFirst({
-        where: { attachmentId: attachment.id },
-        orderBy: { versionNumber: 'desc' },
-        select: { versionNumber: true }
-      })
-      const version = await transaction.literatureAttachmentVersion.create({
-        data: {
-          attachmentId: attachment.id,
-          contentBlobId: blob.id,
-          versionNumber: (latest?.versionNumber ?? 0) + 1,
-          filename,
-          contentType,
-          sizeBytes: BigInt(input.sizeBytes),
-          checksum: input.checksum,
-          pageCount: input.pageCount,
-          provenanceJson
-        },
-        select: { id: true }
-      })
-      return { attachmentId: attachment.id, versionId: version.id }
-    })
+        const existing = await transaction.literatureAttachmentVersion.findUnique({
+          where: {
+            attachmentId_checksum: { attachmentId: attachment.id, checksum: input.checksum }
+          },
+          select: { id: true }
+        })
+        if (existing) return { attachmentId: attachment.id, versionId: existing.id }
+        const latest = await transaction.literatureAttachmentVersion.findFirst({
+          where: { attachmentId: attachment.id },
+          orderBy: { versionNumber: 'desc' },
+          select: { versionNumber: true }
+        })
+        const version = await transaction.literatureAttachmentVersion.create({
+          data: {
+            attachmentId: attachment.id,
+            contentBlobId: blob.id,
+            versionNumber: (latest?.versionNumber ?? 0) + 1,
+            filename,
+            contentType,
+            sizeBytes: BigInt(input.sizeBytes),
+            checksum: input.checksum,
+            pageCount: input.pageCount,
+            provenanceJson
+          },
+          select: { id: true }
+        })
+        return { attachmentId: attachment.id, versionId: version.id }
+      },
+      { itemIds: [itemId] }
+    )
   }
 
   async transact(command: LiteratureCatalogCommand): Promise<LiteratureCatalogReceipt> {
@@ -1362,20 +1407,24 @@ class LiteratureCatalog {
     assertUnreferenced: (attachmentIds: readonly string[]) => void
   ): Promise<string[]> {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
-      const attachment = await transaction.literatureAttachment.findFirst({
-        where: {
-          id: command.attachmentId,
-          itemId: command.itemId,
-          item: { deletedAt: null, mergedIntoItemId: null }
-        },
-        select: { versions: { select: { contentBlobId: true } } }
-      })
-      if (!attachment) throw new Error('Literature Attachment is unavailable.')
-      assertUnreferenced([command.attachmentId])
-      await transaction.literatureAttachment.delete({ where: { id: command.attachmentId } })
-      return attachment.versions.map(({ contentBlobId }) => contentBlobId)
-    })
+    return this.commit(
+      client,
+      async (transaction) => {
+        const attachment = await transaction.literatureAttachment.findFirst({
+          where: {
+            id: command.attachmentId,
+            itemId: command.itemId,
+            item: { deletedAt: null, mergedIntoItemId: null }
+          },
+          select: { versions: { select: { contentBlobId: true } } }
+        })
+        if (!attachment) throw new Error('Literature Attachment is unavailable.')
+        assertUnreferenced([command.attachmentId])
+        await transaction.literatureAttachment.delete({ where: { id: command.attachmentId } })
+        return attachment.versions.map(({ contentBlobId }) => contentBlobId)
+      },
+      { itemIds: [command.itemId] }
+    )
   }
 
   private async verifyAttachment(
@@ -1392,6 +1441,9 @@ class LiteratureCatalog {
     })
     if (!version) throw new Error('Literature Attachment is unavailable.')
     const verification = await this.content.verify(version.contentBlobId, { retry: true })
+    // Verification persists its observation before returning, including an unavailable result.
+    // This invalidates that committed observation; it is not a successful verification notice.
+    this.publishChanged({ itemIds: [command.itemId] })
     if (verification.state === 'unavailable') {
       throw new Error(`Literature attachment verification failed: ${verification.reason}`)
     }
@@ -1450,69 +1502,70 @@ class LiteratureCatalog {
   ): Promise<LiteratureRecordImportReceipt> {
     const items = inputs.map((item) => literatureItemInputSchema.parse(item))
     const client = await this.getClient()
-    return client
-      .$transaction(
-        async (transaction) => {
-          let nextSortOrder = 0
-          if (collectionId) {
-            const collection = await transaction.literatureCollection.findUnique({
-              where: { id: collectionId },
-              select: { id: true }
-            })
-            if (!collection) throw new Error('Literature Collection is unavailable.')
-            const last = await transaction.literatureCollectionItem.findFirst({
-              where: { collectionId },
-              orderBy: { sortOrder: 'desc' },
-              select: { sortOrder: true }
-            })
-            nextSortOrder = (last?.sortOrder ?? -1) + 1
-          }
+    return this.commit(
+      client,
+      async (transaction) => {
+        let nextSortOrder = 0
+        if (collectionId) {
+          const collection = await transaction.literatureCollection.findUnique({
+            where: { id: collectionId },
+            select: { id: true }
+          })
+          if (!collection) throw new Error('Literature Collection is unavailable.')
+          const last = await transaction.literatureCollectionItem.findFirst({
+            where: { collectionId },
+            orderBy: { sortOrder: 'desc' },
+            select: { sortOrder: true }
+          })
+          nextSortOrder = (last?.sortOrder ?? -1) + 1
+        }
 
-          const identities = await importIdentityMap(transaction, items)
-          const resolutions =
-            duplicatePolicy === 'separate' ? [] : resolveImportItems(identities, items)
-          if (resolutions.some(({ conflict }) => conflict))
-            throw new Error(LITERATURE_IMPORT_IDENTITY_CONFLICT)
-          const importedTargets = new Map<number, string>()
-          const itemIds: string[] = []
-          let createdCount = 0
-          let reusedCount = 0
-          for (const [inputIndex, item] of items.entries()) {
-            const target = resolutions[inputIndex]?.target
-            const existingId =
-              typeof target === 'string'
-                ? target
-                : target === undefined
-                  ? undefined
-                  : importedTargets.get(target)
-            const itemId = existingId ?? (await createItem(transaction, item))
-            if (existingId) {
-              await restoreExistingItem(transaction, existingId)
-              if (duplicatePolicy === 'fill-missing') {
-                await supplementExistingItem(transaction, existingId, item)
-              }
-              reusedCount += 1
-            } else {
-              createdCount += 1
+        const identities = await importIdentityMap(transaction, items)
+        const resolutions =
+          duplicatePolicy === 'separate' ? [] : resolveImportItems(identities, items)
+        if (resolutions.some(({ conflict }) => conflict))
+          throw new Error(LITERATURE_IMPORT_IDENTITY_CONFLICT)
+        const importedTargets = new Map<number, string>()
+        const itemIds: string[] = []
+        let createdCount = 0
+        let reusedCount = 0
+        for (const [inputIndex, item] of items.entries()) {
+          const target = resolutions[inputIndex]?.target
+          const existingId =
+            typeof target === 'string'
+              ? target
+              : target === undefined
+                ? undefined
+                : importedTargets.get(target)
+          const itemId = existingId ?? (await createItem(transaction, item))
+          if (existingId) {
+            await restoreExistingItem(transaction, existingId)
+            if (duplicatePolicy === 'fill-missing') {
+              await supplementExistingItem(transaction, existingId, item)
             }
-            importedTargets.set(inputIndex, itemId)
-            if (!itemIds.includes(itemId)) itemIds.push(itemId)
-            if (collectionId) {
-              await transaction.literatureCollectionItem.upsert({
-                where: { collectionId_itemId: { collectionId, itemId } },
-                create: { collectionId, itemId, sortOrder: nextSortOrder },
-                update: {}
-              })
-              nextSortOrder += 1
-            }
+            reusedCount += 1
+          } else {
+            createdCount += 1
           }
-          return { itemIds, createdCount, reusedCount }
-        },
-        // The parser admits up to 1,000 references, including large author lists. Keep this
-        // operation atomic without applying Prisma's five-second single-command deadline.
-        { timeout: 60_000 }
-      )
-      .finally(() => duplicateGroups.delete(client))
+          importedTargets.set(inputIndex, itemId)
+          if (!itemIds.includes(itemId)) itemIds.push(itemId)
+          if (collectionId) {
+            await transaction.literatureCollectionItem.upsert({
+              where: { collectionId_itemId: { collectionId, itemId } },
+              create: { collectionId, itemId, sortOrder: nextSortOrder },
+              update: {}
+            })
+            nextSortOrder += 1
+          }
+        }
+        return { itemIds, createdCount, reusedCount }
+      },
+      (result) => ({
+        itemIds: result.itemIds,
+        collectionIds: collectionId ? [collectionId] : undefined
+      }),
+      { timeout: 60_000 }
+    ).finally(() => duplicateGroups.delete(client))
   }
 
   async inspectImportItems(
@@ -1584,8 +1637,9 @@ class LiteratureCatalog {
     const item = literatureItemInputSchema.parse(command.item)
     const client = await this.getClient()
 
-    return client
-      .$transaction(async (transaction): Promise<LiteratureCatalogReceipt> => {
+    return this.commit(
+      client,
+      async (transaction): Promise<LiteratureCatalogReceipt> => {
         if (operationId) {
           const receipt = await transaction.literatureMetadataCommitReceipt.findUnique({
             where: { operationId }
@@ -1616,8 +1670,9 @@ class LiteratureCatalog {
           })
         }
         return { kind: 'item', id: itemId, state: 'present' }
-      })
-      .finally(() => duplicateGroups.delete(client))
+      },
+      { itemIds: [itemId] }
+    ).finally(() => duplicateGroups.delete(client))
   }
 
   private async stageCandidate(
@@ -1631,123 +1686,137 @@ class LiteratureCatalog {
       : null
     const identifiers = normalizedIdentifiers(candidate.item.identifiers)
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
-      signal?.throwIfAborted()
-      const existingItemId = await findIdentityItem(transaction, identifiers)
-      const existingItem = existingItemId
-        ? await transaction.literatureItem.findUnique({
-            where: { id: existingItemId },
-            select: { deletedAt: true }
-          })
-        : undefined
-      signal?.throwIfAborted()
-      // From the first write onward this transaction settles atomically, even if cancelled.
-      if (existingItemId && existingItem?.deletedAt === null && !pdf) {
-        await attachProjectIfPresent(
-          transaction,
-          candidate.origin.projectId,
-          existingItemId,
-          candidate.origin.kind
-        )
-        await this.attachSource(transaction, { source: candidate.source, itemId: existingItemId })
-        return { kind: 'item', id: existingItemId, state: 'present' }
-      }
-      const dedupeKey = pdf
-        ? sha256(`pdf:${candidateDedupeKey(candidate)}:${pdf.checksum}`)
-        : candidateDedupeKey(candidate)
-      const previous = await transaction.literatureInboxCandidate.findUnique({
-        where: { dedupeKey },
-        include: { acceptedItem: { select: { deletedAt: true } } }
-      })
-      if (previous?.state === 'accepted' && previous.acceptedItem?.deletedAt) {
-        // Keep the accepted review history while giving this deletion a new review opportunity.
-        await transaction.literatureInboxCandidate.update({
-          where: { id: previous.id },
-          data: { dedupeKey: `accepted:${previous.id}` }
-        })
-      }
-      const candidateJson = canonicalJson(candidate)
-      const metadataChecksum = sha256(candidateJson)
-      const persisted = await transaction.literatureInboxCandidate.upsert({
-        where: { dedupeKey },
-        create: {
-          dedupeKey,
-          itemType: candidate.item.itemType,
-          title: candidate.item.title,
-          abstract: candidate.item.abstract,
-          issuedYear: candidate.item.issuedYear,
-          candidateJson,
-          metadataChecksum,
-          origin: candidate.origin.kind,
-          sourceProjectId: candidate.origin.projectId,
-          sourceSessionId: candidate.origin.sessionId
-        },
-        update: {},
-        select: { id: true, state: true }
-      })
-      const contextKey = canonicalJson([
-        candidate.origin.kind,
-        candidate.origin.projectId ?? null,
-        candidate.origin.sessionId ?? null
-      ])
-      await transaction.literatureCandidateDiscovery.upsert({
-        where: { candidateId_contextKey: { candidateId: persisted.id, contextKey } },
-        create: {
-          candidateId: persisted.id,
-          contextKey,
-          origin: candidate.origin.kind,
-          projectId: candidate.origin.projectId,
-          sessionId: candidate.origin.sessionId
-        },
-        update: {}
-      })
-      if (persisted.state === 'pending') {
-        if (pdf) {
-          const blob = await transaction.contentBlob.findUnique({
-            where: { id: pdf.contentBlobId }
-          })
-          if (
-            !blob ||
-            blob.state !== 'available' ||
-            blob.checksum !== pdf.checksum ||
-            blob.sizeBytes !== BigInt(pdf.sizeBytes) ||
-            (blob.contentType && blob.contentType !== 'application/pdf')
+    return this.commit(
+      client,
+      async (transaction) => {
+        signal?.throwIfAborted()
+        const existingItemId = await findIdentityItem(transaction, identifiers)
+        const existingItem = existingItemId
+          ? await transaction.literatureItem.findUnique({
+              where: { id: existingItemId },
+              select: { deletedAt: true }
+            })
+          : undefined
+        signal?.throwIfAborted()
+        // From the first write onward this transaction settles atomically, even if cancelled.
+        if (existingItemId && existingItem?.deletedAt === null && !pdf) {
+          await attachProjectIfPresent(
+            transaction,
+            candidate.origin.projectId,
+            existingItemId,
+            candidate.origin.kind
           )
-            throw new Error('Inbox PDF content or ownership changed.')
-          await transaction.literatureInboxPdf.upsert({
-            where: { candidateId_checksum: { candidateId: persisted.id, checksum: pdf.checksum } },
-            create: {
-              candidateId: persisted.id,
-              contentBlobId: blob.id,
-              filename: pdf.filename,
-              sizeBytes: blob.sizeBytes,
-              checksum: blob.checksum,
-              pageCount: pdf.pageCount,
-              sourceUrl: pdf.sourceUrl,
-              provenanceJson
-            },
-            update: {}
+          await this.attachSource(transaction, { source: candidate.source, itemId: existingItemId })
+          return { kind: 'item', id: existingItemId, state: 'present' }
+        }
+        const dedupeKey = pdf
+          ? sha256(`pdf:${candidateDedupeKey(candidate)}:${pdf.checksum}`)
+          : candidateDedupeKey(candidate)
+        const previous = await transaction.literatureInboxCandidate.findUnique({
+          where: { dedupeKey },
+          include: { acceptedItem: { select: { deletedAt: true } } }
+        })
+        if (previous?.state === 'accepted' && previous.acceptedItem?.deletedAt) {
+          // Keep the accepted review history while giving this deletion a new review opportunity.
+          await transaction.literatureInboxCandidate.update({
+            where: { id: previous.id },
+            data: { dedupeKey: `accepted:${previous.id}` }
           })
         }
-        // Repeated discoveries retain the first reviewed candidate and its matching evidence.
-        if (previous?.id !== persisted.id) {
-          await this.attachSource(transaction, {
-            source: candidate.source,
-            candidateId: persisted.id
-          })
+        const candidateJson = canonicalJson(candidate)
+        const metadataChecksum = sha256(candidateJson)
+        const persisted = await transaction.literatureInboxCandidate.upsert({
+          where: { dedupeKey },
+          create: {
+            dedupeKey,
+            itemType: candidate.item.itemType,
+            title: candidate.item.title,
+            abstract: candidate.item.abstract,
+            issuedYear: candidate.item.issuedYear,
+            candidateJson,
+            metadataChecksum,
+            origin: candidate.origin.kind,
+            sourceProjectId: candidate.origin.projectId,
+            sourceSessionId: candidate.origin.sessionId
+          },
+          update: {},
+          select: { id: true, state: true }
+        })
+        const contextKey = canonicalJson([
+          candidate.origin.kind,
+          candidate.origin.projectId ?? null,
+          candidate.origin.sessionId ?? null
+        ])
+        await transaction.literatureCandidateDiscovery.upsert({
+          where: { candidateId_contextKey: { candidateId: persisted.id, contextKey } },
+          create: {
+            candidateId: persisted.id,
+            contextKey,
+            origin: candidate.origin.kind,
+            projectId: candidate.origin.projectId,
+            sessionId: candidate.origin.sessionId
+          },
+          update: {}
+        })
+        if (persisted.state === 'pending') {
+          if (pdf) {
+            const blob = await transaction.contentBlob.findUnique({
+              where: { id: pdf.contentBlobId }
+            })
+            if (
+              !blob ||
+              blob.state !== 'available' ||
+              blob.checksum !== pdf.checksum ||
+              blob.sizeBytes !== BigInt(pdf.sizeBytes) ||
+              (blob.contentType && blob.contentType !== 'application/pdf')
+            )
+              throw new Error('Inbox PDF content or ownership changed.')
+            await transaction.literatureInboxPdf.upsert({
+              where: {
+                candidateId_checksum: { candidateId: persisted.id, checksum: pdf.checksum }
+              },
+              create: {
+                candidateId: persisted.id,
+                contentBlobId: blob.id,
+                filename: pdf.filename,
+                sizeBytes: blob.sizeBytes,
+                checksum: blob.checksum,
+                pageCount: pdf.pageCount,
+                sourceUrl: pdf.sourceUrl,
+                provenanceJson
+              },
+              update: {}
+            })
+          }
+          // Repeated discoveries retain the first reviewed candidate and its matching evidence.
+          if (previous?.id !== persisted.id) {
+            await this.attachSource(transaction, {
+              source: candidate.source,
+              candidateId: persisted.id
+            })
+          }
         }
-      }
-      return {
-        kind: 'candidate',
-        id: persisted.id,
-        state: persisted.state as LiteratureInboxState
-      }
-    })
+        return {
+          kind: 'candidate',
+          id: persisted.id,
+          state: persisted.state as LiteratureInboxState
+        }
+      },
+      (result) =>
+        result.kind === 'item' ? { itemIds: [result.id] } : { candidateIds: [result.id] }
+    )
   }
 
   private async acceptCandidate(candidateId: string): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    return client.$transaction((transaction) => acceptInboxCandidate(transaction, candidateId))
+    return this.commit(
+      client,
+      (transaction) => acceptInboxCandidate(transaction, candidateId),
+      (result) => ({
+        candidateIds: [candidateId],
+        itemIds: result.kind === 'item' ? [result.id] : undefined
+      })
+    )
   }
 
   async stageAcquiredPdf(
@@ -1760,10 +1829,15 @@ class LiteratureCatalog {
 
   private async dismissCandidate(candidateId: string): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    const updated = await client.literatureInboxCandidate.updateMany({
-      where: { id: candidateId, state: 'pending' },
-      data: { state: 'dismissed', settledAt: new Date() }
-    })
+    const updated = await this.commit(
+      client,
+      (transaction) =>
+        transaction.literatureInboxCandidate.updateMany({
+          where: { id: candidateId, state: 'pending' },
+          data: { state: 'dismissed', settledAt: new Date() }
+        }),
+      { candidateIds: [candidateId] }
+    )
     if (updated.count === 0) throw new Error('Literature Inbox candidate is not pending.')
     return { kind: 'candidate', id: candidateId, state: 'dismissed' }
   }
@@ -1772,48 +1846,56 @@ class LiteratureCatalog {
     command: Extract<LiteratureCatalogCommand, { kind: 'settle-candidates' }>
   ): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
-      if (command.state === 'accepted') {
-        for (const candidateId of command.candidateIds) {
-          await acceptInboxCandidate(transaction, candidateId)
+    return this.commit(
+      client,
+      async (transaction) => {
+        if (command.state === 'accepted') {
+          for (const candidateId of command.candidateIds) {
+            await acceptInboxCandidate(transaction, candidateId)
+          }
+        } else {
+          const updated = await transaction.literatureInboxCandidate.updateMany({
+            where: { id: { in: command.candidateIds }, state: 'pending' },
+            data: { state: 'dismissed', settledAt: new Date() }
+          })
+          if (updated.count !== command.candidateIds.length) {
+            throw new Error('One or more Literature Inbox candidates are not pending.')
+          }
         }
-      } else {
-        const updated = await transaction.literatureInboxCandidate.updateMany({
-          where: { id: { in: command.candidateIds }, state: 'pending' },
-          data: { state: 'dismissed', settledAt: new Date() }
-        })
-        if (updated.count !== command.candidateIds.length) {
-          throw new Error('One or more Literature Inbox candidates are not pending.')
+        return {
+          kind: 'candidate',
+          id: command.candidateIds[0]!,
+          state: command.state,
+          count: command.candidateIds.length
         }
-      }
-      return {
-        kind: 'candidate',
-        id: command.candidateIds[0]!,
-        state: command.state,
-        count: command.candidateIds.length
-      }
-    })
+      },
+      { candidateIds: command.candidateIds }
+    )
   }
 
   private async restoreCandidates(
     candidateIds: readonly string[]
   ): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
-      const updated = await transaction.literatureInboxCandidate.updateMany({
-        where: { id: { in: [...candidateIds] }, state: 'dismissed' },
-        data: { state: 'pending', settledAt: null }
-      })
-      if (updated.count !== candidateIds.length) {
-        throw new Error('One or more Literature Inbox candidates are not dismissed.')
-      }
-      return {
-        kind: 'candidate',
-        id: candidateIds[0]!,
-        state: 'pending',
-        count: candidateIds.length
-      }
-    })
+    return this.commit(
+      client,
+      async (transaction) => {
+        const updated = await transaction.literatureInboxCandidate.updateMany({
+          where: { id: { in: [...candidateIds] }, state: 'dismissed' },
+          data: { state: 'pending', settledAt: null }
+        })
+        if (updated.count !== candidateIds.length) {
+          throw new Error('One or more Literature Inbox candidates are not dismissed.')
+        }
+        return {
+          kind: 'candidate',
+          id: candidateIds[0]!,
+          state: 'pending',
+          count: candidateIds.length
+        }
+      },
+      { candidateIds }
+    )
   }
 
   private async createCollection(
@@ -1829,23 +1911,26 @@ class LiteratureCatalog {
       orderBy: { sortOrder: 'desc' },
       select: { sortOrder: true }
     })
-    const collection = await client.literatureCollection
-      .create({
-        data: {
-          name,
-          nameKey: name.toLowerCase(),
-          description: descriptionInput?.trim() ?? '',
-          parentId,
-          sortOrder: (last?.sortOrder ?? -1) + 1
-        },
-        select: { id: true }
-      })
-      .catch((error: unknown) => {
-        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-          throw new Error(LITERATURE_COLLECTION_NAME_CONFLICT)
-        }
-        throw error
-      })
+    const collection = await this.commit(
+      client,
+      (transaction) =>
+        transaction.literatureCollection.create({
+          data: {
+            name,
+            nameKey: name.toLowerCase(),
+            description: descriptionInput?.trim() ?? '',
+            parentId,
+            sortOrder: (last?.sortOrder ?? -1) + 1
+          },
+          select: { id: true }
+        }),
+      (result) => ({ collectionIds: [result.id] })
+    ).catch((error: unknown) => {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
+        throw new Error(LITERATURE_COLLECTION_NAME_CONFLICT)
+      }
+      throw error
+    })
     return { kind: 'collection', id: collection.id }
   }
 
@@ -1854,41 +1939,50 @@ class LiteratureCatalog {
   ): Promise<LiteratureCatalogReceipt> {
     const name = normalizeSpace(command.name)
     if (!name) throw new Error('Literature Collection name is required.')
+    if (!Number.isSafeInteger(command.expectedRevision) || command.expectedRevision < 1)
+      throw new Error(LITERATURE_COLLECTION_REVISION_CONFLICT)
     const client = await this.getClient()
-    const collection = await client.literatureCollection
-      .update({
-        where: { id: command.collectionId },
-        data: {
-          name,
-          nameKey: name.toLowerCase(),
-          description: command.description.trim()
-        },
-        select: { id: true }
-      })
-      .catch((error: unknown) => {
-        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-          throw new Error(LITERATURE_COLLECTION_NAME_CONFLICT)
-        }
-        throw error
-      })
-    return { kind: 'collection', id: collection.id }
+    const updated = await this.commit(
+      client,
+      (transaction) =>
+        transaction.literatureCollection.updateMany({
+          where: { id: command.collectionId, revision: command.expectedRevision },
+          data: {
+            name,
+            nameKey: name.toLowerCase(),
+            description: command.description.trim(),
+            revision: { increment: 1 }
+          }
+        }),
+      { collectionIds: [command.collectionId] }
+    ).catch((error: unknown) => {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002')
+        throw new Error(LITERATURE_COLLECTION_NAME_CONFLICT)
+      throw error
+    })
+    if (updated.count !== 1) throw new Error(LITERATURE_COLLECTION_REVISION_CONFLICT)
+    return { kind: 'collection', id: command.collectionId }
   }
 
   private async deleteCollection(collectionId: string): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    const collection = await client.literatureCollection
-      .delete({
-        where: { id: collectionId },
-        select: { id: true }
-      })
-      .catch((error: unknown) => {
-        // SQLite rolls back the entire delete if promoting a child would duplicate a root name.
-        if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-          throw new Error(LITERATURE_COLLECTION_NAME_CONFLICT)
-        }
-        throw error
-      })
-    return { kind: 'collection', id: collection.id }
+    await this.commit(
+      client,
+      async (transaction) => {
+        // Child promotion changes the structural context captured by an open editor.
+        await transaction.literatureCollection.updateMany({
+          where: { parentId: collectionId },
+          data: { revision: { increment: 1 } }
+        })
+        await transaction.literatureCollection.delete({ where: { id: collectionId } })
+      },
+      { collectionIds: [collectionId] }
+    ).catch((error: unknown) => {
+      if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002')
+        throw new Error(LITERATURE_COLLECTION_NAME_CONFLICT)
+      throw error
+    })
+    return { kind: 'collection', id: collectionId }
   }
 
   private async setCollectionItem(
@@ -1896,35 +1990,42 @@ class LiteratureCatalog {
   ): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
     if (!command.included) {
-      await client.$transaction((transaction) =>
-        transaction.literatureCollectionItem.deleteMany({
-          where: { collectionId: command.collectionId, itemId: command.itemId }
-        })
+      await this.commit(
+        client,
+        (transaction) =>
+          transaction.literatureCollectionItem.deleteMany({
+            where: { collectionId: command.collectionId, itemId: command.itemId }
+          }),
+        { itemIds: [command.itemId], collectionIds: [command.collectionId] }
       )
       return { kind: 'item', id: command.itemId, state: 'unlinked' }
     }
-    await client.$transaction(async (transaction) => {
-      const available = await transaction.literatureItem.count({
-        where: { id: command.itemId, deletedAt: null, mergedIntoItemId: null }
-      })
-      if (!available) throw new Error('One or more Literature Items are unavailable.')
-      const last = await transaction.literatureCollectionItem.findFirst({
-        where: { collectionId: command.collectionId },
-        orderBy: { sortOrder: 'desc' },
-        select: { sortOrder: true }
-      })
-      await transaction.literatureCollectionItem.upsert({
-        where: {
-          collectionId_itemId: { collectionId: command.collectionId, itemId: command.itemId }
-        },
-        create: {
-          collectionId: command.collectionId,
-          itemId: command.itemId,
-          sortOrder: (last?.sortOrder ?? -1) + 1
-        },
-        update: {}
-      })
-    })
+    await this.commit(
+      client,
+      async (transaction) => {
+        const available = await transaction.literatureItem.count({
+          where: { id: command.itemId, deletedAt: null, mergedIntoItemId: null }
+        })
+        if (!available) throw new Error('One or more Literature Items are unavailable.')
+        const last = await transaction.literatureCollectionItem.findFirst({
+          where: { collectionId: command.collectionId },
+          orderBy: { sortOrder: 'desc' },
+          select: { sortOrder: true }
+        })
+        await transaction.literatureCollectionItem.upsert({
+          where: {
+            collectionId_itemId: { collectionId: command.collectionId, itemId: command.itemId }
+          },
+          create: {
+            collectionId: command.collectionId,
+            itemId: command.itemId,
+            sortOrder: (last?.sortOrder ?? -1) + 1
+          },
+          update: {}
+        })
+      },
+      { itemIds: [command.itemId], collectionIds: [command.collectionId] }
+    )
     return { kind: 'item', id: command.itemId, state: 'linked' }
   }
 
@@ -1944,31 +2045,38 @@ class LiteratureCatalog {
     const itemIds = [...new Set(command.itemIds)]
     const client = await this.getClient()
     if (!command.included) {
-      await client.$transaction((transaction) =>
-        transaction.projectLiterature.deleteMany({
-          where: { projectId: command.projectId, itemId: { in: itemIds } }
-        })
+      await this.commit(
+        client,
+        (transaction) =>
+          transaction.projectLiterature.deleteMany({
+            where: { projectId: command.projectId, itemId: { in: itemIds } }
+          }),
+        { itemIds }
       )
       return { kind: 'item', id: itemIds[0]!, state: 'unlinked' }
     }
     const source = normalizeSpace(command.source)
     if (!source) throw new Error('Project Literature source is required.')
-    await client.$transaction(async (transaction) => {
-      const available = await transaction.literatureItem.count({
-        where: { id: { in: itemIds }, deletedAt: null, mergedIntoItemId: null }
-      })
-      if (available !== itemIds.length)
-        throw new Error('One or more Literature Items are unavailable.')
-      await Promise.all(
-        itemIds.map((itemId) =>
-          transaction.projectLiterature.upsert({
-            where: { projectId_itemId: { projectId: command.projectId, itemId } },
-            create: { projectId: command.projectId, itemId, source },
-            update: { source }
-          })
+    await this.commit(
+      client,
+      async (transaction) => {
+        const available = await transaction.literatureItem.count({
+          where: { id: { in: itemIds }, deletedAt: null, mergedIntoItemId: null }
+        })
+        if (available !== itemIds.length)
+          throw new Error('One or more Literature Items are unavailable.')
+        await Promise.all(
+          itemIds.map((itemId) =>
+            transaction.projectLiterature.upsert({
+              where: { projectId_itemId: { projectId: command.projectId, itemId } },
+              create: { projectId: command.projectId, itemId, source },
+              update: { source }
+            })
+          )
         )
-      )
-    })
+      },
+      { itemIds }
+    )
     return { kind: 'item', id: itemIds[0]!, state: 'linked' }
   }
 
@@ -1978,15 +2086,19 @@ class LiteratureCatalog {
     const itemIds = [...new Set(command.itemIds)]
     const client = await this.getClient()
     const now = new Date()
-    await client.$transaction(async (transaction) => {
-      const updated = await transaction.literatureItem.updateMany({
-        where: { id: { in: itemIds }, mergedIntoItemId: null },
-        data: command.state === 'deleted' ? { deletedAt: now } : { deletedAt: null }
-      })
-      if (updated.count !== itemIds.length) {
-        throw new Error('One or more Literature Items are unavailable.')
-      }
-    })
+    await this.commit(
+      client,
+      async (transaction) => {
+        const updated = await transaction.literatureItem.updateMany({
+          where: { id: { in: itemIds }, mergedIntoItemId: null },
+          data: command.state === 'deleted' ? { deletedAt: now } : { deletedAt: null }
+        })
+        if (updated.count !== itemIds.length) {
+          throw new Error('One or more Literature Items are unavailable.')
+        }
+      },
+      { itemIds }
+    )
     return { kind: 'item', id: itemIds[0]!, state: command.state }
   }
 
@@ -2018,54 +2130,58 @@ class LiteratureCatalog {
     const client = await this.getClient()
     let tagsChanged = false
     const receipt = await this.withAttachmentRemoval((assertUnreferenced) =>
-      client.$transaction<LiteratureCatalogReceipt>(async (transaction) => {
-        const requestedItems = await transaction.literatureItem.findMany({
-          where: { id: { in: itemIds } },
-          select: { id: true, deletedAt: true }
-        })
-        if (
-          requestedItems.length !== itemIds.length ||
-          requestedItems.some(({ deletedAt }) => deletedAt === null)
-        ) {
-          throw new Error('Only Literature Items in Trash can be permanently deleted.')
-        }
-
-        const mergedItems = await transaction.literatureItem.findMany({
-          where: { mergedIntoItemId: { in: itemIds } },
-          select: { id: true }
-        })
-        const deletionIds = [...new Set([...itemIds, ...mergedItems.map(({ id }) => id)])]
-        const attachments = await transaction.literatureAttachment.findMany({
-          where: { itemId: { in: deletionIds } },
-          select: { id: true }
-        })
-        assertUnreferenced(attachments.map(({ id }) => id))
-        const creatorLinks = await transaction.literatureItemCreator.findMany({
-          where: { itemId: { in: deletionIds } },
-          select: { creatorId: true }
-        })
-
-        await transaction.literatureInboxCandidate.deleteMany({
-          where: { acceptedItemId: { in: deletionIds } }
-        })
-        const removedTags = await transaction.tagAssignment.deleteMany({
-          where: { resourceType: 'literature.item', resourceId: { in: deletionIds } }
-        })
-        tagsChanged = removedTags.count > 0
-        await transaction.literatureItem.updateMany({
-          where: { id: { in: deletionIds } },
-          data: { mergedIntoItemId: null }
-        })
-        await transaction.literatureItem.deleteMany({ where: { id: { in: deletionIds } } })
-
-        const creatorIds = [...new Set(creatorLinks.map(({ creatorId }) => creatorId))]
-        if (creatorIds.length > 0) {
-          await transaction.literatureCreator.deleteMany({
-            where: { id: { in: creatorIds }, items: { none: {} } }
+      this.commit<LiteratureCatalogReceipt>(
+        client,
+        async (transaction) => {
+          const requestedItems = await transaction.literatureItem.findMany({
+            where: { id: { in: itemIds } },
+            select: { id: true, deletedAt: true }
           })
-        }
-        return { kind: 'item', id: itemIds[0]!, state: 'deleted-permanently' }
-      })
+          if (
+            requestedItems.length !== itemIds.length ||
+            requestedItems.some(({ deletedAt }) => deletedAt === null)
+          ) {
+            throw new Error('Only Literature Items in Trash can be permanently deleted.')
+          }
+
+          const mergedItems = await transaction.literatureItem.findMany({
+            where: { mergedIntoItemId: { in: itemIds } },
+            select: { id: true }
+          })
+          const deletionIds = [...new Set([...itemIds, ...mergedItems.map(({ id }) => id)])]
+          const attachments = await transaction.literatureAttachment.findMany({
+            where: { itemId: { in: deletionIds } },
+            select: { id: true }
+          })
+          assertUnreferenced(attachments.map(({ id }) => id))
+          const creatorLinks = await transaction.literatureItemCreator.findMany({
+            where: { itemId: { in: deletionIds } },
+            select: { creatorId: true }
+          })
+
+          await transaction.literatureInboxCandidate.deleteMany({
+            where: { acceptedItemId: { in: deletionIds } }
+          })
+          const removedTags = await transaction.tagAssignment.deleteMany({
+            where: { resourceType: 'literature.item', resourceId: { in: deletionIds } }
+          })
+          tagsChanged = removedTags.count > 0
+          await transaction.literatureItem.updateMany({
+            where: { id: { in: deletionIds } },
+            data: { mergedIntoItemId: null }
+          })
+          await transaction.literatureItem.deleteMany({ where: { id: { in: deletionIds } } })
+
+          const creatorIds = [...new Set(creatorLinks.map(({ creatorId }) => creatorId))]
+          if (creatorIds.length > 0) {
+            await transaction.literatureCreator.deleteMany({
+              where: { id: { in: creatorIds }, items: { none: {} } }
+            })
+          }
+          return { kind: 'item', id: itemIds[0]!, state: 'deleted-permanently' }
+        },
+        { itemIds }
+      )
     )
     if (tagsChanged) await this.publishTagAssignmentsChanged()
     return receipt
@@ -2076,46 +2192,61 @@ class LiteratureCatalog {
   ): Promise<LiteratureCatalogReceipt> {
     const itemIds = [...new Set(command.itemIds)]
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
-      const target = await transaction.literatureCollection.findUnique({
-        where: { id: command.targetCollectionId },
-        select: { id: true }
-      })
-      if (!target) throw new Error('Literature Collection is unavailable.')
-      const available = await transaction.literatureItem.count({
-        where: { id: { in: itemIds }, deletedAt: null, mergedIntoItemId: null }
-      })
-      if (available !== itemIds.length)
-        throw new Error('One or more Literature Items are unavailable.')
-      const last = await transaction.literatureCollectionItem.findFirst({
-        where: { collectionId: target.id },
-        orderBy: { sortOrder: 'desc' },
-        select: { sortOrder: true }
-      })
-      let sortOrder = (last?.sortOrder ?? -1) + 1
-      for (const itemId of itemIds) {
-        await transaction.literatureCollectionItem.upsert({
-          where: { collectionId_itemId: { collectionId: target.id, itemId } },
-          create: { collectionId: target.id, itemId, sortOrder },
-          update: {}
+    return this.commit(
+      client,
+      async (transaction) => {
+        const target = await transaction.literatureCollection.findUnique({
+          where: { id: command.targetCollectionId },
+          select: { id: true }
         })
-        sortOrder += 1
-      }
-      if (command.sourceCollectionId && command.sourceCollectionId !== command.targetCollectionId) {
-        await transaction.literatureCollectionItem.deleteMany({
-          where: { collectionId: command.sourceCollectionId, itemId: { in: itemIds } }
+        if (!target) throw new Error('Literature Collection is unavailable.')
+        const available = await transaction.literatureItem.count({
+          where: { id: { in: itemIds }, deletedAt: null, mergedIntoItemId: null }
         })
+        if (available !== itemIds.length)
+          throw new Error('One or more Literature Items are unavailable.')
+        const last = await transaction.literatureCollectionItem.findFirst({
+          where: { collectionId: target.id },
+          orderBy: { sortOrder: 'desc' },
+          select: { sortOrder: true }
+        })
+        let sortOrder = (last?.sortOrder ?? -1) + 1
+        for (const itemId of itemIds) {
+          await transaction.literatureCollectionItem.upsert({
+            where: { collectionId_itemId: { collectionId: target.id, itemId } },
+            create: { collectionId: target.id, itemId, sortOrder },
+            update: {}
+          })
+          sortOrder += 1
+        }
+        if (
+          command.sourceCollectionId &&
+          command.sourceCollectionId !== command.targetCollectionId
+        ) {
+          await transaction.literatureCollectionItem.deleteMany({
+            where: { collectionId: command.sourceCollectionId, itemId: { in: itemIds } }
+          })
+        }
+        return { kind: 'item', id: itemIds[0]!, state: 'linked' }
+      },
+      {
+        itemIds,
+        collectionIds: [
+          command.targetCollectionId,
+          ...(command.sourceCollectionId ? [command.sourceCollectionId] : [])
+        ]
       }
-      return { kind: 'item', id: itemIds[0]!, state: 'linked' }
-    })
+    )
   }
 
   private async mergeItems(
     command: Extract<LiteratureCatalogCommand, { kind: 'merge-items' }>
   ): Promise<LiteratureCatalogReceipt> {
     const client = await this.getClient()
-    const result = await client.$transaction((transaction) =>
-      this.mergeItemsInTransaction(transaction, command)
+    const result = await this.commit(
+      client,
+      (transaction) => this.mergeItemsInTransaction(transaction, command),
+      { itemIds: [command.survivorId, ...command.duplicateIds] }
     )
     if (result.tagsChanged) await this.publishTagAssignmentsChanged()
     return result.receipt
@@ -2152,65 +2283,71 @@ class LiteratureCatalog {
       ids.forEach((id) => seen.add(id))
       try {
         let tagsChanged = false
-        const merged = await client.$transaction(async (transaction) => {
-          const rows = await transaction.literatureItem.findMany({
-            where: { id: { in: ids }, deletedAt: null, mergedIntoItemId: null },
-            include: itemInclude,
-            orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
-          })
-          if (rows.length !== ids.length) {
-            detail.reason = 'unavailable'
-            return undefined
-          }
-          const views = rows.map(toItemView)
-          detail.title = views[0]?.item.title
-          if (
-            command.mode === 'commit' &&
-            command.expectedItems &&
-            views.some(
-              (view) =>
-                !command.expectedItems!.some(
-                  (expected) =>
-                    expected.id === view.id &&
-                    expected.metadataRevision === view.metadataRevision &&
-                    expected.updatedAt === view.updatedAt
-                )
-            )
-          ) {
-            detail.reason = 'changed'
-            return undefined
-          }
-          const plan = planLiteratureMerge(views, strategy)
-          if (!plan) {
-            detail.reason =
-              strategy === 'conflict-free' && planLiteratureMerge(views, 'oldest')
-                ? 'conflicts'
-                : 'identity'
-            return undefined
-          }
-          const items = views.map(({ id, metadataRevision, updatedAt }) => ({
-            id,
-            metadataRevision,
-            updatedAt
-          }))
-          if (command.mode === 'commit') {
-            const result = await this.mergeItemsInTransaction(transaction, {
-              kind: 'merge-items',
-              survivorId: plan.survivor.id,
-              duplicateIds: rows.filter((row) => row.id !== plan.survivor.id).map((row) => row.id),
-              expectedMetadataRevision: plan.survivor.metadataRevision,
-              expectedItems: items,
-              item: plan.item
+        const merged = await this.commit(
+          client,
+          async (transaction) => {
+            const rows = await transaction.literatureItem.findMany({
+              where: { id: { in: ids }, deletedAt: null, mergedIntoItemId: null },
+              include: itemInclude,
+              orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
             })
-            tagsChanged = result.tagsChanged
-          }
-          return {
-            survivorId: plan.survivor.id,
-            survivorTitle: plan.survivor.item.title,
-            conflicts: plan.conflicts,
-            items
-          }
-        })
+            if (rows.length !== ids.length) {
+              detail.reason = 'unavailable'
+              return undefined
+            }
+            const views = rows.map(toItemView)
+            detail.title = views[0]?.item.title
+            if (
+              command.mode === 'commit' &&
+              command.expectedItems &&
+              views.some(
+                (view) =>
+                  !command.expectedItems!.some(
+                    (expected) =>
+                      expected.id === view.id &&
+                      expected.metadataRevision === view.metadataRevision &&
+                      expected.updatedAt === view.updatedAt
+                  )
+              )
+            ) {
+              detail.reason = 'changed'
+              return undefined
+            }
+            const plan = planLiteratureMerge(views, strategy)
+            if (!plan) {
+              detail.reason =
+                strategy === 'conflict-free' && planLiteratureMerge(views, 'oldest')
+                  ? 'conflicts'
+                  : 'identity'
+              return undefined
+            }
+            const items = views.map(({ id, metadataRevision, updatedAt }) => ({
+              id,
+              metadataRevision,
+              updatedAt
+            }))
+            if (command.mode === 'commit') {
+              const result = await this.mergeItemsInTransaction(transaction, {
+                kind: 'merge-items',
+                survivorId: plan.survivor.id,
+                duplicateIds: rows
+                  .filter((row) => row.id !== plan.survivor.id)
+                  .map((row) => row.id),
+                expectedMetadataRevision: plan.survivor.metadataRevision,
+                expectedItems: items,
+                item: plan.item
+              })
+              tagsChanged = result.tagsChanged
+            }
+            return {
+              survivorId: plan.survivor.id,
+              survivorTitle: plan.survivor.item.title,
+              conflicts: plan.conflicts,
+              items
+            }
+          },
+          { itemIds: ids }
+        )
         if (merged) {
           // Publish the result only after the transaction commits successfully.
           if (tagsChanged) await this.publishTagAssignmentsChanged()

--- a/src/main/literature/pdf-attachment-reliability.test.ts
+++ b/src/main/literature/pdf-attachment-reliability.test.ts
@@ -74,6 +74,7 @@ describe('Literature PDF attachment reliability', () => {
     bytes = pdf()
   ): Promise<{
     catalog: LiteratureCatalog
+    changed: ReturnType<typeof vi.fn>
     content: ContentRepository
     importer: LiteraturePdfImporter
     request: LiteraturePdfImportRequest
@@ -90,11 +91,13 @@ describe('Literature PDF attachment reliability', () => {
     const coordinator = new SessionPersistenceCoordinator(sessions, {
       syncSession: async () => []
     } as unknown as SessionFileIndex)
+    const changed = vi.fn()
     const catalog = new LiteratureCatalog(
       async () => client!,
       undefined,
       content,
-      (remove) => coordinator.withLiteratureAttachmentRemoval(remove)
+      (remove) => coordinator.withLiteratureAttachmentRemoval(remove),
+      changed
     )
     const item = await catalog.transact({
       kind: 'create-item',
@@ -120,6 +123,7 @@ describe('Literature PDF attachment reliability', () => {
       }
     }
     return {
+      changed,
       catalog,
       sessions,
       coordinator,
@@ -781,6 +785,33 @@ describe('Literature PDF attachment reliability', () => {
       })
     }
   )
+
+  it('invalidates other clients after attachment verification persists a changed observation', async () => {
+    const { catalog, importer, request, authority, changed } = await setup()
+    const imported = await importer.import(request)
+    const version = imported.item.attachments[0].versions[0]
+    const resolved = await authority.resolveVersion(version.id)
+    await rm(resolved!.path)
+    changed.mockClear()
+    await expect(
+      catalog.transact({ kind: 'verify-attachment', itemId: request.itemId, versionId: version.id })
+    ).rejects.toThrow()
+    expect((await catalog.get(request.itemId))!.attachments[0].versions[0].availability).toBe(
+      'unavailable'
+    )
+    expect(changed).toHaveBeenCalledWith(expect.objectContaining({ itemIds: [request.itemId] }))
+    changed.mockClear()
+    await writeFile(resolved!.path, pdf())
+    await catalog.transact({
+      kind: 'verify-attachment',
+      itemId: request.itemId,
+      versionId: version.id
+    })
+    expect(changed).toHaveBeenCalledTimes(1)
+    expect((await catalog.get(request.itemId))!.attachments[0].versions[0].availability).toBe(
+      'available'
+    )
+  })
 
   it('rejects a header-only corrupt PDF before creating an attachment', async () => {
     const { importer, request, path } = await setup(Buffer.from('%PDF-1.7\nnot a document'))

--- a/src/main/literature/pdf-attachment-reliability.test.ts
+++ b/src/main/literature/pdf-attachment-reliability.test.ts
@@ -748,7 +748,7 @@ describe('Literature PDF attachment reliability', () => {
   it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
     'records a permission-denied verification attempt and recovers after permission restoration',
     async () => {
-      const { importer, request, catalog, authority } = await setup()
+      const { importer, request, catalog, authority, changed } = await setup()
       const version = (await importer.import(request)).item.attachments[0].versions[0]
       const resolved = await authority.resolveVersion(version.id)
       const row = await client!.literatureAttachmentVersion.findUniqueOrThrow({
@@ -767,7 +767,11 @@ describe('Literature PDF attachment reliability', () => {
       try {
         await chmod(resolved!.path, 0o000)
         await expect(readFile(resolved!.path)).rejects.toMatchObject({ code: 'EACCES' })
+        changed.mockClear()
         await expect(catalog.transact(retry)).rejects.toThrow()
+        expect
+          .soft(changed)
+          .toHaveBeenCalledWith(expect.objectContaining({ itemIds: [request.itemId] }))
         const after = (await catalog.get(request.itemId))!.attachments[0].versions[0]
         expect.soft(after.availability).toBe('unavailable')
         expect.soft(after.verificationFailure).toBeTruthy()
@@ -785,6 +789,26 @@ describe('Literature PDF attachment reliability', () => {
       })
     }
   )
+
+  it('does not notify when the verification observation cannot be persisted', async () => {
+    const { catalog, importer, request, changed } = await setup()
+    const version = (await importer.import(request)).item.attachments[0].versions[0]
+    const failure = new Error('Observation write failed')
+    const persist = vi.spyOn(client!.contentBlob, 'updateMany').mockRejectedValueOnce(failure)
+    changed.mockClear()
+    try {
+      await expect(
+        catalog.transact({
+          kind: 'verify-attachment',
+          itemId: request.itemId,
+          versionId: version.id
+        })
+      ).rejects.toBe(failure)
+      expect(changed).not.toHaveBeenCalled()
+    } finally {
+      persist.mockRestore()
+    }
+  })
 
   it('invalidates other clients after attachment verification persists a changed observation', async () => {
     const { catalog, importer, request, authority, changed } = await setup()

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -10339,6 +10339,7 @@ describe('notebook runtime service', () => {
       const root = await createStorageRoot()
       const events: string[] = []
       let releaseInstall: (() => void) | undefined
+      const installStarted = Promise.withResolvers<void>()
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
@@ -10373,6 +10374,7 @@ describe('notebook runtime service', () => {
           events.push('install:start')
           await new Promise<void>((resolve) => {
             releaseInstall = resolve
+            installStarted.resolve()
           })
           events.push('install:end')
           return { ok: true, needsRestart: false, log: '' }
@@ -10380,7 +10382,7 @@ describe('notebook runtime service', () => {
       })
 
       const install = service.managePackages({ language: 'python', packages: ['numpy'] })
-      await vi.waitFor(() => expect(releaseInstall).toBeDefined())
+      await installStarted.promise
 
       const run = service.execute({
         sessionId: 's',
@@ -10400,6 +10402,7 @@ describe('notebook runtime service', () => {
     it('rechecks the repair gate after a queued run acquires the environment lock', async () => {
       const root = await createStorageRoot()
       let releaseInstall: (() => void) | undefined
+      const installStarted = Promise.withResolvers<void>()
       const execute = vi.fn(async (request): Promise<NotebookExecutionResult> => ({
         status: 'completed',
         stdout: '',
@@ -10422,6 +10425,7 @@ describe('notebook runtime service', () => {
         installPackagesImpl: async () => {
           await new Promise<void>((resolve) => {
             releaseInstall = resolve
+            installStarted.resolve()
           })
           return {
             ok: false,
@@ -10434,7 +10438,7 @@ describe('notebook runtime service', () => {
       })
 
       const install = service.managePackages({ language: 'python', packages: ['numpy'] })
-      await vi.waitFor(() => expect(releaseInstall).toBeDefined())
+      await installStarted.promise
       const run = service.execute({
         sessionId: 's',
         workspaceCwd: root,

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -359,6 +359,7 @@ describe('preload bridge — public surface inventory', () => {
       'literature.importRecords',
       'literature.jobs',
       'literature.lookupMetadata',
+      'literature.onChanged',
       'literature.search',
       'literature.sources',
       'literature.transact',

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -1,4 +1,5 @@
 import { readLiteratureSelectionPage } from '../../pages/literature/literature-read-pages'
+import { useLiteratureChanges } from '@/pages/literature/useLiteratureChanges'
 /* Hallmark · pre-emit critique: P5 H5 E4 S5 R5 V4
  * component: command palette · genre: modern-minimal · theme: Open Science tokens
  * structural fingerprint: fixed header / single scroll plane / fixed shortcut footer
@@ -438,6 +439,10 @@ export const GlobalSearchDialog = ({
     const timer = window.setTimeout(() => void reloadLiterature(), 150)
     return () => window.clearTimeout(timer)
   }, [isSearchMode, open, reloadLiterature, trimmedQuery])
+
+  useLiteratureChanges(() => {
+    if (open) void reloadLiterature()
+  })
 
   const handleQueryChange = (nextQuery: string): void => {
     // Clear synchronously with the input event, before the next debounced Artifact request starts.

--- a/src/renderer/src/pages/literature/CollectionEditorDialog.test.tsx
+++ b/src/renderer/src/pages/literature/CollectionEditorDialog.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { createRef } from 'react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { CollectionEditorDialog, type CollectionEditorDialogHandle } from './CollectionEditorDialog'
+import { LITERATURE_COLLECTION_REVISION_CONFLICT } from '../../../../shared/literature'
+
+afterEach(cleanup)
+it('retains a conflicting draft and only submits the loaded latest version after explicit confirmation', async () => {
+  const original = {
+    id: 'collection',
+    name: 'Original',
+    description: 'Original description',
+    revision: 1,
+    itemCount: 0,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  const latest = {
+    ...original,
+    name: 'Renamed by another client',
+    description: 'Latest description',
+    revision: 2
+  }
+  const transact = vi
+    .fn()
+    .mockRejectedValueOnce(new Error(LITERATURE_COLLECTION_REVISION_CONFLICT))
+    .mockResolvedValue({ kind: 'collection', id: original.id })
+  const search = vi.fn().mockResolvedValue({ entries: [latest] })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { literature: { transact, search } }
+  })
+  const ref = createRef<CollectionEditorDialogHandle>()
+  const saved = vi.fn()
+  render(<CollectionEditorDialog ref={ref} onSaved={saved} />)
+  act(() => ref.current!.openEdit(original))
+  fireEvent.change(screen.getByLabelText('Description'), {
+    target: { value: 'My unsaved description' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+  await screen.findByText('Renamed by another client')
+  expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe(
+    'My unsaved description'
+  )
+  expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe('Original')
+  expect(saved).not.toHaveBeenCalled()
+  expect(transact).toHaveBeenCalledTimes(1)
+  fireEvent.click(screen.getByRole('button', { name: 'Load latest version' }))
+  expect((screen.getByLabelText('Name') as HTMLInputElement).value).toBe(latest.name)
+  expect((screen.getByLabelText('Description') as HTMLTextAreaElement).value).toBe(
+    latest.description
+  )
+  expect(transact).toHaveBeenCalledTimes(1)
+  fireEvent.change(screen.getByLabelText('Description'), {
+    target: { value: 'Reconciled description' }
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Save changes' }))
+  await waitFor(() => expect(saved).toHaveBeenCalledTimes(1))
+  expect(transact).toHaveBeenLastCalledWith({
+    kind: 'update-collection',
+    collectionId: original.id,
+    expectedRevision: 2,
+    name: latest.name,
+    description: 'Reconciled description'
+  })
+})

--- a/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
+++ b/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
@@ -1,8 +1,10 @@
+import { useLiteratureChanges } from './useLiteratureChanges'
 import * as Dialog from '@/components/ui/dialog'
 import { Info, LoaderCircle, X } from 'lucide-react'
-import { forwardRef, useImperativeHandle, useState } from 'react'
+import { forwardRef, useImperativeHandle, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ErrorNotice } from '@/components/error-notice'
 import { Button } from '@/components/ui/button'
 import {
   dialogBodyClassName,
@@ -25,6 +27,7 @@ import type { LiteratureCollectionView } from '../../../../shared/literature'
 import {
   LITERATURE_COLLECTION_DESCRIPTION_MAX_LENGTH,
   LITERATURE_COLLECTION_NAME_CONFLICT,
+  LITERATURE_COLLECTION_REVISION_CONFLICT,
   LITERATURE_COLLECTION_NAME_MAX_LENGTH
 } from '../../../../shared/literature'
 
@@ -44,37 +47,90 @@ export const CollectionEditorDialog = forwardRef<
   CollectionEditorDialogProps
 >(({ onSaved }, ref) => {
   const { t } = useTranslation()
+  const generation = useRef(0)
+  const latestRead = useRef(0)
   const [mode, setMode] = useState<CollectionEditorMode>()
   const [editingCollection, setEditingCollection] = useState<LiteratureCollectionView>()
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<'name-conflict' | 'create-failed' | 'update-failed'>()
+  const [error, setError] = useState<string>()
+  const [conflict, setConflict] = useState(false)
+  const [latest, setLatest] = useState<LiteratureCollectionView>()
 
   useImperativeHandle(ref, () => ({
     openCreate: () => {
+      generation.current += 1
       setEditingCollection(undefined)
       setName('')
       setDescription('')
       setError(undefined)
+      setConflict(false)
+      setLatest(undefined)
       setMode('create')
     },
     openEdit: (collection) => {
+      generation.current += 1
       setEditingCollection(collection)
       setName(collection.name)
       setDescription(collection.description)
       setError(undefined)
+      setConflict(false)
+      setLatest(undefined)
       setMode('edit')
     }
   }))
 
   const close = (): void => {
-    if (!saving) setMode(undefined)
+    if (!saving) {
+      generation.current += 1
+      setMode(undefined)
+    }
   }
+
+  const readLatest = async (checkForChanges = false): Promise<void> => {
+    const opening = generation.current
+    const request = ++latestRead.current
+    if (!editingCollection) return
+    try {
+      let offset = 0
+      for (;;) {
+        const page = await window.api.literature.search({
+          scope: 'collections',
+          offset,
+          limit: 100
+        })
+        if (opening !== generation.current || request !== latestRead.current) return
+        const found = page.entries.find(
+          (entry): entry is LiteratureCollectionView =>
+            'revision' in entry && entry.id === editingCollection.id
+        )
+        if (found) {
+          if (checkForChanges && found.revision === editingCollection.revision) return
+          setConflict(true)
+          setError('This collection changed. Your edits have been kept.')
+          setLatest(found)
+          return
+        }
+        if (page.nextOffset === undefined) break
+        offset = page.nextOffset
+      }
+      setConflict(true)
+      setLatest(undefined)
+      setError('This collection no longer exists. Your edits have been kept.')
+    } catch {
+      if (opening !== generation.current || request !== latestRead.current) return
+      setError('The latest collection could not be loaded. Your edits have been kept.')
+    }
+  }
+
+  useLiteratureChanges(() => {
+    if (mode === 'edit' && !saving) void readLatest(true)
+  })
 
   const save = async (): Promise<void> => {
     const trimmedName = name.trim()
-    if (!trimmedName || saving || !mode) return
+    if (!trimmedName || saving || !mode || conflict) return
     if (mode === 'edit' && !editingCollection) return
 
     setSaving(true)
@@ -90,6 +146,7 @@ export const CollectionEditorDialog = forwardRef<
       } else if (editingCollection) {
         await window.api.literature.transact({
           kind: 'update-collection',
+          expectedRevision: editingCollection.revision,
           collectionId: editingCollection.id,
           name: trimmedName,
           description: trimmedDescription
@@ -102,6 +159,15 @@ export const CollectionEditorDialog = forwardRef<
         description: trimmedDescription
       })
     } catch (error) {
+      if (
+        error instanceof Error &&
+        error.message.includes(LITERATURE_COLLECTION_REVISION_CONFLICT)
+      ) {
+        setConflict(true)
+        setError('This collection changed. Your edits have been kept.')
+        await readLatest()
+        return
+      }
       setError(
         error instanceof Error && error.message.includes(LITERATURE_COLLECTION_NAME_CONFLICT)
           ? 'name-conflict'
@@ -215,15 +281,64 @@ export const CollectionEditorDialog = forwardRef<
               </div>
             </div>
             {error ? (
-              <p className="px-5 pb-4 text-sm text-danger-000" role="alert">
-                {error === 'name-conflict'
-                  ? t(
-                      'A collection with this name already exists at this level. Choose another name.'
-                    )
-                  : error === 'create-failed'
-                    ? t('Collection could not be created.')
-                    : t('Collection could not be updated.')}
-              </p>
+              <div className="px-5 pb-4">
+                <ErrorNotice
+                  role="alert"
+                  tone="amber"
+                  description={
+                    error === 'name-conflict'
+                      ? t(
+                          'A collection with this name already exists at this level. Choose another name.'
+                        )
+                      : error === 'create-failed'
+                        ? t('Collection could not be created.')
+                        : error === 'update-failed'
+                          ? t('Collection could not be updated.')
+                          : error === 'This collection changed. Your edits have been kept.'
+                            ? t('This collection changed. Your edits have been kept.')
+                            : error ===
+                                'This collection no longer exists. Your edits have been kept.'
+                              ? t('This collection no longer exists. Your edits have been kept.')
+                              : t(
+                                  'The latest collection could not be loaded. Your edits have been kept.'
+                                )
+                  }
+                  secondaryButton={
+                    conflict
+                      ? latest
+                        ? {
+                            label: t('Load latest version'),
+                            description: t(
+                              'Replace your unsaved edits with the latest saved collection.'
+                            ),
+                            onClick: () => {
+                              latestRead.current += 1
+                              setEditingCollection(latest)
+                              setName(latest.name)
+                              setDescription(latest.description)
+                              setConflict(false)
+                              setLatest(undefined)
+                              setError(undefined)
+                            }
+                          }
+                        : {
+                            label: t('Retry'),
+                            onClick: () => {
+                              void readLatest()
+                            }
+                          }
+                      : undefined
+                  }
+                >
+                  {latest ? (
+                    <div className="min-w-0 space-y-1 text-sm break-words">
+                      <p className="font-medium">{t('Latest saved version')}</p>
+                      <p>{latest.name}</p>
+                      <p className="whitespace-pre-wrap">{latest.description}</p>
+                    </div>
+                  ) : null}
+                </ErrorNotice>
+              </div>
             ) : null}
             <div
               className={`${dialogFooterClassName} flex-wrap items-center [&_button]:max-w-full [&_button]:whitespace-normal [&_button]:h-auto [&_button]:min-h-8 [&_button]:py-1`}
@@ -237,7 +352,7 @@ export const CollectionEditorDialog = forwardRef<
               >
                 {t('Cancel')}
               </Button>
-              <Button type="submit" disabled={!name.trim() || saving}>
+              <Button type="submit" disabled={!name.trim() || saving || conflict}>
                 {saving ? (
                   <LoaderCircle
                     className="size-4 animate-spin motion-reduce:animate-none"

--- a/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
+++ b/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
@@ -39,7 +39,12 @@ export type CollectionEditorDialogHandle = {
 }
 
 type CollectionEditorDialogProps = {
-  onSaved: (collection: { id?: string; name: string; description: string }) => void
+  onSaved: (collection: {
+    id?: string
+    revision?: number
+    name: string
+    description: string
+  }) => void
 }
 
 export const CollectionEditorDialog = forwardRef<
@@ -155,6 +160,8 @@ export const CollectionEditorDialog = forwardRef<
       setMode(undefined)
       onSaved({
         id: mode === 'edit' ? editingCollection?.id : undefined,
+        // A successful compare-and-swap increments the submitted revision exactly once.
+        revision: mode === 'edit' && editingCollection ? editingCollection.revision + 1 : undefined,
         name: trimmedName,
         description: trimmedDescription
       })

--- a/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { literatureItemInputSchema, type LiteratureItemView } from '../../../../shared/literature'
 import { literatureDeletionError } from '../../../../shared/literature-deletion'
 import { useAttachmentOperations } from './literature-attachment-operations'
+import { createLiteratureDetailController } from './LiteratureDetailController'
 import { LiteratureAttachments } from './LiteratureAttachments'
 
 const version = (
@@ -73,7 +74,13 @@ describe('Attachment safety and version access', () => {
       const item = useAttachmentOperations(
         (state) => state.operations.find((operation) => operation.itemId === available.id)?.item
       )
-      return <LiteratureAttachments item={item ?? available} onPreview={vi.fn()} />
+      return (
+        <LiteratureAttachments
+          readItem={window.api.literature.get}
+          item={item ?? available}
+          onPreview={vi.fn()}
+        />
+      )
     }
     render(<View />)
     const retry = async (): Promise<void> => {
@@ -111,6 +118,30 @@ describe('Attachment safety and version access', () => {
     ).toBe(false)
   })
 
+  it('keeps newer attachment history when an operation refresh finishes last', async () => {
+    const oldItem = makeItem(1)
+    const latest = makeItem(2)
+    const delayed = Promise.withResolvers<LiteratureItemView>()
+    const get = vi.mocked(window.api.literature.get)
+    get.mockReturnValueOnce(delayed.promise).mockResolvedValue(latest)
+    const controller = createLiteratureDetailController()
+    render(<LiteratureAttachments item={oldItem} readItem={controller.read} onPreview={vi.fn()} />)
+    fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v1.pdf' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Retry file verification' }))
+    await waitFor(() => expect(get).toHaveBeenCalledTimes(1))
+    await act(async () => {
+      expect(await controller.read(oldItem.id)).toEqual(latest)
+    })
+    await act(async () => {
+      delayed.resolve(oldItem)
+    })
+    await waitFor(() => {
+      const operation = useAttachmentOperations.getState().operations[0]
+      expect(operation.pending).toBe(false)
+      expect(operation.item?.attachments).toEqual(latest.attachments)
+    })
+  })
+
   it.each(['referenced', 'scan-incomplete'] as const)(
     'retains structured %s diagnostics after confirming deletion',
     async (reason) => {
@@ -137,7 +168,13 @@ describe('Attachment safety and version access', () => {
           truncated: false
         })
       )
-      render(<LiteratureAttachments item={makeItem(2)} onPreview={vi.fn()} />)
+      render(
+        <LiteratureAttachments
+          readItem={window.api.literature.get}
+          item={makeItem(2)}
+          onPreview={vi.fn()}
+        />
+      )
       await openRemoval()
       fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
       await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
@@ -163,7 +200,13 @@ describe('Attachment safety and version access', () => {
   it.each(['cancel', 'escape'])(
     'does not delete on %s and returns focus to the attachment menu',
     async (close) => {
-      render(<LiteratureAttachments item={makeItem(2)} onPreview={vi.fn()} />)
+      render(
+        <LiteratureAttachments
+          readItem={window.api.literature.get}
+          item={makeItem(2)}
+          onPreview={vi.fn()}
+        />
+      )
       const trigger = screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' })
       trigger.focus()
       await openRemoval()
@@ -190,7 +233,13 @@ describe('Attachment safety and version access', () => {
           finish = resolve
         })
     )
-    render(<LiteratureAttachments item={makeItem(2)} onPreview={vi.fn()} />)
+    render(
+      <LiteratureAttachments
+        readItem={window.api.literature.get}
+        item={makeItem(2)}
+        onPreview={vi.fn()}
+      />
+    )
     await openRemoval()
     const confirm = screen.getByRole('button', { name: 'Permanently delete attachment' })
     fireEvent.click(confirm)
@@ -214,7 +263,13 @@ describe('Attachment safety and version access', () => {
 
   it('preserves the attachment and explains saved chat references when deletion is refused', async () => {
     transact.mockRejectedValue(new Error('LITERATURE_ATTACHMENT_IN_USE'))
-    render(<LiteratureAttachments item={makeItem(2)} onPreview={vi.fn()} />)
+    render(
+      <LiteratureAttachments
+        readItem={window.api.literature.get}
+        item={makeItem(2)}
+        onPreview={vi.fn()}
+      />
+    )
     await openRemoval()
     fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
     await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
@@ -229,10 +284,13 @@ describe('Attachment safety and version access', () => {
     'invalidates confirmation when the %s changes',
     async (change) => {
       const props = { onPreview: vi.fn() }
-      const view = render(<LiteratureAttachments item={makeItem(2)} {...props} />)
+      const view = render(
+        <LiteratureAttachments readItem={window.api.literature.get} item={makeItem(2)} {...props} />
+      )
       await openRemoval()
       view.rerender(
         <LiteratureAttachments
+          readItem={window.api.literature.get}
           item={change === 'reference' ? { ...makeItem(2), id: 'other' } : makeItem(3)}
           {...props}
         />
@@ -244,7 +302,13 @@ describe('Attachment safety and version access', () => {
 
   it('shows version metadata and prevents previewing a missing version', async () => {
     const onPreview = vi.fn()
-    render(<LiteratureAttachments item={makeItem(2, true)} onPreview={onPreview} />)
+    render(
+      <LiteratureAttachments
+        readItem={window.api.literature.get}
+        item={makeItem(2, true)}
+        onPreview={onPreview}
+      />
+    )
     fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' }))
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Version history' }))
     const dialog = screen.getByRole('dialog')
@@ -265,7 +329,13 @@ describe('Attachment safety and version access', () => {
   it.each([1, 2])(
     'requires confirmation before deleting an attachment with %i versions',
     async (count) => {
-      render(<LiteratureAttachments item={makeItem(count)} onPreview={vi.fn()} />)
+      render(
+        <LiteratureAttachments
+          readItem={window.api.literature.get}
+          item={makeItem(count)}
+          onPreview={vi.fn()}
+        />
+      )
       fireEvent.click(
         screen.getByRole('button', { name: `Attachment actions for paper-v${count}.pdf` })
       )
@@ -284,6 +354,7 @@ describe('Attachment safety and version access', () => {
       const onPreview = vi.fn()
       render(
         <LiteratureAttachments
+          readItem={window.api.literature.get}
           item={makeItem(2, missing)}
 
           onPreview={onPreview}

--- a/src/renderer/src/pages/literature/LiteratureAttachments.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.tsx
@@ -138,9 +138,11 @@ const AttachmentPreview = ({
 
 export const LiteratureAttachments = ({
   item,
+  readItem,
   onPreview
 }: {
   item: LiteratureItemView
+  readItem: (id: string) => Promise<LiteratureItemView | undefined>
   onPreview: (version: Version) => void
 }): React.JSX.Element => {
   const { t, i18n } = useTranslation()

--- a/src/renderer/src/pages/literature/LiteratureAttachments.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.tsx
@@ -175,7 +175,7 @@ export const LiteratureAttachments = ({
   const itemOperations = operations.filter((operation) => operation.itemId === item.id)
   const pending = itemOperations.some((operation) => operation.pending)
   const run = (action: AttachmentAction, attachmentId: string, versionId?: string): Promise<void> =>
-    useAttachmentOperations.getState().run(item, attachmentId, action, versionId)
+    useAttachmentOperations.getState().run(item, attachmentId, action, versionId, readItem)
   return (
     <ActionMenuProvider>
       <div className="mt-2 space-y-2">

--- a/src/renderer/src/pages/literature/LiteratureDetailController.test.ts
+++ b/src/renderer/src/pages/literature/LiteratureDetailController.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { LiteratureItemView } from '../../../../shared/literature'
+import { createLiteratureDetailController } from './LiteratureDetailController'
+
+describe('Literature detail reads', () => {
+  it('does not return an older relationship snapshot after a newer read has completed', async () => {
+    const older = {
+      id: 'item',
+      metadataRevision: 1,
+      collectionIds: []
+    } as unknown as LiteratureItemView
+    const newer = { ...older, collectionIds: ['collection'] }
+    let finish!: (item: LiteratureItemView) => void
+    const get = vi
+      .fn()
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve
+          })
+      )
+      .mockResolvedValue(newer)
+    vi.stubGlobal('window', { api: { literature: { get } } })
+    try {
+      const controller = createLiteratureDetailController()
+      const pending = controller.read(older.id)
+      expect(await controller.read(older.id)).toEqual(newer)
+      finish(older)
+      expect(await pending).toEqual(newer)
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/src/renderer/src/pages/literature/LiteratureDetailController.ts
+++ b/src/renderer/src/pages/literature/LiteratureDetailController.ts
@@ -12,11 +12,39 @@ export type LiteratureDetailController = Readonly<{
   close: () => void
   open: (item: LiteratureItemView) => void
   replace: (item: LiteratureItemView) => void
+  invalidate: () => void
+  read: (id: string) => Promise<LiteratureItemView | undefined>
 }>
 
 const createLiteratureDetailController = (): LiteratureDetailController => {
   let snapshot: LiteratureDetailSnapshot = { open: false, generation: 0 }
   const listeners = new Set<() => void>()
+  const reads = new Map<
+    string,
+    { promise: Promise<LiteratureItemView | undefined>; invalidated: boolean }
+  >()
+  const read = (id: string): Promise<LiteratureItemView | undefined> => {
+    const previous = reads.get(id)
+    if (previous) previous.invalidated = true
+    const entry = {
+      promise: undefined as unknown as Promise<LiteratureItemView | undefined>,
+      invalidated: false
+    }
+    entry.promise = window.api.literature
+      .get(id)
+      .then((item): Promise<LiteratureItemView | undefined> | LiteratureItemView | undefined => {
+        const newer = reads.get(id)
+        if (newer && newer !== entry) return newer.promise
+        // A committed relation publication invalidates the whole view, even at equal metadata revision.
+        // Merely reopening a detail does not invalidate data already being read for that identity.
+        return entry.invalidated ? read(id) : item
+      })
+      .finally(() => {
+        if (reads.get(id) === entry) reads.delete(id)
+      })
+    reads.set(id, entry)
+    return entry.promise
+  }
   const publish = (next: LiteratureDetailSnapshot): void => {
     snapshot = next
     listeners.forEach((listener) => listener())
@@ -24,6 +52,10 @@ const createLiteratureDetailController = (): LiteratureDetailController => {
 
   return {
     getSnapshot: () => snapshot,
+    read,
+    invalidate: () => {
+      for (const pending of reads.values()) pending.invalidated = true
+    },
     subscribe: (listener) => {
       listeners.add(listener)
       return () => listeners.delete(listener)
@@ -33,6 +65,8 @@ const createLiteratureDetailController = (): LiteratureDetailController => {
     },
     open: (item) => publish({ item, open: true, generation: snapshot.generation + 1 }),
     replace: (item) => {
+      const pending = reads.get(item.id)
+      if (pending) pending.invalidated = true
       if (snapshot.item?.id !== item.id || item.metadataRevision < snapshot.item.metadataRevision)
         return
       publish({ ...snapshot, item })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -2138,6 +2138,60 @@ describe('LiteratureLibraryPage', () => {
     expect(screen.getByRole('dialog')).toBe(dialog)
   })
 
+  it.each(['pending', 'failed'] as const)(
+    'reopens a saved Collection with its committed revision while directory reload is %s',
+    async (reload) => {
+      let collection = {
+        id: 'collection-1',
+        name: 'Screening',
+        description: 'Original description',
+        revision: 1,
+        itemCount: 0,
+        createdAt: 1,
+        updatedAt: 1
+      }
+      search.mockImplementation((request: { scope: string }) => {
+        if (request.scope === 'collections') {
+          if (collection.revision > 1) {
+            return reload === 'failed'
+              ? Promise.reject(new Error('Directory unavailable'))
+              : new Promise(() => {})
+          }
+          return Promise.resolve({ entries: [{ ...collection }], totalCount: 1 })
+        }
+        return Promise.resolve(request.scope === 'inbox' ? inboxPage : { entries: [] })
+      })
+      transact.mockImplementation(
+        (command: { expectedRevision?: number; name?: string; description?: string }) => {
+          if (command.expectedRevision !== collection.revision)
+            return Promise.reject(new Error('literature_collection_revision_conflict'))
+          collection = {
+            ...collection,
+            name: command.name ?? collection.name,
+            description: command.description ?? collection.description,
+            revision: collection.revision + 1
+          }
+          return Promise.resolve({ kind: 'collection', id: collection.id })
+        }
+      )
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(await screen.findByRole('button', { name: collection.name }))
+      for (const description of ['First saved description', 'Second saved description']) {
+        await openMenu(screen.getByRole('button', { name: 'Collection actions' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: 'Edit collection' }))
+        const dialog = await screen.findByRole('dialog')
+        fireEvent.change(within(dialog).getByLabelText('Description'), {
+          target: { value: description }
+        })
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Save changes' }))
+        await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+      }
+      expect(collection.revision).toBe(3)
+      expect(collection.description).toBe('Second saved description')
+      expect(transact.mock.calls.map(([command]) => command.expectedRevision)).toEqual([1, 2])
+    }
+  )
+
   it('creates and edits Collections with one shared name and description form', async () => {
     let collection:
       | {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -8930,6 +8930,89 @@ describe('LiteratureLibraryPage', () => {
       }
     )
 
+    it.each(
+      ['notification', 'focus', 'reconnect'].flatMap((trigger) =>
+        [false, true].map((editing) => ({ trigger, editing }))
+      )
+    )(
+      'handles an externally removed reference after $trigger without discarding a draft (editing: $editing)',
+      async ({ trigger, editing }) => {
+        await showLibrary()
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        if (editing) {
+          await editDetail()
+          fireEvent.change(screen.getByLabelText('Title'), {
+            target: { value: 'Keep this unsaved title' }
+          })
+        }
+        get.mockResolvedValue(undefined)
+        search.mockResolvedValue({ entries: [], totalCount: 0 })
+        await act(async () => {
+          if (trigger === 'notification')
+            vi.mocked(window.api.literature.onChanged).mock.calls.forEach(([listener]) =>
+              listener({ revision: 1, itemIds: [libraryItem.id] })
+            )
+          else
+            window.dispatchEvent(
+              new Event(trigger === 'focus' ? 'focus' : 'open-science:web-events-open')
+            )
+        })
+        await (editing ? within(screen.getByRole('dialog')) : screen).findByText(
+          'This reference is no longer in your Library.'
+        )
+        if (editing) {
+          expect(
+            (screen.getByRole('button', { name: 'Save', exact: true }) as HTMLButtonElement)
+              .disabled
+          ).toBe(true)
+          expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe(
+            'Keep this unsaved title'
+          )
+        } else {
+          await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+        }
+        expect(transact).not.toHaveBeenCalled()
+      }
+    )
+
+    it.each(['edit', 'reopen'] as const)(
+      'does not let a pending removal read discard a later %s',
+      async (interaction) => {
+        await showLibrary()
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        const removal = deferred<LiteratureItemView | undefined>()
+        get.mockReturnValueOnce(removal.promise)
+        await act(async () => {
+          vi.mocked(window.api.literature.onChanged).mock.calls.forEach(([listener]) =>
+            listener({ revision: 1, itemIds: [libraryItem.id] })
+          )
+        })
+        if (interaction === 'edit') {
+          await editDetail()
+          fireEvent.change(screen.getByLabelText('Title'), {
+            target: { value: 'Started editing during refresh' }
+          })
+        } else {
+          closeDetail()
+          get.mockResolvedValue({
+            ...version(1, 'Different reference'),
+            id: 'different-reference'
+          })
+          act(() => useNavigationStore.getState().openLiteratureItem('different-reference', 'user'))
+          await screen.findByRole('heading', { name: 'Different reference' })
+        }
+        await act(async () => removal.resolve(undefined))
+        if (interaction === 'edit') {
+          expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe(
+            'Started editing during refresh'
+          )
+        } else {
+          expect(screen.getByRole('heading', { name: 'Different reference' })).not.toBeNull()
+          expect(screen.queryByText('This reference is no longer in your Library.')).toBeNull()
+        }
+      }
+    )
+
     it('keeps a reopened reference newer than an earlier save readback', async () => {
       await showLibrary()
       await openReferenceDetail(screen.getByText(libraryItem.item.title))

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -366,6 +366,7 @@ describe('LiteratureLibraryPage', () => {
         literature: {
           exportRecord: vi.fn(),
           sources: vi.fn(async () => []),
+          onChanged: vi.fn(() => () => undefined),
           lookupMetadata: vi.fn(async () => libraryItem.item),
           jobs: vi.fn(async () => ({ jobs: [], summaries: [] })),
           search: async (request: LiteratureCatalogSearchRequest) => {
@@ -611,6 +612,59 @@ describe('LiteratureLibraryPage', () => {
       vi.useRealTimers()
     }
   })
+
+  it.each(['focus', 'visibility', 'scope return', 'remount'] as const)(
+    'reads externally committed references after %s',
+    async (recovery) => {
+      const original = {
+        ...libraryItem,
+        item: { ...libraryItem.item, title: 'Original from server' }
+      }
+      let records = [original]
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => ({
+        entries: request.scope === 'library' ? records : [],
+        totalCount: request.scope === 'library' ? records.length : 0
+      }))
+      const mounted = render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await screen.findByText('Original from server')
+      const libraryQueries = (): number =>
+        search.mock.calls.filter(([request]) => request.scope === 'library' && !request.allItemIds)
+          .length
+      const before = libraryQueries()
+      records = [
+        {
+          ...original,
+          metadataRevision: 2,
+          item: { ...original.item, title: 'Updated by another client' }
+        },
+        {
+          ...original,
+          id: 'external-new-item',
+          item: { ...original.item, title: 'Added by another client' }
+        }
+      ]
+      if (recovery === 'remount') {
+        mounted.unmount()
+        render(<LiteratureLibraryPage />)
+        fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      } else {
+        await act(async () => {
+          if (recovery !== 'visibility') window.dispatchEvent(new Event('focus'))
+          if (recovery !== 'focus') document.dispatchEvent(new Event('visibilitychange'))
+        })
+        if (recovery === 'scope return') {
+          fireEvent.click(screen.getByRole('button', { name: 'Inbox' }))
+          await screen.findByRole('heading', { name: 'Inbox' })
+          fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+        }
+      }
+      await waitFor(() => expect(libraryQueries()).toBeGreaterThan(before))
+      expect(await screen.findByText('Updated by another client')).not.toBeNull()
+      expect(await screen.findByText('Added by another client')).not.toBeNull()
+      expect(screen.queryByText('Original from server')).toBeNull()
+    }
+  )
 
   it('trashes all 26 members despite an update between target reads', async () => {
     const { mkdtemp, rm } = await import('node:fs/promises')
@@ -2021,6 +2075,7 @@ describe('LiteratureLibraryPage', () => {
   it('opens an explicitly scoped Collection view', async () => {
     const collection = {
       id: 'collection-1',
+      revision: 1,
       name: 'TP53 evidence',
       description: 'Curated TP53 studies.',
       itemCount: 1,
@@ -2090,6 +2145,7 @@ describe('LiteratureLibraryPage', () => {
           name: string
           description: string
           itemCount: number
+          revision: number
           createdAt: number
           updatedAt: number
         }
@@ -2108,6 +2164,7 @@ describe('LiteratureLibraryPage', () => {
         if (command.kind === 'create-collection') {
           collection = {
             id: 'collection-1',
+            revision: 1,
             name: command.name ?? '',
             description: command.description ?? '',
             itemCount: 0,
@@ -2175,6 +2232,7 @@ describe('LiteratureLibraryPage', () => {
     await waitFor(() =>
       expect(transact).toHaveBeenCalledWith({
         kind: 'update-collection',
+        expectedRevision: 1,
         collectionId: 'collection-1',
         name: 'Included studies',
         description: 'Final synthesis set.'
@@ -2208,6 +2266,7 @@ describe('LiteratureLibraryPage', () => {
     async (nameConflict) => {
       const collection = {
         id: 'collection-1',
+        revision: 1,
         name: 'Screening',
         description: 'Papers awaiting review.',
         itemCount: 1,
@@ -4147,6 +4206,7 @@ describe('LiteratureLibraryPage', () => {
           entries: [
             {
               id: 'collection-1',
+              revision: 1,
               name: 'Retrieval methods',
               itemCount: 0,
               createdAt: 1,
@@ -4207,6 +4267,7 @@ describe('LiteratureLibraryPage', () => {
           entries: [
             {
               id: 'collection-1',
+              revision: 1,
               name: 'Retrieval methods',
               itemCount: 0,
               createdAt: 1,
@@ -5237,6 +5298,7 @@ describe('LiteratureLibraryPage', () => {
   it('links a manually created reference to the current Collection', async () => {
     const collection = {
       id: 'collection-1',
+      revision: 1,
       name: 'Review set',
       description: '',
       itemCount: 0,
@@ -7510,6 +7572,7 @@ describe('LiteratureLibraryPage', () => {
                 entries: [
                   {
                     id: 'collection-1',
+                    revision: 1,
                     name: 'Review queue',
                     description: '',
                     itemCount: 0,
@@ -8780,6 +8843,38 @@ describe('LiteratureLibraryPage', () => {
     const closeDetail = (): void => {
       fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
     }
+
+    it.each(['notification', 'reconnect'] as const)(
+      'refreshes external metadata after %s while retaining an open draft',
+      async (trigger) => {
+        await showLibrary()
+        await openReferenceDetail(screen.getByText(libraryItem.item.title))
+        await editDetail()
+        fireEvent.change(screen.getByLabelText('Title'), { target: { value: 'My unsaved title' } })
+        const latest = version(2, 'Externally saved title')
+        get.mockResolvedValue(latest)
+        search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => ({
+          entries: request.scope === 'library' ? [latest] : [],
+          totalCount: request.scope === 'library' ? 1 : 0
+        }))
+        await act(async () => {
+          if (trigger === 'reconnect')
+            window.dispatchEvent(new Event('open-science:web-events-open'))
+          else
+            vi.mocked(window.api.literature.onChanged).mock.calls.forEach(([listener]) =>
+              listener({ revision: 1, itemIds: [latest.id] })
+            )
+        })
+        await waitFor(() =>
+          expect(
+            document.querySelector('[data-slot="literature-table-scroll"]')!.textContent
+          ).toContain(latest.item.title)
+        )
+        expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe('My unsaved title')
+        expect(transact).not.toHaveBeenCalled()
+        expect(screen.getByRole('button', { name: 'Load latest version' })).not.toBeNull()
+      }
+    )
 
     it('keeps a reopened reference newer than an earlier save readback', async () => {
       await showLibrary()

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -8961,10 +8961,9 @@ describe('LiteratureLibraryPage', () => {
           'This reference is no longer in your Library.'
         )
         if (editing) {
-          expect(
-            (screen.getByRole('button', { name: 'Save', exact: true }) as HTMLButtonElement)
-              .disabled
-          ).toBe(true)
+          expect((screen.getByRole('button', { name: 'Save' }) as HTMLButtonElement).disabled).toBe(
+            true
+          )
           expect((screen.getByLabelText('Title') as HTMLInputElement).value).toBe(
             'Keep this unsaved title'
           )

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -8899,6 +8899,95 @@ describe('LiteratureLibraryPage', () => {
       fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Close' }))
     }
 
+    it('returns to all references after the active collection is deleted externally', async () => {
+      let removed = false
+      const collection = {
+        id: 'collection-1',
+        revision: 1,
+        name: 'Remote collection',
+        description: '',
+        itemCount: 1,
+        createdAt: 1,
+        updatedAt: 1
+      }
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => ({
+        entries:
+          request.scope === 'collections'
+            ? removed
+              ? []
+              : [collection]
+            : request.scope === 'library' && (!removed || !request.collectionId)
+              ? [libraryItem]
+              : [],
+        totalCount: request.scope === 'library' && (!removed || !request.collectionId) ? 1 : 0
+      }))
+      useNavigationStore.setState({ pendingLiteratureCollectionId: collection.id })
+      render(<LiteratureLibraryPage />)
+      await screen.findByRole('heading', { name: collection.name })
+      await screen.findByText(libraryItem.item.title)
+      fireEvent.click(screen.getByRole('checkbox', { name: `Select ${libraryItem.item.title}` }))
+      removed = true
+      search.mockClear()
+      await act(async () => {
+        vi.mocked(window.api.literature.onChanged).mock.calls.forEach(([listener]) =>
+          listener({ revision: 1, collectionIds: [collection.id] })
+        )
+      })
+      await screen.findByRole('heading', { name: 'All references' })
+      await waitFor(() =>
+        expect(
+          search.mock.calls.some(
+            ([request]) =>
+              request.scope === 'library' &&
+              !request.countOnly &&
+              request.collectionId === undefined
+          )
+        ).toBe(true)
+      )
+      expect(await screen.findByText(libraryItem.item.title)).not.toBeNull()
+      expect(
+        screen.getByRole('checkbox', { name: `Select ${libraryItem.item.title}` })
+      ).toHaveProperty('checked', false)
+    })
+
+    it('keeps a newly selected collection when an older navigation refresh completes', async () => {
+      const first = {
+        id: 'first',
+        revision: 1,
+        name: 'First collection',
+        description: '',
+        itemCount: 1,
+        createdAt: 1,
+        updatedAt: 1
+      }
+      const second = { ...first, id: 'second', name: 'Second collection' }
+      const delayed = Promise.withResolvers<{ entries: (typeof first)[] }>()
+      let refreshing = false
+      search.mockImplementation(async (request: LiteratureCatalogSearchRequest) => {
+        if (request.scope === 'collections')
+          return refreshing ? delayed.promise : { entries: [first, second] }
+        return { entries: request.scope === 'library' ? [libraryItem] : [], totalCount: 1 }
+      })
+      useNavigationStore.setState({ pendingLiteratureCollectionId: first.id })
+      render(<LiteratureLibraryPage />)
+      await screen.findByRole('heading', { name: first.name })
+      refreshing = true
+      await act(async () => {
+        vi.mocked(window.api.literature.onChanged).mock.calls.forEach(([listener]) =>
+          listener({ revision: 1, collectionIds: [first.id] })
+        )
+      })
+      await act(async () => {
+        useNavigationStore.setState({ pendingLiteratureCollectionId: second.id })
+      })
+      await screen.findByRole('heading', { name: second.name })
+      await act(async () => {
+        delayed.resolve({ entries: [second] })
+      })
+      expect(screen.getByRole('heading', { name: second.name })).not.toBeNull()
+      expect(screen.queryByRole('heading', { name: 'All references' })).toBeNull()
+    })
+
     it.each(['notification', 'reconnect'] as const)(
       'refreshes external metadata after %s while retaining an open draft',
       async (trigger) => {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -23,6 +23,7 @@ import { createInitialProjectState, useProjectStore } from '@/stores/project-sto
 import { createInitialTagState, useTagStore } from '@/stores/tag-store'
 import { LiteratureLibraryPage } from './LiteratureLibraryPage'
 import { useAttachmentOperations } from './literature-attachment-operations'
+import { i18next } from '@/i18n'
 
 if (!Element.prototype.scrollIntoView) {
   Element.prototype.scrollIntoView = (): void => undefined
@@ -8973,6 +8974,48 @@ describe('LiteratureLibraryPage', () => {
         expect(transact).not.toHaveBeenCalled()
       }
     )
+
+    it('keeps a removed reference unsaveable after switching locale without losing its draft', async () => {
+      await showLibrary()
+      await openReferenceDetail(screen.getByText(libraryItem.item.title))
+      await editDetail()
+      fireEvent.change(screen.getByLabelText('Title'), {
+        target: { value: 'Keep this unsaved title' }
+      })
+      get.mockResolvedValue(undefined)
+      search.mockResolvedValue({ entries: [], totalCount: 0 })
+      await act(async () => {
+        vi.mocked(window.api.literature.onChanged).mock.calls.forEach(([listener]) =>
+          listener({ revision: 1, itemIds: [libraryItem.id] })
+        )
+      })
+      await within(screen.getByRole('dialog')).findByText(
+        'This reference is no longer in your Library.'
+      )
+      try {
+        await act(async () => {
+          await i18next.changeLanguage('zh-Hans')
+        })
+        const save = screen.getByRole('button', { name: i18next.t('Save') }) as HTMLButtonElement
+        expect.soft(save.disabled).toBe(true)
+        expect
+          .soft(
+            within(screen.getByRole('dialog')).queryByText(
+              i18next.t('This reference is no longer in your Library.')
+            )
+          )
+          .not.toBeNull()
+        expect((screen.getByLabelText(i18next.t('Title')) as HTMLInputElement).value).toBe(
+          'Keep this unsaved title'
+        )
+        fireEvent.click(save)
+        expect(transact).not.toHaveBeenCalled()
+      } finally {
+        await act(async () => {
+          await i18next.changeLanguage('en')
+        })
+      }
+    })
 
     it.each(['edit', 'reopen'] as const)(
       'does not let a pending removal read discard a later %s',

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1550,6 +1550,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       0
     )
 
+  const [removedDetailItemId, setRemovedDetailItemId] = useState<string>()
   const detailInteractionRef = useRef(0)
   const openSelectedItemDetail = useCallback(
     (item: LiteratureItemView, initiator?: HTMLElement): void => {
@@ -1560,6 +1561,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
           (document.activeElement instanceof HTMLElement ? document.activeElement : null)
       }
       detailInteractionRef.current += 1
+      setRemovedDetailItemId(undefined)
       setError(undefined)
       detailController.open(item)
     },
@@ -1960,6 +1962,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     detailSelectOpenRef.current = false
     childLayerDismissGuardUntilRef.current = 0
     detailController.close()
+    setRemovedDetailItemId(undefined)
     startTransition(() => {
       setPdfError(undefined)
       changeDetailMode('view')
@@ -2018,9 +2021,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
           if (detailModeRef.current === 'view') {
             setPreviewItem(undefined)
             closeSelectedItemDetail()
-          }
+          } else setRemovedDetailItemId(snapshot.item.id)
           setError(t('This reference is no longer in your Library.'))
-        } else detailController.replace(latest)
+        } else {
+          setRemovedDetailItemId((id) => (id === latest.id ? undefined : id))
+          detailController.replace(latest)
+        }
       })()
     ]).catch(() => setError(t('Literature could not be loaded.')))
   })
@@ -5998,12 +6004,11 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                         item={metadata.editBase?.item ?? selectedItem.item}
                         saving={metadata.saving || metadata.awaitingReload}
                         saveDisabled={
-                          metadata.externallyUpdated() ||
-                          error === t('This reference is no longer in your Library.')
+                          metadata.externallyUpdated() || removedDetailItemId === selectedItem.id
                         }
                         error={
-                          error === t('This reference is no longer in your Library.')
-                            ? error
+                          removedDetailItemId === selectedItem.id
+                            ? t('This reference is no longer in your Library.')
                             : metadata.awaitingReload || metadata.externallyUpdated()
                               ? undefined
                               : metadata.error

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1560,6 +1560,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
           (document.activeElement instanceof HTMLElement ? document.activeElement : null)
       }
       detailInteractionRef.current += 1
+      setError(undefined)
       detailController.open(item)
     },
     [detailController]
@@ -1947,6 +1948,10 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }
   const metadata = useLiteratureMetadata(detailController, updateMetadataItem)
   const { changeMode: changeDetailMode } = metadata
+  const detailModeRef = useRef(metadata.mode)
+  useLayoutEffect(() => {
+    detailModeRef.current = metadata.mode
+  }, [metadata.mode])
 
   const closeSelectedItemDetail = useCallback((): void => {
     if (addingPdfRef.current) return
@@ -1962,35 +1967,6 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       setCollectionLinkError(undefined)
     })
   }, [changeDetailMode, detailController])
-
-  useEffect(() => {
-    let request = 0
-    const refreshOpenDetail = (): void => {
-      const snapshot = detailController.getSnapshot()
-      if (!snapshot.open || !snapshot.item) return
-      const currentRequest = ++request
-      void window.api.literature.get(snapshot.item.id).then(
-        (item) => {
-          if (
-            currentRequest !== request ||
-            detailController.getSnapshot().generation !== snapshot.generation
-          )
-            return
-          if (!item || item.id !== snapshot.item?.id || item.deletedAt !== undefined) {
-            setPreviewItem(undefined)
-            closeSelectedItemDetail()
-            void reloadEntries(true, true)
-          }
-        },
-        () => undefined
-      )
-    }
-    window.addEventListener('focus', refreshOpenDetail)
-    return () => {
-      request += 1
-      window.removeEventListener('focus', refreshOpenDetail)
-    }
-  }, [closeSelectedItemDetail, detailController, reloadEntries])
 
   const appliedTagRevision = useRef(tagRevision)
   useEffect(() => {
@@ -2033,11 +2009,18 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       loadInboxPendingCount(),
       loadProjectCounts(),
       (async () => {
-        const { item } = detailController.getSnapshot()
-        if (!item) return
-        const latest = await detailController.read(item.id)
-        if (latest) detailController.replace(latest)
-        else setError(t('This reference is no longer in your Library.'))
+        const snapshot = detailController.getSnapshot()
+        if (!snapshot.open || !snapshot.item) return
+        const latest = await detailController.read(snapshot.item.id)
+        if (detailController.getSnapshot().generation !== snapshot.generation) return
+        if (!latest || latest.id !== snapshot.item.id || latest.deletedAt !== undefined) {
+          // Read the current mode after awaiting: an edit may have started during the refresh.
+          if (detailModeRef.current === 'view') {
+            setPreviewItem(undefined)
+            closeSelectedItemDetail()
+          }
+          setError(t('This reference is no longer in your Library.'))
+        } else detailController.replace(latest)
       })()
     ]).catch(() => setError(t('Literature could not be loaded.')))
   })
@@ -6014,11 +5997,16 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                         key={`${selectedItem.id}:${metadata.editBase?.metadataRevision}`}
                         item={metadata.editBase?.item ?? selectedItem.item}
                         saving={metadata.saving || metadata.awaitingReload}
-                        saveDisabled={metadata.externallyUpdated()}
+                        saveDisabled={
+                          metadata.externallyUpdated() ||
+                          error === t('This reference is no longer in your Library.')
+                        }
                         error={
-                          metadata.awaitingReload || metadata.externallyUpdated()
-                            ? undefined
-                            : metadata.error
+                          error === t('This reference is no longer in your Library.')
+                            ? error
+                            : metadata.awaitingReload || metadata.externallyUpdated()
+                              ? undefined
+                              : metadata.error
                         }
                         className="min-h-0 flex-1 max-h-none"
                         onCancel={() => changeDetailMode('view')}

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -6423,12 +6423,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       </LiteratureDetailBoundary>
       <CollectionEditorDialog
         ref={collectionEditorRef}
-        onSaved={({ id, name, description }) => {
-          if (id) {
+        onSaved={({ id, revision, name, description }) => {
+          if (id && revision !== undefined) {
             setCollections((current) =>
               current.map((collection) =>
-                collection.id === id
-                  ? { ...collection, name, description, updatedAt: Date.now() }
+                collection.id === id && collection.revision <= revision
+                  ? { ...collection, revision, name, description, updatedAt: Date.now() }
                   : collection
               )
             )

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -9,6 +9,7 @@ import {
 import { LiteratureDeletionNotice } from './LiteratureDeletionNotice'
 import { readLiteratureSelectionPage } from './literature-read-pages'
 import { LiteratureOversizedNotice } from './LiteratureOversizedNotice'
+import { useLiteratureChanges } from './useLiteratureChanges'
 import type { TFunction } from 'i18next'
 import { LiteratureSources } from './LiteratureSources'
 import { LiteratureAttachments } from './LiteratureAttachments'
@@ -1655,7 +1656,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       clearSelection()
       setError(undefined)
       setLinkedItemError(undefined)
-      void window.api.literature.get(itemId).then(
+      void detailController.read(itemId).then(
         (item) => {
           if (!active) return
           if (detailInteractionRef.current !== interaction) {
@@ -1681,7 +1682,14 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     return () => {
       active = false
     }
-  }, [clearSelection, consumeLiteratureItem, openSelectedItemDetail, pendingLiteratureItemId, t])
+  }, [
+    clearSelection,
+    consumeLiteratureItem,
+    detailController,
+    openSelectedItemDetail,
+    pendingLiteratureItemId,
+    t
+  ])
 
   useEffect(() => {
     if (!pendingLiteratureProjectId) return
@@ -1723,13 +1731,16 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     setCollections(collections)
   }, [])
 
+  const inboxCountGeneration = useRef(0)
   const loadInboxPendingCount = useCallback(async (): Promise<void> => {
+    const generation = ++inboxCountGeneration.current
     const page = await window.api.literature.search({
       scope: 'inbox',
       inboxState: 'pending',
       limit: 1
     })
-    setInboxPendingCount(page.totalCount ?? page.entries.length)
+    if (generation === inboxCountGeneration.current)
+      setInboxPendingCount(page.totalCount ?? page.entries.length)
   }, [])
 
   const projectCountsGenerationRef = useRef(0)
@@ -1902,6 +1913,12 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     (failed: boolean): void => setError(failed ? t('Literature could not be loaded.') : undefined),
     [t]
   )
+  const receiveItems = useCallback(
+    (updated: LiteratureItemView[]): void => {
+      updated.forEach((item) => detailController.replace(item))
+    },
+    [detailController]
+  )
   const entriesRequest = useMemo(() => buildEntriesRequest(), [buildEntriesRequest])
   const {
     oversizedItemId,
@@ -1915,6 +1932,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     request: entriesRequest,
     scopeKey: entriesKey,
     onPage: receiveEntries,
+    onItems: receiveItems,
     onEmptyPage: setEntriesOffset,
     onError: receiveEntriesError
   })
@@ -1991,31 +2009,38 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   const loadEntries = useCallback(
     (force = false, preservePage = false): Promise<void> => {
       if (force) {
+        detailController.invalidate()
         setDuplicatesRevision((value) => value + 1)
         setLibraryCountRevision((value) => value + 1)
       }
       return reloadEntries(force, preservePage)
     },
-    [reloadEntries]
+    [detailController, reloadEntries]
   )
   const receiveBackgroundItems = useCallback(
     (itemIds: string[]): void => {
       setDuplicatesRevision((value) => value + 1)
-      void Promise.allSettled(itemIds.map((id) => window.api.literature.get(id))).then(
-        (results) => {
-          const updated = results.flatMap((result) =>
-            result.status === 'fulfilled' && result.value ? [result.value] : []
-          )
-          void refreshItems(itemIds, updated)
-          // Data publication follows item identity/revision, not the opening that started the read.
-          updated.forEach((item) => detailController.replace(item))
-          if (results.some((result) => result.status === 'rejected'))
-            setError(t('Literature could not be loaded.'))
-        }
-      )
+      void refreshItems(itemIds, undefined, true)
     },
-    [detailController, refreshItems, t]
+    [refreshItems]
   )
+
+  useLiteratureChanges(() => {
+    // Starting the new reads invalidates outstanding list/navigation requests immediately.
+    void Promise.all([
+      loadEntries(true, true),
+      loadCollections(),
+      loadInboxPendingCount(),
+      loadProjectCounts(),
+      (async () => {
+        const { item } = detailController.getSnapshot()
+        if (!item) return
+        const latest = await detailController.read(item.id)
+        if (latest) detailController.replace(latest)
+        else setError(t('This reference is no longer in your Library.'))
+      })()
+    ]).catch(() => setError(t('Literature could not be loaded.')))
+  })
 
   useEffect(() => {
     const loadNavigation = async (): Promise<void> => {
@@ -2492,7 +2517,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       })
       // An attachment receipt may predate metadata edits in a reopened detail. Re-read rather
       // than using metadataRevision as an attachment version or rolling metadata backwards.
-      const updated = await window.api.literature.get(current.id).catch(() => undefined)
+      const updated = await detailController.read(current.id).catch(() => undefined)
       detailController.replace(updated ?? receipt.item)
       await loadEntries(true)
     } catch (error) {
@@ -2653,7 +2678,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       persisted = true
       const reload = async (): Promise<LiteratureItemView> => {
         try {
-          const updated = await window.api.literature.get(entry.id)
+          const updated = await detailController.read(entry.id)
           if (!updated) throw new Error('Literature Item is unavailable after updating.')
           await refreshItems([updated.id], [updated])
           detailController.replace(updated)
@@ -2789,7 +2814,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
           await window.api.literature.importPdf({ itemId: pending.id, attachment: staged })
         ).item
       }
-      const created = pending.pdfItem ?? (await window.api.literature.get(pending.id))
+      const created = pending.pdfItem ?? (await detailController.read(pending.id))
       if (!created) throw new Error('Literature Item is unavailable after creating.')
       setItems((entries) =>
         entries.some((entry) => entry.id === created.id)
@@ -2805,7 +2830,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       // Retain the existing PDF-error detail recovery only once destination linking has completed.
       const created =
         pending?.file && !pending.destination && !pending.pdfItem
-          ? await window.api.literature.get(pending.id).catch(() => undefined)
+          ? await detailController.read(pending.id).catch(() => undefined)
           : undefined
       if (created) {
         closeItemEditor()
@@ -3259,8 +3284,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       if (!selection.allMatchingSelected) {
         entries = await Promise.all(
           [...selection.selectedIds].map(async (id) => {
-            const entry =
-              items.find((item) => item.id === id) ?? (await window.api.literature.get(id))
+            const entry = items.find((item) => item.id === id) ?? (await detailController.read(id))
             if (!entry || !isItem(entry)) throw new Error('Selected reference unavailable')
             return entry
           })
@@ -3312,7 +3336,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         const activeIds: string[] = []
         for (let offset = 0; offset < resolvedIds.length; offset += LITERATURE_BATCH_COMMAND_SIZE) {
           const batch = resolvedIds.slice(offset, offset + LITERATURE_BATCH_COMMAND_SIZE)
-          const entries = await Promise.all(batch.map((id) => window.api.literature.get(id)))
+          const entries = await Promise.all(batch.map((id) => detailController.read(id)))
           entries.forEach((entry, index) => {
             // get resolves merged aliases; never redirect the original association intent.
             if (
@@ -6339,6 +6363,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                           </p>
                         ) : null}
                         <LiteratureAttachments
+                          readItem={detailController.read}
                           key={selectedItem.id}
                           item={selectedItem}
                           onPreview={(version) =>

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1721,7 +1721,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }, [clearSelection, consumeLiteratureCollection, pendingLiteratureCollectionId])
 
   const collectionsGenerationRef = useRef(0)
-  const loadCollections = useCallback(async (): Promise<void> => {
+  const loadCollections = useCallback(async (): Promise<LiteratureCollectionView[] | undefined> => {
     const generation = ++collectionsGenerationRef.current
     const collections: LiteratureCollectionView[] = []
     let offset: number | undefined = 0
@@ -1732,6 +1732,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       offset = page.nextOffset
     } while (offset !== undefined)
     setCollections(collections)
+    return collections
   }, [])
 
   const inboxCountGeneration = useRef(0)
@@ -2004,11 +2005,25 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     [refreshItems]
   )
 
+  const currentCollectionId = useRef(collectionId)
+  useLayoutEffect(() => {
+    currentCollectionId.current = collectionId
+  }, [collectionId])
+
   useLiteratureChanges(() => {
     // Starting the new reads invalidates outstanding list/navigation requests immediately.
     void Promise.all([
       loadEntries(true, true),
-      loadCollections(),
+      loadCollections().then((collections) => {
+        const selectedId = currentCollectionId.current
+        if (
+          collections &&
+          selectedId &&
+          !collections.some((collection) => collection.id === selectedId)
+        ) {
+          selectLibrary()
+        }
+      }),
       loadInboxPendingCount(),
       loadProjectCounts(),
       (async () => {

--- a/src/renderer/src/pages/literature/literature-attachment-operations.ts
+++ b/src/renderer/src/pages/literature/literature-attachment-operations.ts
@@ -20,7 +20,8 @@ type AttachmentOperations = {
     item: LiteratureItemView,
     attachmentId: string,
     action: AttachmentAction,
-    versionId?: string
+    versionId: string | undefined,
+    readItem: (id: string) => Promise<LiteratureItemView | undefined>
   ) => Promise<void>
   dismiss: (operation: AttachmentOperation) => void
 }
@@ -32,7 +33,7 @@ export const useAttachmentOperations = create<AttachmentOperations>((set, get) =
     if (!operation.pending)
       set({ operations: get().operations.filter((entry) => entry !== operation) })
   },
-  run: async (item, attachmentId, action, versionId) => {
+  run: async (item, attachmentId, action, versionId, readItem) => {
     // Preserve the existing per-item exclusion, including conflicting actions on other attachments.
     if (get().operations.some((entry) => entry.itemId === item.id && entry.pending)) return
     const attachment = item.attachments.find((entry) => entry.id === attachmentId)
@@ -64,9 +65,7 @@ export const useAttachmentOperations = create<AttachmentOperations>((set, get) =
       error = failure
     }
     const updated =
-      receipt || action === 'verify'
-        ? await window.api.literature.get(item.id).catch(() => undefined)
-        : undefined
+      receipt || action === 'verify' ? await readItem(item.id).catch(() => undefined) : undefined
     // A refresh failure cannot restore an attachment whose deletion has committed.
     const result =
       updated ??

--- a/src/renderer/src/pages/literature/literature-localization.render.test.tsx
+++ b/src/renderer/src/pages/literature/literature-localization.render.test.tsx
@@ -62,6 +62,7 @@ it.each([
         ref.current!.openEdit({
           id: 'collection-a',
           name: 'Existing',
+          revision: 1,
           description: '',
           itemCount: 0,
           createdAt: 1,
@@ -106,6 +107,7 @@ it.each([
     expect(transact.mock.calls[1]).toEqual(transact.mock.calls[0])
     expect(onSaved).toHaveBeenCalledWith({
       id: mode === 'edit' ? 'collection-a' : undefined,
+      revision: mode === 'edit' ? 2 : undefined,
       name: 'Research 北京',
       description: 'Draft description'
     })

--- a/src/renderer/src/pages/literature/useLiteratureChanges.test.tsx
+++ b/src/renderer/src/pages/literature/useLiteratureChanges.test.tsx
@@ -1,0 +1,39 @@
+// @vitest-environment jsdom
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { useLiteratureChanges } from './useLiteratureChanges'
+
+afterEach(cleanup)
+it('coalesces mutation bursts and restores missed changes on visibility and replay without leaking subscriptions', async () => {
+  let notify!: () => void
+  const unsubscribe = vi.fn()
+  const onChanged = vi.fn((listener: () => void) => {
+    notify = listener
+    return unsubscribe
+  })
+  Object.defineProperty(window, 'api', { configurable: true, value: { literature: { onChanged } } })
+  const first = vi.fn(),
+    latest = vi.fn()
+  const { rerender, unmount } = renderHook(({ invalidate }) => useLiteratureChanges(invalidate), {
+    initialProps: { invalidate: first }
+  })
+  await act(async () => {
+    notify()
+    notify()
+    window.dispatchEvent(new Event('focus'))
+  })
+  expect(first).toHaveBeenCalledTimes(1)
+  rerender({ invalidate: latest })
+  await act(async () => document.dispatchEvent(new Event('visibilitychange')))
+  await act(async () => window.dispatchEvent(new Event('open-science:web-events-open')))
+  expect(latest).toHaveBeenCalledTimes(2)
+  expect(onChanged).toHaveBeenCalledTimes(1)
+  notify()
+  unmount()
+  await act(async () => {
+    window.dispatchEvent(new Event('focus'))
+    notify()
+  })
+  expect(latest).toHaveBeenCalledTimes(2)
+  expect(unsubscribe).toHaveBeenCalledTimes(1)
+})

--- a/src/renderer/src/pages/literature/useLiteratureChanges.ts
+++ b/src/renderer/src/pages/literature/useLiteratureChanges.ts
@@ -1,0 +1,36 @@
+import { useLayoutEffect, useRef } from 'react'
+
+// One subscription recipe for Literature consumers. The transport already owns replay/gap handling;
+// focus and replay completion revalidate even when a client missed the original mutation event.
+export const useLiteratureChanges = (invalidate: () => void): void => {
+  const latest = useRef(invalidate)
+  useLayoutEffect(() => {
+    latest.current = invalidate
+  })
+  useLayoutEffect(() => {
+    let active = true
+    let queued = false
+    const refresh = (): void => {
+      if (queued) return
+      queued = true
+      queueMicrotask(() => {
+        queued = false
+        if (active) latest.current()
+      })
+    }
+    const visible = (): void => {
+      if (document.visibilityState === 'visible') refresh()
+    }
+    const remove = window.api?.literature?.onChanged?.(refresh)
+    window.addEventListener('focus', refresh)
+    document.addEventListener('visibilitychange', visible)
+    window.addEventListener('open-science:web-events-open', refresh)
+    return () => {
+      active = false
+      remove?.()
+      window.removeEventListener('focus', refresh)
+      document.removeEventListener('visibilitychange', visible)
+      window.removeEventListener('open-science:web-events-open', refresh)
+    }
+  }, [])
+}

--- a/src/renderer/src/pages/literature/useLiteratureEntries.test.tsx
+++ b/src/renderer/src/pages/literature/useLiteratureEntries.test.tsx
@@ -321,6 +321,108 @@ describe('useLiteratureEntries', () => {
     })
     expect(onPage.mock.lastCall?.[0].entries[0].metadataRevision).toBe(3)
   })
+  it.each(['attachments', 'collectionIds', 'projectIds'] as const)(
+    'keeps newer %s when an earlier read with the same metadata revision completes',
+    async (field) => {
+      const original: LiteratureItemView = {
+        id: 'a',
+        item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'Reference' }),
+        attachments: [],
+        collectionIds: [],
+        projectIds: [],
+        metadataRevision: 1,
+        createdAt: 1,
+        updatedAt: 1
+      }
+      const updated: LiteratureItemView = {
+        ...original,
+        ...(field === 'attachments'
+          ? {
+              attachments: [
+                {
+                  id: 'attachment-new',
+                  kind: 'fullText',
+                  title: '',
+                  sortOrder: 0,
+                  createdAt: 2,
+                  updatedAt: 2,
+                  versions: [
+                    {
+                      id: 'version-new',
+                      versionNumber: 1,
+                      filename: 'new.pdf',
+                      contentType: 'application/pdf',
+                      sizeBytes: 128,
+                      checksum: 'a'.repeat(64),
+                      createdAt: 2
+                    }
+                  ]
+                }
+              ]
+            }
+          : { [field]: ['new-relation'] })
+      }
+      search.mockResolvedValue({ entries: [original], totalCount: 1 })
+      let finish!: (item: LiteratureItemView) => void
+      window.api.literature.get = vi.fn(
+        () =>
+          new Promise<LiteratureItemView>((resolve) => {
+            finish = resolve
+          })
+      )
+      const { result, onPage } = setup()
+      await act(async () => {})
+      let pending!: Promise<void>
+      act(() => {
+        pending = result.current.refreshItems(['a'])
+      })
+      await act(() => result.current.refreshItems(['a'], [updated]))
+      expect(onPage.mock.lastCall?.[0].entries[0][field]).toEqual(updated[field])
+      await act(async () => {
+        finish(original)
+        await pending
+      })
+      expect(onPage.mock.lastCall?.[0].entries[0][field]).toEqual(updated[field])
+    }
+  )
+
+  it('keeps independent item reads when another item is updated', async () => {
+    const first: LiteratureItemView = {
+      id: 'a',
+      item: literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'A' }),
+      attachments: [],
+      collectionIds: [],
+      projectIds: [],
+      metadataRevision: 1,
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const second = { ...first, id: 'b', item: { ...first.item, title: 'B' } }
+    search.mockResolvedValue({ entries: [first, second], totalCount: 2 })
+    let finish!: (item: LiteratureItemView) => void
+    window.api.literature.get = vi.fn(
+      () =>
+        new Promise<LiteratureItemView>((resolve) => {
+          finish = resolve
+        })
+    )
+    const { result, onPage } = setup()
+    await act(async () => {})
+    let pending!: Promise<void>
+    act(() => {
+      pending = result.current.refreshItems(['b'])
+    })
+    await act(() => result.current.refreshItems(['a'], [{ ...first, collectionIds: ['new-a'] }]))
+    await act(async () => {
+      finish({ ...second, projectIds: ['new-b'] })
+      await pending
+    })
+    expect(onPage.mock.lastCall?.[0].entries).toMatchObject([
+      { id: 'a', collectionIds: ['new-a'] },
+      { id: 'b', projectIds: ['new-b'] }
+    ])
+  })
+
   it('retains the displayed page during a failed background refresh and retries its dirty cache', async () => {
     const item: LiteratureItemView = {
       id: 'a',

--- a/src/renderer/src/pages/literature/useLiteratureEntries.ts
+++ b/src/renderer/src/pages/literature/useLiteratureEntries.ts
@@ -20,6 +20,7 @@ type LiteratureEntriesOptions = Readonly<{
     fromCache: boolean,
     preservePosition?: boolean
   ) => void
+  onItems?: (items: LiteratureItemView[]) => void
   onEmptyPage: (offset: number) => void
   onError: (failed: boolean) => void
 }>
@@ -31,6 +32,7 @@ const useLiteratureEntries = ({
   scopeKey,
   onPage,
   onEmptyPage,
+  onItems,
   onError
 }: LiteratureEntriesOptions): {
   oversizedItemId?: string
@@ -38,7 +40,11 @@ const useLiteratureEntries = ({
   failed: boolean
   pageTransitionLoading: boolean
   reload: (force?: boolean, preservePage?: boolean) => Promise<void>
-  refreshItems: (itemIds: string[], updatedItems?: LiteratureItemView[]) => Promise<void>
+  refreshItems: (
+    itemIds: string[],
+    updatedItems?: LiteratureItemView[],
+    includeHidden?: boolean
+  ) => Promise<void>
 } => {
   const [oversizedItemId, setOversizedItemId] = useState<string>()
   const [loading, setLoading] = useState(true)
@@ -46,6 +52,14 @@ const useLiteratureEntries = ({
   const [failedKey, setFailedKey] = useState<string>()
   const generationRef = useRef(0)
   const dataRevisionRef = useRef(0)
+  const mounted = useRef(true)
+  useLayoutEffect(() => {
+    mounted.current = true
+    return () => {
+      mounted.current = false
+    }
+  }, [])
+  const itemReads = useRef(new Map<string, object>())
   const cacheRef = useRef(new Map<string, LiteratureCatalogSearchPage>())
   const dirtyKeys = useRef(new Set<string>())
   const [cachedKeys, setCachedKeys] = useState<ReadonlySet<string>>(() => new Set())
@@ -61,6 +75,7 @@ const useLiteratureEntries = ({
       const retained =
         preservePage && appliedPageRef.current?.key === pageKey ? appliedPageRef.current : undefined
       if (force) {
+        itemReads.current.clear()
         cacheRef.current.clear()
         dirtyKeys.current.clear()
         if (retained) {
@@ -116,7 +131,8 @@ const useLiteratureEntries = ({
           cacheRef.current.delete(oldestKey)
         }
         if (!cached) setCachedKeys(new Set(cacheRef.current.keys()))
-        onPage(page, request, Boolean(cached))
+        if (retained) onPage(page, request, Boolean(cached), true)
+        else onPage(page, request, Boolean(cached))
         appliedPageRef.current = { key: pageKey, page }
         setLoadedKey(pageKey)
       } catch (error) {
@@ -133,7 +149,11 @@ const useLiteratureEntries = ({
   )
 
   const refreshItems = useCallback(
-    async (itemIds: string[], updatedItems?: LiteratureItemView[]): Promise<void> => {
+    async (
+      itemIds: string[],
+      updatedItems?: LiteratureItemView[],
+      includeHidden = false
+    ): Promise<void> => {
       dataRevisionRef.current += 1
       const displayed = appliedPageRef.current
       const ids = new Set(itemIds)
@@ -143,18 +163,39 @@ const useLiteratureEntries = ({
       if (displayed) cacheRef.current.set(displayed.key, displayed.page)
       if (displayed) dirtyKeys.current.add(displayed.key)
       setCachedKeys(new Set(cacheRef.current.keys()))
-      if (!displayed || displayed.key !== pageKey || request.scope !== 'library') return
       const generation = generationRef.current
-      const visible = displayed.page.entries.flatMap((entry) =>
+      const visible = (displayed?.page.entries ?? []).flatMap((entry) =>
         'metadataRevision' in entry && ids.has(entry.id) ? [entry.id] : []
       )
+      const reading = includeHidden ? itemIds : visible
+      const tickets = new Map(reading.map((id) => [id, {}]))
+      for (const id of itemIds) itemReads.current.delete(id)
+      for (const [id, ticket] of tickets) itemReads.current.set(id, ticket)
       try {
+        const results = updatedItems
+          ? []
+          : await Promise.allSettled(
+              reading.map(async (id) => {
+                const item = await window.api.literature.get(id)
+                return itemReads.current.get(id) === tickets.get(id) ? item : undefined
+              })
+            )
         const updated =
-          updatedItems ?? (await Promise.all(visible.map((id) => window.api.literature.get(id))))
-        if (generation !== generationRef.current || appliedPageRef.current?.key !== pageKey) return
-        const replacements = new Map(
-          updated.flatMap((entry) => (entry ? [[entry.id, entry] as const] : []))
+          updatedItems ??
+          results.flatMap((result) =>
+            result.status === 'fulfilled' && result.value ? [result.value] : []
+          )
+        // Recheck at publication: a sibling response may have arrived while the batch waited.
+        const accepted = updated.filter(
+          (entry) => updatedItems || itemReads.current.get(entry.id) === tickets.get(entry.id)
         )
+        if (!mounted.current) return
+        onItems?.(accepted)
+        if (generation !== generationRef.current) return
+        if (results.some((result) => result.status === 'rejected')) onError(true)
+        if (!displayed || appliedPageRef.current?.key !== pageKey || request.scope !== 'library')
+          return
+        const replacements = new Map(accepted.map((entry) => [entry.id, entry]))
         const current = appliedPageRef.current.page
         const page = {
           ...current,
@@ -170,9 +211,13 @@ const useLiteratureEntries = ({
         if (visible.length) onPage(page, request, true, true)
       } catch {
         onError(true)
+      } finally {
+        for (const [id, ticket] of tickets) {
+          if (itemReads.current.get(id) === ticket) itemReads.current.delete(id)
+        }
       }
     },
-    [onError, onPage, pageKey, request]
+    [onError, onItems, onPage, pageKey, request]
   )
 
   // Apply cached data before paint; returning to a cached scope must not tear down

--- a/src/renderer/src/pages/literature/useLiteratureMetadata.ts
+++ b/src/renderer/src/pages/literature/useLiteratureMetadata.ts
@@ -103,7 +103,7 @@ const useLiteratureMetadata = (
       controller.getSnapshot().generation === current.generation && requestRef.current === request
     setSaving(true)
     try {
-      const updated = await window.api.literature.get(current.item.id)
+      const updated = await controller.read(current.item.id)
       if (!updated) throw new Error('Literature Item is unavailable after updating.')
       onItemChange(updated)
       controller.replace(updated)
@@ -135,7 +135,7 @@ const useLiteratureMetadata = (
         item
       })
       persisted = true
-      const updated = await window.api.literature.get(current.id)
+      const updated = await controller.read(current.id)
       if (!updated) throw new Error('Literature Item is unavailable after updating.')
       onItemChange(updated)
       controller.replace(updated)
@@ -152,7 +152,7 @@ const useLiteratureMetadata = (
       if (!persisted) {
         // Read the conflicting version without rebasing the user's whole draft onto it.
         try {
-          const latest = await window.api.literature.get(current.id)
+          const latest = await controller.read(current.id)
           if (latest) {
             onItemChange(latest)
             controller.replace(latest)

--- a/src/renderer/src/pages/workspace/ArtifactLiteratureDetailDialog.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactLiteratureDetailDialog.tsx
@@ -1,3 +1,4 @@
+import { useLiteratureChanges } from '@/pages/literature/useLiteratureChanges'
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import * as Dialog from '@/components/ui/dialog'
 import { FileText, X } from 'lucide-react'
@@ -69,6 +70,10 @@ const ArtifactLiteratureDetailDialog = ({
   onOpenChange
 }: ArtifactLiteratureDetailDialogProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const [literatureRevision, setLiteratureRevision] = useState(0)
+  useLiteratureChanges(() => {
+    if (reference) setLiteratureRevision((value) => value + 1)
+  })
   const [liveReference, setLiveReference] = useState<LiveReferenceState>({ status: 'idle' })
 
   useEffect(() => {
@@ -92,7 +97,7 @@ const ArtifactLiteratureDetailDialog = ({
     return () => {
       active = false
     }
-  }, [reference])
+  }, [reference, literatureRevision])
 
   const resolvedReference =
     reference && liveReference.itemId === reference.itemId ? liveReference : undefined

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.render.test.tsx
@@ -417,6 +417,7 @@ describe('ArtifactMentionPopup', () => {
           ? [
               {
                 id: 'collection-1',
+                revision: 1,
                 name: 'TP53 evidence',
                 description: '',
                 itemCount: 27,

--- a/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
+++ b/src/renderer/src/pages/workspace/composer/ArtifactMentionPopup.tsx
@@ -1,3 +1,4 @@
+import { useLiteratureChanges } from '@/pages/literature/useLiteratureChanges'
 import { useCallback, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { BookOpenText, FolderOpen } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -110,6 +111,10 @@ export const ArtifactMentionPopup = ({
   const [fileRetry, setFileRetry] = useState(0)
   const [libraryRetry, setLibraryRetry] = useState(0)
   const [collectionRetry, setCollectionRetry] = useState(0)
+  useLiteratureChanges(() => {
+    setLibraryRetry((value) => value + 1)
+    setCollectionRetry((value) => value + 1)
+  })
 
   useEffect(() => {
     let cancelled = false

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5011,6 +5011,10 @@
     "Retry unfinished": "Unfertige erneut versuchen",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDFs werden passenden Referenzen angehängt. Identische Anhänge werden wiederverwendet; unterschiedliche PDFs werden separat aufbewahrt.",
     "{{completed}} / {{total}} completed": "{{completed}} / {{total}} abgeschlossen",
-    "Finishing the current operation before stopping. Completed references are kept.": "Der aktuelle Vorgang wird vor dem Stoppen abgeschlossen. Abgeschlossene Referenzen bleiben erhalten."
+    "Finishing the current operation before stopping. Completed references are kept.": "Der aktuelle Vorgang wird vor dem Stoppen abgeschlossen. Abgeschlossene Referenzen bleiben erhalten.",
+    "This collection changed. Your edits have been kept.": "Diese Sammlung wurde geändert. Ihre Eingaben wurden beibehalten.",
+    "This collection no longer exists. Your edits have been kept.": "Diese Sammlung existiert nicht mehr. Ihre Eingaben wurden beibehalten.",
+    "The latest collection could not be loaded. Your edits have been kept.": "Die aktuelle Sammlung konnte nicht geladen werden. Ihre Eingaben wurden beibehalten.",
+    "Replace your unsaved edits with the latest saved collection.": "Ersetzen Sie Ihre ungespeicherten Änderungen durch die zuletzt gespeicherte Sammlung."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5173,6 +5173,10 @@
     "Retry unfinished": "Reintentar los pendientes",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "Los PDF se adjuntan a las referencias coincidentes. Los adjuntos idénticos se reutilizan; los PDF diferentes se conservan por separado.",
     "{{completed}} / {{total}} completed": "{{completed}} / {{total}} completados",
-    "Finishing the current operation before stopping. Completed references are kept.": "Se completará la operación actual antes de detenerse. Las referencias completadas se conservan."
+    "Finishing the current operation before stopping. Completed references are kept.": "Se completará la operación actual antes de detenerse. Las referencias completadas se conservan.",
+    "This collection changed. Your edits have been kept.": "Esta colección ha cambiado. Se han conservado sus cambios.",
+    "This collection no longer exists. Your edits have been kept.": "Esta colección ya no existe. Se han conservado sus cambios.",
+    "The latest collection could not be loaded. Your edits have been kept.": "No se pudo cargar la versión más reciente de la colección. Se han conservado sus cambios.",
+    "Replace your unsaved edits with the latest saved collection.": "Sustituir los cambios sin guardar por la última versión guardada de la colección."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5173,6 +5173,10 @@
     "Retry unfinished": "Réessayer les éléments inachevés",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "Les PDF sont joints aux références correspondantes. Les pièces jointes identiques sont réutilisées ; les PDF différents sont conservés séparément.",
     "{{completed}} / {{total}} completed": "{{completed}} / {{total}} terminés",
-    "Finishing the current operation before stopping. Completed references are kept.": "L’opération en cours se terminera avant l’arrêt. Les références terminées sont conservées."
+    "Finishing the current operation before stopping. Completed references are kept.": "L’opération en cours se terminera avant l’arrêt. Les références terminées sont conservées.",
+    "This collection changed. Your edits have been kept.": "Cette collection a été modifiée. Vos modifications ont été conservées.",
+    "This collection no longer exists. Your edits have been kept.": "Cette collection n’existe plus. Vos modifications ont été conservées.",
+    "The latest collection could not be loaded. Your edits have been kept.": "La dernière version de la collection n’a pas pu être chargée. Vos modifications ont été conservées.",
+    "Replace your unsaved edits with the latest saved collection.": "Remplacer les modifications non enregistrées par la dernière version enregistrée de la collection."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4857,6 +4857,10 @@
     "Retry unfinished": "未完了の項目を再試行",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF は一致する文献に添付されます。同一の添付ファイルは再利用し、異なる PDF は個別に保持します。",
     "{{completed}} / {{total}} completed": "{{completed}} / {{total}} 完了",
-    "Finishing the current operation before stopping. Completed references are kept.": "現在の操作を完了してから停止します。完了した文献は保持されます。"
+    "Finishing the current operation before stopping. Completed references are kept.": "現在の操作を完了してから停止します。完了した文献は保持されます。",
+    "This collection changed. Your edits have been kept.": "このコレクションは変更されています。編集内容は保持されています。",
+    "This collection no longer exists. Your edits have been kept.": "このコレクションは存在しません。編集内容は保持されています。",
+    "The latest collection could not be loaded. Your edits have been kept.": "最新のコレクションを読み込めませんでした。編集内容は保持されています。",
+    "Replace your unsaved edits with the latest saved collection.": "未保存の編集内容を最後に保存されたコレクションで置き換えます。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4855,6 +4855,10 @@
     "Retry unfinished": "미완료 항목 다시 시도",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF는 일치하는 문헌에 첨부됩니다. 동일한 첨부 파일은 재사용하고 서로 다른 PDF는 별도로 유지합니다.",
     "{{completed}} / {{total}} completed": "{{completed}} / {{total}} 완료",
-    "Finishing the current operation before stopping. Completed references are kept.": "현재 작업을 완료한 후 중지합니다. 완료된 문헌은 유지됩니다."
+    "Finishing the current operation before stopping. Completed references are kept.": "현재 작업을 완료한 후 중지합니다. 완료된 문헌은 유지됩니다.",
+    "This collection changed. Your edits have been kept.": "이 컬렉션이 변경되었습니다. 편집 내용은 유지됩니다.",
+    "This collection no longer exists. Your edits have been kept.": "이 컬렉션이 더 이상 존재하지 않습니다. 편집 내용은 유지됩니다.",
+    "The latest collection could not be loaded. Your edits have been kept.": "최신 컬렉션을 불러올 수 없습니다. 편집 내용은 유지됩니다.",
+    "Replace your unsaved edits with the latest saved collection.": "저장하지 않은 편집 내용을 최근 저장된 컬렉션으로 바꿉니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5306,6 +5306,10 @@
     "Retry unfinished": "Повторить незавершённые",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF прикрепляются к соответствующим ссылкам. Одинаковые вложения используются повторно, а разные PDF сохраняются отдельно.",
     "{{completed}} / {{total}} completed": "Завершено {{completed}} / {{total}}",
-    "Finishing the current operation before stopping. Completed references are kept.": "Остановка после завершения текущей операции. Завершённые ссылки сохраняются."
+    "Finishing the current operation before stopping. Completed references are kept.": "Остановка после завершения текущей операции. Завершённые ссылки сохраняются.",
+    "This collection changed. Your edits have been kept.": "Эта коллекция изменена. Ваши правки сохранены в форме.",
+    "This collection no longer exists. Your edits have been kept.": "Эта коллекция больше не существует. Ваши правки сохранены в форме.",
+    "The latest collection could not be loaded. Your edits have been kept.": "Не удалось загрузить последнюю версию коллекции. Ваши правки сохранены в форме.",
+    "Replace your unsaved edits with the latest saved collection.": "Заменить несохранённые правки последней сохранённой версией коллекции."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4857,6 +4857,10 @@
     "Retry unfinished": "重试未完成项",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF 将添加到匹配的文献。相同附件会复用，不同 PDF 会分别保留。",
     "{{completed}} / {{total}} completed": "已完成 {{completed}} / {{total}}",
-    "Finishing the current operation before stopping. Completed references are kept.": "完成当前操作后停止。已完成的文献会保留。"
+    "Finishing the current operation before stopping. Completed references are kept.": "完成当前操作后停止。已完成的文献会保留。",
+    "This collection changed. Your edits have been kept.": "此合集已更改。已保留您的编辑内容。",
+    "This collection no longer exists. Your edits have been kept.": "此合集已不存在。已保留您的编辑内容。",
+    "The latest collection could not be loaded. Your edits have been kept.": "无法加载最新合集。已保留您的编辑内容。",
+    "Replace your unsaved edits with the latest saved collection.": "用最新保存的合集替换您尚未保存的编辑内容。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4857,6 +4857,10 @@
     "Retry unfinished": "重試未完成項目",
     "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF 將新增至相符的文獻。相同附件會重複使用，不同 PDF 會分別保留。",
     "{{completed}} / {{total}} completed": "已完成 {{completed}} / {{total}}",
-    "Finishing the current operation before stopping. Completed references are kept.": "完成目前操作後停止。已完成的文獻會保留。"
+    "Finishing the current operation before stopping. Completed references are kept.": "完成目前操作後停止。已完成的文獻會保留。",
+    "This collection changed. Your edits have been kept.": "此合集已變更。已保留您的編輯內容。",
+    "This collection no longer exists. Your edits have been kept.": "此合集已不存在。已保留您的編輯內容。",
+    "The latest collection could not be loaded. Your edits have been kept.": "無法載入最新合集。已保留您的編輯內容。",
+    "Replace your unsaved edits with the latest saved collection.": "以最新儲存的合集取代您尚未儲存的編輯內容。"
   }
 }

--- a/src/shared/literature.test.ts
+++ b/src/shared/literature.test.ts
@@ -180,11 +180,16 @@ describe('Literature Collection contracts', () => {
     expect(
       literatureCatalogCommandSchema.parse({
         kind: 'update-collection',
+        expectedRevision: 1,
         collectionId: 'collection-1',
         name: 'Included studies',
         description: 'Final synthesis set.'
       })
-    ).toMatchObject({ kind: 'update-collection', collectionId: 'collection-1' })
+    ).toMatchObject({
+      kind: 'update-collection',
+      expectedRevision: 1,
+      collectionId: 'collection-1'
+    })
     expect(
       literatureCatalogCommandSchema.parse({
         kind: 'delete-collection',
@@ -193,6 +198,7 @@ describe('Literature Collection contracts', () => {
     ).toEqual({ kind: 'delete-collection', collectionId: 'collection-1' })
     expect(
       literatureCollectionViewSchema.parse({
+        revision: 1,
         id: 'collection-1',
         name: 'Included studies',
         description: 'Final synthesis set.',

--- a/src/shared/literature.ts
+++ b/src/shared/literature.ts
@@ -348,8 +348,11 @@ const literatureInboxCandidateViewSchema = z
   })
   .strict()
 
+const LITERATURE_COLLECTION_REVISION_CONFLICT = 'literature_collection_revision_conflict'
+
 const literatureCollectionViewSchema = z
   .object({
+    revision: z.number().int().positive(),
     id: nonEmptyTextSchema,
     name: nonEmptyTextSchema.max(LITERATURE_COLLECTION_NAME_MAX_LENGTH),
     description: z.string().max(LITERATURE_COLLECTION_DESCRIPTION_MAX_LENGTH),
@@ -528,6 +531,7 @@ const literatureCatalogCommandSchema = z.discriminatedUnion('kind', [
   z
     .object({
       kind: z.literal('update-collection'),
+      expectedRevision: z.number().int().positive(),
       collectionId: nonEmptyTextSchema,
       name: nonEmptyTextSchema.max(LITERATURE_COLLECTION_NAME_MAX_LENGTH),
       description: z.string().trim().max(LITERATURE_COLLECTION_DESCRIPTION_MAX_LENGTH)
@@ -1175,6 +1179,7 @@ export {
   literatureCatalogReceiptSchema,
   literatureCatalogSearchPageSchema,
   literatureCatalogSearchRequestSchema,
+  LITERATURE_COLLECTION_REVISION_CONFLICT,
   literatureCollectionViewSchema,
   literatureFilterSchema,
   literatureCreatorInputSchema,
@@ -1255,3 +1260,11 @@ export type {
   LiteraturePdfImportRequest,
   LiteratureSourceInput
 }
+
+// Invalidation hints only; clients re-read authoritative records rather than applying event content.
+export type LiteratureChangedEvent = Readonly<{
+  revision: number
+  itemIds?: readonly string[]
+  collectionIds?: readonly string[]
+  candidateIds?: readonly string[]
+}>

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -2,6 +2,7 @@ import type {
   LiteratureExportRecordRequest,
   LiteratureExportRecordResult
 } from './literature-export'
+import type { LiteratureChangedEvent } from './literature'
 import type { ProvenanceReadResult } from './provenance-read-result'
 import type { LiteratureJobRequest, LiteratureJobsResult } from './literature-jobs'
 import type { LiteratureFullTextRequest, LiteratureFullTextResult } from './literature'
@@ -1165,6 +1166,9 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'literature.importRecords': callable<
     (request: LiteratureRecordImportRequest) => Promise<LiteratureRecordImportResult>
   >()('literature', ['literature:import-records', WEB, undefined, undefined, RUNTIME_VALIDATED]),
+  'literature.onChanged': callable<
+    (listener: AcpListener<LiteratureChangedEvent>) => RemoveListener
+  >()('literature', ['literature:changed', EVENT]),
   'literature.search': callable<
     (request: LiteratureCatalogSearchRequest) => Promise<LiteratureCatalogSearchPage>
   >()('literature', ['literature:search', WEB, undefined, undefined, RUNTIME_VALIDATED]),

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -366,6 +366,7 @@ export const WEB_EVENT_CHANNELS = {
   'compute.onApprovalRequest': 'compute:approval-request',
   'compute.onApprovalSettled': 'compute:approval-settled',
   'compute.onJobUpdated': 'compute:job-updated',
+  'literature.onChanged': 'literature:changed',
   'memory.onChanged': 'memory:changed',
   'notebook.onAvailable': 'notebook:available',
   'notebook.onChanged': 'notebook:changed',


### PR DESCRIPTION
## Problem

Ordinary Library changes remained invisible in other clients, stale collection forms could overwrite previously saved fields, and late reads with equal metadata revisions could replace newer attachment or relationship snapshots.

## Proposed change

- Publish committed catalog invalidations through the existing Electron/Web event contracts. Refresh active Library views, counts, collection navigation, live details, search and mention consumers on changes, focus and Web recovery. Keep unsaved drafts.
- Use atomic collection revision comparisons and show a retained-draft conflict with the latest saved values. Loading the latest version is an explicit action; different-field edits also conflict.
- Reject obsolete per-item reads in the existing list and detail owners, including reverse completion and independent-item batches.

## Scope and compatibility

Migration `0040_literature_collection_revision` adds one persisted integer column, backfilling existing collections to 1 without changing their IDs, metadata or hierarchy. Update requests now require `expectedRevision`; old clients must refresh/upgrade. Previously overwritten values cannot be recovered by this migration. No new persisted state enum, relationship entity, event journal or draft storage is introduced.

Events contain resource IDs and a process-local monotonic revision, not full reference contents. Focus/recovery rereads authoritative data; this does not introduce a durable global version protocol. Transaction rollback and no-op writes emit no mutation event, and failed delivery cannot undo a commit. Attachment verification invalidates its persisted observation even when the observation reports unavailable bytes.

## Acceptance criteria and validation

Before production edits, the same regressions failed twice at the existing SQLite catalog, React page and hook boundaries: 8 matching failures and 4 passing controls. The fixed regressions pass. Additional tests cover atomic conflict/retry/deletion, migration backfill, event delivery failure/rollback/no-ops, subscriber cleanup, read ordering and retained drafts.

Behavior-to-check mapping (the original implementation checks preceded the latest base update; the final-head rechecks are identified below):

| Behavior | Repository check | Result |
| --- | --- | --- |
| Catalog writes, cached reads, collection conflicts, drafts and all translated UI strings | `npx vitest run src/main/literature src/renderer/src/pages/literature src/shared/literature.test.ts src/shared/literature-csl.test.ts src/shared/renderer-contract.test.ts src/shared/renderer-contract-catalog.test.ts src/preload/index.test.ts src/main/application-events.test.ts src/main/renderer-broadcast.test.ts src/main/lifecycle-broadcast.test.ts src/main/data-content-application-commands.test.ts src/renderer/src/i18n/resources.test.ts` | 1,773 passed; one capacity test failed during concurrent build/test load and passed standalone without code changes |
| Migration history, upgrades and retained values | `npx vitest run src/main/database` | 305 passed |
| Packaged migration certification and historical upgrade fixtures | `npx vitest run scripts/database-migration-ledger-smoke.test.ts src/main/database/literature-collection-revision.test.ts` plus the Linux/macOS/Windows package smoke test files | 16 migration checks and 45 consumer checks passed after fixing an omitted certification ledger entry |
| Event projection, Web bootstrap/recovery, search and mention consumers | Explicit application event flow, renderer surface matrix, Web API installer/bootstrap, Web event projection/controller/stream, GlobalSearchDialog and ArtifactMentionPopup test files | 290 passed |
| Two real Electron renderers plus one real Web client: create/edit/delete/accept/classify and offline recovery | `npx playwright test e2e/literature-client-sync.spec.ts --workers=1` against rebuilt Electron/Web outputs | Passed |
| Types, formatting and generated persistence/transport contracts | `npm run typecheck`, `npm run lint`, `npm run db:schema:check`, `npm run check:web-api-map` | Passed |

The impact explain command selects the full CI fallback because these paths are not completely module-owned. Per maintainer instruction, no full local `npm test` was run; exact-head PR CI is authoritative. The new three-client scenario is a standalone macOS check; the existing Windows/Linux CI lanes do not establish that exact scenario on those platforms. The live scenario exercises all three transports but not every operation-by-client permutation. The conflict screenshot was captured from the real dialog with a controlled conflict API fixture; its interaction is also covered by the dialog test.

Latest head `63cbb337` is rebased onto `684bdaa3`, preserving upstream relocation, deletion protection, import progress and cancellation. After the final edits, 1,384 Literature/catalog/i18n tests passed; two page timing failures in the concurrent run passed unchanged in isolation. All 374 Notebook runtime tests passed on serial rerun after two unrelated startup-wait failures in the concurrent run. Process typechecks, lint, formatting, generated schema/API-map checks and PR policy pass. Earlier transport, persistence and live multi-client evidence above remains a prior checkpoint; exact-head CI is required.

Review fixes propagate the committed collection revision to the local directory. Removed or merged references close read-only details; editors retain their input and disable Save. A separate transient removed-reference ID now keeps that protection intact across locale-triggered list reloads, and the notice translates at render time. It clears on detail open/close or confirmed restoration. No new persistence or enum is added. Nine focused real-page regressions pass; browser verification confirms the retained draft, Chinese notice and disabled Save.

CI fixes await existing shell admission or explicit installer-start signals and use public batch import to prepare the 201-item collection test. The original ordering, repair-gate, atomicity and count assertions remain. Installer-start failures were reproduced with a temporary 1.3-second mock delay and passed after the fix with the same delay; the delay is removed. The previous Windows startup failure passed on retry; no timeout or flaky-test gate was relaxed. New-head CI and review remain pending.

Latest rebase checkpoint `f30de451` is based on `f4a82d4a`. Upstream attachment confirmation/version-history behavior is retained. The new component fixtures now provide this PR's required `readItem` callback. Rebase checks passed 1,320 tests and exposed one missing-callback failure; all 13 attachment component tests pass after correction, along with renderer typecheck, lint, formatting and PR policy. Node/sandbox checks also passed. The remote-deleted collection scope and non-edit detail panel findings are reproduced and awaiting interaction confirmation; they remain unresolved. Windows startup latency is under a focused `windows-e2e` dry-run; new-head CI remains required.

## Review focus

Please check committed-event boundaries and Web recovery, revision comparison/backfill, preservation of unsaved input, and obsolete-read rejection. Also verify that the retained upstream metadata-operation receipts and manual-entry recovery behavior remain intact. Independent review and required CI must complete before merge.
