### PR TITLE
fix(literature): confirm attachment deletion and expose version history

### DIFF
--- a/src/main/literature/pdf-attachment-reliability.test.ts
+++ b/src/main/literature/pdf-attachment-reliability.test.ts
@@ -10,6 +10,7 @@ import {
   literatureCatalogCommandSchema,
   literatureCatalogReceiptSchema,
   literatureItemInputSchema,
+  literaturePdfImportRequestSchema,
   type LiteraturePdfImportRequest
 } from '../../shared/literature'
 import { createTestPdf as pdf } from '../../../test/fixtures/literature-pdf'
@@ -784,6 +785,63 @@ describe('Literature PDF attachment reliability', () => {
     expect(
       result.item.attachments.map((entry) => entry.versions.map((version) => version.versionNumber))
     ).toEqual([[1], [1]])
+  })
+
+  it('keeps old versions resolvable and removes the entire version chain without trashing the reference', async () => {
+    const { importer, request, path, catalog, content, authority } = await setup()
+    const first = await importer.import(request)
+    const attachment = first.item.attachments[0]
+    const oldVersion = attachment.versions[0]
+    const oldContent = await authority.resolveVersion(oldVersion.id)
+    expect(
+      literaturePdfImportRequestSchema.safeParse({ ...request, attachmentId: attachment.id })
+        .success
+    ).toBe(false)
+
+    // Version chains currently require the internal Catalog boundary, not normal local import.
+    await writeFile(path, pdf('second'))
+    await content.withPublishedContent(
+      { sourcePath: path, contentType: 'application/pdf' },
+      async (blob) => {
+        await catalog.attachContent({
+          itemId: request.itemId,
+          attachmentId: attachment.id,
+          contentBlobId: blob.id,
+          filename: 'second.pdf',
+          contentType: 'application/pdf',
+          checksum: blob.checksum,
+          sizeBytes: Number(blob.sizeBytes),
+          pageCount: 1
+        })
+      }
+    )
+    const versions = (await catalog.get(request.itemId))!.attachments[0].versions
+    expect(versions.map((entry) => entry.versionNumber)).toEqual([2, 1])
+    const latestContent = await authority.resolveVersion(versions[0].id)
+    await expect(authority.resolveVersion(oldVersion.id)).resolves.toMatchObject({
+      path: oldContent!.path
+    })
+    await writeFile(path, pdf())
+    const deduplicated = await importer.import(request)
+    expect(deduplicated.item.attachments).toHaveLength(1)
+    expect(deduplicated.item.attachments[0].versions.map((entry) => entry.id)).toEqual(
+      versions.map((entry) => entry.id)
+    )
+
+    await catalog.transact({
+      kind: 'delete-attachment',
+      itemId: request.itemId,
+      attachmentId: attachment.id
+    })
+    expect(await client!.literatureAttachmentVersion.count()).toBe(0)
+    expect(await client!.contentBlob.count()).toBe(0)
+    await expect(access(oldContent!.path)).rejects.toThrow()
+    await expect(access(latestContent!.path)).rejects.toThrow()
+    await expect(access(path)).resolves.toBeUndefined()
+    expect((await catalog.get(request.itemId))!.deletedAt).toBeUndefined()
+    expect((await catalog.search({ scope: 'library', lifecycle: 'deleted' })).entries).toHaveLength(
+      0
+    )
   })
 
   it('retains a PDF above the automatic processing limit without claiming a page count', async () => {

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4114,7 +4114,8 @@ describe('notebook runtime service', () => {
         command: 'first',
         provenanceContext: rootContext
       })
-      await vi.waitFor(() => expect(entered).toEqual(['first']))
+      // Filesystem preparation can exceed waitFor's default 1s under CI coverage.
+      await firstStarted.promise
       const second = service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
@@ -4123,9 +4124,6 @@ describe('notebook runtime service', () => {
       })
 
       try {
-        // Filesystem preparation can exceed waitFor's default 1s under CI coverage.
-        // Observe process admission directly before checking the second call is still queued.
-        await firstStarted.promise
         await vi.waitFor(
           async () => {
             const state = await service.state({ sessionId: 'session-1', workspaceCwd: root })

--- a/src/renderer/src/components/ui/confirm-action-dialog.tsx
+++ b/src/renderer/src/components/ui/confirm-action-dialog.tsx
@@ -25,6 +25,7 @@ type ConfirmActionDialogProps = {
   testId?: string
   onCancel: () => void
   onConfirm: () => void
+  onCloseAutoFocus?: React.ComponentProps<typeof AlertDialog.Content>['onCloseAutoFocus']
 }
 
 const ConfirmActionDialog = ({
@@ -38,7 +39,8 @@ const ConfirmActionDialog = ({
   destructive = false,
   testId,
   onCancel,
-  onConfirm
+  onConfirm,
+  onCloseAutoFocus
 }: ConfirmActionDialogProps): React.JSX.Element => (
   <AlertDialog.Root
     open={open}
@@ -51,6 +53,7 @@ const ConfirmActionDialog = ({
       <AlertDialog.Content
         className={dialogPanelClassName('z-[70] w-[min(420px,calc(100vw-2rem))] p-0')}
         data-testid={testId}
+        onCloseAutoFocus={onCloseAutoFocus}
         onEscapeKeyDown={(event) => {
           if (loading) event.preventDefault()
         }}

--- a/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { literatureItemInputSchema, type LiteratureItemView } from '../../../../shared/literature'
+import { LiteratureAttachments } from './LiteratureAttachments'
+
+const version = (versionNumber: number, missing = false) => ({
+  id: `version-${versionNumber}`,
+  versionNumber,
+  filename: `paper-v${versionNumber}.pdf`,
+  contentType: 'application/pdf',
+  sizeBytes: 1024,
+  checksum: String(versionNumber).repeat(64),
+  pageCount: 1,
+  availability: missing ? ('unavailable' as const) : ('available' as const),
+  ...(missing ? { verificationFailure: 'missing' } : {}),
+  createdAt: 1700000000000 + versionNumber
+})
+
+const makeItem = (count: number, missing = false): LiteratureItemView => ({
+  id: 'paper',
+  metadataRevision: 1,
+  item: literatureItemInputSchema.parse({ title: 'Paper', itemType: 'journalArticle' }),
+  projectIds: [],
+  collectionIds: [],
+  createdAt: 1,
+  updatedAt: 1,
+  attachments: [
+    {
+      id: 'attachment',
+      kind: 'fullText',
+      title: 'Paper',
+      sortOrder: 0,
+      createdAt: 1,
+      updatedAt: 1,
+      versions: Array.from({ length: count }, (_, index) =>
+        version(count - index, index === 0 && missing)
+      )
+    }
+  ]
+})
+
+const transact = vi.fn()
+beforeEach(() => {
+  transact.mockReset().mockResolvedValue({ state: 'unlinked' })
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: { literature: { transact, get: vi.fn().mockResolvedValue(undefined) } }
+  })
+})
+afterEach(cleanup)
+
+describe('Attachment safety and version access', () => {
+  it.each([1, 2])(
+    'requires confirmation before deleting an attachment with %i versions',
+    async (count) => {
+      render(
+        <LiteratureAttachments item={makeItem(count)} onChanged={vi.fn()} onPreview={vi.fn()} />
+      )
+      fireEvent.click(
+        screen.getByRole('button', { name: `Attachment actions for paper-v${count}.pdf` })
+      )
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+      expect(
+        transact,
+        'Opening removal must not submit an irreversible deletion'
+      ).not.toHaveBeenCalled()
+      expect(screen.getByRole('alertdialog').textContent).toContain(`paper-v${count}.pdf`)
+    }
+  )
+
+  it.each([false, true])(
+    'offers access to older versions when the latest is missing: %s',
+    async (missing) => {
+      const onPreview = vi.fn()
+      render(
+        <LiteratureAttachments
+          item={makeItem(2, missing)}
+          onChanged={vi.fn()}
+          onPreview={onPreview}
+        />
+      )
+      const latest = screen.getByRole('button', {
+        name: 'Preview paper-v2.pdf'
+      }) as HTMLButtonElement
+      expect(latest.disabled).toBe(missing)
+      if (!missing) {
+        fireEvent.click(latest)
+        expect(onPreview).toHaveBeenCalledWith(version(2))
+      }
+      fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' }))
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'Version history' }))
+      fireEvent.click(screen.getByRole('button', { name: 'Preview paper-v1.pdf' }))
+      expect(onPreview).toHaveBeenLastCalledWith(version(1))
+      expect(transact).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
@@ -1,10 +1,14 @@
 // @vitest-environment jsdom
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { literatureItemInputSchema, type LiteratureItemView } from '../../../../shared/literature'
+import { literatureDeletionError } from '../../../../shared/literature-deletion'
 import { LiteratureAttachments } from './LiteratureAttachments'
 
-const version = (versionNumber: number, missing = false) => ({
+const version = (
+  versionNumber: number,
+  missing = false
+): LiteratureItemView['attachments'][number]['versions'][number] => ({
   id: `version-${versionNumber}`,
   versionNumber,
   filename: `paper-v${versionNumber}.pdf`,
@@ -51,6 +55,158 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('Attachment safety and version access', () => {
+  it.each(['referenced', 'scan-incomplete'] as const)(
+    'retains structured %s diagnostics after confirming deletion',
+    async (reason) => {
+      transact.mockRejectedValue(
+        literatureDeletionError({
+          reason,
+          references:
+            reason === 'referenced'
+              ? [
+                  {
+                    attachmentId: 'attachment',
+                    versionId: 'version-1',
+                    projectId: 'project',
+                    sessionId: 'session',
+                    sessionTitle: 'Saved research discussion',
+                    location: 'message-history'
+                  }
+                ]
+              : [],
+          issues:
+            reason === 'scan-incomplete'
+              ? [{ kind: 'corrupt', fileName: 'conversation.json', recovered: true }]
+              : [],
+          truncated: false
+        })
+      )
+      render(<LiteratureAttachments item={makeItem(2)} onChanged={vi.fn()} onPreview={vi.fn()} />)
+      await openRemoval()
+      fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
+      await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: reason === 'referenced' ? 'View affected conversations' : 'View recovery details'
+        })
+      )
+      expect(
+        screen.getByText(
+          reason === 'referenced' ? 'Saved research discussion' : 'conversation.json'
+        )
+      ).toBeDefined()
+      expect(screen.getByRole('button', { name: 'Preview paper-v2.pdf' })).toBeDefined()
+    }
+  )
+
+  const openRemoval = async (): Promise<void> => {
+    fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+  }
+
+  it.each(['cancel', 'escape'])(
+    'does not delete on %s and returns focus to the attachment menu',
+    async (close) => {
+      render(<LiteratureAttachments item={makeItem(2)} onChanged={vi.fn()} onPreview={vi.fn()} />)
+      const trigger = screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' })
+      trigger.focus()
+      await openRemoval()
+      const dialog = screen.getByRole('alertdialog')
+      expect(dialog.textContent).toContain('All 2 versions will be deleted.')
+      expect(dialog.textContent).toContain('This cannot be undone')
+      expect(dialog.textContent).toContain(
+        'Original files imported from your computer are not deleted.'
+      )
+      if (close === 'cancel')
+        fireEvent.click(within(dialog).getByRole('button', { name: 'Cancel' }))
+      else fireEvent.keyDown(dialog, { key: 'Escape' })
+      await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+      expect(transact).not.toHaveBeenCalled()
+      await waitFor(() => expect(document.activeElement).toBe(trigger))
+    }
+  )
+
+  it('submits the confirmed attachment only once and keeps the committed removal if refresh fails', async () => {
+    let finish!: (value: unknown) => void
+    transact.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve
+        })
+    )
+    const onChanged = vi.fn()
+    render(<LiteratureAttachments item={makeItem(2)} onChanged={onChanged} onPreview={vi.fn()} />)
+    await openRemoval()
+    const confirm = screen.getByRole('button', { name: 'Permanently delete attachment' })
+    fireEvent.click(confirm)
+    fireEvent.click(confirm)
+    expect(transact).toHaveBeenCalledTimes(1)
+    expect(transact).toHaveBeenCalledWith({
+      kind: 'delete-attachment',
+      itemId: 'paper',
+      attachmentId: 'attachment'
+    })
+    expect((confirm as HTMLButtonElement).disabled).toBe(true)
+    fireEvent.keyDown(screen.getByRole('alertdialog'), { key: 'Escape' })
+    expect(screen.getByRole('alertdialog')).toBeDefined()
+    await act(async () => finish({ state: 'unlinked' }))
+    expect(onChanged).toHaveBeenCalledWith(expect.objectContaining({ attachments: [] }))
+    expect(screen.getByRole('alert').textContent).toContain('details could not be refreshed')
+  })
+
+  it('preserves the attachment and explains saved chat references when deletion is refused', async () => {
+    transact.mockRejectedValue(new Error('LITERATURE_ATTACHMENT_IN_USE'))
+    const onChanged = vi.fn()
+    render(<LiteratureAttachments item={makeItem(2)} onChanged={onChanged} onPreview={vi.fn()} />)
+    await openRemoval()
+    fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
+    await waitFor(() => expect(screen.queryByRole('alertdialog')).toBeNull())
+    expect(screen.getByRole('alert').textContent).toContain(
+      'referenced by a chat or its message history'
+    )
+    expect(onChanged).not.toHaveBeenCalled()
+    expect(screen.getByRole('button', { name: 'Preview paper-v2.pdf' })).toBeDefined()
+  })
+
+  it.each(['reference', 'versions'])(
+    'invalidates confirmation when the %s changes',
+    async (change) => {
+      const props = { onChanged: vi.fn(), onPreview: vi.fn() }
+      const view = render(<LiteratureAttachments item={makeItem(2)} {...props} />)
+      await openRemoval()
+      view.rerender(
+        <LiteratureAttachments
+          item={change === 'reference' ? { ...makeItem(2), id: 'other' } : makeItem(3)}
+          {...props}
+        />
+      )
+      expect(screen.queryByRole('alertdialog')).toBeNull()
+      expect(transact).not.toHaveBeenCalled()
+    }
+  )
+
+  it('shows version metadata and prevents previewing a missing version', async () => {
+    const onPreview = vi.fn()
+    render(
+      <LiteratureAttachments item={makeItem(2, true)} onChanged={vi.fn()} onPreview={onPreview} />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Version history' }))
+    const dialog = screen.getByRole('dialog')
+    expect(dialog.textContent).toContain('Version 2')
+    expect(dialog.textContent).toContain('Version 1')
+    expect(dialog.querySelectorAll('time')).toHaveLength(2)
+    const missing = within(dialog).getByRole('button', {
+      name: 'Preview paper-v2.pdf'
+    }) as HTMLButtonElement
+    expect(missing.disabled).toBe(true)
+    expect(missing.textContent).toContain('File missing')
+    fireEvent.click(missing)
+    expect(onPreview).not.toHaveBeenCalled()
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close' }))
+    expect(transact).not.toHaveBeenCalled()
+  })
+
   it.each([1, 2])(
     'requires confirmation before deleting an attachment with %i versions',
     async (count) => {

--- a/src/renderer/src/pages/literature/LiteratureAttachments.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.tsx
@@ -4,10 +4,22 @@ import {
 } from '../../../../shared/literature-deletion'
 import { LiteratureDeletionNotice } from './LiteratureDeletionNotice'
 import { useRef, useState } from 'react'
-import { FileText, MoreHorizontal, RotateCcw, Trash2 } from 'lucide-react'
+import { FileText, History, MoreHorizontal, RotateCcw, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
 import type { LiteratureItemView } from '../../../../shared/literature'
+import { Button } from '@/components/ui/button'
+import { ConfirmActionDialog } from '@/components/ui/confirm-action-dialog'
+import * as Dialog from '@/components/ui/dialog'
+import {
+  dialogBodyClassName,
+  dialogFooterClassName,
+  dialogHeaderClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName,
+  dialogDescriptionClassName
+} from '@/components/ui/dialog-chrome'
 import { formatBytes } from '../../../../shared/update'
 import {
   ActionMenuProvider,
@@ -18,12 +30,15 @@ import {
 } from '@/components/action-menu'
 
 type Version = LiteratureItemView['attachments'][number]['versions'][number]
-type AttachmentAction = 'verify' | 'remove'
+type Attachment = LiteratureItemView['attachments'][number]
+type AttachmentAction = 'verify' | 'remove' | 'history'
 const attachmentActionCatalog: Record<AttachmentAction, ActionMenuDefinition> = {
+  history: { labelKey: 'Version history', icon: History },
   verify: { labelKey: 'Retry file verification', icon: RotateCcw },
   remove: { labelKey: 'Remove attachment', icon: Trash2, danger: true }
 }
 const attachmentActionRecipe: readonly ActionMenuRecipeEntry<AttachmentAction>[] = [
+  { kind: 'action', action: 'history' },
   { kind: 'action', action: 'verify' },
   { kind: 'separator' },
   { kind: 'action', action: 'remove' }
@@ -31,15 +46,18 @@ const attachmentActionRecipe: readonly ActionMenuRecipeEntry<AttachmentAction>[]
 
 const AttachmentMenuButton = ({
   targetId,
-  title
+  title,
+  ref
 }: {
   targetId: string
   title: string
+  ref: React.Ref<HTMLButtonElement>
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const { openMenu } = useActionMenu()
   return (
     <button
+      ref={ref}
       type="button"
       aria-label={t('Attachment actions for {{title}}', { title })}
       className="m-1 rounded-md p-2 hover:bg-muted focus-visible:ring-2 focus-visible:ring-ring"
@@ -57,6 +75,69 @@ const AttachmentMenuButton = ({
   )
 }
 
+const AttachmentPreview = ({
+  version,
+  title,
+  onPreview
+}: {
+  version?: Version
+  title: string
+  onPreview: (version: Version) => void
+}): React.JSX.Element => {
+  const { t } = useTranslation()
+  const failure = version?.verificationFailure
+  const health =
+    version?.availability === 'unavailable'
+      ? failure === 'missing'
+        ? t('File missing')
+        : [
+              'checksum-mismatch',
+              'size-mismatch',
+              'not-file',
+              'changed-during-verification'
+            ].includes(failure ?? '')
+          ? t('File damaged')
+          : t('File unavailable')
+      : version?.availability === 'available'
+        ? t('File integrity verified')
+        : t('File integrity not yet verified')
+  return (
+    <button
+      type="button"
+      disabled={!version || version.availability === 'unavailable'}
+      aria-label={t('Preview {{title}}', { title })}
+      className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
+      onClick={() => version && onPreview(version)}
+    >
+      <FileText className="size-4 shrink-0 text-primary" aria-hidden="true" />
+      <span className="min-w-0 flex-1">
+        <span className="block truncate font-medium">{title}</span>
+        {version ? (
+          <span className="block text-xs text-muted-foreground">
+            {formatBytes(version.sizeBytes)}
+          </span>
+        ) : null}
+        <span
+          className={
+            version?.availability === 'unavailable'
+              ? 'block text-xs text-danger-000'
+              : 'block text-xs text-muted-foreground'
+          }
+        >
+          {health}
+        </span>
+        {version && !version.pageCount ? (
+          <span className="block text-xs text-muted-foreground">
+            {version.sizeBytes > 50 * 1024 * 1024
+              ? t('PDF not validated: exceeds the 50 MiB automatic processing limit.')
+              : t('PDF structure not yet validated.')}
+          </span>
+        ) : null}
+      </span>
+    </button>
+  )
+}
+
 export const LiteratureAttachments = ({
   item,
   onChanged,
@@ -66,13 +147,38 @@ export const LiteratureAttachments = ({
   onChanged: (item: LiteratureItemView) => void
   onPreview: (version: Version) => void
 }): React.JSX.Element => {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
+  const menuButtons = useRef(new Map<string, HTMLButtonElement>())
+  const returnFocus = useRef<HTMLButtonElement | undefined>(undefined)
+  const restoreFocus = (event: Event): void => {
+    if (returnFocus.current?.isConnected) {
+      event.preventDefault()
+      returnFocus.current.focus()
+    }
+  }
+  const [removal, setRemoval] = useState<{ itemId: string; attachment: Attachment }>()
+  const [history, setHistory] = useState<{ itemId: string; attachmentId: string }>()
+  const removalAttachment =
+    removal?.itemId === item.id
+      ? item.attachments.find(
+          (entry) =>
+            entry.id === removal.attachment.id &&
+            entry.versions.length === removal.attachment.versions.length &&
+            entry.versions.every(
+              (version, index) => version.id === removal.attachment.versions[index].id
+            )
+        )
+      : undefined
+  const historyAttachment =
+    history?.itemId === item.id
+      ? item.attachments.find((entry) => entry.id === history.attachmentId)
+      : undefined
   const [error, setError] = useState<string>()
   const [deletionDiagnostic, setDeletionDiagnostic] = useState<LiteratureDeletionDiagnostic>()
   const busy = useRef(false)
   const [pending, setPending] = useState(false)
   const run = async (
-    action: AttachmentAction,
+    action: 'verify' | 'remove',
     attachmentId: string,
     versionId?: string
   ): Promise<void> => {
@@ -115,14 +221,13 @@ export const LiteratureAttachments = ({
       setPending(false)
     }
   }
+  const showError = (error: unknown): void => {
+    const diagnostic = parseLiteratureDeletionError(error)
+    setDeletionDiagnostic(diagnostic)
+    if (!diagnostic) setError(t('The attachment operation failed. Try again.'))
+  }
   return (
-    <ActionMenuProvider
-      onActionError={(error) => {
-        const diagnostic = parseLiteratureDeletionError(error)
-        setDeletionDiagnostic(diagnostic)
-        if (!diagnostic) setError(t('The attachment operation failed. Try again.'))
-      }}
-    >
+    <ActionMenuProvider onActionError={showError}>
       <div className="mt-2 space-y-2">
         {deletionDiagnostic ? <LiteratureDeletionNotice diagnostic={deletionDiagnostic} /> : null}
         {error ? (
@@ -134,22 +239,6 @@ export const LiteratureAttachments = ({
           const version = attachment.versions[0]
           const title = version?.filename ?? attachment.title
           const targetId = `literature-attachment:${attachment.id}`
-          const failure = version?.verificationFailure
-          const health =
-            version?.availability === 'unavailable'
-              ? failure === 'missing'
-                ? t('File missing')
-                : [
-                      'checksum-mismatch',
-                      'size-mismatch',
-                      'not-file',
-                      'changed-during-verification'
-                    ].includes(failure ?? '')
-                  ? t('File damaged')
-                  : t('File unavailable')
-              : version?.availability === 'available'
-                ? t('File integrity verified')
-                : t('File integrity not yet verified')
           return (
             <ActionMenuTarget
               key={attachment.id}
@@ -164,49 +253,122 @@ export const LiteratureAttachments = ({
                   execute: () => run('verify', attachment.id, version?.id),
                   disabled: pending || !version
                 },
-                remove: { execute: () => run('remove', attachment.id), disabled: pending }
+                history: {
+                  execute: () => {
+                    returnFocus.current = menuButtons.current.get(attachment.id)
+                    setHistory({ itemId: item.id, attachmentId: attachment.id })
+                  },
+                  hidden: attachment.versions.length < 2,
+                  disabled: pending
+                },
+                remove: {
+                  execute: () => {
+                    returnFocus.current = menuButtons.current.get(attachment.id)
+                    setRemoval({ itemId: item.id, attachment })
+                  },
+                  disabled: pending
+                }
               }}
             >
               <div className="flex items-center rounded-lg border border-border bg-background">
-                <button
-                  type="button"
-                  disabled={!version || version.availability === 'unavailable'}
-                  aria-label={t('Preview {{title}}', { title })}
-                  className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
-                  onClick={() => version && onPreview(version)}
-                >
-                  <FileText className="size-4 shrink-0 text-primary" aria-hidden="true" />
-                  <span className="min-w-0 flex-1">
-                    <span className="block truncate font-medium">{title}</span>
-                    {version ? (
-                      <span className="block text-xs text-muted-foreground">
-                        {formatBytes(version.sizeBytes)}
-                      </span>
-                    ) : null}
-                    <span
-                      className={
-                        version?.availability === 'unavailable'
-                          ? 'block text-xs text-danger-000'
-                          : 'block text-xs text-muted-foreground'
-                      }
-                    >
-                      {health}
-                    </span>
-                    {version && !version.pageCount ? (
-                      <span className="block text-xs text-muted-foreground">
-                        {version.sizeBytes > 50 * 1024 * 1024
-                          ? t('PDF not validated: exceeds the 50 MiB automatic processing limit.')
-                          : t('PDF structure not yet validated.')}
-                      </span>
-                    ) : null}
-                  </span>
-                </button>
-                <AttachmentMenuButton targetId={targetId} title={title} />
+                <AttachmentPreview version={version} title={title} onPreview={onPreview} />
+                <AttachmentMenuButton
+                  targetId={targetId}
+                  title={title}
+                  ref={(node) => {
+                    if (node) menuButtons.current.set(attachment.id, node)
+                    else menuButtons.current.delete(attachment.id)
+                  }}
+                />
               </div>
             </ActionMenuTarget>
           )
         })}
       </div>
+      <ConfirmActionDialog
+        open={Boolean(removalAttachment)}
+        title={t('Permanently delete attachment')}
+        description={[
+          t('Permanently delete “{{filename}}”?', {
+            filename: removalAttachment?.versions[0]?.filename ?? removalAttachment?.title ?? ''
+          }),
+          removalAttachment && removalAttachment.versions.length > 1
+            ? t('All {{count}} versions will be deleted.', {
+                count: removalAttachment.versions.length,
+                defaultValue_one: 'The only version will be deleted.'
+              })
+            : '',
+          t(
+            'Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.'
+          )
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        cancelLabel={t('Cancel')}
+        confirmLabel={t('Permanently delete attachment')}
+        destructive
+        loading={pending}
+        onCloseAutoFocus={restoreFocus}
+        onCancel={() => setRemoval(undefined)}
+        onConfirm={() => {
+          if (!removalAttachment || busy.current) return
+          void run('remove', removalAttachment.id)
+            .catch(showError)
+            .finally(() => setRemoval(undefined))
+        }}
+      />
+      <Dialog.Root
+        open={Boolean(historyAttachment)}
+        onOpenChange={(open) => {
+          if (!open) setHistory(undefined)
+        }}
+      >
+        <Dialog.Portal>
+          <Dialog.Overlay className={dialogOverlayClassName} />
+          <Dialog.Content
+            onCloseAutoFocus={restoreFocus}
+            className={dialogPanelClassName(
+              'flex max-h-[80vh] w-[min(560px,calc(100vw-2rem))] flex-col p-0'
+            )}
+          >
+            <div className={dialogHeaderClassName}>
+              <div className="min-w-0">
+                <Dialog.Title className={dialogTitleClassName}>{t('Version history')}</Dialog.Title>
+                <Dialog.Description className={`${dialogDescriptionClassName} break-words`}>
+                  {t('Previewing an older version does not change the latest version.')}
+                </Dialog.Description>
+              </div>
+            </div>
+            <div className={`${dialogBodyClassName} space-y-3 overflow-y-auto`}>
+              {historyAttachment?.versions.map((version) => (
+                <div key={version.id} className="rounded-lg border border-border">
+                  <div className="flex flex-wrap justify-between gap-2 px-3 pt-3 text-xs text-muted-foreground">
+                    <span>{t('Version {{number}}', { number: version.versionNumber })}</span>
+                    <time dateTime={new Date(version.createdAt).toISOString()}>
+                      {new Date(version.createdAt).toLocaleString(i18n.language)}
+                    </time>
+                  </div>
+                  <div className="flex">
+                    <AttachmentPreview
+                      version={version}
+                      title={version.filename}
+                      onPreview={(selected) => {
+                        setHistory(undefined)
+                        onPreview(selected)
+                      }}
+                    />
+                  </div>
+                </div>
+              ))}
+            </div>
+            <div className={dialogFooterClassName}>
+              <Dialog.Close asChild>
+                <Button variant="ghost">{t('Close')}</Button>
+              </Dialog.Close>
+            </div>
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
     </ActionMenuProvider>
   )
 }

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -6286,7 +6286,9 @@ describe('LiteratureLibraryPage', () => {
 
     fireEvent.change(screen.getByLabelText('Import references'), { target: { files: [file] } })
     await screen.findByRole('dialog')
-    expect(screen.getByText('Only the first 1,000 references will be imported.')).not.toBeNull()
+    expect(
+      await screen.findByText('Only the first 1,000 references will be imported.')
+    ).not.toBeNull()
     fireEvent.click(screen.getByRole('button', { name: 'Import references' }))
     expect(await screen.findByText('Created')).not.toBeNull()
     expect(screen.getByText('Skipped').parentElement?.textContent).toContain('1001Skipped')

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -3144,6 +3144,8 @@ describe('LiteratureLibraryPage', () => {
       within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
     )
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    expect(screen.getByRole('alertdialog').textContent).toContain('paper.pdf')
+    fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
     await waitFor(() =>
       expect(transact).toHaveBeenCalledWith({
         kind: 'delete-attachment',
@@ -3210,6 +3212,8 @@ describe('LiteratureLibraryPage', () => {
       within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
     )
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    expect(screen.getByRole('alertdialog').textContent).toContain('paper.pdf')
+    fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
     expect(
       await within(detail).findByText(
         'This PDF is referenced by a chat or its message history and cannot be removed. Unlinking the current chat does not remove historical references.'
@@ -3416,6 +3420,8 @@ describe('LiteratureLibraryPage', () => {
       within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
     )
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    expect(screen.getByRole('alertdialog').textContent).toContain('paper.pdf')
+    fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
     expect(await within(detail).findByRole('alert')).not.toBeNull()
     expect(
       within(detail).getByText('Attachment removed. Storage cleanup could not finish.')

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -3241,6 +3241,8 @@ describe('LiteratureLibraryPage', () => {
       within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
     )
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    expect(screen.getByRole('alertdialog').textContent).toContain('paper.pdf')
+    fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
     const alert = await within(detail).findByRole('alert')
     expect(within(detail).getByRole('button', { name: 'Preview paper.pdf' })).not.toBeNull()
     expect.soft(alert.textContent).not.toBe('The attachment operation failed. Try again.')
@@ -3303,6 +3305,9 @@ describe('LiteratureLibraryPage', () => {
         if (entryPoint === 'permanent item') {
           container = screen.getByRole('alertdialog')
           fireEvent.click(within(container).getByRole('button', { name: 'Delete permanently' }))
+        } else {
+          expect(screen.getByRole('alertdialog').textContent).toContain('paper.pdf')
+          fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
         }
         fireEvent.click(await screen.findByRole('button', { name: 'View affected conversations' }))
         expect(screen.getByText('Retained history')).not.toBeNull()
@@ -3360,6 +3365,8 @@ describe('LiteratureLibraryPage', () => {
       within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
     )
     fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    expect(screen.getByRole('alertdialog').textContent).toContain('paper.pdf')
+    fireEvent.click(screen.getByRole('button', { name: 'Permanently delete attachment' }))
     fireEvent.click(await screen.findByRole('button', { name: 'View recovery details' }))
     expect(screen.getByText('damaged-session.json')).not.toBeNull()
     expect(

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4984,6 +4984,14 @@
     "Search again resets unfinished results and their selections.": "Eine erneute Suche setzt nicht abgeschlossene Ergebnisse und deren Auswahl zurück.",
     "Apply selected": "Auswahl anwenden",
     "Add selected": "Auswahl hinzufügen",
-    "Some references failed. Search again to retry unfinished references.": "Einige Literaturstellen sind fehlgeschlagen. Suchen Sie erneut, um nicht abgeschlossene Literaturstellen erneut zu versuchen."
+    "Some references failed. Search again to retry unfinished references.": "Einige Literaturstellen sind fehlgeschlagen. Suchen Sie erneut, um nicht abgeschlossene Literaturstellen erneut zu versuchen.",
+    "Version history": "Versionsverlauf",
+    "Permanently delete attachment": "Anhang endgültig löschen",
+    "Permanently delete “{{filename}}”?": "„{{filename}}“ endgültig löschen?",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "Von der Anwendung gespeicherte Dateien werden gelöscht, wenn keine anderen Referenzen sie verwenden. Dies kann nicht rückgängig gemacht werden und verschiebt den Anhang nicht in den Papierkorb. Vom Computer importierte Originaldateien werden nicht gelöscht.",
+    "Previewing an older version does not change the latest version.": "Die Vorschau einer älteren Version ändert die neueste Version nicht.",
+    "Version {{number}}": "Version {{number}}",
+    "All {{count}} versions will be deleted._one": "Die einzige Version ({{count}}) wird gelöscht.",
+    "All {{count}} versions will be deleted._other": "Alle {{count}} Versionen werden gelöscht."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5145,6 +5145,15 @@
     "Search again resets unfinished results and their selections.": "Volver a buscar restablece los resultados pendientes y sus selecciones.",
     "Apply selected": "Aplicar selección",
     "Add selected": "Añadir selección",
-    "Some references failed. Search again to retry unfinished references.": "Algunas referencias fallaron. Repita la búsqueda para reintentar las referencias pendientes."
+    "Some references failed. Search again to retry unfinished references.": "Algunas referencias fallaron. Repita la búsqueda para reintentar las referencias pendientes.",
+    "Version history": "Historial de versiones",
+    "Permanently delete attachment": "Eliminar permanentemente el archivo adjunto",
+    "Permanently delete “{{filename}}”?": "¿Eliminar permanentemente «{{filename}}»?",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "Los archivos guardados por la aplicación se eliminarán cuando ninguna otra referencia los utilice. Esta acción no se puede deshacer y no mueve el archivo adjunto a la papelera. Los archivos originales importados desde su equipo no se eliminarán.",
+    "Previewing an older version does not change the latest version.": "La vista previa de una versión anterior no cambia la versión más reciente.",
+    "Version {{number}}": "Versión {{number}}",
+    "All {{count}} versions will be deleted._one": "Se eliminará la única versión ({{count}}).",
+    "All {{count}} versions will be deleted._many": "Se eliminarán las {{count}} versiones.",
+    "All {{count}} versions will be deleted._other": "Se eliminarán las {{count}} versiones."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5145,6 +5145,15 @@
     "Search again resets unfinished results and their selections.": "Relancer la recherche réinitialise les résultats inachevés et les sélections associées.",
     "Apply selected": "Appliquer la sélection",
     "Add selected": "Ajouter la sélection",
-    "Some references failed. Search again to retry unfinished references.": "Certaines références ont échoué. Relancez la recherche pour réessayer les références inachevées."
+    "Some references failed. Search again to retry unfinished references.": "Certaines références ont échoué. Relancez la recherche pour réessayer les références inachevées.",
+    "Version history": "Historique des versions",
+    "Permanently delete attachment": "Supprimer définitivement la pièce jointe",
+    "Permanently delete “{{filename}}”?": "Supprimer définitivement « {{filename}} » ?",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "Les fichiers enregistrés par l’application seront supprimés si aucune autre référence ne les utilise. Cette action est irréversible et ne déplace pas la pièce jointe dans la corbeille. Les fichiers originaux importés depuis votre ordinateur ne seront pas supprimés.",
+    "Previewing an older version does not change the latest version.": "L’aperçu d’une ancienne version ne modifie pas la dernière version.",
+    "Version {{number}}": "Version {{number}}",
+    "All {{count}} versions will be deleted._one": "L’unique version ({{count}}) sera supprimée.",
+    "All {{count}} versions will be deleted._many": "Les {{count}} versions seront toutes supprimées.",
+    "All {{count}} versions will be deleted._other": "Les {{count}} versions seront toutes supprimées."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4831,6 +4831,13 @@
     "Search again resets unfinished results and their selections.": "再検索すると、未完了の結果とその選択内容がリセットされます。",
     "Apply selected": "選択項目を適用",
     "Add selected": "選択項目を追加",
-    "Some references failed. Search again to retry unfinished references.": "一部の文献の処理に失敗しました。再検索して未完了の文献を再試行してください。"
+    "Some references failed. Search again to retry unfinished references.": "一部の文献の処理に失敗しました。再検索して未完了の文献を再試行してください。",
+    "Version history": "バージョン履歴",
+    "Permanently delete attachment": "添付ファイルを完全に削除",
+    "Permanently delete “{{filename}}”?": "「{{filename}}」を完全に削除しますか？",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "他の参照で使用されていない場合、アプリに保存されたファイルは削除されます。この操作は取り消せず、添付ファイルはゴミ箱に移動されません。コンピューターからインポートした元のファイルは削除されません。",
+    "Previewing an older version does not change the latest version.": "古いバージョンをプレビューしても、最新バージョンは変わりません。",
+    "Version {{number}}": "バージョン {{number}}",
+    "All {{count}} versions will be deleted._other": "すべての {{count}} バージョンが削除されます。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4829,6 +4829,13 @@
     "Search again resets unfinished results and their selections.": "다시 검색하면 완료되지 않은 결과와 선택 사항이 초기화됩니다.",
     "Apply selected": "선택 항목 적용",
     "Add selected": "선택 항목 추가",
-    "Some references failed. Search again to retry unfinished references.": "일부 문헌 처리에 실패했습니다. 다시 검색하여 미완료 문헌을 재시도하세요."
+    "Some references failed. Search again to retry unfinished references.": "일부 문헌 처리에 실패했습니다. 다시 검색하여 미완료 문헌을 재시도하세요.",
+    "Version history": "버전 기록",
+    "Permanently delete attachment": "첨부 파일 영구 삭제",
+    "Permanently delete “{{filename}}”?": "“{{filename}}”을(를) 영구 삭제하시겠습니까?",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "다른 참조에서 사용하지 않는 경우 앱에 저장된 파일이 삭제됩니다. 이 작업은 실행 취소할 수 없으며 첨부 파일은 휴지통으로 이동하지 않습니다. 컴퓨터에서 가져온 원본 파일은 삭제되지 않습니다.",
+    "Previewing an older version does not change the latest version.": "이전 버전을 미리 보아도 최신 버전은 변경되지 않습니다.",
+    "Version {{number}}": "버전 {{number}}",
+    "All {{count}} versions will be deleted._other": "모든 {{count}}개 버전이 삭제됩니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5277,6 +5277,16 @@
     "Search again resets unfinished results and their selections.": "Повторный поиск сбрасывает незавершённые результаты и их выбор.",
     "Apply selected": "Применить выбранное",
     "Add selected": "Добавить выбранное",
-    "Some references failed. Search again to retry unfinished references.": "Не удалось обработать некоторые источники. Повторите поиск, чтобы снова обработать незавершённые источники."
+    "Some references failed. Search again to retry unfinished references.": "Не удалось обработать некоторые источники. Повторите поиск, чтобы снова обработать незавершённые источники.",
+    "Version history": "История версий",
+    "Permanently delete attachment": "Удалить вложение навсегда",
+    "Permanently delete “{{filename}}”?": "Удалить «{{filename}}» навсегда?",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "Файлы, сохранённые приложением, будут удалены, если их не используют другие записи. Это действие нельзя отменить, и вложение не будет перемещено в корзину. Исходные файлы, импортированные с компьютера, не будут удалены.",
+    "Previewing an older version does not change the latest version.": "Предпросмотр старой версии не изменяет последнюю версию.",
+    "Version {{number}}": "Версия {{number}}",
+    "All {{count}} versions will be deleted._one": "Будет удалена {{count}} версия.",
+    "All {{count}} versions will be deleted._few": "Будут удалены все {{count}} версии.",
+    "All {{count}} versions will be deleted._many": "Будут удалены все {{count}} версий.",
+    "All {{count}} versions will be deleted._other": "Будут удалены все {{count}} версии."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4831,6 +4831,13 @@
     "Search again resets unfinished results and their selections.": "重新检索会重置未完成的结果及其选择。",
     "Apply selected": "应用所选",
     "Add selected": "添加所选",
-    "Some references failed. Search again to retry unfinished references.": "部分文献处理失败。重新检索可重试未完成的文献。"
+    "Some references failed. Search again to retry unfinished references.": "部分文献处理失败。重新检索可重试未完成的文献。",
+    "Version history": "版本历史",
+    "Permanently delete attachment": "永久删除附件",
+    "Permanently delete “{{filename}}”?": "永久删除“{{filename}}”？",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "没有其他引用使用这些文件时，应用保存的文件将被删除。此操作无法撤销，附件不会移至回收站。从您的计算机导入的原始文件不会被删除。",
+    "Previewing an older version does not change the latest version.": "预览旧版本不会改变最新版本。",
+    "Version {{number}}": "版本 {{number}}",
+    "All {{count}} versions will be deleted._other": "全部 {{count}} 个版本都将被删除。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4831,6 +4831,13 @@
     "Search again resets unfinished results and their selections.": "重新檢索會重設未完成的結果及其選取項目。",
     "Apply selected": "套用所選",
     "Add selected": "新增所選",
-    "Some references failed. Search again to retry unfinished references.": "部分文獻處理失敗。重新檢索可重試未完成的文獻。"
+    "Some references failed. Search again to retry unfinished references.": "部分文獻處理失敗。重新檢索可重試未完成的文獻。",
+    "Version history": "版本歷史",
+    "Permanently delete attachment": "永久刪除附件",
+    "Permanently delete “{{filename}}”?": "永久刪除「{{filename}}」？",
+    "Files saved by the application will be deleted when no other references use them. This cannot be undone and does not move the attachment to Trash. Original files imported from your computer are not deleted.": "沒有其他參照使用這些檔案時，應用程式儲存的檔案將被刪除。此操作無法復原，附件不會移至垃圾桶。從您的電腦匯入的原始檔案不會被刪除。",
+    "Previewing an older version does not change the latest version.": "預覽舊版本不會變更最新版本。",
+    "Version {{number}}": "版本 {{number}}",
+    "All {{count}} versions will be deleted._other": "全部 {{count}} 個版本都將被刪除。"
   }
 }


### PR DESCRIPTION
## Problem

Removing a PDF from reference details immediately deleted its logical attachment and every version, potentially sweeping the application's only saved copy. Existing version chains also exposed only their latest PDF, leaving an intact older version inaccessible when the latest file was missing.

## Proposed change

Require a destructive confirmation showing the filename, all-version count, managed-file cleanup scope, and lack of Trash/Undo recovery. Reuse the shared confirmation dialog with an optional Radix focus-return callback. Cancel/Escape never submit; pending confirmation submits once; an observed reference/version-chain change invalidates confirmation.

Expose read-only version history for multi-version attachments, with version number, filename, date, integrity status, and previews through the existing exact-version callback. Missing versions remain disabled. Preserve chat-reference errors and post-commit refresh/cleanup handling. Include all eight translations.

## Scope and non-goals

No database fields, migrations, entity relationships, persisted status values, API request changes, or new dependencies. Dialog selection is transient; the new history menu action is not a persisted lifecycle state. Existing version arrays work without backfill. Deletion still uses the existing command; history does not write or select a new current version. No local version import, rollback, delayed cleanup, or persistent Undo. Ordinary local imports still create independent attachments for different content; multi-version fixtures use the existing internal Catalog boundary.

## Acceptance criteria and validation

Four new real-component scenarios failed twice on original production code and again after rebasing, for immediate deletion and missing history access. They pass with the fix; additional tests cover cancellation, focus return, submission deduplication, chat-reference refusal, changing confirmation targets, and unavailable historical files. Real SQLite characterization verifies exact old-version resolution, checksum deduplication, all-version cleanup, source-file preservation, and the reference staying out of Trash.

Final checks (after the last material edit):

- Attachment interaction, literature owner/consumer behavior and contracts → `npx vitest run src/renderer/src/pages/literature src/main/literature src/shared/literature.test.ts` as part of the focused selection.
- Shared menu/dialog consumers → action-menu, dialog, NetworkPanel, UnavailablePlanNotice, GrantFolderAccessDialog, and PreviewFileSurface suites in the same selection.
- Translation completeness and plurals → `src/renderer/src/i18n/resources.test.ts` in the same selection.
- Focused selection: literature owner/consumer, SQLite reliability, shared deletion diagnostics, shared UI consumers and i18n. After rebasing onto `684bdaa3`, preserve main's structured chat-reference and recovery diagnostics in both menu and confirmation error paths. Two additional regressions fail with the old error handler and pass with the merged handler. Main's new deletion-diagnostic page tests now include confirmation before asserting the existing diagnostics/navigation behavior.
- Final result after rebasing: **2,314 tests covered by successful final runs**. The focused selection passed 1,939 checks outside the two process-dependent suites. `npm test -- src/main/notebook/runtime-service.test.ts src/main/literature/catalog-capacity.test.ts` passed all 375 checks outside the agent sandbox; the original sandbox run blocked real shell execution and the concurrent database fixture. The selection also includes `scripts/electron-app-fixture.test.ts`, preserving strict graceful-restart cleanup semantics.
- Runtime types → `npm run typecheck:web` and `npm run typecheck:node` passed.
- Lint/format → `npm run lint`, targeted Prettier and `git diff --check` passed.
- Actual Chromium interaction inspection using ego-browser and real components with isolated API fixtures: confirmation does not write, Cancel restores focus, an available older version previews without writes, and confirmation sends one delete command. Screenshots supplied to the maintainer locally; this is not a packaged Electron end-to-end run.

The affected-plan explain tool selects the full fallback because literature is not registered in its module manifest. Per maintainer request, local validation uses the explicit literature module and shared UI consumer set rather than the complete portable suite. PR CI remains authoritative for full/platform lanes. No production backend, platform path handling, schema or IPC contract changed, so migration/platform E2E was not added locally.

## Review focus

Review whole-attachment deletion copy, focus return from menu-opened dialogs, exact-version preview behavior, and the mapping from the final diff to the checks above. Broader concurrent view/revision semantics remain unchanged.

The earlier E2E report aggregation failure was an HTTP 403 while listing artifacts, not an E2E assertion failure. Rerunning only failed jobs of run 34241486513 succeeded, including report aggregation; no workflow changes were needed. CI for the updated head is being checked separately.

The portable CI shard and merged report shared a shell queue test failure: a default one-second wait ran before the existing process-start signal. A temporary 1,200 ms delay through the injected shell-process boundary reproduced the exact empty-admission-array assertion; moving the existing signal await before the second submission passed with the same delay. Only that synchronization correction is committed, with no runtime change or raised timeout. The Windows restart failure passed on the original retry but was reported as flaky; its failed job was rerun separately, with the new-head platform checks remaining authoritative.

After the first CI repair, all Windows/macOS E2E lanes and the previously failing queue shard passed. The remaining portable failure was an existing import-preview test assuming that dialog visibility meant parsing had finished; main now opens the dialog during reading. A 200 ms delay in the existing File.text fixture reproduced the exact missing-result-text assertion. Awaiting the result text passed with that same delay; the diagnostic delay was then removed. Final page/attachment suites, web typecheck and lint passed after this test-only correction. The next CI run verifies the final head.
