### PR TITLE
fix(literature): respect input composition during editing and search

### DIFF
--- a/src/renderer/src/components/ui/dialog.render.test.tsx
+++ b/src/renderer/src/components/ui/dialog.render.test.tsx
@@ -114,3 +114,33 @@ it('forwards content refs and preserves stricter caller dismissal policies', asy
   view.unmount()
   expect(cleanupRef).toHaveBeenCalledOnce()
 })
+
+it.each([false, true])(
+  'ignores composing Escape before caller effects and preserves ordinary Escape policy (custom=%s)',
+  (custom) => {
+    const onEscapeKeyDown = vi.fn((event: KeyboardEvent) => event.preventDefault())
+    render(
+      <Dialog.Root defaultOpen>
+        <Dialog.Content onEscapeKeyDown={custom ? onEscapeKeyDown : undefined}>
+          <Dialog.Title>Edit reference</Dialog.Title>
+          <Dialog.Description>Unsaved draft</Dialog.Description>
+          <input aria-label="Draft" defaultValue="Existing draft" />
+        </Dialog.Content>
+      </Dialog.Root>
+    )
+    const dialog = screen.getByRole('dialog')
+    const input = screen.getByRole('textbox', { name: 'Draft' })
+    fireEvent.compositionStart(input)
+    fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+    expect(onEscapeKeyDown).not.toHaveBeenCalled()
+    expect(screen.queryByRole('dialog')).toBe(dialog)
+    fireEvent.compositionEnd(input)
+    fireEvent.keyDown(input, { key: 'Escape', isComposing: false })
+    if (custom) {
+      expect(onEscapeKeyDown).toHaveBeenCalledOnce()
+      expect(screen.queryByRole('dialog')).toBe(dialog)
+    } else {
+      expect(screen.queryByRole('dialog')).toBeNull()
+    }
+  }
+)

--- a/src/renderer/src/components/ui/dialog.tsx
+++ b/src/renderer/src/components/ui/dialog.tsx
@@ -6,6 +6,7 @@ import { useChildLayerDismissalGuard } from './use-child-layer-dismissal-guard'
 function Content({
   ref,
   onInteractOutside,
+  onEscapeKeyDown,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content>): React.JSX.Element {
   const { setContentRef, onInteractOutside: guardChildDismissal } = useChildLayerDismissalGuard(ref)
@@ -13,6 +14,14 @@ function Content({
     <DialogPrimitive.Content
       {...props}
       ref={setContentRef}
+      onEscapeKeyDown={(event) => {
+        // Guard before caller effects as well as Radix's default dismissal.
+        if (event.isComposing) {
+          event.preventDefault()
+          return
+        }
+        onEscapeKeyDown?.(event)
+      }}
       onInteractOutside={(event) => {
         guardChildDismissal(event)
         onInteractOutside?.(event)
@@ -21,7 +30,7 @@ function Content({
   )
 }
 
-// Keep Radix's API and behavior, with child-layer dismissal protection at every
+// Keep Radix's API and behavior, with composition and child-layer protection at every
 // Dialog boundary. Callers still own styles and any stricter dismissal policy.
 const Root = DialogPrimitive.Root
 const Trigger = DialogPrimitive.Trigger

--- a/src/renderer/src/i18n/resources.test.ts
+++ b/src/renderer/src/i18n/resources.test.ts
@@ -1732,7 +1732,7 @@ describe('mandatory product glossary', () => {
       readFileSync(join(__dirname, '..', '..', '..', '..', 'package.json'), 'utf8')
     ) as { version: string }
     // The banner assertion tracks the repo version instead of a hardcoded bump target.
-    expect(readme).toContain(`Open Science v${rootPackage.version} veröffentlicht`)
+    expect(readme).toContain(`AIPOCH Open-Science v${rootPackage.version} veröffentlicht`)
     expect(readme).toContain('30-Tage-Aktivitäts-Heatmap')
     expect(readme).toContain('10 GB')
     expect(readme).toContain('22 hervorgehobenen')

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -557,6 +557,25 @@ describe('LiteratureLibraryPage', () => {
     }
   })
 
+  it.each(['中文', ''])(
+    'keeps selection aligned with a composition-end-only search value: %s',
+    async (final) => {
+      search.mockImplementation((request: { scope: string }) =>
+        Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })
+      )
+      render(<LiteratureLibraryPage />)
+      fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+      await screen.findByText(libraryItem.item.title)
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Select all references' }))
+      expect(screen.queryByText('1 selected')).not.toBeNull()
+      const input = screen.getByLabelText('Search references')
+      fireEvent.compositionStart(input)
+      fireEvent.compositionEnd(input, { data: final, target: { value: final } })
+      if (final) expect(screen.queryByText('1 selected')).toBeNull()
+      else expect(screen.queryByText('1 selected')).not.toBeNull()
+    }
+  )
+
   it('cancels a pending catalog search when composition starts before another change', async () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -447,6 +447,147 @@ describe('LiteratureLibraryPage', () => {
     vi.unstubAllGlobals()
   })
 
+  it.each(['Edit metadata', 'New collection'])(
+    'preserves the %s draft when Escape cancels composition',
+    async (action) => {
+      search.mockImplementation((request: { scope: string }) =>
+        Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })
+      )
+      render(<LiteratureLibraryPage />)
+      if (action === 'Edit metadata') {
+        fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+        await openReferenceDetail(await screen.findByText(libraryItem.item.title))
+        await openMenu(screen.getByRole('button', { name: 'More actions' }))
+        fireEvent.click(screen.getByRole('menuitem', { name: action }))
+      } else {
+        fireEvent.click(screen.getByRole('button', { name: action }))
+      }
+      const dialog = screen.getByRole('dialog')
+      const input = within(dialog).getByLabelText(action === 'Edit metadata' ? 'Title' : 'Name')
+      fireEvent.change(input, { target: { value: 'Existing draft' } })
+      fireEvent.compositionStart(input)
+      // Move beyond the unrelated child-menu dismissal grace period.
+      vi.useFakeTimers()
+      try {
+        await act(async () => {
+          await vi.advanceTimersByTimeAsync(1000)
+        })
+        fireEvent.keyDown(input, { key: 'Escape', isComposing: true })
+        expect(transact).not.toHaveBeenCalled()
+        expect(screen.queryByRole('dialog')).toBe(dialog)
+        expect((input as HTMLInputElement).value).toBe('Existing draft')
+        fireEvent.compositionEnd(input)
+        fireEvent.keyDown(input, { key: 'Escape', isComposing: false })
+        expect(screen.queryByRole('dialog')).toBeNull()
+      } finally {
+        vi.useRealTimers()
+      }
+    }
+  )
+
+  it('waits for an explicit Enter after metadata identifier composition before querying', async () => {
+    search.mockImplementation((request: { scope: string }) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [libraryItem] } : { entries: [] })
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await openReferenceDetail(await screen.findByText(libraryItem.item.title))
+    await openMenu(screen.getByRole('button', { name: 'More actions' }))
+    fireEvent.click(screen.getByRole('menuitem', { name: 'Complete metadata' }))
+    const input = screen.getByRole('textbox', { name: 'DOI' })
+    fireEvent.change(input, { target: { value: '' } })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: false })
+    expect(completeMetadata).not.toHaveBeenCalled()
+    fireEvent.compositionStart(input)
+    fireEvent.change(input, { target: { value: '10.1234/zhong' } })
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true })
+    expect(completeMetadata).not.toHaveBeenCalled()
+    expect(transact).not.toHaveBeenCalled()
+    fireEvent.compositionEnd(input)
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: false })
+    expect(screen.getByRole('button', { name: 'Search', hidden: true }).matches(':disabled')).toBe(
+      true
+    )
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: false })
+    await waitFor(() =>
+      expect(completeMetadata).toHaveBeenCalledExactlyOnceWith({
+        mode: 'preview',
+        itemId: libraryItem.id,
+        identifier: { scheme: 'doi', value: '10.1234/zhong' }
+      })
+    )
+  })
+
+  it.each([
+    ['zhong', '中文'],
+    ['にほん', '日本'],
+    ['ㅎ', '한']
+  ])('defers catalog search until composition ends: %s → %s', async (intermediate, final) => {
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(expect.objectContaining({ scope: 'library' }))
+    )
+    const input = screen.getByLabelText('Search references')
+    vi.useFakeTimers()
+    try {
+      search.mockClear()
+      fireEvent.compositionStart(input)
+      fireEvent.change(input, { target: { value: intermediate } })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(301)
+      })
+      expect(search).not.toHaveBeenCalledWith(expect.objectContaining({ query: intermediate }))
+      fireEvent.compositionEnd(input, { data: final, target: { value: final } })
+      // Some browsers send a final input/change after compositionend.
+      fireEvent.change(input, { target: { value: final } })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(299)
+      })
+      expect(search).not.toHaveBeenCalledWith(expect.objectContaining({ query: final }))
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1)
+      })
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'library', query: final })
+      )
+      expect(search.mock.calls.filter(([request]) => request.query === final)).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('cancels a pending catalog search when composition starts before another change', async () => {
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await waitFor(() =>
+      expect(search).toHaveBeenCalledWith(expect.objectContaining({ scope: 'library' }))
+    )
+    const input = screen.getByLabelText('Search references')
+    vi.useFakeTimers()
+    try {
+      search.mockClear()
+      fireEvent.change(input, { target: { value: 'draft' } })
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(200)
+      })
+      fireEvent.compositionStart(input)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(301)
+      })
+      expect(search).not.toHaveBeenCalledWith(expect.objectContaining({ query: 'draft' }))
+      fireEvent.compositionEnd(input)
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(301)
+      })
+      expect(search).toHaveBeenCalledWith(
+        expect.objectContaining({ scope: 'library', query: 'draft' })
+      )
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('trashes all 26 members despite an update between target reads', async () => {
     const { mkdtemp, rm } = await import('node:fs/promises')
     const { tmpdir } = await import('node:os')

--- a/src/renderer/src/pages/literature/LiteratureMetadataLookup.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMetadataLookup.tsx
@@ -118,7 +118,7 @@ const LiteratureMetadataLookup = ({
               updateIdentifier({ ...identifier, value: event.currentTarget.value })
             }
             onKeyDown={(event) => {
-              if (event.key === 'Enter') search()
+              if (event.key === 'Enter' && !event.nativeEvent.isComposing) search()
             }}
           />
           <Button

--- a/src/renderer/src/pages/literature/LiteratureSearchInput.tsx
+++ b/src/renderer/src/pages/literature/LiteratureSearchInput.tsx
@@ -17,16 +17,17 @@ const LiteratureSearchInput = ({
 }>): React.JSX.Element => {
   const { t } = useTranslation()
   const [draft, setDraft] = useState(initialValue)
+  const [isComposing, setIsComposing] = useState(false)
   const committedRef = useRef(initialValue)
 
   useEffect(() => {
-    if (draft === committedRef.current) return
+    if (isComposing || draft === committedRef.current) return
     const timeout = window.setTimeout(() => {
       committedRef.current = draft
       onCommit(draft)
     }, SEARCH_DEBOUNCE_MS)
     return () => window.clearTimeout(timeout)
-  }, [draft, onCommit])
+  }, [draft, isComposing, onCommit])
 
   return (
     <label className="relative block min-w-0 flex-1 sm:w-80 sm:flex-none">
@@ -36,6 +37,11 @@ const LiteratureSearchInput = ({
       />
       <Input
         value={draft}
+        onCompositionStart={() => setIsComposing(true)}
+        onCompositionEnd={(event) => {
+          setDraft(event.currentTarget.value)
+          setIsComposing(false)
+        }}
         onChange={(event) => {
           setDraft(event.target.value)
           onDraftChange()

--- a/src/renderer/src/pages/literature/LiteratureSearchInput.tsx
+++ b/src/renderer/src/pages/literature/LiteratureSearchInput.tsx
@@ -20,6 +20,12 @@ const LiteratureSearchInput = ({
   const [isComposing, setIsComposing] = useState(false)
   const committedRef = useRef(initialValue)
 
+  const updateDraft = (value: string): void => {
+    if (value === draft) return
+    setDraft(value)
+    onDraftChange()
+  }
+
   useEffect(() => {
     if (isComposing || draft === committedRef.current) return
     const timeout = window.setTimeout(() => {
@@ -39,13 +45,10 @@ const LiteratureSearchInput = ({
         value={draft}
         onCompositionStart={() => setIsComposing(true)}
         onCompositionEnd={(event) => {
-          setDraft(event.currentTarget.value)
+          updateDraft(event.currentTarget.value)
           setIsComposing(false)
         }}
-        onChange={(event) => {
-          setDraft(event.target.value)
-          onDraftChange()
-        }}
+        onChange={(event) => updateDraft(event.target.value)}
         placeholder={t('Search references')}
         aria-label={t('Search references')}
         className="pl-9"


### PR DESCRIPTION
## Problem

Escape used to dismiss literature and collection editors during IME composition, discarding unsaved drafts. Enter could query an intermediate metadata identifier, and the search debounce could submit unfinished composition text, including a timer started before composition.

## Proposed change

- Guard composing Escape in shared Dialog Content before Radix dismissal or caller callbacks. This covers default and custom close paths across regular Dialog consumers.
- Ignore composing Enter in metadata lookup while retaining ordinary Enter, empty-value and busy checks.
- Pause literature search debounce during composition, cancel pending timers at composition start, and debounce the final value for 300 ms after composition ends. Route final-value changes through the existing draft callback so selection is cleared even without a following change event; unchanged/canceled composition remains a no-op.

No database/schema/API changes, persistence, migration, historical-data compatibility layer, new enum or dependency. The only new state is a component-local composition Boolean. Ordinary dismissal, selection policy and explicit query behavior remain unchanged.

## Acceptance criteria and validation

Tests exercise real Dialog/input components and existing literature API boundaries; no production test seam was added. Seven page regressions failed twice on unchanged production code at the reported behaviors. Two shared Dialog cases also failed before the fix. All nine pass after the fix, including ordinary Escape, empty/busy Enter, final-query timing and pending-timer controls. Two additional selection controls cover changed and unchanged composition-end-only values: the changed-value case failed with stale selection before correction. All 11 composition cases now pass.

Latest commit: `7f059795`. Translation guards, renderer typecheck and lint passed after the final test assertion correction. Literature and shared Dialog consumer results below cover the unchanged production implementation; current-head CI validates the full suite and platform lanes.

| Behavior | Command | Result |
| --- | --- | --- |
| Literature editing/search plus shared Dialog contract | `node node_modules/vitest/vitest.mjs run src/renderer/src/pages/literature src/renderer/src/components/ui/dialog.render.test.tsx src/renderer/src/components/ui/use-retained-dialog-value.test.tsx --maxWorkers=2` | 19 files / 376 passed |
| Shared Dialog consumers | `node node_modules/vitest/vitest.mjs run <files below> --maxWorkers=2` | 32 files / 522 tests passed |
| Translation guards | `node node_modules/vitest/vitest.mjs run src/renderer/src/i18n/resources.test.ts` | 804 passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Lint | `npm run lint` | Passed |

CI also exposed an existing German README version-banner assertion that still expected the old product name after the README was renamed. The focused test reproduced the same failure locally. This PR aligns that one assertion with `AIPOCH Open-Science`, retaining the dynamic package-version check; all 804 translation guards then passed. No product behavior or CI rule was changed for this correction.

Current-head CI passed, including Static checks, all Ubuntu portable shards, module coverage, Windows core/E2E, macOS build/E2E, CodeQL and PR Gate. Independent review for `7f059795` returned mergeable with no actionable findings. One initial Windows E2E run hit the existing database startup gate (still `migrating` after 60 seconds), then passed its built-in retry and was correctly rejected by the flaky-test policy. A targeted rerun of only that Windows job and dependent summaries passed without code, timeout or policy changes. This rerun is not a claim that the intermittent startup condition was fixed.

The module classifier reports an unknown owner for shared Dialog and selects full verification. Per maintainer instruction, local verification used the explicit owner/consumer set above; exact-head PR CI remains authoritative for the full suite and platform lanes. Main/preload code and persisted formats are unchanged.

Browser verification used the production literature page with fixture native APIs and synthetic composition events: both editors retained drafts without transactions, composing Enter made no request while ordinary Enter did, and only the final search text reached the search API. Screenshots were captured for the maintainer. **Actual system-IME candidate cancellation has not been manually verified**; synthetic DOM events do not establish that OS-level behavior.

<details>
<summary>Existing shared Dialog consumer test files</summary>

```text
src/renderer/src/components/JobDetailModal.render.test.tsx
src/renderer/src/components/SessionCatalogRecoveryAlert.render.test.tsx
src/renderer/src/components/UpdateDialog.lifecycle.test.tsx
src/renderer/src/components/UpdateDialog.render.test.tsx
src/renderer/src/components/global-search/GlobalSearchDialog.i18n.render.test.tsx
src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
src/renderer/src/pages/home/ProjectFormDialog.behavior.test.tsx
src/renderer/src/pages/home/home-dialogs.render.test.tsx
src/renderer/src/pages/settings/ComputeApprovalDialog.render.test.tsx
src/renderer/src/pages/settings/ConnectorApprovalDialog.render.test.tsx
src/renderer/src/pages/settings/ConnectorCredentialDialog.render.test.tsx
src/renderer/src/pages/settings/FileBrowserModal.render.test.tsx
src/renderer/src/pages/settings/RemoteControlPanel.render.test.tsx
src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
src/renderer/src/pages/settings/SettingsPage.render.test.tsx
src/renderer/src/pages/settings/SkillImportApprovalDialog.render.test.tsx
src/renderer/src/pages/settings/SkillImportCandidatePreview.render.test.tsx
src/renderer/src/pages/settings/StorageMigrationModal.render.test.tsx
src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx
src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx
src/renderer/src/pages/workspace/DownloadProjectArtifactsDialog.render.test.tsx
src/renderer/src/pages/workspace/DownloadSessionArtifactsDialog.interaction.test.tsx
src/renderer/src/pages/workspace/EditSessionDialog.interaction.test.tsx
src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx
src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx
src/renderer/src/pages/workspace/FilePreviewDialog.versioning.test.tsx
src/renderer/src/pages/workspace/GrantFolderAccessDialog.interaction.test.tsx
src/renderer/src/pages/workspace/GrantFolderAccessDialog.layers.test.tsx
src/renderer/src/pages/workspace/ReportErrorDialog.interaction.test.tsx
src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
src/renderer/src/pages/workspace/session-dialogs.render.test.tsx
```

</details>

## Review focus

Check that composing Escape is rejected before custom callback side effects, and that composition start cancels a timer even when no subsequent change event arrives. Check that final-only composition changes notify selection consumers and unchanged composition does not. Review the evidence mapping and shared Dialog consumer scope. Native IME acceptance remains the uncovered manual check.

