### PR TITLE
fix(lifecycle): protect preview edits and deleted project links

### DIFF
--- a/src/main/artifacts/literature-manifest.test.ts
+++ b/src/main/artifacts/literature-manifest.test.ts
@@ -52,6 +52,7 @@ const owner = (metadataRevision = 3): ArtifactLiteratureManifestOwner =>
   new ArtifactLiteratureManifestOwner(
     async () =>
       ({
+        projectDeletionIntent: { findMany: vi.fn(async () => []) },
         literatureItem: { findMany: vi.fn(async () => [literatureRow(metadataRevision)]) }
       }) as unknown as PrismaClient
   )
@@ -268,6 +269,7 @@ describe('Literature evidence delivered to a review', () => {
     const manifestOwner = new ArtifactLiteratureManifestOwner(
       async () =>
         ({
+          projectDeletionIntent: { findMany: vi.fn(async () => []) },
           literatureItem: { findMany: vi.fn(async () => [literatureRow(), uncited]) }
         }) as unknown as PrismaClient
     )

--- a/src/main/literature/catalog.test.ts
+++ b/src/main/literature/catalog.test.ts
@@ -20,6 +20,7 @@ import { migrateApplicationDatabase } from '../database/migration-service'
 import { createProjectDbClient } from '../projects/prisma-client'
 import { LiteratureCatalog, normalizeIdentifier } from './catalog'
 import { LiteratureCitationFormatter } from './citation-formatter'
+import { ProjectRepository } from '../projects/repository'
 import { TagRepository } from '../tags/repository'
 import { TagResourceCatalog } from '../tags/resource-catalog'
 import { TagService } from '../tags/service'
@@ -86,6 +87,103 @@ describe('LiteratureCatalog', () => {
     await client.project.create({ data: { id: 'project-1', name: 'Research' } })
     return new LiteratureCatalog(async () => client!)
   }
+
+  it('excludes deleted project membership from item views and counts', async () => {
+    const catalog = await setup()
+    const projects = new ProjectRepository(async () => client!)
+    const item = await catalog.transact({ kind: 'create-item', item: candidate().item })
+    await catalog.transact({
+      kind: 'set-project-item',
+      projectId: 'project-1',
+      itemId: item.id,
+      included: true,
+      source: 'library'
+    })
+    await projects.delete('project-1')
+    expect(await projects.get('project-1')).toBeNull()
+    expect(await client!.projectLiterature.count()).toBe(0)
+    expect.soft((await catalog.get(item.id))?.projectIds).toEqual([])
+    expect((await catalog.search({ scope: 'project-counts' })).entries).toEqual([])
+  })
+
+  it.each(['deleted', 'deleting', 'missing'] as const)(
+    'rejects single and bulk membership for a %s project',
+    async (state) => {
+      const catalog = await setup()
+      const projects = new ProjectRepository(async () => client!)
+      const item = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      if (state === 'deleted') await projects.delete('project-1')
+      if (state === 'deleting') await projects.createDeletionIntent('project-1')
+      const projectId = state === 'missing' ? 'missing-project' : 'project-1'
+      for (const command of [
+        { kind: 'set-project-item' as const, itemId: item.id },
+        { kind: 'set-project-items' as const, itemIds: [item.id] }
+      ]) {
+        await expect(
+          catalog.transact({ ...command, projectId, included: true, source: 'library' })
+        ).rejects.toThrow('Project is unavailable')
+      }
+      expect(await client!.projectLiterature.count()).toBe(0)
+    }
+  )
+
+  it.each(['deleted', 'deleting'] as const)(
+    'hides retained %s project membership from active reads',
+    async (state) => {
+      const catalog = await setup()
+      const item = await catalog.transact({ kind: 'create-item', item: candidate().item })
+      await client!.projectLiterature.create({
+        data: { projectId: 'project-1', itemId: item.id, source: 'library' }
+      })
+      if (state === 'deleted')
+        await client!.project.update({
+          where: { id: 'project-1' },
+          data: { deletedAt: new Date() }
+        })
+      else await new ProjectRepository(async () => client!).createDeletionIntent('project-1')
+      expect.soft((await catalog.get(item.id))?.projectIds).toEqual([])
+      expect.soft((await catalog.getMany([item.id]))[0].projectIds).toEqual([])
+      expect
+        .soft((await catalog.search({ scope: 'library', projectId: 'project-1' })).totalCount)
+        .toBe(0)
+      expect.soft((await catalog.search({ scope: 'project-counts' })).entries).toEqual([])
+      expect(await client!.projectLiterature.count()).toBe(1)
+    }
+  )
+
+  it('preserves archived membership and other projects when deleting a project', async () => {
+    const catalog = await setup()
+    const projects = new ProjectRepository(async () => client!)
+    await client!.project.create({
+      data: { id: 'archived-project', name: 'Archived', archivedAt: new Date() }
+    })
+    const staged = await catalog.transact({ kind: 'stage-candidate', candidate: candidate() })
+    const accepted = await catalog.transact({ kind: 'accept-candidate', candidateId: staged.id })
+    await catalog.transact({
+      kind: 'set-project-items',
+      itemIds: [accepted.id],
+      projectId: 'archived-project',
+      included: true,
+      source: 'library'
+    })
+    await projects.delete('project-1')
+    expect((await catalog.get(accepted.id))?.projectIds).toEqual(['archived-project'])
+    expect(
+      await client!.literatureCandidateDiscovery.count({ where: { projectId: 'project-1' } })
+    ).toBe(1)
+    expect(
+      (await catalog.search({ scope: 'library', projectId: 'archived-project' })).totalCount
+    ).toBe(1)
+  })
+
+  it('accepts a retained candidate without reattaching its deleted source project', async () => {
+    const catalog = await setup()
+    const projects = new ProjectRepository(async () => client!)
+    const staged = await catalog.transact({ kind: 'stage-candidate', candidate: candidate() })
+    await projects.delete('project-1')
+    const accepted = await catalog.transact({ kind: 'accept-candidate', candidateId: staged.id })
+    expect((await catalog.get(accepted.id))?.projectIds).toEqual([])
+  })
 
   it.each(['10.2468/exact-reference', '39876543'])(
     'finds an exact identifier through ordinary search: %s',

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -59,6 +59,7 @@ type LiteratureCatalogClient = Pick<
   | 'literatureInboxCandidate'
   | 'literatureItem'
   | 'projectLiterature'
+  | 'projectDeletionIntent'
   | 'tagAssignment'
 >
 
@@ -196,6 +197,18 @@ const candidateDedupeKey = (candidate: LiteratureCandidateInput): string => {
   )}`
 }
 
+// Deletion intents are independent recovery records, not a Project foreign-key relation.
+const availableProjectWhere = async (
+  client: Pick<Prisma.TransactionClient, 'projectDeletionIntent'>
+): Promise<Prisma.ProjectWhereInput> => ({
+  deletedAt: null,
+  id: {
+    notIn: (await client.projectDeletionIntent.findMany({ select: { projectId: true } })).map(
+      ({ projectId }) => projectId
+    )
+  }
+})
+
 const itemInclude = {
   creators: { include: { creator: true }, orderBy: { ordinal: 'asc' as const } },
   identifiers: { orderBy: [{ isPrimary: 'desc' as const }, { createdAt: 'asc' as const }] },
@@ -215,6 +228,17 @@ const itemInclude = {
     orderBy: [{ sortOrder: 'asc' as const }, { createdAt: 'asc' as const }]
   }
 } satisfies Prisma.LiteratureItemInclude
+
+const activeItemInclude = async (
+  client: Pick<Prisma.TransactionClient, 'projectDeletionIntent'>
+): Promise<
+  typeof itemInclude & {
+    projects: typeof itemInclude.projects & { where: Prisma.ProjectLiteratureWhereInput }
+  }
+> => ({
+  ...itemInclude,
+  projects: { ...itemInclude.projects, where: { project: await availableProjectWhere(client) } }
+})
 
 type LiteratureItemRow = Prisma.LiteratureItemGetPayload<{ include: typeof itemInclude }>
 
@@ -333,8 +357,8 @@ const attachProjectIfPresent = async (
   source: string
 ): Promise<void> => {
   if (!projectId) return
-  const project = await transaction.project.findUnique({
-    where: { id: projectId },
+  const project = await transaction.project.findFirst({
+    where: { AND: [{ id: projectId }, await availableProjectWhere(transaction)] },
     select: { id: true }
   })
   if (!project) return
@@ -876,7 +900,10 @@ class LiteratureCatalog {
     if (request.scope === 'project-counts') {
       const rows = await client.projectLiterature.groupBy({
         by: ['projectId'],
-        where: { item: { deletedAt: null, mergedIntoItemId: null } },
+        where: {
+          project: await availableProjectWhere(client),
+          item: { deletedAt: null, mergedIntoItemId: null }
+        },
         _count: { itemId: true },
         orderBy: { projectId: 'asc' }
       })
@@ -976,7 +1003,7 @@ class LiteratureCatalog {
 
   private async searchLibrary(
     request: LiteratureCatalogSearchRequest,
-    client: Pick<LiteratureCatalogClient, 'literatureItem' | '$queryRaw'>,
+    client: Pick<LiteratureCatalogClient, 'literatureItem' | '$queryRaw' | 'projectDeletionIntent'>,
     boundResponse = true
   ): Promise<LiteratureCatalogSearchPage> {
     const offset = Math.max(0, request.offset ?? 0)
@@ -1028,7 +1055,7 @@ class LiteratureCatalog {
     const projectId = request.projectId ?? filter?.projectId
     if (projectId)
       predicates.push(
-        Prisma.sql`EXISTS (SELECT 1 FROM "ProjectLiterature" p WHERE p."itemId" = i.id AND p."projectId" = ${projectId})`
+        Prisma.sql`EXISTS (SELECT 1 FROM "ProjectLiterature" p JOIN "Project" project ON project.id = p."projectId" WHERE p."itemId" = i.id AND p."projectId" = ${projectId} AND project."deletedAt" IS NULL AND NOT EXISTS (SELECT 1 FROM "ProjectDeletionIntent" d WHERE d."projectId" = project.id))`
       )
     const collectionId = request.collectionId ?? filter?.collectionId
     if (collectionId)
@@ -1097,7 +1124,7 @@ class LiteratureCatalog {
     const rows = itemIds.length
       ? await client.literatureItem.findMany({
           where: { id: { in: itemIds } },
-          include: itemInclude
+          include: await activeItemInclude(client)
         })
       : []
     const byId = new Map(rows.map((row) => [row.id, row]))
@@ -1130,7 +1157,7 @@ class LiteratureCatalog {
     // Normal get() deliberately hides deleted records and follows active aliases.
     const row = await client.literatureItem.findUnique({
       where: { id: request.itemId },
-      include: itemInclude
+      include: await activeItemInclude(client)
     })
     if (!row) throw new Error('Reference unavailable')
     const content = JSON.stringify(toItemView(row))
@@ -1153,12 +1180,12 @@ class LiteratureCatalog {
     const client = await this.getClient()
     const requested = await client.literatureItem.findUnique({
       where: { id: itemId },
-      include: itemInclude
+      include: await activeItemInclude(client)
     })
     const row = requested?.mergedIntoItemId
       ? await client.literatureItem.findFirst({
           where: { id: requested.mergedIntoItemId, deletedAt: null },
-          include: itemInclude
+          include: await activeItemInclude(client)
         })
       : requested?.deletedAt
         ? undefined
@@ -1195,7 +1222,7 @@ class LiteratureCatalog {
     const client = await this.getClient()
     const requestedRows = await client.literatureItem.findMany({
       where: { id: { in: ids } },
-      include: itemInclude
+      include: await activeItemInclude(client)
     })
     const requestedById = new Map(requestedRows.map((row) => [row.id, row]))
     const survivorIds = requestedRows.flatMap((row) =>
@@ -1206,7 +1233,7 @@ class LiteratureCatalog {
         ? []
         : await client.literatureItem.findMany({
             where: { id: { in: survivorIds }, deletedAt: null },
-            include: itemInclude
+            include: await activeItemInclude(client)
           })
     const survivorsById = new Map(survivors.map((row) => [row.id, row]))
     return ids.flatMap((id) => {
@@ -2073,6 +2100,11 @@ class LiteratureCatalog {
     await this.commit(
       client,
       async (transaction) => {
+        const project = await transaction.project.findFirst({
+          where: { AND: [{ id: command.projectId }, await availableProjectWhere(transaction)] },
+          select: { id: true }
+        })
+        if (!project) throw new Error('Project is unavailable.')
         const available = await transaction.literatureItem.count({
           where: { id: { in: itemIds }, deletedAt: null, mergedIntoItemId: null }
         })
@@ -2301,7 +2333,7 @@ class LiteratureCatalog {
           async (transaction) => {
             const rows = await transaction.literatureItem.findMany({
               where: { id: { in: ids }, deletedAt: null, mergedIntoItemId: null },
-              include: itemInclude,
+              include: await activeItemInclude(transaction),
               orderBy: [{ createdAt: 'asc' }, { id: 'asc' }]
             })
             if (rows.length !== ids.length) {
@@ -2433,7 +2465,7 @@ class LiteratureCatalog {
         select: { collectionId: true, itemId: true, sortOrder: true }
       }),
       transaction.projectLiterature.findMany({
-        where: { itemId: { in: duplicateIds } },
+        where: { itemId: { in: duplicateIds }, project: await availableProjectWhere(transaction) },
         select: { projectId: true, itemId: true, source: true }
       }),
       transaction.tagAssignment.findMany({

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -14,6 +14,34 @@ afterEach(() => {
 })
 
 describe('ProjectDeletionCoordinator', () => {
+  it('invalidates project availability after the intent commits while runtime cleanup is blocked', async () => {
+    const projects = createProjects()
+    const blocked = createDeferred<void>()
+    const beforeProjectDelete = vi.fn(() => blocked.promise)
+    const events = { publish: vi.fn() }
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      createSessions(),
+      undefined,
+      undefined,
+      undefined,
+      { beforeProjectDelete },
+      events
+    )
+    const deletion = coordinator.deleteProject('project-1')
+    try {
+      await vi.waitFor(() => expect(beforeProjectDelete).toHaveBeenCalled())
+      expect(projects.delete).not.toHaveBeenCalled()
+      expect(events.publish).toHaveBeenCalledWith('project:deletion-cleanup-changed', undefined)
+      expect(vi.mocked(projects.createDeletionIntent).mock.invocationCallOrder[0]).toBeLessThan(
+        events.publish.mock.invocationCallOrder[0]
+      )
+    } finally {
+      blocked.resolve()
+      await deletion
+    }
+  })
+
   it('rejects deletion recovery while a data-root migration is pending', async () => {
     const projects = createProjects()
     const coordinator = new ProjectDeletionCoordinator(projects, createSessions())

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -388,6 +388,7 @@ class ProjectDeletionCoordinator {
       }
       throw error
     }
+    this.events?.publish('project:deletion-cleanup-changed', undefined)
   }
 
   private async prepareDeletion(projectId: string): Promise<void> {

--- a/src/main/projects/project-owned-data.catalog.ts
+++ b/src/main/projects/project-owned-data.catalog.ts
@@ -316,8 +316,11 @@ const PROJECT_OWNED_DATA_CATALOG: readonly ProjectOwnedDataCatalogEntry[] = [
       }
     ],
     policy: {
-      kind: 'foreign-key-cascade',
-      note: 'Project Literature membership is removed if its owning Project row is hard-deleted.'
+      kind: 'coordinator-cleanup',
+      effect: 'hard-delete',
+      path: 'project-metadata-soft-delete',
+      operation: 'ProjectRepository.delete',
+      note: 'Remove active Literature membership in the Project soft-delete transaction; retain global references and discovery provenance.'
     }
   },
   {

--- a/src/main/projects/repository.test.ts
+++ b/src/main/projects/repository.test.ts
@@ -28,6 +28,7 @@ const createMockClient = (
   project: Record<string, ReturnType<typeof vi.fn>>
   projectDeletionIntent: Record<string, ReturnType<typeof vi.fn>>
   projectPreviewState: { deleteMany: ReturnType<typeof vi.fn> }
+  projectLiterature: { deleteMany: ReturnType<typeof vi.fn> }
   visionEvidence: { deleteMany: ReturnType<typeof vi.fn> }
   memoryEntry: { deleteMany: ReturnType<typeof vi.fn> }
   memorySettings: { update: ReturnType<typeof vi.fn> }
@@ -47,6 +48,7 @@ const createMockClient = (
     findMany: vi.fn().mockResolvedValue([])
   }
   const executeRaw = vi.fn().mockResolvedValue(1)
+  const projectLiterature = { deleteMany: vi.fn(() => Promise.resolve({ count: 1 })) }
   const projectPreviewState = { deleteMany: vi.fn().mockResolvedValue({ count: 1 }) }
   const visionEvidence = { deleteMany: vi.fn().mockResolvedValue({ count: 1 }) }
   const memoryEntry = { deleteMany: vi.fn().mockResolvedValue({ count: 1 }) }
@@ -60,6 +62,7 @@ const createMockClient = (
     project,
     projectDeletionIntent,
     projectPreviewState,
+    projectLiterature,
     visionEvidence,
     memoryEntry,
     memorySettings
@@ -71,6 +74,7 @@ const createMockClient = (
     project,
     projectDeletionIntent,
     projectPreviewState,
+    projectLiterature,
     visionEvidence,
     memoryEntry,
     memorySettings

--- a/src/main/projects/repository.ts
+++ b/src/main/projects/repository.ts
@@ -272,6 +272,7 @@ class ProjectRepository {
         transaction as unknown as Prisma.TransactionClient,
         'PRAGMA secure_delete = ON'
       )
+      await transaction.projectLiterature.deleteMany({ where: { projectId: id } })
       await transaction.projectPreviewState.deleteMany({ where: { projectId: id } })
       await transaction.visionEvidence.deleteMany({ where: { projectId: id } })
       const deletedMemory = await transaction.memoryEntry.deleteMany({ where: { projectId: id } })

--- a/src/main/windows.test.ts
+++ b/src/main/windows.test.ts
@@ -21,12 +21,14 @@ const {
   ipcMainOnMock,
   ipcMainRemoveListenerMock,
   showMessageBoxMock,
+  showMessageBoxSyncMock,
   webFrameMainFromIdMock
 } = vi.hoisted(() => ({
   openExternalMock: vi.fn(async () => undefined),
   ipcMainOnMock: vi.fn(),
   ipcMainRemoveListenerMock: vi.fn(),
   showMessageBoxMock: vi.fn(),
+  showMessageBoxSyncMock: vi.fn(),
   webFrameMainFromIdMock: vi.fn()
 }))
 
@@ -214,7 +216,7 @@ vi.mock('electron', () => ({
     }
   },
   WebContentsView: class {},
-  dialog: { showMessageBox: showMessageBoxMock },
+  dialog: { showMessageBox: showMessageBoxMock, showMessageBoxSync: showMessageBoxSyncMock },
   ipcMain: { on: ipcMainOnMock, removeListener: ipcMainRemoveListenerMock },
   shell: { openExternal: openExternalMock },
   webFrameMain: { fromId: webFrameMainFromIdMock }
@@ -2079,4 +2081,19 @@ describe('createMainWindow close handling', () => {
     expect(resolveCloseAction).toHaveBeenCalledTimes(1)
     resolveFn('cancel')
   })
+})
+
+it.each([0, 1])('requires explicit discard to override an unsaved page unload: %s', (choice) => {
+  createMainWindow()
+  const window = lastWindow!
+  const event = { preventDefault: vi.fn() }
+  showMessageBoxSyncMock.mockReturnValueOnce(choice)
+  const handler = window.webContentsHandlers.get('will-prevent-unload')
+  expect(handler).toBeDefined()
+  handler!(event)
+  expect(showMessageBoxSyncMock).toHaveBeenCalledWith(
+    window,
+    expect.objectContaining({ defaultId: 0, cancelId: 0 })
+  )
+  expect(event.preventDefault).toHaveBeenCalledTimes(choice === 1 ? 1 : 0)
 })

--- a/src/main/windows.ts
+++ b/src/main/windows.ts
@@ -642,6 +642,20 @@ const createMainWindow = (
     }
   })
 
+  // Electron otherwise silently refuses a dirty page's close/reload. Only an explicit discard
+  // overrides beforeunload; hiding to tray never reaches this event.
+  window.webContents.on('will-prevent-unload', (event) => {
+    const choice = dialog.showMessageBoxSync(window, {
+      type: 'warning',
+      buttons: [translate('Cancel'), translate('Discard changes')],
+      defaultId: 0,
+      cancelId: 0,
+      title: translate('Discard unsaved changes?'),
+      message: translate('Your unsaved changes will be lost.')
+    })
+    if (choice === 1) event.preventDefault()
+  })
+
   // Close handling. classifyClose decides synchronously: darwin and mid-quit close instantly; 'hide'
   // minimizes to tray (Linux); 'quit' retains a no-tray renderer through app teardown; 'confirm'
   // (Windows X) asks the user. The

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -176,7 +176,7 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
       message={
         startup.quitPersistence.notice.reason === 'conflict'
           ? t('A conversation changed elsewhere and could not be saved safely.')
-          : t('One or more conversations could not be saved.')
+          : t('Some changes have not been saved.')
       }
       onDismiss={startup.quitPersistence.dismissNotice}
       onRetry={() => {

--- a/src/renderer/src/components/WebEventRecoveryDialog.tsx
+++ b/src/renderer/src/components/WebEventRecoveryDialog.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next'
 
 import type { WebEventConnectionPhase } from '../../../shared/web-event-connection'
 import { Button } from '@/components/ui/button'
+import { previewLeaveGuards } from '@/stores/preview-leave-guard'
 import {
   dialogBodyClassName,
   dialogDescriptionClassName,
@@ -67,7 +68,15 @@ const WebEventRecoveryDialog = ({
           </div>
           {reloadAvailable ? (
             <div className={dialogFooterClassName}>
-              <Button type="button" onClick={() => window.location.reload()}>
+              <Button
+                type="button"
+                onClick={() =>
+                  previewLeaveGuards.requestAll(() => {
+                    // Let the confirmed editor discards commit before beforeunload runs.
+                    window.setTimeout(() => window.location.reload(), 0)
+                  })
+                }
+              >
                 <RefreshCw aria-hidden="true" />
                 {t('Reload', { context: 'window', ns: 'common' })}
               </Button>

--- a/src/renderer/src/hooks/useQuitPersistenceFlush.ts
+++ b/src/renderer/src/hooks/useQuitPersistenceFlush.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react'
+import { previewLeaveGuards } from '../stores/preview-leave-guard'
 
 import type {
   SessionPersistenceFlushAbortedEvent,
@@ -39,6 +40,8 @@ export const completeQuitPersistenceFlush = async (
     await deps.drainRuntimeEvents()
     await deps.flushPersistence()
     await deps.flushPreviewPersistence()
+    // Tab persistence does not save edited file content. Reuse Main's existing retry/force-quit gate.
+    if (previewLeaveGuards.hasUnsavedChanges()) throw new Error('Preview has unsaved changes.')
   } catch (error) {
     failure = error
     status = isSessionRevisionConflictError(error) ? 'conflict' : 'failed'

--- a/src/renderer/src/pages/literature/useLiteratureChanges.test.tsx
+++ b/src/renderer/src/pages/literature/useLiteratureChanges.test.tsx
@@ -37,3 +37,22 @@ it('coalesces mutation bursts and restores missed changes on visibility and repl
   expect(latest).toHaveBeenCalledTimes(2)
   expect(unsubscribe).toHaveBeenCalledTimes(1)
 })
+
+it('refreshes literature after a project deletion and releases that subscription', async () => {
+  let notify!: () => void
+  const remove = vi.fn()
+  const onDeleted = vi.fn((listener: () => void) => {
+    notify = listener
+    return remove
+  })
+  Object.defineProperty(window, 'api', { configurable: true, value: { projects: { onDeleted } } })
+  const invalidate = vi.fn()
+  const { unmount } = renderHook(() => useLiteratureChanges(invalidate))
+  expect(onDeleted).toHaveBeenCalledOnce()
+  await act(async () => notify())
+  expect(invalidate).toHaveBeenCalledOnce()
+  unmount()
+  expect(remove).toHaveBeenCalledOnce()
+  await act(async () => notify())
+  expect(invalidate).toHaveBeenCalledOnce()
+})

--- a/src/renderer/src/pages/literature/useLiteratureChanges.test.tsx
+++ b/src/renderer/src/pages/literature/useLiteratureChanges.test.tsx
@@ -38,21 +38,27 @@ it('coalesces mutation bursts and restores missed changes on visibility and repl
   expect(unsubscribe).toHaveBeenCalledTimes(1)
 })
 
-it('refreshes literature after a project deletion and releases that subscription', async () => {
-  let notify!: () => void
-  const remove = vi.fn()
-  const onDeleted = vi.fn((listener: () => void) => {
-    notify = listener
-    return remove
-  })
-  Object.defineProperty(window, 'api', { configurable: true, value: { projects: { onDeleted } } })
-  const invalidate = vi.fn()
-  const { unmount } = renderHook(() => useLiteratureChanges(invalidate))
-  expect(onDeleted).toHaveBeenCalledOnce()
-  await act(async () => notify())
-  expect(invalidate).toHaveBeenCalledOnce()
-  unmount()
-  expect(remove).toHaveBeenCalledOnce()
-  await act(async () => notify())
-  expect(invalidate).toHaveBeenCalledOnce()
-})
+it.each(['onDeleted', 'onDeletionCleanupChanged'] as const)(
+  'refreshes literature when project availability changes through %s and releases that subscription',
+  async (subscription) => {
+    let notify!: () => void
+    const remove = vi.fn()
+    const onDeleted = vi.fn((listener: () => void) => {
+      notify = listener
+      return remove
+    })
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { projects: { [subscription]: onDeleted } }
+    })
+    const invalidate = vi.fn()
+    const { unmount } = renderHook(() => useLiteratureChanges(invalidate))
+    expect(onDeleted).toHaveBeenCalledOnce()
+    await act(async () => notify())
+    expect(invalidate).toHaveBeenCalledOnce()
+    unmount()
+    expect(remove).toHaveBeenCalledOnce()
+    await act(async () => notify())
+    expect(invalidate).toHaveBeenCalledOnce()
+  }
+)

--- a/src/renderer/src/pages/literature/useLiteratureChanges.ts
+++ b/src/renderer/src/pages/literature/useLiteratureChanges.ts
@@ -22,12 +22,14 @@ export const useLiteratureChanges = (invalidate: () => void): void => {
       if (document.visibilityState === 'visible') refresh()
     }
     const remove = window.api?.literature?.onChanged?.(refresh)
+    const removeProjectDeleted = window.api?.projects?.onDeleted?.(refresh)
     window.addEventListener('focus', refresh)
     document.addEventListener('visibilitychange', visible)
     window.addEventListener('open-science:web-events-open', refresh)
     return () => {
       active = false
       remove?.()
+      removeProjectDeleted?.()
       window.removeEventListener('focus', refresh)
       document.removeEventListener('visibilitychange', visible)
       window.removeEventListener('open-science:web-events-open', refresh)

--- a/src/renderer/src/pages/literature/useLiteratureChanges.ts
+++ b/src/renderer/src/pages/literature/useLiteratureChanges.ts
@@ -23,6 +23,7 @@ export const useLiteratureChanges = (invalidate: () => void): void => {
     }
     const remove = window.api?.literature?.onChanged?.(refresh)
     const removeProjectDeleted = window.api?.projects?.onDeleted?.(refresh)
+    const removeProjectCleanup = window.api?.projects?.onDeletionCleanupChanged?.(refresh)
     window.addEventListener('focus', refresh)
     document.addEventListener('visibilitychange', visible)
     window.addEventListener('open-science:web-events-open', refresh)
@@ -30,6 +31,7 @@ export const useLiteratureChanges = (invalidate: () => void): void => {
       active = false
       remove?.()
       removeProjectDeleted?.()
+      removeProjectCleanup?.()
       window.removeEventListener('focus', refresh)
       document.removeEventListener('visibilitychange', visible)
       window.removeEventListener('open-science:web-events-open', refresh)

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -996,6 +996,16 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
     // Copy feedback is transient and must not outlive a closed or replaced preview.
     useEffect(() => () => clearTimeout(copiedTimer.current), [])
     const isDirty = mode === 'edit' && editBaseline !== undefined && draft !== editBaseline.text
+    useEffect(() => {
+      if (!isDirty) return
+      const preventUnload = (event: BeforeUnloadEvent): void => {
+        event.preventDefault()
+        // Chromium/Electron's legacy path also requires a return value.
+        event.returnValue = ''
+      }
+      window.addEventListener('beforeunload', preventUnload)
+      return () => window.removeEventListener('beforeunload', preventUnload)
+    }, [isDirty])
     const discardEdit = useCallback((): void => {
       saveGenerationRef.current += 1
       pendingSaveRef.current = undefined
@@ -1041,8 +1051,10 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
 
     useEffect(
       () =>
-        leaveGuardScope ? previewLeaveGuards.register(leaveGuardScope, guardLeave) : undefined,
-      [guardLeave, leaveGuardScope]
+        leaveGuardScope
+          ? previewLeaveGuards.register(leaveGuardScope, guardLeave, () => isDirty)
+          : undefined,
+      [guardLeave, leaveGuardScope, isDirty]
     )
 
     useEffect(() => {
@@ -1628,6 +1640,7 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                         autoFocus
                         aria-label={t('Edit {{name}} source', { name: resolvedPreviewItem.name })}
                         className="min-h-0 flex-1 resize-none bg-bg-000 p-4 font-mono text-sm leading-6 text-text-000 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
+                        readOnly={saving}
                         value={draft}
                         onChange={(event) => setDraft(event.target.value)}
                       />

--- a/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
+++ b/src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 import { act } from 'react'
+import { WebEventRecoveryDialog } from '@/components/WebEventRecoveryDialog'
+import { completeQuitPersistenceFlush } from '@/hooks/useQuitPersistenceFlush'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -487,4 +489,122 @@ describe('preview draft lifecycle', () => {
       )
     }
   )
+})
+
+it('refuses a successful quit acknowledgement while preview text is unsaved', async () => {
+  await act(async () => root.render(<PersistentPreview />))
+  await startEditing()
+  const acknowledge = vi.fn()
+  await expect(
+    completeQuitPersistenceFlush(
+      { requestId: 'dirty-preview' },
+      {
+        suppressAutoReviews: vi.fn(),
+        drainRuntimeEvents: async () => undefined,
+        flushPersistence: async () => undefined,
+        flushPreviewPersistence,
+        acknowledge
+      }
+    )
+  ).rejects.toThrow()
+  expect(acknowledge).toHaveBeenCalledWith({ requestId: 'dirty-preview', status: 'failed' })
+  expect(editor()?.value).toBe(draft)
+  expect(window.api.managedFileVersions.saveTextEdit).not.toHaveBeenCalled()
+})
+
+it('protects dirty preview text from browser unload', async () => {
+  await act(async () => root.render(<PersistentPreview />))
+  await startEditing()
+  const event = new Event('beforeunload', { cancelable: true })
+  expect(window.dispatchEvent(event)).toBe(false)
+  expect(event.defaultPrevented).toBe(true)
+  expect(confirmation()).toBeNull()
+  expect(editor()?.value).toBe(draft)
+})
+
+it('keeps the editor readonly until its save resolves successfully', async () => {
+  await act(async () => root.render(<PersistentPreview />))
+  await startEditing()
+  let complete!: (
+    value: Awaited<ReturnType<Window['api']['managedFileVersions']['saveTextEdit']>>
+  ) => void
+  vi.mocked(window.api.managedFileVersions.saveTextEdit).mockImplementationOnce(
+    () =>
+      new Promise((resolve) => {
+        complete = resolve
+      })
+  )
+  await act(async () =>
+    document.body.querySelector<HTMLButtonElement>('[aria-label="Save changes"]')!.click()
+  )
+  expect(window.api.managedFileVersions.saveTextEdit).toHaveBeenCalledWith(
+    expect.objectContaining({ content: draft })
+  )
+  expect(editor()?.readOnly).toBe(true)
+  expect(editor()?.value).toBe(draft)
+  const inspection = await window.api.managedFileVersions.inspect({
+    source: 'upload',
+    projectId,
+    fileId: 'readme'
+  })
+  if (!inspection.ok) throw new Error('Fixture inspection failed')
+  const selected = inspection.value
+  await act(async () =>
+    complete({
+      ok: true,
+      value: {
+        kind: 'created',
+        version: { ...selected.versions[0], id: 'v2', versionNumber: 2 },
+        headVersionId: 'v2',
+        replayed: false
+      }
+    })
+  )
+  expect(editor()).toBeNull()
+  expect(window.api.managedFileVersions.saveTextEdit).toHaveBeenCalledTimes(1)
+})
+
+it('restores editing after a save failure and releases unload protection after discard', async () => {
+  await act(async () => root.render(<PersistentPreview />))
+  const cleanUnload = new Event('beforeunload', { cancelable: true })
+  expect(window.dispatchEvent(cleanUnload)).toBe(true)
+  await startEditing()
+  await act(async () =>
+    document.body.querySelector<HTMLButtonElement>('[aria-label="Save changes"]')!.click()
+  )
+  expect(editor()?.readOnly).toBe(false)
+  expect(editor()?.value).toBe(draft)
+  expect(previewLeaveGuards.hasUnsavedChanges()).toBe(true)
+  // Existing close protection owns the discard decision.
+  await act(async () => usePreviewWorkbenchStore.getState().removeItem(file.id))
+  const discard = [...confirmation()!.querySelectorAll('button')].find(
+    (button) => button.textContent === 'Discard changes'
+  )
+  await act(async () => discard!.click())
+  expect(previewLeaveGuards.hasUnsavedChanges()).toBe(false)
+  expect(window.dispatchEvent(new Event('beforeunload', { cancelable: true }))).toBe(true)
+})
+
+it('asks before the Web recovery action reloads a dirty preview and keeps text on cancel', async () => {
+  await act(async () => root.render(<PersistentPreview />))
+  await startEditing()
+  await act(async () =>
+    root.render(
+      <>
+        <PersistentPreview />
+        <WebEventRecoveryDialog active phase="reload-required" />
+      </>
+    )
+  )
+  const reload = [...document.body.querySelectorAll('button')].find(
+    (button) => button.textContent === 'Reload'
+  )!
+  await act(async () => reload.click())
+  expect(confirmation()).not.toBeNull()
+  const cancel = [...confirmation()!.querySelectorAll('button')].find(
+    (button) => button.textContent === 'Cancel'
+  )!
+  await act(async () => cancel.click())
+  expect(confirmation()).toBeNull()
+  expect(editor()?.value).toBe(draft)
 })

--- a/src/renderer/src/stores/preview-leave-guard.test.ts
+++ b/src/renderer/src/stores/preview-leave-guard.test.ts
@@ -63,4 +63,22 @@ describe('preview leave guard coordinator', () => {
     expect(otherAction).not.toHaveBeenCalled()
     expect(otherGuard).toHaveBeenCalledOnce()
   })
+  it('requires every page guard to approve before running the unload action', () => {
+    const action = vi.fn()
+    const approvals: Array<() => boolean | void> = []
+    for (const scope of ['first', 'second']) {
+      previewLeaveGuards.register(scope, (next) => {
+        approvals.push(next)
+        return false
+      })
+    }
+    previewLeaveGuards.requestAll(action)
+    expect(action).not.toHaveBeenCalled()
+    expect(approvals).toHaveLength(1)
+    approvals[0]()
+    expect(action).not.toHaveBeenCalled()
+    expect(approvals).toHaveLength(2)
+    approvals[1]()
+    expect(action).toHaveBeenCalledOnce()
+  })
 })

--- a/src/renderer/src/stores/preview-leave-guard.ts
+++ b/src/renderer/src/stores/preview-leave-guard.ts
@@ -2,13 +2,17 @@ type PreviewLeaveAction = () => boolean | void
 type PreviewLeaveGuard = (action: PreviewLeaveAction) => boolean
 
 class PreviewLeaveGuardCoordinator {
-  private readonly guards = new Map<string, PreviewLeaveGuard>()
+  private readonly guards = new Map<string, { guard: PreviewLeaveGuard; isDirty: () => boolean }>()
   private approvedScope: string | undefined
 
-  register(scope: string, guard: PreviewLeaveGuard): () => void {
-    this.guards.set(scope, guard)
+  register(
+    scope: string,
+    guard: PreviewLeaveGuard,
+    isDirty: () => boolean = () => false
+  ): () => void {
+    this.guards.set(scope, { guard, isDirty })
     return () => {
-      if (this.guards.get(scope) === guard) this.guards.delete(scope)
+      if (this.guards.get(scope)?.guard === guard) this.guards.delete(scope)
     }
   }
 
@@ -17,7 +21,7 @@ class PreviewLeaveGuardCoordinator {
       this.approvedScope = undefined
       return action() !== false
     }
-    const guard = scope ? this.guards.get(scope) : undefined
+    const guard = scope ? this.guards.get(scope)?.guard : undefined
     if (guard && !guard(action)) return false
     return action() !== false
   }
@@ -30,6 +34,24 @@ class PreviewLeaveGuardCoordinator {
     } finally {
       this.approvedScope = previousApprovedScope
     }
+  }
+
+  requestAll(action: () => void): void {
+    const scopes = [...this.guards.keys()]
+    const visit = (index: number): void => {
+      if (index === scopes.length) {
+        action()
+        return
+      }
+      // Each confirmation discards only its own draft. Canceling a later confirmation stops
+      // the page action, without undoing an earlier explicit discard.
+      this.request(scopes[index], () => visit(index + 1))
+    }
+    visit(0)
+  }
+
+  hasUnsavedChanges(): boolean {
+    return [...this.guards.values()].some(({ isDirty }) => isDirty())
   }
 
   clear(): void {

--- a/src/renderer/web/bootstrap.test.ts
+++ b/src/renderer/web/bootstrap.test.ts
@@ -57,6 +57,7 @@ class FakeWebSocket {
 }
 
 type WebApi = {
+  storage: Window['api']['storage']
   uploads: Record<'appendTransfer' | 'getTransferStatus', (request: unknown) => Promise<unknown>>
   specialist: Record<
     | 'beginPackageUpload'
@@ -98,6 +99,11 @@ const chunkOperations = [
 
 // Exercise the installed public API: only HTTP completion and event liveness are controlled.
 const longRunningOperations = [
+  {
+    channel: 'storage:migrate',
+    result: { ok: true, cleanupPending: false },
+    invoke: (api: WebApi) => api.storage.migrate('migration-target')
+  },
   {
     channel: 'notebook:execute',
     result: { runId: 'run-1', status: 'completed' },

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -59,6 +59,7 @@ const WEB_BLOB_DOWNLOAD_MAX_BYTES = 512 * 1024 * 1024
 const EVENT_CONNECTION_ATTEMPTS = 8
 const EVENT_CONNECTION_IDLE_TIMEOUT_MS = 30_000
 const DOMAIN_OWNED_WEB_RPC_CHANNELS = new Set([
+  'storage:migrate',
   'notebook:execute',
   'notebook:run-cell',
   'specialist:package-upload-begin',

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -38,7 +38,9 @@
     "Open the app for details.": "Öffnen Sie die App, um weitere Informationen zu erhalten.",
     "Test notification": "Testbenachrichtigung",
     "System notifications from Open Science are working.": "Systembenachrichtigungen von Open Science funktionieren.",
-    "Task needs attention": "Aufgabe erfordert Aufmerksamkeit"
+    "Task needs attention": "Aufgabe erfordert Aufmerksamkeit",
+    "Discard changes": "Änderungen verwerfen",
+    "Discard unsaved changes?": "Nicht gespeicherte Änderungen verwerfen?"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "Der Konversationsexport ist zu groß. Wählen Sie weniger Konversationsrunden aus.",
@@ -98,7 +100,8 @@
     "Import {{source}}": "{{source}} importieren",
     "{{taskName}} has a plan ready for review.": "Für {{taskName}} liegt ein Plan zur Prüfung vor.",
     "Review the proposed plan: {{summary}}": "Prüfen Sie den vorgeschlagenen Plan: {{summary}}",
-    "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}"
+    "Could not open the update installer: {{error}}": "Das Update-Installationsprogramm konnte nicht geöffnet werden: {{error}}",
+    "Your unsaved changes will be lost.": "Ihre ungespeicherten Änderungen gehen verloren."
   },
   "renderer": {
     "Shared content": "Gemeinsame Inhalte",
@@ -4000,7 +4003,6 @@
     "CodeBuddy is required for this framework. Install it below, or install it manually and re-detect.": "Für dieses Framework ist CodeBuddy erforderlich. Installieren Sie CodeBuddy über die Optionen unten oder manuell und starten Sie anschließend die Erkennung erneut.",
     "Downloads CodeBuddy into the app-managed runtime and runs it with the app runtime — no global Node.js or npm required.": "Lädt CodeBuddy in die von der App verwaltete Laufzeit herunter und führt es dort aus – Node.js und npm müssen nicht global installiert sein.",
     "A conversation changed elsewhere and could not be saved safely.": "Eine Konversation wurde an anderer Stelle geändert und konnte nicht sicher gespeichert werden.",
-    "One or more conversations could not be saved.": "Mindestens eine Konversation konnte nicht gespeichert werden.",
     "Quit was canceled": "Das Beenden wurde abgebrochen",
     "This session was deleted or is unavailable.": "Diese Sitzung wurde gelöscht oder ist nicht verfügbar.",
     "A quick host check confirms this computer is ready, then you choose where your data lives before connecting the model you want to use.": "Eine kurze Systemprüfung bestätigt, dass dieser Computer bereit ist. Wählen Sie anschließend den Speicherort Ihrer Daten aus, bevor Sie das gewünschte Modell verbinden.",
@@ -4349,8 +4351,6 @@
     "Compare {{name}} with its source version": "{{name}} mit der Quellversion vergleichen",
     "Compare with source version": "Mit Quellversion vergleichen",
     "Comparing versions...": "Versionen werden verglichen…",
-    "Discard unsaved changes?": "Nicht gespeicherte Änderungen verwerfen?",
-    "Discard changes": "Änderungen verwerfen",
     "Changes could not be saved.": "Änderungen konnten nicht gespeichert werden.",
     "File storage is unavailable. Check the storage location and try again.": "Der Dateispeicher ist nicht verfügbar. Überprüfen Sie den Speicherort und versuchen Sie es erneut.",
     "Open Science does not have permission to save this file.": "Open Science hat keine Berechtigung, diese Datei zu speichern.",
@@ -5023,6 +5023,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Fehlgeschlagen: {{failed}} · Übersprungen: {{skipped}}",
     "You can import unfinished files or close this window.": "Sie können unfertige Dateien importieren oder dieses Fenster schließen.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Neue Compute-Aufträge bleiben möglicherweise in der Warteschlange, weil die gespeicherten Parallelitätsgrenzen nicht überprüft werden konnten. Bewahren Sie die betroffenen Dateien auf, stellen Sie eine gültige Kopie wieder her und prüfen Sie erneut, um die Auftragsvergabe fortzusetzen.",
-    "Recheck saved conversations": "Gespeicherte Konversationen erneut prüfen"
+    "Recheck saved conversations": "Gespeicherte Konversationen erneut prüfen",
+    "Some changes have not been saved.": "Einige Änderungen wurden nicht gespeichert."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -38,7 +38,9 @@
     "Skill": "Habilidad",
     "Specialist": "Especialista",
     "Connector": "Conector",
-    "Export Connector configuration": "Exportar configuración del conector"
+    "Export Connector configuration": "Exportar configuración del conector",
+    "Discard changes": "Descartar cambios",
+    "Discard unsaved changes?": "¿Descartar los cambios no guardados?"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "La exportación de la conversación es demasiado grande. Seleccione menos turnos de conversación.",
@@ -99,7 +101,8 @@
     "Specialist ZIP": "ZIP del especialista",
     "JSON report": "Informe JSON",
     "Connector configuration": "Configuración del conector",
-    "Import Connector configuration": "Importar configuración del conector"
+    "Import Connector configuration": "Importar configuración del conector",
+    "Your unsaved changes will be lost.": "Se perderán los cambios sin guardar."
   },
   "renderer": {
     "Shared content": "Contenido compartido",
@@ -329,7 +332,6 @@
     "Scientific literature": "Literatura científica",
     "Clinical and translational research": "Investigación clínica y traslacional",
     "A conversation changed elsewhere and could not be saved safely.": "Una conversación cambió en otro lugar y no se pudo guardar de forma segura.",
-    "One or more conversations could not be saved.": "No se pudieron guardar una o más conversaciones.",
     "Quit was canceled": "Se canceló la salida",
     "This session was deleted or is unavailable.": "Esta sesión se eliminó o no está disponible.",
     "Architect": "Arquitecto",
@@ -4423,8 +4425,6 @@
     "Compare {{name}} with its source version": "Comparar {{name}} con su versión de origen",
     "Compare with source version": "Comparar con la versión de origen",
     "Comparing versions...": "Comparando versiones…",
-    "Discard unsaved changes?": "¿Descartar los cambios no guardados?",
-    "Discard changes": "Descartar cambios",
     "Changes could not be saved.": "No se pudieron guardar los cambios.",
     "File storage is unavailable. Check the storage location and try again.": "El almacenamiento de archivos no está disponible. Compruebe la ubicación de almacenamiento e inténtelo de nuevo.",
     "Open Science does not have permission to save this file.": "Open Science no tiene permiso para guardar este archivo.",
@@ -5185,6 +5185,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Fallidos: {{failed}} · Omitidos: {{skipped}}",
     "You can import unfinished files or close this window.": "Puede importar los archivos pendientes o cerrar esta ventana.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Los nuevos trabajos de Compute pueden permanecer en cola porque no se pudieron verificar los límites de concurrencia guardados. Conserve los archivos afectados, restaure una copia válida y vuelva a comprobarlos para reanudar el envío de trabajos.",
-    "Recheck saved conversations": "Volver a comprobar las conversaciones guardadas"
+    "Recheck saved conversations": "Volver a comprobar las conversaciones guardadas",
+    "Some changes have not been saved.": "Algunos cambios no se han guardado."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -38,7 +38,9 @@
     "Skill": "Compétence",
     "Specialist": "Spécialiste",
     "Connector": "Connecteur",
-    "Export Connector configuration": "Exporter la configuration du connecteur"
+    "Export Connector configuration": "Exporter la configuration du connecteur",
+    "Discard changes": "Ignorer les modifications",
+    "Discard unsaved changes?": "Ignorer les modifications non enregistrées ?"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "L’exportation de la conversation est trop volumineuse. Sélectionnez moins de tours de conversation.",
@@ -99,7 +101,8 @@
     "Specialist ZIP": "Archive ZIP du spécialiste",
     "JSON report": "Rapport JSON",
     "Connector configuration": "Configuration du connecteur",
-    "Import Connector configuration": "Importer la configuration du connecteur"
+    "Import Connector configuration": "Importer la configuration du connecteur",
+    "Your unsaved changes will be lost.": "Vos modifications non enregistrées seront perdues."
   },
   "renderer": {
     "Shared content": "Contenu partagé",
@@ -329,7 +332,6 @@
     "Scientific literature": "Littérature scientifique",
     "Clinical and translational research": "Recherche clinique et translationnelle",
     "A conversation changed elsewhere and could not be saved safely.": "Une conversation a été modifiée ailleurs et n’a pas pu être enregistrée en toute sécurité.",
-    "One or more conversations could not be saved.": "Une ou plusieurs conversations n’ont pas pu être enregistrées.",
     "Quit was canceled": "La fermeture a été annulée",
     "This session was deleted or is unavailable.": "Cette session a été supprimée ou n’est pas disponible.",
     "Add context for the Agent": "Ajouter du contexte pour l’Agent",
@@ -4423,8 +4425,6 @@
     "Compare {{name}} with its source version": "Comparer {{name}} à sa version source",
     "Compare with source version": "Comparer à la version source",
     "Comparing versions...": "Comparaison des versions…",
-    "Discard unsaved changes?": "Ignorer les modifications non enregistrées ?",
-    "Discard changes": "Ignorer les modifications",
     "Changes could not be saved.": "Les modifications n’ont pas pu être enregistrées.",
     "File storage is unavailable. Check the storage location and try again.": "Le stockage des fichiers est indisponible. Vérifiez l’emplacement de stockage, puis réessayez.",
     "Open Science does not have permission to save this file.": "Open Science n’a pas l’autorisation d’enregistrer ce fichier.",
@@ -5185,6 +5185,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Échecs : {{failed}} · Ignorés : {{skipped}}",
     "You can import unfinished files or close this window.": "Vous pouvez importer les fichiers inachevés ou fermer cette fenêtre.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Les nouvelles tâches Compute peuvent rester en attente, car les limites de simultanéité enregistrées n’ont pas pu être vérifiées. Conservez les fichiers concernés, restaurez une copie valide, puis relancez la vérification pour reprendre l’envoi des tâches.",
-    "Recheck saved conversations": "Revérifier les conversations enregistrées"
+    "Recheck saved conversations": "Revérifier les conversations enregistrées",
+    "Some changes have not been saved.": "Certaines modifications n’ont pas été enregistrées."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -38,7 +38,9 @@
     "Skill": "スキル",
     "Specialist": "スペシャリスト",
     "Connector": "コネクタ",
-    "Export Connector configuration": "コネクタ構成をエクスポート"
+    "Export Connector configuration": "コネクタ構成をエクスポート",
+    "Discard changes": "変更を破棄",
+    "Discard unsaved changes?": "未保存の変更を破棄しますか？"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "会話のエクスポートが大きすぎます。選択する会話ターンを減らしてください。",
@@ -97,7 +99,8 @@
     "Specialist ZIP": "スペシャリスト ZIP",
     "JSON report": "JSON レポート",
     "Connector configuration": "コネクタ構成",
-    "Import Connector configuration": "コネクタ構成のインポート"
+    "Import Connector configuration": "コネクタ構成のインポート",
+    "Your unsaved changes will be lost.": "保存されていない変更は失われます。"
   },
   "renderer": {
     "Shared content": "共有コンテンツ",
@@ -319,7 +322,6 @@
     "Scientific literature": "科学文献",
     "Clinical and translational research": "臨床・トランスレーショナル研究",
     "A conversation changed elsewhere and could not be saved safely.": "別の場所で会話が変更されたため、安全に保存できませんでした。",
-    "One or more conversations could not be saved.": "1件以上の会話を保存できませんでした。",
     "Quit was canceled": "終了はキャンセルされました",
     "This session was deleted or is unavailable.": "このセッションは削除されたか、利用できません。",
     "Add context for the Agent": "エージェント向けの補足を追加",
@@ -4123,8 +4125,6 @@
     "Compare {{name}} with its source version": "{{name}} を元のバージョンと比較",
     "Compare with source version": "元のバージョンと比較",
     "Comparing versions...": "バージョンを比較中…",
-    "Discard unsaved changes?": "未保存の変更を破棄しますか？",
-    "Discard changes": "変更を破棄",
     "Changes could not be saved.": "変更を保存できませんでした。",
     "File storage is unavailable. Check the storage location and try again.": "ファイルストレージを利用できません。保存場所を確認して、もう一度お試しください。",
     "Open Science does not have permission to save this file.": "Open Science にはこのファイルを保存する権限がありません。",
@@ -4869,6 +4869,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "失敗: {{failed}} · スキップ: {{skipped}}",
     "You can import unfinished files or close this window.": "未完了のファイルをインポートするか、このウィンドウを閉じることができます。",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "保存された同時実行数の制限を検証できないため、新しい Compute ジョブがキューに残る場合があります。対象ファイルを保持し、有効なコピーを復元してから再確認すると、ジョブの送信を再開できます。",
-    "Recheck saved conversations": "保存済みの会話を再確認"
+    "Recheck saved conversations": "保存済みの会話を再確認",
+    "Some changes have not been saved.": "一部の変更が保存されていません。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -38,7 +38,9 @@
     "Skill": "스킬",
     "Specialist": "스페셜리스트",
     "Connector": "커넥터",
-    "Export Connector configuration": "커넥터 구성 내보내기"
+    "Export Connector configuration": "커넥터 구성 내보내기",
+    "Discard changes": "변경 사항 버리기",
+    "Discard unsaved changes?": "저장되지 않은 변경 사항을 버리시겠습니까?"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "대화 내보내기 용량이 너무 큽니다. 더 적은 대화 턴을 선택하세요.",
@@ -97,7 +99,8 @@
     "Specialist ZIP": "스페셜리스트 ZIP",
     "JSON report": "JSON 보고서",
     "Connector configuration": "커넥터 구성",
-    "Import Connector configuration": "커넥터 구성 가져오기"
+    "Import Connector configuration": "커넥터 구성 가져오기",
+    "Your unsaved changes will be lost.": "저장하지 않은 변경 사항이 사라집니다."
   },
   "renderer": {
     "Shared content": "공유 콘텐츠",
@@ -319,7 +322,6 @@
     "Scientific literature": "과학 문헌",
     "Clinical and translational research": "임상 및 중개 연구",
     "A conversation changed elsewhere and could not be saved safely.": "다른 곳에서 대화가 변경되어 안전하게 저장할 수 없습니다.",
-    "One or more conversations could not be saved.": "하나 이상의 대화를 저장할 수 없습니다.",
     "Quit was canceled": "종료가 취소되었습니다",
     "This session was deleted or is unavailable.": "이 세션은 삭제되었거나 사용할 수 없습니다.",
     "Add context for the Agent": "에이전트에게 전달할 컨텍스트 추가",
@@ -4121,8 +4123,6 @@
     "Compare {{name}} with its source version": "{{name}} 파일을 원본 버전과 비교",
     "Compare with source version": "원본 버전과 비교",
     "Comparing versions...": "버전을 비교하는 중...",
-    "Discard unsaved changes?": "저장되지 않은 변경 사항을 버리시겠습니까?",
-    "Discard changes": "변경 사항 버리기",
     "Changes could not be saved.": "변경 사항을 저장할 수 없습니다.",
     "File storage is unavailable. Check the storage location and try again.": "파일 저장소를 사용할 수 없습니다. 저장 위치를 확인한 후 다시 시도하세요.",
     "Open Science does not have permission to save this file.": "Open Science에 이 파일을 저장할 권한이 없습니다.",
@@ -4867,6 +4867,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "실패: {{failed}} · 건너뜀: {{skipped}}",
     "You can import unfinished files or close this window.": "미완료 파일을 가져오거나 이 창을 닫을 수 있습니다.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "저장된 동시 실행 제한을 확인할 수 없어 새 Compute 작업이 대기열에 남을 수 있습니다. 영향을 받은 파일을 보존하고 유효한 사본을 복원한 다음 다시 확인하여 작업 전송을 재개하세요.",
-    "Recheck saved conversations": "저장된 대화 다시 확인"
+    "Recheck saved conversations": "저장된 대화 다시 확인",
+    "Some changes have not been saved.": "일부 변경 사항이 저장되지 않았습니다."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -38,7 +38,9 @@
     "Skill": "Навык",
     "Specialist": "Специалист",
     "Connector": "Коннектор",
-    "Export Connector configuration": "Экспорт конфигурации коннектора"
+    "Export Connector configuration": "Экспорт конфигурации коннектора",
+    "Discard changes": "Отбросить изменения",
+    "Discard unsaved changes?": "Отменить несохранённые изменения?"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "Экспорт беседы слишком велик. Выберите меньше реплик беседы.",
@@ -100,7 +102,8 @@
     "Specialist ZIP": "ZIP-архив специалиста",
     "JSON report": "Отчёт JSON",
     "Connector configuration": "Конфигурация коннектора",
-    "Import Connector configuration": "Импорт конфигурации коннектора"
+    "Import Connector configuration": "Импорт конфигурации коннектора",
+    "Your unsaved changes will be lost.": "Несохранённые изменения будут потеряны."
   },
   "renderer": {
     "Shared content": "Общее содержимое",
@@ -334,7 +337,6 @@
     "Scientific literature": "Научная литература",
     "Clinical and translational research": "Клинические и трансляционные исследования",
     "A conversation changed elsewhere and could not be saved safely.": "Диалог был изменён в другом месте, поэтому его не удалось безопасно сохранить.",
-    "One or more conversations could not be saved.": "Не удалось сохранить один или несколько диалогов.",
     "Quit was canceled": "Выход отменён",
     "This session was deleted or is unavailable.": "Эта сессия удалена или недоступна.",
     "Add context for the Agent": "Добавить контекст для Агента",
@@ -4548,8 +4550,6 @@
     "Comparing versions...": "Сравнение версий...",
     "Could not resolve file version.": "Не удалось определить версию файла.",
     "Diff could not be loaded.": "Не удалось загрузить различия.",
-    "Discard unsaved changes?": "Отменить несохранённые изменения?",
-    "Discard changes": "Отбросить изменения",
     "Download latest version v{{version}}": "Загрузить последнюю версию v{{version}}",
     "Download options for {{name}}": "Варианты загрузки для {{name}}",
     "Download version v{{version}}": "Загрузить версию v{{version}}",
@@ -5318,6 +5318,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Ошибки: {{failed}} · Пропущено: {{skipped}}",
     "You can import unfinished files or close this window.": "Можно импортировать незавершённые файлы или закрыть это окно.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Новые задания Compute могут оставаться в очереди, поскольку не удалось проверить сохранённые ограничения параллельного выполнения. Сохраните затронутые файлы, восстановите корректную копию и повторите проверку, чтобы возобновить отправку заданий.",
-    "Recheck saved conversations": "Повторно проверить сохранённые диалоги"
+    "Recheck saved conversations": "Повторно проверить сохранённые диалоги",
+    "Some changes have not been saved.": "Некоторые изменения не сохранены."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -38,7 +38,9 @@
     "Skill": "技能",
     "Specialist": "专家",
     "Connector": "连接器",
-    "Export Connector configuration": "导出连接器配置"
+    "Export Connector configuration": "导出连接器配置",
+    "Discard changes": "放弃更改",
+    "Discard unsaved changes?": "要放弃未保存的更改吗？"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "对话导出内容过大。请选择较少的对话轮次。",
@@ -97,7 +99,8 @@
     "Specialist ZIP": "专家 ZIP",
     "JSON report": "JSON 报告",
     "Connector configuration": "连接器配置",
-    "Import Connector configuration": "导入连接器配置"
+    "Import Connector configuration": "导入连接器配置",
+    "Your unsaved changes will be lost.": "未保存的更改将会丢失。"
   },
   "renderer": {
     "Shared content": "共享内容",
@@ -319,7 +322,6 @@
     "Scientific literature": "科学文献",
     "Clinical and translational research": "临床与转化研究",
     "A conversation changed elsewhere and could not be saved safely.": "会话已在其他位置更改，无法安全保存。",
-    "One or more conversations could not be saved.": "一个或多个会话无法保存。",
     "Quit was canceled": "已取消退出",
     "This session was deleted or is unavailable.": "该会话已被删除或不可用。",
     "Add context for the Agent": "为智能体添加上下文",
@@ -4124,8 +4126,6 @@
     "Compare {{name}} with its source version": "将 {{name}} 与其源版本比较",
     "Compare with source version": "与源版本比较",
     "Comparing versions...": "正在比较版本……",
-    "Discard unsaved changes?": "要放弃未保存的更改吗？",
-    "Discard changes": "放弃更改",
     "Changes could not be saved.": "无法保存更改。",
     "File storage is unavailable. Check the storage location and try again.": "文件存储不可用。请检查存储位置后重试。",
     "Open Science does not have permission to save this file.": "Open Science 没有保存此文件的权限。",
@@ -4869,6 +4869,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "失败：{{failed}} · 已跳过：{{skipped}}",
     "You can import unfinished files or close this window.": "您可以导入未完成的文件或关闭此窗口。",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "无法验证已保存的并发限制，新 Compute 任务可能会一直排队。请保留受影响的文件，恢复有效副本后重新检查，以恢复任务派发。",
-    "Recheck saved conversations": "重新检查已保存的对话"
+    "Recheck saved conversations": "重新检查已保存的对话",
+    "Some changes have not been saved.": "部分更改尚未保存。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -38,7 +38,9 @@
     "Skill": "技能",
     "Specialist": "專家",
     "Connector": "連接器",
-    "Export Connector configuration": "匯出連接器設定"
+    "Export Connector configuration": "匯出連接器設定",
+    "Discard changes": "捨棄變更",
+    "Discard unsaved changes?": "要捨棄未儲存的變更嗎？"
   },
   "native": {
     "Conversation export is too large. Select fewer conversation turns.": "對話匯出內容過大。請選擇較少的對話輪次。",
@@ -97,7 +99,8 @@
     "Specialist ZIP": "專家 ZIP",
     "JSON report": "JSON 報告",
     "Connector configuration": "連接器設定",
-    "Import Connector configuration": "匯入連接器設定"
+    "Import Connector configuration": "匯入連接器設定",
+    "Your unsaved changes will be lost.": "未儲存的變更將會遺失。"
   },
   "renderer": {
     "Shared content": "共用內容",
@@ -319,7 +322,6 @@
     "Scientific literature": "科學文獻",
     "Clinical and translational research": "臨床與轉譯研究",
     "A conversation changed elsewhere and could not be saved safely.": "會話已在其他位置變更，無法安全儲存。",
-    "One or more conversations could not be saved.": "一個或多個會話無法儲存。",
     "Quit was canceled": "已取消結束",
     "This session was deleted or is unavailable.": "此會話已刪除或無法使用。",
     "Add context for the Agent": "為智能體新增上下文",
@@ -4124,8 +4126,6 @@
     "Compare {{name}} with its source version": "將 {{name}} 與其來源版本比較",
     "Compare with source version": "與來源版本比較",
     "Comparing versions...": "正在比較版本……",
-    "Discard unsaved changes?": "要捨棄未儲存的變更嗎？",
-    "Discard changes": "捨棄變更",
     "Changes could not be saved.": "無法儲存變更。",
     "File storage is unavailable. Check the storage location and try again.": "檔案儲存空間無法使用。請檢查儲存位置後再試一次。",
     "Open Science does not have permission to save this file.": "Open Science 沒有儲存此檔案的權限。",
@@ -4869,6 +4869,7 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "失敗：{{failed}} · 已略過：{{skipped}}",
     "You can import unfinished files or close this window.": "您可以匯入未完成的檔案或關閉此視窗。",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "無法驗證已儲存的並行限制，新 Compute 任務可能會持續排隊。請保留受影響的檔案，還原有效副本後重新檢查，以恢復任務派發。",
-    "Recheck saved conversations": "重新檢查已儲存的對話"
+    "Recheck saved conversations": "重新檢查已儲存的對話",
+    "Some changes have not been saved.": "部分變更尚未儲存。"
   }
 }


### PR DESCRIPTION
## Problem

Deleted or deleting projects can still gain Literature memberships, and retained memberships appear in active queries. A local Web data move can time out after 30 seconds despite a healthy connection. Preview edits can be lost on exit/reload or when an earlier save completes while more text is being typed.

## Proposed change

- Check project lifecycle and deletion intents inside Literature transactions, including automatic candidate attachment and membership transfer during merges. Remove active membership in the project soft-delete transaction, filter stale memberships from reads, and refresh Literature consumers on the existing project-deleted and deletion-cleanup events. Publish the existing cleanup event after the deletion intent commits, before potentially blocked runtime cleanup. Preserve archived-project behavior and discovery provenance.
- Give `storage:migrate` the existing domain-owned Web RPC timeout policy, retaining heartbeat/disconnect handling and backend-owned cancellation.
- Report dirty previews through the existing failed-flush shutdown gate. Use existing leave confirmations before the Web recovery action reloads; add native Electron discard confirmation when `beforeunload` blocks closing or reloading.
- Make the textarea readonly during save, preserving selection/copy and restoring editing on failure. Keep operation-ID retry and immutable-version behavior intact.

## Scope and non-goals

No new database fields, schema migrations, shared enums or durable draft records. Project deletion now removes its active Literature relationships; global references, attachments, other projects and discovery history remain intact. Historical stale rows are filtered on read without a bulk cleanup migration.

Crash recovery for unsaved text and migration-result reconciliation after a lost connection remain separate work. Browser-toolbar unload protection depends on browser support; the application-owned Web reload action has explicit confirmation. No automatic saving of drafts as formal file versions.

## Acceptance criteria and validation

Expected-correct regressions failed repeatedly on unfixed production code with matching symptoms. The readonly and explicit Web-reload expectations were each reproduced in red before their implementations. Independent review identified missing invalidation while deletion cleanup is blocked; producer and subscriber regressions failed twice before reusing the existing cleanup event. After the final source/test edit, the selected owner/contract/consumer checks have passing results: **82 files, 2583 tests**. The initial expanded run passed 2582 tests; its capacity test hit the transaction-start limit while competing with typecheck/lint, then passed alone without changing its assertions. Typechecks, lint, formatting and `git diff --check` passed. Exact-head CI exposed a missed Artifact Literature consumer fixture; both mocks now provide the existing deletion-intent delegate, and the complete artifact consumer module is included in the final local set.

| Behavior | Checks included in the passing targeted run |
| --- | --- |
| Project/Literature lifecycle and old residual rows | All `src/main/literature` and `src/main/artifacts` suites; project repository, deletion coordinator and ownership contract; Literature change/entry consumers |
| Long Web migration and adapters | Web bootstrap, API installer, shared RPC contract, preload, storage command-owner atomicity |
| Dirty preview quit/reload and save lifecycle | Preview editor/panel/dialog, draft lifecycle, leave guards, quit flush, Web recovery dialog, close-confirm modal, application presentation |
| Native exit and translation boundaries | Windows, close-confirm, app lifecycle, renderer-flush and i18n guard suites |

<details>
<summary>Exact final targeted test command</summary>

```sh
node node_modules/vitest/vitest.mjs run \
  src/main/literature \
  src/main/artifacts \
  src/main/projects/repository.test.ts \
  src/main/projects/ipc.test.ts \
  src/main/application-events.test.ts \
  src/renderer/src/hooks/useLifecycleSync.test.tsx \
  src/main/projects/deletion-coordinator.test.ts \
  src/main/projects/project-owned-data.catalog.architecture.test.ts \
  src/main/windows.test.ts \
  src/main/window-close-confirm.test.ts \
  src/main/app-lifecycle.test.ts \
  src/main/session-persistence/renderer-flush.test.ts \
  src/main/storage/command-owner.atomicity.test.ts \
  src/renderer/src/hooks/useQuitPersistenceFlush.test.ts \
  src/renderer/src/pages/literature/useLiteratureChanges.test.tsx \
  src/renderer/src/pages/literature/useLiteratureEntries.test.tsx \
  src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx \
  src/renderer/src/pages/workspace/PreviewFileSurface.freshness.test.tsx \
  src/renderer/src/pages/workspace/preview-draft-lifecycle.test.tsx \
  src/renderer/src/pages/workspace/PreviewPanel.test.tsx \
  src/renderer/src/pages/workspace/FilePreviewDialog.lifecycle.test.tsx \
  src/renderer/src/pages/workspace/FilePreviewDialog.escape.test.tsx \
  src/renderer/src/pages/workspace/FilePreviewDialog.versioning.test.tsx \
  src/renderer/src/stores/preview-leave-guard.test.ts \
  src/renderer/src/components/CloseConfirmModal.render.test.tsx \
  src/renderer/src/components/WebEventRecoveryDialog.test.tsx \
  src/renderer/web/bootstrap.test.ts \
  src/renderer/src/i18n/resources.test.ts \
  src/preload/index.test.ts \
  src/shared/web-rpc-contract.test.ts \
  src/renderer/web/api-installer.test.ts \
  src/renderer/src/App.test.tsx --maxWorkers=3
node node_modules/vitest/vitest.mjs run src/main/literature/catalog-capacity.test.ts
npm run typecheck
npm run lint
```

</details>

Real browser checks mounted the production preview and confirmation components with controlled backend responses: keyboard input is ignored while saving; save failure restores editing; canceling quit/reload preserves text; explicitly discarding permits the application reload. Screenshots were inspected. Native OS dialog and full Electron shutdown were covered at the component/IPC boundaries rather than claimed as real OS end-to-end execution.

The automatic test-impact explain falls back to full because Literature has no registered module owner. At the maintainer's request, local verification uses the explicit impact map above; full and cross-platform verification remain exact-head PR CI's responsibility. Loopback RPC tests required running outside the sandbox. The four agent-framework adapters and their branch replay/subscription behavior are unchanged; the new guard runs after their existing common renderer drain.

## Review focus

Transaction ordering against deletion intents; preservation of global Literature and provenance; no premature successful quit acknowledgement; leave-guard continuation across confirmations; native unload consent; unchanged save retry identity. Exact-head CI and independent PR review remain the final validation authority.
