### PR TITLE
fix(preview): hide reading entry for single-page PDFs

### DIFF
--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -3397,6 +3397,59 @@ describe('PreviewFileSurface PDF context action matrix', () => {
     }
   )
 
+  it.each([undefined, 1, 2])(
+    'gates the PDF content-menu reading entry for %s pages',
+    async (pageCount) => {
+      pdfPageReport.enabled = false
+      selectPdfContextSession()
+      installPdfContextApi()
+      await act(async () => {
+        root.render(<PreviewFileSurface item={pdfItem} onClose={vi.fn()} />)
+      })
+      if (pageCount !== undefined) {
+        act(() => {
+          previewContentSpy.mock.calls.at(-1)?.[0].onPdfReadingPositionChange({
+            pageNumber: 1,
+            pageCount
+          })
+        })
+      }
+      act(() => {
+        container
+          .querySelector('[data-testid="preview-file-content-surface"]')
+          ?.dispatchEvent(
+            new MouseEvent('contextmenu', { bubbles: true, clientX: 80, clientY: 120 })
+          )
+      })
+      await act(async () => Promise.resolve())
+      const menu = document.body.querySelector('[data-testid="preview-content-context-menu"]')
+      expect(menu).not.toBeNull()
+      expect(menu?.textContent?.includes('Read with agent')).toBe(pageCount === 2)
+      expect(menu?.textContent).toContain('Download')
+    }
+  )
+
+  it('keeps the content-menu removal action for a linked single-page PDF', async () => {
+    selectPdfContextSession(linkedPdfContext)
+    const { unlinkPdfContext } = installPdfContextApi()
+    await act(async () => {
+      root.render(<PreviewFileSurface item={pdfItem} onClose={vi.fn()} />)
+    })
+    act(() => {
+      previewContentSpy.mock.calls
+        .at(-1)?.[0]
+        .onPdfReadingPositionChange({ pageNumber: 1, pageCount: 1 })
+      container
+        .querySelector('[data-testid="preview-file-content-surface"]')
+        ?.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, clientX: 80, clientY: 120 }))
+    })
+    await act(async () => Promise.resolve())
+    await clickMenuItem('Remove PDF from context')
+    expect(unlinkPdfContext).toHaveBeenCalledWith(
+      expect.objectContaining({ bindingId: 'binding-1' })
+    )
+  })
+
   it('retains the removal control for an already linked single-page PDF', async () => {
     selectPdfContextSession(linkedPdfContext)
     const { unlinkPdfContext } = installPdfContextApi()

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, createRef } from 'react'
+import { act, createRef, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -23,6 +23,7 @@ import {
 
 const provenancePanelSpy = vi.hoisted(() => vi.fn())
 const previewContentSpy = vi.hoisted(() => vi.fn())
+const pdfPageReport = vi.hoisted(() => ({ enabled: true }))
 const diffContentSpy = vi.hoisted(() => vi.fn())
 const downloadButtonSpy = vi.hoisted(() => vi.fn())
 
@@ -66,6 +67,12 @@ vi.mock('./previews/PreviewFileContent', () => ({
     onPdfReadingPositionChange?: (position: { pageNumber: number; pageCount: number }) => void
   }) => {
     previewContentSpy(props)
+    const { onPdfReadingPositionChange } = props
+    useEffect(() => {
+      if (pdfPageReport.enabled) {
+        onPdfReadingPositionChange?.({ pageNumber: 1, pageCount: 2 })
+      }
+    }, [onPdfReadingPositionChange])
     return (
       <div data-testid="preview-content" data-path={props.item.path}>
         Preview content
@@ -248,6 +255,7 @@ const selectPdfContextSession = (
 }
 
 beforeEach(() => {
+  pdfPageReport.enabled = true
   previewLeaveGuards.clear()
   provenancePanelSpy.mockClear()
   previewContentSpy.mockClear()
@@ -3344,6 +3352,66 @@ describe('PreviewFileSurface PDF context action matrix', () => {
     })
     await act(async () => Promise.resolve())
     expect(document.body.querySelector('[data-testid="pdf-preview-context-menu"]')).toBeNull()
+  })
+
+  it.each([false, true])(
+    'hides the single-page PDF header entry (Library: %s)',
+    async (library) => {
+      pdfPageReport.enabled = false
+      selectPdfContextSession()
+      installPdfContextApi()
+      const render = async (item: PreviewFileItem): Promise<void> => {
+        await act(async () => {
+          root.render(
+            <PreviewFileSurface
+              item={item}
+              onReadWithAgent={library ? vi.fn() : undefined}
+              onClose={vi.fn()}
+            />
+          )
+        })
+      }
+      const reportPages = (pageCount: number): void => {
+        const props = previewContentSpy.mock.calls.at(-1)?.[0]
+        expect(props.onPdfReadingPositionChange).toBeTypeOf('function')
+        act(() => props.onPdfReadingPositionChange({ pageNumber: 1, pageCount }))
+      }
+      const headerAction = (): Element | null =>
+        container.querySelector('[data-testid="pdf-context-action"]')
+
+      await render(pdfItem)
+      expect(headerAction()).toBeNull()
+      reportPages(1)
+      expect(headerAction()).toBeNull()
+      expect(usePreviewWorkbenchStore.getState().pdfReadingPositionByBindingId).toEqual({})
+
+      await render({ ...pdfItem, selectedVersionId: 'another-version' })
+      expect(headerAction()).toBeNull()
+      reportPages(2)
+      expect(headerAction()?.textContent).toContain('Read with agent')
+
+      await render({ ...pdfItem, id: 'another-pdf', path: 'another.pdf' })
+      expect(headerAction()).toBeNull()
+      reportPages(1)
+      expect(headerAction()).toBeNull()
+    }
+  )
+
+  it('retains the removal control for an already linked single-page PDF', async () => {
+    selectPdfContextSession(linkedPdfContext)
+    const { unlinkPdfContext } = installPdfContextApi()
+    await act(async () => {
+      root.render(<PreviewFileSurface item={pdfItem} onClose={vi.fn()} />)
+    })
+    act(() => {
+      previewContentSpy.mock.calls.at(-1)?.[0].onPdfReadingPositionChange({
+        pageNumber: 1,
+        pageCount: 1
+      })
+    })
+    await openMenu(container.querySelector('[data-testid="pdf-context-status"]'))
+    await clickMenuItem('Remove PDF from context')
+    expect(unlinkPdfContext).toHaveBeenCalled()
   })
 
   it('lets a Library preview supply its own Read with agent action without linking a Session', async () => {

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -893,12 +893,27 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
         : {}),
       suggestedName: resolvedPreviewItem.name
     })
+    const pdfPageCountKey = JSON.stringify([
+      contentItem.id,
+      contentItem.path,
+      contentItem.selectedVersionId,
+      previewContentKey
+    ])
+    const [pdfPageCount, setPdfPageCount] = useState<{ key: string; count: number }>()
+    const hidePdfReadingEntry =
+      contentItem.format === 'pdf' &&
+      (pdfPageCount?.key !== pdfPageCountKey || pdfPageCount.count <= 1)
     const reportPdfReadingPosition = useCallback(
       (position: { pageNumber: number; pageCount: number }): void => {
+        setPdfPageCount((current) =>
+          current?.key === pdfPageCountKey && current.count === position.pageCount
+            ? current
+            : { key: pdfPageCountKey, count: position.pageCount }
+        )
         if (!readingContextBindingId) return
         usePreviewWorkbenchStore.getState().setPdfReadingPosition(readingContextBindingId, position)
       },
-      [readingContextBindingId]
+      [pdfPageCountKey, readingContextBindingId]
     )
     const stageLocalPath = window.api.uploads?.stageLocalPath
 
@@ -1430,7 +1445,11 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                 onClose={closePreview}
                 onOpenFullScreen={onOpenFullScreen}
                 onReload={() => setReloadToken((token) => token + 1)}
-                pdfContextAction={pdfContextAction}
+                pdfContextAction={
+                  hidePdfReadingEntry && pdfContextAction?.state === 'link'
+                    ? undefined
+                    : pdfContextAction
+                }
                 saveAsArtifactState={saveAsArtifactState}
                 managedDownload={managedDownload}
                 provenanceEntry={provenanceEntry}
@@ -1659,9 +1678,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                           onRedoAnnotation={onRedoAnnotation}
                           onAnnotationError={onAnnotationError}
                           onRetry={retryManagedPreview}
-                          onPdfReadingPositionChange={
-                            readingContextBindingId ? reportPdfReadingPosition : undefined
-                          }
+                          onPdfReadingPositionChange={reportPdfReadingPosition}
                         />
                       ) : null
                     ) : managedWorkflow.diffResult ? (
@@ -1695,9 +1712,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                       onRedoAnnotation={onRedoAnnotation}
                       onAnnotationError={onAnnotationError}
                       onRetry={retryManagedPreview}
-                      onPdfReadingPositionChange={
-                        readingContextBindingId ? reportPdfReadingPosition : undefined
-                      }
+                      onPdfReadingPositionChange={reportPdfReadingPosition}
                     />
                   ) : null}
                 </div>

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -99,6 +99,7 @@ type PreviewFileSurfaceProps = PreviewInteractionPort & {
   item: PreviewFileItem
   allowReadingContext?: boolean
   onReadWithAgent?: (item: PreviewFileItem) => void
+  onPdfPageCountChange?: (pageCount: number | undefined) => void
   contentKey?: string
   renderContent?: boolean
   tooltipClassName?: string
@@ -630,6 +631,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
       item,
       allowReadingContext = true,
       onReadWithAgent,
+      onPdfPageCountChange,
       contentKey,
       renderContent = true,
       tooltipClassName,
@@ -900,9 +902,14 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
       previewContentKey
     ])
     const [pdfPageCount, setPdfPageCount] = useState<{ key: string; count: number }>()
-    const hidePdfReadingEntry =
-      contentItem.format === 'pdf' &&
-      (pdfPageCount?.key !== pdfPageCountKey || pdfPageCount.count <= 1)
+    const confirmedPdfPageCount =
+      contentItem.format === 'pdf' && pdfPageCount?.key === pdfPageCountKey
+        ? pdfPageCount.count
+        : undefined
+    useEffect(() => {
+      onPdfPageCountChange?.(confirmedPdfPageCount)
+    }, [confirmedPdfPageCount, onPdfPageCountChange])
+    const hidePdfReadingEntry = contentItem.format === 'pdf' && (confirmedPdfPageCount ?? 0) <= 1
     const visiblePdfContextAction =
       hidePdfReadingEntry && pdfContextAction?.state === 'link' ? undefined : pdfContextAction
     const reportPdfReadingPosition = useCallback(

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -903,6 +903,8 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     const hidePdfReadingEntry =
       contentItem.format === 'pdf' &&
       (pdfPageCount?.key !== pdfPageCountKey || pdfPageCount.count <= 1)
+    const visiblePdfContextAction =
+      hidePdfReadingEntry && pdfContextAction?.state === 'link' ? undefined : pdfContextAction
     const reportPdfReadingPosition = useCallback(
       (position: { pageNumber: number; pageCount: number }): void => {
         setPdfPageCount((current) =>
@@ -1355,21 +1357,21 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
             close: { execute: closePreview }
           }
         : {
-            ...(pdfContextAction
+            ...(visiblePdfContextAction
               ? {
                   'pdf-context': {
                     execute: () => {
                       // Linking intentionally moves focus to the composer after the menu closes.
                       contextMenuComposerFocusRequestedRef.current =
-                        pdfContextAction.state !== 'remove'
-                      return pdfContextAction.run()
+                        visiblePdfContextAction.state !== 'remove'
+                      return visiblePdfContextAction.run()
                     },
-                    disabled: pdfContextAction.disabled || pdfContextAction.pending,
+                    disabled: visiblePdfContextAction.disabled || visiblePdfContextAction.pending,
                     labelKey:
-                      pdfContextAction.state === 'remove'
+                      visiblePdfContextAction.state === 'remove'
                         ? 'Remove PDF from context'
                         : 'Read with agent',
-                    icon: pdfContextAction.state === 'remove' ? Link2Off : BookOpen
+                    icon: visiblePdfContextAction.state === 'remove' ? Link2Off : BookOpen
                   }
                 }
               : {}),
@@ -1445,11 +1447,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                 onClose={closePreview}
                 onOpenFullScreen={onOpenFullScreen}
                 onReload={() => setReloadToken((token) => token + 1)}
-                pdfContextAction={
-                  hidePdfReadingEntry && pdfContextAction?.state === 'link'
-                    ? undefined
-                    : pdfContextAction
-                }
+                pdfContextAction={visiblePdfContextAction}
                 saveAsArtifactState={saveAsArtifactState}
                 managedDownload={managedDownload}
                 provenanceEntry={provenanceEntry}

--- a/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { act, StrictMode } from 'react'
+import { act, StrictMode, useEffect } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -22,25 +22,37 @@ vi.mock('@/components/ui/resizable', () => ({
   )
 }))
 
+const pdfPreviewReport = vi.hoisted(() => ({ pageCount: 2 as number | undefined, props: vi.fn() }))
+
 vi.mock('./previews/PreviewFileContent', () => ({
   PreviewFileContent: ({
     item,
     activeAnnotations,
-    onAddAnnotation
+    onAddAnnotation,
+    onPdfReadingPositionChange
   }: {
     item: PreviewFileItem
     activeAnnotations?: readonly Annotation[]
     onAddAnnotation?: (annotation: Annotation) => void
-  }): React.JSX.Element => (
-    <button
-      type="button"
-      data-testid="file-content"
-      data-annotation-count={activeAnnotations?.length ?? 0}
-      onClick={() => activeAnnotations?.[0] && onAddAnnotation?.(activeAnnotations[0])}
-    >
-      file:{item.format}:{item.source ?? 'artifact'}:{item.name}:{item.path}
-    </button>
-  )
+    onPdfReadingPositionChange?: (position: { pageNumber: number; pageCount: number }) => void
+  }): React.JSX.Element => {
+    pdfPreviewReport.props({ item, onPdfReadingPositionChange })
+    useEffect(() => {
+      if (item.format === 'pdf' && pdfPreviewReport.pageCount !== undefined) {
+        onPdfReadingPositionChange?.({ pageNumber: 1, pageCount: pdfPreviewReport.pageCount })
+      }
+    }, [item.format, onPdfReadingPositionChange])
+    return (
+      <button
+        type="button"
+        data-testid="file-content"
+        data-annotation-count={activeAnnotations?.length ?? 0}
+        onClick={() => activeAnnotations?.[0] && onAddAnnotation?.(activeAnnotations[0])}
+      >
+        file:{item.format}:{item.source ?? 'artifact'}:{item.name}:{item.path}
+      </button>
+    )
+  }
 }))
 
 vi.mock('./previews/PreviewToolContent', () => ({
@@ -90,6 +102,8 @@ describe('PreviewPanel', () => {
   let releaseSourcePreview: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    pdfPreviewReport.pageCount = 2
+    pdfPreviewReport.props.mockClear()
     usePreviewWorkbenchStore.setState(createInitialPreviewWorkbenchState())
     releaseSourcePreview = vi.fn()
     window.api = {
@@ -1481,6 +1495,99 @@ describe('PreviewPanel', () => {
     ).toBeNull()
   })
 
+  it.each([undefined, 1, 2])(
+    'gates the PDF tab reading entry for %s confirmed pages',
+    async (pageCount) => {
+      pdfPreviewReport.pageCount = pageCount
+      useSessionStore.setState({ sessions: [], selectedSessionId: undefined })
+      usePreviewWorkbenchStore.getState().activateProject('project-1')
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+        createFileItem({
+          projectId: 'project-1',
+          format: 'pdf',
+          name: 'paper.pdf',
+          title: 'paper.pdf',
+          selectedVersionId: 'version-1'
+        })
+      )
+      await renderPanel()
+      await openTabContextMenu(0)
+      expect(menuCommands().includes('toggle-pdf-context')).toBe(pageCount === 2)
+      expect(menuCommands()).toContain('download')
+    }
+  )
+
+  it('keeps confirmed inactive PDF counts and invalidates replaced or reopened tabs', async () => {
+    useSessionStore.setState({ sessions: [], selectedSessionId: undefined })
+    usePreviewWorkbenchStore.getState().activateProject('project-1')
+    const pdf = createFileItem({
+      projectId: 'project-1',
+      format: 'pdf',
+      name: 'paper.pdf',
+      title: 'paper.pdf',
+      selectedVersionId: 'version-1'
+    })
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(pdf)
+    await renderPanel()
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(createToolItem({}))
+    })
+    await openTabContextMenu(0)
+    expect(menuCommands()).toContain('toggle-pdf-context')
+
+    pdfPreviewReport.pageCount = undefined
+    await act(async () => {
+      usePreviewWorkbenchStore
+        .getState()
+        .upsertAndActivateItem({ ...pdf, selectedVersionId: 'version-2' })
+    })
+    await openTabContextMenu(0)
+    expect(menuCommands()).not.toContain('toggle-pdf-context')
+    await act(async () => {
+      pdfPreviewReport.props.mock.calls
+        .at(-1)?.[0]
+        .onPdfReadingPositionChange({ pageNumber: 1, pageCount: 2 })
+    })
+    await openTabContextMenu(0)
+    expect(menuCommands()).toContain('toggle-pdf-context')
+
+    const current = usePreviewWorkbenchStore.getState().items.find((entry) => entry.id === pdf.id)!
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().removeItem(pdf.id)
+    })
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(current)
+    })
+    await openTabContextMenu(1)
+    expect(menuCommands()).not.toContain('toggle-pdf-context')
+  })
+
+  it('does not reuse a previous project PDF count', async () => {
+    useSessionStore.setState({ sessions: [], selectedSessionId: undefined })
+    usePreviewWorkbenchStore.getState().activateProject('project-1')
+    const pdf = createFileItem({
+      projectId: 'project-1',
+      format: 'pdf',
+      name: 'paper.pdf',
+      title: 'paper.pdf',
+      selectedVersionId: 'version-1'
+    })
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(pdf)
+    await renderPanel()
+    await openTabContextMenu(0)
+    expect(menuCommands()).toContain('toggle-pdf-context')
+
+    pdfPreviewReport.pageCount = undefined
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().activateProject('project-2')
+    })
+    await act(async () => {
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem({ ...pdf, projectId: 'project-2' })
+    })
+    await openTabContextMenu(0)
+    expect(menuCommands()).not.toContain('toggle-pdf-context')
+  })
+
   it('leads a linkable PDF tab menu with Read with agent and links through it', async () => {
     const linkPdfContext = vi.fn().mockResolvedValue({ version: 1, revision: 2 })
     usePreviewWorkbenchStore.getState().activateProject('project-1')
@@ -1691,67 +1798,77 @@ describe('PreviewPanel', () => {
     expect(document.activeElement).toBe(document.getElementById('preview-tab-item-1'))
   })
 
-  it('labels the PDF tab command Remove PDF from context when the tab is the current binding', async () => {
-    usePreviewWorkbenchStore.getState().activateProject('project-1')
-    window.api.artifacts = {
-      getLineage: vi.fn().mockResolvedValue(undefined)
-    } as unknown as Window['api']['artifacts']
-    useSessionStore.setState({
-      sessions: [
-        {
-          id: 'session-1',
-          projectId: 'project-1',
-          title: 'Session',
-          cwd: '/workspace',
-          status: 'idle',
-          messages: [],
-          runtimeContext: {
-            version: 1,
-            revision: 1,
-            pdfContext: {
+  it.each([undefined, 1])(
+    'keeps the linked PDF tab removal command with %s confirmed pages',
+    async (pageCount) => {
+      pdfPreviewReport.pageCount = pageCount
+      const unlinkPdfContext = vi.fn().mockResolvedValue(undefined)
+      window.api.sessions = { unlinkPdfContext } as unknown as Window['api']['sessions']
+      usePreviewWorkbenchStore.getState().activateProject('project-1')
+      window.api.artifacts = {
+        getLineage: vi.fn().mockResolvedValue(undefined)
+      } as unknown as Window['api']['artifacts']
+      useSessionStore.setState({
+        sessions: [
+          {
+            id: 'session-1',
+            projectId: 'project-1',
+            title: 'Session',
+            cwd: '/workspace',
+            status: 'idle',
+            messages: [],
+            runtimeContext: {
               version: 1,
-              bindings: [
-                {
-                  version: 1,
-                  bindingId: 'binding-1',
-                  sourceKind: 'artifact-version',
-                  sourceFileId: 'artifact-1',
-                  sourceVersionId: 'version-1',
-                  sourceSessionId: 'session-1',
-                  name: 'paper.pdf',
-                  mimeType: 'application/pdf',
-                  sizeBytes: 12,
-                  checksum: 'checksum-1',
-                  linkedAt: 1
-                }
-              ]
-            }
-          },
-          createdAt: 1,
-          updatedAt: 1
-        } as ChatSession
-      ],
-      selectedSessionId: 'session-1'
-    })
-    usePreviewWorkbenchStore.getState().upsertAndActivateItem(
-      createFileItem({
-        format: 'pdf',
-        title: 'paper.pdf',
-        name: 'paper.pdf',
-        artifactId: 'artifact-1',
-        selectedVersionId: 'version-1',
-        path: 'artifact-version:project-1/session-1/artifact-1/version-1'
+              revision: 1,
+              pdfContext: {
+                version: 1,
+                bindings: [
+                  {
+                    version: 1,
+                    bindingId: 'binding-1',
+                    sourceKind: 'artifact-version',
+                    sourceFileId: 'artifact-1',
+                    sourceVersionId: 'version-1',
+                    sourceSessionId: 'session-1',
+                    name: 'paper.pdf',
+                    mimeType: 'application/pdf',
+                    sizeBytes: 12,
+                    checksum: 'checksum-1',
+                    linkedAt: 1
+                  }
+                ]
+              }
+            },
+            createdAt: 1,
+            updatedAt: 1
+          } as ChatSession
+        ],
+        selectedSessionId: 'session-1'
       })
-    )
-    await renderPanel()
+      usePreviewWorkbenchStore.getState().upsertAndActivateItem(
+        createFileItem({
+          format: 'pdf',
+          title: 'paper.pdf',
+          name: 'paper.pdf',
+          artifactId: 'artifact-1',
+          selectedVersionId: 'version-1',
+          path: 'artifact-version:project-1/session-1/artifact-1/version-1'
+        })
+      )
+      await renderPanel()
 
-    await openTabContextMenu(0)
+      await openTabContextMenu(0)
 
-    const command = document.body.querySelector('[data-action-id="toggle-pdf-context"]')
-    expect(command?.textContent).toContain('Remove PDF from context')
-    // Unlink is reversible, so it never takes the danger styling.
-    expect(command?.className).not.toContain('danger')
-  })
+      const command = document.body.querySelector('[data-action-id="toggle-pdf-context"]')
+      expect(command?.textContent).toContain('Remove PDF from context')
+      // Unlink is reversible, so it never takes the danger styling.
+      expect(command?.className).not.toContain('danger')
+      await clickMenuCommand('toggle-pdf-context')
+      expect(unlinkPdfContext).toHaveBeenCalledWith(
+        expect.objectContaining({ bindingId: 'binding-1' })
+      )
+    }
+  )
 
   it('omits the reading-context command for non-PDF and non-linkable tabs', async () => {
     useSessionStore.setState({ sessions: [], selectedSessionId: undefined })

--- a/src/renderer/src/pages/workspace/PreviewPanel.tsx
+++ b/src/renderer/src/pages/workspace/PreviewPanel.tsx
@@ -96,6 +96,7 @@ const PREVIEW_TAB_EDGE_INSET = 8
 const PreviewTabActionTarget = ({
   item,
   tabCount,
+  pdfPageCount,
   retryPendingKeys,
   onPdfContextError,
   onFileActionSuccess,
@@ -105,6 +106,7 @@ const PreviewTabActionTarget = ({
 }: {
   item: PreviewItem
   tabCount: number
+  pdfPageCount?: number
   retryPendingKeys?: ReadonlySet<string>
   onPdfContextError?: (message: string | null) => void
   onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
@@ -117,11 +119,15 @@ const PreviewTabActionTarget = ({
   const removeItem = usePreviewWorkbenchStore((state) => state.removeItem)
   const removeOtherItems = usePreviewWorkbenchStore((state) => state.removeOtherItems)
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
-  const { action: pdfAction } = usePdfContextAction(
+  const { action: availablePdfAction } = usePdfContextAction(
     item.type === 'file' ? item : undefined,
     onPdfContextError,
     { link: onLinkReadingContext, unlink: onUnlinkReadingContext }
   )
+  const pdfAction =
+    availablePdfAction?.state === 'remove' || (pdfPageCount ?? 0) > 1
+      ? availablePdfAction
+      : undefined
   const context: PreviewTabActionContext = {
     tabCount,
     retryPendingKeys,
@@ -246,6 +252,7 @@ const PreviewTab = ({
   containerRef,
   tabRef,
   tabCount,
+  pdfPageCount,
   retryPendingKeys,
   onPdfContextError,
   onFileActionSuccess,
@@ -260,6 +267,7 @@ const PreviewTab = ({
   containerRef: (element: HTMLDivElement | null) => void
   tabRef: (element: HTMLButtonElement | null) => void
   tabCount: number
+  pdfPageCount?: number
   retryPendingKeys?: ReadonlySet<string>
   onPdfContextError?: (message: string | null) => void
   onFileActionSuccess?: (command: PreviewTabActionCommand, item: PreviewItem) => void
@@ -284,6 +292,7 @@ const PreviewTab = ({
       <PreviewTabActionTarget
         item={tab}
         tabCount={tabCount}
+        pdfPageCount={pdfPageCount}
         retryPendingKeys={retryPendingKeys}
         onPdfContextError={onPdfContextError}
         onFileActionSuccess={onFileActionSuccess}
@@ -348,6 +357,7 @@ const PreviewTab = ({
 // Horizontal, scrollable strip of every file the user has asked to preview this session.
 const PreviewTabBar = ({
   tabs,
+  pdfPageCounts,
   retryPendingKeys,
   activeItemId,
   onActivate,
@@ -358,6 +368,7 @@ const PreviewTabBar = ({
   onUnlinkReadingContext
 }: {
   tabs: PreviewItem[]
+  pdfPageCounts: ReadonlyMap<PreviewFileItem, number>
   retryPendingKeys?: ReadonlySet<string>
   activeItemId: string | undefined
   onActivate: (id: string) => void
@@ -460,6 +471,7 @@ const PreviewTabBar = ({
             tabRefs.current[index] = element
           }}
           tabCount={tabs.length}
+          pdfPageCount={tab.type === 'file' ? pdfPageCounts.get(tab) : undefined}
           retryPendingKeys={retryPendingKeys}
           onPdfContextError={onPdfContextError}
           onFileActionSuccess={onFileActionSuccess}
@@ -552,12 +564,14 @@ const usePreviewModalSurface = ({
 const PreviewFilePanel = ({
   item,
   contentKey,
+  onPdfPageCountChange,
   onClose,
   onPdfContextError,
   ...annotationPort
 }: {
   item: PreviewFileItem
   contentKey: string
+  onPdfPageCountChange: (item: PreviewFileItem, pageCount: number | undefined) => void
   onClose: (id: string) => boolean
   onPdfContextError?: (message: string | null) => void
 } & PreviewInteractionPort): React.JSX.Element => {
@@ -565,6 +579,10 @@ const PreviewFilePanel = ({
   const [isFullScreenOpen, setIsFullScreenOpen] = useState(false)
   const surfaceRef = useRef<HTMLElement | null>(null)
   const previewSurfaceRef = useRef<PreviewFileSurfaceHandle | null>(null)
+  const reportPdfPageCount = useCallback(
+    (pageCount: number | undefined): void => onPdfPageCountChange(item, pageCount),
+    [item, onPdfPageCountChange]
+  )
 
   const closeFullScreen = useCallback((checkGuard = true): void => {
     if (checkGuard && previewSurfaceRef.current) {
@@ -619,6 +637,7 @@ const PreviewFilePanel = ({
           ref={previewSurfaceRef}
           item={item}
           contentKey={contentKey}
+          onPdfPageCountChange={reportPdfPageCount}
           // Full-screen mode floats above the modal panel (z-[61]); tooltips must follow.
           tooltipClassName={isFullScreenOpen ? 'z-[70]' : undefined}
           actionMenuContentClassName={isFullScreenOpen ? 'z-[70]' : undefined}
@@ -791,6 +810,31 @@ const PreviewPanelSurface = ({
   }
 
   const items = usePreviewWorkbenchStore((state) => state.items)
+  // Object identity invalidates counts when a tab's file/version is replaced. Keep only open tabs;
+  // inactive file renderers unmount, but their confirmed counts remain useful in the tab menu.
+  const [pdfPageCounts, setPdfPageCounts] = useState<ReadonlyMap<PreviewFileItem, number>>(
+    () => new Map()
+  )
+  const reportPdfPageCount = useCallback(
+    (item: PreviewFileItem, pageCount: number | undefined): void => {
+      setPdfPageCounts((current) => {
+        if (current.get(item) === pageCount) return current
+        const next = new Map(current)
+        if (pageCount === undefined) next.delete(item)
+        else next.set(item, pageCount)
+        return next
+      })
+    },
+    []
+  )
+  useEffect(() => {
+    setPdfPageCounts((current) => {
+      const next = new Map(
+        [...current].filter(([item]) => items.some((openItem) => openItem === item))
+      )
+      return next.size === current.size ? current : next
+    })
+  }, [items])
   const activeItemId = usePreviewWorkbenchStore((state) => state.activeItemId)
   const panelState = usePreviewWorkbenchStore((state) => state.panelState)
   const activateItem = usePreviewWorkbenchStore((state) => state.activateItem)
@@ -834,6 +878,7 @@ const PreviewPanelSurface = ({
           >
             <PreviewTabBar
               tabs={items}
+              pdfPageCounts={pdfPageCounts}
               retryPendingKeys={retryPendingKeys}
               onFileActionSuccess={clearActionFailure}
               activeItemId={activeItemId}
@@ -918,6 +963,7 @@ const PreviewPanelSurface = ({
                 key={item.id}
                 item={item}
                 contentKey={activeContentKey}
+                onPdfPageCountChange={reportPdfPageCount}
                 onClose={(itemId) => {
                   const before = usePreviewWorkbenchStore.getState().items.length
                   removeItem(itemId)


### PR DESCRIPTION
## Problem

Single-page PDFs, such as generated figure exports, show Read with agent in the preview header, content context menu, and tab context menu even though the backend only accepts multi-page PDFs.

## Proposed change

Hide all three reading entries until the current PDF is confirmed to have more than one page. Reuse the existing PDF reading-position callback and keep the page count in transient, content-keyed component state. Report confirmed counts to PreviewPanel for its tab menu, retaining counts for inactive open tab objects and discarding replaced or closed objects. Preserve the removal control for PDFs already in session context and all other context-menu actions.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Header/content/tab-menu visibility, Library override, loading/file/version/project transitions, inactive and reopened tabs, and linked-PDF removal → `npx vitest run src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx src/renderer/src/pages/workspace/PreviewPanel.test.tsx src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx src/renderer/src/pages/workspace/preview-actions/preview-action-adapter.test.tsx src/renderer/src/pages/workspace/preview-tab-actions.test.ts` → 336 tests passed across 6 files.
- Renderer types → `npm run typecheck:web` → passed.
- Source conventions → `npm run lint` and targeted Prettier check → passed.
- Web packaging → `npm run build:web` → passed (existing chunk-size advisory).
- Independent review → no blocking findings; the selected checks cover the final implementation.

The module-impact classifier reports an unknown module owner for PreviewFileSurface and selects full validation. Per the maintainer's explicit request, full tests are delegated to PR CI; local validation uses the focused preview/consumer checks above. No main/preload contract or platform-specific behavior changed. Authenticated local Web verification with production PDF.js passed: a real one-page PDF shows 1 / 1 and no header reading entry; a real two-page PDF shows 1 / 2 and retains Read with agent. Real right-clicks also verify the same restriction in the content menu, with Download retained. Both screenshots were captured with installed Chrome through Playwright after Ego Lite screenshot requests timed out. Test records were seeded through the existing application APIs in disposable storage. Electron-specific E2E is not required locally for this renderer-only condition.

## Scope and review focus

Real workbench tab-menu verification also passed with production PDF.js: the one-page PDF offers Close, Close others, and Download; the two-page PDF additionally offers Read with agent. Screenshots of both states were captured in the isolated Web test project.

Only PreviewFileSurface, PreviewPanel, and their existing test files change. No new enum values, persistence format, migration, or historical-data compatibility work. The added panel Map is transient React state. Existing linked PDFs remain removable. Review content-identity isolation and the absence of the entry while page count is unknown. Replacing a tab object (including reactivation) or returning to another project conservatively requires the PDF to report its page count again; inactive tabs retain a confirmed count while their object remains open in the current project.
