### PR TITLE
feat(literature): support batch PDF import

### DIFF
--- a/src/main/uploads/repository.test.ts
+++ b/src/main/uploads/repository.test.ts
@@ -437,6 +437,76 @@ describe('upload repository', () => {
     await expect(readFile(again.path, 'utf8')).resolves.toBe('hello upload')
   })
 
+  it('publishes a batch without enqueueing competing SQLite writers', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
+    const attachments = await stageUploadFixtures(new UploadRepository(root), {
+      files: Array.from({ length: 10 }, (_, index) => ({
+        name: `research-${index}.md`,
+        content: Buffer.from('Research notes').toString('base64')
+      }))
+    })
+    let release!: (value: typeof client) => void
+    const ready = new Promise<typeof client>((resolve) => {
+      release = resolve
+    })
+    const getClient = vi.fn(() => ready)
+    const repository = new UploadRepository(root, { getClient })
+    const pending = repository.finalizePendingSessionUploads('session-1', attachments, 'project-1')
+    // Keep the first publication waiting at the database boundary. A batch must not queue
+    // every file behind SQLite's single writer before the first publication can finish.
+    const startedBeforeDatabaseReady = getClient.mock.calls.length
+    release(client)
+    const finalized = await pending
+    expect(startedBeforeDatabaseReady).toBe(1)
+    expect(finalized.map(({ id }) => id)).toEqual(attachments.map(({ id }) => id))
+    expect(await client.uploadFile.count()).toBe(10)
+    const retried = await repository.finalizePendingSessionUploads(
+      'session-1',
+      attachments,
+      'project-1'
+    )
+    expect(retried.map(({ versionId }) => versionId)).toEqual(
+      finalized.map(({ versionId }) => versionId)
+    )
+    expect(await client.uploadFile.count()).toBe(10)
+  })
+
+  it('keeps unstarted batch files staged and reuses committed files after a publication failure', async () => {
+    const root = await createStorageRoot()
+    const client = createProjectDbClient(root)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project one' } })
+    const repository = new UploadRepository(root, { getClient: () => Promise.resolve(client) })
+    const attachments = await stageUploadFixtures(repository, {
+      files: ['first.md', 'second.md', 'third.md'].map((name) => ({
+        name,
+        content: Buffer.from(name).toString('base64')
+      }))
+    })
+    await expect(
+      repository.finalizePendingSessionUploads(
+        'session-1',
+        [attachments[0], { ...attachments[1], sessionId: 'different-session' }, attachments[2]],
+        'project-1'
+      )
+    ).rejects.toThrow('different session')
+    expect(await client.uploadFile.count()).toBe(1)
+    await expect(readFile(attachments[2].path, 'utf8')).resolves.toBe('third.md')
+    const finalized = await repository.finalizePendingSessionUploads(
+      'session-1',
+      attachments,
+      'project-1'
+    )
+    expect(finalized.map(({ id }) => id)).toEqual(attachments.map(({ id }) => id))
+    expect(await client.uploadFile.count()).toBe(3)
+    expect(await client.uploadVersion.count()).toBe(3)
+  })
+
   it('registers each upload as an independent SQLite file with immutable v1 bytes', async () => {
     const root = await createStorageRoot()
     const client = createProjectDbClient(root)

--- a/src/main/uploads/staged-publication-owner.ts
+++ b/src/main/uploads/staged-publication-owner.ts
@@ -153,17 +153,16 @@ class StagedPublicationOwner {
       throw new Error('Legacy Upload authority is unavailable for orphan recovery.')
     }
 
-    const finalized = await Promise.all(
-      attachments.map(async (attachment) => {
-        if (this.options.getClient) {
-          return this.publishAttachment(safeProjectId, safeSessionId, attachment, options)
-        }
-        return this.finalizeAttachment(safeSessionId, attachment)
-      })
-    )
-    return finalized.filter(
-      (attachment): attachment is UploadedAttachment => attachment !== undefined
-    )
+    const finalized: UploadedAttachment[] = []
+    // SQLite has one writer. Do not let a batch consume its transaction wait budget
+    // queueing behind its own files; retries recover already-published identities.
+    for (const attachment of attachments) {
+      const published = this.options.getClient
+        ? await this.publishAttachment(safeProjectId, safeSessionId, attachment, options)
+        : await this.finalizeAttachment(safeSessionId, attachment)
+      if (published) finalized.push(published)
+    }
+    return finalized
   }
 
   // Converts one pending attachment record into a durable Session-owned upload record.

--- a/src/renderer/src/pages/literature/LiteratureImportDialogFrame.tsx
+++ b/src/renderer/src/pages/literature/LiteratureImportDialogFrame.tsx
@@ -1,0 +1,74 @@
+import type { ReactNode } from 'react'
+import * as Dialog from '@/components/ui/dialog'
+import { X } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import {
+  dialogCloseButtonClassName,
+  dialogDescriptionClassName,
+  dialogHeaderClassName,
+  dialogOverlayClassName,
+  dialogPanelClassName,
+  dialogTitleClassName
+} from '@/components/ui/dialog-chrome'
+import { cn } from '@/lib/utils'
+
+export function LiteratureImportDialogFrame({
+  title,
+  description,
+  busy,
+  onClose,
+  children,
+  footer
+}: {
+  title: string
+  description: string
+  busy: boolean
+  onClose: () => void
+  children: ReactNode
+  footer: ReactNode
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  return (
+    <Dialog.Root
+      open
+      onOpenChange={(open) => {
+        if (!open && !busy) onClose()
+      }}
+    >
+      <Dialog.Portal>
+        <Dialog.Overlay className={dialogOverlayClassName} />
+        <Dialog.Content
+          className={dialogPanelClassName(
+            'flex max-h-[calc(100dvh-2rem)] w-[min(740px,calc(100vw-2rem))] flex-col p-0'
+          )}
+        >
+          <div className={cn(dialogHeaderClassName, 'shrink-0')}>
+            <div className="min-w-0">
+              <Dialog.Title className={dialogTitleClassName}>{title}</Dialog.Title>
+              <Dialog.Description
+                className={cn(dialogDescriptionClassName, '[overflow-wrap:anywhere]')}
+              >
+                {description}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon-sm"
+                className={dialogCloseButtonClassName}
+                disabled={busy}
+                aria-label={t('Close')}
+              >
+                <X className="size-4" aria-hidden="true" />
+              </Button>
+            </Dialog.Close>
+          </div>
+          {children}
+          {footer}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  )
+}

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -6306,6 +6306,24 @@ describe('LiteratureLibraryPage', () => {
     )
   })
 
+  it('imports PDFs with empty normalized stems using their original filenames', async () => {
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    fireEvent.change(screen.getByLabelText('Import PDF'), {
+      target: {
+        files: ['.pdf', '___---.PDF'].map(
+          (name) => new File(['%PDF-1.7'], name, { type: 'application/pdf' })
+        )
+      }
+    })
+    const dialog = await screen.findByRole('dialog', { name: 'Import PDFs' })
+    fireEvent.click(within(dialog).getByRole('button', { name: 'Import selected' }))
+    await waitFor(() => {
+      const created = transact.mock.calls.filter(([command]) => command.kind === 'create-item')
+      expect(created.map(([command]) => command.item.title)).toEqual(['.pdf', '___---.PDF'])
+    })
+  })
+
   it('falls back to the PDF filename when local metadata cannot be read', async () => {
     extractLiteraturePdfDraft.mockRejectedValueOnce(new Error('Unreadable PDF'))
 

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -6279,6 +6279,33 @@ describe('LiteratureLibraryPage', () => {
     )
   })
 
+  it('opens one batch preview for multiple PDFs without creating references', async () => {
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    const picker = screen.getByLabelText('Import PDF') as HTMLInputElement
+    expect(picker.multiple).toBe(true)
+    fireEvent.change(picker, {
+      target: {
+        files: [
+          new File(['%PDF-1.7'], 'first.pdf', { type: 'application/pdf' }),
+          new File(['%PDF-1.7'], 'second.pdf', { type: 'application/pdf' })
+        ]
+      }
+    })
+    const dialog = await screen.findByRole('dialog', { name: 'Import PDFs' })
+    expect(within(dialog).getByRole('checkbox', { name: 'Select first.pdf' })).not.toBeNull()
+    expect(within(dialog).getByRole('checkbox', { name: 'Select second.pdf' })).not.toBeNull()
+    expect(transact.mock.calls.filter(([command]) => command.kind === 'create-item')).toHaveLength(
+      0
+    )
+    await waitFor(() =>
+      expect(
+        (within(dialog).getByRole('button', { name: 'Import selected' }) as HTMLButtonElement)
+          .disabled
+      ).toBe(false)
+    )
+  })
+
   it('falls back to the PDF filename when local metadata cannot be read', async () => {
     extractLiteraturePdfDraft.mockRejectedValueOnce(new Error('Unreadable PDF'))
 

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1251,7 +1251,7 @@ const titleFromPdfFilename = (filename: string): string =>
     .replace(/\.pdf$/iu, '')
     .replace(/[_-]+/gu, ' ')
     .replace(/\s+/gu, ' ')
-    .trim()
+    .trim() || filename
 
 const LITERATURE_REVIEW_CTA_ATTENTION_KEY = 'open-science:literature-review-cta-attention-seen'
 

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1,4 +1,8 @@
 import {
+  LiteraturePdfBatchImportDialog,
+  type PdfImportDestination
+} from './LiteraturePdfBatchImportDialog'
+import {
   parseLiteratureDeletionError,
   type LiteratureDeletionDiagnostic
 } from '../../../../shared/literature-deletion'
@@ -1363,6 +1367,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
     file?: File
     pdfItem?: LiteratureItemView
   }>(undefined)
+  const [pdfBatch, setPdfBatch] = useState<{ files: File[]; destination: PdfImportDestination }>()
   const [pendingImportPdf, setPendingImportPdf] = useState<File>()
   const [pendingImportDraft, setPendingImportDraft] = useState<LiteratureItemInput>()
   const [isReadingImportMetadata, setIsReadingImportMetadata] = useState(false)
@@ -4124,15 +4129,27 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                 <div>
                   <input
                     ref={importPdfInputRef}
+                    multiple
                     type="file"
                     accept="application/pdf,.pdf"
                     className="sr-only"
                     aria-label={t('Import PDF')}
                     onChange={(event) => {
-                      const file = event.currentTarget.files?.[0]
+                      const files = Array.from(event.currentTarget.files ?? [])
                       event.currentTarget.value = ''
-                      if (!file) return
-                      beginPdfImport(file)
+                      if (files.length > 1)
+                        setPdfBatch({
+                          files,
+                          destination: {
+                            name:
+                              selectedProject?.name ??
+                              selectedCollection?.name ??
+                              t('All references'),
+                            projectId,
+                            collectionId
+                          }
+                        })
+                      else if (files[0]) beginPdfImport(files[0])
                     }}
                   />
                   <input
@@ -5425,6 +5442,21 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
         </Dialog.Portal>
       </Dialog.Root>
 
+      {pdfBatch ? (
+        <LiteraturePdfBatchImportDialog
+          {...pdfBatch}
+          createDraft={(file) => ({
+            ...emptyLiteratureItem(),
+            title: titleFromPdfFilename(file.name)
+          })}
+          onClose={() => {
+            setPdfBatch(undefined)
+            void loadEntries(true)
+            void loadCollections()
+            void loadProjectCounts()
+          }}
+        />
+      ) : null}
       {recordImport ? (
         <LiteratureRecordImportDialog
           recordImport={recordImport}

--- a/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx
@@ -264,3 +264,27 @@ it('retries a failed destination link with the original creation receipt', async
   expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
   expect(importPdf.mock.calls.map(([c]) => c.itemId)).toEqual(['second.pdf', 'first.pdf'])
 })
+
+it('releases a failed claim before continuing and keeps its reference for retry', async () => {
+  claimLocalFile.mockRejectedValueOnce(new Error('Claim failed'))
+  open()
+  await start()
+  await screen.findByText('1 / 2 completed')
+  expect(abortTransfer).toHaveBeenCalledWith({
+    transferId: mocks.stage.mock.calls[0][2].transferId
+  })
+  expect(abortTransfer.mock.invocationCallOrder[0]).toBeLessThan(
+    mocks.stage.mock.invocationCallOrder[1]
+  )
+  expect(deleteUpload).toHaveBeenCalledTimes(2)
+  expect(importPdf.mock.calls.map(([request]) => request.itemId)).toEqual(['item-2'])
+  await waitFor(() =>
+    expect(
+      (screen.getByRole('button', { name: 'Retry unfinished' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'Retry unfinished' }))
+  await screen.findByText('2 / 2 completed')
+  expect(transact.mock.calls.filter(([command]) => command.kind === 'create-item')).toHaveLength(2)
+  expect(importPdf.mock.calls.map(([request]) => request.itemId)).toEqual(['item-2', 'item-1'])
+})

--- a/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx
@@ -1,0 +1,266 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import {
+  literatureItemInputSchema,
+  LITERATURE_IMPORT_IDENTITY_CONFLICT
+} from '../../../../shared/literature'
+import { LiteraturePdfBatchImportDialog } from './LiteraturePdfBatchImportDialog'
+
+const mocks = vi.hoisted(() => ({ extract: vi.fn(), complete: vi.fn(), stage: vi.fn() }))
+vi.mock('./literature-pdf-metadata', () => ({
+  extractLiteraturePdfDraft: mocks.extract,
+  completeLiteraturePdfDraft: mocks.complete
+}))
+vi.mock('../workspace/composer-upload-transfer', () => ({ stageComposerFile: mocks.stage }))
+const transact = vi.fn()
+const importPdf = vi.fn()
+const deleteUpload = vi.fn()
+const abortTransfer = vi.fn()
+const claimLocalFile = vi.fn()
+const close = vi.fn()
+const files = ['first.pdf', 'second.pdf'].map(
+  (name) => new File(['%PDF-1.7'], name, { type: 'application/pdf' })
+)
+const attachment = { path: '/managed/pdf' }
+const createDraft = (file: File): ReturnType<typeof literatureItemInputSchema.parse> =>
+  literatureItemInputSchema.parse({ itemType: 'journalArticle', title: file.name })
+const deferred = <T,>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+} => {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((yes, no) => {
+    resolve = yes
+    reject = no
+  })
+  return { promise, resolve, reject }
+}
+const open = (): ReturnType<typeof render> =>
+  render(
+    <LiteraturePdfBatchImportDialog
+      files={files}
+      destination={{ name: 'Captured project', projectId: 'project-original' }}
+      createDraft={createDraft}
+      onClose={close}
+    />
+  )
+const start = async (): Promise<void> => {
+  const button = await screen.findByRole('button', { name: 'Import selected' })
+  await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(false))
+  fireEvent.click(button)
+}
+beforeEach(() => {
+  vi.resetAllMocks()
+  mocks.extract.mockImplementation(async (_file, draft) => draft)
+  mocks.complete.mockImplementation(async (draft) => draft)
+  mocks.stage.mockResolvedValue(attachment)
+  let id = 0
+  transact.mockImplementation(async (command) => ({
+    id: command.kind === 'create-item' ? `item-${++id}` : command.itemId
+  }))
+  importPdf.mockResolvedValue({ item: {} })
+  deleteUpload.mockResolvedValue(undefined)
+  abortTransfer.mockResolvedValue(undefined)
+  claimLocalFile.mockResolvedValue(undefined)
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      literature: { transact, importPdf },
+      uploads: { deleteUpload, abortTransfer, claimLocalFile }
+    }
+  })
+})
+afterEach(cleanup)
+
+it('shows filenames before metadata resolves and writes nothing until confirmation', async () => {
+  const read = deferred<ReturnType<typeof createDraft>>()
+  mocks.extract.mockReturnValueOnce(read.promise)
+  open()
+  expect(screen.getAllByText('first.pdf').length).toBeGreaterThan(0)
+  expect(screen.getByText('Captured project')).not.toBeNull()
+  expect(
+    (screen.getByRole('button', { name: 'Import selected' }) as HTMLButtonElement).disabled
+  ).toBe(true)
+  expect(transact).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: 'Cancel' }))
+  expect(close).toHaveBeenCalledOnce()
+  await act(async () => read.resolve(createDraft(files[0])))
+})
+
+it('continues after an attachment failure and retries the existing reference without duplicating successful rows', async () => {
+  importPdf.mockRejectedValueOnce(new Error('Bad PDF'))
+  open()
+  await start()
+  await screen.findByText('1 / 2 completed')
+  await waitFor(() =>
+    expect(
+      (screen.getByRole('button', { name: 'Retry unfinished' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+  )
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
+  expect(transact).toHaveBeenCalledWith({
+    kind: 'set-project-item',
+    projectId: 'project-original',
+    itemId: 'item-2',
+    included: true,
+    source: 'library'
+  })
+  fireEvent.click(screen.getByRole('button', { name: 'Retry unfinished' }))
+  await screen.findByText('2 / 2 completed')
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
+  expect(importPdf.mock.calls.map(([c]) => c.itemId)).toEqual(['item-1', 'item-2', 'item-1'])
+  expect(deleteUpload).toHaveBeenCalledTimes(3)
+})
+
+it('reports identifier conflicts without attaching and allows an explicit retry', async () => {
+  transact.mockRejectedValueOnce(new Error(LITERATURE_IMPORT_IDENTITY_CONFLICT))
+  open()
+  await start()
+  await screen.findByText('Conflicting identifiers')
+  await screen.findByText('1 / 2 completed')
+  expect(importPdf).toHaveBeenCalledTimes(1)
+  await waitFor(() =>
+    expect(
+      (screen.getByRole('button', { name: 'Retry unfinished' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'Retry unfinished' }))
+  await screen.findByText('2 / 2 completed')
+})
+
+it('does not replay an unconfirmed creation and still imports other files', async () => {
+  transact.mockRejectedValueOnce(new Error('Response lost'))
+  open()
+  await start()
+  await screen.findByText(
+    'The result could not be confirmed. Check your library before importing this file again.'
+  )
+  await screen.findByText('1 / 2 completed')
+  expect(
+    (screen.getByRole('button', { name: 'Retry unfinished' }) as HTMLButtonElement).disabled
+  ).toBe(true)
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
+})
+
+it('honors deselection and retains filename metadata fallback', async () => {
+  mocks.extract.mockRejectedValueOnce(new Error('No metadata'))
+  open()
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select second.pdf' }))
+  await start()
+  await screen.findByText('1 / 2 completed')
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(1)
+  expect(transact).toHaveBeenCalledWith(
+    expect.objectContaining({
+      kind: 'create-item',
+      item: expect.objectContaining({ title: 'first.pdf' })
+    })
+  )
+})
+
+it('stops an active upload, cleans its late stage and retries without creating a second reference', async () => {
+  const staged = deferred<typeof attachment>()
+  mocks.stage.mockReturnValueOnce(staged.promise)
+  open()
+  await start()
+  await waitFor(() => expect(mocks.stage).toHaveBeenCalledOnce())
+  fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+  expect(mocks.stage.mock.calls[0][2].signal.aborted).toBe(true)
+  expect(abortTransfer).toHaveBeenCalledOnce()
+  await act(async () => staged.resolve(attachment))
+  await screen.findByText('PDF upload cancelled. The reference was kept.')
+  expect(deleteUpload).toHaveBeenCalledWith({ path: attachment.path })
+  expect(importPdf).not.toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: 'Retry unfinished' }))
+  await screen.findByText('2 / 2 completed')
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
+})
+
+it('finishes a submitted import before stopping and does not start the next file', async () => {
+  const result = deferred<{ item: object }>()
+  importPdf.mockReturnValueOnce(result.promise)
+  open()
+  await start()
+  await waitFor(() => expect(importPdf).toHaveBeenCalledOnce())
+  fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+  expect(abortTransfer).not.toHaveBeenCalled()
+  expect((screen.getByRole('button', { name: 'Close' }) as HTMLButtonElement).disabled).toBe(true)
+  await act(async () => result.resolve({ item: {} }))
+  await screen.findByText('1 / 2 completed')
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(1)
+})
+
+it('does not start uploads after unmount while creation is pending', async () => {
+  const created = deferred<{ id: string }>()
+  transact.mockReturnValueOnce(created.promise)
+  const view = open()
+  await start()
+  await waitFor(() => expect(transact).toHaveBeenCalledOnce())
+  view.unmount()
+  await act(async () => created.resolve({ id: 'late-item' }))
+  expect(mocks.stage).not.toHaveBeenCalled()
+  expect(transact).toHaveBeenCalledOnce()
+})
+
+it('aborts the backend upload on unmount and never imports late bytes', async () => {
+  const staged = deferred<typeof attachment>()
+  mocks.stage.mockReturnValueOnce(staged.promise)
+  const view = open()
+  await start()
+  await waitFor(() => expect(mocks.stage).toHaveBeenCalledOnce())
+  view.unmount()
+  expect(abortTransfer).toHaveBeenCalledOnce()
+  await act(async () => staged.resolve(attachment))
+  expect(importPdf).not.toHaveBeenCalled()
+  expect(deleteUpload).toHaveBeenCalledOnce()
+})
+
+it('shows current upload progress alongside both file rows', async () => {
+  const stage = deferred<typeof attachment>()
+  mocks.stage.mockImplementationOnce((_file, _api, options) => {
+    options.onProgress({
+      transferId: options.transferId,
+      name: 'first.pdf',
+      receivedBytes: 4,
+      totalBytes: 8
+    })
+    return stage.promise
+  })
+  open()
+  await start()
+  expect(await screen.findByRole('progressbar', { name: 'Upload progress' })).toHaveProperty(
+    'value',
+    4
+  )
+  const list = screen.getByRole('list')
+  expect(within(list).getAllByRole('listitem')).toHaveLength(2)
+  await act(async () => stage.resolve(attachment))
+  await screen.findByText('2 / 2 completed')
+})
+
+it('retries a failed destination link with the original creation receipt', async () => {
+  let failLink = true
+  transact.mockImplementation(async (command) => {
+    if (command.kind === 'create-item') return { id: command.item.title }
+    if (command.itemId === 'first.pdf' && failLink) {
+      failLink = false
+      throw new Error('Link failed')
+    }
+    return { id: command.itemId }
+  })
+  open()
+  await start()
+  await screen.findByText('1 / 2 completed')
+  await waitFor(() =>
+    expect(
+      (screen.getByRole('button', { name: 'Retry unfinished' }) as HTMLButtonElement).disabled
+    ).toBe(false)
+  )
+  expect(importPdf.mock.calls.map(([c]) => c.itemId)).toEqual(['second.pdf'])
+  fireEvent.click(screen.getByRole('button', { name: 'Retry unfinished' }))
+  await screen.findByText('2 / 2 completed')
+  expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
+  expect(importPdf.mock.calls.map(([c]) => c.itemId)).toEqual(['second.pdf', 'first.pdf'])
+})

--- a/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.tsx
@@ -1,0 +1,346 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Button } from '@/components/ui/button'
+import { LiteratureImportDialogFrame } from './LiteratureImportDialogFrame'
+import { LiteratureDuplicatePolicyField } from './LiteratureDuplicatePolicyField'
+import { LiteratureErrorNotice } from './LiteratureErrorNotice'
+import { stageComposerFile } from '../workspace/composer-upload-transfer'
+import {
+  LITERATURE_IMPORT_IDENTITY_CONFLICT,
+  type LiteratureItemInput,
+  type LiteratureDuplicatePolicy
+} from '../../../../shared/literature'
+import type { UploadTransferProgress, UploadedAttachment } from '../../../../shared/uploads'
+
+type Row = {
+  file: File
+  draft: LiteratureItemInput
+  checked: boolean
+  status: 'pending' | 'reading' | 'ready' | 'importing' | 'done' | 'error'
+  itemId?: string
+  linked?: boolean
+  uncertain?: boolean
+  error?: string
+}
+export type PdfImportDestination = { name: string; projectId?: string; collectionId?: string }
+
+export function LiteraturePdfBatchImportDialog({
+  files,
+  destination,
+  createDraft,
+  onClose
+}: {
+  files: File[]
+  destination: PdfImportDestination
+  createDraft: (file: File) => LiteratureItemInput
+  onClose: () => void
+}): React.JSX.Element {
+  const { t } = useTranslation()
+  const [rows, setRows] = useState<Row[]>(() =>
+    files.map((file) => ({ file, draft: createDraft(file), checked: true, status: 'pending' }))
+  )
+  const rowsRef = useRef(rows.map((row) => ({ ...row })))
+  const [policy, setPolicy] = useState<LiteratureDuplicatePolicy>('reuse')
+  const [reading, setReading] = useState(true)
+  const [busy, setBusy] = useState(false)
+  const [stopping, setStopping] = useState(false)
+  const [visible, setVisible] = useState(100)
+  const [progress, setProgress] = useState<UploadTransferProgress>()
+  const active = useRef(true)
+  const running = useRef(false)
+  const stopped = useRef(false)
+  const upload = useRef<{ controller: AbortController; transferId: string } | undefined>(undefined)
+  const publish = (): void => {
+    if (active.current) setRows(rowsRef.current.map((row) => ({ ...row })))
+  }
+  const selectAll = (checked: boolean): void => {
+    rowsRef.current.forEach((row) => {
+      if (row.status !== 'done' && !row.uncertain) row.checked = checked
+    })
+    publish()
+  }
+  const stop = (): void => {
+    stopped.current = true
+    setStopping(true)
+    const transfer = upload.current
+    if (transfer) {
+      transfer.controller.abort()
+      void window.api.uploads
+        .abortTransfer({ transferId: transfer.transferId })
+        .catch(() => undefined)
+    }
+  }
+  useEffect(() => {
+    active.current = true
+    let disposed = false
+    const read = async (): Promise<void> => {
+      const { extractLiteraturePdfDraft, completeLiteraturePdfDraft } =
+        await import('./literature-pdf-metadata')
+      for (const row of rowsRef.current) {
+        if (disposed) return
+        row.status = 'reading'
+        publish()
+        try {
+          const local = await extractLiteraturePdfDraft(row.file, row.draft)
+          if (disposed) return
+          const draft = await completeLiteraturePdfDraft(local)
+          if (disposed) return
+          row.draft = draft
+        } catch {
+          // Metadata is optional; the importer validates PDF bytes before attaching them.
+        }
+        if (disposed) return
+        row.status = 'ready'
+        publish()
+      }
+    }
+    void read()
+      .catch(() => {
+        if (!disposed) {
+          for (const row of rowsRef.current) row.status = 'ready'
+          publish()
+        }
+      })
+      .finally(() => {
+        if (!disposed) setReading(false)
+      })
+    return () => {
+      disposed = true
+      active.current = false
+      stopped.current = true
+      const transfer = upload.current
+      if (transfer) {
+        transfer.controller.abort()
+        void window.api.uploads
+          .abortTransfer({ transferId: transfer.transferId })
+          .catch(() => undefined)
+      }
+    }
+  }, [])
+
+  const run = async (): Promise<void> => {
+    if (running.current || reading) return
+    running.current = true
+    stopped.current = false
+    setBusy(true)
+    setStopping(false)
+    try {
+      for (const row of rowsRef.current) {
+        if (stopped.current || !active.current) break
+        if (!row.checked || row.status === 'done' || row.uncertain) continue
+        row.status = 'importing'
+        row.error = undefined
+        publish()
+        let staged: UploadedAttachment | undefined
+        let creating = false
+        try {
+          if (!row.itemId) {
+            creating = true
+            const receipt = await window.api.literature.transact({
+              kind: 'create-item',
+              item: row.draft,
+              duplicatePolicy: policy
+            })
+            row.itemId = receipt.id
+            creating = false
+          }
+          if (stopped.current || !active.current) {
+            row.status = 'ready'
+            continue
+          }
+          if (!row.linked) {
+            if (destination.projectId)
+              await window.api.literature.transact({
+                kind: 'set-project-item',
+                projectId: destination.projectId,
+                itemId: row.itemId,
+                included: true,
+                source: 'library'
+              })
+            else if (destination.collectionId)
+              await window.api.literature.transact({
+                kind: 'set-collection-item',
+                collectionId: destination.collectionId,
+                itemId: row.itemId,
+                included: true
+              })
+            row.linked = true
+          }
+          if (stopped.current || !active.current) {
+            row.status = 'ready'
+            continue
+          }
+          const transfer = { controller: new AbortController(), transferId: crypto.randomUUID() }
+          upload.current = transfer
+          staged = await stageComposerFile(row.file, window.api.uploads, {
+            transferId: transfer.transferId,
+            name: row.file.name,
+            signal: transfer.controller.signal,
+            onProgress: (value) => {
+              if (active.current) setProgress(value)
+            }
+          })
+          await window.api.uploads.claimLocalFile?.({ transferId: transfer.transferId })
+          if (transfer.controller.signal.aborted || !active.current)
+            throw new DOMException('Upload cancelled.', 'AbortError')
+          // Once submitted, finish the write before stopping; the upload is no longer cancellable.
+          upload.current = undefined
+          if (active.current) setProgress(undefined)
+          await window.api.literature.importPdf({ itemId: row.itemId, attachment: staged })
+          row.status = 'done'
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          const conflict = message.includes(LITERATURE_IMPORT_IDENTITY_CONFLICT)
+          row.uncertain = creating && !conflict
+          row.status = 'error'
+          row.error = row.uncertain
+            ? t(
+                'The result could not be confirmed. Check your library before importing this file again.'
+              )
+            : conflict
+              ? t('Conflicting identifiers')
+              : stopped.current
+                ? t('PDF upload cancelled. The reference was kept.')
+                : row.itemId
+                  ? t('The reference was kept. Retry to finish adding its PDF.')
+                  : t('PDF could not be added.')
+        } finally {
+          if (staged)
+            await window.api.uploads.deleteUpload({ path: staged.path }).catch(() => undefined)
+          upload.current = undefined
+          if (active.current) setProgress(undefined)
+          publish()
+        }
+      }
+    } finally {
+      running.current = false
+      if (active.current) {
+        setBusy(false)
+        setStopping(false)
+      }
+    }
+  }
+  const completed = rows.filter((row) => row.status === 'done').length
+  const remaining = rows.filter(
+    (row) => row.checked && row.status !== 'done' && !row.uncertain
+  ).length
+  const selectable = rows.filter((row) => row.status !== 'done' && !row.uncertain)
+  const labels = {
+    pending: t('Pending'),
+    reading: t('Reading…'),
+    ready: t('Ready'),
+    importing: t('Importing…'),
+    done: t('Completed'),
+    error: t('Failed')
+  }
+  return (
+    <LiteratureImportDialogFrame
+      title={t('Import PDFs')}
+      description={t(
+        'Review the files, then import the selected PDFs. Keep this window open until the batch finishes.'
+      )}
+      busy={busy}
+      onClose={onClose}
+      footer={
+        <div className="flex shrink-0 flex-wrap justify-end gap-2 border-t border-border-300/80 px-5 py-4">
+          {busy ? (
+            <Button variant="outline" disabled={stopping} onClick={stop}>
+              {stopping ? t('Stopping…') : t('Stop')}
+            </Button>
+          ) : (
+            <Button variant="outline" onClick={onClose}>
+              {completed ? t('Done') : t('Cancel')}
+            </Button>
+          )}
+          <Button disabled={reading || busy || remaining === 0} onClick={() => void run()}>
+            {rows.some((row) => row.itemId || row.status === 'error')
+              ? t('Retry unfinished')
+              : t('Import selected')}
+          </Button>
+        </div>
+      }
+    >
+      <div className="min-h-0 space-y-4 overflow-y-auto p-5">
+        <p className="text-sm [overflow-wrap:anywhere]">
+          {t('Import to')} · <strong>{destination.name}</strong>
+        </p>
+        <LiteratureDuplicatePolicyField value={policy} onChange={setPolicy} disabled={busy} />
+        <p className="text-xs text-muted-foreground">
+          {t(
+            'PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.'
+          )}
+        </p>
+        <div role="status" className="space-y-2 text-sm">
+          <p>
+            {reading
+              ? t('Reading…')
+              : t('{{completed}} / {{total}} completed', { completed, total: rows.length })}
+          </p>
+          {stopping ? (
+            <p>
+              {t('Finishing the current operation before stopping. Completed references are kept.')}
+            </p>
+          ) : null}
+          {progress ? (
+            <>
+              <p className="break-all">{progress.name}</p>
+              <progress
+                aria-label={t('Upload progress')}
+                className="h-2 w-full accent-primary"
+                max={Math.max(1, progress.totalBytes)}
+                value={progress.receivedBytes}
+              />
+              <p className="text-xs text-muted-foreground">
+                {t('{{received}} / {{total}} bytes uploaded', {
+                  received: progress.receivedBytes.toLocaleString(),
+                  total: progress.totalBytes.toLocaleString()
+                })}
+              </p>
+            </>
+          ) : null}
+        </div>
+        <label className="flex items-center gap-2 text-sm">
+          <input
+            type="checkbox"
+            disabled={busy || selectable.length === 0}
+            checked={selectable.length > 0 && selectable.every((row) => row.checked)}
+            onChange={(event) => selectAll(event.target.checked)}
+          />
+          {t('Select all')}
+        </label>
+        <ul className="divide-y divide-border-300/80 rounded-lg border border-border-300/80">
+          {rows.slice(0, visible).map((row, index) => (
+            <li key={index} className="space-y-2 px-3 py-3">
+              <div className="flex items-start gap-3">
+                <input
+                  className="mt-1"
+                  type="checkbox"
+                  aria-label={t('Select {{name}}', { name: row.file.name })}
+                  disabled={busy || row.status === 'done' || row.uncertain}
+                  checked={row.checked}
+                  onChange={(event) => {
+                    rowsRef.current[index].checked = event.target.checked
+                    publish()
+                  }}
+                />
+                <div className="min-w-0 flex-1">
+                  <p className="break-words text-sm font-medium">{row.draft.title}</p>
+                  <p className="break-all text-xs text-muted-foreground">{row.file.name}</p>
+                </div>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {!row.checked ? t('Skipped') : labels[row.status]}
+                </span>
+              </div>
+              {row.error ? <LiteratureErrorNotice title={row.error} /> : null}
+            </li>
+          ))}
+        </ul>
+        {visible < rows.length ? (
+          <Button variant="ghost" onClick={() => setVisible((value) => value + 100)}>
+            {t('Show more')}
+          </Button>
+        ) : null}
+      </div>
+    </LiteratureImportDialogFrame>
+  )
+}

--- a/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.tsx
@@ -180,7 +180,14 @@ export function LiteraturePdfBatchImportDialog({
               if (active.current) setProgress(value)
             }
           })
-          await window.api.uploads.claimLocalFile?.({ transferId: transfer.transferId })
+          try {
+            await window.api.uploads.claimLocalFile?.({ transferId: transfer.transferId })
+          } catch (claimError) {
+            await window.api.uploads
+              .abortTransfer({ transferId: transfer.transferId })
+              .catch(() => undefined)
+            throw claimError
+          }
           if (transfer.controller.signal.aborted || !active.current)
             throw new DOMException('Upload cancelled.', 'AbortError')
           // Once submitted, finish the write before stopping; the upload is no longer cancellable.

--- a/src/renderer/src/pages/literature/LiteratureRecordImportDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteratureRecordImportDialog.tsx
@@ -3,19 +3,11 @@
  * pre-emit critique: P5 H4 E4 S5 R5 V4
  */
 import { useState } from 'react'
-import * as Dialog from '@/components/ui/dialog'
-import { Check, Info, LoaderCircle, Upload, X } from 'lucide-react'
+import { Check, Info, LoaderCircle, Upload } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { LiteratureErrorNotice } from './LiteratureErrorNotice'
 import { Button } from '@/components/ui/button'
-import {
-  dialogCloseButtonClassName,
-  dialogDescriptionClassName,
-  dialogHeaderClassName,
-  dialogOverlayClassName,
-  dialogPanelClassName,
-  dialogTitleClassName
-} from '@/components/ui/dialog-chrome'
+import { LiteratureImportDialogFrame } from './LiteratureImportDialogFrame'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import { LiteratureDuplicatePolicyField } from './LiteratureDuplicatePolicyField'
@@ -72,364 +64,329 @@ export const LiteratureRecordImportDialog = ({
     recordImport.preview?.entries.filter((entry) => entry.status === 'conflict').length ?? 0
   const blockedByConflict = conflictCount > 0 && duplicatePolicy !== 'separate'
   return (
-    <Dialog.Root
-      open
-      onOpenChange={(open) => {
-        if (!open && !isImportingRecords) onClose()
-      }}
-    >
-      <Dialog.Portal>
-        <Dialog.Overlay className={dialogOverlayClassName} />
-        <Dialog.Content
-          className={dialogPanelClassName(
-            'flex max-h-[calc(100dvh-2rem)] w-[min(740px,calc(100vw-2rem))] flex-col p-0'
-          )}
-        >
-          <div className={cn(dialogHeaderClassName, 'shrink-0')}>
-            <div className="min-w-0">
-              <Dialog.Title className={dialogTitleClassName}>{t('Import references')}</Dialog.Title>
-              <Dialog.Description
-                className={cn(dialogDescriptionClassName, '[overflow-wrap:anywhere]')}
-              >
-                {recordImport.fileName}
-              </Dialog.Description>
-            </div>
-            <Dialog.Close asChild>
+    <LiteratureImportDialogFrame
+      title={t('Import references')}
+      description={recordImport.fileName}
+      busy={isImportingRecords}
+      onClose={onClose}
+      footer={
+        <div className="flex shrink-0 flex-wrap justify-end gap-2 border-t border-border-300/80 px-5 py-4">
+          {recordImport.preview?.imported ? (
+            <Button type="button" onClick={() => onClose()}>
+              {t('Done')}
+            </Button>
+          ) : (
+            <>
               <Button
                 type="button"
-                variant="ghost"
-                size="icon-sm"
-                className={dialogCloseButtonClassName}
+                variant="outline"
                 disabled={isImportingRecords}
-                aria-label={t('Close')}
+                onClick={() => onClose()}
               >
-                <X className="size-4" aria-hidden="true" />
+                {t('Cancel')}
               </Button>
-            </Dialog.Close>
-          </div>
-          <div className="min-h-0 overflow-y-auto p-5">
-            {recordImport.error && !recordImport.preview ? (
-              <LiteratureErrorNotice title={recordImport.error} />
-            ) : !recordImport.preview ? (
-              <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Button
+                type="button"
+                disabled={
+                  isImportingRecords ||
+                  blockedByConflict ||
+                  !recordImport.preview ||
+                  recordImport.preview.items.length === 0
+                }
+                onClick={() => onImport()}
+              >
+                {isImportingRecords ? (
+                  <LoaderCircle
+                    className="size-4 animate-spin motion-reduce:animate-none"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Upload className="size-4" aria-hidden="true" />
+                )}
+                {isImportingRecords ? t('Importing…') : t('Import references')}
+              </Button>
+            </>
+          )}
+        </div>
+      }
+    >
+      <div className="min-h-0 overflow-y-auto p-5">
+        {recordImport.error && !recordImport.preview ? (
+          <LiteratureErrorNotice title={recordImport.error} />
+        ) : !recordImport.preview ? (
+          <p role="status" className="flex items-center gap-2 text-sm text-muted-foreground">
+            <LoaderCircle
+              className="size-4 animate-spin motion-reduce:animate-none"
+              aria-hidden="true"
+            />
+            {recordImport.reading ? t('Reading…') : t('Loading…')}
+          </p>
+        ) : (
+          <div className="space-y-4">
+            {recordImport.error ? <LiteratureErrorNotice title={recordImport.error} /> : null}
+            <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
+              <span className="rounded border border-border-300/80 px-2 py-1 font-medium">
+                {recordImport.preview.format === 'nbib'
+                  ? t('PubMed NBIB')
+                  : recordImport.preview.format.toUpperCase()}
+              </span>
+              <span>
+                {t('{{count}} references', {
+                  count: recordImport.preview.scannedEntries,
+                  defaultValue_one: '{{count}} reference'
+                })}
+              </span>
+            </div>
+            <div className="flex min-w-0 items-baseline gap-2 text-sm">
+              <span className="shrink-0 text-muted-foreground">{t('Import to')}</span>
+              <span className="min-w-0 font-medium [overflow-wrap:anywhere]">{destination}</span>
+            </div>
+            {!recordImport.preview.imported && recordImport.failedCount === undefined ? (
+              <div
+                className={cn(
+                  'grid divide-x divide-border-300/80 border-y border-border-300/80 py-3 text-center',
+                  conflictCount > 0 ? 'grid-cols-4' : 'grid-cols-3'
+                )}
+              >
+                <div>
+                  <strong className="block text-xl tabular-nums">
+                    {recordImport.preview.items.length -
+                      (duplicatePolicy === 'separate' ? 0 : existingCount + conflictCount)}
+                  </strong>
+                  <span className="text-xs text-muted-foreground">{t('New references')}</span>
+                </div>
+                <div>
+                  <strong className="block text-xl tabular-nums">{existingCount}</strong>
+                  <span className="text-xs text-muted-foreground">{t('Existing')}</span>
+                </div>
+                <div>
+                  <strong className="block text-xl tabular-nums">{skippedImportCount}</strong>
+                  <span className="text-xs text-muted-foreground">{t('Skipped')}</span>
+                </div>
+                {conflictCount > 0 ? (
+                  <div>
+                    <strong className="block text-xl tabular-nums">{conflictCount}</strong>
+                    <span className="text-xs text-muted-foreground">
+                      {t('Conflicting identifiers')}
+                    </span>
+                  </div>
+                ) : null}
+              </div>
+            ) : null}
+            {!recordImport.preview.imported ? (
+              <LiteratureDuplicatePolicyField
+                value={duplicatePolicy}
+                onChange={onDuplicatePolicyChange}
+                disabled={isImportingRecords}
+              />
+            ) : null}
+            {conflictCount > 0 && !recordImport.preview.imported ? (
+              <LiteratureErrorNotice
+                title={t('Conflicting identifiers')}
+                description={t(
+                  'Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.'
+                )}
+              />
+            ) : null}
+            {recordImport.preview.truncated && !recordImport.preview.imported ? (
+              <p
+                role="status"
+                className="flex items-start gap-2 rounded-lg bg-status-warning-surface px-3 py-2.5 text-sm text-status-warning-foreground dark:bg-status-warning-dark-surface dark:text-status-warning-dark-foreground"
+              >
+                <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+                <span>{t('Only the first 1,000 references will be imported.')}</span>
+              </p>
+            ) : null}
+            {isImportingRecords ? (
+              <p role="status" className="flex items-start gap-2 text-sm text-muted-foreground">
                 <LoaderCircle
-                  className="size-4 animate-spin motion-reduce:animate-none"
+                  className="mt-0.5 size-4 shrink-0 animate-spin motion-reduce:animate-none"
                   aria-hidden="true"
                 />
-                {recordImport.reading ? t('Reading…') : t('Loading…')}
+                {t('Saving references and authors. Large imports may take a moment.')}
+              </p>
+            ) : recordImport.preview.imported ? (
+              <p role="status" className="flex items-center gap-2 text-sm font-medium">
+                <Check className="size-4 text-primary" aria-hidden="true" />
+                {t('Import complete')}
               </p>
             ) : (
-              <div className="space-y-4">
-                {recordImport.error ? <LiteratureErrorNotice title={recordImport.error} /> : null}
-                <div className="flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
-                  <span className="rounded border border-border-300/80 px-2 py-1 font-medium">
-                    {recordImport.preview.format === 'nbib'
-                      ? t('PubMed NBIB')
-                      : recordImport.preview.format.toUpperCase()}
-                  </span>
-                  <span>
-                    {t('{{count}} references', {
-                      count: recordImport.preview.scannedEntries,
-                      defaultValue_one: '{{count}} reference'
-                    })}
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {duplicatePolicy === 'reuse' && conflictCount === 0
+                  ? t(
+                      'Matching DOI, PMID or PMCID references will be reused. PDFs are not downloaded.'
+                    )
+                  : t('PDFs are not downloaded.')}
+              </p>
+            )}
+            {recordImport.preview.items.length === 0 ? (
+              <p role="alert" className="text-sm text-danger-000">
+                {t('No valid references found.')}
+              </p>
+            ) : null}
+            {recordImport.preview.imported || recordImport.failedCount !== undefined ? (
+              <div className="grid grid-cols-2 gap-3 border-y border-border-300/80 py-3 text-center text-sm sm:grid-cols-4">
+                <div>
+                  <strong className="block text-lg">
+                    {recordImport.preview.imported?.createdCount ?? 0}
+                  </strong>
+                  <span className="text-xs text-muted-foreground">{t('Created')}</span>
+                </div>
+                <div>
+                  <strong className="block text-lg">
+                    {recordImport.preview.imported?.reusedCount ?? 0}
+                  </strong>
+                  <span className="text-xs text-muted-foreground">{t('Reused')}</span>
+                </div>
+                <div>
+                  <strong className="block text-lg">{skippedImportCount}</strong>
+                  <span className="inline-flex items-center justify-center gap-0.5 text-xs text-muted-foreground">
+                    {t('Skipped')}
+                    {skippedImportCount > 0 ? (
+                      <TooltipProvider delayDuration={800}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="icon-xs"
+                              className="-my-1 text-muted-foreground"
+                              aria-label={t('Why were references skipped?')}
+                            >
+                              <Info className="size-3" aria-hidden="true" />
+                            </Button>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="max-w-72 space-y-1 p-2">
+                            {truncatedImportCount > 0 ? (
+                              <p>{t('References after the first 1,000 were skipped.')}</p>
+                            ) : null}
+                            {invalidImportCount > 0 ? (
+                              <p>
+                                {t(
+                                  'Invalid references were skipped. Open View details to review their errors.'
+                                )}
+                              </p>
+                            ) : null}
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    ) : null}
                   </span>
                 </div>
-                <div className="flex min-w-0 items-baseline gap-2 text-sm">
-                  <span className="shrink-0 text-muted-foreground">{t('Import to')}</span>
-                  <span className="min-w-0 font-medium [overflow-wrap:anywhere]">
-                    {destination}
-                  </span>
+                <div>
+                  <strong className="block text-lg">{recordImport.failedCount ?? 0}</strong>
+                  <span className="text-xs text-muted-foreground">{t('Failed')}</span>
                 </div>
-                {!recordImport.preview.imported && recordImport.failedCount === undefined ? (
-                  <div
-                    className={cn(
-                      'grid divide-x divide-border-300/80 border-y border-border-300/80 py-3 text-center',
-                      conflictCount > 0 ? 'grid-cols-4' : 'grid-cols-3'
-                    )}
-                  >
-                    <div>
-                      <strong className="block text-xl tabular-nums">
-                        {recordImport.preview.items.length -
-                          (duplicatePolicy === 'separate' ? 0 : existingCount + conflictCount)}
-                      </strong>
-                      <span className="text-xs text-muted-foreground">{t('New references')}</span>
-                    </div>
-                    <div>
-                      <strong className="block text-xl tabular-nums">{existingCount}</strong>
-                      <span className="text-xs text-muted-foreground">{t('Existing')}</span>
-                    </div>
-                    <div>
-                      <strong className="block text-xl tabular-nums">{skippedImportCount}</strong>
-                      <span className="text-xs text-muted-foreground">{t('Skipped')}</span>
-                    </div>
-                    {conflictCount > 0 ? (
-                      <div>
-                        <strong className="block text-xl tabular-nums">{conflictCount}</strong>
-                        <span className="text-xs text-muted-foreground">
-                          {t('Conflicting identifiers')}
-                        </span>
-                      </div>
-                    ) : null}
-                  </div>
-                ) : null}
-                {!recordImport.preview.imported ? (
-                  <LiteratureDuplicatePolicyField
-                    value={duplicatePolicy}
-                    onChange={onDuplicatePolicyChange}
-                    disabled={isImportingRecords}
-                  />
-                ) : null}
-                {conflictCount > 0 && !recordImport.preview.imported ? (
-                  <LiteratureErrorNotice
-                    title={t('Conflicting identifiers')}
-                    description={t(
-                      'Some identifiers disagree or match different references. Correct the source file or keep separate copies of every reference in this import.'
-                    )}
-                  />
-                ) : null}
-                {recordImport.preview.truncated && !recordImport.preview.imported ? (
-                  <p
-                    role="status"
-                    className="flex items-start gap-2 rounded-lg bg-status-warning-surface px-3 py-2.5 text-sm text-status-warning-foreground dark:bg-status-warning-dark-surface dark:text-status-warning-dark-foreground"
-                  >
-                    <Info className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
-                    <span>{t('Only the first 1,000 references will be imported.')}</span>
-                  </p>
-                ) : null}
-                {isImportingRecords ? (
-                  <p role="status" className="flex items-start gap-2 text-sm text-muted-foreground">
-                    <LoaderCircle
-                      className="mt-0.5 size-4 shrink-0 animate-spin motion-reduce:animate-none"
-                      aria-hidden="true"
-                    />
-                    {t('Saving references and authors. Large imports may take a moment.')}
-                  </p>
-                ) : recordImport.preview.imported ? (
-                  <p role="status" className="flex items-center gap-2 text-sm font-medium">
-                    <Check className="size-4 text-primary" aria-hidden="true" />
-                    {t('Import complete')}
-                  </p>
-                ) : (
-                  <p className="text-xs leading-relaxed text-muted-foreground">
-                    {duplicatePolicy === 'reuse' && conflictCount === 0
-                      ? t(
-                          'Matching DOI, PMID or PMCID references will be reused. PDFs are not downloaded.'
-                        )
-                      : t('PDFs are not downloaded.')}
-                  </p>
-                )}
-                {recordImport.preview.items.length === 0 ? (
-                  <p role="alert" className="text-sm text-danger-000">
-                    {t('No valid references found.')}
-                  </p>
-                ) : null}
-                {recordImport.preview.imported || recordImport.failedCount !== undefined ? (
-                  <div className="grid grid-cols-2 gap-3 border-y border-border-300/80 py-3 text-center text-sm sm:grid-cols-4">
-                    <div>
-                      <strong className="block text-lg">
-                        {recordImport.preview.imported?.createdCount ?? 0}
-                      </strong>
-                      <span className="text-xs text-muted-foreground">{t('Created')}</span>
-                    </div>
-                    <div>
-                      <strong className="block text-lg">
-                        {recordImport.preview.imported?.reusedCount ?? 0}
-                      </strong>
-                      <span className="text-xs text-muted-foreground">{t('Reused')}</span>
-                    </div>
-                    <div>
-                      <strong className="block text-lg">{skippedImportCount}</strong>
-                      <span className="inline-flex items-center justify-center gap-0.5 text-xs text-muted-foreground">
-                        {t('Skipped')}
-                        {skippedImportCount > 0 ? (
-                          <TooltipProvider delayDuration={800}>
-                            <Tooltip>
-                              <TooltipTrigger asChild>
-                                <Button
-                                  type="button"
-                                  variant="ghost"
-                                  size="icon-xs"
-                                  className="-my-1 text-muted-foreground"
-                                  aria-label={t('Why were references skipped?')}
-                                >
-                                  <Info className="size-3" aria-hidden="true" />
-                                </Button>
-                              </TooltipTrigger>
-                              <TooltipContent side="top" className="max-w-72 space-y-1 p-2">
-                                {truncatedImportCount > 0 ? (
-                                  <p>{t('References after the first 1,000 were skipped.')}</p>
-                                ) : null}
-                                {invalidImportCount > 0 ? (
-                                  <p>
-                                    {t(
-                                      'Invalid references were skipped. Open View details to review their errors.'
-                                    )}
-                                  </p>
-                                ) : null}
-                              </TooltipContent>
-                            </Tooltip>
-                          </TooltipProvider>
-                        ) : null}
-                      </span>
-                    </div>
-                    <div>
-                      <strong className="block text-lg">{recordImport.failedCount ?? 0}</strong>
-                      <span className="text-xs text-muted-foreground">{t('Failed')}</span>
-                    </div>
-                  </div>
-                ) : null}
-                <details
-                  key={recordImport.preview.imported ? 'imported' : 'preview'}
-                  open={!recordImport.preview.imported}
-                  className="overflow-hidden rounded-lg border border-border-300/80"
-                >
-                  <summary className="cursor-pointer bg-bg-100 px-3 py-2.5 text-sm font-medium hover:bg-bg-200 focus-visible:outline-2 focus-visible:outline-ring active:bg-bg-300">
-                    {t('View details')} · {recordImport.preview.entries.length}
-                  </summary>
-                  <div className="max-h-[min(38vh,360px)] overflow-y-auto overscroll-contain divide-y divide-border-300/80 border-t border-border-300/80">
-                    {recordImport.preview.entries
-                      .slice(0, recordImportVisibleCount)
-                      .map((entry) => (
-                        <div
-                          key={`${entry.index}:${entry.title}`}
-                          className="grid grid-cols-[1.75rem_minmax(0,1fr)] items-start gap-2 px-3 py-2.5"
-                        >
-                          <span
-                            className="pt-0.5 text-xs tabular-nums text-muted-foreground"
-                            aria-hidden="true"
-                          >
-                            {entry.index + 1}
-                          </span>
-                          <div className="min-w-0">
-                            <div className="flex items-start gap-2">
-                              <p
-                                title={entry.title}
-                                className="min-w-0 flex-1 line-clamp-2 text-sm font-medium [overflow-wrap:anywhere]"
-                              >
-                                {entry.title || t('Unknown')}
-                              </p>
-                              {entry.status !== 'ready' ? (
-                                <span className="shrink-0 rounded bg-bg-200 px-2 py-0.5 text-[11px] text-muted-foreground">
-                                  {entry.status === 'conflict'
-                                    ? t('Conflicting identifiers')
-                                    : entry.status === 'existing'
-                                      ? t('Existing')
-                                      : entry.status === 'warning'
-                                        ? t('Warning')
-                                        : t('Invalid')}
-                                </span>
-                              ) : null}
-                            </div>
-                            {entry.item ? (
-                              <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
-                                {itemDescription(entry.item) || itemTypeLabels[entry.item.itemType]}
-                              </p>
-                            ) : null}
-                            {entry.conflict ? (
-                              <div className="mt-1 space-y-1 text-xs [overflow-wrap:anywhere]">
-                                <p>
-                                  {entry.conflict.identifiers
-                                    .map(({ scheme, value }) => `${scheme.toUpperCase()}: ${value}`)
-                                    .join(' · ')}
-                                </p>
-                                {entry.conflict.matches.map((match) => (
-                                  <p key={match.itemId ?? match.inputIndex}>
-                                    {match.inputIndex === undefined
-                                      ? t('Library reference: {{title}}', { title: match.title })
-                                      : t('File reference {{number}}: {{title}}', {
-                                          number: match.inputIndex + 1,
-                                          title: match.title
-                                        })}
-                                  </p>
-                                ))}
-                              </div>
-                            ) : null}
-                            {entry.warnings.length > 0 ? (
-                              <p className="mt-1 text-xs text-status-warning-foreground dark:text-status-warning-dark-foreground">
-                                {entry.warnings
-                                  .map((warning) =>
-                                    warning === 'uncertain-author-name'
-                                      ? t('Check author names. Original text is kept in Extra.')
-                                      : warning === 'missing-authors'
-                                        ? t('Missing authors')
-                                        : warning === 'missing-year'
-                                          ? t('Missing year')
-                                          : t('Missing journal or venue')
-                                  )
-                                  .join(' · ')}
-                              </p>
-                            ) : entry.error ? (
-                              <p className="mt-1 line-clamp-2 text-xs text-danger-000">
-                                {entry.error}
-                              </p>
-                            ) : null}
-                          </div>
-                        </div>
-                      ))}
-                    {recordImportVisibleCount < recordImport.preview.entries.length ? (
-                      <div className="flex justify-center border-t border-border-300/80 p-2">
-                        <Button
-                          type="button"
-                          variant="ghost"
-                          size="sm"
-                          onClick={() =>
-                            setRecordImportVisibleCount((count) =>
-                              Math.min(
-                                count + LITERATURE_IMPORT_PREVIEW_PAGE_SIZE,
-                                recordImport.preview!.entries.length
-                              )
-                            )
-                          }
-                        >
-                          {t('Show more')}
-                        </Button>
-                      </div>
-                    ) : null}
-                  </div>
-                </details>
               </div>
-            )}
-          </div>
-          <div className="flex shrink-0 flex-wrap justify-end gap-2 border-t border-border-300/80 px-5 py-4">
-            {recordImport.preview?.imported ? (
-              <Button type="button" onClick={() => onClose()}>
-                {t('Done')}
-              </Button>
-            ) : (
-              <>
-                <Button
-                  type="button"
-                  variant="outline"
-                  disabled={isImportingRecords}
-                  onClick={() => onClose()}
-                >
-                  {t('Cancel')}
-                </Button>
-                <Button
-                  type="button"
-                  disabled={
-                    isImportingRecords ||
-                    blockedByConflict ||
-                    !recordImport.preview ||
-                    recordImport.preview.items.length === 0
-                  }
-                  onClick={() => onImport()}
-                >
-                  {isImportingRecords ? (
-                    <LoaderCircle
-                      className="size-4 animate-spin motion-reduce:animate-none"
+            ) : null}
+            <details
+              key={recordImport.preview.imported ? 'imported' : 'preview'}
+              open={!recordImport.preview.imported}
+              className="overflow-hidden rounded-lg border border-border-300/80"
+            >
+              <summary className="cursor-pointer bg-bg-100 px-3 py-2.5 text-sm font-medium hover:bg-bg-200 focus-visible:outline-2 focus-visible:outline-ring active:bg-bg-300">
+                {t('View details')} · {recordImport.preview.entries.length}
+              </summary>
+              <div className="max-h-[min(38vh,360px)] overflow-y-auto overscroll-contain divide-y divide-border-300/80 border-t border-border-300/80">
+                {recordImport.preview.entries.slice(0, recordImportVisibleCount).map((entry) => (
+                  <div
+                    key={`${entry.index}:${entry.title}`}
+                    className="grid grid-cols-[1.75rem_minmax(0,1fr)] items-start gap-2 px-3 py-2.5"
+                  >
+                    <span
+                      className="pt-0.5 text-xs tabular-nums text-muted-foreground"
                       aria-hidden="true"
-                    />
-                  ) : (
-                    <Upload className="size-4" aria-hidden="true" />
-                  )}
-                  {isImportingRecords ? t('Importing…') : t('Import references')}
-                </Button>
-              </>
-            )}
+                    >
+                      {entry.index + 1}
+                    </span>
+                    <div className="min-w-0">
+                      <div className="flex items-start gap-2">
+                        <p
+                          title={entry.title}
+                          className="min-w-0 flex-1 line-clamp-2 text-sm font-medium [overflow-wrap:anywhere]"
+                        >
+                          {entry.title || t('Unknown')}
+                        </p>
+                        {entry.status !== 'ready' ? (
+                          <span className="shrink-0 rounded bg-bg-200 px-2 py-0.5 text-[11px] text-muted-foreground">
+                            {entry.status === 'conflict'
+                              ? t('Conflicting identifiers')
+                              : entry.status === 'existing'
+                                ? t('Existing')
+                                : entry.status === 'warning'
+                                  ? t('Warning')
+                                  : t('Invalid')}
+                          </span>
+                        ) : null}
+                      </div>
+                      {entry.item ? (
+                        <p className="mt-0.5 line-clamp-1 text-xs text-muted-foreground">
+                          {itemDescription(entry.item) || itemTypeLabels[entry.item.itemType]}
+                        </p>
+                      ) : null}
+                      {entry.conflict ? (
+                        <div className="mt-1 space-y-1 text-xs [overflow-wrap:anywhere]">
+                          <p>
+                            {entry.conflict.identifiers
+                              .map(({ scheme, value }) => `${scheme.toUpperCase()}: ${value}`)
+                              .join(' · ')}
+                          </p>
+                          {entry.conflict.matches.map((match) => (
+                            <p key={match.itemId ?? match.inputIndex}>
+                              {match.inputIndex === undefined
+                                ? t('Library reference: {{title}}', { title: match.title })
+                                : t('File reference {{number}}: {{title}}', {
+                                    number: match.inputIndex + 1,
+                                    title: match.title
+                                  })}
+                            </p>
+                          ))}
+                        </div>
+                      ) : null}
+                      {entry.warnings.length > 0 ? (
+                        <p className="mt-1 text-xs text-status-warning-foreground dark:text-status-warning-dark-foreground">
+                          {entry.warnings
+                            .map((warning) =>
+                              warning === 'uncertain-author-name'
+                                ? t('Check author names. Original text is kept in Extra.')
+                                : warning === 'missing-authors'
+                                  ? t('Missing authors')
+                                  : warning === 'missing-year'
+                                    ? t('Missing year')
+                                    : t('Missing journal or venue')
+                            )
+                            .join(' · ')}
+                        </p>
+                      ) : entry.error ? (
+                        <p className="mt-1 line-clamp-2 text-xs text-danger-000">{entry.error}</p>
+                      ) : null}
+                    </div>
+                  </div>
+                ))}
+                {recordImportVisibleCount < recordImport.preview.entries.length ? (
+                  <div className="flex justify-center border-t border-border-300/80 p-2">
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() =>
+                        setRecordImportVisibleCount((count) =>
+                          Math.min(
+                            count + LITERATURE_IMPORT_PREVIEW_PAGE_SIZE,
+                            recordImport.preview!.entries.length
+                          )
+                        )
+                      }
+                    >
+                      {t('Show more')}
+                    </Button>
+                  </div>
+                ) : null}
+              </div>
+            </details>
           </div>
-        </Dialog.Content>
-      </Dialog.Portal>
-    </Dialog.Root>
+        )}
+      </div>
+    </LiteratureImportDialogFrame>
   )
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5003,6 +5003,14 @@
     "Source record saved: {{time}}": "Quellendatensatz gespeichert: {{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "Gespeicherte Quellendatensätze, kein vollständiger Änderungsverlauf. Die Zeiten geben an, wann der jeweilige Datensatz gespeichert wurde.",
     "Could not load metadata sources": "Metadatenquellen konnten nicht geladen werden",
-    "No saved metadata sources for this reference.": "Für diesen Literaturverweis sind keine Metadatenquellen gespeichert."
+    "No saved metadata sources for this reference.": "Für diesen Literaturverweis sind keine Metadatenquellen gespeichert.",
+    "Import PDFs": "PDFs importieren",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Prüfen Sie die Dateien und importieren Sie die ausgewählten PDFs. Lassen Sie dieses Fenster geöffnet, bis der Stapel abgeschlossen ist.",
+    "The result could not be confirmed. Check your library before importing this file again.": "Das Ergebnis konnte nicht bestätigt werden. Prüfen Sie Ihre Bibliothek, bevor Sie diese Datei erneut importieren.",
+    "The reference was kept. Retry to finish adding its PDF.": "Die Referenz wurde beibehalten. Versuchen Sie erneut, das PDF hinzuzufügen.",
+    "Retry unfinished": "Unfertige erneut versuchen",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDFs werden passenden Referenzen angehängt. Identische Anhänge werden wiederverwendet; unterschiedliche PDFs werden separat aufbewahrt.",
+    "{{completed}} / {{total}} completed": "{{completed}} / {{total}} abgeschlossen",
+    "Finishing the current operation before stopping. Completed references are kept.": "Der aktuelle Vorgang wird vor dem Stoppen abgeschlossen. Abgeschlossene Referenzen bleiben erhalten."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5165,6 +5165,14 @@
     "Source record saved: {{time}}": "Registro de fuente guardado: {{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "Registros de fuentes guardados, sin un historial completo de cambios. Las fechas indican cuándo se guardó cada registro.",
     "Could not load metadata sources": "No se pudieron cargar las fuentes de metadatos",
-    "No saved metadata sources for this reference.": "No hay fuentes de metadatos guardadas para esta referencia."
+    "No saved metadata sources for this reference.": "No hay fuentes de metadatos guardadas para esta referencia.",
+    "Import PDFs": "Importar PDF",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Revise los archivos e importe los PDF seleccionados. Mantenga esta ventana abierta hasta que finalice el lote.",
+    "The result could not be confirmed. Check your library before importing this file again.": "No se pudo confirmar el resultado. Revise su biblioteca antes de volver a importar este archivo.",
+    "The reference was kept. Retry to finish adding its PDF.": "Se conservó la referencia. Vuelva a intentarlo para terminar de añadir el PDF.",
+    "Retry unfinished": "Reintentar los pendientes",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "Los PDF se adjuntan a las referencias coincidentes. Los adjuntos idénticos se reutilizan; los PDF diferentes se conservan por separado.",
+    "{{completed}} / {{total}} completed": "{{completed}} / {{total}} completados",
+    "Finishing the current operation before stopping. Completed references are kept.": "Se completará la operación actual antes de detenerse. Las referencias completadas se conservan."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5165,6 +5165,14 @@
     "Source record saved: {{time}}": "Enregistrement de la source : {{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "Sources enregistrées, sans historique complet des modifications. Les dates indiquent quand chaque enregistrement a été sauvegardé.",
     "Could not load metadata sources": "Impossible de charger les sources des métadonnées",
-    "No saved metadata sources for this reference.": "Aucune source de métadonnées enregistrée pour cette référence."
+    "No saved metadata sources for this reference.": "Aucune source de métadonnées enregistrée pour cette référence.",
+    "Import PDFs": "Importer des PDF",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Vérifiez les fichiers, puis importez les PDF sélectionnés. Gardez cette fenêtre ouverte jusqu’à la fin du lot.",
+    "The result could not be confirmed. Check your library before importing this file again.": "Le résultat n’a pas pu être confirmé. Vérifiez votre bibliothèque avant de réimporter ce fichier.",
+    "The reference was kept. Retry to finish adding its PDF.": "La référence a été conservée. Réessayez pour terminer l’ajout du PDF.",
+    "Retry unfinished": "Réessayer les éléments inachevés",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "Les PDF sont joints aux références correspondantes. Les pièces jointes identiques sont réutilisées ; les PDF différents sont conservés séparément.",
+    "{{completed}} / {{total}} completed": "{{completed}} / {{total}} terminés",
+    "Finishing the current operation before stopping. Completed references are kept.": "L’opération en cours se terminera avant l’arrêt. Les références terminées sont conservées."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4849,6 +4849,14 @@
     "Source record saved: {{time}}": "出典レコードの保存日時：{{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "保存済みの出典レコードであり、完全な変更履歴ではありません。日時は各レコードが保存された時刻を示します。",
     "Could not load metadata sources": "メタデータの出典を読み込めませんでした",
-    "No saved metadata sources for this reference.": "この文献には保存済みのメタデータの出典がありません。"
+    "No saved metadata sources for this reference.": "この文献には保存済みのメタデータの出典がありません。",
+    "Import PDFs": "PDF をインポート",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "ファイルを確認して、選択した PDF をインポートします。一括インポートが完了するまで、このウィンドウを開いたままにしてください。",
+    "The result could not be confirmed. Check your library before importing this file again.": "結果を確認できませんでした。このファイルを再度インポートする前に、ライブラリを確認してください。",
+    "The reference was kept. Retry to finish adding its PDF.": "文献は保持されています。再試行して PDF の追加を完了してください。",
+    "Retry unfinished": "未完了の項目を再試行",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF は一致する文献に添付されます。同一の添付ファイルは再利用し、異なる PDF は個別に保持します。",
+    "{{completed}} / {{total}} completed": "{{completed}} / {{total}} 完了",
+    "Finishing the current operation before stopping. Completed references are kept.": "現在の操作を完了してから停止します。完了した文献は保持されます。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4847,6 +4847,14 @@
     "Source record saved: {{time}}": "출처 기록 저장 시간: {{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "저장된 출처 기록이며 전체 변경 이력은 아닙니다. 시간은 각 기록이 저장된 시점을 나타냅니다.",
     "Could not load metadata sources": "메타데이터 출처를 불러오지 못했습니다",
-    "No saved metadata sources for this reference.": "이 문헌에 저장된 메타데이터 출처가 없습니다."
+    "No saved metadata sources for this reference.": "이 문헌에 저장된 메타데이터 출처가 없습니다.",
+    "Import PDFs": "PDF 가져오기",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "파일을 검토한 후 선택한 PDF를 가져오세요. 일괄 가져오기가 완료될 때까지 이 창을 열어 두세요.",
+    "The result could not be confirmed. Check your library before importing this file again.": "결과를 확인할 수 없습니다. 이 파일을 다시 가져오기 전에 라이브러리를 확인하세요.",
+    "The reference was kept. Retry to finish adding its PDF.": "문헌은 유지되었습니다. 다시 시도하여 PDF 추가를 완료하세요.",
+    "Retry unfinished": "미완료 항목 다시 시도",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF는 일치하는 문헌에 첨부됩니다. 동일한 첨부 파일은 재사용하고 서로 다른 PDF는 별도로 유지합니다.",
+    "{{completed}} / {{total}} completed": "{{completed}} / {{total}} 완료",
+    "Finishing the current operation before stopping. Completed references are kept.": "현재 작업을 완료한 후 중지합니다. 완료된 문헌은 유지됩니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5298,6 +5298,14 @@
     "Source record saved: {{time}}": "Запись источника сохранена: {{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "Сохранённые записи источников, а не полная история изменений. Указано время сохранения каждой записи.",
     "Could not load metadata sources": "Не удалось загрузить источники метаданных",
-    "No saved metadata sources for this reference.": "Для этой публикации нет сохранённых источников метаданных."
+    "No saved metadata sources for this reference.": "Для этой публикации нет сохранённых источников метаданных.",
+    "Import PDFs": "Импорт PDF",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Проверьте файлы и импортируйте выбранные PDF. Не закрывайте это окно до завершения пакетного импорта.",
+    "The result could not be confirmed. Check your library before importing this file again.": "Не удалось подтвердить результат. Проверьте библиотеку перед повторным импортом этого файла.",
+    "The reference was kept. Retry to finish adding its PDF.": "Ссылка сохранена. Повторите попытку, чтобы завершить добавление PDF.",
+    "Retry unfinished": "Повторить незавершённые",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF прикрепляются к соответствующим ссылкам. Одинаковые вложения используются повторно, а разные PDF сохраняются отдельно.",
+    "{{completed}} / {{total}} completed": "Завершено {{completed}} / {{total}}",
+    "Finishing the current operation before stopping. Completed references are kept.": "Остановка после завершения текущей операции. Завершённые ссылки сохраняются."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4849,6 +4849,14 @@
     "Source record saved: {{time}}": "来源记录保存时间：{{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "此处为已保存的来源记录，并非完整修改历史。时间表示各条记录的保存时间。",
     "Could not load metadata sources": "无法加载元数据来源",
-    "No saved metadata sources for this reference.": "此文献没有已保存的元数据来源。"
+    "No saved metadata sources for this reference.": "此文献没有已保存的元数据来源。",
+    "Import PDFs": "导入 PDF",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "检查文件，然后导入所选 PDF。请保持此窗口打开，直到批量导入完成。",
+    "The result could not be confirmed. Check your library before importing this file again.": "无法确认结果。再次导入此文件前，请检查文献库。",
+    "The reference was kept. Retry to finish adding its PDF.": "文献已保留。请重试以完成 PDF 添加。",
+    "Retry unfinished": "重试未完成项",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF 将添加到匹配的文献。相同附件会复用，不同 PDF 会分别保留。",
+    "{{completed}} / {{total}} completed": "已完成 {{completed}} / {{total}}",
+    "Finishing the current operation before stopping. Completed references are kept.": "完成当前操作后停止。已完成的文献会保留。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4849,6 +4849,14 @@
     "Source record saved: {{time}}": "來源記錄儲存時間：{{time}}",
     "Saved source records, not a complete change history. Times show when each record was saved.": "此處為已儲存的來源記錄，並非完整修改歷史。時間表示各筆記錄的儲存時間。",
     "Could not load metadata sources": "無法載入中繼資料來源",
-    "No saved metadata sources for this reference.": "此文獻沒有已儲存的中繼資料來源。"
+    "No saved metadata sources for this reference.": "此文獻沒有已儲存的中繼資料來源。",
+    "Import PDFs": "匯入 PDF",
+    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "檢查檔案，然後匯入所選 PDF。請保持此視窗開啟，直到批次匯入完成。",
+    "The result could not be confirmed. Check your library before importing this file again.": "無法確認結果。再次匯入此檔案前，請檢查文獻庫。",
+    "The reference was kept. Retry to finish adding its PDF.": "文獻已保留。請重試以完成 PDF 新增。",
+    "Retry unfinished": "重試未完成項目",
+    "PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.": "PDF 將新增至相符的文獻。相同附件會重複使用，不同 PDF 會分別保留。",
+    "{{completed}} / {{total}} completed": "已完成 {{completed}} / {{total}}",
+    "Finishing the current operation before stopping. Completed references are kept.": "完成目前操作後停止。已完成的文獻會保留。"
   }
 }


### PR DESCRIPTION
## Problem

Library → Import PDF reads only the first selected file and requires a separate editor flow for each reference.

## Proposed change

Allow multiple PDFs in the picker. Multiple selection opens one preview with selection, destination, existing duplicate policy, sequential import progress, per-file results, Stop, and retry of unfinished files. Single selection retains the existing editor.

Reuse a shared import dialog frame with bibliography import, the duplicate-policy component, metadata extraction/completion, managed upload staging, and existing catalog/PDF APIs. Retain created reference IDs and completed destination links for retries. Unconfirmed creation outcomes require a library check instead of replaying a potentially committed creation.

## Scope and non-goals

- Foreground batch only; no automatic resume after closing/restarting the app.
- Existing single-reference PDF attachment/drop behavior remains unchanged.
- No historical migration or compatibility layer. No schema, persistent job enum, checkpoint or API change.
- New per-file statuses are renderer-only. Normal reference, destination-link and attachment writes use existing persistence owners. A reference may remain without its PDF after failure; the row explains this and supports retry when its ID is known.

## Acceptance criteria and validation

After rebasing onto main d3d6e03d, **1,256 tests passed across 10 focused files**. Independent review then identified a failed upload-claim cleanup path. The new regression failed before the fix; the final follow-up Test Impact Set (batch dialog, composer transfer, and main upload command-owner tests) passed **37 tests** after the last material edit, together with renderer typecheck and full repository lint. The broader feature results precede this focused follow-up. Full local `npm test` was intentionally omitted per maintainer instruction; exact-head PR CI remains authoritative. The affected-plan classifier selects full CI because Literature is not covered by module routing. No new module routing was introduced.

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| Multi-selection, preview, failure isolation, destination receipt, stop/unmount, retry | Library page and new PDF batch dialog render tests | Passed |
| Shared dialog consumer, unchanged single import, local/remote metadata | Import identity and PDF metadata/completion tests | Passed |
| Upload cancellation, catalog identity, managed PDF attachment cleanup/deduplication | Composer transfer, catalog, PDF importer and attachment reliability tests | Passed |
| Eight locale catalogs and renderer contracts | i18n resources tests; `npm run typecheck:web`; `npm run lint` | Passed |

<details><summary>Reproduce the focused suite</summary>

```sh
npx vitest run \
  src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx \
  src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx \
  src/renderer/src/pages/literature/LiteratureImportIdentity.render.test.tsx \
  src/renderer/src/pages/literature/literature-pdf-metadata.test.ts \
  src/renderer/src/pages/literature/literature-pdf-completion.test.ts \
  src/renderer/src/pages/workspace/composer-upload-transfer.test.ts \
  src/main/literature/catalog.test.ts \
  src/main/literature/pdf-importer.test.ts \
  src/main/literature/pdf-attachment-reliability.test.ts \
  src/renderer/src/i18n/resources.test.ts
```

</details>

The shared frame's bibliography consumer is included because its dialog shell changed. Existing upload/catalog owners are included because batch execution now calls them repeatedly. The upload publication follow-up changes main-process scheduling behind the existing facade, so node typechecking and upload lifecycle/architecture/consumer tests are included. No schema migration is needed. Cross-platform E2E and independent review remain CI responsibilities.

## Review focus

Failed staging claims now abort the transfer before continuing, matching the composer owner. Check the cancellation/submission boundary, uncertain creation response handling, and retention of completed work during retry. CodeGraph's base-tree relationships informed analysis; its index does not cover this worktree, so final imports and consumer tests were checked directly.

Browser interaction exercised through ego-browser using production components/CSS with controlled API responses: preview → upload progress → 2/3 complete → retry → 3/3 complete. This is UI evidence, not a real database/browser integration test.


Final follow-up command: `npx vitest run src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx src/renderer/src/pages/workspace/composer-upload-transfer.test.ts src/main/uploads/command-owner.test.ts` (37 passed). This covers the changed cleanup branch, shared staging contract, and main-process lease owner. No interface, UI, or persisted format changed in the follow-up. Independent review accepted this cleanup commit; the subsequent Windows CI repair below requires fresh exact-head checks and review.


### Windows CI repair

Windows E2E failed while finalizing a ten-file attachment batch: concurrent SQLite publication transactions exhausted the existing transaction-start wait budget. Publish each batch sequentially through the existing upload owner, preserving attachment order and idempotent retry. If publication fails, later files remain staged. The transaction timeout is unchanged.

After the last material edit, the focused upload Test Impact Set passed **82 tests across six files**. It covers repository persistence/retry, characterization, owner boundaries, publication recovery, command ownership and the composer consumer. A deterministic regression fails against the previous concurrent implementation (ten publications started instead of one). The exact previously failing Electron test also passed locally on macOS; Windows remains subject to CI.

```sh
npx vitest run \
  src/main/uploads/repository.test.ts \
  src/main/uploads/repository.characterization.test.ts \
  src/main/uploads/repository.architecture.test.ts \
  src/main/uploads/publication-lifecycle.integration.test.ts \
  src/main/uploads/command-owner.test.ts \
  src/renderer/src/pages/workspace/composer-upload-transfer.test.ts
npm run typecheck:node
npm run lint
npm run build:e2e
npx playwright test e2e/workspace-files.spec.ts \
  --grep 'preserves expanded uploads after saving a file version' --workers=1
```

The repair changes scheduling of existing persistent upload writes; it adds no tables, stored fields, enums, migration or historical compatibility layer. It has no UI changes. Review sequential failure/retry behavior and cross-platform transaction handling. Exact-head CI and independent review are pending.


### Empty filename-stem review fix

Preserve the original filename when removing the PDF extension and separators yields an empty title (for example `.pdf` or `___---.PDF`). This shared helper serves both single and batch import, preventing an invalid empty title from reaching reference creation. No new UI copy, schema, enum or migration is introduced.

After this final material edit: **303 tests passed across four files**, plus `npm run typecheck:web` and `npm run lint`. The new batch regression fails before the fix. Checks: `npx vitest run src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx src/renderer/src/pages/literature/literature-pdf-metadata.test.ts src/renderer/src/pages/literature/literature-pdf-completion.test.ts`. These cover the helper's single/batch consumers and metadata fallback path. Earlier upload verification precedes this renderer-only follow-up. Final CI and independent review remain pending.
