### PR TITLE
fix(literature): localize validation errors and merge labels

### DIFF
--- a/e2e/electron-foundation.spec.ts
+++ b/e2e/electron-foundation.spec.ts
@@ -4,6 +4,41 @@ import { test } from './fixtures/electron-app'
 
 const PROJECT_NAME = 'Electron E2E project'
 
+test('localizes CSL validation failures across the desktop bridge', async ({ app }, testInfo) => {
+  const page = await app.completeOnboarding()
+  await page.getByRole('button', { name: 'Library', exact: true }).click()
+  await page.getByRole('button', { name: 'Settings', exact: true }).click()
+  await page.evaluate(() => window.api.locale.setPreference({ preference: 'zh-Hans' }))
+  await expect(page.getByRole('heading', { name: '引文样式', exact: true })).toBeVisible()
+
+  const style = (info: string, citation = '<text variable="title"/>'): string =>
+    `<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0"><info>${info}</info><citation><layout>${citation}</layout></citation><bibliography><layout><text variable="title"/></layout></bibliography></style>`
+  const info = '<title>Original title</title><id>https://example.test/style</id>'
+  for (const [content, message] of [
+    ['<', '所选文件不是有效的 CSL XML。'],
+    [style('<id>https://example.test/style</id>'), 'CSL 样式必须包含标题和 ID。'],
+    [style('<title>Original title</title>'), 'CSL 样式必须包含标题和 ID。'],
+    [
+      style(`${info}<link rel="independent-parent" href="https://example.test/parent"/>`),
+      '暂不支持依赖型 CSL 样式。请导入独立样式。'
+    ],
+    [style(info, '<text macro="author-原名"/>'), 'CSL 样式引用了未定义的宏：author-原名']
+  ]) {
+    await page.locator('input[type="file"][accept=".csl,application/xml,text/xml"]').setInputFiles({
+      name: 'invalid.csl',
+      mimeType: 'application/xml',
+      buffer: Buffer.from(content)
+    })
+    await expect(page.locator('button').filter({ hasText: /^导入 CSL$/ })).toBeEnabled()
+    await expect(page.getByRole('alert')).toHaveText(message)
+  }
+  await page.screenshot({ path: testInfo.outputPath('csl-validation-zh-Hans.png') })
+  await page.evaluate(() => window.api.locale.setPreference({ preference: 'en' }))
+  await expect(page.getByRole('alert')).toHaveText(
+    'The CSL style references an undefined macro: author-原名'
+  )
+})
+
 const createProject = async (page: Page, name: string): Promise<void> => {
   await page.getByRole('button', { name: 'New project' }).click()
   const dialog = page.getByRole('dialog', { name: 'New project' })

--- a/src/main/application-command-electron-adapter.test.ts
+++ b/src/main/application-command-electron-adapter.test.ts
@@ -145,3 +145,26 @@ describe('Electron Application Command adapter', () => {
     expect(handlers).toEqual(new Map())
   })
 })
+
+it('preserves CSL validation parameters through the Electron command adapter', async () => {
+  registerApplicationCommandElectronAdapter(
+    dispatcher(
+      vi.fn().mockRejectedValue(
+        new ApplicationCommandError('csl-undefined-macro', 'Undefined macro', {
+          macro: 'author-原名'
+        })
+      )
+    ),
+    { warn }
+  )
+  await expect(
+    handlers.get('literature:citation-styles')?.(eventWithLease(), { kind: 'import', content: '<' })
+  ).resolves.toEqual({
+    ok: false,
+    error: {
+      code: 'csl-undefined-macro',
+      message: 'Undefined macro',
+      parameters: { macro: 'author-原名' }
+    }
+  })
+})

--- a/src/main/literature/citation-style-library.test.ts
+++ b/src/main/literature/citation-style-library.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -214,4 +214,34 @@ it('CS-02 checks and restores stored bytes even when UTF-8 decoding masks corrup
   expect.soft((await library.list()).some(({ id }) => id === styleId)).toBe(false)
   expect(await library.import(content)).toBe(styleId)
   expect(await readFile(path)).toEqual(original)
+})
+
+it.each([
+  ['csl-file-too-large', 'x'.repeat(1024 * 1024 + 1)],
+  ['csl-invalid-xml', '<'],
+  [
+    'csl-unsupported-doctype',
+    '<!DOCTYPE style>' + independentStyle().replace('<?xml version="1.0"?>', '')
+  ],
+  ['csl-unsupported-style', '<style/>'],
+  ['csl-missing-metadata', independentStyle().replace(/<title>.*?<\/title>/u, '')],
+  [
+    'csl-dependent-style',
+    independentStyle().replace(
+      '<info>',
+      '<info><link rel="independent-parent" href="https://example.test/parent"/>'
+    )
+  ],
+  [
+    'csl-undefined-macro',
+    independentStyle().replace('<text variable="title"/>', '<text macro="author-原名"/>')
+  ],
+  ['csl-missing-sections', independentStyle().replace(/<bibliography>.*?<\/bibliography>/u, '')]
+])('rejects imports with the stable code %s before writing files', async (code, content) => {
+  const { library, stylesDirectory } = await createLibrary()
+  await expect(library.import(content)).rejects.toMatchObject({
+    code,
+    ...(code === 'csl-undefined-macro' ? { parameters: { macro: 'author-原名' } } : {})
+  })
+  await expect(readdir(stylesDirectory)).rejects.toMatchObject({ code: 'ENOENT' })
 })

--- a/src/main/literature/citation-style-library.ts
+++ b/src/main/literature/citation-style-library.ts
@@ -5,6 +5,8 @@ import { createRequire } from 'node:module'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
+import { ApplicationCommandError } from '../../shared/application-command-contract'
+
 import { SaxesParser } from 'saxes'
 import { createEngine } from 'citeme-engine-wasm'
 
@@ -43,7 +45,7 @@ const parseCitationStyle = (
   source: LiteratureCitationStyleView['source']
 ): CitationStyleSource => {
   if (Buffer.byteLength(content, 'utf8') > LITERATURE_CSL_MAX_BYTES) {
-    throw new Error('The CSL file must be 1 MB or smaller.')
+    throw new ApplicationCommandError('csl-file-too-large', 'The CSL file must be 1 MB or smaller.')
   }
 
   let depth = 0
@@ -59,10 +61,13 @@ const parseCitationStyle = (
   const parser = new SaxesParser({ xmlns: true })
 
   parser.on('error', () => {
-    throw new Error('The selected file is not valid CSL XML.')
+    throw new ApplicationCommandError('csl-invalid-xml', 'The selected file is not valid CSL XML.')
   })
   parser.on('doctype', () => {
-    throw new Error('CSL files with a document type declaration are not supported.')
+    throw new ApplicationCommandError(
+      'csl-unsupported-doctype',
+      'CSL files with a document type declaration are not supported.'
+    )
   })
   parser.on('opentag', (tag) => {
     depth += 1
@@ -75,7 +80,10 @@ const parseCitationStyle = (
         tag.uri !== CSL_NAMESPACE ||
         !/^1\.0(?:\.\d+)?$/u.test(version ?? '')
       ) {
-        throw new Error('The selected file must be an independent CSL 1.0 style.')
+        throw new ApplicationCommandError(
+          'csl-unsupported-style',
+          'The selected file must be an independent CSL 1.0 style.'
+        )
       }
       rootSeen = true
       return
@@ -127,25 +135,36 @@ const parseCitationStyle = (
   try {
     parser.write(content).close()
   } catch (error) {
-    if (error instanceof Error && error.message.startsWith('The selected file')) throw error
-    if (error instanceof Error && error.message.startsWith('CSL files')) throw error
-    throw new Error('The selected file is not valid CSL XML.')
+    if (error instanceof ApplicationCommandError) throw error
+    throw new ApplicationCommandError('csl-invalid-xml', 'The selected file is not valid CSL XML.')
   }
 
   const title = normalizeXmlText(captured.title)
   const canonicalId = normalizeXmlText(captured.id)
   if (!rootSeen || !title || !canonicalId) {
-    throw new Error('The CSL style must include a title and an id.')
+    throw new ApplicationCommandError(
+      'csl-missing-metadata',
+      'The CSL style must include a title and an id.'
+    )
   }
   if (dependent) {
-    throw new Error('Dependent CSL styles are not supported yet. Import an independent style.')
+    throw new ApplicationCommandError(
+      'csl-dependent-style',
+      'Dependent CSL styles are not supported yet. Import an independent style.'
+    )
   }
 
   for (const name of macroReferences) {
-    if (!macros.has(name)) throw new Error(`The CSL style references an undefined macro: ${name}`)
+    if (!macros.has(name))
+      throw new ApplicationCommandError(
+        'csl-undefined-macro',
+        `The CSL style references an undefined macro: ${name}`,
+        { macro: name }
+      )
   }
   if (!citation || !bibliography) {
-    throw new Error(
+    throw new ApplicationCommandError(
+      'csl-missing-sections',
       'Open Science requires CSL styles with both citation and bibliography sections.'
     )
   }
@@ -237,7 +256,10 @@ class LiteratureCitationStyleLibrary {
     try {
       engine.loadStyle(styleId, content)
     } catch {
-      throw new Error('The selected file is not valid CSL XML.')
+      throw new ApplicationCommandError(
+        'csl-invalid-xml',
+        'The selected file is not valid CSL XML.'
+      )
     } finally {
       engine.free()
     }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -882,9 +882,16 @@ describe('startWebHttpServer', () => {
     for (const [code, expectedStatus] of [
       ['command-unavailable', 404],
       ['session-details-conflict', 409],
-      ['session-revision-conflict', 409]
+      ['session-revision-conflict', 409],
+      ['csl-undefined-macro', 400]
     ] as const) {
-      directInvoke.mockRejectedValueOnce(new ApplicationCommandError(code, `Rejected: ${code}`))
+      directInvoke.mockRejectedValueOnce(
+        new ApplicationCommandError(
+          code,
+          `Rejected: ${code}`,
+          code === 'csl-undefined-macro' ? { macro: 'author-原名' } : undefined
+        )
+      )
       const rejectedResponse = await fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
         method: 'POST',
         headers: {
@@ -897,7 +904,10 @@ describe('startWebHttpServer', () => {
       expect(rejectedResponse.status).toBe(expectedStatus)
       expect(await rejectedResponse.json()).toMatchObject({
         ok: false,
-        error: { code }
+        error: {
+          code,
+          ...(code === 'csl-undefined-macro' ? { parameters: { macro: 'author-原名' } } : {})
+        }
       })
     }
 

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -430,7 +430,7 @@ const publicApplicationCommandError = (
     : { code: 'command-failed', message: INTERNAL_SERVER_ERROR_MESSAGE }
 
 const applicationCommandErrorStatus = (error: ApplicationCommandError): number => {
-  if (error.code === 'invalid-command-arguments') return 400
+  if (error.code === 'invalid-command-arguments' || error.code.startsWith('csl-')) return 400
   if (error.code === 'command-unavailable') return 404
   if (error.code === 'session-details-conflict') return 409
   if (error.code === 'session-revision-conflict') return 409
@@ -538,12 +538,13 @@ const webRpcError = (
   response: ServerResponse,
   status: number,
   code: WebRpcErrorCode,
-  message: string
+  message: string,
+  parameters?: ApplicationCommandError['parameters']
 ): void => {
   json(response, status, {
     protocolVersion: WEB_RPC_PROTOCOL_VERSION,
     ok: false,
-    error: { code, message }
+    error: { code, message, ...(parameters ? { parameters } : {}) }
   })
 }
 
@@ -1658,7 +1659,13 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
           const publicError = publicApplicationCommandError(error)
           const status =
             error instanceof ApplicationCommandError ? applicationCommandErrorStatus(error) : 500
-          webRpcError(response, status, publicError.code, publicError.message)
+          webRpcError(
+            response,
+            status,
+            publicError.code,
+            publicError.message,
+            publicError.parameters
+          )
         } finally {
           request.off('aborted', releaseDisconnectedClient)
           response.off('close', releaseDisconnectedClient)

--- a/src/preload/electron-renderer-contract-adapter.test.ts
+++ b/src/preload/electron-renderer-contract-adapter.test.ts
@@ -194,6 +194,27 @@ describe('electron renderer contract adapter', () => {
     })
   })
 
+  it.each([
+    { code: 'csl-invalid-xml', message: 'Invalid XML.' },
+    {
+      code: 'csl-undefined-macro',
+      message: 'Undefined macro.',
+      parameters: { macro: 'author-原名' }
+    }
+  ])('preserves $code as a serializable rejection for contextBridge', async (error) => {
+    const port = createPort()
+    port.invoke.mockResolvedValue({ ok: false, error })
+    const adapter = createElectronRendererContractAdapter(port)
+
+    const failure = await adapter
+      .invoke('literature.citationStyles', { kind: 'import', content: '<' })
+      .catch((cause: unknown) => cause)
+
+    expect(failure).not.toBeInstanceOf(Error)
+    expect(failure).toEqual(error)
+    expect(JSON.parse(JSON.stringify(failure))).toEqual(error)
+  })
+
   it('rejects surface-native methods from the IPC request path', async () => {
     const port = createPort()
     const adapter = createElectronRendererContractAdapter(port)

--- a/src/preload/electron-renderer-contract-adapter.ts
+++ b/src/preload/electron-renderer-contract-adapter.ts
@@ -1,5 +1,9 @@
 import { RENDERER_CONTRACT_CATALOG } from '../shared/renderer-contract-catalog'
-import { unwrapApplicationCommandOutcome } from '../shared/application-command-contract'
+import {
+  ApplicationCommandError,
+  toApplicationCommandErrorEnvelope,
+  unwrapApplicationCommandOutcome
+} from '../shared/application-command-contract'
 import type {
   RendererContractDescriptor,
   RendererParameterCodec
@@ -134,9 +138,21 @@ export const createElectronRendererContractAdapter = (
     )
     if (encodedArgs === null) return null as Result
     const result = await port.invoke(channel, ...encodedArgs)
-    return contract.applicationCommand === 'runtime-validated'
-      ? unwrapApplicationCommandOutcome<Result>(result)
-      : (result as Result)
+    try {
+      return contract.applicationCommand === 'runtime-validated'
+        ? unwrapApplicationCommandOutcome<Result>(result)
+        : (result as Result)
+    } catch (error) {
+      if (
+        publicPath === 'literature.citationStyles' &&
+        error instanceof ApplicationCommandError &&
+        error.code.startsWith('csl-')
+      ) {
+        // contextBridge strips custom Error properties; plain rejections retain CSL diagnostics.
+        throw toApplicationCommandErrorEnvelope(error)
+      }
+      throw error
+    }
   },
   send: (publicPath: string, ...args: unknown[]): void => {
     port.send(requireSendContract(publicPath), ...args)

--- a/src/renderer/src/pages/literature/CitationStylesView.tsx
+++ b/src/renderer/src/pages/literature/CitationStylesView.tsx
@@ -4,7 +4,10 @@ import { ArrowLeft, BookOpenText, FileText, LoaderCircle, Trash2, Upload } from 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
-import { ApplicationCommandError } from '../../../../shared/application-command-contract'
+import {
+  ApplicationCommandError,
+  parseApplicationCommandError
+} from '../../../../shared/application-command-contract'
 
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
@@ -200,7 +203,7 @@ const CitationStylesView = ({
       })
       onStylesChange(result.styles)
     } catch (cause) {
-      setError(cause instanceof ApplicationCommandError ? cause : 'import-failed')
+      setError(parseApplicationCommandError(cause) ?? 'import-failed')
     } finally {
       setImporting(false)
     }

--- a/src/renderer/src/pages/literature/CitationStylesView.tsx
+++ b/src/renderer/src/pages/literature/CitationStylesView.tsx
@@ -4,6 +4,8 @@ import { ArrowLeft, BookOpenText, FileText, LoaderCircle, Trash2, Upload } from 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 
+import { ApplicationCommandError } from '../../../../shared/application-command-contract'
+
 import { Button } from '@/components/ui/button'
 import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { ExternalTextLink } from '@/components/ExternalTextLink'
@@ -36,7 +38,14 @@ const CitationStylesView = ({
   const [deletingId, setDeletingId] = useState<string>()
   const mutating = importing || deletingId !== undefined
   const [previewStates, setPreviewStates] = useState<Record<string, CitationStylePreviewState>>({})
-  const [error, setError] = useState<string>()
+  const [error, setError] = useState<
+    | ApplicationCommandError
+    | 'file-extension'
+    | 'file-too-large'
+    | 'load-failed'
+    | 'import-failed'
+    | 'delete-failed'
+  >()
   const previewRequestsRef = useRef(new Set<string>())
   const [activePreviewId, setActivePreviewId] = useState<string | null>(null)
   const activePreviewRef = useRef<string | null>(null)
@@ -114,9 +123,9 @@ const CitationStylesView = ({
         onStylesChange(result.styles)
         setLoading(false)
       },
-      (cause: unknown) => {
+      () => {
         if (!active) return
-        setError(cause instanceof Error ? cause.message : String(cause))
+        setError('load-failed')
         setLoading(false)
       }
     )
@@ -176,11 +185,11 @@ const CitationStylesView = ({
     if (mutating) return
     setError(undefined)
     if (!file.name.toLowerCase().endsWith('.csl')) {
-      setError(t('Choose a .csl file.'))
+      setError('file-extension')
       return
     }
     if (file.size > LITERATURE_CSL_MAX_BYTES) {
-      setError(t('The CSL file must be 1 MB or smaller.'))
+      setError('file-too-large')
       return
     }
     setImporting(true)
@@ -191,7 +200,7 @@ const CitationStylesView = ({
       })
       onStylesChange(result.styles)
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause))
+      setError(cause instanceof ApplicationCommandError ? cause : 'import-failed')
     } finally {
       setImporting(false)
     }
@@ -204,10 +213,46 @@ const CitationStylesView = ({
     try {
       const result = await window.api.literature.citationStyles({ kind: 'delete', styleId })
       onStylesChange(result.styles)
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : String(cause))
+    } catch {
+      setError('delete-failed')
     } finally {
       setDeletingId(undefined)
+    }
+  }
+
+  const errorMessage = (): string => {
+    const code = error instanceof ApplicationCommandError ? error.code : error
+    switch (code) {
+      case 'file-extension':
+        return t('Choose a .csl file.')
+      case 'file-too-large':
+      case 'csl-file-too-large':
+        return t('The CSL file must be 1 MB or smaller.')
+      case 'csl-invalid-xml':
+        return t('The selected file is not valid CSL XML.')
+      case 'csl-unsupported-doctype':
+        return t('CSL files with a document type declaration are not supported.')
+      case 'csl-unsupported-style':
+        return t('The selected file must be an independent CSL 1.0 style.')
+      case 'csl-missing-metadata':
+        return t('The CSL style must include a title and an id.')
+      case 'csl-dependent-style':
+        return t('Dependent CSL styles are not supported yet. Import an independent style.')
+      case 'csl-missing-sections':
+        return t('Open Science requires CSL styles with both citation and bibliography sections.')
+      case 'csl-undefined-macro':
+        if (error instanceof ApplicationCommandError && error.parameters) {
+          return t('The CSL style references an undefined macro: {{macro}}', {
+            macro: error.parameters.macro
+          })
+        }
+        return t('The CSL style could not be imported. Please try again.')
+      case 'load-failed':
+        return t('Citation styles could not be loaded. Please try again.')
+      case 'delete-failed':
+        return t('The CSL style could not be deleted. Please try again.')
+      default:
+        return t('The CSL style could not be imported. Please try again.')
     }
   }
 
@@ -435,7 +480,7 @@ const CitationStylesView = ({
             role="alert"
             className="mt-5 rounded-lg bg-danger-900 px-3 py-2 text-sm text-danger-000"
           >
-            {error}
+            {errorMessage()}
           </p>
         ) : null}
 

--- a/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
+++ b/src/renderer/src/pages/literature/CollectionEditorDialog.tsx
@@ -49,7 +49,7 @@ export const CollectionEditorDialog = forwardRef<
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
   const [saving, setSaving] = useState(false)
-  const [error, setError] = useState<string>()
+  const [error, setError] = useState<'name-conflict' | 'create-failed' | 'update-failed'>()
 
   useImperativeHandle(ref, () => ({
     openCreate: () => {
@@ -104,10 +104,10 @@ export const CollectionEditorDialog = forwardRef<
     } catch (error) {
       setError(
         error instanceof Error && error.message.includes(LITERATURE_COLLECTION_NAME_CONFLICT)
-          ? t('A collection with this name already exists at this level. Choose another name.')
+          ? 'name-conflict'
           : mode === 'create'
-            ? t('Collection could not be created.')
-            : t('Collection could not be updated.')
+            ? 'create-failed'
+            : 'update-failed'
       )
     } finally {
       setSaving(false)
@@ -216,7 +216,13 @@ export const CollectionEditorDialog = forwardRef<
             </div>
             {error ? (
               <p className="px-5 pb-4 text-sm text-danger-000" role="alert">
-                {error}
+                {error === 'name-conflict'
+                  ? t(
+                      'A collection with this name already exists at this level. Choose another name.'
+                    )
+                  : error === 'create-failed'
+                    ? t('Collection could not be created.')
+                    : t('Collection could not be updated.')}
               </p>
             ) : null}
             <div

--- a/src/renderer/src/pages/literature/LiteratureMergeReview.tsx
+++ b/src/renderer/src/pages/literature/LiteratureMergeReview.tsx
@@ -58,6 +58,7 @@ export function LiteratureMergeReview({
     publisher: t('Publisher'),
     edition: t('Edition'),
     place: t('Place'),
+    publisherPlace: t('Place'),
     series: t('Series'),
     isbn: t('ISBN'),
     issn: t('ISSN')

--- a/src/renderer/src/pages/literature/literature-localization.render.test.tsx
+++ b/src/renderer/src/pages/literature/literature-localization.render.test.tsx
@@ -112,7 +112,10 @@ it.each([
   }
 )
 
-const importInvalidStyle = async (content: string): Promise<string> => {
+const importInvalidStyle = async (
+  content: string,
+  transport: 'electron' | 'web' = 'electron'
+): Promise<string> => {
   const root = await mkdtemp(join(tmpdir(), 'literature-i18n-'))
   roots.push(root)
   const library = new LiteratureCitationStyleLibrary(join(root, 'styles'))
@@ -122,15 +125,10 @@ const importInvalidStyle = async (content: string): Promise<string> => {
       await library.import(request.content)
       return { styles: [] }
     } catch (cause) {
-      // Exercise the real command error transport, including loss of custom Error properties.
-      return unwrapApplicationCommandOutcome(
-        JSON.parse(
-          JSON.stringify({
-            ok: false,
-            error: toApplicationCommandErrorEnvelope(cause)
-          })
-        )
-      )
+      const error = JSON.parse(JSON.stringify(toApplicationCommandErrorEnvelope(cause)))
+      // Electron copies plain rejections; Web reconstructs errors in the renderer realm.
+      if (transport === 'electron') throw error
+      return unwrapApplicationCommandOutcome({ ok: false, error })
     }
   })
   window.api = { literature: { citationStyles } } as unknown as Window['api']
@@ -151,7 +149,7 @@ const importInvalidStyle = async (content: string): Promise<string> => {
 
 it.each(locales)('localizes real invalid CSL XML in %s', async (locale) => {
   await switchLanguage(locale)
-  const message = await importInvalidStyle('<')
+  const message = await importInvalidStyle('<', 'web')
   expect(message).not.toBe('The selected file is not valid CSL XML.')
   expect(message).toBe(i18next.t('The selected file is not valid CSL XML.'))
   await switchLanguage('en')

--- a/src/renderer/src/pages/literature/literature-localization.render.test.tsx
+++ b/src/renderer/src/pages/literature/literature-localization.render.test.tsx
@@ -1,0 +1,313 @@
+// @vitest-environment jsdom
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createRef } from 'react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+import { i18next } from '@/i18n'
+import { LiteratureCitationStyleLibrary } from '../../../../main/literature/citation-style-library'
+import {
+  toApplicationCommandErrorEnvelope,
+  unwrapApplicationCommandOutcome
+} from '../../../../shared/application-command-contract'
+import {
+  LITERATURE_COLLECTION_NAME_CONFLICT,
+  LITERATURE_ITEM_TYPES,
+  literatureItemInputSchema,
+  type LiteratureItemType,
+  type LiteratureItemView
+} from '../../../../shared/literature'
+import { CollectionEditorDialog, type CollectionEditorDialogHandle } from './CollectionEditorDialog'
+import { CitationStylesView } from './CitationStylesView'
+import { LiteratureMergeReview } from './LiteratureMergeReview'
+import { LiteratureMetadataEditor } from './LiteratureMetadataEditor'
+
+const previousApi = window.api
+const roots: string[] = []
+const locales = ['de', 'es', 'fr', 'zh-Hans', 'zh-Hant', 'ja', 'ko', 'ru'] as const
+const switchLanguage = async (language: string): Promise<void> => {
+  await act(async () => {
+    await i18next.changeLanguage(language)
+  })
+}
+
+afterEach(async () => {
+  cleanup()
+  window.api = previousApi
+  await switchLanguage('en')
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+it.each([
+  ['create', 'offline', 'Collection could not be created.'],
+  ['edit', 'offline', 'Collection could not be updated.'],
+  [
+    'create',
+    LITERATURE_COLLECTION_NAME_CONFLICT,
+    'A collection with this name already exists at this level. Choose another name.'
+  ]
+] as const)(
+  'retranslates an existing %s error (%s) without losing the draft or retry target',
+  async (mode, cause, message) => {
+    const transact = vi.fn().mockRejectedValueOnce(new Error(cause)).mockResolvedValue({})
+    window.api = { literature: { transact } } as unknown as Window['api']
+    const ref = createRef<CollectionEditorDialogHandle>()
+    const onSaved = vi.fn()
+    render(<CollectionEditorDialog ref={ref} onSaved={onSaved} />)
+    act(() => {
+      if (mode === 'create') ref.current!.openCreate()
+      else
+        ref.current!.openEdit({
+          id: 'collection-a',
+          name: 'Existing',
+          description: '',
+          itemCount: 0,
+          createdAt: 1,
+          updatedAt: 1
+        })
+    })
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Research 北京' } })
+    fireEvent.change(screen.getByLabelText('Description'), {
+      target: { value: 'Draft description' }
+    })
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: mode === 'create' ? 'Create collection' : 'Save changes'
+        })
+      )
+    })
+    expect(screen.getByRole('alert').textContent).toBe(message)
+    const dialog = screen.getByRole('dialog')
+    await switchLanguage('zh-Hans')
+    expect(screen.getByRole('dialog')).toBe(dialog)
+    expect(
+      screen.getByRole('heading', {
+        name: i18next.t(mode === 'create' ? 'New collection' : 'Edit collection')
+      })
+    ).toBeTruthy()
+    expect((screen.getByLabelText(i18next.t('Name')) as HTMLInputElement).value).toBe(
+      'Research 北京'
+    )
+    expect((screen.getByLabelText(i18next.t('Description')) as HTMLTextAreaElement).value).toBe(
+      'Draft description'
+    )
+    const retry = screen.getByRole('button', {
+      name: i18next.t(mode === 'create' ? 'Create collection' : 'Save changes')
+    })
+    expect(i18next.t(message)).not.toBe(message)
+    expect.soft(screen.getByRole('alert').textContent).toBe(i18next.t(message))
+    await act(async () => {
+      fireEvent.click(retry)
+    })
+    expect(transact).toHaveBeenCalledTimes(2)
+    expect(transact.mock.calls[1]).toEqual(transact.mock.calls[0])
+    expect(onSaved).toHaveBeenCalledWith({
+      id: mode === 'edit' ? 'collection-a' : undefined,
+      name: 'Research 北京',
+      description: 'Draft description'
+    })
+  }
+)
+
+const importInvalidStyle = async (content: string): Promise<string> => {
+  const root = await mkdtemp(join(tmpdir(), 'literature-i18n-'))
+  roots.push(root)
+  const library = new LiteratureCitationStyleLibrary(join(root, 'styles'))
+  const citationStyles = vi.fn(async (request: { kind: string; content: string }) => {
+    expect(request.kind).toBe('import')
+    try {
+      await library.import(request.content)
+      return { styles: [] }
+    } catch (cause) {
+      // Exercise the real command error transport, including loss of custom Error properties.
+      return unwrapApplicationCommandOutcome(
+        JSON.parse(
+          JSON.stringify({
+            ok: false,
+            error: toApplicationCommandErrorEnvelope(cause)
+          })
+        )
+      )
+    }
+  })
+  window.api = { literature: { citationStyles } } as unknown as Window['api']
+  const onStylesChange = vi.fn()
+  render(<CitationStylesView styles={[]} onBack={vi.fn()} onStylesChange={onStylesChange} />)
+  expect(screen.getByRole('button', { name: i18next.t('Import CSL') })).toBeTruthy()
+  const file = new File([content], 'invalid.csl', { type: 'application/xml' })
+  Object.defineProperty(file, 'text', { value: async () => content })
+  await act(async () => {
+    fireEvent.change(screen.getByLabelText(i18next.t('Import CSL'), { selector: 'input' }), {
+      target: { files: [file] }
+    })
+  })
+  expect(citationStyles).toHaveBeenCalledExactlyOnceWith({ kind: 'import', content })
+  expect(onStylesChange).not.toHaveBeenCalled()
+  return screen.getByRole('alert').textContent ?? ''
+}
+
+it.each(locales)('localizes real invalid CSL XML in %s', async (locale) => {
+  await switchLanguage(locale)
+  const message = await importInvalidStyle('<')
+  expect(message).not.toBe('The selected file is not valid CSL XML.')
+  expect(message).toBe(i18next.t('The selected file is not valid CSL XML.'))
+  await switchLanguage('en')
+  expect(screen.getByRole('alert').textContent).toBe('The selected file is not valid CSL XML.')
+  await switchLanguage(locale)
+  expect(screen.getByRole('alert').textContent).toBe(message)
+})
+
+const csl = (info: string, citation = '<text variable="title"/>'): string =>
+  `<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0"><info>${info}</info><citation><layout>${citation}</layout></citation><bibliography><layout><text variable="title"/></layout></bibliography></style>`
+it.each([
+  [
+    'missing title',
+    csl('<id>https://example.test/style</id>'),
+    'The CSL style must include a title and an id.'
+  ],
+  [
+    'missing id',
+    csl('<title>Original title</title>'),
+    'The CSL style must include a title and an id.'
+  ],
+  [
+    'dependent style',
+    csl(
+      '<title>Original title</title><id>https://example.test/style</id><link rel="independent-parent" href="https://example.test/parent"/>'
+    ),
+    'Dependent CSL styles are not supported yet. Import an independent style.'
+  ]
+])('localizes a real %s validation error', async (_name, content, english) => {
+  await switchLanguage('zh-Hans')
+  const message = await importInvalidStyle(content)
+  expect(message).not.toBe(english)
+  expect(message).toBe(i18next.t(english))
+})
+
+it('localizes an undefined CSL macro while preserving its exact name', async () => {
+  await switchLanguage('zh-Hans')
+  const macro = 'author-原名'
+  const message = await importInvalidStyle(
+    csl(
+      '<title>Original title</title><id>https://example.test/style</id>',
+      `<text macro="${macro}"/>`
+    )
+  )
+  expect.soft(message).toContain(macro)
+  expect(message).not.toBe(`The CSL style references an undefined macro: ${macro}`)
+  expect(message).toBe(
+    i18next.t('The CSL style references an undefined macro: {{macro}}', { macro })
+  )
+})
+
+it.each(locales)(
+  'uses the editor Place label in merge headings and choices in %s',
+  async (locale) => {
+    await switchLanguage(locale)
+    const entries: LiteratureItemView[] = ['北京', 'Paris'].map((place, index) => ({
+      id: `reference-${index}`,
+      item: literatureItemInputSchema.parse({
+        itemType: 'book',
+        title: index === 0 ? '原书名' : 'Original title',
+        typeFields: { publisherPlace: place }
+      }),
+      metadataRevision: 1,
+      createdAt: 1,
+      updatedAt: 1,
+      attachments: [],
+      collectionIds: [],
+      projectIds: []
+    }))
+    const editor = render(
+      <LiteratureMetadataEditor
+        item={entries[0].item}
+        saving={false}
+        onSave={vi.fn()}
+        onCancel={vi.fn()}
+      />
+    )
+    const label = i18next.t('Place')
+    expect((screen.getByLabelText(label) as HTMLInputElement).value).toBe('北京')
+    editor.unmount()
+    const onSourceChange = vi.fn()
+    render(
+      <LiteratureMergeReview
+        entries={entries}
+        survivorId={entries[0].id}
+        onSurvivorChange={vi.fn()}
+        sources={{}}
+        onSourceChange={onSourceChange}
+        fieldLabel={(field) => field}
+        creatorLabel={() => ''}
+        itemTypeLabels={
+          Object.fromEntries(LITERATURE_ITEM_TYPES.map((type) => [type, type])) as Record<
+            LiteratureItemType,
+            string
+          >
+        }
+        disabled={false}
+      />
+    )
+    expect(screen.getAllByText('原书名').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Original title').length).toBeGreaterThan(0)
+    expect(screen.getByText('北京')).toBeTruthy()
+    expect(screen.getByText('Paris')).toBeTruthy()
+    expect.soft(screen.queryByText('publisherPlace')).toBeNull()
+    expect.soft(screen.queryByText(label)).not.toBeNull()
+    const choice = screen.getByRole('radio', {
+      name: i18next.t('Use {{field}} from reference {{number}}', { field: label, number: 2 })
+    })
+    fireEvent.click(choice)
+    expect(onSourceChange).toHaveBeenCalledWith('type:publisherPlace', entries[1].id)
+  }
+)
+
+it.each([
+  ['list', 'Citation styles could not be loaded. Please try again.'],
+  ['import', 'The CSL style could not be imported. Please try again.'],
+  ['delete', 'The CSL style could not be deleted. Please try again.']
+] as const)(
+  'localizes unknown %s errors without exposing raw diagnostics',
+  async (kind, message) => {
+    await switchLanguage('zh-Hans')
+    const citationStyles = vi.fn().mockRejectedValue(new Error('EACCES: /private/style.csl'))
+    window.api = { literature: { citationStyles } } as unknown as Window['api']
+    await act(async () => {
+      render(
+        <CitationStylesView
+          styles={
+            kind === 'list'
+              ? undefined
+              : [{ id: 'custom:style', title: 'Original title', source: 'custom' }]
+          }
+          onBack={vi.fn()}
+          onStylesChange={vi.fn()}
+        />
+      )
+    })
+    if (kind === 'delete') {
+      await act(async () => {
+        fireEvent.click(
+          screen.getByRole('button', {
+            name: i18next.t('Delete {{style}}', { style: 'Original title' })
+          })
+        )
+      })
+    } else if (kind === 'import') {
+      const file = new File(['<'], 'invalid.csl')
+      Object.defineProperty(file, 'text', { value: async () => '<' })
+      await act(async () => {
+        fireEvent.change(screen.getByLabelText(i18next.t('Import CSL'), { selector: 'input' }), {
+          target: { files: [file] }
+        })
+      })
+    }
+    expect(screen.getByRole('alert').textContent).toBe(i18next.t(message))
+    expect(screen.getByRole('alert').textContent).not.toContain('/private')
+    await switchLanguage('en')
+    expect(screen.getByRole('alert').textContent).toBe(message)
+  }
+)

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -336,7 +336,14 @@ describe('Web bootstrap event connection', () => {
     expect(document.querySelector('button')?.textContent).toBe('重试')
   })
 
-  it('reconstructs Application Command errors returned by Web RPC', async () => {
+  it.each([
+    { code: 'invalid-command-arguments', message: 'Invalid project request.' },
+    {
+      code: 'csl-undefined-macro',
+      message: 'Undefined macro',
+      parameters: { macro: 'author-原名' }
+    }
+  ])('reconstructs Application Command errors returned by Web RPC: $code', async (error) => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async (input: RequestInfo | URL) => {
@@ -351,10 +358,7 @@ describe('Web bootstrap event connection', () => {
             JSON.stringify({
               protocolVersion: WEB_RPC_PROTOCOL_VERSION,
               ok: false,
-              error: {
-                code: 'invalid-command-arguments',
-                message: 'Invalid project request.'
-              }
+              error
             }),
             { status: 400, headers: { 'content-type': 'application/json' } }
           )
@@ -366,8 +370,7 @@ describe('Web bootstrap event connection', () => {
     const api = await loadBootstrap()
     await expect(api.projects.create({ name: 42 })).rejects.toMatchObject({
       name: 'ApplicationCommandError',
-      code: 'invalid-command-arguments',
-      message: 'Invalid project request.'
+      ...error
     })
   })
 

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -1,6 +1,6 @@
 import { flushSync } from 'react-dom'
 import {
-  ApplicationCommandError,
+  unwrapApplicationCommandOutcome,
   isApplicationCommandErrorCode
 } from '../../shared/application-command-contract'
 import {
@@ -270,7 +270,7 @@ const invoke = async (channel: string, args: unknown[]): Promise<unknown> => {
   }
   if (!payload.ok) {
     if (isApplicationCommandErrorCode(payload.error.code)) {
-      throw new ApplicationCommandError(payload.error.code, payload.error.message)
+      return unwrapApplicationCommandOutcome(payload)
     }
     throw responseError(response, body, payload.error.message)
   }

--- a/src/shared/application-command-contract.test.ts
+++ b/src/shared/application-command-contract.test.ts
@@ -59,3 +59,45 @@ describe('application command contract', () => {
     ).toThrow(expect.objectContaining({ code: 'invalid-command-result' }))
   })
 })
+
+// Error parameters must survive transport without becoming arbitrary diagnostic payloads.
+it('round-trips a CSL macro name through the public error envelope', () => {
+  const error = new ApplicationCommandError('csl-undefined-macro', 'Undefined macro', {
+    macro: 'author-原名'
+  })
+  const envelope = toApplicationCommandErrorEnvelope(error)
+  expect(envelope).toEqual({
+    code: 'csl-undefined-macro',
+    message: 'Undefined macro',
+    parameters: { macro: 'author-原名' }
+  })
+  expect(() =>
+    unwrapApplicationCommandOutcome(JSON.parse(JSON.stringify({ ok: false, error: envelope })))
+  ).toThrow(expect.objectContaining({ code: error.code, parameters: error.parameters }))
+})
+
+it.each([undefined, null, {}, { macro: 42 }, { macro: 'name', privatePath: '/private' }])(
+  'rejects malformed CSL parameters: %j',
+  (parameters) => {
+    expect(() =>
+      unwrapApplicationCommandOutcome({
+        ok: false,
+        error: { code: 'csl-undefined-macro', message: 'Undefined macro', parameters }
+      })
+    ).toThrow(expect.objectContaining({ code: 'invalid-command-result' }))
+  }
+)
+
+it('does not forward parameters on unrelated command failures', () => {
+  expect(
+    toApplicationCommandErrorEnvelope(
+      new ApplicationCommandError('command-failed', 'Failed', { macro: 'private' })
+    )
+  ).toEqual({ code: 'command-failed', message: 'Failed' })
+  expect(() =>
+    unwrapApplicationCommandOutcome({
+      ok: false,
+      error: { code: 'command-failed', message: 'Failed', parameters: { macro: 'private' } }
+    })
+  ).toThrow(expect.objectContaining({ code: 'invalid-command-result' }))
+})

--- a/src/shared/application-command-contract.ts
+++ b/src/shared/application-command-contract.ts
@@ -5,7 +5,15 @@ export const APPLICATION_COMMAND_ERROR_CODES = [
   'command-failed',
   'session-details-conflict',
   'session-size-limit',
-  'session-revision-conflict'
+  'session-revision-conflict',
+  'csl-file-too-large',
+  'csl-invalid-xml',
+  'csl-unsupported-doctype',
+  'csl-unsupported-style',
+  'csl-missing-metadata',
+  'csl-dependent-style',
+  'csl-undefined-macro',
+  'csl-missing-sections'
 ] as const
 
 export type ApplicationCommandErrorCode = (typeof APPLICATION_COMMAND_ERROR_CODES)[number]
@@ -37,6 +45,7 @@ export const defineApplicationCommandContract = <Args extends readonly unknown[]
 export type ApplicationCommandErrorEnvelope = Readonly<{
   code: ApplicationCommandErrorCode
   message: string
+  parameters?: Readonly<{ macro: string }>
 }>
 
 export type ApplicationCommandOutcome<Result> =
@@ -52,7 +61,8 @@ export const isApplicationCommandErrorCode = (
 export class ApplicationCommandError extends Error {
   constructor(
     readonly code: ApplicationCommandErrorCode,
-    message: string
+    message: string,
+    readonly parameters?: Readonly<{ macro: string }>
   ) {
     super(message)
     this.name = 'ApplicationCommandError'
@@ -64,7 +74,13 @@ export const toApplicationCommandErrorEnvelope = (
 ): ApplicationCommandErrorEnvelope =>
   Object.freeze(
     error instanceof ApplicationCommandError
-      ? { code: error.code, message: error.message }
+      ? {
+          code: error.code,
+          message: error.message,
+          ...(error.code === 'csl-undefined-macro' && error.parameters
+            ? { parameters: { macro: error.parameters.macro } }
+            : {})
+        }
       : {
           code: 'command-failed' as const,
           message: error instanceof Error ? error.message : String(error)
@@ -90,6 +106,21 @@ export const unwrapApplicationCommandOutcome = <Result>(value: unknown): Result 
     'message' in value.error &&
     typeof value.error.message === 'string'
   ) {
+    const parameters = 'parameters' in value.error ? value.error.parameters : undefined
+    if (value.error.code === 'csl-undefined-macro') {
+      if (
+        !parameters ||
+        typeof parameters !== 'object' ||
+        !('macro' in parameters) ||
+        typeof parameters.macro !== 'string' ||
+        Object.keys(parameters).length !== 1
+      )
+        throw invalidOutcome()
+      throw new ApplicationCommandError(value.error.code, value.error.message, {
+        macro: parameters.macro
+      })
+    }
+    if (parameters !== undefined) throw invalidOutcome()
     throw new ApplicationCommandError(value.error.code, value.error.message)
   }
   throw invalidOutcome()

--- a/src/shared/application-command-contract.ts
+++ b/src/shared/application-command-contract.ts
@@ -93,21 +93,19 @@ const invalidOutcome = (): ApplicationCommandError =>
     'Application command returned an invalid response.'
   )
 
-export const unwrapApplicationCommandOutcome = <Result>(value: unknown): Result => {
-  if (!value || typeof value !== 'object' || !('ok' in value)) throw invalidOutcome()
-  if (value.ok === true && 'result' in value) return value.result as Result
+export const parseApplicationCommandError = (
+  error: unknown
+): ApplicationCommandError | undefined => {
   if (
-    value.ok === false &&
-    'error' in value &&
-    value.error != null &&
-    typeof value.error === 'object' &&
-    'code' in value.error &&
-    isApplicationCommandErrorCode(value.error.code) &&
-    'message' in value.error &&
-    typeof value.error.message === 'string'
+    error != null &&
+    typeof error === 'object' &&
+    'code' in error &&
+    isApplicationCommandErrorCode(error.code) &&
+    'message' in error &&
+    typeof error.message === 'string'
   ) {
-    const parameters = 'parameters' in value.error ? value.error.parameters : undefined
-    if (value.error.code === 'csl-undefined-macro') {
+    const parameters = 'parameters' in error ? error.parameters : undefined
+    if (error.code === 'csl-undefined-macro') {
       if (
         !parameters ||
         typeof parameters !== 'object' ||
@@ -115,13 +113,22 @@ export const unwrapApplicationCommandOutcome = <Result>(value: unknown): Result 
         typeof parameters.macro !== 'string' ||
         Object.keys(parameters).length !== 1
       )
-        throw invalidOutcome()
-      throw new ApplicationCommandError(value.error.code, value.error.message, {
+        return undefined
+      return new ApplicationCommandError(error.code, error.message, {
         macro: parameters.macro
       })
     }
-    if (parameters !== undefined) throw invalidOutcome()
-    throw new ApplicationCommandError(value.error.code, value.error.message)
+    if (parameters !== undefined) return undefined
+    return new ApplicationCommandError(error.code, error.message)
+  }
+  return undefined
+}
+
+export const unwrapApplicationCommandOutcome = <Result>(value: unknown): Result => {
+  if (!value || typeof value !== 'object' || !('ok' in value)) throw invalidOutcome()
+  if (value.ok === true && 'result' in value) return value.result as Result
+  if (value.ok === false && 'error' in value) {
+    throw parseApplicationCommandError(value.error) ?? invalidOutcome()
   }
   throw invalidOutcome()
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4935,6 +4935,16 @@
     "Saving stopped. Completed results are kept.": "Speichern gestoppt. Abgeschlossene Ergebnisse bleiben erhalten.",
     "Could not save reference {{number}}. Earlier results are kept.": "Quelle {{number}} konnte nicht gespeichert werden. Frühere Ergebnisse bleiben erhalten.",
     "Open Inbox": "Posteingang öffnen",
-    "Open existing reference {{number}}": "Vorhandene Quelle {{number}} öffnen"
+    "Open existing reference {{number}}": "Vorhandene Quelle {{number}} öffnen",
+    "The selected file is not valid CSL XML.": "Die ausgewählte Datei enthält kein gültiges CSL-XML.",
+    "CSL files with a document type declaration are not supported.": "CSL-Dateien mit einer Dokumenttypdeklaration werden nicht unterstützt.",
+    "The selected file must be an independent CSL 1.0 style.": "Die ausgewählte Datei muss ein unabhängiger CSL-1.0-Stil sein.",
+    "The CSL style must include a title and an id.": "Der CSL-Stil muss einen Titel und eine ID enthalten.",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "Abhängige CSL-Stile werden noch nicht unterstützt. Importieren Sie einen unabhängigen Stil.",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science benötigt CSL-Stile mit Abschnitten für Zitate und Literaturverzeichnis.",
+    "The CSL style references an undefined macro: {{macro}}": "Der CSL-Stil verweist auf ein nicht definiertes Makro: {{macro}}",
+    "Citation styles could not be loaded. Please try again.": "Die Zitierstile konnten nicht geladen werden. Versuchen Sie es erneut.",
+    "The CSL style could not be imported. Please try again.": "Der CSL-Stil konnte nicht importiert werden. Versuchen Sie es erneut.",
+    "The CSL style could not be deleted. Please try again.": "Der CSL-Stil konnte nicht gelöscht werden. Versuchen Sie es erneut."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5096,6 +5096,16 @@
     "Saving stopped. Completed results are kept.": "Se detuvo el guardado. Se conservan los resultados completados.",
     "Could not save reference {{number}}. Earlier results are kept.": "No se pudo guardar la referencia {{number}}. Se conservan los resultados anteriores.",
     "Open Inbox": "Abrir bandeja de entrada",
-    "Open existing reference {{number}}": "Abrir referencia existente {{number}}"
+    "Open existing reference {{number}}": "Abrir referencia existente {{number}}",
+    "The selected file is not valid CSL XML.": "El archivo seleccionado no contiene XML de CSL válido.",
+    "CSL files with a document type declaration are not supported.": "No se admiten archivos CSL con una declaración de tipo de documento.",
+    "The selected file must be an independent CSL 1.0 style.": "El archivo seleccionado debe ser un estilo CSL 1.0 independiente.",
+    "The CSL style must include a title and an id.": "El estilo CSL debe incluir un título y un ID.",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "Aún no se admiten estilos CSL dependientes. Importe un estilo independiente.",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science requiere estilos CSL con secciones de citas y bibliografía.",
+    "The CSL style references an undefined macro: {{macro}}": "El estilo CSL hace referencia a una macro no definida: {{macro}}",
+    "Citation styles could not be loaded. Please try again.": "No se han podido cargar los estilos de cita. Vuelva a intentarlo.",
+    "The CSL style could not be imported. Please try again.": "No se ha podido importar el estilo CSL. Vuelva a intentarlo.",
+    "The CSL style could not be deleted. Please try again.": "No se ha podido eliminar el estilo CSL. Vuelva a intentarlo."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5096,6 +5096,16 @@
     "Saving stopped. Completed results are kept.": "Enregistrement arrêté. Les résultats terminés sont conservés.",
     "Could not save reference {{number}}. Earlier results are kept.": "Impossible d’enregistrer la référence {{number}}. Les résultats précédents sont conservés.",
     "Open Inbox": "Ouvrir la boîte de réception",
-    "Open existing reference {{number}}": "Ouvrir la référence existante {{number}}"
+    "Open existing reference {{number}}": "Ouvrir la référence existante {{number}}",
+    "The selected file is not valid CSL XML.": "Le fichier sélectionné ne contient pas de XML CSL valide.",
+    "CSL files with a document type declaration are not supported.": "Les fichiers CSL contenant une déclaration de type de document ne sont pas pris en charge.",
+    "The selected file must be an independent CSL 1.0 style.": "Le fichier sélectionné doit être un style CSL 1.0 indépendant.",
+    "The CSL style must include a title and an id.": "Le style CSL doit inclure un titre et un identifiant.",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "Les styles CSL dépendants ne sont pas encore pris en charge. Importez un style indépendant.",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science nécessite des styles CSL comprenant des sections de citation et de bibliographie.",
+    "The CSL style references an undefined macro: {{macro}}": "Le style CSL fait référence à une macro non définie : {{macro}}",
+    "Citation styles could not be loaded. Please try again.": "Impossible de charger les styles de citation. Réessayez.",
+    "The CSL style could not be imported. Please try again.": "Impossible d’importer le style CSL. Réessayez.",
+    "The CSL style could not be deleted. Please try again.": "Impossible de supprimer le style CSL. Réessayez."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4782,6 +4782,16 @@
     "Saving stopped. Completed results are kept.": "保存を停止しました。完了した結果は保持されます。",
     "Could not save reference {{number}}. Earlier results are kept.": "文献 {{number}} を保存できませんでした。それまでの結果は保持されます。",
     "Open Inbox": "受信トレイを開く",
-    "Open existing reference {{number}}": "既存の文献 {{number}} を開く"
+    "Open existing reference {{number}}": "既存の文献 {{number}} を開く",
+    "The selected file is not valid CSL XML.": "選択したファイルは有効な CSL XML ではありません。",
+    "CSL files with a document type declaration are not supported.": "文書型宣言を含む CSL ファイルには対応していません。",
+    "The selected file must be an independent CSL 1.0 style.": "独立した CSL 1.0 スタイルのファイルを選択してください。",
+    "The CSL style must include a title and an id.": "CSL スタイルにはタイトルと ID が必要です。",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "従属 CSL スタイルにはまだ対応していません。独立したスタイルをインポートしてください。",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science では、引用と参考文献の両方のセクションを含む CSL スタイルが必要です。",
+    "The CSL style references an undefined macro: {{macro}}": "CSL スタイルが未定義のマクロを参照しています：{{macro}}",
+    "Citation styles could not be loaded. Please try again.": "引用スタイルを読み込めませんでした。再試行してください。",
+    "The CSL style could not be imported. Please try again.": "CSL スタイルをインポートできませんでした。再試行してください。",
+    "The CSL style could not be deleted. Please try again.": "CSL スタイルを削除できませんでした。再試行してください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4780,6 +4780,16 @@
     "Saving stopped. Completed results are kept.": "저장이 중지되었습니다. 완료된 결과는 유지됩니다.",
     "Could not save reference {{number}}. Earlier results are kept.": "문헌 {{number}}을(를) 저장하지 못했습니다. 이전 결과는 유지됩니다.",
     "Open Inbox": "받은 편지함 열기",
-    "Open existing reference {{number}}": "기존 문헌 {{number}} 열기"
+    "Open existing reference {{number}}": "기존 문헌 {{number}} 열기",
+    "The selected file is not valid CSL XML.": "선택한 파일은 유효한 CSL XML이 아닙니다.",
+    "CSL files with a document type declaration are not supported.": "문서 유형 선언이 포함된 CSL 파일은 지원하지 않습니다.",
+    "The selected file must be an independent CSL 1.0 style.": "선택한 파일은 독립형 CSL 1.0 스타일이어야 합니다.",
+    "The CSL style must include a title and an id.": "CSL 스타일에는 제목과 ID가 포함되어야 합니다.",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "종속형 CSL 스타일은 아직 지원하지 않습니다. 독립형 스타일을 가져오세요.",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science에는 인용 및 참고문헌 섹션이 모두 포함된 CSL 스타일이 필요합니다.",
+    "The CSL style references an undefined macro: {{macro}}": "CSL 스타일이 정의되지 않은 매크로를 참조합니다: {{macro}}",
+    "Citation styles could not be loaded. Please try again.": "인용 스타일을 불러오지 못했습니다. 다시 시도하세요.",
+    "The CSL style could not be imported. Please try again.": "CSL 스타일을 가져오지 못했습니다. 다시 시도하세요.",
+    "The CSL style could not be deleted. Please try again.": "CSL 스타일을 삭제하지 못했습니다. 다시 시도하세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5228,6 +5228,16 @@
     "Saving stopped. Completed results are kept.": "Сохранение остановлено. Завершённые результаты сохранены.",
     "Could not save reference {{number}}. Earlier results are kept.": "Не удалось сохранить источник {{number}}. Предыдущие результаты сохранены.",
     "Open Inbox": "Открыть входящие",
-    "Open existing reference {{number}}": "Открыть существующий источник {{number}}"
+    "Open existing reference {{number}}": "Открыть существующий источник {{number}}",
+    "The selected file is not valid CSL XML.": "Выбранный файл не является корректным XML-файлом CSL.",
+    "CSL files with a document type declaration are not supported.": "Файлы CSL с объявлением типа документа не поддерживаются.",
+    "The selected file must be an independent CSL 1.0 style.": "Выбранный файл должен содержать независимый стиль CSL 1.0.",
+    "The CSL style must include a title and an id.": "Стиль CSL должен содержать название и идентификатор.",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "Зависимые стили CSL пока не поддерживаются. Импортируйте независимый стиль.",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science требует наличия в стилях CSL разделов цитирования и библиографии.",
+    "The CSL style references an undefined macro: {{macro}}": "Стиль CSL ссылается на неопределённый макрос: {{macro}}",
+    "Citation styles could not be loaded. Please try again.": "Не удалось загрузить стили цитирования. Повторите попытку.",
+    "The CSL style could not be imported. Please try again.": "Не удалось импортировать стиль CSL. Повторите попытку.",
+    "The CSL style could not be deleted. Please try again.": "Не удалось удалить стиль CSL. Повторите попытку."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4782,6 +4782,16 @@
     "Saving stopped. Completed results are kept.": "保存已停止。已完成的结果会保留。",
     "Could not save reference {{number}}. Earlier results are kept.": "无法保存第 {{number}} 条文献。此前的结果会保留。",
     "Open Inbox": "打开收件箱",
-    "Open existing reference {{number}}": "打开已有文献 {{number}}"
+    "Open existing reference {{number}}": "打开已有文献 {{number}}",
+    "The selected file is not valid CSL XML.": "所选文件不是有效的 CSL XML。",
+    "CSL files with a document type declaration are not supported.": "不支持包含文档类型声明的 CSL 文件。",
+    "The selected file must be an independent CSL 1.0 style.": "所选文件必须是独立的 CSL 1.0 样式。",
+    "The CSL style must include a title and an id.": "CSL 样式必须包含标题和 ID。",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "暂不支持依赖型 CSL 样式。请导入独立样式。",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science 要求 CSL 样式同时包含引文和参考文献部分。",
+    "The CSL style references an undefined macro: {{macro}}": "CSL 样式引用了未定义的宏：{{macro}}",
+    "Citation styles could not be loaded. Please try again.": "无法加载引用样式。请重试。",
+    "The CSL style could not be imported. Please try again.": "无法导入 CSL 样式。请重试。",
+    "The CSL style could not be deleted. Please try again.": "无法删除 CSL 样式。请重试。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4782,6 +4782,16 @@
     "Saving stopped. Completed results are kept.": "儲存已停止。已完成的結果會保留。",
     "Could not save reference {{number}}. Earlier results are kept.": "無法儲存第 {{number}} 筆文獻。先前的結果會保留。",
     "Open Inbox": "開啟收件匣",
-    "Open existing reference {{number}}": "開啟已有文獻 {{number}}"
+    "Open existing reference {{number}}": "開啟已有文獻 {{number}}",
+    "The selected file is not valid CSL XML.": "所選檔案不是有效的 CSL XML。",
+    "CSL files with a document type declaration are not supported.": "不支援含有文件類型宣告的 CSL 檔案。",
+    "The selected file must be an independent CSL 1.0 style.": "所選檔案必須是獨立的 CSL 1.0 樣式。",
+    "The CSL style must include a title and an id.": "CSL 樣式必須包含標題與 ID。",
+    "Dependent CSL styles are not supported yet. Import an independent style.": "尚不支援相依型 CSL 樣式。請匯入獨立樣式。",
+    "Open Science requires CSL styles with both citation and bibliography sections.": "Open Science 要求 CSL 樣式同時包含引文與參考文獻區段。",
+    "The CSL style references an undefined macro: {{macro}}": "CSL 樣式參照了未定義的巨集：{{macro}}",
+    "Citation styles could not be loaded. Please try again.": "無法載入引用樣式。請重試。",
+    "The CSL style could not be imported. Please try again.": "無法匯入 CSL 樣式。請重試。",
+    "The CSL style could not be deleted. Please try again.": "無法刪除 CSL 樣式。請重試。"
   }
 }

--- a/src/shared/web-rpc-contract.ts
+++ b/src/shared/web-rpc-contract.ts
@@ -92,7 +92,8 @@ export const webRpcResponseSchema = z.discriminatedUnion('ok', [
       error: z
         .object({
           code: z.enum(WEB_RPC_ERROR_CODES),
-          message: z.string()
+          message: z.string(),
+          parameters: z.object({ macro: z.string() }).strict().optional()
         })
         .strict()
     })


### PR DESCRIPTION
## Problem

An existing collection error stays in the previous language after switching languages. CSL validation failures bypass renderer translation, and merge review exposes `publisherPlace` instead of the editor's localized Place label.

## Proposed change

Translate collection error reasons at render time without resetting drafts or retry targets. Carry eight expected CSL validation codes and an optional exact macro parameter through the existing Application Command error envelope, Electron adapter, HTTP response, and Web reconstruction. Translate known errors in all eight locales, and use localized generic messages for unexpected list/import/delete failures. Map `publisherPlace` to the existing Place translation while retaining the existing `place` alias and unknown extension-field labels.

## Scope and non-goals

- No database/schema migration, stored-field rename, persisted-format change, dependency, or new error framework.
- New transient state: three collection error reasons; eight CSL error codes; an optional `{ macro: string }` error parameter; local operation-failure reasons.
- Same controls, error locations, drafts, and retry behavior. Titles, values, and macro names remain original text.
- No historical data migration. The error contract follows the existing matching-version desktop/Web deployment policy; this does not add mixed-version client compatibility or English-message parsing.
- Other unverified metadata/page error candidates are outside this patch.

## Acceptance criteria and validation

Before changing production code, the actual collection dialog, CSL import view with the real library validator, and merge/editor components were exercised through their existing public boundaries. Two consecutive runs produced the same 23 symptom-specific failures and 10 passing existing controls. The same regression assertions now pass; additional checks cover all eight validation codes, malformed parameters, live language switching, and generic fallback messages. No production test seam was added.

Final checks on `bdecf357` cover 58 Vitest files / 1,862 tests and four real Electron journeys:

| Behavior | Command | Result |
| --- | --- | --- |
| Literature UI/service consumers, shared error contract, Electron adapter/preload, Web client | Focused Vitest command below | 56 files passed initially; one capacity test passed on isolated rerun (see below) |
| Actual HTTP serialization, status codes, and macro parameter delivery | `npx vitest run src/main/web-service/http-server.test.ts` | 62 passed |
| Eight-language coverage and renderer surface guards | Included in focused command below | Passed |
| Real contextBridge failures and unchanged Project journeys | `npx playwright test e2e/electron-foundation.spec.ts` | 4 passed |
| Main, shared, preload, and Web types | `npm run typecheck` | Passed |
| Repository lint | `npm run lint` | Passed |
| Patch whitespace | `git diff --check` | Passed |

```sh
npx vitest run src/renderer/src/pages/literature src/main/literature src/shared/literature.test.ts src/shared/literature-csl.test.ts src/shared/application-command-contract.test.ts src/shared/web-rpc-contract.test.ts src/main/application-command-electron-adapter.test.ts src/main/application-command-router.test.ts src/preload/electron-renderer-contract-adapter.test.ts src/renderer/web/bootstrap.test.ts src/renderer/web/api-installer.test.ts src/shared/renderer-surface-matrix.test.ts src/renderer/src/i18n/resources.test.ts
```

CodeGraph caller mapping identified the library page and existing command adapters as consumers; explicit tests cover the dynamic Electron/HTTP/Web error paths. The affected-test explain command selects full fallback because the foundation E2E file has no declared Vitest module owner. Per maintainer instruction, full local Vitest was not run; exact-head PR CI remains authoritative for full and platform verification. No platform-specific or persisted behavior changes were introduced.

Browser verification used real components and production CSS: an existing English collection error becomes Chinese with the name/description retained; the actual CSL validator produces a Chinese invalid-XML alert; merge review shows 出版地 while 北京, Paris, and original titles remain unchanged. Screenshots were captured locally and supplied to the maintainer. The additional production Electron journey now verifies real file input, main-process validation, preload/contextBridge delivery, and rendered error text using isolated profiles.

A shared generated Prisma Client initially mismatched this worktree's schema; an isolated worktree client was generated, after which the complete focused literature run passed. No schema was changed.

Review correction on `bdecf357`: preload serializes expected CSL rejections because Electron strips custom `Error` properties across contextBridge. The renderer reuses the existing validated error decoder. The new real Electron test failed twice on the pre-correction build with the specific reported generic-error symptom, and now passes for invalid XML, missing title/ID, dependent styles, original macro names, and live language switching. All four Electron foundation journeys pass after rebasing. No additional codes or persistence were added. The post-rebase focused Vitest run passed 1,799 of 1,800 tests initially. Its unchanged 50,000-record capacity test hit a Prisma transaction-start timeout while the build and typecheck were running; an isolated rerun passed. The separate HTTP suite passed all 62 tests. Typecheck, lint, and whitespace checks also passed. Full local Vitest was not run, per maintainer instruction.

Rebasing preserved main's additive catalog entries. The previous README guard correction is now upstream and no longer part of this PR.

## Review focus

Check error-parameter validation and preservation through HTTP/Web, the finite CSL code-to-copy mapping, and draft/field identity preservation. Full/platform CI and independent review remain the final verification authority.
