### PR TITLE
fix(preview): preserve edits and recover preview resources

### DIFF
--- a/src/main/managed-preview-protocol.test.ts
+++ b/src/main/managed-preview-protocol.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, open, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, open, readFile, rename, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -12,6 +12,104 @@ import {
 } from './managed-preview-protocol'
 
 describe('managed preview protocol', () => {
+  it.each([
+    ['bytes=-4', 'GHIJ', 'bytes 6-9/10'],
+    ['bytes=-99', 'ABCDEFGHIJ', 'bytes 0-9/10']
+  ])(
+    'serves the suffix range %s for an uncapped local capability',
+    async (range, text, contentRange) => {
+      const directory = await mkdtemp(join(tmpdir(), 'local-preview-suffix-'))
+      const filePath = join(directory, 'report.txt')
+      await writeFile(filePath, 'ABCDEFGHIJ')
+      const resources = new (await import('./managed-preview-resources')).ManagedPreviewResources({
+        resolvePath: async () => filePath
+      })
+      try {
+        const resource = await resources.acquire(17, { source: 'local', path: filePath })
+        const response = await createManagedPreviewProtocolHandler(resources)(
+          new Request(resource.url, { headers: { Range: range } })
+        )
+        const body = await response.text()
+        expect(response.status).toBe(206)
+        expect(body).toBe(text)
+        expect(response.headers.get('content-range')).toBe(contentRange)
+      } finally {
+        resources.releaseOwner(17)
+        await rm(directory, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it.each([
+    ['protocol', 'inode replacement'],
+    ['protocol', 'directory junction'],
+    ['IPC', 'inode replacement'],
+    ['IPC', 'directory junction'],
+    ['capped IPC', 'inode replacement'],
+    ['capped IPC', 'directory junction']
+  ])('rejects %s reads after %s between local preview pages', async (transport, replacement) => {
+    const directory = await mkdtemp(join(tmpdir(), 'local-preview-capability-'))
+    const granted = join(directory, 'granted')
+    const current = join(granted, 'current')
+    const outside = join(directory, 'outside')
+    const filePath = join(current, 'report.txt')
+    await mkdir(current, { recursive: true })
+    await mkdir(outside)
+    await writeFile(filePath, Buffer.alloc(2 * 1024 * 1024, 65))
+    await writeFile(join(outside, 'report.txt'), Buffer.alloc(2 * 1024 * 1024, 83))
+    const resources = new (await import('./managed-preview-resources')).ManagedPreviewResources({
+      resolvePath: async () => filePath
+    })
+    const request = { source: 'local' as const, path: filePath }
+    const options =
+      transport === 'capped IPC'
+        ? { snapshot: await resources.inspect(request), maxBytes: 2 * 1024 * 1024 }
+        : undefined
+    const resource = await resources.acquire(17, request, options)
+    const handle = createManagedPreviewProtocolHandler(resources, async (path, request) => {
+      // Electron's path transport is the only substitute; both branches read real files.
+      const range = request.headers.get('range')!.match(/^bytes=(\d+)-(\d+)$/)!
+      const bytes = await readFile(path)
+      return new Response(bytes.subarray(Number(range[1]), Number(range[2]) + 1), {
+        status: 206
+      })
+    })
+    const readPage = async (begin: number): Promise<string> => {
+      if (transport !== 'protocol') {
+        const result = await resources.readRange(17, {
+          resourceId: resource.id,
+          begin,
+          end: begin + 4
+        })
+        return new TextDecoder().decode(result.data)
+      }
+      const response = await handle(
+        new Request(resource.url, { headers: { Range: `bytes=${begin}-${begin + 3}` } })
+      )
+      if (!response.ok) {
+        expect(response.status).toBe(404)
+        throw new Error('Preview capability is unavailable')
+      }
+      expect(response.status).toBe(206)
+      return response.text()
+    }
+    try {
+      expect(await readPage(0)).toBe('AAAA')
+      if (replacement === 'inode replacement') {
+        await rename(filePath, join(current, 'original.txt'))
+        await writeFile(filePath, Buffer.alloc(2 * 1024 * 1024, 83))
+      } else {
+        await rename(current, join(granted, 'original'))
+        // A directory junction also runs on Windows without file-symlink privileges.
+        await symlink(outside, current, 'junction')
+      }
+      await expect(readPage(4096)).rejects.toThrow()
+    } finally {
+      resources.releaseOwner(17)
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
+
   it('can register the capability handler on an isolated Electron session', () => {
     const resources = {} as ManagedPreviewResources
     const targetProtocol = { handle: vi.fn(), unhandle: vi.fn() }

--- a/src/main/managed-preview-protocol.ts
+++ b/src/main/managed-preview-protocol.ts
@@ -59,8 +59,15 @@ const parseRange = (
   size: number
 ): { start: number; end: number } | undefined => {
   if (!rangeHeader) return size > 0 ? { start: 0, end: size - 1 } : undefined
-  const match = /^bytes=(\d+)-(\d*)$/.exec(rangeHeader.trim())
+  const match = /^bytes=(\d*)-(\d*)$/i.exec(rangeHeader.trim())
   if (!match) throw new Error('Managed preview range is invalid.')
+  if (!match[1]) {
+    const suffixLength = Number(match[2])
+    if (!Number.isSafeInteger(suffixLength) || suffixLength <= 0) {
+      throw new Error('Managed preview suffix range is invalid.')
+    }
+    return size > 0 ? { start: Math.max(0, size - suffixLength), end: size - 1 } : undefined
+  }
 
   const start = Number(match[1])
   const requestedEnd = match[2] ? Number(match[2]) : size - 1
@@ -104,7 +111,7 @@ const createStrictFileResponse = async (
   try {
     const rangeHeader = request.headers.get('range')
     const range = parseRange(rangeHeader, resource.size)
-    const isPartial = rangeHeader !== null
+    const isPartial = rangeHeader !== null && range !== undefined
     const headers = new Headers({
       'accept-ranges': 'bytes',
       'content-length': String(range ? range.end - range.start + 1 : 0)

--- a/src/main/managed-preview-resources.test.ts
+++ b/src/main/managed-preview-resources.test.ts
@@ -564,31 +564,38 @@ describe('ManagedPreviewResources', () => {
     expect(createId).not.toHaveBeenCalled()
   })
 
-  it('never serves replacement bytes swapped after capability admission', async () => {
-    const filePath = await createFile(Buffer.from('trusted-office'), 'report.docx')
-    const verifiedObservation = await observe(filePath)
-    const resources = new ManagedPreviewResources({
-      resolvePath: async () => filePath,
-      createId: () => 'verified-capability'
-    })
-    const resource = await resources.acquireResolvedFile(
-      17,
-      {
-        path: filePath,
-        verifiedObservation,
-        verifiedChecksum: 'trusted-checksum'
-      },
-      100
-    )
-    const replacementPath = join(temporaryDirectory!, 'replacement-after-admission.docx')
-    await writeFile(replacementPath, Buffer.from('hostile-office'))
-    await rename(replacementPath, filePath)
+  it.each(['protocol', 'IPC'])(
+    'never serves replacement bytes swapped after Reviewer capability admission through %s',
+    async (transport) => {
+      const filePath = await createFile(Buffer.from('trusted-office'), 'report.docx')
+      const verifiedObservation = await observe(filePath)
+      const resources = new ManagedPreviewResources({
+        resolvePath: async () => filePath,
+        createId: () => 'verified-capability'
+      })
+      const resource = await resources.acquireResolvedFile(
+        17,
+        {
+          path: filePath,
+          verifiedObservation,
+          verifiedChecksum: 'trusted-checksum'
+        },
+        100
+      )
+      const replacementPath = join(temporaryDirectory!, 'replacement-after-admission.docx')
+      await writeFile(replacementPath, Buffer.from('hostile-office'))
+      await rename(replacementPath, filePath)
 
-    await expect(resources.resolveProtocolResource(resource.id)).rejects.toMatchObject({
-      name: 'FileObservationMismatchError'
-    })
-    await expect(resources.resolveProtocolResource(resource.id)).rejects.toThrow(/not available/i)
-  })
+      await expect(
+        transport === 'protocol'
+          ? resources.resolveProtocolResource(resource.id)
+          : resources.readRange(17, { resourceId: resource.id, begin: 0, end: 4 })
+      ).rejects.toMatchObject({
+        name: 'FileObservationMismatchError'
+      })
+      await expect(resources.resolveProtocolResource(resource.id)).rejects.toThrow(/not available/i)
+    }
+  )
 
   it('rejects oversized ranges and access from another owner', async () => {
     const filePath = await createFile(new Uint8Array(2 * 1024 * 1024))
@@ -811,21 +818,29 @@ describe('ManagedPreviewResources', () => {
     expect(createId).not.toHaveBeenCalled()
   })
 
-  it('returns the filePath variant when a non-strict resource is resolved for protocol streaming', async () => {
-    const filePath = await createFile(Buffer.from('non-strict-protocol'))
+  it('returns a verified handle for protocol streaming without a whole-file limit', async () => {
+    const content = Buffer.from('verified-protocol')
+    const filePath = await createFile(content)
     const resources = new ManagedPreviewResources({
       resolvePath: async () => filePath,
-      createId: () => 'non-strict-resource'
+      createId: () => 'uncapped-resource'
     })
     const resource = await resources.acquire(17, { source: 'local', path: filePath })
 
     const protocolResource = await resources.resolveProtocolResource(resource.id)
 
-    expect(protocolResource).toEqual({
-      filePath,
-      mimeType: 'application/pdf'
-    })
-    expect('fileHandle' in protocolResource).toBe(false)
+    expect('fileHandle' in protocolResource).toBe(true)
+    if (!('fileHandle' in protocolResource)) throw new Error('Expected a verified handle')
+    try {
+      expect('filePath' in protocolResource).toBe(false)
+      expect(protocolResource.mimeType).toBe('application/pdf')
+      const bytes = Buffer.alloc(content.length)
+      await readExactRange(protocolResource.fileHandle, bytes, 0)
+      await protocolResource.verifyUnchanged()
+      expect(bytes).toEqual(content)
+    } finally {
+      await protocolResource.fileHandle.close()
+    }
   })
 
   it('rejects resolveProtocolResource for an unknown resource id', async () => {

--- a/src/main/managed-preview-resources.ts
+++ b/src/main/managed-preview-resources.ts
@@ -112,7 +112,6 @@ type ResourceEntry = ManagedPreviewResource & {
     dev: bigint
     ino: bigint
     mtimeNs: bigint
-    maxBytes: number
   }
   strictObservation?: FileObservation & { maxBytes: number }
 }
@@ -330,13 +329,13 @@ class ManagedPreviewResources {
         ownerId,
         filePath,
         ...(trustedLease ? { trustedLease } : {}),
-        ...(options
+        // Capability identity is independent of an optional whole-file admission limit.
+        ...(!trustedLease
           ? {
               strictSnapshot: {
-                dev: options.snapshot.dev,
-                ino: options.snapshot.ino,
-                mtimeNs: options.snapshot.mtimeNs,
-                maxBytes: options.maxBytes
+                dev: fileSnapshot.dev,
+                ino: fileSnapshot.ino,
+                mtimeNs: fileSnapshot.mtimeNs
               }
             }
           : {})
@@ -428,9 +427,14 @@ class ManagedPreviewResources {
     }
 
     const buffer = Buffer.allocUnsafe(end - begin)
-    const fileHandle = await open(resource.filePath, 'r')
+    const verified = await this.resolveProtocolResource(resource.id)
+    if (!('fileHandle' in verified)) {
+      throw new Error('Managed preview resource has no verified file handle.')
+    }
+    const { fileHandle } = verified
     try {
       await readExactRange(fileHandle, buffer, begin)
+      await verified.verifyUnchanged()
 
       return {
         begin,
@@ -543,7 +547,6 @@ class ManagedPreviewResources {
       if (
         !fileStat.isFile() ||
         fileStat.size !== BigInt(resource.size) ||
-        fileStat.size > BigInt(strictSnapshot.maxBytes) ||
         fileStat.mtimeNs !== strictSnapshot.mtimeNs ||
         fileStat.dev !== strictSnapshot.dev ||
         fileStat.ino !== strictSnapshot.ino
@@ -557,7 +560,6 @@ class ManagedPreviewResources {
         if (
           !finalStat.isFile() ||
           finalStat.size !== BigInt(resource.size) ||
-          finalStat.size > BigInt(strictSnapshot.maxBytes) ||
           finalStat.mtimeNs !== strictSnapshot.mtimeNs ||
           finalStat.dev !== strictSnapshot.dev ||
           finalStat.ino !== strictSnapshot.ino

--- a/src/main/office-preview/office-preview-ipc.test.ts
+++ b/src/main/office-preview/office-preview-ipc.test.ts
@@ -55,7 +55,7 @@ describe('registerOfficePreviewIpcHandlers', () => {
     supervisor.open.mockResolvedValue({ kind: 'started', sessionId: 'session-1' })
     supervisor.attachFrame.mockResolvedValue({ kind: 'attached', start: {} })
     registerOfficePreviewIpcHandlers(supervisor as never)
-    const sender = { id: 7, once: vi.fn() }
+    const sender = { id: 7, on: vi.fn(), removeListener: vi.fn(), once: vi.fn() }
     const event = { sender }
     const request = {
       requestId: 'request-1',
@@ -85,6 +85,8 @@ describe('registerOfficePreviewIpcHandlers', () => {
     const exitListeners = new Map<string, () => void>()
     const sender = {
       id: 7,
+      on: vi.fn(),
+      removeListener: vi.fn(),
       once: vi.fn((event: string, listener: () => void) => exitListeners.set(event, listener))
     }
 
@@ -110,7 +112,7 @@ describe('registerOfficePreviewIpcHandlers', () => {
   it('ignores malformed frame and runtime-state messages', async () => {
     const supervisor = createSupervisor()
     registerOfficePreviewIpcHandlers(supervisor as never)
-    const event = { sender: { id: 7, once: vi.fn() } }
+    const event = { sender: { id: 7, on: vi.fn(), removeListener: vi.fn(), once: vi.fn() } }
 
     await handlers.get('office-preview:attach-frame')?.(event, 123)
     listeners.get('office-preview:report-state')?.(event, 'session-1', {
@@ -131,7 +133,7 @@ describe('registerOfficePreviewIpcHandlers', () => {
       throw new Error('state failure')
     })
     registerOfficePreviewIpcHandlers(supervisor as never)
-    const event = { sender: { id: 7, once: vi.fn() } }
+    const event = { sender: { id: 7, on: vi.fn(), removeListener: vi.fn(), once: vi.fn() } }
 
     expect(() =>
       listeners.get('office-preview:report-state')?.(event, 'session-1', {
@@ -148,7 +150,7 @@ describe('registerOfficePreviewIpcHandlers', () => {
     const supervisor = createSupervisor()
     supervisor.open.mockRejectedValue(new OfficePreviewOpenSupersededError())
     registerOfficePreviewIpcHandlers(supervisor as never)
-    const event = { sender: { id: 8, once: vi.fn() } }
+    const event = { sender: { id: 8, on: vi.fn(), removeListener: vi.fn(), once: vi.fn() } }
 
     await expect(
       handlers.get('office-preview:open')?.(event, {

--- a/src/main/office-preview/office-preview-ipc.ts
+++ b/src/main/office-preview/office-preview-ipc.ts
@@ -34,8 +34,18 @@ const registerOfficePreviewIpcHandlers = (supervisor: OfficePreviewSupervisorPor
         if (closed || trackedOwners.get(ownerId) !== event.sender) return
         closed = true
         trackedOwners.delete(ownerId)
+        event.sender.removeListener('did-start-navigation', onNavigation)
+        event.sender.removeListener('destroyed', closeOwner)
+        event.sender.removeListener('render-process-gone', closeOwner)
         void supervisor.closeOwner(ownerId)
       }
+      const onNavigation = ({
+        isSameDocument,
+        isMainFrame
+      }: Electron.Event<Electron.WebContentsDidStartNavigationEventParams>): void => {
+        if (isMainFrame && !isSameDocument) closeOwner()
+      }
+      event.sender.on('did-start-navigation', onNavigation)
       event.sender.once('destroyed', closeOwner)
       event.sender.once('render-process-gone', closeOwner)
     }

--- a/src/main/office-preview/office-preview-navigation.test.ts
+++ b/src/main/office-preview/office-preview-navigation.test.ts
@@ -1,0 +1,195 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { ManagedPreviewResources } from '../managed-preview-resources'
+import { registerOfficePreviewIpcHandlers } from './office-preview-ipc'
+import { OfficePreviewSupervisor } from './office-preview-supervisor'
+import type { ManagedFileReadLease } from '../managed-file-versions/service'
+import type { OfficePreviewOpenRequest, OfficePreviewOpenResult } from '../../shared/office-preview'
+import type { ManagedPreviewResource } from '../../shared/preview-resources'
+type OpenHandler = (
+  event: { sender: EventEmitter & { id: number } },
+  request: OfficePreviewOpenRequest
+) => Promise<OfficePreviewOpenResult>
+const ipc = vi.hoisted(() => ({ handlers: new Map<string, OpenHandler>() }))
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (name: string, handler: OpenHandler) => ipc.handlers.set(name, handler),
+    on: () => {}
+  },
+  net: { fetch: vi.fn() },
+  protocol: { handle: vi.fn(), unhandle: vi.fn() }
+}))
+vi.mock('../logger', () => ({
+  createLogger: () => ({ warn: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() }),
+  diagnosticErrorFields: () => ({})
+}))
+const deferred = <T>(): { resolve: (value: T) => void; promise: Promise<T> } => {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((r) => (resolve = r))
+  return { resolve, promise }
+}
+const request = { source: 'artifact' as const, projectId: 'p', fileId: 'f' }
+let senderId = 100
+const sender = (): EventEmitter & { id: number } =>
+  Object.assign(new EventEmitter(), { id: ++senderId })
+const setup = (
+  size = 4
+): {
+  resources: ManagedPreviewResources
+  lease: ManagedFileReadLease
+  close: ReturnType<typeof vi.fn<() => Promise<void>>>
+} => {
+  const close = vi.fn(async () => {})
+  const makeLease = (): ManagedFileReadLease => {
+    let closed = false
+    const assertOpen = (): void => {
+      if (closed) throw new Error('lease is closed')
+    }
+    // The resource owner consumes only byte-lease operations; version catalog metadata is outside this boundary.
+    return {
+      path: '/managed/document.docx',
+      size,
+      versionToken: 1,
+      snapshot: { dev: 1n, ino: 2n, size: BigInt(size), mtimeNs: 1n },
+      read: vi.fn(async (buffer: Uint8Array, offset: number, length: number) => {
+        assertOpen()
+        buffer.fill(65, offset, offset + length)
+        return { bytesRead: length }
+      }),
+      readRange: vi.fn(async (begin: number, end: number) => {
+        assertOpen()
+        return Buffer.alloc(end - begin, 65)
+      }),
+      verifyUnchanged: vi.fn(async () => assertOpen()),
+      close: async () => {
+        if (closed) return
+        closed = true
+        await close()
+      }
+    } as unknown as ManagedFileReadLease
+  }
+  const lease = makeLease()
+  let id = 0
+  const resources = new ManagedPreviewResources({
+    resolvePath: async () => {
+      throw new Error('unused')
+    },
+    openLatestManagedFile: async () => makeLease(),
+    createId: () => `r-${++id}`
+  })
+  return { resources, lease, close }
+}
+afterEach(() => {
+  vi.useRealTimers()
+  ipc.handlers.clear()
+})
+describe('Office host navigation', () => {
+  const office = (
+    size = 4
+  ): ReturnType<typeof setup> & {
+    supervisor: OfficePreviewSupervisor
+    publish: ReturnType<typeof vi.fn>
+    acquired: ManagedPreviewResource[]
+  } => {
+    const env = setup(size)
+    let session = 0
+    const publish = vi.fn()
+    const acquired: ManagedPreviewResource[] = []
+    const supervisor = new OfficePreviewSupervisor({
+      inspectResource: () => env.resources.inspect(request),
+      acquireResource: async (owner, _req, snapshot, maxBytes) => {
+        const r = await env.resources.acquire(owner, request, { snapshot, maxBytes })
+        acquired.push(r)
+        return r
+      },
+      releaseResource: (owner, id) => env.resources.release(owner, { resourceId: id }),
+      createSessionId: () => `session-${++session}`,
+      createRuntimeUrl: (id) => `open-science-office-preview://runtime/${id}`,
+      resolveFrameProcess: () => undefined,
+      publishState: publish
+    })
+    registerOfficePreviewIpcHandlers(supervisor)
+    return { ...env, supervisor, publish, acquired }
+  }
+  it.each([false, true])(
+    'Office navigation immediately closes an unattached session (retry=%s)',
+    async (retry) => {
+      vi.useFakeTimers()
+      const env = office(25 * 1024 * 1024)
+      const s = sender()
+      const result = await ipc.handlers.get('office-preview:open')!(
+        { sender: s },
+        {
+          ...request,
+          requestId: 'old',
+          name: 'document.docx',
+          extension: 'docx',
+          attempt: retry ? 1 : 0
+        }
+      )
+      expect(result.kind).toBe('started')
+      expect(env.close).toHaveBeenCalledOnce()
+      env.close.mockClear()
+      s.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false })
+      await Promise.resolve()
+      expect(env.close).toHaveBeenCalledOnce()
+      await expect(env.resources.resolveProtocolResource(env.acquired[0].id)).rejects.toThrow(
+        'not available'
+      )
+      s.emit('destroyed')
+    }
+  )
+  it.each(['navigation', 'destroyed'])(
+    'Office acquisition finishing after %s has the documented lifecycle outcome',
+    async (eventName) => {
+      vi.useFakeTimers()
+      const env = office()
+      const s = sender()
+      const gate = deferred<void>()
+      const original = env.resources.inspect.bind(env.resources)
+      vi.spyOn(env.resources, 'inspect').mockImplementation(async (r) => {
+        await gate.promise
+        return original(r)
+      })
+      const pending = ipc.handlers.get('office-preview:open')!(
+        { sender: s },
+        { ...request, requestId: 'old', name: 'document.docx', extension: 'docx', attempt: 0 }
+      )
+      if (eventName === 'navigation')
+        s.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false })
+      else s.emit('destroyed')
+      gate.resolve()
+      const result = await pending
+      expect(result).toEqual({ kind: 'cancelled' })
+      expect(env.acquired).toHaveLength(0)
+      s.emit('destroyed')
+    }
+  )
+  it('keeps same-document and subframe navigation alive and retracks a replaced document', async () => {
+    const env = office()
+    const s = sender()
+    const open = (): Promise<OfficePreviewOpenResult> =>
+      ipc.handlers.get('office-preview:open')!(
+        { sender: s },
+        { ...request, requestId: 'current', name: 'document.docx', extension: 'docx', attempt: 0 }
+      )
+    await open()
+    const events = ['did-start-navigation', 'destroyed', 'render-process-gone']
+    const listenerCounts = events.map((event) => s.listenerCount(event))
+    env.close.mockClear()
+    s.emit('did-start-navigation', { isMainFrame: true, isSameDocument: true })
+    s.emit('did-start-navigation', { isMainFrame: false, isSameDocument: false })
+    expect(env.close).not.toHaveBeenCalled()
+    s.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false })
+    await Promise.resolve()
+    expect(env.close).toHaveBeenCalledOnce()
+    expect(s.listenerCount('did-start-navigation')).toBe(0)
+    await open()
+    expect(events.map((event) => s.listenerCount(event))).toEqual(listenerCounts)
+    env.close.mockClear()
+    s.emit('destroyed')
+    await Promise.resolve()
+    expect(env.close).toHaveBeenCalledOnce()
+    expect(s.listenerCount('did-start-navigation')).toBe(0)
+  })
+})

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -6796,6 +6796,7 @@ const LiteratureLibraryPage = (): React.JSX.Element => {
       ) : null}
       <ProjectFormDialog {...batchProjectFormDialog.dialogProps} />
       <FilePreviewDialog
+        onFocusFallback={() => libraryEntryRef.current?.focus()}
         item={previewItem}
         allowReadingContext={false}
         onReadWithAgent={requestReadWithAgent}

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.focus.test.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.focus.test.tsx
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+import { act, useState, useImperativeHandle, type Ref } from 'react'
+import type { PreviewFileItem } from '@/stores/preview-workbench-store'
+import type { PreviewFileSurfaceHandle } from './PreviewFileSurface'
+import { createRoot, type Root } from 'react-dom/client'
+import { beforeEach, afterEach, expect, it, vi } from 'vitest'
+vi.mock('./PreviewFileSurface', () => ({
+  PreviewFileSurface: ({
+    ref,
+    onClose
+  }: {
+    ref: Ref<PreviewFileSurfaceHandle>
+    onClose: () => void
+  }) => {
+    useImperativeHandle(ref, () => ({
+      requestLeave: (action: () => void) => {
+        action()
+        return true
+      }
+    }))
+    return (
+      <>
+        <input aria-label="Preview text" />
+        <button id="close" onClick={onClose}>
+          Close preview
+        </button>
+      </>
+    )
+  }
+}))
+import { FilePreviewDialog } from './FilePreviewDialog'
+const item: PreviewFileItem = {
+  id: 'p1',
+  projectId: 'p1',
+  sessionId: 's1',
+  type: 'file',
+  title: 'report.pdf',
+  name: 'report.pdf',
+  path: '/audit/report.pdf',
+  format: 'pdf',
+  source: 'artifact'
+}
+let container: HTMLDivElement, root: Root
+beforeEach(() => {
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  vi.stubGlobal('matchMedia', () => ({
+    matches: true,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn()
+  }))
+  container = document.createElement('div')
+  container.id = 'root'
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+afterEach(async () => {
+  await act(async () => root.unmount())
+  container.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+function App({
+  triggerState = 'normal'
+}: {
+  triggerState?: 'normal' | 'removed' | 'disabled'
+}): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  return (
+    <>
+      {triggerState !== 'removed' && (
+        <button id="card" disabled={triggerState === 'disabled'} onClick={() => setOpen(true)}>
+          Preview report.pdf
+        </button>
+      )}
+      <button id="fallback">Files</button>
+      <FilePreviewDialog
+        onFocusFallback={() => container.querySelector<HTMLButtonElement>('#fallback')?.focus()}
+        item={open ? item : undefined}
+        onClose={() => setOpen(false)}
+      />
+    </>
+  )
+}
+it.each(['normal', 'removed', 'disabled'] as const)(
+  'close restoration with %s original card',
+  async (triggerState) => {
+    await act(async () => root.render(<App />))
+    const original = container.querySelector<HTMLButtonElement>('#card')!
+    await act(async () => {
+      original.focus()
+      original.click()
+    })
+    expect(document.body.querySelector('[role="dialog"]')).not.toBeNull()
+    expect(container.inert).toBe(true)
+    if (triggerState !== 'normal')
+      await act(async () => root.render(<App triggerState={triggerState} />))
+    const close = document.body.querySelector<HTMLButtonElement>('#close')!
+    await act(async () => {
+      close.focus()
+      close.click()
+      await new Promise((r) => setTimeout(r, 30))
+    })
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 30))
+    })
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+    expect(container.inert).toBe(false)
+    if (triggerState === 'normal') expect(document.activeElement).toBe(original)
+    else expect(document.activeElement).toBe(container.querySelector('#fallback'))
+  }
+)
+it('IME composing Escape leaves preview open', async () => {
+  await act(async () => root.render(<App />))
+  await act(async () => container.querySelector<HTMLButtonElement>('#card')!.click())
+  const field = document.body.querySelector('input')!
+  await act(async () => {
+    field.focus()
+    field.dispatchEvent(
+      new KeyboardEvent('keydown', {
+        key: 'Escape',
+        isComposing: true,
+        bubbles: true,
+        cancelable: true
+      })
+    )
+  })
+  expect(document.body.querySelector('[role="dialog"]')).not.toBeNull()
+  expect(document.activeElement).toBe(field)
+})

--- a/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
+++ b/src/renderer/src/pages/workspace/FilePreviewDialog.tsx
@@ -19,6 +19,7 @@ type FilePreviewDialogProps = PreviewInteractionPort & {
   allowReadingContext?: boolean
   onReadWithAgent?: (item: PreviewFileItem) => void
   onPdfContextError?: (message: string | null) => void
+  onFocusFallback?: () => void
 }
 
 const hasStreamdownFullscreen = (): boolean =>
@@ -59,6 +60,7 @@ const FilePreviewDialog = ({
   allowReadingContext = true,
   onReadWithAgent,
   onPdfContextError,
+  onFocusFallback,
   ...annotationPort
 }: FilePreviewDialogProps): React.JSX.Element | null => {
   const { t } = useTranslation()
@@ -66,6 +68,7 @@ const FilePreviewDialog = ({
   const open = Boolean(item)
   const [hasNestedFullscreen, setHasNestedFullscreen] = useState(hasStreamdownFullscreen)
   const isBackgroundIsolatedRef = useRef(false)
+  const returnFocusRef = useRef<HTMLElement | null>(null)
   const previewSurfaceRef = useRef<PreviewFileSurfaceHandle | null>(null)
   const requestClose = useCallback(
     (checkGuard = true): void => {
@@ -123,6 +126,7 @@ const FilePreviewDialog = ({
           data-slot="file-preview-dialog"
           aria-describedby={undefined}
           aria-modal="true"
+          onCloseAutoFocus={(event) => event.preventDefault()}
           onInteractOutside={(event) => event.preventDefault()}
           onAnimationEnd={(event) => {
             if (!open && event.target === event.currentTarget) releaseBackgroundIsolation()
@@ -134,7 +138,28 @@ const FilePreviewDialog = ({
           <Dialog.Title className="sr-only">
             {dialogItem ? t('Preview {{title}}', { title: dialogItem.title }) : t('File preview')}
           </Dialog.Title>
-          <FocusScope asChild loop trapped={!(open && hasNestedFullscreen)}>
+          <FocusScope
+            asChild
+            loop
+            trapped={!(open && hasNestedFullscreen)}
+            onMountAutoFocus={() => {
+              returnFocusRef.current =
+                document.activeElement instanceof HTMLElement ? document.activeElement : null
+            }}
+            onUnmountAutoFocus={(event) => {
+              releaseBackgroundIsolation()
+              const trigger = returnFocusRef.current
+              if (
+                !trigger?.isConnected ||
+                trigger.matches(':disabled, [inert], [aria-disabled="true"]')
+              ) {
+                if (onFocusFallback) {
+                  event.preventDefault()
+                  onFocusFallback()
+                }
+              }
+            }}
+          >
             <div className="flex size-full min-h-0 min-w-0">
               {dialogItem ? (
                 <PreviewFileSurface

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx
@@ -355,6 +355,56 @@ describe('PreviewFileSurface managed text versions', () => {
       .mockResolvedValue({ ok: true, value: managedInspect })
   })
 
+  it.each([false, true])(
+    'preserves input accepted while saving (workbenchConnected=%s)',
+    async (workbenchConnected) => {
+      type SaveResult = Awaited<ReturnType<typeof window.api.managedFileVersions.saveTextEdit>>
+      let complete!: (result: SaveResult) => void
+      const save = vi.fn(() => new Promise<SaveResult>((resolve) => (complete = resolve)))
+      window.api.managedFileVersions.saveTextEdit = save
+      if (workbenchConnected) {
+        usePreviewWorkbenchStore.getState().upsertAndActivateItem(managedUploadItem)
+      }
+      await act(async () =>
+        root.render(
+          <PreviewFileSurface
+            item={managedUploadItem}
+            onClose={vi.fn()}
+            workbenchConnected={workbenchConnected}
+          />
+        )
+      )
+      await click(container.querySelector('[aria-label="Edit README.md"]'))
+      const submitted = '# Submitted A\n'
+      await changeTextarea(container.querySelector('textarea')!, submitted)
+      await click(container.querySelector('[aria-label="Save changes"]'))
+      const editor = container.querySelector('textarea')!
+      const acceptsInput = !editor.readOnly && !editor.disabled
+      const newerDraft = `${submitted}New unsaved B\n`
+      if (acceptsInput) await changeTextarea(editor, newerDraft)
+      expect(save).toHaveBeenCalledTimes(1)
+      expect(save.mock.calls[0]).toEqual([expect.objectContaining({ content: submitted })])
+      await act(async () => {
+        complete({
+          ok: true,
+          value: {
+            kind: 'created',
+            replayed: false,
+            version: { ...managedInspect.versions[1], id: 'upload-v3', versionNumber: 3 },
+            headVersionId: 'upload-v3'
+          }
+        })
+      })
+      if (acceptsInput) {
+        expect(container.querySelector('textarea')?.value).toBe(newerDraft)
+      } else {
+        expect(container.querySelector('textarea')).toBeNull()
+      }
+      expect(save).toHaveBeenCalledTimes(1)
+      expect(discardConfirmation()).toBeNull()
+    }
+  )
+
   it.each([
     ['initial', 'result'],
     ['initial', 'rejection'],

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1625,6 +1625,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                   {mode === 'edit' ? (
                     <div className="flex size-full min-h-0 flex-col">
                       <textarea
+                        readOnly={saving}
                         autoFocus
                         aria-label={t('Edit {{name}} source', { name: resolvedPreviewItem.name })}
                         className="min-h-0 flex-1 resize-none bg-bg-000 p-4 font-mono text-sm leading-6 text-text-000 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -243,6 +243,7 @@ const WorkspacePage = ({
   const [manualReviewRequests, setManualReviewRequests] = useState<
     Record<string, ManualReviewRequestState>
   >({})
+  const previewFocusFallbackRef = useRef<HTMLElement>(null)
   const manualReviewPendingSessionIdsRef = useRef(new Set<string>())
   const syncPreviewPanelState = usePreviewWorkbenchStore((state) => state.syncPanelState)
   const runtime = useWorkspaceAgentRuntime()
@@ -1165,7 +1166,11 @@ const WorkspacePage = ({
     typeof window.api.backgroundResultDelivery?.getProjectActivity === 'function'
 
   return (
-    <main className="h-[100dvh] overflow-hidden bg-bg-10 text-[13px] leading-normal text-text-000 md:h-screen md:p-[10px]">
+    <main
+      ref={previewFocusFallbackRef}
+      tabIndex={-1}
+      className="h-[100dvh] overflow-hidden bg-bg-10 text-[13px] leading-normal text-text-000 md:h-screen md:p-[10px]"
+    >
       <WorkspacePanelLayout
         hasPreviewItems={previewItems.length > 0}
         isPreviewPresentationActive={isPreviewPresentationActive}
@@ -1482,6 +1487,7 @@ const WorkspacePage = ({
       />
 
       <FilePreviewDialog
+        onFocusFallback={() => previewFocusFallbackRef.current?.focus()}
         item={
           isPreviewPresentationActive && fileDialogItem?.projectId === activeProjectId
             ? fileDialogItem

--- a/src/renderer/src/pages/workspace/previews/PreviewFallback.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFallback.tsx
@@ -211,6 +211,7 @@ export const PreviewErrorCard = (props: {
   name: string
   error?: unknown
   fallbackMessage: string
+  retryable?: boolean
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const { name, error, fallbackMessage } = props
@@ -230,7 +231,7 @@ export const PreviewErrorCard = (props: {
       name={name}
       title={t(unavailable ? 'File unavailable' : 'Preview unavailable')}
       message={message}
-      retryable
+      retryable={props.retryable ?? true}
     />
   )
 }

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx
@@ -577,8 +577,7 @@ describe('PreviewFileContent', () => {
     expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
       source: 'artifact',
       projectId: 'project-1',
-      fileId: 'canonical-artifact-id',
-      maxBytes: expect.any(Number)
+      fileId: 'canonical-artifact-id'
     })
     consoleError.mockRestore()
   })
@@ -596,8 +595,7 @@ describe('PreviewFileContent', () => {
     expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
       source: 'artifact',
       projectId: 'project-1',
-      fileId: 'file-1',
-      maxBytes: 1024 * 1024
+      fileId: 'file-1'
     })
     expect(container.querySelector('pre')?.textContent).toContain('"name":"sample"')
     expect(container.querySelector('pre')?.textContent).toContain('"values":[')
@@ -852,20 +850,33 @@ describe('PreviewFileContent', () => {
     expect(window.api.artifacts.openFile).not.toHaveBeenCalled()
   })
 
-  it('keeps the unavailable classification when a managed fetch returns 404 after acquire', async () => {
+  it('reacquires an expired preview after a protocol 404 without reporting a missing file', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
-    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 404 }))
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }))
+    vi.mocked(window.api.artifacts.readPreview).mockResolvedValue({
+      content: 'Recovered preview',
+      encoding: 'utf8',
+      size: 17,
+      truncated: false
+    })
 
     await renderFile(
       createFileItem({ format: 'text', name: 'gone.txt', path: '/workspace/gone.txt' })
     )
 
-    expect(container.textContent).toContain('This file is no longer available')
+    expect(container.textContent).not.toContain('This file is no longer available')
+    expect(container.textContent).toContain("File couldn't be read")
     expect(container.querySelector('pre')).toBeNull()
-    expect(consoleError).not.toHaveBeenCalledWith('Failed to read file preview', expect.anything())
     expect(window.api.previewResources.release).toHaveBeenCalledWith({
       resourceId: 'resource-1'
     })
+    const retry = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Retry'
+    )
+    expect(retry).toBeDefined()
+    await act(async () => retry!.click())
+    await vi.waitFor(() => expect(container.textContent).toContain('Recovered preview'))
+    expect(window.api.previewResources.acquire).toHaveBeenCalledTimes(2)
 
     consoleError.mockRestore()
   })
@@ -1351,8 +1362,7 @@ describe('PreviewFileContent', () => {
     expect(window.api.previewResources.acquire).toHaveBeenCalledWith({
       source: 'upload',
       projectId: 'project-1',
-      fileId: 'file-1',
-      maxBytes: 1024 * 1024
+      fileId: 'file-1'
     })
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
     expect(container.textContent).toContain('uploaded content')

--- a/src/renderer/src/pages/workspace/previews/preview-pagination-contract.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/preview-pagination-contract.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment jsdom
+import { mkdtemp, open, writeFile, rm, readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, expect, it, vi } from 'vitest'
+import type { ManagedFileReadLease } from '../../../../../main/managed-file-versions/service'
+import type {
+  AcquireManagedPreviewRequest,
+  ReleaseManagedPreviewRequest,
+  ReadManagedPreviewRangeRequest
+} from '../../../../../shared/preview-resources'
+import type { PreviewFileSource } from '@/stores/preview-workbench-store'
+import { ManagedPreviewResources } from '../../../../../main/managed-preview-resources'
+import { createManagedPreviewOwnerRegistry } from '../../../../../main/managed-preview-ipc'
+import { createManagedPreviewProtocolHandler } from '../../../../../main/managed-preview-protocol'
+import { ApplicationCallerLeaseRegistry } from '../../../../../main/caller-lifecycle'
+import { createElectronCallerContext } from '../../../../../main/caller-context'
+import { usePreviewFileContent, PREVIEW_TEXT_MAX_BYTES } from './usePreviewFileContent'
+import { PreviewTextContent } from './renderers/TextPreview'
+vi.mock('electron', () => ({
+  ipcMain: { handle: vi.fn() },
+  net: { fetch: vi.fn() },
+  protocol: { handle: vi.fn(), unhandle: vi.fn() }
+}))
+let directory: string | undefined,
+  root: Root | undefined,
+  container: HTMLDivElement | undefined,
+  cleanup: undefined | (() => void)
+afterEach(async () => {
+  await act(async () => root?.unmount())
+  await cleanup?.()
+  container?.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+  if (directory) await rm(directory, { recursive: true, force: true })
+  root = undefined
+  cleanup = undefined
+  directory = undefined
+})
+const setup = async (
+  size: number
+): Promise<{
+  path: string
+  resources: ManagedPreviewResources
+  owners: ReturnType<typeof createManagedPreviewOwnerRegistry>
+  caller: ReturnType<ApplicationCallerLeaseRegistry['acquire']>
+}> => {
+  directory = await mkdtemp(join(tmpdir(), 'preview-contract-'))
+  const path = join(directory, 'report.txt')
+  await writeFile(path, Buffer.alloc(size, 65))
+  const handles: Awaited<ReturnType<typeof open>>[] = []
+  const openLease = async (): Promise<ManagedFileReadLease> => {
+    const handle = await open(path, 'r')
+    handles.push(handle)
+    const snapshot = await handle.stat({ bigint: true })
+    let closed = false
+    // The resource owner consumes only byte-lease operations; version catalog metadata is outside this boundary.
+    return {
+      path,
+      size: Number(snapshot.size),
+      versionToken: 1,
+      snapshot,
+      read: handle.read.bind(handle),
+      readRange: async (begin: number, end: number) => {
+        const b = Buffer.alloc(end - begin)
+        await handle.read(b, 0, b.length, begin)
+        return b
+      },
+      verifyUnchanged: async () => {
+        const now = await handle.stat({ bigint: true })
+        expect(now.size).toBe(snapshot.size)
+        expect(now.mtimeNs).toBe(snapshot.mtimeNs)
+      },
+      close: async () => {
+        if (closed) return
+        closed = true
+        await handle.close()
+      }
+    } as unknown as ManagedFileReadLease
+  }
+  const resources = new ManagedPreviewResources({
+    resolvePath: async () => path,
+    openLatestManagedFile: openLease,
+    openManagedFileVersion: openLease,
+    openNotebookInput: openLease
+  })
+  const lifecycle = new ApplicationCallerLeaseRegistry()
+  const caller = lifecycle.acquire(createElectronCallerContext(9))
+  const owners = createManagedPreviewOwnerRegistry(resources)
+  const acquire = vi.fn((r: AcquireManagedPreviewRequest) => owners.acquire(caller.lease, r))
+  const fetcher = vi.fn((input: RequestInfo | URL, init?: RequestInit) =>
+    createManagedPreviewProtocolHandler(resources, async (filePath, request) => {
+      const bytes = await readFile(filePath)
+      const range = request.headers.get('range')!.match(/^bytes=(\d+)-(\d+)$/)!
+      const begin = Number(range[1]),
+        end = Math.min(bytes.length, Number(range[2]) + 1)
+      return new Response(bytes.subarray(begin, end), {
+        status: 206,
+        headers: { 'Content-Range': `bytes ${begin}-${end - 1}/${bytes.length}` }
+      })
+    })(new Request(String(input), init))
+  )
+  window.api = {
+    previewResources: {
+      acquire,
+      release: async (r: ReleaseManagedPreviewRequest) => owners.release(caller.lease, r),
+      readRange: (r: ReadManagedPreviewRangeRequest) => owners.readRange(caller.lease, r)
+    }
+  } as unknown as Window['api']
+  vi.stubGlobal('fetch', fetcher)
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  cleanup = async () => {
+    caller.release()
+    await Promise.all(handles.map((h) => h.close().catch(() => {})))
+  }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  return { path, resources, owners, caller }
+}
+const Probe = ({
+  path,
+  source = 'artifact',
+  maxBytes,
+  maxFileBytes
+}: {
+  path: string
+  source?: PreviewFileSource
+  maxBytes?: number
+  maxFileBytes?: number
+}): React.JSX.Element => {
+  const result = usePreviewFileContent({
+    path,
+    source,
+    projectId: 'p',
+    managedFileId: 'f',
+    selectedVersionId: 'old',
+    maxBytes,
+    maxFileBytes
+  })
+  return result.status === 'ready' ? (
+    <button onClick={result.pagination.nextPage} disabled={!result.pagination.hasNext}>
+      {result.preview.content}
+    </button>
+  ) : (
+    <div>{result.status}</div>
+  )
+}
+const settle = async (): Promise<void> => {
+  await act(async () => {
+    await new Promise((r) => setTimeout(r, 30))
+  })
+}
+it.each(['artifact', 'upload', 'notebook-input', 'local'] as const)(
+  'reads bounded pages of a larger %s file',
+  async (source) => {
+    const env = await setup(8)
+    await act(async () => root!.render(<Probe path={env.path} source={source} maxBytes={4} />))
+    await settle()
+    expect(container!.textContent).toBe('AAAA')
+    expect(container!.querySelector('button')?.disabled).toBe(false)
+    await act(async () => container!.querySelector('button')!.click())
+    await settle()
+    expect(container!.textContent).toBe('AAAA')
+    expect(container!.querySelector('button')?.disabled).toBe(true)
+  }
+)
+it('text above 1 MiB exposes bounded page navigation', async () => {
+  const env = await setup(PREVIEW_TEXT_MAX_BYTES + 1)
+  await act(async () =>
+    root!.render(
+      <PreviewTextContent
+        path={env.path}
+        name="report.txt"
+        source="artifact"
+        projectId="p"
+        managedFileId="f"
+        selectedVersionId="old"
+      />
+    )
+  )
+  await settle()
+  expect(container!.querySelector('[aria-label="Next preview page"]')).not.toBeNull()
+})
+it('same resource and protocol can serve bounded pages when no whole-file admission cap is requested', async () => {
+  const env = await setup(8)
+  const resource = await env.owners.acquire(env.caller.lease, {
+    source: 'artifact',
+    projectId: 'p',
+    fileId: 'f',
+    versionId: 'old'
+  })
+  const handler = createManagedPreviewProtocolHandler(env.resources)
+  const first = await handler(new Request(resource.url, { headers: { Range: 'bytes=0-3' } })),
+    second = await handler(new Request(resource.url, { headers: { Range: 'bytes=4-7' } }))
+  expect(await first.text()).toBe('AAAA')
+  expect(await second.text()).toBe('AAAA')
+  env.owners.release(env.caller.lease, { resourceId: resource.id })
+})
+
+it('retains an explicit full-file admission cap independently of the page size', async () => {
+  const env = await setup(8)
+  await act(async () => root!.render(<Probe path={env.path} maxBytes={4} maxFileBytes={8} />))
+  await settle()
+  expect(container!.textContent).toBe('AAAA')
+  await act(async () => root!.render(<Probe path={env.path} maxBytes={4} maxFileBytes={7} />))
+  await settle()
+  expect(container!.textContent).toBe('error')
+})

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfOutlineSidebar.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfOutlineSidebar.tsx
@@ -219,6 +219,14 @@ const PdfThumbnailList = ({
     updateVisibleRange()
   }, [currentPage, pageCount, updateVisibleRange])
 
+  useEffect(() => {
+    const scroll = scrollRef.current
+    if (!scroll) return
+    const observer = new ResizeObserver(updateVisibleRange)
+    observer.observe(scroll)
+    return () => observer.disconnect()
+  }, [updateVisibleRange])
+
   return (
     <div
       ref={scrollRef}

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.test.tsx
@@ -181,6 +181,157 @@ describe('PdfPreviewContent', () => {
     delete (Element.prototype as { scrollIntoView?: unknown }).scrollIntoView
   })
 
+  const flush = async (): Promise<void> => {
+    for (let i = 0; i < 20; i++) await Promise.resolve()
+  }
+  const observe = (): {
+    targets: Element[]
+    disconnect: ReturnType<typeof vi.fn>
+    unobserve: ReturnType<typeof vi.fn>
+    notify: (target: Element, near: boolean) => Promise<void>
+  } => {
+    let callback!: IntersectionObserverCallback
+    const targets: Element[] = []
+    const disconnect = vi.fn(),
+      unobserve = vi.fn()
+    vi.stubGlobal(
+      'IntersectionObserver',
+      class {
+        constructor(cb: IntersectionObserverCallback) {
+          callback = cb
+        }
+        observe(element: Element): void {
+          targets.push(element)
+        }
+        unobserve = unobserve
+        disconnect = disconnect
+      }
+    )
+    return {
+      targets,
+      disconnect,
+      unobserve,
+      notify: async (target: Element, near: boolean) =>
+        act(async () => {
+          callback(
+            [{ target, isIntersecting: near } as IntersectionObserverEntry],
+            {} as IntersectionObserver
+          )
+          await flush()
+        })
+    }
+  }
+
+  it.each(['ready', 'error'] as const)(
+    're-entering a previously %s page displays loading while pending',
+    async (firstStatus) => {
+      const io = observe()
+      const errorLog = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      const page = await (getPage as ReturnType<typeof vi.fn<() => Promise<unknown>>>)()
+      getPage.mockClear()
+      if (firstStatus === 'error')
+        getPage.mockRejectedValueOnce(new Error('Temporary page read failure'))
+      await act(async () => {
+        root.render(<PdfPreviewContent path="/audit/reenter.pdf" name="reenter.pdf" />)
+        await flush()
+      })
+      const element = container.querySelector('[data-page-number="1"]')!
+      await io.notify(element, true)
+      expect(getPage).toHaveBeenCalledTimes(1)
+      expect(element.textContent?.includes('could not be rendered')).toBe(firstStatus === 'error')
+      await io.notify(element, false)
+      let complete!: (value: unknown) => void
+      getPage.mockReturnValueOnce(new Promise((resolve) => (complete = resolve)))
+      await io.notify(element, true)
+      expect(getPage).toHaveBeenCalledTimes(2)
+      expect(element.querySelector('canvas')).not.toBeNull()
+      expect(element.querySelector('[data-preview-status="compact-loading"]')).not.toBeNull()
+      expect(element.textContent).not.toContain('could not be rendered')
+      await act(async () => {
+        complete(page)
+        await flush()
+      })
+      expect(element.textContent).not.toContain('could not be rendered')
+      expect(element.querySelector('canvas')?.width).toBeGreaterThan(0)
+      errorLog.mockRestore()
+    }
+  )
+
+  it('sidebar expands its visible range when its container grows', async () => {
+    observe()
+    const observers: Array<{ callback: ResizeObserverCallback; targets: Element[] }> = []
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        entry: { callback: ResizeObserverCallback; targets: Element[] }
+        constructor(callback: ResizeObserverCallback) {
+          this.entry = { callback, targets: [] }
+          observers.push(this.entry)
+        }
+        observe(target: Element): void {
+          this.entry.targets.push(target)
+        }
+        unobserve = vi.fn()
+        disconnect = vi.fn()
+      }
+    )
+    let height = 224
+    vi.spyOn(HTMLElement.prototype, 'clientHeight', 'get').mockImplementation(() => height)
+    const sidebar = (pageCount = 100, currentPage = 1): React.JSX.Element => (
+      <PdfOutlineSidebar
+        document={{ getPage } as never}
+        items={[]}
+        pageCount={pageCount}
+        currentPage={currentPage}
+        width={240}
+        onNavigate={vi.fn()}
+        onClose={vi.fn()}
+        onWidthChange={vi.fn()}
+      />
+    )
+    await act(async () => {
+      root.render(sidebar())
+      await flush()
+    })
+    const list = container.querySelector('[aria-label="Pages"]')!.parentElement!
+    const buttons = (): HTMLButtonElement[] =>
+      Array.from(container.querySelectorAll<HTMLButtonElement>('button[aria-label^="Page "]'))
+    expect(buttons()).toHaveLength(9)
+    height = 2400
+    await act(async () => {
+      window.dispatchEvent(new Event('resize'))
+      observers.forEach(({ callback, targets }) =>
+        callback(
+          targets.map((target) => ({ target, contentRect: { height } }) as ResizeObserverEntry),
+          {} as ResizeObserver
+        )
+      )
+      root.render(sidebar())
+      await flush()
+    })
+    expect(buttons()).toHaveLength(19)
+    await act(async () => {
+      list.dispatchEvent(new Event('scroll'))
+      await flush()
+    })
+    expect(buttons()).toHaveLength(19)
+    await act(async () => {
+      root.render(sidebar(100, 90))
+      await flush()
+    })
+    expect(buttons().some((b) => b.getAttribute('aria-label') === 'Page 90')).toBe(true)
+    expect(buttons().length).toBeLessThanOrEqual(24)
+    await act(async () => {
+      root.render(sidebar(3, 1))
+      await flush()
+    })
+    expect(buttons().map((b) => b.getAttribute('aria-label'))).toEqual([
+      'Page 1',
+      'Page 2',
+      'Page 3'
+    ])
+  })
+
   it('renders through the managed range resource and releases it on unmount', async () => {
     await act(async () => {
       root.render(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfPreview.tsx
@@ -896,6 +896,9 @@ const PdfPageCanvas = ({
     if (!isNearViewport) return
 
     let canceled = false
+    queueMicrotask(() => {
+      if (!canceled) setStatus('loading')
+    })
     let disposed = false
     // Clear canvas backing storage on exit; removing the DOM node alone may retain its bitmap.
     const dispose = (): void => {

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfThumbnail.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfThumbnail.test.tsx
@@ -96,6 +96,62 @@ describe('PdfThumbnail', () => {
     vi.unstubAllGlobals()
   })
 
+  it.each([false, true])(
+    'retries a thumbnail once after re-entry (persistent failure=%s)',
+    async (persistent) => {
+      let callback!: IntersectionObserverCallback
+      vi.stubGlobal(
+        'IntersectionObserver',
+        class {
+          constructor(cb: IntersectionObserverCallback) {
+            callback = cb
+          }
+          observe = vi.fn()
+          unobserve = vi.fn()
+          disconnect = vi.fn()
+        }
+      )
+      const acquire = vi.mocked(window.api.previewResources.acquire)
+      if (persistent) acquire.mockRejectedValue(new Error('Temporary read failure'))
+      else acquire.mockRejectedValueOnce(new Error('Temporary read failure'))
+      vi.spyOn(console, 'error').mockImplementation(() => {})
+      const tile = (
+        <PdfThumbnail
+          source="local"
+          path={`/audit/transient-${persistent}.pdf`}
+          name="transient.pdf"
+        />
+      )
+      const visible = async (value: boolean): Promise<void> =>
+        act(async () => {
+          callback(
+            [
+              {
+                target: container.firstElementChild!,
+                isIntersecting: value
+              } as IntersectionObserverEntry
+            ],
+            {} as IntersectionObserver
+          )
+          await flushMicrotasks()
+        })
+      await act(async () => {
+        root.render(tile)
+        await flushMicrotasks()
+      })
+      await visible(true)
+      expect(acquire).toHaveBeenCalledOnce()
+      expect(container.querySelector('img')).toBeNull()
+      await visible(false)
+      await visible(true)
+      expect(acquire).toHaveBeenCalledTimes(2)
+      expect(Boolean(container.querySelector('img'))).toBe(!persistent)
+      await visible(false)
+      await visible(true)
+      expect(acquire).toHaveBeenCalledTimes(2)
+    }
+  )
+
   it('loads a large PDF through the range resource and renders only page one', async () => {
     await act(async () => {
       root.render(

--- a/src/renderer/src/pages/workspace/previews/renderers/PdfThumbnail.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/PdfThumbnail.tsx
@@ -1,5 +1,5 @@
 import { usePreviewResourceKey } from '../usePreviewResourceGeneration'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { FileText } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 
@@ -313,6 +313,14 @@ export const PdfThumbnail = ({
   const cached = getCachedThumbnail(requestKey)
   const hasCurrentResult = result?.requestKey === requestKey
   const hasCurrentError = hasCurrentResult && result.status === 'error'
+  const retryRef = useRef({ requestKey, used: false })
+  useEffect(() => {
+    if (retryRef.current.requestKey !== requestKey) retryRef.current = { requestKey, used: false }
+    if (!isNearViewport && hasCurrentError && !retryRef.current.used) {
+      retryRef.current.used = true
+      setResult(null)
+    }
+  }, [requestKey, isNearViewport, hasCurrentError])
   // Off-screen tiles retain only an encoded thumbnail and do not keep a PDF document alive.
   const shouldRender = isNearViewport && !hasCurrentError && (!hasCurrentResult || !cached)
 

--- a/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.test.tsx
@@ -122,6 +122,21 @@ describe('TiffPreviewContent', () => {
     container.remove()
   })
 
+  it.each([
+    new Error('Managed preview file is too large.'),
+    Object.assign(new Error('Managed preview file is too large.'), { code: 'FILE_TOO_LARGE' })
+  ])('explains TIFF admission limits without offering an unchanged retry (%s)', async (error) => {
+    vi.mocked(window.api.previewResources.acquire).mockRejectedValue(error)
+    root = createRoot(container)
+    await act(async () =>
+      root.render(<TiffPreviewContent source="local" path="/large.tiff" name="large.tiff" />)
+    )
+    expect(container.textContent).toContain('40 MiB')
+    expect(container.textContent).toContain('limit')
+    expect(container.textContent).not.toContain('Retry')
+    expect(fetch).not.toHaveBeenCalled()
+  })
+
   it('renders an LZW TIFF page with the same zoom surface as other images', async () => {
     root = createRoot(container)
     await act(async () => {

--- a/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffPreview.tsx
@@ -263,11 +263,25 @@ const TiffPreviewContent = ({
   }, [pageIndex, requestKey, resourceKey, resourceState])
 
   if (resourceState.status === 'error') {
+    const error = resourceState.error
+    const tooLarge =
+      (error as { code?: unknown } | undefined)?.code === 'FILE_TOO_LARGE' ||
+      (error instanceof Error && error.message.includes('Managed preview file is too large.'))
     return (
       <PreviewErrorCard
         name={name}
-        error={resourceState.error}
-        fallbackMessage={t("TIFF couldn't be loaded for preview")}
+        error={error}
+        retryable={!tooLarge}
+        fallbackMessage={
+          tooLarge
+            ? t(
+                'This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.',
+                {
+                  limit: DEFAULT_TIFF_PREVIEW_LIMITS.maxFileBytes / (1024 * 1024)
+                }
+              )
+            : t("TIFF couldn't be loaded for preview")
+        }
       />
     )
   }

--- a/src/renderer/src/pages/workspace/previews/renderers/TiffThumbnail.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffThumbnail.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { TiffThumbnail } from './TiffThumbnail'
+type Resource = Awaited<ReturnType<Window['api']['previewResources']['acquire']>>
+let container: HTMLDivElement, root: Root
+const flush = async (): Promise<void> => {
+  for (let i = 0; i < 20; i++) await Promise.resolve()
+}
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true)
+})
+afterEach(async () => {
+  await act(async () => {
+    root.unmount()
+    await flush()
+  })
+  container.remove()
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+it('bounds TIFF acquisition to two jobs and releases late results', async () => {
+  const gates: Array<(value: Resource) => void> = []
+  const acquire = vi.fn(() => new Promise<Resource>((resolve) => gates.push(resolve))),
+    release = vi.fn().mockResolvedValue(undefined)
+  window.api = { previewResources: { acquire, release } } as unknown as Window['api']
+  const fetcher = vi.fn()
+  vi.stubGlobal('fetch', fetcher)
+  const tiles = (enabled: boolean): React.JSX.Element => (
+    <>
+      {Array.from({ length: 12 }, (_, i) => (
+        <TiffThumbnail
+          key={i}
+          enabled={enabled}
+          source="artifact"
+          projectId="p"
+          managedFileId={'f' + i}
+          selectedVersionId={'v' + i}
+          path={'/image' + i + '.tif'}
+          name={'image' + i + '.tif'}
+          fallback={<span>TIFF</span>}
+        />
+      ))}
+    </>
+  )
+  await act(async () => {
+    root.render(tiles(true))
+    await flush()
+  })
+  expect(acquire).toHaveBeenCalledTimes(2)
+  expect(gates).toHaveLength(2)
+  expect(fetcher).not.toHaveBeenCalled()
+  await act(async () => {
+    root.render(tiles(false))
+    await flush()
+  })
+  await act(async () => {
+    gates.forEach((resolve, i) =>
+      resolve({
+        id: 'resource-' + i,
+        url: 'https://unused/' + i,
+        size: 8,
+        mimeType: 'image/tiff',
+        version: 1
+      })
+    )
+    await flush()
+  })
+  expect(release).toHaveBeenCalledTimes(2)
+  expect(fetcher).not.toHaveBeenCalled()
+})

--- a/src/renderer/src/pages/workspace/previews/renderers/TiffThumbnail.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/TiffThumbnail.tsx
@@ -10,7 +10,7 @@ import {
   type DecodedTiffPage
 } from '../tiff-preview-types'
 import { createTiffDecodeSession } from '../tiff-preview-worker-client'
-import { useManagedPreviewResource } from '../useManagedPreviewResource'
+import { createManagedPreviewRequest } from '../preview-file-reader'
 import { TiffCanvas } from './TiffCanvas'
 
 type TiffThumbnailResult = { status: 'ready'; page: DecodedTiffPage } | { status: 'error' }
@@ -44,62 +44,60 @@ const EnabledTiffThumbnail = ({
   managedFileId,
   selectedVersionId,
   mimeType,
-  size,
-  mtimeMs,
   fallback
 }: EnabledTiffThumbnailProps): React.JSX.Element => {
   const [result, setResult] = useState<TiffThumbnailResult | null>(null)
-  const resourceState = useManagedPreviewResource(
-    {
-      projectId,
-      sessionId,
-      managedFileId,
-      selectedVersionId,
-      source,
-      path,
-      mimeType,
-      size,
-      mtimeMs,
-      maxBytes: TIFF_THUMBNAIL_LIMITS.maxFileBytes
-    },
-    result === null
-  )
-
   useEffect(() => {
-    if (resourceState.status !== 'ready' || result !== null) return
-
-    const resource = resourceState.resource
     const controller = new AbortController()
     let disposed = false
 
     void tiffThumbnailScheduler
       .schedule(controller.signal, async () => {
-        if (resource.size > TIFF_THUMBNAIL_LIMITS.maxFileBytes) {
-          throw new Error('TIFF file is too large to preview safely')
-        }
-
-        const response = await fetch(resource.url, {
-          cache: 'no-store',
-          signal: controller.signal
-        })
-        if (!response.ok) {
-          throw new Error(`TIFF thumbnail read failed with status ${response.status}`)
-        }
-
-        const data = await response.arrayBuffer()
-        if (data.byteLength !== resource.size) {
-          throw new Error('TIFF file changed during the thumbnail read')
-        }
-        if (controller.signal.aborted) throw controller.signal.reason
-
-        const session = createTiffDecodeSession(data, {
-          limits: TIFF_THUMBNAIL_LIMITS,
-          maxOutputDimension: TIFF_THUMBNAIL_MAX_DIMENSION
-        })
+        const resource = await window.api.previewResources.acquire(
+          createManagedPreviewRequest({
+            projectId,
+            sessionId,
+            managedFileId,
+            selectedVersionId,
+            source,
+            path,
+            mimeType,
+            maxBytes: TIFF_THUMBNAIL_LIMITS.maxFileBytes
+          })
+        )
         try {
-          return await session.decodePage(0, controller.signal)
+          if (controller.signal.aborted) throw controller.signal.reason
+          if (resource.size > TIFF_THUMBNAIL_LIMITS.maxFileBytes) {
+            throw new Error('TIFF file is too large to preview safely')
+          }
+
+          const response = await fetch(resource.url, {
+            cache: 'no-store',
+            signal: controller.signal
+          })
+          if (!response.ok) {
+            throw new Error(`TIFF thumbnail read failed with status ${response.status}`)
+          }
+
+          const data = await response.arrayBuffer()
+          if (data.byteLength !== resource.size) {
+            throw new Error('TIFF file changed during the thumbnail read')
+          }
+          if (controller.signal.aborted) throw controller.signal.reason
+
+          const session = createTiffDecodeSession(data, {
+            limits: TIFF_THUMBNAIL_LIMITS,
+            maxOutputDimension: TIFF_THUMBNAIL_MAX_DIMENSION
+          })
+          try {
+            return await session.decodePage(0, controller.signal)
+          } finally {
+            session.dispose()
+          }
         } finally {
-          session.dispose()
+          await window.api.previewResources
+            .release({ resourceId: resource.id })
+            .catch(() => undefined)
         }
       })
       .then((page) => {
@@ -113,7 +111,7 @@ const EnabledTiffThumbnail = ({
       disposed = true
       controller.abort()
     }
-  }, [requestKey, resourceState, result])
+  }, [requestKey, projectId, sessionId, managedFileId, selectedVersionId, source, path, mimeType])
 
   const handleDrawError = useCallback(() => setResult({ status: 'error' }), [])
 

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.test.tsx
@@ -181,6 +181,20 @@ describe('usePreviewFileContent', () => {
     }
   )
 
+  it('does not describe an expired protocol capability as a missing file', async () => {
+    vi.mocked(fetch).mockResolvedValue(new Response(null, { status: 404 }))
+    const log = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+    const FailureProbe = (): React.JSX.Element => {
+      const state = usePreviewFileContent({ source: 'local', path: '/available.txt' })
+      return <div>{state.status === 'error' ? String(state.error) : state.status}</div>
+    }
+    root = createRoot(container)
+    await act(async () => root.render(<FailureProbe />))
+    expect(container.textContent).not.toMatch(/ENOENT|no longer available/)
+    expect(window.api.previewResources.release).toHaveBeenCalledOnce()
+    log.mockRestore()
+  })
+
   it('keeps project and session scope when acquiring a version-backed upload', async () => {
     root = createRoot(container)
     await act(async () => root.render(<Probe />))
@@ -189,8 +203,7 @@ describe('usePreviewFileContent', () => {
       projectId: 'project-1',
       source: 'upload',
       fileId: 'upload-file-1',
-      versionId: 'upload-version-1',
-      maxBytes: 1024 * 1024
+      versionId: 'upload-version-1'
     })
     expect(fetch).toHaveBeenCalledWith('https://preview.test/upload-file-1', {
       cache: 'no-store',

--- a/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
+++ b/src/renderer/src/pages/workspace/previews/usePreviewFileContent.ts
@@ -45,7 +45,9 @@ type UsePreviewFileContentRequest = {
   selectedVersionId?: string
   path: string
   source?: PreviewFileSource
+  // Per-page read budget; never an admission limit for the complete file.
   maxBytes?: number
+  maxFileBytes?: number
   encoding?: 'utf8' | 'base64'
 }
 
@@ -78,7 +80,7 @@ const readManagedPreviewPage = async (
   },
   owner?: PreviewResourceOwner
 ): Promise<ArtifactPreviewResult> => {
-  const previewRequest = createManagedPreviewRequest(request)
+  const previewRequest = createManagedPreviewRequest({ ...request, maxBytes: request.maxFileBytes })
   let resource = owner?.resource
   for (let attempt = 0; !resource; attempt += 1) {
     if (request.signal.aborted) throw request.signal.reason
@@ -120,11 +122,6 @@ const readManagedPreviewPage = async (
         signal: request.signal
       })
       if (!response.ok) {
-        if (response.status === 404) {
-          throw Object.assign(new Error('ENOENT: managed preview file is no longer available.'), {
-            code: 'ENOENT'
-          })
-        }
         throw new Error(`Managed preview request failed with status ${response.status}.`)
       }
       size = readResponseSize(response, resource.size)
@@ -181,6 +178,7 @@ export const usePreviewFileContent = ({
   path,
   source = 'artifact',
   maxBytes = PREVIEW_TEXT_MAX_BYTES,
+  maxFileBytes,
   encoding = 'utf8'
 }: UsePreviewFileContentRequest): PreviewFileContentLoadState => {
   const generation = usePreviewResourceGeneration()
@@ -193,6 +191,7 @@ export const usePreviewFileContent = ({
     selectedVersionId ?? null,
     encoding,
     maxBytes,
+    maxFileBytes,
     path
   ])
   // Retain locations, not previous page contents, for the pinned resource sequence.
@@ -244,6 +243,7 @@ export const usePreviewFileContent = ({
         ...(managedFileId ? { managedFileId } : {}),
         ...(selectedVersionId ? { selectedVersionId } : {}),
         maxBytes,
+        maxFileBytes,
         encoding,
         offset,
         signal: abortController.signal
@@ -269,6 +269,7 @@ export const usePreviewFileContent = ({
     encoding,
     managedFileId,
     maxBytes,
+    maxFileBytes,
     offset,
     path,
     projectId,

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -101,6 +101,7 @@
     "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Diese TIFF-Datei überschreitet die Vorschaugrenze von {{limit}} MiB. Laden Sie sie herunter oder öffnen Sie sie extern.",
     "Shared content": "Gemeinsame Inhalte",
     "Literature settings and tasks": "Literatureinstellungen und Aufgaben",
     "Select no more than {{limit}} references for this task.": "Wählen Sie für diese Aufgabe höchstens {{limit}} Referenzen aus.",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Importar configuración del conector"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Este archivo TIFF supera el límite de vista previa de {{limit}} MiB. Descárguelo o ábralo en una aplicación externa.",
     "Shared content": "Contenido compartido",
     "Literature settings and tasks": "Configuración y tareas bibliográficas",
     "Select no more than {{limit}} references for this task.": "Seleccione como máximo {{limit}} referencias para esta tarea.",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -102,6 +102,7 @@
     "Import Connector configuration": "Importer la configuration du connecteur"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Ce fichier TIFF dépasse la limite d’aperçu de {{limit}} Mio. Téléchargez-le ou ouvrez-le dans une application externe.",
     "Shared content": "Contenu partagé",
     "Literature settings and tasks": "Paramètres et tâches bibliographiques",
     "Select no more than {{limit}} references for this task.": "Sélectionnez au maximum {{limit}} références pour cette tâche.",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "コネクタ構成のインポート"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "このTIFFはプレビューの上限（{{limit}} MiB）を超えています。ダウンロードするか、外部アプリで開いてください。",
     "Shared content": "共有コンテンツ",
     "Literature settings and tasks": "文献の設定とタスク",
     "Select no more than {{limit}} references for this task.": "このタスクでは {{limit}} 件以下の文献を選択してください。",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "커넥터 구성 가져오기"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "이 TIFF는 미리보기 제한인 {{limit}} MiB를 초과합니다. 다운로드하거나 외부 앱에서 여세요.",
     "Shared content": "공유 콘텐츠",
     "Literature settings and tasks": "문헌 설정 및 작업",
     "Select no more than {{limit}} references for this task.": "이 작업에는 문헌을 {{limit}}개 이하로 선택하세요.",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -103,6 +103,7 @@
     "Import Connector configuration": "Импорт конфигурации коннектора"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Этот TIFF превышает ограничение предпросмотра в {{limit}} МиБ. Скачайте его или откройте во внешнем приложении.",
     "Shared content": "Общее содержимое",
     "Literature settings and tasks": "Настройки и задачи литературы",
     "Select no more than {{limit}} references for this task.": "Выберите не более {{limit}} источников для этой задачи.",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "导入连接器配置"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "此 TIFF 超过 {{limit}} MiB 的预览限制。请下载或使用外部应用打开。",
     "Shared content": "共享内容",
     "Literature settings and tasks": "文献配置与任务",
     "Select no more than {{limit}} references for this task.": "此任务最多支持 {{limit}} 篇文献，请调整选择。",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -100,6 +100,7 @@
     "Import Connector configuration": "匯入連接器設定"
   },
   "renderer": {
+    "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "此 TIFF 超過 {{limit}} MiB 的預覽限制。請下載或使用外部應用程式開啟。",
     "Shared content": "共用內容",
     "Literature settings and tasks": "文獻設定與任務",
     "Select no more than {{limit}} references for this task.": "此任務最多支援 {{limit}} 篇文獻，請調整選取範圍。",


### PR DESCRIPTION
## Problem

Preview editing can accept text while an older save is pending and then discard the newer input. The preview review also reproduced large text files rejected by the page-size budget, expired resources reported as missing files, unhelpful oversized-TIFF retries, stale PDF states, unbounded TIFF resource acquisition, lost dialog focus, and Office sessions surviving host navigation.

## Proposed change

- Make the editor read-only while its save request is pending.
- Separate each text page's byte budget from an optional whole-file admission cap; keep protocol 404 failures retryable. Preserve the admitted file snapshot independently of that cap, and use the verified handle for both protocol and IPC range reads.
- Explain the existing 40 MiB TIFF limit without an ineffective Retry action, with all eight translations.
- Allow one PDF thumbnail retry on viewport re-entry, reset page loading feedback on re-entry, and recalculate sidebar virtualization when its height changes.
- Put TIFF resource acquisition inside the existing two-slot thumbnail queue and release late/cancelled acquisitions.
- Restore dialog focus to an owner-provided fallback when its original trigger is unavailable.
- Close Office owner sessions on main-document navigation using the existing generation invalidation; ignore same-document/subframe navigation and clean up listeners before retracking the owner.

## Scope and non-goals

The maintainer chose **exit means discard**. No exit confirmation, beforeunload guard, quit-handshake enum, or crash-recovery storage is added.

- **Persistence and history:** no database/table/column, draft files, migration, historical compatibility layer, or saved-format change.
- **State:** no new business enum. The retry latch and file-budget option are transient component/request state.
- **Architecture:** retain the existing preview owners, resource APIs, worker queue, and Office supervisor; the dialog gets an optional focus callback.
- A partially applied local Office package patch was reconciled in an isolated worktree dependency copy. The checked-in patch and dependency versions are unchanged; its existing 16 behavior tests pass.

## Acceptance criteria and validation

All fixes were preceded by public-behavior reproductions. The permanent regressions were run twice against unmodified baseline production files, then unchanged against the fixes. Test doubles control transport, visibility, scheduling and file leases; actual hooks, components, resource/protocol handlers and the Office supervisor exercise the behaviors. No production test seam was introduced.

CI initially identified four stale consumer assertions in PreviewFileContent.test.tsx. They were reproduced twice locally and updated to the approved page-admission and retryable-404 contracts. The 404 case now clicks Retry and asserts reacquisition plus recovered content; it fails twice against baseline production code. No production change was needed for this CI follow-up. The full preview consumer slice then passed 494 tests.

Local impact checks for the preview behavior changes (the capability follow-up has an additional final validation set below):

| Behavior / impact | Project-owned check | Result |
| --- | --- | --- |
| Save, paging, errors, PDF/TIFF lifecycle, dialog focus, Office navigation | Targeted PreviewFileSurface, usePreviewFileContent, preview-pagination-contract, PdfPreview, PdfThumbnail, TiffPreview, TiffThumbnail, FilePreviewDialog.focus and office-preview-navigation suites | Repeated red on baseline; green on fixed code |
| Owner, interfaces and consumers | Curated `project_files_view`, `workspace_page`, `artifact_provenance`, `i18n_catalog` module plans, plus preview dialog/resource/protocol contract suites | 3,959 passed |
| Office adapter/supervisor/runtime contracts, package behavior, existing draft lifecycle | `vitest run src/main/office-preview src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts src/renderer/src/pages/workspace/previews/renderers/office-preview-lease.test.ts` | 68 passed; final navigation control additionally 5 passed |
| Both runtime process types | `npm run typecheck` | Passed |
| Source quality | `npm run lint -- --ignore-pattern 'docs/internal/**'`, changed-file Prettier and `git diff --check` | Passed; ignored path contains only uncommitted local reproduction material |

CodeGraph was consulted for consumers and owner boundaries; its worktree index mismatch was recorded, so current source and public behavior tests are authoritative. The automatic affected plan falls back to full CI because Office preview paths do not have a declared module owner. The maintainer explicitly requested module-only local testing; no complete local `npm test` was run. PR Gate remains the authority for the full and platform lanes.

Actual production components were checked in an isolated Chromium fixture: input remains unchanged during a pending save; the oversized TIFF has a clear limit and no Retry; resizing a real 100-page PDF from 400 / 2400 / 1000 px produces 10 / 19 / 12 mounted sidebar thumbnails; disabling the original dialog trigger returns focus to the supplied fallback. Screenshots were delivered to the maintainer. These are component-fixture checks, not packaged Electron E2E certification. Native Electron navigation and Windows/Linux UI behavior were not locally exercised; CI and reviewers should evaluate this remaining platform risk.

A subsequent independent review identified missing path identity validation when acquisition omits a file-size cap. Real file/inode and ancestor-junction replacements reproduced replacement-byte reads through protocol and IPC; the same IPC gap affected explicitly capped and Reviewer-observed capabilities. Seven trigger cases failed twice before the fix, while the strict Reviewer protocol control passed. The fix retains existing snapshot metadata regardless of size-cap options and reuses the verified handle plus final check in IPC reads. Repository evidence shows local browsing intentionally allows arbitrary local paths, so this is an admitted-capability identity failure, not a demonstrated granted-root authorization bypass. No persisted fields or public request fields are added.

The independent candidate review found a suffix-Range compatibility regression in the stricter path. Two real-file tests (`bytes=-4` and a suffix larger than the file) failed twice with the previous parser and pass with bounded suffix parsing. The fix retains exact file-size/inode/mtime checks; it does not claim cryptographic content immutability or solve pre-existing admission-time canonicalization races.

Final capability follow-up checks ran after the last material production edit: `npm run typecheck:node` and repository lint passed; `vitest run src/main/managed-preview-resources.test.ts src/main/managed-preview-protocol.test.ts src/main/managed-preview-ipc.test.ts src/main/literature/pdf-attachment-reliability.test.ts src/main/session-persistence/artifact-finalization-recovery.integration.test.ts` passed 177 tests. These cover the shared owner, both read interfaces, unchanged-file and large-file controls, and durable artifact/literature consumers. Renderer types had already passed and the follow-up adds no renderer API/type changes.

The final consumer rerun (`vitest run src/renderer/src/pages/workspace/previews src/main/office-preview`) passed 528 tests in 46 files, including the real resource-to-text-page contract and Office lifecycle suites.

## Review focus

Check page-budget versus file-admission semantics across artifact/upload/notebook/local sources, resource release after cancellation, uncapped/capped/Reviewer capability identity across protocol and IPC reads, one retry per thumbnail identity, nested focus-scope restoration, and Office event arguments/generation invalidation. Independent AI Review should confirm that this evidence mapping covers the final head before the change is marked verified.
