### PR TITLE
fix(literature): clarify PDF batch import actions

### DIFF
--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -2769,7 +2769,7 @@ describe('LiteratureLibraryPage', () => {
     importPdf.mockResolvedValue({ item: libraryItem })
     const page = render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
-    fireEvent.change(screen.getByLabelText('Import PDF'), {
+    fireEvent.change(screen.getByLabelText('Import PDFs'), {
       target: { files: [new File(['pdf'], 'paper.pdf')] }
     })
     await screen.findByLabelText('Title')
@@ -2844,7 +2844,7 @@ describe('LiteratureLibraryPage', () => {
         await openReferenceDetail(await screen.findByText(libraryItem.item.title))
         fireEvent.change(screen.getByLabelText('Add PDF'), { target: { files: [file] } })
       } else {
-        fireEvent.change(screen.getByLabelText('Import PDF'), { target: { files: [file] } })
+        fireEvent.change(screen.getByLabelText('Import PDFs'), { target: { files: [file] } })
         await screen.findByLabelText('Title')
         fireEvent.click(screen.getByRole('button', { name: 'Save' }))
       }
@@ -2909,7 +2909,7 @@ describe('LiteratureLibraryPage', () => {
         )
         fireEvent.change(screen.getByLabelText('Add PDF'), { target: { files: [file] } })
       } else {
-        fireEvent.change(screen.getByLabelText('Import PDF'), { target: { files: [file] } })
+        fireEvent.change(screen.getByLabelText('Import PDFs'), { target: { files: [file] } })
         await screen.findByLabelText('Title')
         fireEvent.click(screen.getByRole('button', { name: 'Save' }))
       }
@@ -5488,14 +5488,14 @@ describe('LiteratureLibraryPage', () => {
     expect(screen.getByRole('columnheader', { name: 'Notes' })).not.toBeNull()
     expect(screen.getByRole('columnheader', { name: 'Publication' })).not.toBeNull()
     expect(screen.queryByRole('button', { name: 'Edit metadata' })).toBeNull()
-    expect(screen.queryByRole('button', { name: 'Import PDF' })).toBeNull()
+    expect(screen.queryByRole('button', { name: 'Import PDFs' })).toBeNull()
     await openMenu(screen.getByRole('button', { name: 'Add' }))
     expect(screen.getByRole('menuitem', { name: 'Add reference' })).not.toBeNull()
-    expect(screen.getByRole('menuitem', { name: 'Import PDF' })).not.toBeNull()
+    expect(screen.getByRole('menuitem', { name: 'Import PDFs' })).not.toBeNull()
     expect(screen.getByRole('menuitem', { name: 'Import references' })).not.toBeNull()
     expect(screen.queryByRole('menuitem', { name: 'Smart collection' })).toBeNull()
     expect(screen.getByText('Create metadata manually')).not.toBeNull()
-    expect(screen.getByText('Create a reference from a PDF')).not.toBeNull()
+    expect(screen.getByText('Create references from PDF files')).not.toBeNull()
     expect(screen.getByText('BibTeX, RIS, or PubMed NBIB')).not.toBeNull()
     expect(screen.queryByText('Only the first 1,000 references will be imported.')).toBeNull()
   })
@@ -6281,7 +6281,7 @@ describe('LiteratureLibraryPage', () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
     const file = new File(['%PDF-1.7'], staged.name, { type: 'application/pdf' })
-    fireEvent.change(screen.getByLabelText('Import PDF'), { target: { files: [file] } })
+    fireEvent.change(screen.getByLabelText('Import PDFs'), { target: { files: [file] } })
 
     expect(((await screen.findByLabelText('Title')) as HTMLInputElement).value).toBe(
       '2024 corrective rag'
@@ -6314,7 +6314,7 @@ describe('LiteratureLibraryPage', () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
     const file = new File(['%PDF-1.7'], 'opaque-name.pdf', { type: 'application/pdf' })
-    fireEvent.change(screen.getByLabelText('Import PDF'), { target: { files: [file] } })
+    fireEvent.change(screen.getByLabelText('Import PDFs'), { target: { files: [file] } })
 
     expect(screen.getByRole('dialog')).not.toBeNull()
     expect(screen.getByRole('status').textContent).toContain('Reading…')
@@ -6369,7 +6369,7 @@ describe('LiteratureLibraryPage', () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
     const upload = (name: string): void => {
-      fireEvent.change(screen.getByLabelText('Import PDF'), {
+      fireEvent.change(screen.getByLabelText('Import PDFs'), {
         target: { files: [new File(['%PDF-1.7'], name, { type: 'application/pdf' })] }
       })
     }
@@ -6399,7 +6399,7 @@ describe('LiteratureLibraryPage', () => {
   it('opens one batch preview for multiple PDFs without creating references', async () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
-    const picker = screen.getByLabelText('Import PDF') as HTMLInputElement
+    const picker = screen.getByLabelText('Import PDFs') as HTMLInputElement
     expect(picker.multiple).toBe(true)
     fireEvent.change(picker, {
       target: {
@@ -6426,7 +6426,7 @@ describe('LiteratureLibraryPage', () => {
   it('imports PDFs with empty normalized stems using their original filenames', async () => {
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
-    fireEvent.change(screen.getByLabelText('Import PDF'), {
+    fireEvent.change(screen.getByLabelText('Import PDFs'), {
       target: {
         files: ['.pdf', '___---.PDF'].map(
           (name) => new File(['%PDF-1.7'], name, { type: 'application/pdf' })
@@ -6446,7 +6446,7 @@ describe('LiteratureLibraryPage', () => {
 
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
-    fireEvent.change(screen.getByLabelText('Import PDF'), {
+    fireEvent.change(screen.getByLabelText('Import PDFs'), {
       target: {
         files: [new File(['not-a-pdf'], 'fallback-title.pdf', { type: 'application/pdf' })]
       }
@@ -8734,7 +8734,7 @@ describe('LiteratureLibraryPage', () => {
 
     render(<LiteratureLibraryPage />)
     fireEvent.click(screen.getByRole('button', { name: 'All references' }))
-    fireEvent.change(screen.getByLabelText('Import PDF'), {
+    fireEvent.change(screen.getByLabelText('Import PDFs'), {
       target: { files: [new File(['broken'], staged.name, { type: 'application/pdf' })] }
     })
     fireEvent.change(await screen.findByLabelText('Title'), { target: { value: 'Paper' } })

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -671,12 +671,12 @@ function LiteratureAddMenu({
             <span className="text-xs text-muted-foreground">{t('Create metadata manually')}</span>
           </span>
         </DropdownMenuItem>
-        <DropdownMenuItem className="gap-2.5" aria-label={t('Import PDF')} onSelect={onImportPdf}>
+        <DropdownMenuItem className="gap-2.5" aria-label={t('Import PDFs')} onSelect={onImportPdf}>
           <FilePlus2 className="size-4 shrink-0" aria-hidden="true" />
           <span className="min-w-0 flex flex-col">
-            <span>{t('Import PDF')}</span>
+            <span>{t('Import PDFs')}</span>
             <span className="text-xs text-muted-foreground">
-              {t('Create a reference from a PDF')}
+              {t('Create references from PDF files')}
             </span>
           </span>
         </DropdownMenuItem>
@@ -4161,7 +4161,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
                     type="file"
                     accept="application/pdf,.pdf"
                     className="sr-only"
-                    aria-label={t('Import PDF')}
+                    aria-label={t('Import PDFs')}
                     onChange={(event) => {
                       const files = Array.from(event.currentTarget.files ?? [])
                       event.currentTarget.value = ''

--- a/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx
+++ b/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx
@@ -1,4 +1,5 @@
 // @vitest-environment jsdom
+import { StrictMode } from 'react'
 import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 import {
@@ -135,13 +136,12 @@ it('does not replay an unconfirmed creation and still imports other files', asyn
   transact.mockRejectedValueOnce(new Error('Response lost'))
   open()
   await start()
-  await screen.findByText(
+  await screen.findAllByText(
     'The result could not be confirmed. Check your library before importing this file again.'
   )
   await screen.findByText('1 / 2 completed')
-  expect(
-    (screen.getByRole('button', { name: 'Retry unfinished' }) as HTMLButtonElement).disabled
-  ).toBe(true)
+  await screen.findByRole('button', { name: 'Done' })
+  expect(screen.queryByRole('button', { name: 'Retry unfinished' })).toBeNull()
   expect(transact.mock.calls.filter(([c]) => c.kind === 'create-item')).toHaveLength(2)
 })
 
@@ -287,4 +287,111 @@ it('releases a failed claim before continuing and keeps its reference for retry'
   await screen.findByText('2 / 2 completed')
   expect(transact.mock.calls.filter(([command]) => command.kind === 'create-item')).toHaveLength(2)
   expect(importPdf.mock.calls.map(([request]) => request.itemId)).toEqual(['item-2', 'item-1'])
+})
+
+const footerButtons = (): HTMLElement[] => {
+  const dialog = screen.getByRole('dialog', { name: 'Import PDFs' })
+  return within(dialog.lastElementChild as HTMLElement).getAllByRole('button')
+}
+
+it('keeps import discoverable but disabled for an empty initial selection', async () => {
+  open()
+  await waitFor(() =>
+    expect(screen.getByRole('button', { name: 'Import selected' })).toHaveProperty(
+      'disabled',
+      false
+    )
+  )
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
+  expect(screen.getByRole('button', { name: 'Import selected' })).toHaveProperty('disabled', true)
+  expect(footerButtons().map((button) => [button.textContent, button.dataset.variant])).toEqual([
+    ['Cancel', 'outline'],
+    ['Import selected', 'default']
+  ])
+})
+
+it('shows only primary Done after all files succeed and removes obsolete controls', async () => {
+  open()
+  await start()
+  await screen.findByRole('button', { name: 'Done' })
+  expect(footerButtons().map((button) => [button.textContent, button.dataset.variant])).toEqual([
+    ['Done', 'default']
+  ])
+  expect(screen.queryByRole('checkbox')).toBeNull()
+  expect(screen.queryByRole('combobox')).toBeNull()
+  expect(screen.getByText('Selected PDFs imported. You can close this window.')).not.toBeNull()
+  fireEvent.click(screen.getByRole('button', { name: 'Done' }))
+  expect(close).toHaveBeenCalledOnce()
+})
+
+it('places retry before primary Close when every attachment fails, hiding retry on deselection', async () => {
+  importPdf.mockRejectedValue(new Error('Bad PDF'))
+  open()
+  await start()
+  await screen.findByRole('button', { name: 'Retry unfinished' })
+  expect(footerButtons().map((button) => [button.textContent, button.dataset.variant])).toEqual([
+    ['Retry unfinished', 'outline'],
+    ['Close', 'default']
+  ])
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
+  expect(footerButtons().map((button) => button.textContent)).toEqual(['Close'])
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select first.pdf' }))
+  expect(screen.getByRole('button', { name: 'Retry unfinished' })).toHaveProperty('disabled', false)
+})
+
+it('offers importing skipped files as a secondary action without calling them retries', async () => {
+  open()
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select second.pdf' }))
+  await start()
+  await screen.findByRole('button', { name: 'Done' })
+  expect(footerButtons().map((button) => button.textContent)).toEqual(['Done'])
+  expect(screen.getByText('Failed: 0 · Skipped: 1')).not.toBeNull()
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select second.pdf' }))
+  expect(footerButtons().map((button) => [button.textContent, button.dataset.variant])).toEqual([
+    ['Import selected', 'outline'],
+    ['Done', 'default']
+  ])
+  fireEvent.click(screen.getByRole('button', { name: 'Import selected' }))
+  await screen.findByText('2 / 2 completed')
+  expect(transact.mock.calls.filter(([command]) => command.kind === 'create-item')).toHaveLength(2)
+})
+
+it('shows only Stop while importing and only disabled Stopping while settling', async () => {
+  const created = deferred<{ id: string }>()
+  transact.mockReturnValueOnce(created.promise)
+  open()
+  await start()
+  expect(footerButtons().map((button) => [button.textContent, button.dataset.variant])).toEqual([
+    ['Stop', 'outline']
+  ])
+  fireEvent.click(screen.getByRole('button', { name: 'Stop' }))
+  expect(footerButtons().map((button) => button.textContent)).toEqual(['Stopping…'])
+  expect(screen.getByRole('button', { name: 'Stopping…' })).toHaveProperty('disabled', true)
+  await act(async () => created.resolve({ id: 'kept-reference' }))
+  expect(footerButtons().map((button) => button.textContent)).toEqual(['Retry unfinished', 'Close'])
+  expect(importPdf).not.toHaveBeenCalled()
+})
+
+it('keeps the initial reading actions under StrictMode effect replay', async () => {
+  const read = deferred<ReturnType<typeof createDraft>>()
+  mocks.extract.mockReturnValue(read.promise)
+  render(
+    <StrictMode>
+      <LiteraturePdfBatchImportDialog
+        files={files}
+        destination={{ name: 'All references' }}
+        createDraft={createDraft}
+        onClose={close}
+      />
+    </StrictMode>
+  )
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
+  fireEvent.click(screen.getByRole('checkbox', { name: 'Select all' }))
+  expect(footerButtons().map((button) => [button.textContent, button.dataset.variant])).toEqual([
+    ['Cancel', 'outline'],
+    ['Import selected', 'default']
+  ])
+  expect(screen.getByRole('button', { name: 'Import selected' })).toHaveProperty('disabled', true)
+  expect(transact).not.toHaveBeenCalled()
+  await act(async () => read.resolve(createDraft(files[0])))
 })

--- a/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.tsx
+++ b/src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { Check } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
 import { LiteratureImportDialogFrame } from './LiteratureImportDialogFrame'
@@ -232,6 +233,34 @@ export function LiteraturePdfBatchImportDialog({
     (row) => row.checked && row.status !== 'done' && !row.uncertain
   ).length
   const selectable = rows.filter((row) => row.status !== 'done' && !row.uncertain)
+  const attempted = rows.some((row) => row.itemId || row.status === 'error')
+  const retrySelected = rows.some(
+    (row) =>
+      row.checked &&
+      !row.uncertain &&
+      row.status !== 'done' &&
+      (row.itemId || row.status === 'error')
+  )
+  const failed = rows.filter((row) => row.status === 'error').length
+  const skipped = rows.filter(
+    (row) => !row.checked && row.status !== 'done' && row.status !== 'error'
+  ).length
+  const canCreate = selectable.some((row) => !row.itemId)
+  const description = busy
+    ? t(
+        'Keep this window open until the batch finishes. You can stop without losing completed imports.'
+      )
+    : !attempted
+      ? t('Review the files, then import the selected PDFs.')
+      : rows.some((row) => row.uncertain)
+        ? t(
+            'The result could not be confirmed. Check your library before importing this file again.'
+          )
+        : failed > 0
+          ? t('Some PDFs could not be imported. Review the details below before retrying.')
+          : remaining > 0
+            ? t('You can import unfinished files or close this window.')
+            : t('Selected PDFs imported. You can close this window.')
   const labels = {
     pending: t('Pending'),
     reading: t('Reading…'),
@@ -243,9 +272,7 @@ export function LiteraturePdfBatchImportDialog({
   return (
     <LiteratureImportDialogFrame
       title={t('Import PDFs')}
-      description={t(
-        'Review the files, then import the selected PDFs. Keep this window open until the batch finishes.'
-      )}
+      description={description}
       busy={busy}
       onClose={onClose}
       footer={
@@ -254,16 +281,25 @@ export function LiteraturePdfBatchImportDialog({
             <Button variant="outline" disabled={stopping} onClick={stop}>
               {stopping ? t('Stopping…') : t('Stop')}
             </Button>
+          ) : attempted ? (
+            <>
+              {remaining > 0 ? (
+                <Button variant="outline" onClick={() => void run()}>
+                  {retrySelected ? t('Retry unfinished') : t('Import selected')}
+                </Button>
+              ) : null}
+              <Button onClick={onClose}>{completed ? t('Done') : t('Close')}</Button>
+            </>
           ) : (
-            <Button variant="outline" onClick={onClose}>
-              {completed ? t('Done') : t('Cancel')}
-            </Button>
+            <>
+              <Button variant="outline" onClick={onClose}>
+                {t('Cancel')}
+              </Button>
+              <Button disabled={reading || remaining === 0} onClick={() => void run()}>
+                {t('Import selected')}
+              </Button>
+            </>
           )}
-          <Button disabled={reading || busy || remaining === 0} onClick={() => void run()}>
-            {rows.some((row) => row.itemId || row.status === 'error')
-              ? t('Retry unfinished')
-              : t('Import selected')}
-          </Button>
         </div>
       }
     >
@@ -271,18 +307,36 @@ export function LiteraturePdfBatchImportDialog({
         <p className="text-sm [overflow-wrap:anywhere]">
           {t('Import to')} · <strong>{destination.name}</strong>
         </p>
-        <LiteratureDuplicatePolicyField value={policy} onChange={setPolicy} disabled={busy} />
-        <p className="text-xs text-muted-foreground">
-          {t(
-            'PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.'
-          )}
-        </p>
+        {canCreate ? (
+          <LiteratureDuplicatePolicyField value={policy} onChange={setPolicy} disabled={busy} />
+        ) : (
+          <p className="text-xs text-muted-foreground">
+            {t('When identifiers match')} ·{' '}
+            {policy === 'reuse'
+              ? t('Reuse existing reference')
+              : policy === 'separate'
+                ? t('Keep as separate reference')
+                : t('Fill empty fields')}
+          </p>
+        )}
+        {!attempted ? (
+          <p className="text-xs text-muted-foreground">
+            {t(
+              'PDFs are attached to matching references. Identical attachments are reused; different PDFs are kept separately.'
+            )}
+          </p>
+        ) : null}
         <div role="status" className="space-y-2 text-sm">
           <p>
             {reading
               ? t('Reading…')
               : t('{{completed}} / {{total}} completed', { completed, total: rows.length })}
           </p>
+          {!reading && !busy && attempted ? (
+            <p className="text-xs text-muted-foreground">
+              {t('Failed: {{failed}} · Skipped: {{skipped}}', { failed, skipped })}
+            </p>
+          ) : null}
           {stopping ? (
             <p>
               {t('Finishing the current operation before stopping. Completed references are kept.')}
@@ -306,30 +360,36 @@ export function LiteraturePdfBatchImportDialog({
             </>
           ) : null}
         </div>
-        <label className="flex items-center gap-2 text-sm">
-          <input
-            type="checkbox"
-            disabled={busy || selectable.length === 0}
-            checked={selectable.length > 0 && selectable.every((row) => row.checked)}
-            onChange={(event) => selectAll(event.target.checked)}
-          />
-          {t('Select all')}
-        </label>
+        {selectable.length > 0 ? (
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              disabled={busy}
+              checked={selectable.every((row) => row.checked)}
+              onChange={(event) => selectAll(event.target.checked)}
+            />
+            {t('Select all')}
+          </label>
+        ) : null}
         <ul className="divide-y divide-border-300/80 rounded-lg border border-border-300/80">
           {rows.slice(0, visible).map((row, index) => (
             <li key={index} className="space-y-2 px-3 py-3">
               <div className="flex items-start gap-3">
-                <input
-                  className="mt-1"
-                  type="checkbox"
-                  aria-label={t('Select {{name}}', { name: row.file.name })}
-                  disabled={busy || row.status === 'done' || row.uncertain}
-                  checked={row.checked}
-                  onChange={(event) => {
-                    rowsRef.current[index].checked = event.target.checked
-                    publish()
-                  }}
-                />
+                {row.status === 'done' ? (
+                  <Check className="mt-1 size-4 shrink-0 text-primary" aria-hidden="true" />
+                ) : (
+                  <input
+                    className="mt-1"
+                    type="checkbox"
+                    aria-label={t('Select {{name}}', { name: row.file.name })}
+                    disabled={busy || row.uncertain}
+                    checked={row.checked}
+                    onChange={(event) => {
+                      rowsRef.current[index].checked = event.target.checked
+                      publish()
+                    }}
+                  />
+                )}
                 <div className="min-w-0 flex-1">
                   <p className="break-words text-sm font-medium">{row.draft.title}</p>
                   <p className="break-all text-xs text-muted-foreground">{row.file.name}</p>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -4439,7 +4439,6 @@
     "Copy RIS": "RIS kopieren",
     "Copy in-text citation": "Kurzbeleg kopieren",
     "Copy reference": "Literaturangabe kopieren",
-    "Create a reference from a PDF": "Literaturangabe aus einer PDF erstellen",
     "Create a reference in your library.": "Erstellen Sie eine Literaturangabe in Ihrer Bibliothek.",
     "Create collection": "Sammlung erstellen",
     "Create a collection for the selected references.": "Erstellen Sie eine Sammlung für die ausgewählten Literaturangaben.",
@@ -5005,7 +5004,6 @@
     "Could not load metadata sources": "Metadatenquellen konnten nicht geladen werden",
     "No saved metadata sources for this reference.": "Für diesen Literaturverweis sind keine Metadatenquellen gespeichert.",
     "Import PDFs": "PDFs importieren",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Prüfen Sie die Dateien und importieren Sie die ausgewählten PDFs. Lassen Sie dieses Fenster geöffnet, bis der Stapel abgeschlossen ist.",
     "The result could not be confirmed. Check your library before importing this file again.": "Das Ergebnis konnte nicht bestätigt werden. Prüfen Sie Ihre Bibliothek, bevor Sie diese Datei erneut importieren.",
     "The reference was kept. Retry to finish adding its PDF.": "Die Referenz wurde beibehalten. Versuchen Sie erneut, das PDF hinzuzufügen.",
     "Retry unfinished": "Unfertige erneut versuchen",
@@ -5015,6 +5013,13 @@
     "This collection changed. Your edits have been kept.": "Diese Sammlung wurde geändert. Ihre Eingaben wurden beibehalten.",
     "This collection no longer exists. Your edits have been kept.": "Diese Sammlung existiert nicht mehr. Ihre Eingaben wurden beibehalten.",
     "The latest collection could not be loaded. Your edits have been kept.": "Die aktuelle Sammlung konnte nicht geladen werden. Ihre Eingaben wurden beibehalten.",
-    "Replace your unsaved edits with the latest saved collection.": "Ersetzen Sie Ihre ungespeicherten Änderungen durch die zuletzt gespeicherte Sammlung."
+    "Replace your unsaved edits with the latest saved collection.": "Ersetzen Sie Ihre ungespeicherten Änderungen durch die zuletzt gespeicherte Sammlung.",
+    "Create references from PDF files": "Literaturangaben aus PDF-Dateien erstellen",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "Lassen Sie dieses Fenster geöffnet, bis der Stapel abgeschlossen ist. Beim Stoppen bleiben abgeschlossene Importe erhalten.",
+    "Review the files, then import the selected PDFs.": "Prüfen Sie die Dateien und importieren Sie die ausgewählten PDFs.",
+    "Some PDFs could not be imported. Review the details below before retrying.": "Einige PDFs konnten nicht importiert werden. Prüfen Sie vor einem erneuten Versuch die Details unten.",
+    "Selected PDFs imported. You can close this window.": "Ausgewählte PDFs importiert. Sie können dieses Fenster schließen.",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "Fehlgeschlagen: {{failed}} · Übersprungen: {{skipped}}",
+    "You can import unfinished files or close this window.": "Sie können unfertige Dateien importieren oder dieses Fenster schließen."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4760,7 +4760,6 @@
     "Import PDF": "Importar PDF",
     "Import references": "Importar referencias",
     "Create metadata manually": "Crear metadatos manualmente",
-    "Create a reference from a PDF": "Crear una referencia a partir de un PDF",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX, RIS o NBIB de PubMed",
     "Only the first 1,000 references will be imported.": "Solo se importarán las primeras 1.000 referencias.",
     "References per page": "Referencias por página",
@@ -5167,7 +5166,6 @@
     "Could not load metadata sources": "No se pudieron cargar las fuentes de metadatos",
     "No saved metadata sources for this reference.": "No hay fuentes de metadatos guardadas para esta referencia.",
     "Import PDFs": "Importar PDF",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Revise los archivos e importe los PDF seleccionados. Mantenga esta ventana abierta hasta que finalice el lote.",
     "The result could not be confirmed. Check your library before importing this file again.": "No se pudo confirmar el resultado. Revise su biblioteca antes de volver a importar este archivo.",
     "The reference was kept. Retry to finish adding its PDF.": "Se conservó la referencia. Vuelva a intentarlo para terminar de añadir el PDF.",
     "Retry unfinished": "Reintentar los pendientes",
@@ -5177,6 +5175,13 @@
     "This collection changed. Your edits have been kept.": "Esta colección ha cambiado. Se han conservado sus cambios.",
     "This collection no longer exists. Your edits have been kept.": "Esta colección ya no existe. Se han conservado sus cambios.",
     "The latest collection could not be loaded. Your edits have been kept.": "No se pudo cargar la versión más reciente de la colección. Se han conservado sus cambios.",
-    "Replace your unsaved edits with the latest saved collection.": "Sustituir los cambios sin guardar por la última versión guardada de la colección."
+    "Replace your unsaved edits with the latest saved collection.": "Sustituir los cambios sin guardar por la última versión guardada de la colección.",
+    "Create references from PDF files": "Crear referencias a partir de archivos PDF",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "Mantenga esta ventana abierta hasta que finalice el lote. Puede detenerlo sin perder las importaciones completadas.",
+    "Review the files, then import the selected PDFs.": "Revise los archivos e importe los PDF seleccionados.",
+    "Some PDFs could not be imported. Review the details below before retrying.": "No se pudieron importar algunos PDF. Revise los detalles a continuación antes de reintentar.",
+    "Selected PDFs imported. You can close this window.": "Se han importado los PDF seleccionados. Puede cerrar esta ventana.",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "Fallidos: {{failed}} · Omitidos: {{skipped}}",
+    "You can import unfinished files or close this window.": "Puede importar los archivos pendientes o cerrar esta ventana."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4760,7 +4760,6 @@
     "Import PDF": "Importer un PDF",
     "Import references": "Importer les références",
     "Create metadata manually": "Créer les métadonnées manuellement",
-    "Create a reference from a PDF": "Créer une référence à partir d’un PDF",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX, RIS ou NBIB PubMed",
     "Only the first 1,000 references will be imported.": "Seules les 1 000 premières références seront importées.",
     "References per page": "Références par page",
@@ -5167,7 +5166,6 @@
     "Could not load metadata sources": "Impossible de charger les sources des métadonnées",
     "No saved metadata sources for this reference.": "Aucune source de métadonnées enregistrée pour cette référence.",
     "Import PDFs": "Importer des PDF",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Vérifiez les fichiers, puis importez les PDF sélectionnés. Gardez cette fenêtre ouverte jusqu’à la fin du lot.",
     "The result could not be confirmed. Check your library before importing this file again.": "Le résultat n’a pas pu être confirmé. Vérifiez votre bibliothèque avant de réimporter ce fichier.",
     "The reference was kept. Retry to finish adding its PDF.": "La référence a été conservée. Réessayez pour terminer l’ajout du PDF.",
     "Retry unfinished": "Réessayer les éléments inachevés",
@@ -5177,6 +5175,13 @@
     "This collection changed. Your edits have been kept.": "Cette collection a été modifiée. Vos modifications ont été conservées.",
     "This collection no longer exists. Your edits have been kept.": "Cette collection n’existe plus. Vos modifications ont été conservées.",
     "The latest collection could not be loaded. Your edits have been kept.": "La dernière version de la collection n’a pas pu être chargée. Vos modifications ont été conservées.",
-    "Replace your unsaved edits with the latest saved collection.": "Remplacer les modifications non enregistrées par la dernière version enregistrée de la collection."
+    "Replace your unsaved edits with the latest saved collection.": "Remplacer les modifications non enregistrées par la dernière version enregistrée de la collection.",
+    "Create references from PDF files": "Créer des références à partir de fichiers PDF",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "Gardez cette fenêtre ouverte jusqu’à la fin du lot. Vous pouvez arrêter sans perdre les imports terminés.",
+    "Review the files, then import the selected PDFs.": "Vérifiez les fichiers, puis importez les PDF sélectionnés.",
+    "Some PDFs could not be imported. Review the details below before retrying.": "Certains PDF n’ont pas pu être importés. Vérifiez les détails ci-dessous avant de réessayer.",
+    "Selected PDFs imported. You can close this window.": "Les PDF sélectionnés ont été importés. Vous pouvez fermer cette fenêtre.",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "Échecs : {{failed}} · Ignorés : {{skipped}}",
+    "You can import unfinished files or close this window.": "Vous pouvez importer les fichiers inachevés ou fermer cette fenêtre."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4454,7 +4454,6 @@
     "Import PDF": "PDF を読み込む",
     "Import references": "参考文献を読み込む",
     "Create metadata manually": "メタデータを手動で作成",
-    "Create a reference from a PDF": "PDF から参考文献を作成",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX、RIS、PubMed NBIB",
     "Only the first 1,000 references will be imported.": "先頭の 1,000 件のみ読み込みます。",
     "References per page": "1ページあたりの文献数",
@@ -4851,7 +4850,6 @@
     "Could not load metadata sources": "メタデータの出典を読み込めませんでした",
     "No saved metadata sources for this reference.": "この文献には保存済みのメタデータの出典がありません。",
     "Import PDFs": "PDF をインポート",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "ファイルを確認して、選択した PDF をインポートします。一括インポートが完了するまで、このウィンドウを開いたままにしてください。",
     "The result could not be confirmed. Check your library before importing this file again.": "結果を確認できませんでした。このファイルを再度インポートする前に、ライブラリを確認してください。",
     "The reference was kept. Retry to finish adding its PDF.": "文献は保持されています。再試行して PDF の追加を完了してください。",
     "Retry unfinished": "未完了の項目を再試行",
@@ -4861,6 +4859,13 @@
     "This collection changed. Your edits have been kept.": "このコレクションは変更されています。編集内容は保持されています。",
     "This collection no longer exists. Your edits have been kept.": "このコレクションは存在しません。編集内容は保持されています。",
     "The latest collection could not be loaded. Your edits have been kept.": "最新のコレクションを読み込めませんでした。編集内容は保持されています。",
-    "Replace your unsaved edits with the latest saved collection.": "未保存の編集内容を最後に保存されたコレクションで置き換えます。"
+    "Replace your unsaved edits with the latest saved collection.": "未保存の編集内容を最後に保存されたコレクションで置き換えます。",
+    "Create references from PDF files": "PDF ファイルから参考文献を作成",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "一括インポートが完了するまで、このウィンドウを開いたままにしてください。停止しても、完了したインポートは保持されます。",
+    "Review the files, then import the selected PDFs.": "ファイルを確認して、選択した PDF をインポートします。",
+    "Some PDFs could not be imported. Review the details below before retrying.": "一部の PDF をインポートできませんでした。再試行する前に、以下の詳細を確認してください。",
+    "Selected PDFs imported. You can close this window.": "選択した PDF をインポートしました。このウィンドウを閉じることができます。",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "失敗: {{failed}} · スキップ: {{skipped}}",
+    "You can import unfinished files or close this window.": "未完了のファイルをインポートするか、このウィンドウを閉じることができます。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4452,7 +4452,6 @@
     "Import PDF": "PDF 가져오기",
     "Import references": "문헌 가져오기",
     "Create metadata manually": "메타데이터 직접 만들기",
-    "Create a reference from a PDF": "PDF에서 문헌 정보 만들기",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX, RIS 또는 PubMed NBIB",
     "Only the first 1,000 references will be imported.": "처음 1,000개 문헌만 가져옵니다.",
     "References per page": "페이지당 문헌 수",
@@ -4849,7 +4848,6 @@
     "Could not load metadata sources": "메타데이터 출처를 불러오지 못했습니다",
     "No saved metadata sources for this reference.": "이 문헌에 저장된 메타데이터 출처가 없습니다.",
     "Import PDFs": "PDF 가져오기",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "파일을 검토한 후 선택한 PDF를 가져오세요. 일괄 가져오기가 완료될 때까지 이 창을 열어 두세요.",
     "The result could not be confirmed. Check your library before importing this file again.": "결과를 확인할 수 없습니다. 이 파일을 다시 가져오기 전에 라이브러리를 확인하세요.",
     "The reference was kept. Retry to finish adding its PDF.": "문헌은 유지되었습니다. 다시 시도하여 PDF 추가를 완료하세요.",
     "Retry unfinished": "미완료 항목 다시 시도",
@@ -4859,6 +4857,13 @@
     "This collection changed. Your edits have been kept.": "이 컬렉션이 변경되었습니다. 편집 내용은 유지됩니다.",
     "This collection no longer exists. Your edits have been kept.": "이 컬렉션이 더 이상 존재하지 않습니다. 편집 내용은 유지됩니다.",
     "The latest collection could not be loaded. Your edits have been kept.": "최신 컬렉션을 불러올 수 없습니다. 편집 내용은 유지됩니다.",
-    "Replace your unsaved edits with the latest saved collection.": "저장하지 않은 편집 내용을 최근 저장된 컬렉션으로 바꿉니다."
+    "Replace your unsaved edits with the latest saved collection.": "저장하지 않은 편집 내용을 최근 저장된 컬렉션으로 바꿉니다.",
+    "Create references from PDF files": "PDF 파일에서 문헌 정보 만들기",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "일괄 가져오기가 완료될 때까지 이 창을 열어 두세요. 중지해도 완료된 가져오기 항목은 유지됩니다.",
+    "Review the files, then import the selected PDFs.": "파일을 검토한 후 선택한 PDF를 가져오세요.",
+    "Some PDFs could not be imported. Review the details below before retrying.": "일부 PDF를 가져오지 못했습니다. 다시 시도하기 전에 아래 세부 정보를 확인하세요.",
+    "Selected PDFs imported. You can close this window.": "선택한 PDF를 가져왔습니다. 이 창을 닫을 수 있습니다.",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "실패: {{failed}} · 건너뜀: {{skipped}}",
+    "You can import unfinished files or close this window.": "미완료 파일을 가져오거나 이 창을 닫을 수 있습니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4888,7 +4888,6 @@
     "Import PDF": "Импортировать PDF",
     "Import references": "Импортировать источники",
     "Create metadata manually": "Создать метаданные вручную",
-    "Create a reference from a PDF": "Создать источник из PDF",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX, RIS или PubMed NBIB",
     "Only the first 1,000 references will be imported.": "Будут импортированы только первые 1 000 источников.",
     "References per page": "Источников на странице",
@@ -5300,7 +5299,6 @@
     "Could not load metadata sources": "Не удалось загрузить источники метаданных",
     "No saved metadata sources for this reference.": "Для этой публикации нет сохранённых источников метаданных.",
     "Import PDFs": "Импорт PDF",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "Проверьте файлы и импортируйте выбранные PDF. Не закрывайте это окно до завершения пакетного импорта.",
     "The result could not be confirmed. Check your library before importing this file again.": "Не удалось подтвердить результат. Проверьте библиотеку перед повторным импортом этого файла.",
     "The reference was kept. Retry to finish adding its PDF.": "Ссылка сохранена. Повторите попытку, чтобы завершить добавление PDF.",
     "Retry unfinished": "Повторить незавершённые",
@@ -5310,6 +5308,13 @@
     "This collection changed. Your edits have been kept.": "Эта коллекция изменена. Ваши правки сохранены в форме.",
     "This collection no longer exists. Your edits have been kept.": "Эта коллекция больше не существует. Ваши правки сохранены в форме.",
     "The latest collection could not be loaded. Your edits have been kept.": "Не удалось загрузить последнюю версию коллекции. Ваши правки сохранены в форме.",
-    "Replace your unsaved edits with the latest saved collection.": "Заменить несохранённые правки последней сохранённой версией коллекции."
+    "Replace your unsaved edits with the latest saved collection.": "Заменить несохранённые правки последней сохранённой версией коллекции.",
+    "Create references from PDF files": "Создать источники из файлов PDF",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "Не закрывайте это окно до завершения пакетного импорта. При остановке завершённые импорты сохраняются.",
+    "Review the files, then import the selected PDFs.": "Проверьте файлы и импортируйте выбранные PDF.",
+    "Some PDFs could not be imported. Review the details below before retrying.": "Некоторые PDF не удалось импортировать. Перед повторной попыткой проверьте сведения ниже.",
+    "Selected PDFs imported. You can close this window.": "Выбранные PDF импортированы. Можно закрыть это окно.",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "Ошибки: {{failed}} · Пропущено: {{skipped}}",
+    "You can import unfinished files or close this window.": "Можно импортировать незавершённые файлы или закрыть это окно."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4455,7 +4455,6 @@
     "Import PDF": "导入 PDF",
     "Import references": "导入文献",
     "Create metadata manually": "手动创建题录信息",
-    "Create a reference from a PDF": "从 PDF 创建题录",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX、RIS 或 PubMed NBIB",
     "Only the first 1,000 references will be imported.": "仅导入前 1,000 篇文献。",
     "References per page": "每页文献数",
@@ -4851,7 +4850,6 @@
     "Could not load metadata sources": "无法加载元数据来源",
     "No saved metadata sources for this reference.": "此文献没有已保存的元数据来源。",
     "Import PDFs": "导入 PDF",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "检查文件，然后导入所选 PDF。请保持此窗口打开，直到批量导入完成。",
     "The result could not be confirmed. Check your library before importing this file again.": "无法确认结果。再次导入此文件前，请检查文献库。",
     "The reference was kept. Retry to finish adding its PDF.": "文献已保留。请重试以完成 PDF 添加。",
     "Retry unfinished": "重试未完成项",
@@ -4861,6 +4859,13 @@
     "This collection changed. Your edits have been kept.": "此合集已更改。已保留您的编辑内容。",
     "This collection no longer exists. Your edits have been kept.": "此合集已不存在。已保留您的编辑内容。",
     "The latest collection could not be loaded. Your edits have been kept.": "无法加载最新合集。已保留您的编辑内容。",
-    "Replace your unsaved edits with the latest saved collection.": "用最新保存的合集替换您尚未保存的编辑内容。"
+    "Replace your unsaved edits with the latest saved collection.": "用最新保存的合集替换您尚未保存的编辑内容。",
+    "Create references from PDF files": "从 PDF 文件创建题录",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "请保持此窗口打开，直到批量导入完成。停止导入不会丢失已完成的导入项。",
+    "Review the files, then import the selected PDFs.": "检查文件，然后导入所选 PDF。",
+    "Some PDFs could not be imported. Review the details below before retrying.": "部分 PDF 无法导入。请先查看下方详情，再重试。",
+    "Selected PDFs imported. You can close this window.": "所选 PDF 已导入。您可以关闭此窗口。",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "失败：{{failed}} · 已跳过：{{skipped}}",
+    "You can import unfinished files or close this window.": "您可以导入未完成的文件或关闭此窗口。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4455,7 +4455,6 @@
     "Import PDF": "匯入 PDF",
     "Import references": "匯入文獻",
     "Create metadata manually": "手動建立題錄資訊",
-    "Create a reference from a PDF": "從 PDF 建立題錄",
     "BibTeX, RIS, or PubMed NBIB": "BibTeX、RIS 或 PubMed NBIB",
     "Only the first 1,000 references will be imported.": "僅匯入前 1,000 篇文獻。",
     "References per page": "每頁文獻數",
@@ -4851,7 +4850,6 @@
     "Could not load metadata sources": "無法載入中繼資料來源",
     "No saved metadata sources for this reference.": "此文獻沒有已儲存的中繼資料來源。",
     "Import PDFs": "匯入 PDF",
-    "Review the files, then import the selected PDFs. Keep this window open until the batch finishes.": "檢查檔案，然後匯入所選 PDF。請保持此視窗開啟，直到批次匯入完成。",
     "The result could not be confirmed. Check your library before importing this file again.": "無法確認結果。再次匯入此檔案前，請檢查文獻庫。",
     "The reference was kept. Retry to finish adding its PDF.": "文獻已保留。請重試以完成 PDF 新增。",
     "Retry unfinished": "重試未完成項目",
@@ -4861,6 +4859,13 @@
     "This collection changed. Your edits have been kept.": "此合集已變更。已保留您的編輯內容。",
     "This collection no longer exists. Your edits have been kept.": "此合集已不存在。已保留您的編輯內容。",
     "The latest collection could not be loaded. Your edits have been kept.": "無法載入最新合集。已保留您的編輯內容。",
-    "Replace your unsaved edits with the latest saved collection.": "以最新儲存的合集取代您尚未儲存的編輯內容。"
+    "Replace your unsaved edits with the latest saved collection.": "以最新儲存的合集取代您尚未儲存的編輯內容。",
+    "Create references from PDF files": "從 PDF 檔案建立題錄",
+    "Keep this window open until the batch finishes. You can stop without losing completed imports.": "請保持此視窗開啟，直到批次匯入完成。停止匯入不會遺失已完成的匯入項目。",
+    "Review the files, then import the selected PDFs.": "檢查檔案，然後匯入所選 PDF。",
+    "Some PDFs could not be imported. Review the details below before retrying.": "部分 PDF 無法匯入。請先查看下方詳細資訊，再重試。",
+    "Selected PDFs imported. You can close this window.": "所選 PDF 已匯入。您可以關閉此視窗。",
+    "Failed: {{failed}} · Skipped: {{skipped}}": "失敗：{{failed}} · 已略過：{{skipped}}",
+    "You can import unfinished files or close this window.": "您可以匯入未完成的檔案或關閉此視窗。"
   }
 }


### PR DESCRIPTION
## Problem

After a PDF batch finished successfully, the dialog still showed a disabled primary “Retry unfinished” button to the right of secondary “Done”. The Add menu also described a single PDF despite supporting multiple files.

## Proposed change

- Keep Cancel and primary Import selected before importing; disable import while reading metadata or when nothing is selected.
- Show only neutral Stop/disabled Stopping while work is active.
- After an attempt, place primary Done (or Close when nothing completed) last. Show a secondary import/retry action only for selected, eligible unfinished files; successful files and uncertain creations cannot be replayed.
- Show result-specific guidance, failure/skipped counts, completed indicators, and compact duplicate-policy context when no new creation remains.
- Use “Import PDFs” / “Create references from PDF files” in the Add menu, with translations in all eight catalogs.

## Scope and non-goals

Renderer presentation and existing tests/catalogs only. No new status enum, persistence format, database migration, historical-data compatibility layer, or renderer/backend contract changes. Existing reference writes, deduplication, upload cancellation/cleanup, and uncertain-result replay protections are preserved.

## Acceptance criteria and validation

Final Test Impact Set (checks run after the last material edit):

| Behavior | Check | Result |
| --- | --- | --- |
| Footer order, color variants, conditional visibility, initial empty selection, success/failure, stop, uncertain results, skipped-file import, StrictMode | `npx vitest run src/renderer/src/pages/literature/LiteraturePdfBatchImportDialog.test.tsx src/renderer/src/i18n/resources.test.ts` | 18 dialog + 804 i18n tests passed |
| PDF picker/menu consumers, single/multiple PDF routing, and two asynchronous checks retried from the broad Library run | `npx vitest run src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx -t 'PDF|Add menu|detection errors with retry|explicitly scoped Collection'` | 24 passed |
| Add menu labels and description | `npx vitest run src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx -t 'groups creation actions'` | Passed |
| Renderer types | `npm run typecheck:web` | Passed |
| Source conventions | `npm run lint` | Passed |
| Web production bundle | `npm run build:web` | Passed; existing CSS/minification and large-chunk warnings |
| Real PDF batch success and partial failure | Authenticated isolated localhost Web UI in Chrome; three valid PDF fixtures, followed by one valid and one deliberately invalid PDF | Passed; preparation, menu, completed, partial-failure screenshots inspected |

Independent Standards and Spec reviews completed with no remaining findings. The Spec review prompted the StrictMode regression. An earlier broader Library render run passed 303/305 tests; its two asynchronous failures passed on focused rerun. Final affected checks above passed. Per maintainer request, no complete local portable suite was run; PR CI remains authoritative. Backend/platform suites are excluded locally because this diff changes no IPC, filesystem handling, import implementation, or persistence contracts. Real UI verification covers local Web; Electron shares this renderer, but its native picker was not exercised in this task.

## Review focus

Primary completion action must remain rightmost, retry must disappear when no eligible selected work remains, skipped files must not be mislabeled as retries, and unconfirmed creation must remain non-replayable. Review selection/stop/StrictMode boundaries without expanding the import state machine.
