### PR TITLE
fix(literature): protect recoverable chat history during deletion

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1776,8 +1776,7 @@ const createApplicationModules = async (
     () => getProjectDbClient(configRoot),
     () => tagService.notifyAssignmentsChanged(),
     contentRepository,
-    (attachmentId, remove) =>
-      sessionPersistenceCoordinator.withUnreferencedLiteratureAttachment(attachmentId, remove)
+    (remove) => sessionPersistenceCoordinator.withLiteratureAttachmentRemoval(remove)
   )
   const literatureCitationStyles = new LiteratureCitationStyleLibrary(
     join(resolveDataRoot(), 'literature', 'citation-styles')

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -765,10 +765,15 @@ class LiteratureCatalog {
     private readonly getClient: LiteratureCatalogClientProvider,
     private readonly onTagAssignmentsChanged?: () => Promise<void>,
     private readonly content?: Pick<ContentRepository, 'verify' | 'sweep'>,
-    private readonly withAttachmentRemoval?: (
-      attachmentId: string,
-      remove: () => Promise<LiteratureCatalogReceipt>
-    ) => Promise<LiteratureCatalogReceipt>
+    private readonly withAttachmentRemoval: (
+      remove: (
+        assertUnreferenced: (attachmentIds: readonly string[]) => void
+      ) => Promise<LiteratureCatalogReceipt>
+    ) => Promise<LiteratureCatalogReceipt> = async (remove) =>
+      remove((attachmentIds) => {
+        // Metadata-only clients may delete metadata, but cannot bypass attachment authority.
+        if (attachmentIds.length) throw new Error('Literature attachment removal is unavailable.')
+      })
   ) {}
 
   private async publishTagAssignmentsChanged(): Promise<void> {
@@ -1249,15 +1254,14 @@ class LiteratureCatalog {
   private deleteAttachment(
     command: Extract<LiteratureCatalogCommand, { kind: 'delete-attachment' }>
   ): Promise<LiteratureCatalogReceipt> {
-    if (!this.withAttachmentRemoval)
-      throw new Error('Literature attachment removal is unavailable.')
-    return this.withAttachmentRemoval(command.attachmentId, () =>
-      this.deleteUnreferencedAttachment(command)
+    return this.withAttachmentRemoval((assertUnreferenced) =>
+      this.deleteUnreferencedAttachment(command, assertUnreferenced)
     )
   }
 
   private async deleteUnreferencedAttachment(
-    command: Extract<LiteratureCatalogCommand, { kind: 'delete-attachment' }>
+    command: Extract<LiteratureCatalogCommand, { kind: 'delete-attachment' }>,
+    assertUnreferenced: (attachmentIds: readonly string[]) => void
   ): Promise<LiteratureCatalogReceipt> {
     if (!this.content) throw new Error('Literature content operations are unavailable.')
     const client = await this.getClient()
@@ -1271,6 +1275,7 @@ class LiteratureCatalog {
         select: { versions: { select: { contentBlobId: true } } }
       })
       if (!attachment) throw new Error('Literature Attachment is unavailable.')
+      assertUnreferenced([command.attachmentId])
       await transaction.literatureAttachment.delete({ where: { id: command.attachmentId } })
       return attachment.versions.map(({ contentBlobId }) => contentBlobId)
     })
@@ -1923,49 +1928,56 @@ class LiteratureCatalog {
     const itemIds = [...new Set(command.itemIds)]
     const client = await this.getClient()
     let tagsChanged = false
-    const receipt = await client.$transaction<LiteratureCatalogReceipt>(async (transaction) => {
-      const requestedItems = await transaction.literatureItem.findMany({
-        where: { id: { in: itemIds } },
-        select: { id: true, deletedAt: true }
-      })
-      if (
-        requestedItems.length !== itemIds.length ||
-        requestedItems.some(({ deletedAt }) => deletedAt === null)
-      ) {
-        throw new Error('Only Literature Items in Trash can be permanently deleted.')
-      }
-
-      const mergedItems = await transaction.literatureItem.findMany({
-        where: { mergedIntoItemId: { in: itemIds } },
-        select: { id: true }
-      })
-      const deletionIds = [...new Set([...itemIds, ...mergedItems.map(({ id }) => id)])]
-      const creatorLinks = await transaction.literatureItemCreator.findMany({
-        where: { itemId: { in: deletionIds } },
-        select: { creatorId: true }
-      })
-
-      await transaction.literatureInboxCandidate.deleteMany({
-        where: { acceptedItemId: { in: deletionIds } }
-      })
-      const removedTags = await transaction.tagAssignment.deleteMany({
-        where: { resourceType: 'literature.item', resourceId: { in: deletionIds } }
-      })
-      tagsChanged = removedTags.count > 0
-      await transaction.literatureItem.updateMany({
-        where: { id: { in: deletionIds } },
-        data: { mergedIntoItemId: null }
-      })
-      await transaction.literatureItem.deleteMany({ where: { id: { in: deletionIds } } })
-
-      const creatorIds = [...new Set(creatorLinks.map(({ creatorId }) => creatorId))]
-      if (creatorIds.length > 0) {
-        await transaction.literatureCreator.deleteMany({
-          where: { id: { in: creatorIds }, items: { none: {} } }
+    const receipt = await this.withAttachmentRemoval((assertUnreferenced) =>
+      client.$transaction<LiteratureCatalogReceipt>(async (transaction) => {
+        const requestedItems = await transaction.literatureItem.findMany({
+          where: { id: { in: itemIds } },
+          select: { id: true, deletedAt: true }
         })
-      }
-      return { kind: 'item', id: itemIds[0]!, state: 'deleted-permanently' }
-    })
+        if (
+          requestedItems.length !== itemIds.length ||
+          requestedItems.some(({ deletedAt }) => deletedAt === null)
+        ) {
+          throw new Error('Only Literature Items in Trash can be permanently deleted.')
+        }
+
+        const mergedItems = await transaction.literatureItem.findMany({
+          where: { mergedIntoItemId: { in: itemIds } },
+          select: { id: true }
+        })
+        const deletionIds = [...new Set([...itemIds, ...mergedItems.map(({ id }) => id)])]
+        const attachments = await transaction.literatureAttachment.findMany({
+          where: { itemId: { in: deletionIds } },
+          select: { id: true }
+        })
+        assertUnreferenced(attachments.map(({ id }) => id))
+        const creatorLinks = await transaction.literatureItemCreator.findMany({
+          where: { itemId: { in: deletionIds } },
+          select: { creatorId: true }
+        })
+
+        await transaction.literatureInboxCandidate.deleteMany({
+          where: { acceptedItemId: { in: deletionIds } }
+        })
+        const removedTags = await transaction.tagAssignment.deleteMany({
+          where: { resourceType: 'literature.item', resourceId: { in: deletionIds } }
+        })
+        tagsChanged = removedTags.count > 0
+        await transaction.literatureItem.updateMany({
+          where: { id: { in: deletionIds } },
+          data: { mergedIntoItemId: null }
+        })
+        await transaction.literatureItem.deleteMany({ where: { id: { in: deletionIds } } })
+
+        const creatorIds = [...new Set(creatorLinks.map(({ creatorId }) => creatorId))]
+        if (creatorIds.length > 0) {
+          await transaction.literatureCreator.deleteMany({
+            where: { id: { in: creatorIds }, items: { none: {} } }
+          })
+        }
+        return { kind: 'item', id: itemIds[0]!, state: 'deleted-permanently' }
+      })
+    )
     if (tagsChanged) await this.publishTagAssignmentsChanged()
     return receipt
   }

--- a/src/main/literature/pdf-attachment-reliability.test.ts
+++ b/src/main/literature/pdf-attachment-reliability.test.ts
@@ -1,5 +1,5 @@
 import { transactLiterature } from './transact'
-import { mkdtemp, rm, writeFile, truncate, access, readFile } from 'node:fs/promises'
+import { mkdtemp, rm, writeFile, truncate, access, readFile, readdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PrismaClient } from '@prisma/client'
@@ -202,6 +202,171 @@ describe('Literature PDF attachment reliability', () => {
     expect(sweep).not.toHaveBeenCalled()
     expect(await catalog.get(request.itemId)).toBeDefined()
   })
+  const saveReadingHistory = async (
+    sessions: SessionRepository,
+    attachment: Awaited<ReturnType<LiteraturePdfImporter['import']>>['item']['attachments'][number]
+  ): Promise<void> => {
+    const version = attachment.versions[0]
+    await sessions.saveSession({
+      id: 'reading-history',
+      projectId: 'other-project',
+      title: 'Retained reading history',
+      cwd: root,
+      status: 'idle',
+      filesRevision: 0,
+      createdAt: 1,
+      updatedAt: 1,
+      messages: [
+        {
+          id: 'reading-message',
+          role: 'user',
+          content: 'Read this PDF',
+          status: 'complete',
+          eventIds: [],
+          createdAt: 1,
+          updatedAt: 1,
+          pdfContext: {
+            version: 1,
+            bindings: [
+              {
+                version: 1,
+                bindingId: 'reading-binding',
+                sourceKind: 'literature-attachment-version',
+                sourceFileId: attachment.id,
+                sourceVersionId: version.id,
+                name: version.filename,
+                mimeType: 'application/pdf',
+                sizeBytes: version.sizeBytes,
+                checksum: version.checksum,
+                linkedAt: 1
+              }
+            ]
+          }
+        }
+      ]
+    })
+  }
+
+  it.each(['unrepaired', 'restored without reference'] as const)(
+    'protects recoverable PDF history after quarantine: %s',
+    async (state) => {
+      const { importer, request, catalog, authority, sessions } = await setup()
+      const attachment = (await importer.import(request)).item.attachments[0]
+      await saveReadingHistory(sessions, attachment)
+      const primary = join(sessions.recoveryFolderPath('other-project'), 'reading-history.json')
+      const valid = await readFile(primary, 'utf8')
+      const original = await authority.resolveVersion(attachment.versions[0].id)
+      const remove = {
+        kind: 'delete-attachment' as const,
+        itemId: request.itemId,
+        attachmentId: attachment.id
+      }
+      await writeFile(primary, valid + 'broken trailing bytes')
+      expect((await sessions.loadAllWithDiagnostics({ mode: 'read-only' })).isComplete).toBe(false)
+      await expect(catalog.transact(remove)).rejects.toThrow('complete Session catalog')
+      await sessions.loadAllWithDiagnostics()
+      await expect(access(primary)).rejects.toThrow()
+      expect(
+        (await readdir(sessions.recoveryFolderPath('other-project'))).some((name) =>
+          name.startsWith('reading-history.json.invalid-')
+        )
+      ).toBe(true)
+      const scan = await sessions.loadAllWithDiagnostics({ mode: 'read-only' })
+      expect(scan.result.sessions).toEqual([])
+      expect(scan.warnings).toContainEqual(
+        expect.objectContaining({ kind: 'corrupt', recovered: true })
+      )
+      if (state === 'restored without reference') {
+        const restored = JSON.parse(valid)
+        restored.session.messages = []
+        delete restored.session.conversationGraph
+        await writeFile(primary, JSON.stringify(restored))
+        await expect(catalog.transact(remove)).resolves.toMatchObject({ state: 'unlinked' })
+        return
+      }
+      const outcome = await catalog.transact(remove).then(
+        () => 'removed',
+        () => 'blocked'
+      )
+      expect.soft(outcome).toBe('blocked')
+      expect.soft(await client!.literatureAttachmentVersion.count()).toBe(1)
+      expect
+        .soft(
+          await access(original!.path).then(
+            () => true,
+            () => false
+          )
+        )
+        .toBe(true)
+      await writeFile(primary, valid)
+      const restored = await sessions.loadSessionWithDiagnostics('other-project', 'reading-history')
+      expect(restored.status).toBe('found')
+      if (restored.status !== 'found') throw new Error('Restored history missing')
+      expect(restored.session.messages[0].pdfContext!.bindings[0].sourceVersionId).toBe(
+        attachment.versions[0].id
+      )
+      expect(await authority.resolveVersion(attachment.versions[0].id)).toBeDefined()
+    }
+  )
+
+  it.each(['single', 'batch'] as const)(
+    'preserves chat-bound PDF versions during %s permanent deletion',
+    async (kind) => {
+      const { importer, request, catalog, content, authority, sessions } = await setup()
+      const attachment = (await importer.import(request)).item.attachments[0]
+      await saveReadingHistory(sessions, attachment)
+      const original = await authority.resolveVersion(attachment.versions[0].id)
+      await expect(
+        catalog.transact({
+          kind: 'delete-attachment',
+          itemId: request.itemId,
+          attachmentId: attachment.id
+        })
+      ).rejects.toThrow('LITERATURE_ATTACHMENT_IN_USE')
+      const itemIds = [request.itemId]
+      if (kind === 'batch')
+        itemIds.push(
+          (
+            await catalog.transact({
+              kind: 'create-item',
+              item: literatureItemInputSchema.parse({
+                title: 'Unreferenced control',
+                itemType: 'journalArticle'
+              })
+            })
+          ).id
+        )
+      await catalog.transact({ kind: 'set-item-lifecycle', itemIds, state: 'deleted' })
+      // Exercise the public Catalog command, then the same public cleanup boundary used by IPC.
+      const contentIds = await catalog.contentBlobIdsForItems(itemIds)
+      const outcome = await catalog.transact({ kind: 'delete-items-permanently', itemIds }).then(
+        async () => {
+          await content.sweep({ contentIds, createdBefore: new Date(Date.now() + 1) })
+          return 'removed'
+        },
+        () => 'blocked'
+      )
+      expect.soft(outcome).toBe('blocked')
+      expect
+        .soft(await client!.literatureItem.count({ where: { id: { in: itemIds } } }))
+        .toBe(itemIds.length)
+      expect.soft(await client!.literatureAttachmentVersion.count()).toBe(1)
+      expect
+        .soft(
+          await access(original!.path).then(
+            () => true,
+            () => false
+          )
+        )
+        .toBe(true)
+      const stored = await sessions.loadSessionWithDiagnostics('other-project', 'reading-history')
+      expect(stored.status).toBe('found')
+      if (stored.status !== 'found') throw new Error('Reading history missing')
+      expect(stored.session.messages[0].pdfContext!.bindings[0].sourceVersionId).toBe(
+        attachment.versions[0].id
+      )
+    }
+  )
 
   it('rejects a header-only corrupt PDF before creating an attachment', async () => {
     const { importer, request, path } = await setup(Buffer.from('%PDF-1.7\nnot a document'))

--- a/src/main/literature/pdf-attachment-reliability.test.ts
+++ b/src/main/literature/pdf-attachment-reliability.test.ts
@@ -1,3 +1,4 @@
+import { parseLiteratureDeletionError } from '../../shared/literature-deletion'
 import { transactLiterature } from './transact'
 import { mkdtemp, rm, writeFile, truncate, access, readFile, readdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -72,8 +73,7 @@ describe('Literature PDF attachment reliability', () => {
       async () => client!,
       undefined,
       content,
-      (attachmentId, remove) =>
-        coordinator.withUnreferencedLiteratureAttachment(attachmentId, remove)
+      (remove) => coordinator.withLiteratureAttachmentRemoval(remove)
     )
     const item = await catalog.transact({
       kind: 'create-item',
@@ -286,7 +286,20 @@ describe('Literature PDF attachment reliability', () => {
       }
       const outcome = await catalog.transact(remove).then(
         () => 'removed',
-        () => 'blocked'
+        (error) => {
+          expect(parseLiteratureDeletionError(error)).toMatchObject({
+            reason: 'scan-incomplete',
+            issues: [
+              {
+                projectId: 'other-project',
+                fileName: 'reading-history.json',
+                kind: 'corrupt',
+                recovered: true
+              }
+            ]
+          })
+          return 'blocked'
+        }
       )
       expect.soft(outcome).toBe('blocked')
       expect.soft(await client!.literatureAttachmentVersion.count()).toBe(1)
@@ -337,13 +350,11 @@ describe('Literature PDF attachment reliability', () => {
           ).id
         )
       await catalog.transact({ kind: 'set-item-lifecycle', itemIds, state: 'deleted' })
-      // Exercise the public Catalog command, then the same public cleanup boundary used by IPC.
-      const contentIds = await catalog.contentBlobIdsForItems(itemIds)
-      const outcome = await catalog.transact({ kind: 'delete-items-permanently', itemIds }).then(
-        async () => {
-          await content.sweep({ contentIds, createdBefore: new Date(Date.now() + 1) })
-          return 'removed'
-        },
+      const outcome = await transactLiterature(catalog, content, {
+        kind: 'delete-items-permanently',
+        itemIds
+      }).then(
+        () => 'removed',
         () => 'blocked'
       )
       expect.soft(outcome).toBe('blocked')
@@ -367,6 +378,45 @@ describe('Literature PDF attachment reliability', () => {
       )
     }
   )
+
+  it('checks attachments retained on cascade aliases before deleting a trashed survivor', async () => {
+    const { importer, request, catalog, content, sessions } = await setup()
+    const attachment = (await importer.import(request)).item.attachments[0]
+    await saveReadingHistory(sessions, attachment)
+    const survivor = await catalog.transact({
+      kind: 'create-item',
+      item: literatureItemInputSchema.parse({ title: 'Survivor', itemType: 'journalArticle' })
+    })
+    // Model the Catalog's supported retained alias relation with its own attachment rows.
+    await client!.literatureItem.update({
+      where: { id: request.itemId },
+      data: { mergedIntoItemId: survivor.id, deletedAt: new Date() }
+    })
+    await catalog.transact({ kind: 'set-item-lifecycle', itemIds: [survivor.id], state: 'deleted' })
+    await expect(
+      transactLiterature(catalog, content, {
+        kind: 'delete-items-permanently',
+        itemIds: [survivor.id]
+      })
+    ).rejects.toThrow('LITERATURE_ATTACHMENT_IN_USE')
+    expect(await client!.literatureItem.count()).toBe(2)
+    expect(await client!.literatureAttachmentVersion.count()).toBe(1)
+  })
+
+  it('fails closed for attachment deletion when the Catalog has no session guard', async () => {
+    const { importer, request, content } = await setup()
+    await importer.import(request)
+    const unguarded = new LiteratureCatalog(async () => client!, undefined, content)
+    await unguarded.transact({
+      kind: 'set-item-lifecycle',
+      itemIds: [request.itemId],
+      state: 'deleted'
+    })
+    await expect(
+      unguarded.transact({ kind: 'delete-items-permanently', itemIds: [request.itemId] })
+    ).rejects.toThrow('attachment removal is unavailable')
+    expect(await client!.literatureAttachmentVersion.count()).toBe(1)
+  })
 
   it('rejects a header-only corrupt PDF before creating an attachment', async () => {
     const { importer, request, path } = await setup(Buffer.from('%PDF-1.7\nnot a document'))
@@ -699,6 +749,28 @@ describe('Literature PDF attachment reliability', () => {
         })
       ).rejects.toThrow('LITERATURE_ATTACHMENT_IN_USE')
       await expect(authority.resolveVersion(version.id)).resolves.toBeDefined()
+      const error = await catalog
+        .transact({
+          kind: 'delete-attachment',
+          itemId: request.itemId,
+          attachmentId: attachment.id
+        })
+        .catch((error) => error)
+      expect(parseLiteratureDeletionError(error)).toMatchObject({
+        reason: 'referenced',
+        references: [
+          {
+            location: 'message-history',
+            sessionId: 'history-session',
+            projectId: 'project',
+            messageId: message.id,
+            versionId: version.id,
+            ...(kind === 'inactive branch'
+              ? { frameId: expect.any(String), branchId: expect.any(String) }
+              : {})
+          }
+        ]
+      })
     }
   )
 

--- a/src/main/session-persistence/coordinator.architecture.test.ts
+++ b/src/main/session-persistence/coordinator.architecture.test.ts
@@ -473,6 +473,7 @@ describe('Session persistence coordinator architecture', () => {
         'pruneSessionEnabledComputeHosts',
         'readChildren',
         'withUnreferencedLiteratureAttachment',
+        'withLiteratureAttachmentRemoval',
         'readSessionRuntimeContext',
         'recoverInterruptedDelegatedWork',
         'replaceSessionMetadata',
@@ -685,6 +686,7 @@ describe('Session persistence coordinator architecture', () => {
     const schedulerRoutes: Record<string, string[]> = {
       runGlobal: [
         'withUnreferencedLiteratureAttachment',
+        'withLiteratureAttachmentRemoval',
         'listLegacyProjectSessionTombstones',
         'loadAll',
         'loadAllReadOnly',
@@ -780,7 +782,7 @@ describe('Session persistence coordinator architecture', () => {
       expect(methods(owner, 'private')).not.toContain('enqueue')
     }
 
-    expect(expectedSchedulerRoute.size).toBe(41)
+    expect(expectedSchedulerRoute.size).toBe(42)
     const constructorSource = facade.members.filter(isConstructorDeclaration)[0].getText(facadeFile)
     expect(constructorSource).toContain('this.operationScheduler.runSession(')
     expect(constructorSource).toContain('this.operationScheduler.runGlobal(work)')

--- a/src/main/session-persistence/coordinator.test.ts
+++ b/src/main/session-persistence/coordinator.test.ts
@@ -7129,48 +7129,58 @@ describe('literature attachment removal and session persistence ordering', () =>
     expect(remove).not.toHaveBeenCalled()
   })
 
-  it('checks a queued binding after an earlier attachment removal completes', async () => {
-    const save = vi.fn()
-    const coordinator = new SessionPersistenceCoordinator(
-      createSessionRepository({
-        loadSessionWithDiagnostics: vi
-          .fn()
-          .mockResolvedValue({ status: 'found', session: createSession() }),
-        saveSession: save
-      }),
-      createFileIndex()
-    )
-    let release!: () => void
-    let entered!: () => void
-    const gate = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    const started = new Promise<void>((resolve) => {
-      entered = resolve
-    })
-    let removed = false
-    const removal = coordinator.withUnreferencedLiteratureAttachment('attachment', async () => {
-      entered()
-      await gate
-      removed = true
-    })
-    await started
-    const patch = coordinator.patchSessionRuntimeContext({
-      projectId: 'project-1',
-      sessionId: 'session-1',
-      expectedRevision: 0,
-      patch: { pdfContext: undefined },
-      beforePersist: async () => {
-        await Promise.resolve()
-        if (removed) throw new Error('Source unavailable')
+  it.each(['single attachment', 'item batch'] as const)(
+    'checks a queued binding after %s removal completes',
+    async (kind) => {
+      const save = vi.fn()
+      const coordinator = new SessionPersistenceCoordinator(
+        createSessionRepository({
+          loadSessionWithDiagnostics: vi
+            .fn()
+            .mockResolvedValue({ status: 'found', session: createSession() }),
+          saveSession: save
+        }),
+        createFileIndex()
+      )
+      let release!: () => void
+      let entered!: () => void
+      const gate = new Promise<void>((resolve) => {
+        release = resolve
+      })
+      const started = new Promise<void>((resolve) => {
+        entered = resolve
+      })
+      let removed = false
+      const remove = async (): Promise<void> => {
+        entered()
+        await gate
+        removed = true
       }
-    })
-    const rejected = expect(patch).rejects.toThrow('Source unavailable')
-    release()
-    await removal
-    await rejected
-    expect(save).not.toHaveBeenCalled()
-  })
+      const removal =
+        kind === 'single attachment'
+          ? coordinator.withUnreferencedLiteratureAttachment('attachment', remove)
+          : coordinator.withLiteratureAttachmentRemoval(async (assertUnreferenced) => {
+              assertUnreferenced(['attachment', 'other-attachment'])
+              await remove()
+            })
+      await started
+      const patch = coordinator.patchSessionRuntimeContext({
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        expectedRevision: 0,
+        patch: { pdfContext: undefined },
+        beforePersist: async () => {
+          await Promise.resolve()
+          if (removed) throw new Error('Source unavailable')
+        }
+      })
+      const rejected = expect(patch).rejects.toThrow('Source unavailable')
+      release()
+      await removal
+      await rejected
+      expect(save).not.toHaveBeenCalled()
+    }
+  )
 })
 
 const createSessionRepository = (

--- a/src/main/session-persistence/coordinator.ts
+++ b/src/main/session-persistence/coordinator.ts
@@ -1,3 +1,4 @@
+import { assertLiteratureAttachmentsUnreferenced } from './literature-attachment-removal'
 import { ProjectFilesReconciliationError } from '../project-files/repository'
 import type { ProjectFileSource, ProjectFilesChangedEvent } from '../../shared/project-files'
 import type { ReconcilePendingArtifactsRequest } from '../../shared/artifacts'
@@ -90,7 +91,10 @@ import { sanitizeRendererSaveSessionOptions } from './renderer-save-options'
 import { mutateSessionDetailsAuthority } from './session-details-authority'
 const SESSION_CPU_TRACE_ENABLED = process.env.OPEN_SCIENCE_PERF_SESSION_TRACE === '1'
 type SessionMutationRepository = {
-  loadAllWithDiagnostics(options?: { mode?: 'repair' | 'read-only' }): Promise<{
+  loadAllWithDiagnostics(options?: {
+    mode?: 'repair' | 'read-only'
+    quarantinedIsIncomplete?: boolean
+  }): Promise<{
     result: LoadAllSessionsResult
     isComplete: boolean
     warnings?: SessionLoadWarning[]
@@ -537,29 +541,24 @@ class SessionPersistenceCoordinator implements DelegatedWorkRecordCommands {
     remove: () => Promise<Result>
   ): Promise<Result> {
     return this.operationScheduler.runGlobal(async () => {
-      // Deletion is infrequent. Read the existing authority instead of maintaining a second
-      // persistent reference index, and hold the barrier through the Catalog transaction.
-      const scan = await this.repository.loadAllWithDiagnostics({ mode: 'read-only' })
-      if (!scan.isComplete)
-        throw new Error('Cannot remove an attachment without a complete Session catalog.')
-      if (
-        scan.result.sessions.some((session) =>
-          [
-            ...(session.runtimeContext?.pdfContext?.bindings ?? []),
-            // The graph retains snapshots on inactive branches; session.messages is only
-            // the active projection when a graph exists.
-            ...(session.conversationGraph?.messages ?? session.messages).flatMap(
-              (message) => message.pdfContext?.bindings ?? []
-            )
-          ].some(
-            (binding) =>
-              binding.sourceKind === 'literature-attachment-version' &&
-              binding.sourceFileId === attachmentId
-          )
-        )
-      )
-        throw new Error('LITERATURE_ATTACHMENT_IN_USE')
+      const scan = await this.repository.loadAllWithDiagnostics({
+        mode: 'read-only',
+        quarantinedIsIncomplete: true
+      })
+      assertLiteratureAttachmentsUnreferenced(scan, [attachmentId])
       return remove()
+    })
+  }
+
+  withLiteratureAttachmentRemoval<Result>(
+    remove: (assertUnreferenced: (attachmentIds: readonly string[]) => void) => Promise<Result>
+  ): Promise<Result> {
+    return this.operationScheduler.runGlobal(async () => {
+      const scan = await this.repository.loadAllWithDiagnostics({
+        mode: 'read-only',
+        quarantinedIsIncomplete: true
+      })
+      return remove((attachmentIds) => assertLiteratureAttachmentsUnreferenced(scan, attachmentIds))
     })
   }
 

--- a/src/main/session-persistence/literature-attachment-removal.ts
+++ b/src/main/session-persistence/literature-attachment-removal.ts
@@ -1,0 +1,65 @@
+import {
+  literatureDeletionError,
+  type LiteratureDeletionReference
+} from '../../shared/literature-deletion'
+import type { PersistedChatSession, SessionLoadWarning } from '../../shared/session-persistence'
+
+// Called synchronously inside the Catalog transaction with its actual cascade targets. The
+// coordinator holds the session barrier from this scan through the transaction's completion.
+export function assertLiteratureAttachmentsUnreferenced(
+  scan: {
+    isComplete: boolean
+    result: { sessions: PersistedChatSession[] }
+    warnings?: SessionLoadWarning[]
+  },
+  attachmentIds: readonly string[]
+): void {
+  if (!attachmentIds.length) return
+  if (!scan.isComplete)
+    throw literatureDeletionError({
+      reason: 'scan-incomplete',
+      references: [],
+      issues: (scan.warnings ?? []).slice(0, 100),
+      truncated: (scan.warnings?.length ?? 0) > 100
+    })
+  const ids = new Set(attachmentIds)
+  const references: LiteratureDeletionReference[] = []
+  let truncated = false
+  for (const session of scan.result.sessions) {
+    const locations = [
+      { location: 'runtime-context' as const, context: session.runtimeContext?.pdfContext },
+      // The graph includes inactive branches; the messages projection does not.
+      ...(session.conversationGraph?.messages ?? session.messages).map((message) => ({
+        location: 'message-history' as const,
+        context: message.pdfContext,
+        messageId: message.id,
+        ...('agentFrameId' in message ? { frameId: message.agentFrameId as string } : {}),
+        ...('introducedOnBranchId' in message
+          ? { branchId: message.introducedOnBranchId as string }
+          : {})
+      }))
+    ]
+    for (const { context, ...location } of locations)
+      for (const binding of context?.bindings ?? []) {
+        if (
+          binding.sourceKind !== 'literature-attachment-version' ||
+          !ids.has(binding.sourceFileId)
+        )
+          continue
+        if (references.length === 100) {
+          truncated = true
+          continue
+        }
+        references.push({
+          ...location,
+          projectId: session.projectId,
+          sessionId: session.id,
+          sessionTitle: session.title,
+          attachmentId: binding.sourceFileId,
+          versionId: binding.sourceVersionId
+        })
+      }
+  }
+  if (references.length)
+    throw literatureDeletionError({ reason: 'referenced', references, issues: [], truncated })
+}

--- a/src/main/session-persistence/repository.test.ts
+++ b/src/main/session-persistence/repository.test.ts
@@ -1496,6 +1496,32 @@ describe('session persistence repository (per-session files)', () => {
     expect(readDirectoryEntries).toHaveBeenCalledWith(projectDir)
   })
 
+  it('locates unreadable project directories in a strict deletion scan', async () => {
+    const root = await createStorageRoot()
+    await new SessionRepository(root).saveSession(createSession())
+    const projectDir = join(root, 'sessions', 'project-a')
+    const repository = new SessionRepository(root, {
+      readDirectoryEntries: async (path) => {
+        if (path === projectDir) throw Object.assign(new Error('Read denied'), { code: 'EACCES' })
+        return readdir(path, { withFileTypes: true })
+      }
+    })
+    const scan = await repository.loadAllWithDiagnostics({
+      mode: 'read-only',
+      quarantinedIsIncomplete: true
+    })
+    expect(scan.isComplete).toBe(false)
+    expect(scan.warnings).toContainEqual({
+      kind: 'unreadable',
+      projectId: 'project-a',
+      fileName: '.',
+      recovered: false
+    })
+    await expect(readFile(join(projectDir, 'session-1.json'), 'utf8')).resolves.toContain(
+      'Saved conversation'
+    )
+  })
+
   it('rejects saving through a symbolic link at the active sessions root', async () => {
     const root = await createStorageRoot()
     const outside = await createExternalRoot()

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -142,6 +142,7 @@ type SessionLoadDiagnostics = {
 }
 
 type SessionScanOptions = {
+  quarantinedIsIncomplete?: boolean
   mode?: 'repair' | 'read-only'
   // Main-owned same-process mutations read durable authority without applying app-restart recovery.
   preserveRuntimeState?: boolean
@@ -827,6 +828,7 @@ class SessionRepository {
     }
     const { sessions, isComplete, warnings } = await this.readAllSessions({
       quarantineInvalidFiles,
+      quarantinedIsIncomplete: options.quarantinedIsIncomplete,
       scanMetrics
     })
     const projectIdsBySessionId = new Map<string, Set<string>>()
@@ -1484,6 +1486,7 @@ class SessionRepository {
   // Repair scans quarantine invalid data; read-only scans report it in place. I/O errors keep
   // reconciliation disabled until the next repair.
   private async readAllSessions(options: {
+    quarantinedIsIncomplete?: boolean
     quarantineInvalidFiles: boolean
     scanMetrics: SessionScanMetrics
   }): Promise<{
@@ -1498,13 +1501,22 @@ class SessionRepository {
     let isComplete = projectDirectories.isComplete
 
     for (const projectId of projectDirectories.names) {
+      const warningCount = warnings.length
       const project = await this.readProjectSessions(projectId, {
         missingDirectoryIsIncomplete: true,
         quarantineInvalidFiles: options.quarantineInvalidFiles,
+        quarantinedIsIncomplete: options.quarantinedIsIncomplete,
         warnings,
         scanMetrics: options.scanMetrics,
         sessionsBoundaryValidated: true
       })
+      if (
+        options.quarantinedIsIncomplete &&
+        !project.isComplete &&
+        warnings.length === warningCount
+      ) {
+        warnings.push({ kind: 'unreadable', projectId, fileName: '.', recovered: false })
+      }
       sessions.push(...project.sessions)
       isComplete &&= project.isComplete
     }

--- a/src/preload/electron-renderer-contract-adapter.test.ts
+++ b/src/preload/electron-renderer-contract-adapter.test.ts
@@ -1,6 +1,13 @@
+import {
+  literatureDeletionError,
+  parseLiteratureDeletionError
+} from '../shared/literature-deletion'
 import { describe, expect, it, vi, type Mock } from 'vitest'
 
-import { ApplicationCommandError } from '../shared/application-command-contract'
+import {
+  ApplicationCommandError,
+  toApplicationCommandErrorEnvelope
+} from '../shared/application-command-contract'
 import { createElectronRendererContractAdapter } from './electron-renderer-contract-adapter'
 
 type MockPort = Readonly<{
@@ -74,6 +81,33 @@ describe('electron renderer contract adapter', () => {
       expect(port.send).toHaveBeenCalledWith(channel, ...args)
     }
   )
+
+  it('preserves recoverable deletion diagnostics without turning rejection into success', async () => {
+    const diagnostic = {
+      reason: 'scan-incomplete' as const,
+      references: [],
+      issues: [
+        {
+          kind: 'corrupt' as const,
+          projectId: 'project',
+          fileName: 'session.json',
+          recovered: true
+        }
+      ],
+      truncated: false
+    }
+    const error = literatureDeletionError(diagnostic)
+    const port = createPort()
+    port.invoke.mockResolvedValue(
+      JSON.parse(JSON.stringify({ ok: false, error: toApplicationCommandErrorEnvelope(error) }))
+    )
+    const adapter = createElectronRendererContractAdapter(port)
+    const result = await adapter
+      .invoke('literature.transact', { kind: 'delete-items-permanently', itemIds: ['item'] })
+      .catch((error) => error)
+    expect(result).toBeInstanceOf(Error)
+    expect(parseLiteratureDeletionError(result)).toEqual(diagnostic)
+  })
 
   it('rejects lifecycle-managed contracts from generic send and subscribe paths', () => {
     const port = createPort()

--- a/src/renderer/src/pages/literature/LiteratureAttachments.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.tsx
@@ -1,3 +1,8 @@
+import {
+  parseLiteratureDeletionError,
+  type LiteratureDeletionDiagnostic
+} from '../../../../shared/literature-deletion'
+import { LiteratureDeletionNotice } from './LiteratureDeletionNotice'
 import { useRef, useState } from 'react'
 import { FileText, MoreHorizontal, RotateCcw, Trash2 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
@@ -63,6 +68,7 @@ export const LiteratureAttachments = ({
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const [error, setError] = useState<string>()
+  const [deletionDiagnostic, setDeletionDiagnostic] = useState<LiteratureDeletionDiagnostic>()
   const busy = useRef(false)
   const [pending, setPending] = useState(false)
   const run = async (
@@ -75,6 +81,7 @@ export const LiteratureAttachments = ({
     setPending(true)
     try {
       setError(undefined)
+      setDeletionDiagnostic(undefined)
       const receipt = await window.api.literature.transact(
         action === 'remove'
           ? { kind: 'delete-attachment', itemId: item.id, attachmentId }
@@ -110,17 +117,14 @@ export const LiteratureAttachments = ({
   }
   return (
     <ActionMenuProvider
-      onActionError={(error) =>
-        setError(
-          error instanceof Error && error.message.includes('LITERATURE_ATTACHMENT_IN_USE')
-            ? t(
-                'This PDF is referenced by a chat or its message history and cannot be removed. Unlinking the current chat does not remove historical references.'
-              )
-            : t('The attachment operation failed. Try again.')
-        )
-      }
+      onActionError={(error) => {
+        const diagnostic = parseLiteratureDeletionError(error)
+        setDeletionDiagnostic(diagnostic)
+        if (!diagnostic) setError(t('The attachment operation failed. Try again.'))
+      }}
     >
       <div className="mt-2 space-y-2">
+        {deletionDiagnostic ? <LiteratureDeletionNotice diagnostic={deletionDiagnostic} /> : null}
         {error ? (
           <p role="alert" className="text-sm text-danger-000">
             {error}

--- a/src/renderer/src/pages/literature/LiteratureDeletionNotice.tsx
+++ b/src/renderer/src/pages/literature/LiteratureDeletionNotice.tsx
@@ -1,0 +1,174 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { LiteratureDeletionDiagnostic } from '../../../../shared/literature-deletion'
+import { Button } from '@/components/ui/button'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { useProjectStore } from '@/stores/project-store'
+import { LiteratureErrorNotice } from './LiteratureErrorNotice'
+
+export function LiteratureDeletionNotice({
+  diagnostic,
+  onNavigate
+}: {
+  diagnostic: LiteratureDeletionDiagnostic
+  onNavigate?: () => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  const projects = useProjectStore((state) => state.projects)
+  const [expanded, setExpanded] = useState(false)
+  const [actionError, setActionError] = useState<string>()
+  const referenced = diagnostic.reason === 'referenced'
+  const openRecovery = async (projectId: string): Promise<void> => {
+    setActionError(undefined)
+    try {
+      if (!window.api.sessions.openRecoveryFolder) throw new Error('Unavailable')
+      await window.api.sessions.openRecoveryFolder({ projectId })
+    } catch {
+      setActionError(t('Could not open that folder.'))
+    }
+  }
+  return (
+    <LiteratureErrorNotice
+      tone={referenced ? 'amber' : 'red'}
+      title={t('Deletion blocked')}
+      description={
+        referenced
+          ? t(
+              'This PDF is referenced by a chat or its message history and cannot be removed. Unlinking the current chat does not remove historical references.'
+            )
+          : t(
+              'Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.'
+            )
+      }
+      primaryButton={{
+        label: expanded
+          ? t('Hide details')
+          : referenced
+            ? t('View affected conversations')
+            : t('View recovery details'),
+        onClick: () => setExpanded(!expanded)
+      }}
+    >
+      {expanded ? (
+        <div className="space-y-3 text-sm">
+          {diagnostic.references.length ? (
+            <ul className="max-h-64 space-y-3 overflow-y-auto">
+              {diagnostic.references.map((reference, index) => (
+                <li key={index} className="space-y-1 break-words">
+                  <p className="font-medium">{reference.sessionTitle || reference.sessionId}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {t('Project: {{projectId}}', {
+                      projectId:
+                        projects.find(({ id }) => id === reference.projectId)?.name ??
+                        reference.projectId
+                    })}
+                  </p>
+                  <p>
+                    {reference.location === 'runtime-context'
+                      ? t('Current chat context')
+                      : t('Historical message')}
+                  </p>
+                  <p className="break-all font-mono text-xs text-muted-foreground">
+                    {reference.sessionId}
+                  </p>
+                  {reference.messageId ? (
+                    <p className="break-all text-xs text-muted-foreground">
+                      {t('Message: {{messageId}}', { messageId: reference.messageId })}
+                    </p>
+                  ) : null}
+                  {reference.branchId ? (
+                    <p className="break-all text-xs text-muted-foreground">
+                      {t('Branch: {{branchId}}', { branchId: reference.branchId })}
+                    </p>
+                  ) : null}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      setActionError(undefined)
+                      if (
+                        !useNavigationStore
+                          .getState()
+                          .openSession(reference.projectId, reference.sessionId, 'user', onNavigate)
+                      )
+                        setActionError(
+                          t(
+                            'This conversation is unavailable here. It may be archived or not loaded.'
+                          )
+                        )
+                    }}
+                  >
+                    {t('View conversation')}
+                  </Button>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {diagnostic.issues.length ? (
+            <ul className="max-h-64 space-y-3 overflow-y-auto">
+              {diagnostic.issues.map((issue, index) => (
+                <li key={index} className="space-y-1">
+                  {issue.projectId ? (
+                    <p className="break-words">
+                      {t('Project: {{projectId}}', {
+                        projectId:
+                          projects.find(({ id }) => id === issue.projectId)?.name ?? issue.projectId
+                      })}
+                    </p>
+                  ) : null}
+                  <p className="break-all font-mono text-xs">
+                    {issue.fileName === '.' ? t('Conversation folder') : issue.fileName}
+                  </p>
+                  <p>
+                    {issue.kind === 'corrupt' || issue.kind === 'manifest-corrupt'
+                      ? t('Conversation data is damaged.')
+                      : issue.kind === 'unsupported-version'
+                        ? t('Conversation data requires a newer app version.')
+                        : issue.kind === 'too-large'
+                          ? t('Conversation data exceeds the storage limit.')
+                          : t('Conversation data could not be read.')}
+                  </p>
+                  {issue.recovered ? (
+                    <p className="text-xs text-muted-foreground">
+                      {t('The damaged file was moved aside; its references are still unknown.')}
+                    </p>
+                  ) : null}
+                  {issue.projectId && window.api.sessions.openRecoveryFolder ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant="outline"
+                      onClick={() => void openRecovery(issue.projectId!)}
+                    >
+                      {t('Open recovery folder')}
+                    </Button>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          ) : null}
+          {!referenced ? (
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.'
+              )}
+            </p>
+          ) : null}
+          {diagnostic.truncated || (!diagnostic.references.length && !diagnostic.issues.length) ? (
+            <p className="text-xs text-muted-foreground">
+              {t(
+                'Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.'
+              )}
+            </p>
+          ) : null}
+          {actionError ? (
+            <p role="alert" className="text-sm text-danger-000">
+              {actionError}
+            </p>
+          ) : null}
+        </div>
+      ) : null}
+    </LiteratureErrorNotice>
+  )
+}

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -1,3 +1,4 @@
+import { literatureDeletionError } from '../../../../shared/literature-deletion'
 // @vitest-environment jsdom
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
@@ -2909,6 +2910,130 @@ describe('LiteratureLibraryPage', () => {
     expect(
       [...within(alert).queryAllByRole('button'), ...within(alert).queryAllByRole('link')].length
     ).toBeGreaterThan(0)
+  })
+
+  it.each(['attachment', 'permanent item'] as const)(
+    'shows historical locations and handles unavailable navigation after %s deletion is blocked',
+    async (entryPoint) => {
+      const entry = createLibraryItemWithPdf()
+      const navigate = vi.spyOn(useNavigationStore.getState(), 'openSession').mockReturnValue(false)
+      search.mockImplementation((request: { scope: string }) =>
+        Promise.resolve(request.scope === 'library' ? { entries: [entry] } : { entries: [] })
+      )
+      try {
+        render(<LiteratureLibraryPage />)
+        fireEvent.click(
+          screen.getByRole('button', {
+            name: entryPoint === 'attachment' ? 'All references' : 'Trash'
+          })
+        )
+        let container: HTMLElement
+        if (entryPoint === 'attachment') {
+          container = await openReferenceDetail(await screen.findByText(entry.item.title))
+          fireEvent.click(
+            within(container).getByRole('button', { name: 'Attachment actions for paper.pdf' })
+          )
+        } else {
+          const row = (await screen.findByText(entry.item.title)).closest('tr')!
+          await openMenu(within(row).getByRole('button', { name: 'More actions' }))
+        }
+        transact.mockRejectedValueOnce(
+          literatureDeletionError({
+            reason: 'referenced',
+            issues: [],
+            truncated: false,
+            references: [
+              {
+                attachmentId: 'attachment-1',
+                versionId: 'version-1',
+                projectId: 'project-1',
+                sessionId: 'history-session',
+                sessionTitle: 'Retained history',
+                location: 'message-history',
+                messageId: 'historical-message',
+                branchId: 'inactive-branch',
+                frameId: 'root-frame'
+              }
+            ]
+          })
+        )
+        fireEvent.click(
+          await screen.findByRole('menuitem', {
+            name: entryPoint === 'attachment' ? 'Remove attachment' : 'Delete permanently'
+          })
+        )
+        if (entryPoint === 'permanent item') {
+          container = screen.getByRole('alertdialog')
+          fireEvent.click(within(container).getByRole('button', { name: 'Delete permanently' }))
+        }
+        fireEvent.click(await screen.findByRole('button', { name: 'View affected conversations' }))
+        expect(screen.getByText('Retained history')).not.toBeNull()
+        expect(screen.getByText('Project: Retrieval research')).not.toBeNull()
+        expect(screen.getByText('Historical message')).not.toBeNull()
+        expect(screen.getByText('Message: historical-message')).not.toBeNull()
+        expect(screen.getByText('Branch: inactive-branch')).not.toBeNull()
+        fireEvent.click(screen.getByRole('button', { name: 'View conversation' }))
+        expect(navigate.mock.calls[0]?.slice(0, 3)).toEqual([
+          'project-1',
+          'history-session',
+          'user'
+        ])
+        expect(
+          screen.getByText(
+            'This conversation is unavailable here. It may be archived or not loaded.'
+          )
+        ).not.toBeNull()
+        expect(transact).toHaveBeenCalledTimes(1)
+      } finally {
+        navigate.mockRestore()
+      }
+    }
+  )
+
+  it('opens the diagnosed recovery folder and reports folder access failure without retrying deletion', async () => {
+    const entry = createLibraryItemWithPdf()
+    const openRecovery = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Folder unavailable'))
+      .mockResolvedValue(undefined)
+    window.api.sessions.openRecoveryFolder = openRecovery
+    search.mockImplementation((request: { scope: string }) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [entry] } : { entries: [] })
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const detail = await openReferenceDetail(await screen.findByText(entry.item.title))
+    transact.mockRejectedValueOnce(
+      literatureDeletionError({
+        reason: 'scan-incomplete',
+        references: [],
+        truncated: false,
+        issues: [
+          {
+            projectId: 'project-1',
+            fileName: 'damaged-session.json',
+            kind: 'corrupt',
+            recovered: true
+          }
+        ]
+      })
+    )
+    fireEvent.click(
+      within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
+    )
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    fireEvent.click(await screen.findByRole('button', { name: 'View recovery details' }))
+    expect(screen.getByText('damaged-session.json')).not.toBeNull()
+    expect(
+      screen.getByText('The damaged file was moved aside; its references are still unknown.')
+    ).not.toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Open recovery folder' }))
+    expect(await screen.findByText('Could not open that folder.')).not.toBeNull()
+    expect(openRecovery).toHaveBeenCalledWith({ projectId: 'project-1' })
+    fireEvent.click(screen.getByRole('button', { name: 'Open recovery folder' }))
+    await waitFor(() => expect(screen.queryByText('Could not open that folder.')).toBeNull())
+    expect(transact).toHaveBeenCalledTimes(1)
+    expect(within(detail).getByRole('button', { name: 'Preview paper.pdf' })).not.toBeNull()
   })
 
   it('refreshes the diagnosis when attachment verification fails', async () => {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -2883,6 +2883,34 @@ describe('LiteratureLibraryPage', () => {
     expect(within(detail).getByRole('button', { name: 'Preview paper.pdf' })).not.toBeNull()
   })
 
+  it.each([
+    ['chat reference', 'LITERATURE_ATTACHMENT_IN_USE'],
+    [
+      'unreadable session catalog',
+      'Cannot remove an attachment without a complete Session catalog.'
+    ]
+  ])('offers actionable details when removal is blocked by %s', async (_reason, message) => {
+    const entry = createLibraryItemWithPdf()
+    search.mockImplementation((request: { scope: string }) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [entry] } : { entries: [] })
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const detail = await openReferenceDetail(await screen.findByText(entry.item.title))
+    transact.mockRejectedValueOnce(new Error(message))
+    fireEvent.click(
+      within(detail).getByRole('button', { name: 'Attachment actions for paper.pdf' })
+    )
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Remove attachment' }))
+    const alert = await within(detail).findByRole('alert')
+    expect(within(detail).getByRole('button', { name: 'Preview paper.pdf' })).not.toBeNull()
+    expect.soft(alert.textContent).not.toBe('The attachment operation failed. Try again.')
+    // A user must be able to inspect the blocking reference or recovery diagnosis.
+    expect(
+      [...within(alert).queryAllByRole('button'), ...within(alert).queryAllByRole('link')].length
+    ).toBeGreaterThan(0)
+  })
+
   it('refreshes the diagnosis when attachment verification fails', async () => {
     const entry = createLibraryItemWithPdf()
     search.mockImplementation((request: { scope: string }) =>

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1,3 +1,8 @@
+import {
+  parseLiteratureDeletionError,
+  type LiteratureDeletionDiagnostic
+} from '../../../../shared/literature-deletion'
+import { LiteratureDeletionNotice } from './LiteratureDeletionNotice'
 import type { TFunction } from 'i18next'
 import { LiteratureAttachments } from './LiteratureAttachments'
 import { LITERATURE_JOB_MAX_ITEMS } from '../../../../shared/literature-jobs'
@@ -1305,6 +1310,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
   }>()
   const [permanentDeleteIds, setPermanentDeleteIds] = useState<string[]>([])
   const [permanentDeleteFailed, setPermanentDeleteFailed] = useState(false)
+  const [permanentDeletionDiagnostic, setPermanentDeletionDiagnostic] =
+    useState<LiteratureDeletionDiagnostic>()
   const [permanentDeleteResult, setPermanentDeleteResult] = useState<{
     scope: string
     cleanupPending: boolean
@@ -2960,6 +2967,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
 
   const requestPermanentDeletion = (itemIds: string[]): void => {
     setPermanentDeleteFailed(false)
+    setPermanentDeletionDiagnostic(undefined)
     setPermanentDeleteIds(itemIds)
   }
 
@@ -2997,7 +3005,8 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         kind: 'delete-items-permanently',
         itemIds: permanentDeleteIds
       })
-    } catch {
+    } catch (error) {
+      setPermanentDeletionDiagnostic(parseLiteratureDeletionError(error))
       setPermanentDeleteFailed(true)
       setIsBatching(false)
       return
@@ -6364,7 +6373,14 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                   'Search indexes expire separately after inactivity. Historical outputs are kept. This is not secure erasure.'
                 )}
               </p>
-              {permanentDeleteFailed ? (
+              {permanentDeletionDiagnostic ? (
+                <div className="mt-3">
+                  <LiteratureDeletionNotice
+                    diagnostic={permanentDeletionDiagnostic}
+                    onNavigate={() => setPermanentDeleteIds([])}
+                  />
+                </div>
+              ) : permanentDeleteFailed ? (
                 <div className="mt-3">
                   <LiteratureErrorNotice
                     title={t('Literature could not be deleted permanently.')}

--- a/src/renderer/web/api-installer.test.ts
+++ b/src/renderer/web/api-installer.test.ts
@@ -1,3 +1,7 @@
+import {
+  literatureDeletionError,
+  parseLiteratureDeletionError
+} from '../../shared/literature-deletion'
 import { describe, expect, it, vi } from 'vitest'
 
 import {
@@ -28,6 +32,43 @@ function surface<Electron, Web>(electron: Electron, web: Web): Surface<Electron,
 }
 
 describe('installWebRendererContracts', () => {
+  it('preserves recoverable deletion diagnostics without turning rejection into success', async () => {
+    const diagnostic = {
+      reason: 'scan-incomplete' as const,
+      references: [],
+      issues: [
+        {
+          kind: 'corrupt' as const,
+          projectId: 'project',
+          fileName: 'session.json',
+          recovered: true
+        }
+      ],
+      truncated: false
+    }
+    const error = literatureDeletionError(diagnostic)
+    const api: Record<string, unknown> = {}
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(['literature:transact']),
+      restrictedRpcChannels: new Set(),
+      invoke: vi
+        .fn()
+        .mockRejectedValue(
+          new Error(JSON.parse(JSON.stringify({ message: error.message })).message)
+        ),
+      subscribe: vi.fn(),
+      nativeAdapters: {}
+    })
+    const result = await (
+      methodAt(api, 'literature.transact')!({
+        kind: 'delete-items-permanently',
+        itemIds: ['item']
+      }) as Promise<unknown>
+    ).catch((error) => error)
+    expect(result).toBeInstanceOf(Error)
+    expect(parseLiteratureDeletionError(result)).toEqual(diagnostic)
+  })
+
   it('forwards the Session delegation mutation unchanged and returns the authoritative Session', async () => {
     const api: Record<string, unknown> = {}
     const authoritative = { id: 'session-1', projectId: 'project-1', delegationPolicy: 'deny' }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4945,6 +4945,24 @@
     "The CSL style references an undefined macro: {{macro}}": "Der CSL-Stil verweist auf ein nicht definiertes Makro: {{macro}}",
     "Citation styles could not be loaded. Please try again.": "Die Zitierstile konnten nicht geladen werden. Versuchen Sie es erneut.",
     "The CSL style could not be imported. Please try again.": "Der CSL-Stil konnte nicht importiert werden. Versuchen Sie es erneut.",
-    "The CSL style could not be deleted. Please try again.": "Der CSL-Stil konnte nicht gelöscht werden. Versuchen Sie es erneut."
+    "The CSL style could not be deleted. Please try again.": "Der CSL-Stil konnte nicht gelöscht werden. Versuchen Sie es erneut.",
+    "Deletion blocked": "Löschen blockiert",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "Gespeicherte Konversationen konnten nicht vollständig geprüft werden. Es wurden keine Anhänge gelöscht. Prüfen Sie vor einem erneuten Versuch die Wiederherstellungsdetails.",
+    "Hide details": "Details ausblenden",
+    "View recovery details": "Wiederherstellungsdetails anzeigen",
+    "Current chat context": "Aktueller Chatkontext",
+    "Historical message": "Frühere Nachricht",
+    "Message: {{messageId}}": "Nachricht: {{messageId}}",
+    "Branch: {{branchId}}": "Branch: {{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "Diese Konversation ist hier nicht verfügbar. Sie wurde möglicherweise archiviert oder noch nicht geladen.",
+    "View conversation": "Konversation anzeigen",
+    "Conversation data is damaged.": "Konversationsdaten sind beschädigt.",
+    "Conversation data requires a newer app version.": "Konversationsdaten erfordern eine neuere App-Version.",
+    "Conversation data exceeds the storage limit.": "Konversationsdaten überschreiten das Speicherlimit.",
+    "Conversation data could not be read.": "Konversationsdaten konnten nicht gelesen werden.",
+    "The damaged file was moved aside; its references are still unknown.": "Die beschädigte Datei wurde beiseitegelegt; ihre Verweise sind weiterhin unbekannt.",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "Prüfen Sie die betroffenen Konversationsdateien oder stellen Sie sie wieder her. Ein erneuter Löschversuch allein repariert sie nicht.",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "Vollständige Ortsangaben sind nicht verfügbar. Prüfen Sie die Speicherdiagnose für Konversationen; das Löschen bleibt blockiert.",
+    "Conversation folder": "Konversationsordner"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5106,6 +5106,24 @@
     "The CSL style references an undefined macro: {{macro}}": "El estilo CSL hace referencia a una macro no definida: {{macro}}",
     "Citation styles could not be loaded. Please try again.": "No se han podido cargar los estilos de cita. Vuelva a intentarlo.",
     "The CSL style could not be imported. Please try again.": "No se ha podido importar el estilo CSL. Vuelva a intentarlo.",
-    "The CSL style could not be deleted. Please try again.": "No se ha podido eliminar el estilo CSL. Vuelva a intentarlo."
+    "The CSL style could not be deleted. Please try again.": "No se ha podido eliminar el estilo CSL. Vuelva a intentarlo.",
+    "Deletion blocked": "Eliminación bloqueada",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "No se pudieron comprobar por completo las conversaciones guardadas. No se eliminó ningún archivo adjunto. Revise los detalles de recuperación antes de volver a intentarlo.",
+    "Hide details": "Ocultar detalles",
+    "View recovery details": "Ver detalles de recuperación",
+    "Current chat context": "Contexto actual del chat",
+    "Historical message": "Mensaje histórico",
+    "Message: {{messageId}}": "Mensaje: {{messageId}}",
+    "Branch: {{branchId}}": "Rama: {{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "Esta conversación no está disponible aquí. Puede estar archivada o no haberse cargado todavía.",
+    "View conversation": "Ver conversación",
+    "Conversation data is damaged.": "Los datos de la conversación están dañados.",
+    "Conversation data requires a newer app version.": "Los datos de la conversación requieren una versión más reciente de la aplicación.",
+    "Conversation data exceeds the storage limit.": "Los datos de la conversación superan el límite de almacenamiento.",
+    "Conversation data could not be read.": "No se pudieron leer los datos de la conversación.",
+    "The damaged file was moved aside; its references are still unknown.": "El archivo dañado se apartó, pero sus referencias siguen siendo desconocidas.",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "Inspeccione o recupere los archivos de conversación afectados. Reintentar la eliminación no los reparará.",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "No se dispone de las ubicaciones completas. Revise el diagnóstico del almacenamiento de conversaciones; la eliminación sigue bloqueada.",
+    "Conversation folder": "Carpeta de conversaciones"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5106,6 +5106,24 @@
     "The CSL style references an undefined macro: {{macro}}": "Le style CSL fait référence à une macro non définie : {{macro}}",
     "Citation styles could not be loaded. Please try again.": "Impossible de charger les styles de citation. Réessayez.",
     "The CSL style could not be imported. Please try again.": "Impossible d’importer le style CSL. Réessayez.",
-    "The CSL style could not be deleted. Please try again.": "Impossible de supprimer le style CSL. Réessayez."
+    "The CSL style could not be deleted. Please try again.": "Impossible de supprimer le style CSL. Réessayez.",
+    "Deletion blocked": "Suppression bloquée",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "Les conversations enregistrées n’ont pas pu être vérifiées entièrement. Aucune pièce jointe n’a été supprimée. Consultez les détails de récupération avant de réessayer.",
+    "Hide details": "Masquer les détails",
+    "View recovery details": "Voir les détails de récupération",
+    "Current chat context": "Contexte actuel du chat",
+    "Historical message": "Message historique",
+    "Message: {{messageId}}": "Message : {{messageId}}",
+    "Branch: {{branchId}}": "Branche : {{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "Cette conversation n’est pas disponible ici. Elle est peut-être archivée ou pas encore chargée.",
+    "View conversation": "Voir la conversation",
+    "Conversation data is damaged.": "Les données de conversation sont endommagées.",
+    "Conversation data requires a newer app version.": "Les données de conversation nécessitent une version plus récente de l’application.",
+    "Conversation data exceeds the storage limit.": "Les données de conversation dépassent la limite de stockage.",
+    "Conversation data could not be read.": "Les données de conversation n’ont pas pu être lues.",
+    "The damaged file was moved aside; its references are still unknown.": "Le fichier endommagé a été mis de côté ; ses références restent inconnues.",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "Examinez ou récupérez les fichiers de conversation concernés. Réessayer la suppression ne suffit pas à les réparer.",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "Les emplacements complets ne sont pas disponibles. Consultez le diagnostic du stockage des conversations ; la suppression reste bloquée.",
+    "Conversation folder": "Dossier des conversations"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4792,6 +4792,24 @@
     "The CSL style references an undefined macro: {{macro}}": "CSL スタイルが未定義のマクロを参照しています：{{macro}}",
     "Citation styles could not be loaded. Please try again.": "引用スタイルを読み込めませんでした。再試行してください。",
     "The CSL style could not be imported. Please try again.": "CSL スタイルをインポートできませんでした。再試行してください。",
-    "The CSL style could not be deleted. Please try again.": "CSL スタイルを削除できませんでした。再試行してください。"
+    "The CSL style could not be deleted. Please try again.": "CSL スタイルを削除できませんでした。再試行してください。",
+    "Deletion blocked": "削除がブロックされました",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "保存済みの会話を完全に確認できませんでした。添付ファイルは削除されていません。復元の詳細を確認してから再試行してください。",
+    "Hide details": "詳細を隠す",
+    "View recovery details": "復元の詳細を表示",
+    "Current chat context": "現在のチャットコンテキスト",
+    "Historical message": "過去のメッセージ",
+    "Message: {{messageId}}": "メッセージ：{{messageId}}",
+    "Branch: {{branchId}}": "ブランチ：{{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "この会話はここでは開けません。アーカイブ済みか、まだ読み込まれていない可能性があります。",
+    "View conversation": "会話を表示",
+    "Conversation data is damaged.": "会話データが破損しています。",
+    "Conversation data requires a newer app version.": "会話データには新しいバージョンのアプリが必要です。",
+    "Conversation data exceeds the storage limit.": "会話データがストレージの上限を超えています。",
+    "Conversation data could not be read.": "会話データを読み取れませんでした。",
+    "The damaged file was moved aside; its references are still unknown.": "破損したファイルは退避されましたが、参照の有無はまだ不明です。",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "影響を受けた会話ファイルを確認または復元してください。削除を再試行するだけでは修復されません。",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "すべての場所を表示できません。会話ストレージの診断を確認してください。削除は引き続きブロックされています。",
+    "Conversation folder": "会話フォルダー"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4790,6 +4790,24 @@
     "The CSL style references an undefined macro: {{macro}}": "CSL 스타일이 정의되지 않은 매크로를 참조합니다: {{macro}}",
     "Citation styles could not be loaded. Please try again.": "인용 스타일을 불러오지 못했습니다. 다시 시도하세요.",
     "The CSL style could not be imported. Please try again.": "CSL 스타일을 가져오지 못했습니다. 다시 시도하세요.",
-    "The CSL style could not be deleted. Please try again.": "CSL 스타일을 삭제하지 못했습니다. 다시 시도하세요."
+    "The CSL style could not be deleted. Please try again.": "CSL 스타일을 삭제하지 못했습니다. 다시 시도하세요.",
+    "Deletion blocked": "삭제 차단됨",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "저장된 대화를 완전히 확인하지 못했습니다. 첨부 파일은 삭제되지 않았습니다. 복구 세부 정보를 확인한 후 다시 시도하세요.",
+    "Hide details": "세부 정보 숨기기",
+    "View recovery details": "복구 세부 정보 보기",
+    "Current chat context": "현재 채팅 컨텍스트",
+    "Historical message": "이전 메시지",
+    "Message: {{messageId}}": "메시지: {{messageId}}",
+    "Branch: {{branchId}}": "브랜치: {{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "여기서 이 대화를 열 수 없습니다. 보관되었거나 아직 불러오지 않았을 수 있습니다.",
+    "View conversation": "대화 보기",
+    "Conversation data is damaged.": "대화 데이터가 손상되었습니다.",
+    "Conversation data requires a newer app version.": "대화 데이터에 더 최신 버전의 앱이 필요합니다.",
+    "Conversation data exceeds the storage limit.": "대화 데이터가 저장 한도를 초과합니다.",
+    "Conversation data could not be read.": "대화 데이터를 읽지 못했습니다.",
+    "The damaged file was moved aside; its references are still unknown.": "손상된 파일은 따로 옮겨졌지만 참조 여부는 아직 알 수 없습니다.",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "영향을 받은 대화 파일을 확인하거나 복구하세요. 삭제를 다시 시도하는 것만으로는 복구되지 않습니다.",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "전체 위치 정보를 제공할 수 없습니다. 대화 저장소 진단을 확인하세요. 삭제는 계속 차단됩니다.",
+    "Conversation folder": "대화 폴더"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5238,6 +5238,24 @@
     "The CSL style references an undefined macro: {{macro}}": "Стиль CSL ссылается на неопределённый макрос: {{macro}}",
     "Citation styles could not be loaded. Please try again.": "Не удалось загрузить стили цитирования. Повторите попытку.",
     "The CSL style could not be imported. Please try again.": "Не удалось импортировать стиль CSL. Повторите попытку.",
-    "The CSL style could not be deleted. Please try again.": "Не удалось удалить стиль CSL. Повторите попытку."
+    "The CSL style could not be deleted. Please try again.": "Не удалось удалить стиль CSL. Повторите попытку.",
+    "Deletion blocked": "Удаление заблокировано",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "Не удалось полностью проверить сохранённые диалоги. Вложения не удалены. Просмотрите сведения о восстановлении перед повторной попыткой.",
+    "Hide details": "Скрыть подробности",
+    "View recovery details": "Сведения о восстановлении",
+    "Current chat context": "Текущий контекст чата",
+    "Historical message": "Сообщение из истории",
+    "Message: {{messageId}}": "Сообщение: {{messageId}}",
+    "Branch: {{branchId}}": "Ветка: {{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "Этот диалог здесь недоступен. Возможно, он архивирован или ещё не загружен.",
+    "View conversation": "Открыть диалог",
+    "Conversation data is damaged.": "Данные диалога повреждены.",
+    "Conversation data requires a newer app version.": "Для данных диалога требуется более новая версия приложения.",
+    "Conversation data exceeds the storage limit.": "Данные диалога превышают лимит хранилища.",
+    "Conversation data could not be read.": "Не удалось прочитать данные диалога.",
+    "The damaged file was moved aside; its references are still unknown.": "Повреждённый файл перемещён отдельно, но его ссылки по-прежнему неизвестны.",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "Проверьте или восстановите затронутые файлы диалогов. Повторная попытка удаления сама по себе их не восстановит.",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "Полные сведения о расположении недоступны. Проверьте диагностику хранилища диалогов; удаление остаётся заблокированным.",
+    "Conversation folder": "Папка диалогов"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4792,6 +4792,24 @@
     "The CSL style references an undefined macro: {{macro}}": "CSL 样式引用了未定义的宏：{{macro}}",
     "Citation styles could not be loaded. Please try again.": "无法加载引用样式。请重试。",
     "The CSL style could not be imported. Please try again.": "无法导入 CSL 样式。请重试。",
-    "The CSL style could not be deleted. Please try again.": "无法删除 CSL 样式。请重试。"
+    "The CSL style could not be deleted. Please try again.": "无法删除 CSL 样式。请重试。",
+    "Deletion blocked": "删除已被阻止",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "无法完整检查已保存的会话。未删除任何附件。请先查看恢复详情，再重试。",
+    "Hide details": "收起详情",
+    "View recovery details": "查看恢复详情",
+    "Current chat context": "当前聊天上下文",
+    "Historical message": "历史消息",
+    "Message: {{messageId}}": "消息：{{messageId}}",
+    "Branch: {{branchId}}": "分支：{{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "无法在此打开该会话。它可能已归档或尚未加载。",
+    "View conversation": "查看会话",
+    "Conversation data is damaged.": "会话数据已损坏。",
+    "Conversation data requires a newer app version.": "会话数据需要更新版本的应用。",
+    "Conversation data exceeds the storage limit.": "会话数据超出存储限制。",
+    "Conversation data could not be read.": "无法读取会话数据。",
+    "The damaged file was moved aside; its references are still unknown.": "损坏文件已被移至一旁，但其引用仍无法确定。",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "请检查或恢复受影响的会话文件。仅重试删除无法修复这些文件。",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "无法提供完整位置信息。请检查会话存储诊断；删除仍被阻止。",
+    "Conversation folder": "会话文件夹"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4792,6 +4792,24 @@
     "The CSL style references an undefined macro: {{macro}}": "CSL 樣式參照了未定義的巨集：{{macro}}",
     "Citation styles could not be loaded. Please try again.": "無法載入引用樣式。請重試。",
     "The CSL style could not be imported. Please try again.": "無法匯入 CSL 樣式。請重試。",
-    "The CSL style could not be deleted. Please try again.": "無法刪除 CSL 樣式。請重試。"
+    "The CSL style could not be deleted. Please try again.": "無法刪除 CSL 樣式。請重試。",
+    "Deletion blocked": "刪除已遭阻止",
+    "Saved conversations could not be checked completely. No attachments were deleted. Review the recovery details before trying again.": "無法完整檢查已儲存的對話。未刪除任何附件。請先查看復原詳細資訊，再重試。",
+    "Hide details": "收合詳細資訊",
+    "View recovery details": "查看復原詳細資訊",
+    "Current chat context": "目前聊天上下文",
+    "Historical message": "歷史訊息",
+    "Message: {{messageId}}": "訊息：{{messageId}}",
+    "Branch: {{branchId}}": "分支：{{branchId}}",
+    "This conversation is unavailable here. It may be archived or not loaded.": "無法在此開啟該對話。它可能已封存或尚未載入。",
+    "View conversation": "查看對話",
+    "Conversation data is damaged.": "對話資料已損毀。",
+    "Conversation data requires a newer app version.": "對話資料需要更新版本的應用程式。",
+    "Conversation data exceeds the storage limit.": "對話資料超出儲存限制。",
+    "Conversation data could not be read.": "無法讀取對話資料。",
+    "The damaged file was moved aside; its references are still unknown.": "損毀的檔案已移至一旁，但其參照仍無法確定。",
+    "Inspect or recover the affected conversation files. Retrying deletion alone will not repair them.": "請檢查或復原受影響的對話檔案。僅重試刪除無法修復這些檔案。",
+    "Complete locations are unavailable. Check conversation storage diagnostics; deletion remains blocked.": "無法提供完整位置資訊。請檢查對話儲存診斷；刪除仍遭阻止。",
+    "Conversation folder": "對話資料夾"
   }
 }

--- a/src/shared/literature-deletion.test.ts
+++ b/src/shared/literature-deletion.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import {
+  literatureDeletionError,
+  parseLiteratureDeletionError,
+  type LiteratureDeletionDiagnostic
+} from './literature-deletion'
+
+const diagnostic: LiteratureDeletionDiagnostic = {
+  reason: 'referenced',
+  issues: [],
+  truncated: false,
+  references: [
+    {
+      attachmentId: 'attachment',
+      versionId: 'version',
+      projectId: 'project',
+      sessionId: 'session',
+      sessionTitle: 'Quoted "paper"\n阅读',
+      location: 'message-history',
+      messageId: 'message',
+      branchId: 'inactive-branch',
+      frameId: 'frame'
+    }
+  ]
+}
+
+describe('literature deletion error transport', () => {
+  it.each(['', "Error invoking remote method 'literature:transact': Error: "])(
+    'retains validated locations after message-only serialization with prefix %s',
+    (prefix) => {
+      const transported = JSON.parse(
+        JSON.stringify({ message: literatureDeletionError(diagnostic).message })
+      )
+      expect(parseLiteratureDeletionError(new Error(prefix + transported.message))).toEqual(
+        diagnostic
+      )
+    }
+  )
+  it('retains a useful reason without trusting malformed or truncated details', () => {
+    for (const payload of ['{', '{"reason":"invented"}', '{"references":[{"projectId":null}]}']) {
+      expect(
+        parseLiteratureDeletionError(
+          new Error('LITERATURE_ATTACHMENT_IN_USE\nLITERATURE_DELETION_DETAILS:' + payload)
+        )
+      ).toEqual({ reason: 'referenced', issues: [], references: [], truncated: true })
+    }
+    expect(parseLiteratureDeletionError(new Error('network failure'))).toBeUndefined()
+  })
+})

--- a/src/shared/literature-deletion.ts
+++ b/src/shared/literature-deletion.ts
@@ -1,0 +1,65 @@
+import { z } from 'zod'
+
+const referenceSchema = z.object({
+  attachmentId: z.string(),
+  versionId: z.string(),
+  projectId: z.string(),
+  sessionId: z.string(),
+  sessionTitle: z.string(),
+  location: z.enum(['runtime-context', 'message-history']),
+  messageId: z.string().optional(),
+  frameId: z.string().optional(),
+  branchId: z.string().optional()
+})
+const issueSchema = z.object({
+  kind: z.enum([
+    'corrupt',
+    'unreadable',
+    'unsupported-version',
+    'too-large',
+    'manifest-corrupt',
+    'manifest-unreadable'
+  ]),
+  projectId: z.string().optional(),
+  fileName: z.string(),
+  recovered: z.boolean()
+})
+const diagnosticSchema = z.object({
+  reason: z.enum(['referenced', 'scan-incomplete']),
+  references: z.array(referenceSchema).max(100),
+  issues: z.array(issueSchema).max(100),
+  truncated: z.boolean()
+})
+export type LiteratureDeletionDiagnostic = z.infer<typeof diagnosticSchema>
+export type LiteratureDeletionReference = z.infer<typeof referenceSchema>
+const marker = '\nLITERATURE_DELETION_DETAILS:'
+
+// Electron and Web RPC preserve Error.message, not custom Error properties. Keep the existing
+// rejection contract and success receipts; carry only validated, bounded, transient diagnostics.
+export function literatureDeletionError(diagnostic: LiteratureDeletionDiagnostic): Error {
+  const message =
+    diagnostic.reason === 'referenced'
+      ? 'LITERATURE_ATTACHMENT_IN_USE'
+      : 'Cannot remove an attachment without a complete Session catalog.'
+  return new Error(message + marker + JSON.stringify(diagnosticSchema.parse(diagnostic)))
+}
+
+export function parseLiteratureDeletionError(
+  error: unknown
+): LiteratureDeletionDiagnostic | undefined {
+  if (!(error instanceof Error)) return undefined
+  const offset = error.message.indexOf(marker)
+  if (offset >= 0) {
+    try {
+      return diagnosticSchema.parse(JSON.parse(error.message.slice(offset + marker.length)))
+    } catch {
+      // Preserve a useful reason even if a transport truncates diagnostics.
+    }
+  }
+  const reason = error.message.includes('LITERATURE_ATTACHMENT_IN_USE')
+    ? 'referenced'
+    : error.message.includes('Cannot remove an attachment without a complete Session catalog.')
+      ? 'scan-incomplete'
+      : undefined
+  return reason ? { reason, references: [], issues: [], truncated: true } : undefined
+}


### PR DESCRIPTION
## Problem

A quarantined conversation can still contain recoverable PDF references, but ordinary loading treats successful quarantine as a complete scan. Attachment removal could consequently delete the version and bytes needed by a repaired conversation. Permanent deletion from Trash also bypassed the existing chat-reference guard, and blocked attachment removal offered no way to locate the reference or recovery issue.

## Proposed change

Use strict quarantine semantics for final attachment deletion while retaining normal conversation loading. Both attachment removal and permanent item deletion now hold the session operation barrier and check the actual attachment targets inside the Catalog transaction, including cascade aliases. A blocked batch commits no deletion.

Return bounded, validated diagnostic details through the existing error-message transport. Both deletion surfaces show affected conversations, project/message/branch locations, or recovery-file details and the existing recovery-folder action. Navigation does not switch a persisted branch. All eight locales are updated.

## Scope and non-goals

No database migration, new persisted fields, reference index, or rewritten conversation history. Existing orphan quarantine files now block final attachment deletion; a valid replacement primary supersedes retained backups. Already-deleted versions or bytes are not reconstructed. Trash/restore, active-only PDF resolution, and post-commit cleanup reporting remain unchanged.

The new `referenced` / `scan-incomplete` reasons and `runtime-context` / `message-history` locations are transient diagnostic classifications, not persisted states.

## Acceptance criteria and validation

The regression cases failed consistently before production changes (five failures, one passing valid-primary control), including on the rebased baseline. Real PDF/SQLite tests demonstrated deleted version records and missing bytes while saved bindings remained. Final checks ran after the last material edit and rebase to `986d4221`:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Quarantine, repair, current/history/inactive-branch references, single/batch/cascade deletion, cleanup | `pdf-attachment-reliability.test.ts`, `catalog.test.ts` | 131 passed |
| Scan diagnostics, scheduler ordering, stable facade, project deletion consumers | `repository.test.ts`, `coordinator.test.ts`, `coordinator.architecture.test.ts`, `deletion-integration.test.ts` | 300 passed |
| Error serialization, Electron/Web adapters, command wiring | `literature-deletion.test.ts`, `electron-renderer-contract-adapter.test.ts`, `api-installer.test.ts`, `application-command-composition.test.ts`, `renderer-contract-catalog.test.ts`, `web-rpc-contract.test.ts` | 76 passed |
| Both deletion UI entry points, recovery/navigation failures, localization | `LiteratureLibraryPage.render.test.tsx`, `resources.test.ts` | 1,062 passed |
| Affected runtime types and source lint | `npm run typecheck`, `npm run lint` | passed |

All 14 listed test files ran together via `vitest run`: **1,569 passed, zero failed/skipped**. Browser verification used the real attachment/diagnostic components with controlled backend responses; reference and recovery screenshots were inspected locally, including the recovery action's project identity. This is component/browser verification, not a packaged Electron end-to-end claim.

The impact classifier selects full fallback because Literature/IPC ownership is not fully mapped. Per maintainer instruction, the complete local suite was not run; the explicit owner/interface/consumer checks above cover this patch, and PR CI remains authoritative for the complete and cross-platform suites. Provider execution, message replay, subscriptions, and persistence formats do not change. Independent review and exact-head CI are pending.

## Review focus

Check that all final deletion paths share the same fail-closed policy, that actual cascade identities are checked before committing, and that diagnostics survive transport without changing successful receipts or post-commit cleanup semantics.
