### PR TITLE
fix(literature): preserve verified PDF content identity

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -1134,6 +1134,7 @@ const createApplicationModules = async (
   // One registry owns short-lived capability URLs for both managed artifact repositories.
   const previewResources = new ManagedPreviewResources({
     resolvePath: resolveManagedFilePath,
+    openLiterature: (reference) => literatureAttachmentAuthority.openReference(reference),
     openLatestManagedFile: (source, request) =>
       managedFileVersionService.openLatest({ source, ...request }),
     openManagedFileVersion: (source, request) =>

--- a/src/main/literature/attachment-authority.test.ts
+++ b/src/main/literature/attachment-authority.test.ts
@@ -34,7 +34,7 @@ describe('LiteratureAttachmentAuthority', () => {
     const authority = new LiteratureAttachmentAuthority({
       getClient: async () =>
         ({ literatureAttachmentVersion: { findUnique } }) as unknown as PrismaClient,
-      content: { verify }
+      content: { verify, openLease: vi.fn() }
     })
 
     await expect(authority.resolveVersion('attachment-version-1')).resolves.toEqual({
@@ -64,7 +64,7 @@ describe('LiteratureAttachmentAuthority', () => {
             }))
           }
         }) as unknown as PrismaClient,
-      content: { verify }
+      content: { verify, openLease: vi.fn() }
     })
 
     await expect(authority.resolveVersion('attachment-version-1')).resolves.toBeUndefined()

--- a/src/main/literature/attachment-authority.ts
+++ b/src/main/literature/attachment-authority.ts
@@ -1,6 +1,7 @@
 import type { PrismaClient } from '@prisma/client'
 
-import type { ContentRepository } from '../storage/content-repository'
+import { parseLiteratureAttachmentVersionReference } from '../../shared/literature'
+import type { ContentReadLease, ContentRepository } from '../storage/content-repository'
 
 type ResolvedLiteratureAttachmentVersion = Readonly<{
   itemId: string
@@ -18,13 +19,37 @@ type ResolvedLiteratureAttachmentVersion = Readonly<{
 
 type LiteratureAttachmentAuthorityOptions = Readonly<{
   getClient: () => Promise<PrismaClient>
-  content: Pick<ContentRepository, 'verify'>
+  content: Pick<ContentRepository, 'verify' | 'openLease'>
 }>
 
 class LiteratureAttachmentUnavailableError extends Error {}
 
 class LiteratureAttachmentAuthority {
   constructor(private readonly options: LiteratureAttachmentAuthorityOptions) {}
+
+  async openReference(reference: string): Promise<ContentReadLease> {
+    const versionId = parseLiteratureAttachmentVersionReference(reference)
+    if (!versionId) throw new Error('Invalid Literature attachment reference.')
+    return this.openContent(versionId)
+  }
+
+  async openContent(versionId: string): Promise<ContentReadLease> {
+    const version = await this.resolveVersion(versionId)
+    if (!version)
+      throw new LiteratureAttachmentUnavailableError('Literature attachment is unavailable.')
+    const client = await this.options.getClient()
+    const row = await client.literatureAttachmentVersion.findUnique({ where: { id: versionId } })
+    if (!row)
+      throw new LiteratureAttachmentUnavailableError('Literature attachment is unavailable.')
+    const lease = await this.options.content.openLease(row.contentBlobId)
+    if (lease.checksum !== version.checksum || lease.size !== version.sizeBytes) {
+      await lease.close()
+      throw new LiteratureAttachmentUnavailableError(
+        'Literature attachment content identity changed.'
+      )
+    }
+    return lease
+  }
 
   async resolveVersion(
     versionId: string

--- a/src/main/literature/document-reader.ts
+++ b/src/main/literature/document-reader.ts
@@ -18,7 +18,7 @@ import type {
 
 const log = createLogger('literature-reading-context')
 const EXTRACTOR_FINGERPRINT = createHash('sha256')
-  .update('open-science-pdfjs-selectable-text-v1')
+  .update('open-science-pdfjs-verified-bytes-v2')
   .digest('hex')
 const DOCUMENT_BATCH_CHARS = 16_000
 const INDEX_CHUNK_CHARS = 5_000
@@ -320,9 +320,26 @@ class LiteratureDocumentReader {
     if (input.openContent) {
       const lease = await input.openContent()
       try {
-        extraction = await extractPdfText(lease.path, undefined, {
-          maxChars: MAX_EXTRACTED_CACHE_CHARS
-        })
+        extraction = await extractPdfText(
+          lease.path,
+          {
+            size: lease.size,
+            readBytes: async () => {
+              const bytes = await lease.readRange(0, lease.size)
+              // Validate the exact buffer PDF.js will consume, including replace-and-restore races.
+              if (
+                bytes.byteLength !== input.sizeBytes ||
+                createHash('sha256').update(bytes).digest('hex') !== input.checksum
+              ) {
+                throw new Error(
+                  'LINKED_PDF_UNAVAILABLE: PDF bytes do not match the immutable Version.'
+                )
+              }
+              return bytes
+            }
+          },
+          { maxChars: MAX_EXTRACTED_CACHE_CHARS }
+        )
         await lease.verifyUnchanged()
       } finally {
         await lease.close()

--- a/src/main/literature/pdf-attachment-reliability.test.ts
+++ b/src/main/literature/pdf-attachment-reliability.test.ts
@@ -1,12 +1,25 @@
+import { createHash } from 'node:crypto'
 import { parseLiteratureDeletionError } from '../../shared/literature-deletion'
 import { transactLiterature } from './transact'
-import { mkdtemp, rm, writeFile, truncate, access, readFile, readdir } from 'node:fs/promises'
+import {
+  mkdtemp,
+  rm,
+  writeFile,
+  truncate,
+  access,
+  readFile,
+  readdir,
+  rename,
+  chmod
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
+  createLiteratureAttachmentVersionReference,
+  parseLiteratureAttachmentVersionReference,
   literatureCatalogCommandSchema,
   literatureCatalogReceiptSchema,
   literatureItemInputSchema,
@@ -34,6 +47,11 @@ import {
   type SessionFileIndex
 } from '../session-persistence/coordinator'
 import { LiteraturePdfImporter } from './pdf-importer'
+import { LiteratureFullTextIndex } from './full-text-index'
+import { NodeVersionFileOperator } from '../managed-file-versions/version-file-operator'
+import { LiteratureDocumentReader } from './document-reader'
+import { SessionPdfSourceResolver } from './session-pdf-source-resolver'
+import { ManagedPreviewResources } from '../managed-preview-resources'
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
@@ -420,6 +438,349 @@ describe('Literature PDF attachment reliability', () => {
     ).rejects.toThrow('attachment removal is unavailable')
     expect(await client!.literatureAttachmentVersion.count()).toBe(1)
   })
+
+  // Valid equal-length PDFs keep size checks from masking the content-identity race.
+  const textPdf = (label: string): Buffer => {
+    const stream = `BT /F1 12 Tf 10 50 Td (${label}) Tj ET`
+    const objects = [
+      '<< /Type /Catalog /Pages 2 0 R >>',
+      '<< /Type /Pages /Kids [3 0 R 4 0 R] /Count 2 >>',
+      ...[1, 2].map(
+        () =>
+          '<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 100] /Resources << /Font << /F1 5 0 R >> >> /Contents 6 0 R >>'
+      ),
+      '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+      `<< /Length ${Buffer.byteLength(stream)} >>\nstream\n${stream}\nendstream`
+    ]
+    let text = '%PDF-1.4\n'
+    const offsets: number[] = []
+    objects.forEach((body, index) => {
+      offsets.push(Buffer.byteLength(text))
+      text += `${index + 1} 0 obj\n${body}\nendobj\n`
+    })
+    const xref = Buffer.byteLength(text)
+    text += `xref\n0 7\n0000000000 65535 f \n`
+    text += offsets.map((offset) => `${String(offset).padStart(10, '0')} 00000 n \n`).join('')
+    text += `trailer\n<< /Size 7 /Root 1 0 R >>\nstartxref\n${xref}\n%%EOF\n`
+    return Buffer.from(text)
+  }
+
+  it('keeps replacement text out of extraction caches and persistent search results', async () => {
+    const original = textPdf('ORIGINAL')
+    const replacement = textPdf('REPLACED')
+    expect(replacement.length).toBe(original.length)
+    const { importer, request, catalog, authority } = await setup(original)
+    const imported = await importer.import(request)
+    const attachment = imported.item.attachments[0]
+    const version = attachment.versions[0]
+    expect(version.pageCount).toBe(2)
+    const sources = new SessionPdfSourceResolver({
+      literature: authority,
+      inputs: {
+        resolveVersion: async () => undefined,
+        openContent: async () => {
+          throw new Error('Unexpected upload')
+        }
+      }
+    })
+    const makeReader = (): LiteratureDocumentReader =>
+      new LiteratureDocumentReader({
+        storageRoot: root,
+        sources,
+        sessions: {
+          loadSessionForContinuation: async () => {
+            throw new Error('Unexpected session')
+          }
+        }
+      })
+    const search = {
+      projectId: 'project',
+      attachmentId: attachment.id,
+      attachmentVersionId: version.id,
+      filename: version.filename,
+      sizeBytes: version.sizeBytes,
+      checksum: version.checksum,
+      query: 'REPLACED'
+    }
+    const resolved = await authority.resolveVersion(version.id)
+    const resolve = sources.resolveVersion.bind(sources)
+    vi.spyOn(sources, 'resolveVersion').mockImplementationOnce(async (input) => {
+      const verified = await resolve(input)
+      await writeFile(resolved!.path, replacement)
+      return verified
+    })
+    const reader = makeReader()
+    const raced = await reader.searchAttachment(search).catch(() => undefined)
+    if (raced !== undefined) expect.soft(raced).toMatchObject({ passages: [] })
+    await expect(authority.resolveVersion(version.id)).rejects.toThrow('unavailable')
+    await writeFile(resolved!.path, original)
+    await catalog.transact({
+      kind: 'verify-attachment',
+      itemId: request.itemId,
+      versionId: version.id
+    })
+    const cached = await reader.searchAttachment(search)
+    const persisted = await makeReader().searchAttachment(search)
+    // Inspect returned passages independently of response metadata.
+    for (const result of [cached, persisted]) {
+      expect.soft(result).toMatchObject({ passages: [] })
+    }
+    const control = await makeReader().searchAttachment({ ...search, query: 'ORIGINAL' })
+    expect.soft(control).toMatchObject({
+      passages: expect.arrayContaining([
+        expect.objectContaining({ content: expect.stringContaining('ORIGINAL') })
+      ])
+    })
+  })
+
+  it('rebuilds pre-verification derived indexes from the current verified bytes', async () => {
+    const { importer, request, authority } = await setup(textPdf('ORIGINAL'))
+    const attachment = (await importer.import(request)).item.attachments[0]
+    const version = attachment.versions[0]
+    const fingerprint = createHash('sha256')
+      .update('open-science-pdfjs-selectable-text-v1')
+      .digest('hex')
+    const extractionId = createHash('sha256')
+      .update(`${version.checksum}:${fingerprint}`)
+      .digest('hex')
+    const index = await LiteratureFullTextIndex.open(root)
+    try {
+      await index.replace({
+        extractionId,
+        documentChecksum: version.checksum,
+        extractorFingerprint: fingerprint,
+        chunks: [{ pageStart: 1, pageEnd: 1, textStart: 0, textEnd: 8, content: 'REPLACED' }]
+      })
+    } finally {
+      await index.close()
+    }
+    const reader = new LiteratureDocumentReader({
+      storageRoot: root,
+      sources: new SessionPdfSourceResolver({
+        literature: authority,
+        inputs: { resolveVersion: vi.fn(), openContent: vi.fn() }
+      }),
+      sessions: { loadSessionForContinuation: vi.fn() }
+    })
+    const search = {
+      projectId: 'project',
+      attachmentId: attachment.id,
+      attachmentVersionId: version.id,
+      filename: version.filename,
+      sizeBytes: version.sizeBytes,
+      checksum: version.checksum
+    }
+    expect(await reader.searchAttachment({ ...search, query: 'REPLACED' })).toMatchObject({
+      passages: []
+    })
+    expect(await reader.searchAttachment({ ...search, query: 'ORIGINAL' })).toMatchObject({
+      retrievalMode: 'bm25',
+      passages: expect.arrayContaining([
+        expect.objectContaining({ content: expect.stringContaining('ORIGINAL') })
+      ])
+    })
+  })
+
+  it('counts pages from the held bytes rather than a replacement pathname', async () => {
+    const original = textPdf('ORIGINAL')
+    const { importer, request, authority } = await setup(original)
+    const version = (await importer.import(request)).item.attachments[0].versions[0]
+    const resolved = (await authority.resolveVersion(version.id))!
+    const lease = await new NodeVersionFileOperator({ storageRoot: root }).openImmutable(
+      resolved.storageKey,
+      { checksum: version.checksum, sizeBytes: version.sizeBytes }
+    )
+    try {
+      const replacement = join(root, 'one-page.pdf')
+      await writeFile(replacement, pdf())
+      await rename(replacement, resolved.path)
+      expect(
+        await inspectPdfPageCount(lease.localPath, {
+          size: lease.sizeBytes,
+          readBytes: () => lease.readRange(0, lease.sizeBytes)
+        })
+      ).toBe(2)
+    } finally {
+      await lease.close()
+    }
+  })
+
+  it('extracts from the held lease when its pathname is atomically replaced', async () => {
+    const original = textPdf('ORIGINAL')
+    const { importer, request, authority } = await setup(original)
+    const attachment = (await importer.import(request)).item.attachments[0]
+    const version = attachment.versions[0]
+    const sources = new SessionPdfSourceResolver({
+      literature: authority,
+      inputs: { resolveVersion: vi.fn(), openContent: vi.fn() }
+    })
+    const resolved = await authority.resolveVersion(version.id)
+    const resolve = sources.resolveVersion.bind(sources)
+    const close = vi.fn()
+    vi.spyOn(sources, 'resolveVersion').mockImplementationOnce(async (input) => ({
+      ...(await resolve(input))!,
+      openContent: async () => {
+        const lease = await new NodeVersionFileOperator({ storageRoot: root }).openImmutable(
+          resolved!.storageKey,
+          { checksum: version.checksum, sizeBytes: version.sizeBytes }
+        )
+        const replaced = join(root, 'replacement.pdf')
+        try {
+          await writeFile(replaced, textPdf('REPLACED'))
+          await rename(replaced, resolved!.path)
+        } catch (error) {
+          await lease.close()
+          throw error
+        }
+        return {
+          path: lease.localPath,
+          size: lease.sizeBytes,
+          readRange: lease.readRange,
+          verifyUnchanged: lease.verifyUnchanged,
+          close: async () => {
+            close()
+            await lease.close()
+          }
+        }
+      }
+    }))
+    const reader = new LiteratureDocumentReader({
+      storageRoot: root,
+      sources,
+      sessions: { loadSessionForContinuation: vi.fn() }
+    })
+    expect(
+      await reader.searchAttachment({
+        projectId: 'project',
+        attachmentId: attachment.id,
+        attachmentVersionId: version.id,
+        filename: version.filename,
+        sizeBytes: version.sizeBytes,
+        checksum: version.checksum,
+        query: 'REPLACED'
+      })
+    ).toMatchObject({ passages: [] })
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('refuses old preview resources after their attachment is quarantined', async () => {
+    const original = textPdf('ORIGINAL')
+    const replacement = textPdf('REPLACED')
+    const { importer, request, authority, catalog } = await setup(original)
+    const version = (await importer.import(request)).item.attachments[0].versions[0]
+    const resolved = await authority.resolveVersion(version.id)
+    const resources = new ManagedPreviewResources({
+      openLiterature: (reference) => authority.openReference(reference),
+      resolvePath: async (_source, input) => {
+        const id = parseLiteratureAttachmentVersionReference(input.path)
+        if (!id) throw new Error('Invalid attachment reference')
+        const value = await authority.resolveVersion(id)
+        if (!value) throw new Error('Unavailable attachment')
+        return value.path
+      }
+    })
+    const input = {
+      source: 'literature' as const,
+      path: createLiteratureAttachmentVersionReference(version.id),
+      mimeType: 'application/pdf'
+    }
+    const resource = await resources.acquire(17, input)
+    const protocol = await resources.resolveProtocolResource(resource.id)
+    try {
+      expect(
+        Buffer.from(
+          (
+            await resources.readRange(17, {
+              resourceId: resource.id,
+              begin: 0,
+              end: original.length
+            })
+          ).data
+        )
+      ).toEqual(original)
+      await writeFile(resolved!.path, replacement)
+      await expect(authority.resolveVersion(version.id)).rejects.toThrow('unavailable')
+      await expect(resources.acquire(17, input)).rejects.toThrow('unavailable')
+      await expect(
+        resources.readRange(17, { resourceId: resource.id, begin: 0, end: replacement.length })
+      ).rejects.toThrow()
+      expect(protocol).toHaveProperty('fileHandle')
+      if (!('fileHandle' in protocol)) throw new Error('Expected a trusted protocol lease')
+      await expect(
+        protocol.fileHandle.read(Buffer.alloc(original.length), 0, original.length, 0)
+      ).rejects.toThrow()
+      await writeFile(resolved!.path, original)
+      await catalog.transact({
+        kind: 'verify-attachment',
+        itemId: request.itemId,
+        versionId: version.id
+      })
+      // A rejected resource cannot be resurrected by restoring its path.
+      await expect(
+        resources.readRange(17, { resourceId: resource.id, begin: 0, end: original.length })
+      ).rejects.toThrow()
+      const recovered = await resources.acquire(17, input)
+      try {
+        expect(
+          Buffer.from(
+            (
+              await resources.readRange(17, {
+                resourceId: recovered.id,
+                begin: 0,
+                end: original.length
+              })
+            ).data
+          )
+        ).toEqual(original)
+      } finally {
+        resources.release(17, { resourceId: recovered.id })
+      }
+    } finally {
+      if ('fileHandle' in protocol) await protocol.fileHandle.close()
+      resources.release(17, { resourceId: resource.id })
+    }
+  })
+
+  it.skipIf(process.platform === 'win32' || process.getuid?.() === 0)(
+    'records a permission-denied verification attempt and recovers after permission restoration',
+    async () => {
+      const { importer, request, catalog, authority } = await setup()
+      const version = (await importer.import(request)).item.attachments[0].versions[0]
+      const resolved = await authority.resolveVersion(version.id)
+      const row = await client!.literatureAttachmentVersion.findUniqueOrThrow({
+        where: { id: version.id }
+      })
+      const retry = {
+        kind: 'verify-attachment' as const,
+        itemId: request.itemId,
+        versionId: version.id
+      }
+      // Persist an old timestamp to make the attempt observation deterministic without sleeps.
+      await client!.contentBlob.update({
+        where: { id: row.contentBlobId },
+        data: { lastVerificationAttemptAt: new Date(1) }
+      })
+      try {
+        await chmod(resolved!.path, 0o000)
+        await expect(readFile(resolved!.path)).rejects.toMatchObject({ code: 'EACCES' })
+        await expect(catalog.transact(retry)).rejects.toThrow()
+        const after = (await catalog.get(request.itemId))!.attachments[0].versions[0]
+        expect.soft(after.availability).toBe('unavailable')
+        expect.soft(after.verificationFailure).toBeTruthy()
+        expect.soft(after.verificationAttemptAt).toBeGreaterThan(1)
+        expect(
+          (await client!.contentBlob.findUniqueOrThrow({ where: { id: row.contentBlobId } })).state
+        ).toBe('available')
+      } finally {
+        await chmod(resolved!.path, 0o644)
+      }
+      await catalog.transact(retry)
+      expect((await catalog.get(request.itemId))!.attachments[0].versions[0]).toMatchObject({
+        availability: 'available',
+        verificationFailure: undefined
+      })
+    }
+  )
 
   it('rejects a header-only corrupt PDF before creating an attachment', async () => {
     const { importer, request, path } = await setup(Buffer.from('%PDF-1.7\nnot a document'))

--- a/src/main/literature/session-pdf-source-resolver.test.ts
+++ b/src/main/literature/session-pdf-source-resolver.test.ts
@@ -19,7 +19,7 @@ describe('SessionPdfSourceResolver', () => {
     }))
     const resolver = new SessionPdfSourceResolver({
       inputs: { resolveVersion: resolveInputVersion, openContent: vi.fn() },
-      literature: { resolveVersion: resolveLiteratureVersion }
+      literature: { resolveVersion: resolveLiteratureVersion, openContent: vi.fn() }
     })
 
     await expect(
@@ -37,7 +37,8 @@ describe('SessionPdfSourceResolver', () => {
       contentType: 'application/pdf',
       sizeBytes: 42,
       checksum: 'a'.repeat(64),
-      path: '/managed/paper.pdf'
+      path: '/managed/paper.pdf',
+      openContent: expect.any(Function)
     })
     expect(resolveInputVersion).not.toHaveBeenCalled()
   })
@@ -46,6 +47,7 @@ describe('SessionPdfSourceResolver', () => {
     const resolver = new SessionPdfSourceResolver({
       inputs: { resolveVersion: vi.fn(), openContent: vi.fn() },
       literature: {
+        openContent: vi.fn(),
         resolveVersion: vi.fn(async () => ({
           itemId: 'item-1',
           attachmentId: 'attachment-2',

--- a/src/main/literature/session-pdf-source-resolver.ts
+++ b/src/main/literature/session-pdf-source-resolver.ts
@@ -16,7 +16,9 @@ type ResolvedSessionPdfVersionBase = Readonly<{
   sizeBytes: number
   checksum: string
   path: string
-  openContent?: () => Promise<ImmutableInputContentLease>
+  openContent?: () => Promise<
+    Pick<ImmutableInputContentLease, 'path' | 'size' | 'readRange' | 'verifyUnchanged' | 'close'>
+  >
 }>
 
 type ResolvedSessionPdfVersion = ResolvedSessionPdfVersionBase &
@@ -33,7 +35,7 @@ type ResolvedSessionPdfVersion = ResolvedSessionPdfVersionBase &
 
 type SessionPdfSourceResolverOptions = Readonly<{
   inputs: Pick<ImmutableInputAuthority, 'resolveVersion' | 'openContent'>
-  literature: Pick<LiteratureAttachmentAuthority, 'resolveVersion'>
+  literature: Pick<LiteratureAttachmentAuthority, 'resolveVersion' | 'openContent'>
 }>
 
 const resolvedLiteratureVersion = (
@@ -66,7 +68,10 @@ class SessionPdfSourceResolver {
       ) {
         return undefined
       }
-      return resolvedLiteratureVersion(version)
+      return {
+        ...resolvedLiteratureVersion(version),
+        openContent: () => this.options.literature.openContent(version.versionId)
+      }
     }
 
     const input = await this.options.inputs.resolveVersion({

--- a/src/main/managed-file-versions/version-file-operator.test.ts
+++ b/src/main/managed-file-versions/version-file-operator.test.ts
@@ -545,6 +545,57 @@ describe('NodeVersionFileOperator', () => {
     await invalidRangeLease.close()
   })
 
+  it('rejects bytes changed and restored during a range read', async () => {
+    const { NodeVersionFileOperator } = await import('./version-file-operator')
+    cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-restore-'))
+    const path = join(cleanupRoot, 'content.bin')
+    const original = Buffer.from('ORIGINAL')
+    const fixedTime = new Date('2000-01-01T00:00:00.000Z')
+    await writeFile(path, original)
+    await utimes(path, fixedTime, fixedTime)
+    let replaceDuringRead = false
+    const operator = new NodeVersionFileOperator({
+      storageRoot: cleanupRoot,
+      fileSystem: {
+        open: async (...args) => {
+          const handle = await openFile(...args)
+          return new Proxy(handle, {
+            get(target, property) {
+              if (property === 'read')
+                return async (
+                  buffer: Uint8Array,
+                  offset: number,
+                  length: number,
+                  position: number
+                ) => {
+                  if (!replaceDuringRead) return target.read(buffer, offset, length, position)
+                  replaceDuringRead = false
+                  await writeFile(path, 'REPLACED')
+                  const result = await target.read(buffer, offset, length, position)
+                  await writeFile(path, original)
+                  await utimes(path, fixedTime, fixedTime)
+                  return result
+                }
+              const value = Reflect.get(target, property, target)
+              return typeof value === 'function' ? value.bind(target) : value
+            }
+          })
+        }
+      }
+    })
+    const lease = await operator.openImmutable('content.bin', {
+      sizeBytes: original.length,
+      checksum: createHash('sha256').update(original).digest('hex')
+    })
+    try {
+      replaceDuringRead = true
+      await expect(lease.readRange(0, 4)).rejects.toMatchObject({ code: 'INTEGRITY_FAILED' })
+      expect(await readFile(path)).toEqual(original)
+    } finally {
+      await lease.close()
+    }
+  })
+
   it('does not hash the same unchanged immutable file again on a later open', async () => {
     const module = await import('./version-file-operator')
     cleanupRoot = await mkdtemp(join(tmpdir(), 'open-science-version-file-'))

--- a/src/main/managed-file-versions/version-file-operator.ts
+++ b/src/main/managed-file-versions/version-file-operator.ts
@@ -619,7 +619,15 @@ class NodeVersionFileOperator implements VersionFileOperator, VersionFileRecover
             )
           }
           const buffer = Buffer.allocUnsafe(end - begin)
+          const beforeRead = await leaseHandle.stat({ bigint: true })
           await readExact(leaseHandle, buffer, begin)
+          // Rehashing the current file cannot validate a range captured before bytes were restored.
+          if (!verificationSnapshotMatches(beforeRead, await leaseHandle.stat({ bigint: true }))) {
+            throw new VersionFileOperatorError(
+              'INTEGRITY_FAILED',
+              'Immutable version changed during range reading.'
+            )
+          }
           await verifyUnchanged()
           return new Uint8Array(buffer)
         } catch (error) {

--- a/src/main/managed-preview-resources.ts
+++ b/src/main/managed-preview-resources.ts
@@ -81,6 +81,7 @@ type ManagedPreviewResourcesOptions = {
   openNotebookInput?: (
     request: Extract<AcquireManagedPreviewRequest, { source: 'notebook-input' }>
   ) => Promise<ManagedPreviewTrustedLease>
+  openLiterature?: (reference: string) => Promise<ManagedPreviewTrustedLease>
   createId?: () => string
 }
 
@@ -619,6 +620,11 @@ class ManagedPreviewResources {
   private openTrustedLease(
     request: AcquireManagedPreviewRequest
   ): Promise<ManagedPreviewTrustedLease | undefined> {
+    if (request.source === 'literature') {
+      if (!this.options.openLiterature)
+        return Promise.reject(new Error('Literature preview lease is not configured.'))
+      return this.options.openLiterature(request.path)
+    }
     if (request.source === 'notebook-input') {
       if (!this.options.openNotebookInput) {
         return Promise.reject(new Error('Notebook input preview lease is not configured.'))

--- a/src/main/session-persistence/pdf-context-owner.test.ts
+++ b/src/main/session-persistence/pdf-context-owner.test.ts
@@ -130,7 +130,20 @@ describe('SessionPdfContextOwner', () => {
       const literature = new LiteratureAttachmentAuthority({
         getClient: async () =>
           ({ literatureAttachmentVersion: { findUnique } }) as unknown as PrismaClient,
-        content: { verify }
+        content: {
+          verify,
+          openLease: vi.fn(async (id: string) => ({
+            checksum: id,
+            path: `/managed/${id}.pdf`,
+            size: 42,
+            versionToken: 1,
+            snapshot: { dev: 0n, ino: 1n, size: 42n, mtimeNs: 1n },
+            read: vi.fn(),
+            readRange: vi.fn(),
+            verifyUnchanged: vi.fn(),
+            close: vi.fn()
+          }))
+        }
       })
       const owner = new SessionPdfContextOwner({
         sources: new SessionPdfSourceResolver({
@@ -157,7 +170,7 @@ describe('SessionPdfContextOwner', () => {
           sources: [sources[1]],
           unavailableSources: [sources[0]]
         })
-        expect(findUnique).toHaveBeenCalledTimes(2)
+        expect(findUnique).toHaveBeenCalledWith(expect.objectContaining({ where: { id: 'good' } }))
       }
     }
   )
@@ -379,7 +392,7 @@ describe('SessionPdfContextOwner', () => {
     const owner = new SessionPdfContextOwner({
       sources: new SessionPdfSourceResolver({
         inputs,
-        literature: { resolveVersion: vi.fn() }
+        literature: { resolveVersion: vi.fn(), openContent: vi.fn() }
       }),
       sessions: { readSessionRuntimeContext, patchSessionRuntimeContext }
     })

--- a/src/main/session-persistence/pdf-context-owner.ts
+++ b/src/main/session-persistence/pdf-context-owner.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto'
+import { createHash, randomUUID } from 'node:crypto'
 import { LiteratureAttachmentUnavailableError } from '../literature/attachment-authority'
 
 import {
@@ -282,7 +282,21 @@ class SessionPdfContextOwner {
       if (input.openContent) {
         const lease = await input.openContent()
         try {
-          const pageCount = await inspectPdfPageCount(lease.path)
+          const pageCount = await inspectPdfPageCount(lease.path, {
+            size: lease.size,
+            readBytes: async () => {
+              const bytes = await lease.readRange(0, lease.size)
+              if (
+                bytes.byteLength !== input.sizeBytes ||
+                createHash('sha256').update(bytes).digest('hex') !== input.checksum
+              ) {
+                throw new LiteratureAttachmentUnavailableError(
+                  'Linked PDF bytes do not match their Version.'
+                )
+              }
+              return bytes
+            }
+          })
           await lease.verifyUnchanged()
           return pageCount
         } finally {

--- a/src/main/storage/content-repository.test.ts
+++ b/src/main/storage/content-repository.test.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, writeFile, stat, rename } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -14,7 +14,7 @@ import { ContentRepository, resolveContentStorageKey } from './content-repositor
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs/promises')>()
-  return { ...original, rm: vi.fn(original.rm) }
+  return { ...original, rm: vi.fn(original.rm), stat: vi.fn(original.stat) }
 })
 
 const sha256 = (content: Buffer): string => createHash('sha256').update(content).digest('hex')
@@ -24,6 +24,11 @@ describe('content repository', () => {
   let client: PrismaClient | undefined
 
   afterEach(async () => {
+    vi.mocked(stat)
+      .mockReset()
+      .mockImplementation(
+        (await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')).stat
+      )
     vi.mocked(rm).mockReset()
     vi.mocked(rm).mockImplementation(
       (await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')).rm
@@ -88,6 +93,93 @@ describe('content repository', () => {
       if (fail) await expect(acquisition).rejects.toThrow('Reference insertion failed')
       else await acquisition
       expect((await sweep()).removedIds).toContain(contentId)
+    }
+  )
+
+  it.each(['EACCES', 'EPERM'])('records %s as a retryable permission failure', async (code) => {
+    const repository = await createRepository()
+    await publishFixture('blob-permissions', 'content/project/permissions', Buffer.from('readable'))
+    await repository.verify('blob-permissions')
+    await client!.contentBlob.update({
+      where: { id: 'blob-permissions' },
+      data: { lastVerificationAttemptAt: new Date(1) }
+    })
+    vi.mocked(stat).mockRejectedValueOnce(Object.assign(new Error('Access denied'), { code }))
+    await expect(repository.verify('blob-permissions', { retry: true })).rejects.toMatchObject({
+      code
+    })
+    const failed = await client!.contentBlob.findUniqueOrThrow({
+      where: { id: 'blob-permissions' }
+    })
+    expect(failed).toMatchObject({
+      state: 'available',
+      lastVerificationFailure: 'permission-denied'
+    })
+    expect(failed.lastVerificationAttemptAt!.getTime()).toBeGreaterThan(1)
+    await expect(repository.verify('blob-permissions', { retry: true })).resolves.toMatchObject({
+      state: 'available'
+    })
+    expect(
+      await client!.contentBlob.findUniqueOrThrow({ where: { id: 'blob-permissions' } })
+    ).toMatchObject({ lastVerificationFailure: null })
+  })
+
+  it('validates content availability once per preview chunk before releasing bytes', async () => {
+    const repository = await createRepository()
+    const bytes = Buffer.from('ORIGINAL')
+    await publishFixture('blob-chunks', 'content/project/chunks', bytes)
+    const lease = await repository.openLease('blob-chunks')
+    const lookup = vi.spyOn(client!.contentBlob, 'findUnique')
+    try {
+      const buffer = Buffer.alloc(bytes.length)
+      await expect(lease.read(buffer, 0, buffer.length, 0)).resolves.toEqual({
+        bytesRead: bytes.length
+      })
+      expect(buffer).toEqual(bytes)
+      expect(lookup).toHaveBeenCalledTimes(1)
+      lookup.mockClear()
+      await expect(lease.readRange(0, bytes.length)).resolves.toEqual(new Uint8Array(bytes))
+      expect(lookup).toHaveBeenCalledTimes(1)
+    } finally {
+      lookup.mockRestore()
+      await lease.close()
+    }
+  })
+
+  it.each(['replace', 'overwrite'] as const)(
+    'keeps content leases bound to their verified bytes after %s',
+    async (mode) => {
+      const repository = await createRepository()
+      const bytes = Buffer.from('ORIGINAL')
+      await publishFixture('blob-lease', 'content/project/lease', bytes)
+      const lease = await repository.openLease('blob-lease')
+      try {
+        if (mode === 'replace') {
+          const replacement = join(storageRoot!, 'replacement')
+          await writeFile(replacement, 'REPLACED')
+          await rename(replacement, lease.path)
+          expect(Buffer.from(await lease.readRange(0, bytes.length))).toEqual(bytes)
+        } else {
+          await writeFile(lease.path, 'REPLACED')
+          await expect(lease.readRange(0, bytes.length)).rejects.toThrow()
+        }
+        await expect(repository.verify('blob-lease')).resolves.toMatchObject({
+          state: 'unavailable'
+        })
+        await expect(lease.readRange(0, bytes.length)).rejects.toThrow()
+        await writeFile(lease.path, bytes)
+        await repository.verify('blob-lease', { retry: true })
+        await expect(lease.readRange(0, bytes.length)).rejects.toThrow()
+      } finally {
+        await lease.close()
+      }
+      await expect(lease.readRange(0, bytes.length)).rejects.toThrow()
+      const fresh = await repository.openLease('blob-lease')
+      try {
+        expect(Buffer.from(await fresh.readRange(0, bytes.length))).toEqual(bytes)
+      } finally {
+        await fresh.close()
+      }
     }
   )
 

--- a/src/main/storage/content-repository.ts
+++ b/src/main/storage/content-repository.ts
@@ -4,6 +4,13 @@ import { copyFile, link, mkdir, rename, rm, stat } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
 
 import type { PrismaClient } from '@prisma/client'
+import { NodeVersionFileOperator } from '../managed-file-versions/version-file-operator'
+import type { ManagedFileReadLease } from '../managed-file-versions/service'
+
+type ContentReadLease = Pick<
+  ManagedFileReadLease,
+  'path' | 'size' | 'versionToken' | 'snapshot' | 'read' | 'readRange' | 'verifyUnchanged' | 'close'
+> & { checksum: string }
 
 type OpenedContent = {
   id: string
@@ -255,6 +262,85 @@ class ContentRepository {
     })
   }
 
+  async openLease(contentId: string): Promise<ContentReadLease> {
+    const verified = await this.verify(contentId)
+    if (verified.state !== 'available') {
+      throw new ContentOpenError(verified.reason, 'Content is unavailable.')
+    }
+    const content = verified.content
+    const lease = await new NodeVersionFileOperator({
+      storageRoot: this.options.storageRoot
+    }).openImmutable(content.storageKey, {
+      checksum: content.checksum,
+      sizeBytes: Number(content.sizeBytes)
+    })
+    // Like managed file versions, admission snapshots describe immutable content identity.
+    const versionToken = Number.parseInt(content.checksum.slice(0, 12), 16)
+    let failure: unknown
+    const verifyUnchanged = async (): Promise<void> => {
+      if (failure) throw failure
+      try {
+        const client = await this.options.getClient()
+        const current = await client.contentBlob.findUnique({ where: { id: contentId } })
+        if (
+          !current ||
+          current.state !== 'available' ||
+          current.lastVerificationFailure ||
+          current.checksum !== content.checksum ||
+          current.sizeBytes !== content.sizeBytes ||
+          current.storageKey !== content.storageKey
+        ) {
+          throw new ContentOpenError('not-available', 'Content is unavailable.')
+        }
+        await lease.verifyUnchanged()
+      } catch (error) {
+        failure = error
+        throw error
+      }
+    }
+    const readRange = async (begin: number, end: number): Promise<Uint8Array> => {
+      if (failure) throw failure
+      try {
+        const bytes = await lease.readRange(begin, end)
+        await verifyUnchanged()
+        return bytes
+      } catch (error) {
+        failure = error
+        throw error
+      }
+    }
+    try {
+      await verifyUnchanged()
+      return {
+        path: lease.localPath,
+        size: lease.sizeBytes,
+        checksum: lease.checksum,
+        versionToken,
+        snapshot: {
+          dev: 0n,
+          ino: BigInt(`0x${content.checksum.slice(0, 16)}`),
+          size: content.sizeBytes,
+          mtimeNs: BigInt(versionToken) * 1_000_000n
+        },
+        readRange,
+        read: async (buffer, offset, length, position) => {
+          if (position >= lease.sizeBytes || length <= 0) {
+            await verifyUnchanged()
+            return { bytesRead: 0 }
+          }
+          const bytes = await readRange(position, Math.min(position + length, lease.sizeBytes))
+          buffer.set(bytes, offset)
+          return { bytesRead: bytes.byteLength }
+        },
+        verifyUnchanged,
+        close: lease.close
+      }
+    } catch (error) {
+      await lease.close()
+      throw error
+    }
+  }
+
   async open(contentId: string): Promise<OpenedContent> {
     return this.readContent(contentId)
   }
@@ -351,6 +437,15 @@ class ContentRepository {
       await observe(null)
       return { state: 'available', content }
     } catch (error) {
+      if (
+        typeof error === 'object' &&
+        error !== null &&
+        'code' in error &&
+        (error.code === 'EACCES' || error.code === 'EPERM')
+      ) {
+        await observe('permission-denied')
+        throw error
+      }
       if (missingFile(error)) {
         await this.quarantine(contentId)
         await observe('missing')
@@ -478,3 +573,5 @@ class ContentRepository {
 
 export { ContentRepository, resolveContentStorageKey }
 export type { ContentSweepReceipt, ContentVerification, OpenedContent, PublishContentRequest }
+
+export type { ContentReadLease }

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -156,16 +156,17 @@ type AttachmentByteSource = {
   readBytes: () => Promise<Uint8Array>
 }
 
-export const inspectPdfPageCount = async (filePath: string): Promise<number> => {
-  const fileInfo = await stat(filePath)
-  if (fileInfo.size > MAX_AUTO_EXTRACT_PDF_BYTES) {
-    throw new Error(
-      `PDF source is ${fileInfo.size} bytes, exceeding the automatic extraction limit.`
-    )
+export const inspectPdfPageCount = async (
+  filePath: string,
+  source?: AttachmentByteSource
+): Promise<number> => {
+  const size = source?.size ?? (await stat(filePath)).size
+  if (size > MAX_AUTO_EXTRACT_PDF_BYTES) {
+    throw new Error(`PDF source is ${size} bytes, exceeding the automatic extraction limit.`)
   }
   const pdfjs = (await import('pdfjs-dist/legacy/build/pdf.mjs')) as typeof import('pdfjs-dist')
   const loadingTask = pdfjs.getDocument({
-    url: filePath,
+    ...(source ? { data: new Uint8Array(await source.readBytes()) } : { url: filePath }),
     disableFontFace: true,
     isEvalSupported: false,
     verbosity: 0

--- a/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
@@ -82,6 +82,12 @@ describe('Attachment safety and version access', () => {
     }
     await retry()
     await screen.findByText('File unavailable')
+    const attachmentRow = screen
+      .getByRole('button', { name: 'Preview paper-v2.pdf' })
+      .closest('[aria-busy]')!
+    expect(within(attachmentRow as HTMLElement).getByRole('alert').textContent).toContain(
+      'The attachment operation failed. Try again.'
+    )
     expect(
       (screen.getByRole('button', { name: 'Preview paper-v2.pdf' }) as HTMLButtonElement).disabled
     ).toBe(true)

--- a/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx
@@ -57,6 +57,54 @@ beforeEach(() => {
 afterEach(cleanup)
 
 describe('Attachment safety and version access', () => {
+  it('refreshes permission failures in the attachment and history views, then recovers on retry', async () => {
+    const available = makeItem(2)
+    const unavailable = structuredClone(available)
+    Object.assign(unavailable.attachments[0].versions[0], {
+      availability: 'unavailable',
+      verificationFailure: 'permission-denied',
+      verificationAttemptAt: 2
+    })
+    vi.mocked(window.api.literature.get)
+      .mockResolvedValueOnce(unavailable)
+      .mockResolvedValueOnce(available)
+    transact.mockRejectedValueOnce(new Error('EACCES')).mockResolvedValueOnce({ state: 'present' })
+    const View = (): React.JSX.Element => {
+      const item = useAttachmentOperations(
+        (state) => state.operations.find((operation) => operation.itemId === available.id)?.item
+      )
+      return <LiteratureAttachments item={item ?? available} onPreview={vi.fn()} />
+    }
+    render(<View />)
+    const retry = async (): Promise<void> => {
+      fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' }))
+      fireEvent.click(await screen.findByRole('menuitem', { name: 'Retry file verification' }))
+    }
+    await retry()
+    await screen.findByText('File unavailable')
+    expect(
+      (screen.getByRole('button', { name: 'Preview paper-v2.pdf' }) as HTMLButtonElement).disabled
+    ).toBe(true)
+    expect(screen.queryByText('File integrity verified')).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: 'Attachment actions for paper-v2.pdf' }))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Version history' }))
+    const dialog = screen.getByRole('dialog')
+    expect(
+      (within(dialog).getByRole('button', { name: 'Preview paper-v2.pdf' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(true)
+    expect(
+      (within(dialog).getByRole('button', { name: 'Preview paper-v1.pdf' }) as HTMLButtonElement)
+        .disabled
+    ).toBe(false)
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Close' }))
+    await retry()
+    await screen.findByText('File integrity verified')
+    expect(
+      (screen.getByRole('button', { name: 'Preview paper-v2.pdf' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+  })
+
   it.each(['referenced', 'scan-incomplete'] as const)(
     'retains structured %s diagnostics after confirming deletion',
     async (reason) => {

--- a/src/renderer/src/pages/literature/LiteratureAttachments.tsx
+++ b/src/renderer/src/pages/literature/LiteratureAttachments.tsx
@@ -105,25 +105,24 @@ const AttachmentPreview = ({
       type="button"
       disabled={pending || !version || version.availability === 'unavailable'}
       aria-label={t('Preview {{title}}', { title })}
-      className="flex min-w-0 flex-1 items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
+      className="flex w-full min-w-0 flex-1 items-center gap-3 rounded-lg px-3 py-2 text-left hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
       onClick={() => version && onPreview(version)}
     >
       <FileText className="size-4 shrink-0 text-primary" aria-hidden="true" />
       <span className="min-w-0 flex-1">
         <span className="block truncate font-medium">{title}</span>
-        {version ? (
-          <span className="block text-xs text-muted-foreground">
-            {formatBytes(version.sizeBytes)}
-          </span>
-        ) : null}
-        <span
-          className={
-            version?.availability === 'unavailable'
-              ? 'block text-xs text-danger-000'
-              : 'block text-xs text-muted-foreground'
-          }
-        >
-          {pending ? null : health}
+        <span className="flex flex-wrap items-center gap-x-2 text-xs text-muted-foreground">
+          {version ? <span>{formatBytes(version.sizeBytes)}</span> : null}
+          {!pending ? (
+            <>
+              <span aria-hidden="true">·</span>
+              <span
+                className={version?.availability === 'unavailable' ? 'text-danger-000' : undefined}
+              >
+                {health}
+              </span>
+            </>
+          ) : null}
         </span>
         {version && !version.pageCount ? (
           <span className="block text-xs text-muted-foreground">
@@ -181,10 +180,11 @@ export const LiteratureAttachments = ({
         {itemOperations
           .filter(
             (operation) =>
-              operation.pending ||
-              operation.error ||
-              operation.receipt?.cleanupPending ||
-              operation.refreshFailed
+              !item.attachments.some((attachment) => attachment.id === operation.attachmentId) &&
+              (operation.pending ||
+                operation.error ||
+                operation.receipt?.cleanupPending ||
+                operation.refreshFailed)
           )
           .map((operation) => (
             <AttachmentOperationStatus key={operation.attachmentId} operation={operation} />
@@ -192,6 +192,13 @@ export const LiteratureAttachments = ({
         {item.attachments.map((attachment) => {
           const version = attachment.versions[0]
           const title = version?.filename ?? attachment.title
+          const operation = itemOperations.find((entry) => entry.attachmentId === attachment.id)
+          const showOperation =
+            operation &&
+            (operation.pending ||
+              operation.error ||
+              operation.receipt?.cleanupPending ||
+              operation.refreshFailed)
           const targetId = `literature-attachment:${attachment.id}`
           return (
             <ActionMenuTarget
@@ -228,12 +235,19 @@ export const LiteratureAttachments = ({
                 aria-busy={pending}
                 className="flex items-center rounded-lg border border-border bg-background"
               >
-                <AttachmentPreview
-                  pending={pending}
-                  version={version}
-                  title={title}
-                  onPreview={onPreview}
-                />
+                <div className="min-w-0 flex-1">
+                  <AttachmentPreview
+                    pending={pending}
+                    version={version}
+                    title={title}
+                    onPreview={onPreview}
+                  />
+                  {showOperation ? (
+                    <div className="pb-2 pl-10 pr-3">
+                      <AttachmentOperationStatus operation={operation} />
+                    </div>
+                  ) : null}
+                </div>
                 <AttachmentMenuButton
                   targetId={targetId}
                   title={title}


### PR DESCRIPTION
## Problem

A managed PDF could change after attachment verification but before extraction or preview reads. Replacement text could be cached and indexed under the original checksum, survive restoration of the PDF, and remain visible to a new reader. Existing preview resources could read replacement bytes after the content was quarantined. A verification retry that encountered a permission error also left stale successful status in attachment details.

## Proposed change

- Validate authority once per preview chunk, after the held-byte read and before releasing bytes, avoiding redundant SQLite queries while retaining revocation.
- Open literature content through the existing immutable file operator and trusted preview lease contract. Check current Content Blob availability during reads, and keep failed leases unusable until reacquired. Preserve owner, range, size and response-lifetime controls.
- Feed held bytes to PDF.js for extraction and page counting; verify the exact input buffer against the immutable version checksum. This also corrects the shared upload/artifact lease consumer.
- Compare the same handle's metadata before and after each range read, so restoring bytes and mtime before later revalidation cannot legitimize an already captured replacement range.
- Record `permission-denied` and the latest attempt in existing Content Blob fields for EACCES/EPERM, without quarantining for a permission failure. Successful retry clears the failure; existing attachment UI refreshes and disables/re-enables preview accordingly.
- Advance the extractor fingerprint so old derived indexes are rebuilt lazily from verified bytes. Existing retention and data-relocation guards remain unchanged.

## Scope and non-goals

No database schema migration, new table/column, or new availability/state enum. `permission-denied` is a new diagnostic value in the existing string field. Original PDFs and immutable attachment versions are unchanged. Historical derived-index entries incur a one-time lazy rebuild; they are not trusted or migrated into the new fingerprint. No watcher, background repair service, new preview framework, or maintenance UI.

## Acceptance criteria and validation

The three original regressions failed twice on unchanged production code with real SQLite, content publication, valid PDFs and PDF.js. Additional held-path replacement, legacy-index and portable permission-error cases also failed before their fixes. Real range replacement/restoration and page-count probes failed before the corresponding changes. Tests use existing public behavior boundaries and the existing file-system adapter, with no production test seam.

Final local impact set: **53 files / 1,310 tests**, after the last material edit. The combined run passed 1,309 tests; the upstream large-catalog concurrent-write test failed in that run and passed in isolation afterward (10.8 s). All changed-behavior regressions passed. This local capacity-test instability remains disclosed for CI confirmation. Main/sandbox and renderer typechecks, ESLint and `git diff --check` passed. Independent read-only review covered the final implementation and shared range-reader delta.

| Behavior | Included project-owned checks | Final result |
| --- | --- | --- |
| Verified extraction, cache/index recovery, old-index rebuild, page count | All `src/main/literature` suites, session PDF owner, attachment-media suites | Pass |
| Held-byte reads, restoration races, permissions and recovery | Content repository, version-file operator, managed-file service integration | Pass |
| Existing preview resources and protocol reads, owner/range/lifetime controls | Managed preview resource/protocol/IPC, immutable authority, managed-file preview | Pass |
| Upload/provenance and runtime reader consumers | Upload repository, provenance repository, runtime library evidence, session IPC | Pass |
| UI failure/recovery and historical-version state | Attachment render suite and PDF preview/reader suites | Pass |
| Existing data-root relocation contract | Literature storage migration integration | Pass |
| New main capacity/RPC consumers | Catalog capacity and scale regressions | RPC pass; capacity fails in combined run, passes isolated |

Exact final test invocation:

```sh
node node_modules/vitest/vitest.mjs run src/main/literature src/main/storage/content-repository.test.ts src/main/managed-file-versions/version-file-operator.test.ts src/main/managed-file-versions/service.integration.test.ts src/main/managed-preview-resources.test.ts src/main/managed-preview-protocol.test.ts src/main/immutable-input-authority.test.ts src/main/session-persistence/pdf-context-owner.test.ts src/main/uploads/attachment-media.test.ts src/main/uploads/attachment-media.pdf-preview.test.ts src/main/acp/runtime-library-evidence.test.ts src/renderer/src/pages/literature/LiteratureAttachments.render.test.tsx src/main/storage/literature-migration.integration.test.ts src/main/uploads/repository.test.ts src/main/artifacts/provenance-repository.test.ts src/main/managed-preview-ipc.test.ts src/main/managed-file-preview.test.ts src/main/session-persistence/ipc.test.ts src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx src/main/uploads/attachment-media.sharp.test.ts src/renderer/src/pages/workspace/previews/managed-pdf-document.test.ts src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx src/renderer/src/pages/workspace/previews/preview-file-reader.test.ts --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
node node_modules/vitest/vitest.mjs run src/main/literature/catalog-capacity.test.ts --maxWorkers=1
npm run typecheck:node
npm run typecheck:web
npm run lint -- --ignore-pattern 'docs/internal/**'
git diff --check
```

The impact classifier selects full fallback for the unowned composition file `src/main/ipc.ts`. Per maintainer instruction, local verification uses the owner/contract/consumer set above; complete portable and platform checks remain PR CI. Real chmod/EACCES was exercised on macOS; the chmod case skips Windows/root, while injected EACCES/EPERM contracts are portable. No Electron mixed-page rendering claim is made.

UI verification used the real attachment component and production CSS with a clearly labeled local controlled-IPC fixture: unavailable/disabled preview, history state, and successful retry/re-enabled preview were inspected and captured. Attachment size and health now share one metadata line; active/error operation status is inline inside its owning attachment row. Results for removed attachments remain visible outside rows. Existing copy, menu actions, shared store and translations are retained. Local screenshots and planning artifacts are not committed.

## Review focus

Exact consumed-byte identity, revocation during existing resource reads, handle closure and sticky failure behavior, shared range-reader compatibility, and the historical derived-index boundary.

CI integration follow-up: rebased onto the new attachment-operation store interface and updated the UI regression to subscribe to that public store. The first CI portable failure and renderer typecheck failure came from the removed `onChanged` prop; no production UI workaround was added. A chunk-validation regression reproduced three database lookups before reducing this to one per read.

Inline UI follow-up requested by the maintainer: attachment and library page render suites (297 tests), renderer typecheck and lint passed after the layout change. The permission regression asserts that its alert belongs to the affected attachment row. Updated browser screenshot uses the real component with controlled IPC, hiding fixture controls from the captured product area.
