### PR TITLE
feat(skills): keep application skills always enabled

### DIFF
--- a/resources/skills/manifest.json
+++ b/resources/skills/manifest.json
@@ -101,24 +101,28 @@
       "id": "env-management",
       "name": "Environment & Packages",
       "source": "featured",
+      "activationPolicy": "always-on",
       "updatedAt": "2026-07-14T00:00:00.000Z"
     },
     {
       "id": "compute-env-setup",
       "name": "Compute Environment Setup",
       "source": "featured",
+      "activationPolicy": "always-on",
       "updatedAt": "2026-09-06T00:00:00.000Z"
     },
     {
       "id": "remote-compute-ssh",
       "name": "Remote Compute (SSH)",
       "source": "featured",
+      "activationPolicy": "always-on",
       "updatedAt": "2026-08-02T00:00:00.000Z"
     },
     {
       "id": "customize",
       "name": "Customize",
       "source": "featured",
+      "activationPolicy": "always-on",
       "updatedAt": "2026-08-12T00:00:00.000Z"
     },
     {
@@ -143,6 +147,7 @@
       "id": "self-awareness",
       "name": "Self-awareness",
       "source": "featured",
+      "activationPolicy": "always-on",
       "exposure": "internal",
       "updatedAt": "2026-08-10T00:00:00.000Z"
     },
@@ -150,6 +155,7 @@
       "id": "skill-creator",
       "name": "Skill Creator",
       "source": "featured",
+      "activationPolicy": "always-on",
       "exposure": "internal",
       "updatedAt": "2026-08-09T00:00:00.000Z"
     }

--- a/src/main/settings/repository.test.ts
+++ b/src/main/settings/repository.test.ts
@@ -1492,6 +1492,20 @@ describe('settings repository: v2 official providers & activeModel migration', (
     expect((await repository.getSettings()).disabledSkillIds).toBeUndefined()
   })
 
+  it('rejects disabling an application-required Skill and atomically rejects a mixed batch', async () => {
+    const repository = new SettingsRepository(await createStorageRoot())
+    await repository.setSkillEnabled('ordinary', false)
+
+    await expect(repository.setSkillEnabled('customize', false)).rejects.toThrow(
+      'Application-required Skill cannot be disabled: customize'
+    )
+    await expect(
+      repository.setSkillsEnabled(['ordinary-2', 'skill-creator'], false)
+    ).rejects.toThrow('Application-required Skill cannot be disabled: skill-creator')
+
+    expect((await repository.getSettings()).disabledSkillIds).toEqual(['ordinary'])
+  })
+
   it('serializes Main Skill enablement with package Skill replacement', async () => {
     const root = await createStorageRoot()
     const owner = skillMutationOwnerFor(root)

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -61,6 +61,7 @@ import {
   buildVisionModelMutation
 } from './subagent-model-settings'
 import { relocateManagedRuntimeEnablement } from '../notebook/managed-runtime-relocation'
+import { isApplicationRequiredSkillId } from '../skills/activation-policy'
 
 type SkillMutationGuard = <T>(operation: () => Promise<T>) => Promise<T>
 type Write = Promise<StoredSettings>
@@ -748,6 +749,11 @@ class SettingsRepository {
   }
 
   async setSkillsEnabled(ids: string[], enabled: boolean): Promise<StoredSettings> {
+    if (!enabled) {
+      const requiredId = ids.find(isApplicationRequiredSkillId)
+      if (requiredId)
+        throw new Error(`Application-required Skill cannot be disabled: ${requiredId}`)
+    }
     const update = (): Promise<StoredSettings> =>
       this.mutate((settings) => {
         const disabled = new Set(settings.disabledSkillIds ?? [])

--- a/src/main/settings/skill-catalog.registered-helpers.test.ts
+++ b/src/main/settings/skill-catalog.registered-helpers.test.ts
@@ -226,6 +226,54 @@ describe('SkillCatalogModule registered helper projection', () => {
     ).rejects.toThrow('not authorized')
   })
 
+  it('ignores stale Main disable state for required helpers while preserving Specialist scope', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'required-helper-scope-'))
+    roots.push(storageRoot)
+    const customize = {
+      ...(await skill('featured', 'customize')),
+      activationPolicy: 'always-on' as const
+    }
+    await writeFile(
+      join(storageRoot, 'settings.json'),
+      JSON.stringify({ version: 2, providers: [], disabledSkillIds: ['customize'] })
+    )
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: { list: async () => [customize] } as unknown as SkillRegistry,
+      userSkills: { list: async () => [] } as unknown as UserSkillRepository
+    })
+    const registry = catalog.registeredHelperCatalog()
+
+    await expect(registry.resolve('customize-helper')).resolves.toBeDefined()
+    await expect(
+      registry.resolve('customize-helper', {
+        sessionId: 'specialist-session',
+        allowedSkillIds: []
+      })
+    ).rejects.toThrow('not authorized')
+  })
+
+  it('keeps an injected helper authorization decision authoritative', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'required-helper-authorization-'))
+    roots.push(storageRoot)
+    const customize = {
+      ...(await skill('featured', 'customize')),
+      activationPolicy: 'always-on' as const
+    }
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: { list: async () => [customize] } as unknown as SkillRegistry,
+      userSkills: { list: async () => [] } as unknown as UserSkillRepository,
+      authorizeRegisteredHelper: async () => false
+    })
+
+    await expect(catalog.registeredHelperCatalog().resolve('customize-helper')).rejects.toThrow(
+      'not authorized'
+    )
+  })
+
   it('refreshes direct helper edits for new epochs while an active epoch stays pinned', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'helper-direct-refresh-'))
     roots.push(storageRoot)

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -14,6 +14,7 @@ vi.mock('electron', () => ({
 }))
 
 import { SkillRegistry } from '../skills/registry'
+import { loadSkillDocument } from '../skills/runtime-mcp-server'
 import type { FetchLike } from '../skills/github-import'
 import type { UserSkillRepository } from '../skills/user-skill-repository'
 import { SPECIALIST_PACKAGE_SKILL_METADATA } from '../skills/specialist-package-adapter'
@@ -56,6 +57,7 @@ const createCatalog = async (includeInternal = false): Promise<SkillCatalogModul
                 name: 'Skill Creator',
                 source: 'featured',
                 exposure: 'internal',
+                activationPolicy: 'always-on',
                 updatedAt: '2026-08-09T00:00:00.000Z'
               }
             ]
@@ -523,6 +525,146 @@ describe('SkillCatalogModule', () => {
     ).resolves.toContain('internal body')
     await chmod(join(runtimeRoot, 'skills', 'os-demo'), 0o755)
     await chmod(join(runtimeRoot, 'skills', 'os-skill-creator'), 0o755)
+  })
+
+  it('keeps activation policy independent from internal exposure', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-internal-policy-'))
+    const sourceRoot = await mkdtemp(join(tmpdir(), 'settings-internal-policy-source-'))
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'settings-internal-policy-runtime-'))
+    roots.push(storageRoot, sourceRoot, runtimeRoot)
+    await writeFile(
+      join(sourceRoot, 'SKILL.md'),
+      '---\nname: optional-helper\ndescription: Optional helper.\n---\n\nOptional body.'
+    )
+    await writeFile(
+      join(storageRoot, 'settings.json'),
+      JSON.stringify({ version: 2, providers: [], disabledSkillIds: ['optional-helper'] })
+    )
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: {
+        list: async () => [
+          {
+            id: 'optional-helper',
+            name: 'optional-helper',
+            displayName: 'Optional Helper',
+            description: 'Optional helper.',
+            source: 'featured' as const,
+            updatedAt: '2026-01-01',
+            sourceDir: sourceRoot,
+            exposure: 'internal' as const,
+            activationPolicy: 'user-controlled' as const
+          }
+        ]
+      } as unknown as SkillRegistry
+    })
+
+    await catalog.materializeSkills(runtimeRoot, ['optional-helper'])
+    await expect(
+      readFile(join(runtimeRoot, 'skills', 'os-optional-helper', 'SKILL.md'), 'utf8')
+    ).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('keeps a required Customize Skill enabled and materialized under stale disabled state', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-required-skill-'))
+    const bundleRoot = await mkdtemp(join(tmpdir(), 'settings-required-bundle-'))
+    const runtimeRoot = await mkdtemp(join(tmpdir(), 'settings-required-runtime-'))
+    roots.push(storageRoot, bundleRoot, runtimeRoot)
+    await mkdir(join(bundleRoot, 'customize'), { recursive: true })
+    await writeFile(
+      join(bundleRoot, 'customize', 'SKILL.md'),
+      '---\nname: customize\ndescription: Customize Open Science.\n---\n\nCustomize body.'
+    )
+    await writeFile(
+      join(bundleRoot, 'manifest.json'),
+      JSON.stringify({
+        version: 1,
+        skills: [
+          {
+            id: 'customize',
+            name: 'Customize',
+            source: 'featured',
+            activationPolicy: 'always-on',
+            updatedAt: '2026-08-12T00:00:00.000Z'
+          }
+        ]
+      })
+    )
+    await writeFile(
+      join(storageRoot, 'settings.json'),
+      JSON.stringify({ version: 2, providers: [], disabledSkillIds: ['customize'] })
+    )
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: new SkillRegistry(bundleRoot)
+    })
+
+    await expect(catalog.listSkills()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'customize',
+        enabled: true,
+        activationPolicy: 'always-on'
+      })
+    ])
+    await expect(catalog.skillsNeedingForceLoad(['customize'])).resolves.toEqual([])
+    await catalog.materializeSkills(join(runtimeRoot, '.claude'), ['customize'], new Set(), {
+      directoryLayout: 'agent-facing'
+    })
+    await expect(
+      readFile(join(runtimeRoot, '.claude', 'skills', 'customize', 'SKILL.md'), 'utf8')
+    ).resolves.toContain('Customize body.')
+    await expect(loadSkillDocument({ root: runtimeRoot }, 'customize')).resolves.toContain(
+      'Customize body.'
+    )
+    await catalog.createSkill({ name: 'personal', description: 'Personal.', body: '# Personal' })
+    await expect(catalog.setSkillEnabled({ id: 'customize', enabled: false })).rejects.toThrow(
+      'Application-required Skill cannot be disabled: customize'
+    )
+    await expect(
+      catalog.setSkillsEnabled({ ids: ['personal-personal', 'customize'], enabled: false })
+    ).rejects.toThrow('Application-required Skill cannot be disabled: customize')
+    expect(
+      (await catalog.listSkills()).find((skill) => skill.id === 'personal-personal')?.enabled
+    ).toBe(true)
+    await chmod(join(runtimeRoot, '.claude', 'skills', 'customize'), 0o755)
+  })
+
+  it('does not let user Skill metadata self-promote to always-on', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'settings-user-policy-'))
+    roots.push(storageRoot)
+    await writeFile(
+      join(storageRoot, 'settings.json'),
+      JSON.stringify({ version: 2, providers: [], disabledSkillIds: ['personal-demo'] })
+    )
+    const catalog = new SkillCatalogModule({
+      repository: new SettingsRepository(storageRoot),
+      storageRoot,
+      skillRegistry: { list: async () => [] } as unknown as SkillRegistry,
+      userSkills: {
+        list: async () => [
+          {
+            id: 'personal-demo',
+            name: 'demo',
+            displayName: 'Demo',
+            description: 'Demo.',
+            source: 'personal' as const,
+            activationPolicy: 'always-on' as const,
+            updatedAt: '2026-01-01',
+            sourceDir: storageRoot
+          }
+        ]
+      } as unknown as UserSkillRepository
+    })
+
+    await expect(catalog.listSkills()).resolves.toEqual([
+      expect.objectContaining({
+        id: 'personal-demo',
+        enabled: false,
+        activationPolicy: 'user-controlled'
+      })
+    ])
   })
 
   it('verifies before replacing a saved token and keeps the old token on failure', async () => {

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -68,6 +68,10 @@ import {
   type RegisteredSkillPackage,
   validateRegisteredSkillPackages
 } from '../skills/registered-helper-catalog'
+import {
+  isSkillEffectivelyEnabled,
+  trustedSkillActivationPolicy
+} from '../skills/activation-policy'
 
 type SkillCatalogEntry = {
   name: string
@@ -152,9 +156,10 @@ class SkillCatalogModule {
         const disabled = new Set(
           (await this.options.repository.getSettings()).disabledSkillIds ?? []
         )
+        const skill = (await this.catalog()).find((entry) => entry.id === skillId)
         // A trusted Specialist scope may force-load a globally disabled Skill. Main Agent requests
         // have no allowedSkillIds and continue to honor global enablement.
-        return !disabled.has(skillId)
+        return skill ? isSkillEffectivelyEnabled(skill, disabled) : false
       }
     })
   }
@@ -398,7 +403,7 @@ class SkillCatalogModule {
       frameworkName: skill.name,
       displayName: skill.displayName,
       source: skill.source,
-      mainEnabled: !disabled.has(skill.id),
+      mainEnabled: isSkillEffectivelyEnabled(skill, disabled),
       // Catalog entries are installed skills, so they resolve to a present entry at dispatch time.
       available: true,
       ...(skill.compatibility ? { compatibility: skill.compatibility } : {})
@@ -407,8 +412,11 @@ class SkillCatalogModule {
 
   async skillsNeedingForceLoad(ids: string[]): Promise<string[]> {
     const disabled = new Set((await this.options.repository.getSettings()).disabledSkillIds ?? [])
-    const managedIds = new Set((await this.managedCatalog()).map((skill) => skill.id))
-    return ids.filter((id) => managedIds.has(id) && disabled.has(id))
+    const managedById = new Map((await this.managedCatalog()).map((skill) => [skill.id, skill]))
+    return ids.filter((id) => {
+      const skill = managedById.get(id)
+      return skill !== undefined && disabled.has(id) && !isSkillEffectivelyEnabled(skill, disabled)
+    })
   }
 
   async skillNudgeNamesForIds(ids: string[]): Promise<string[]> {
@@ -484,7 +492,7 @@ class SkillCatalogModule {
     const disabled = new Set(settings.disabledSkillIds ?? [])
     const enabled: AdditionalSkillCatalogEntry[] = [
       ...skills
-        .filter((skill) => skill.exposure === 'internal' || !disabled.has(skill.id))
+        .filter((skill) => isSkillEffectivelyEnabled(skill, disabled))
         .map((skill) => ({
           directory: `${OS_SKILL_PREFIX}${skill.id}`,
           name: skill.name,
@@ -569,8 +577,19 @@ class SkillCatalogModule {
 
   async setSkillsEnabled(request: SetSkillsEnabledRequest): Promise<SkillView[]> {
     const ids = [...new Set(request.ids)]
+    const catalog = await this.managedCatalog()
+    if (!request.enabled) {
+      const required = catalog.find(
+        (skill) =>
+          ids.includes(skill.id) &&
+          trustedSkillActivationPolicy(skill.source, skill.activationPolicy) === 'always-on'
+      )
+      if (required) {
+        throw new Error(`Application-required Skill cannot be disabled: ${required.id}`)
+      }
+    }
     const selectableIds = new Set(
-      (await this.managedCatalog())
+      catalog
         .filter((skill) => skill.source === 'imported' || skill.source === 'personal')
         .map((skill) => skill.id)
     )
@@ -1092,9 +1111,7 @@ class SkillCatalogModule {
     const disabled = new Set(disabledIds.filter((id) => !forcedIds.has(id)))
     await new ClaudeCodeSkillMaterializer().sync(
       configRoot,
-      (await this.catalog()).filter(
-        (skill) => skill.exposure === 'internal' || !disabled.has(skill.id)
-      ),
+      (await this.catalog()).filter((skill) => isSkillEffectivelyEnabled(skill, disabled)),
       options
     )
   }
@@ -1150,7 +1167,8 @@ class SkillCatalogModule {
       description: skill.description,
       source: skill.source,
       updatedAt: skill.updatedAt,
-      enabled: !disabled.has(skill.id),
+      enabled: isSkillEffectivelyEnabled(skill, disabled),
+      activationPolicy: trustedSkillActivationPolicy(skill.source, skill.activationPolicy),
       available: true,
       author: skill.author,
       license: skill.license,

--- a/src/main/skills/activation-policy.ts
+++ b/src/main/skills/activation-policy.ts
@@ -1,0 +1,30 @@
+import type { SkillActivationPolicy, SkillSource } from '../../shared/settings'
+import bundledSkillManifest from '../../../resources/skills/manifest.json'
+
+const APPLICATION_REQUIRED_SKILL_IDS = new Set(
+  bundledSkillManifest.skills.flatMap((skill) =>
+    'activationPolicy' in skill && skill.activationPolicy === 'always-on' ? [skill.id] : []
+  )
+)
+
+const isApplicationRequiredSkillId = (id: string): boolean => APPLICATION_REQUIRED_SKILL_IDS.has(id)
+
+const trustedSkillActivationPolicy = (
+  source: SkillSource,
+  declared: SkillActivationPolicy | undefined
+): SkillActivationPolicy =>
+  source === 'featured' && declared === 'always-on' ? 'always-on' : 'user-controlled'
+
+const isSkillEffectivelyEnabled = (
+  skill: { id: string; source: SkillSource; activationPolicy?: SkillActivationPolicy },
+  disabledIds: ReadonlySet<string>
+): boolean =>
+  trustedSkillActivationPolicy(skill.source, skill.activationPolicy) === 'always-on' ||
+  !disabledIds.has(skill.id)
+
+export {
+  APPLICATION_REQUIRED_SKILL_IDS,
+  isApplicationRequiredSkillId,
+  isSkillEffectivelyEnabled,
+  trustedSkillActivationPolicy
+}

--- a/src/main/skills/registry.test.ts
+++ b/src/main/skills/registry.test.ts
@@ -93,8 +93,64 @@ describe('SkillRegistry', () => {
       category: 'biomodels',
       // `requirements: [gpu]` is a YAML list; the flat frontmatter reader joins it to a string. The
       // materializer only substring-matches gpu/compute, so this stays equivalent.
-      requirements: 'gpu'
+      requirements: 'gpu',
+      activationPolicy: 'user-controlled'
     })
+  })
+
+  it('reads always-on activation from a trusted bundled manifest', async () => {
+    const root = await seedRoot()
+    await mkdir(join(root, 'customize'), { recursive: true })
+    await writeFile(
+      join(root, 'customize', 'SKILL.md'),
+      '---\nname: customize\ndescription: Customize Open Science.\n---\nBody.'
+    )
+    await writeFile(
+      join(root, 'manifest.json'),
+      JSON.stringify({
+        version: 1,
+        skills: [
+          {
+            id: 'customize',
+            name: 'Customize',
+            source: 'featured',
+            activationPolicy: 'always-on',
+            updatedAt: '2026-01-01'
+          },
+          {
+            id: 'demo',
+            name: 'Demo',
+            source: 'featured',
+            activationPolicy: 'always-on',
+            updatedAt: '2026-01-01'
+          }
+        ]
+      })
+    )
+
+    expect(await new SkillRegistry(root).list()).toEqual([
+      expect.objectContaining({ id: 'customize', activationPolicy: 'always-on' }),
+      expect.objectContaining({ id: 'demo', activationPolicy: 'always-on' })
+    ])
+  })
+
+  it('marks exactly the application-required Skills always-on in the production manifest', async () => {
+    const skillsRoot = join(__dirname, '..', '..', '..', 'resources', 'skills')
+    const skills = await new SkillRegistry(skillsRoot).list()
+
+    expect(
+      skills
+        .filter((skill) => skill.activationPolicy === 'always-on')
+        .map((skill) => skill.id)
+        .sort()
+    ).toEqual([
+      'compute-env-setup',
+      'customize',
+      'env-management',
+      'remote-compute-ssh',
+      'self-awareness',
+      'skill-creator'
+    ])
   })
 
   it('uses an optional SKILL.md displayName instead of the manifest presentation name', async () => {

--- a/src/main/skills/registry.ts
+++ b/src/main/skills/registry.ts
@@ -1,12 +1,13 @@
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
-import type { SkillSource } from '../../shared/settings'
+import type { SkillActivationPolicy, SkillSource } from '../../shared/settings'
 import { createLogger } from '../logger'
 import { parseFrontmatter } from './frontmatter'
 import { resolveBundledSkillsRoot } from './resource-path'
 import { skillPackageCompatibility } from './skill-package-compatibility'
 import { readSkillHelperDescriptors, type SkillHelperDescriptor } from './registered-helper-catalog'
+import { trustedSkillActivationPolicy } from './activation-policy'
 
 const log = createLogger('skills')
 
@@ -33,6 +34,7 @@ export type BundledSkill = {
   // and Specialist picker surface. The source remains `featured`; exposure is a presentation rule,
   // not a fourth persisted Skill source.
   exposure?: 'catalog' | 'internal'
+  activationPolicy?: SkillActivationPolicy
   // Host-private executable descriptor metadata. Renderer projections deliberately omit this field.
   helpers?: readonly SkillHelperDescriptor[]
 }
@@ -43,6 +45,7 @@ type ManifestEntry = {
   source: SkillSource
   updatedAt: string
   exposure?: 'catalog' | 'internal'
+  activationPolicy?: SkillActivationPolicy
 }
 
 const SAFE_ID = /^[a-z0-9-]+$/
@@ -71,6 +74,9 @@ const readManifest = async (rootDir: string): Promise<ManifestEntry[]> => {
         (record?.exposure === undefined ||
           record?.exposure === 'catalog' ||
           record?.exposure === 'internal') &&
+        (record?.activationPolicy === undefined ||
+          record?.activationPolicy === 'user-controlled' ||
+          record?.activationPolicy === 'always-on') &&
         typeof record?.updatedAt === 'string'
       )
     })
@@ -120,6 +126,7 @@ class SkillRegistry {
           category: fields.category,
           requirements: fields.requirements,
           exposure: entry.exposure,
+          activationPolicy: trustedSkillActivationPolicy(entry.source, entry.activationPolicy),
           helpers: await readSkillHelperDescriptors(sourceDir)
         })
       } catch (error) {

--- a/src/renderer/src/pages/settings/RequiredSkillToggle.tsx
+++ b/src/renderer/src/pages/settings/RequiredSkillToggle.tsx
@@ -1,0 +1,43 @@
+import { useTranslation } from 'react-i18next'
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { SettingsToggle } from './SettingsLayout'
+
+type RequiredSkillToggleProps = {
+  label: string
+}
+
+const RequiredSkillToggle = ({ label }: RequiredSkillToggleProps): React.JSX.Element => {
+  const { t } = useTranslation()
+  const explanation = t(
+    'This built-in Skill supports core application features and is always enabled.'
+  )
+
+  return (
+    <TooltipProvider delayDuration={0}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            className="inline-flex cursor-default"
+            tabIndex={0}
+            aria-label={explanation}
+            data-testid="required-skill-toggle-tooltip"
+          >
+            <SettingsToggle
+              enabled
+              disabled
+              aria-label={label}
+              className="pointer-events-none"
+              onToggle={() => undefined}
+            />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs leading-relaxed">
+          {explanation}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+export { RequiredSkillToggle }

--- a/src/renderer/src/pages/settings/ResourceAvailability.tsx
+++ b/src/renderer/src/pages/settings/ResourceAvailability.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 
 import { SettingsToggle } from './SettingsLayout'
 import { SkillUsageAgents } from './SkillUsageAgents'
+import { RequiredSkillToggle } from './RequiredSkillToggle'
 import {
   resourceScope,
   type ResourceScope,
@@ -20,6 +21,7 @@ type ResourceAvailabilityProps = {
   mainToggleLabel: string
   usages: readonly SpecialistUsage[]
   onToggleMain: () => void
+  mainRequired?: boolean
   showAgentPopover?: boolean
   onOpenSpecialist?: (usage: SpecialistUsage) => void
 }
@@ -29,6 +31,7 @@ const ResourceAvailability = ({
   mainToggleLabel,
   usages,
   onToggleMain,
+  mainRequired = false,
   showAgentPopover = false,
   onOpenSpecialist
 }: ResourceAvailabilityProps): React.JSX.Element => {
@@ -47,11 +50,15 @@ const ResourceAvailability = ({
           <p className="text-sm text-foreground">{t('Main Agent')}</p>
           <p className="text-xs text-muted-foreground">{t(SCOPE_LABEL_KEYS[scope])}</p>
         </div>
-        <SettingsToggle
-          enabled={mainEnabled}
-          aria-label={mainToggleLabel}
-          onToggle={onToggleMain}
-        />
+        {mainRequired ? (
+          <RequiredSkillToggle label={mainToggleLabel} />
+        ) : (
+          <SettingsToggle
+            enabled={mainEnabled}
+            aria-label={mainToggleLabel}
+            onToggle={onToggleMain}
+          />
+        )}
       </div>
 
       {showAgentPopover && (mainEnabled || usages.length > 0) ? (

--- a/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.render.test.tsx
@@ -200,6 +200,43 @@ describe('SkillDetailView', () => {
     expect(useSettingsStore.getState().setSkillEnabled).toHaveBeenCalledWith('a', false)
   })
 
+  it('shows an inoperable checked toggle with an explanation for required availability', async () => {
+    ;(window as unknown as { api: unknown }).api = {
+      settings: {
+        getSkillDetail: vi.fn().mockResolvedValue({ ...detail, activationPolicy: 'always-on' })
+      }
+    }
+    useSettingsStore.setState({
+      skills: [{ ...detail, activationPolicy: 'always-on' }],
+      setSkillEnabled: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await act(async () => {
+      root.render(<SkillDetailView skillId="a" />)
+      await Promise.resolve()
+    })
+
+    const toggle = document.body.querySelector<HTMLButtonElement>('[aria-label="Toggle Alpha"]')
+    expect(toggle?.getAttribute('data-state')).toBe('checked')
+    expect(toggle?.disabled).toBe(true)
+    expect(toggle?.className).toContain('pointer-events-none')
+    expect(document.body.textContent).not.toContain('Application required')
+    expect(document.body.textContent).not.toContain('Always enabled')
+
+    await act(async () => {
+      const trigger = document.body.querySelector<HTMLElement>(
+        '[data-testid="required-skill-toggle-tooltip"]'
+      )
+      const hover = new MouseEvent('pointermove', { bubbles: true })
+      Object.defineProperty(hover, 'pointerType', { value: 'mouse' })
+      trigger?.dispatchEvent(hover)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toContain(
+      'This built-in Skill supports core application features and is always enabled.'
+    )
+  })
+
   it('omits the agent access row when no agent uses the Skill', async () => {
     useSettingsStore.setState({
       ...createInitialSettingsState(),

--- a/src/renderer/src/pages/settings/SkillDetailView.tsx
+++ b/src/renderer/src/pages/settings/SkillDetailView.tsx
@@ -174,6 +174,7 @@ const SkillDetailView = ({
 
       <ResourceAvailability
         mainEnabled={enabled}
+        mainRequired={(skill?.activationPolicy ?? detail.activationPolicy) === 'always-on'}
         mainToggleLabel={t('Toggle {{name}}', { name })}
         usages={usages}
         onToggleMain={() => void toggleSkill()}

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -249,6 +249,39 @@ describe('SkillsPanel (list view)', () => {
     expect(alphaSwitch?.className).toContain('motion-reduce:transition-none')
   })
 
+  it('shows an inoperable checked toggle with an explanation for application-required Skills', async () => {
+    useSettingsStore.setState({
+      skills: seedSkills.map((skill) =>
+        skill.id === 'a' ? { ...skill, activationPolicy: 'always-on' as const } : skill
+      )
+    })
+
+    act(() => {
+      root.render(<SkillsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)
+    })
+
+    const toggle = document.body.querySelector<HTMLButtonElement>('[aria-label="Toggle Alpha"]')
+    expect(toggle?.getAttribute('data-state')).toBe('checked')
+    expect(toggle?.disabled).toBe(true)
+    expect(toggle?.className).toContain('data-disabled:opacity-50')
+    expect(toggle?.className).toContain('pointer-events-none')
+    expect(document.body.textContent).not.toContain('Application required')
+    expect(document.body.textContent).not.toContain('Always enabled')
+
+    await act(async () => {
+      const trigger = document.body.querySelector<HTMLElement>(
+        '[data-testid="required-skill-toggle-tooltip"]'
+      )
+      const hover = new MouseEvent('pointermove', { bubbles: true })
+      Object.defineProperty(hover, 'pointerType', { value: 'mouse' })
+      trigger?.dispatchEvent(hover)
+      await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+    expect(document.body.querySelector('[role="tooltip"]')?.textContent).toContain(
+      'This built-in Skill supports core application features and is always enabled.'
+    )
+  })
+
   it('keeps filters and search above right-aligned list actions', () => {
     act(() => {
       root.render(<SkillsPanel view={{ kind: 'list' }} onNavigate={vi.fn()} />)

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -43,6 +43,7 @@ import {
   type SpecialistUsage
 } from './specialist-resource-scope'
 import { SkillUsageAgents } from './SkillUsageAgents'
+import { RequiredSkillToggle } from './RequiredSkillToggle'
 import {
   ResourceTagBadges,
   ResourceTagMenu,
@@ -722,21 +723,27 @@ const SkillsPanel = ({
                                 </DropdownMenuContent>
                               </DropdownMenu>
                             ) : null}
-                            <SettingsToggle
-                              enabled={skill.enabled}
-                              disabled={!available}
-                              aria-label={t('Toggle {{name}}', { name: skill.displayName })}
-                              title={
-                                !available
-                                  ? t('This Skill has an identity conflict and cannot be used.')
-                                  : skill.enabled
-                                    ? t('Available to Main Agent')
-                                    : t('Unavailable to Main Agent')
-                              }
-                              onToggle={() => {
-                                if (available) void toggleSkill(skill.id, !skill.enabled)
-                              }}
-                            />
+                            {skill.activationPolicy === 'always-on' ? (
+                              <RequiredSkillToggle
+                                label={t('Toggle {{name}}', { name: skill.displayName })}
+                              />
+                            ) : (
+                              <SettingsToggle
+                                enabled={skill.enabled}
+                                disabled={!available}
+                                aria-label={t('Toggle {{name}}', { name: skill.displayName })}
+                                title={
+                                  !available
+                                    ? t('This Skill has an identity conflict and cannot be used.')
+                                    : skill.enabled
+                                      ? t('Available to Main Agent')
+                                      : t('Unavailable to Main Agent')
+                                }
+                                onToggle={() => {
+                                  if (available) void toggleSkill(skill.id, !skill.enabled)
+                                }}
+                              />
+                            )}
                           </div>
                           {deleteError?.id === skill.id ? (
                             <p

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -3628,6 +3628,7 @@
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._one": "Wird von {{count}} Spezialisten verwendet. Entfernen Sie diese Fähigkeit vor dem Löschen aus dessen Konfiguration.",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "Wird von {{count}} Spezialisten verwendet. Entfernen Sie diese Fähigkeit vor dem Löschen aus deren Konfigurationen.",
     "Availability": "Verfügbarkeit",
+    "This built-in Skill supports core application features and is always enabled.": "Diese integrierte Fähigkeit unterstützt zentrale Anwendungsfunktionen und ist immer aktiviert.",
     "Specialist access is configured on each Specialist.": "Der Spezialistenzugriff wird für jeden Spezialisten konfiguriert.",
     "Resolve Skill conflicts": "Lösen Sie Fähigkeitkonflikte",
     "Choose one version for every conflicting Skill before installing the Specialist.": "Wählen Sie eine Version für jede widersprüchliche Fähigkeit, bevor Sie den Spezialisten installieren.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -4057,6 +4057,7 @@
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "Usada por {{count}} especialistas. Retire esta habilidad de esos especialistas antes de eliminarla.",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._many": "Usada por {{count}} especialistas. Retire esta habilidad de esos especialistas antes de eliminarla.",
     "Availability": "Disponibilidad",
+    "This built-in Skill supports core application features and is always enabled.": "Esta Habilidad integrada admite funciones esenciales de la aplicación y siempre está habilitada.",
     "Specialist access is configured on each Specialist.": "El acceso se configura por separado para cada especialista.",
     "Resolve Skill conflicts": "Resolver conflictos de habilidades",
     "Choose one version for every conflicting Skill before installing the Specialist.": "Elija una versión para cada habilidad en conflicto antes de instalar el especialista.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -4057,6 +4057,7 @@
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "Utilisée par {{count}} spécialistes. Retirez cette compétence de ces spécialistes avant de la supprimer.",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._many": "Utilisée par {{count}} spécialistes. Retirez cette compétence de ces spécialistes avant de la supprimer.",
     "Availability": "Disponibilité",
+    "This built-in Skill supports core application features and is always enabled.": "Cette Compétence intégrée prend en charge des fonctionnalités essentielles de l’application et reste toujours activée.",
     "Specialist access is configured on each Specialist.": "L'accès Spécialiste est configuré sur chaque Spécialiste.",
     "Resolve Skill conflicts": "Résoudre les conflits de compétences",
     "Choose one version for every conflicting Skill before installing the Specialist.": "Choisissez une version pour chaque compétence en conflit avant d'installer le spécialiste.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -3771,6 +3771,7 @@
     "Used by {{name}}. Remove this Skill from that Specialist before deleting it.": "{{name}} が使用しています。削除する前に、そのスペシャリストからこのスキルを取り除いてください。",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "{{count}} 件のスペシャリストが使用しています。削除する前に、これらのスペシャリストからこのスキルを取り除いてください。",
     "Availability": "利用範囲",
+    "This built-in Skill supports core application features and is always enabled.": "この組み込みスキルはアプリケーションの中核機能を支えるため、常に有効です。",
     "Specialist access is configured on each Specialist.": "スペシャリストへのアクセスは、各スペシャリストで設定します。",
     "Resolve Skill conflicts": "スキルの競合を解決",
     "Choose one version for every conflicting Skill before installing the Specialist.": "スペシャリストをインストールする前に、競合するすべてのスキルのバージョンを選択してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -3781,6 +3781,7 @@
     "Used by {{name}}. Remove this Skill from that Specialist before deleting it.": "{{name}}에서 사용됩니다. 삭제하기 전에 스페셜리스트에서 스킬을 제거하세요.",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "스페셜리스트 {{count}}개에서 사용 중입니다. 이 스킬을 삭제하기 전에 해당 스페셜리스트에서 제거하세요.",
     "Availability": "가용성",
+    "This built-in Skill supports core application features and is always enabled.": "이 기본 제공 스킬은 애플리케이션의 핵심 기능을 지원하며 항상 활성화되어 있습니다.",
     "Specialist access is configured on each Specialist.": "각 스페셜리스트에서 액세스를 설정합니다.",
     "Resolve Skill conflicts": "스킬 충돌 해결",
     "Choose one version for every conflicting Skill before installing the Specialist.": "스페셜리스트를 설치하기 전에 충돌하는 모든 스킬에 대해 하나의 버전을 선택하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -4166,6 +4166,7 @@
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._many": "Используется {{count}} специалистами. Перед удалением уберите у них этот навык.",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "Используется {{count}} специалистами. Перед удалением уберите у них этот навык.",
     "Availability": "Доступность",
+    "This built-in Skill supports core application features and is always enabled.": "Этот встроенный Навык поддерживает основные функции приложения и всегда включён.",
     "Specialist access is configured on each Specialist.": "Доступ настраивается отдельно для каждого специалиста.",
     "Resolve Skill conflicts": "Решение конфликтов навыков",
     "Choose one version for every conflicting Skill before installing the Specialist.": "Выберите одну версию для каждого конфликтующего навыка до установки специалиста.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -3858,6 +3858,7 @@
     "Used by {{name}}. Remove this Skill from that Specialist before deleting it.": "正由 {{name}} 使用。请先从该专家中移除此技能，再将其删除。",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "正由 {{count}} 个专家使用。请先从这些专家中移除此技能，再将其删除。",
     "Availability": "可用范围",
+    "This built-in Skill supports core application features and is always enabled.": "此内置技能用于应用核心功能，始终保持启用。",
     "Specialist access is configured on each Specialist.": "专家访问权限需在对应的专家中配置。",
     "Resolve Skill conflicts": "解决技能冲突",
     "Choose one version for every conflicting Skill before installing the Specialist.": "安装专家前，请为每个冲突的技能选择一个版本。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -3858,6 +3858,7 @@
     "Used by {{name}}. Remove this Skill from that Specialist before deleting it.": "正由 {{name}} 使用。請先從該專家中移除此技能，再將其刪除。",
     "Used by {{count}} Specialists. Remove this Skill from them before deleting it._other": "正由 {{count}} 個專家使用。請先從這些專家中移除此技能，再將其刪除。",
     "Availability": "可用範圍",
+    "This built-in Skill supports core application features and is always enabled.": "此內建技能用於應用程式核心功能，始終保持啟用。",
     "Specialist access is configured on each Specialist.": "專家存取權限需在對應的專家中設定。",
     "Resolve Skill conflicts": "解決技能衝突",
     "Choose one version for every conflicting Skill before installing the Specialist.": "安裝專家前，請為每個衝突的技能選擇一個版本。",

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1097,6 +1097,7 @@ export type EnvironmentCheckResult = {
 
 // A bundled skill's source category: app-bundled, imported from GitHub, or user-authored.
 export type SkillSource = 'featured' | 'imported' | 'personal'
+export type SkillActivationPolicy = 'always-on' | 'user-controlled'
 
 // Renderer-safe view of one bundled skill (no file contents).
 export type SkillView = {
@@ -1115,6 +1116,7 @@ export type SkillView = {
   source: SkillSource
   updatedAt: string
   enabled: boolean
+  activationPolicy?: SkillActivationPolicy
   // From the SKILL.md frontmatter; shown in the detail view's "Details" section when present.
   author?: string
   license?: string


### PR DESCRIPTION
## Problem

Open Science exposes several built-in Skills that support core application workflows through the same enable controls as optional Skills. Disabling one of these Skills can leave an application entry point visible while its runtime Skill is absent; for example, opening Customize can fail with `Unknown skill: customize`.

## Proposed change

- Add an `activationPolicy` contract with `always-on` and `user-controlled` values, defaulting to `user-controlled`.
- Mark Customize, Environment & Packages, Remote Compute (SSH), Compute Environment Setup, Self-awareness, and Skill Creator as always enabled in the trusted bundled manifest.
- Apply the effective activation policy consistently to Settings views, runtime projections, force-load decisions, and registered helpers.
- Reject single and mixed-batch attempts to disable application-required Skills while preserving existing behavior for optional Skills.
- Keep required Skill switches visible, checked, muted, and disabled; explain on hover or keyboard focus that the built-in Skill supports core application features and is always enabled.
- Translate the explanation across all eight renderer locales.

## Scope and non-goals

- `exposure` remains independent and controls presentation only; the two internal Skills remain hidden.
- Imported and Personal Skills cannot promote themselves to `always-on`.
- Specialist allowlists and explicit helper authorization decisions remain authoritative.
- Existing `disabledSkillIds` data is not migrated or rewritten. Required Skills simply ignore stale disabled entries when effective availability is calculated.

## Acceptance criteria and validation

The checks below cover the final source state.

- Manifest parsing, default policy, trusted-source handling, disable rejection, runtime projection and actual `loadSkillDocument('customize')`, helper authorization boundaries, internal-exposure independence, Settings list/detail rendering, tooltip interaction, and locale catalog integrity → `npx vitest run src/main/skills/registry.test.ts src/main/settings/repository.test.ts src/main/settings/skill-catalog.test.ts src/main/settings/skill-catalog.registered-helpers.test.ts src/main/settings/backend-resolver.test.ts src/main/skills/materializer.test.ts src/main/skills/materializer-integrity.regression.test.ts src/main/skills/runtime-mcp-server.test.ts src/renderer/src/pages/settings/SkillsPanel.render.test.tsx src/renderer/src/pages/settings/SkillDetailView.render.test.tsx src/renderer/src/i18n/resources.test.ts` → 11 files, 1,147 tests passed.
- Required toggle hover behavior after the final UI refinement → `npx vitest run src/renderer/src/pages/settings/SkillsPanel.render.test.tsx src/renderer/src/pages/settings/SkillDetailView.render.test.tsx src/renderer/src/i18n/resources.test.ts` → 3 files, 874 tests passed.
- Main, notebook sandbox, and renderer TypeScript contracts → `npm run typecheck` → passed.
- Final renderer TypeScript state after the UI refinement → `npm run typecheck:web` → passed.
- Source lint → `npm run lint` → passed.
- Whitespace validation → `git diff --check` → passed.

No platform-specific packaging or Electron E2E lane was run locally. The change does not add a platform-specific path or durable external component; PR Gate remains authoritative for selected platform lanes.

## Review focus

- Confirm the bundled manifest remains the sole source of application-required Skill identity.
- Confirm always-enabled availability does not widen Specialist access or bypass explicit helper authorization.
- Confirm disabled required switches remain discoverable and explain their fixed state through pointer and keyboard interaction.
