### PR TITLE
fix(side-chat): allow Codex subscription startup and resume

### DIFF
--- a/src/main/settings/backend-resolver.test.ts
+++ b/src/main/settings/backend-resolver.test.ts
@@ -1,6 +1,12 @@
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
 import { describe, expect, it, vi } from 'vitest'
+
+import { SideChatRuntimeOwner } from '../side-chat/runtime-owner'
+import { SideChatRelayOwner } from '../acp/side-chat-relay-owner'
+import type { ResolvedAgentBackend } from '../agent-framework'
 
 import { SETTINGS_FILE_VERSION } from '../../shared/settings'
 import type { AgentConfigFile, AgentFrameworkId } from '../agent-framework'
@@ -150,6 +156,7 @@ const makeOpenAiProviderBridgeDouble = (index: number): OpenAiProviderBridgeDoub
 })
 
 type HarnessOptions = {
+  storageRoot?: string
   settings?: StoredSettings
   frameworkOverride?: string
   connectorIds?: string[]
@@ -311,7 +318,7 @@ const makeHarness = (options: HarnessOptions = {}) => {
     providers,
     runtime,
     connectors,
-    storageRoot: '/storage',
+    storageRoot: options.storageRoot ?? '/storage',
     userClaudeDir: '/user/.claude',
     skillRuntimeMcpEntryPath: '/app/main.js',
     readFrameworkOverride,
@@ -478,6 +485,162 @@ describe('AgentBackendResolver configured and explicit targets', () => {
     expect(backend.responsesBridgeLease).toBeDefined()
     await backend.responsesBridgeLease?.release()
   })
+
+  it.each(['start', 'resume'] as const)(
+    '%s Side chat with the same Codex subscription that resolves for Main',
+    async (mode) => {
+      const root = await mkdtemp(join(tmpdir(), 'side-chat-subscription-'))
+      const provider: StoredProvider = {
+        id: 'builtin-codex-subscription',
+        type: 'codex-isolated',
+        codexAuthMode: 'isolated',
+        name: 'Codex subscription',
+        model: 'gpt-5.4'
+      }
+      const harness = makeHarness({
+        storageRoot: root,
+        settings: makeSettings({
+          providers: [provider],
+          activeProviderId: provider.id,
+          activeModel: provider.model,
+          agentFrameworkId: 'codex'
+        }),
+        targetOverride: () => ({
+          apiEndpoints: ['responses'],
+          provider: { apiEndpoints: ['responses'] }
+        })
+      })
+      let prepared: ResolvedAgentBackend | undefined
+      const owner = new SideChatRuntimeOwner({
+        appVersion: '0.26.0',
+        configRoot: root,
+        captureTarget: () => harness.resolver.captureExplicitTarget(),
+        resolveTarget: (target, context) => harness.resolver.resolveExplicitTarget(target, context),
+        relay: new SideChatRelayOwner({
+          targetState: () => 'idle',
+          appendRelay: async () => undefined
+        }),
+        persistence: {
+          save: async (input) => input.sideChat,
+          clear: async () => true
+        },
+        onEvent: vi.fn(),
+        createRuntime: (options) => ({
+          createSession: async () => {
+            prepared = await options.resolveBackend!({
+              forcedSkillIds: [],
+              systemPromptAppends: []
+            })
+            return { sessionId: 'side-provider-session', frameworkId: 'codex' as const }
+          },
+          sendPrompt: async (request) => {
+            options.callbacks?.onProviderPromptAccepted?.(request.sessionId)
+            return { stopReason: 'end_turn' as const }
+          },
+          cancelPrompt: async () => {
+            throw new Error('Unexpected cancellation during startup')
+          },
+          deleteSession: async () => {
+            throw new Error('Unexpected deletion during startup')
+          },
+          resumeSession: async () => {
+            prepared = await options.resolveBackend!({
+              forcedSkillIds: [],
+              systemPromptAppends: []
+            })
+            return { sessionId: 'side-provider-session', frameworkId: 'codex' as const }
+          },
+          respondToPermission: async () => {
+            throw new Error('Unexpected permission during startup')
+          },
+          applyModelChange: async () => false,
+          applyReasoningEffortChange: async () => false,
+          requestProviderReconnect: async () => {
+            prepared = await options.resolveBackend!({
+              forcedSkillIds: [],
+              systemPromptAppends: []
+            })
+          },
+          shutdownForQuit: async () => ({ reaped: true })
+        })
+      })
+      try {
+        const home = join(root, 'codex-subscription')
+        await mkdir(home, { recursive: true })
+        await writeFile(
+          join(home, 'auth.json'),
+          JSON.stringify({
+            tokens: { access_token: 'test-only-token' }
+          })
+        )
+        const target = await harness.resolver.captureExplicitTarget()
+        await expect(harness.resolver.resolveExplicitTarget(target)).resolves.toMatchObject({
+          providerId: provider.id
+        })
+        if (mode === 'start') {
+          await expect(
+            owner.start({
+              parentSessionId: 'main-session',
+              projectId: 'project',
+              text: 'Explain this separately.'
+            })
+          ).resolves.toMatchObject({ frameworkId: 'codex' })
+        } else {
+          owner.hydrate([
+            {
+              parentSessionId: 'main-session',
+              projectId: 'project',
+              sideChat: {
+                version: 1,
+                id: 'side-chat-restored',
+                lifecycle: 'open',
+                frameworkId: 'codex',
+                providerId: provider.id,
+                backendId: `codex:${provider.id}`,
+                providerSessionId: 'side-provider-session',
+                historyPreamble: 'Main conversation snapshot.',
+                entries: [],
+                createdAt: 1,
+                updatedAt: 2
+              }
+            }
+          ])
+          await expect(
+            owner.send({ sideSessionId: 'side-chat-restored', text: 'Continue.' })
+          ).resolves.toBeUndefined()
+        }
+        const sideHome = prepared!.env.CODEX_HOME!
+        expect(sideHome).not.toBe(home)
+        await expect(readFile(join(sideHome, 'auth.json'), 'utf8')).resolves.toContain(
+          'test-only-token'
+        )
+        expect(JSON.parse(prepared!.env.CODEX_CONFIG!)).toMatchObject({
+          features: {
+            shell_tool: false,
+            multi_agent: false,
+            code_mode: false,
+            apply_patch_freeform: false
+          },
+          tools: { web_search: false }
+        })
+        await writeFile(
+          join(home, 'auth.json'),
+          JSON.stringify({ tokens: { access_token: 'refreshed-test-token' } })
+        )
+        await owner.requestProviderReconnect()
+        expect(prepared!.env.CODEX_HOME).toBe(sideHome)
+        await expect(readFile(join(sideHome, 'auth.json'), 'utf8')).resolves.toContain(
+          'refreshed-test-token'
+        )
+        expect(prepared?.providerId).toBe(provider.id)
+        expect(harness.createNativeResponsesProxy).not.toHaveBeenCalled()
+        expect(harness.createResponsesBridge).not.toHaveBeenCalled()
+      } finally {
+        await owner.shutdown()
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('fails closed for Codex subscription reconstruction before starting a runtime', async () => {
     const provider: StoredProvider = {

--- a/src/main/side-chat/runtime-owner.test.ts
+++ b/src/main/side-chat/runtime-owner.test.ts
@@ -310,162 +310,193 @@ describe('SideChatRuntimeOwner lifecycle', () => {
     await expect(access(orphan)).resolves.toBeUndefined()
   })
 
-  it('admits a first turn, binds the trusted MCP sender, and destroys the runtime on close', async () => {
-    temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-owner-'))
-    const closeOrder: string[] = []
-    const registerHostMessageSession = vi.fn()
-    const unregisterHostMessageSession = vi.fn(() => {
-      closeOrder.push('scope')
-      return true
-    })
-    const resolved: ResolvedAgentBackend = {
-      ...backend(claudeCodeFramework),
-      responsesBridgeLease: {
-        selectSkills: vi.fn(async () => []),
-        registerReviewerSession: vi.fn(),
-        unregisterReviewerSession: vi.fn(() => false),
-        registerHostMessageSession,
-        unregisterHostMessageSession,
-        release: vi.fn(async () => undefined)
+  it.each([
+    ['Claude', claudeCodeFramework, false],
+    ['OpenCode', opencodeFramework, false],
+    ['Codex API', codexFramework, false],
+    ['Codex subscription', codexFramework, true]
+  ] as const)(
+    '%s admits a first turn with only host-message permissions and cleans up on close',
+    async (_label, framework, subscription) => {
+      temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-owner-'))
+      const closeOrder: string[] = []
+      const registerHostMessageSession = vi.fn()
+      const unregisterHostMessageSession = vi.fn(() => {
+        closeOrder.push('scope')
+        return true
+      })
+      const resolved: ResolvedAgentBackend = {
+        ...backend(framework),
+        ...(subscription ? { providerId: 'builtin-codex-subscription' } : {}),
+        responsesBridgeLease: subscription
+          ? undefined
+          : {
+              selectSkills: vi.fn(async () => []),
+              registerReviewerSession: vi.fn(),
+              unregisterReviewerSession: vi.fn(() => false),
+              registerHostMessageSession,
+              unregisterHostMessageSession,
+              release: vi.fn(async () => undefined)
+            }
       }
-    }
-    const relay = createRelayOwner()
-    const deliverRelay = vi.fn(async (_parentSessionId, queued) => queued)
-    const setParentInteractionsPaused = vi.fn()
-    let runtimeOptions: AcpRuntimeOptions | undefined
-    const createSession = vi.fn(async () => ({
-      sessionId: 'side-session-1',
-      providerSessionId: 'provider-session-1',
-      frameworkId: 'claude-code' as const
-    }))
-    const permissionDecision = deferred<{
-      requestId: string
-      optionId?: string
-      cancelled?: boolean
-    }>()
-    const respondToPermission = vi.fn(async (decision) => {
-      permissionDecision.resolve(decision)
-      return true
-    })
-    const sendPrompt = vi.fn(async (request: { sessionId: string }) => {
-      runtimeOptions!.callbacks?.onProviderPromptAccepted?.(request.sessionId)
-      runtimeOptions!.callbacks?.onPermissionRequest?.({
+      const relay = createRelayOwner()
+      const deliverRelay = vi.fn(async (_parentSessionId, queued) => queued)
+      const setParentInteractionsPaused = vi.fn()
+      let runtimeOptions: AcpRuntimeOptions | undefined
+      const createSession = vi.fn(async () => ({
+        sessionId: 'side-session-1',
+        providerSessionId: 'provider-session-1',
+        frameworkId: framework.id
+      }))
+      const permissionDecision = deferred<{
+        requestId: string
+        optionId?: string
+        cancelled?: boolean
+      }>()
+      const respondToPermission = vi.fn(async (decision) => {
+        permissionDecision.resolve(decision)
+        return true
+      })
+      const sendPrompt = vi.fn(async (request: { sessionId: string }) => {
+        runtimeOptions!.callbacks?.onProviderPromptAccepted?.(request.sessionId)
+        runtimeOptions!.callbacks?.onPermissionRequest?.({
+          requestId: 'host-message-permission',
+          sessionId: request.sessionId,
+          toolCallId: 'host-message-call',
+          title: 'mcp.open-science-host-message.send_message',
+          providerToolName: 'send_message',
+          isMcp: true,
+          mcpIdentity: 'open-science-host-message/send_message',
+          options: [
+            { optionId: 'allow-once', name: 'Allow', kind: 'allow_once', scope: 'once' },
+            { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
+          ]
+        })
+        const decision = await permissionDecision.promise
+        if (decision.optionId !== 'allow-once')
+          throw new Error('Host message permission was denied.')
+        await runtimeOptions!.sideChat!.sendMessage('trusted-routing-1', {
+          target: 'main',
+          text: 'Use a black line.'
+        })
+        return { stopReason: 'end_turn' as const }
+      })
+      const deleteSession = vi.fn(async () => ({ sessionIds: [] }))
+      const shutdownForQuit = vi.fn(async () => {
+        closeOrder.push('runtime')
+      })
+      const owner = new SideChatRuntimeOwner({
+        appVersion: '0.11.0',
+        configRoot: temporaryRoot,
+        captureTarget: vi.fn(async () => ({
+          ...target,
+          frameworkId: framework.id,
+          providerId: subscription ? 'builtin-codex-subscription' : 'provider-a'
+        })),
+        resolveTarget: vi.fn(async (_target, context) => {
+          expect(context.forceCodexNativeResponsesCompatibility).toBe(!subscription)
+          expect(context.includeSkillAndConnectorContext).toBe(false)
+          return resolved
+        }),
+        relay,
+        deliverRelay,
+        persistence: createPersistence(),
+        onEvent: vi.fn(),
+        setParentInteractionsPaused,
+        createRuntime: (options) => {
+          runtimeOptions = options
+          return {
+            createSession,
+            sendPrompt,
+            cancelPrompt: vi.fn(async () => ({ stopReason: 'cancelled' })),
+            deleteSession,
+            respondToPermission,
+            shutdownForQuit
+          } as never
+        }
+      })
+
+      const started = await owner.start({
+        parentSessionId: 'main-session-1',
+        projectId: 'project-1',
+        text: 'What context do you have?',
+        historyPreamble: 'Main snapshot.'
+      })
+
+      expect(started).toMatchObject({
+        sideSessionId: expect.stringMatching(/^side-chat-/),
+        frameworkId: framework.id,
+        model: 'model-a'
+      })
+      expect(owner.hasForParent('main-session-1')).toBe(true)
+      expect(setParentInteractionsPaused).toHaveBeenCalledWith('main-session-1', true)
+      expect(runtimeOptions?.sessionCapabilityPolicy).toMatchObject({ role: 'side-chat' })
+      expect(sendPrompt).toHaveBeenCalledWith({
+        sessionId: 'side-session-1',
+        text: 'What context do you have?',
+        historyPreamble: 'Main snapshot.',
+        resumeFallback: { historyPreamble: expect.stringContaining('Main snapshot.') }
+      })
+      if (subscription) expect(registerHostMessageSession).not.toHaveBeenCalled()
+      else
+        expect(registerHostMessageSession).toHaveBeenCalledWith(
+          'provider-session-1',
+          [expect.objectContaining({ name: 'send_message' })],
+          { failClosedUnknownKeys: true }
+        )
+      runtimeOptions!.callbacks!.onPermissionRequest!({
+        requestId: 'forbidden-shell',
+        sessionId: 'side-session-1',
+        toolCallId: 'shell-call',
+        title: 'Shell',
+        providerToolName: 'shell',
+        options: [{ optionId: 'allow-once', name: 'Allow', kind: 'allow_once', scope: 'once' }]
+      })
+      expect(respondToPermission).toHaveBeenCalledWith({
+        requestId: 'forbidden-shell',
+        cancelled: true
+      })
+      expect(respondToPermission).toHaveBeenCalledWith({
         requestId: 'host-message-permission',
-        sessionId: request.sessionId,
-        toolCallId: 'host-message-call',
-        title: 'mcp.open-science-host-message.send_message',
-        providerToolName: 'send_message',
-        isMcp: true,
-        mcpIdentity: 'open-science-host-message/send_message',
-        options: [
-          { optionId: 'allow-once', name: 'Allow', kind: 'allow_once', scope: 'once' },
-          { optionId: 'decline', name: 'Decline', kind: 'reject_once' }
-        ]
+        optionId: 'allow-once'
       })
-      const decision = await permissionDecision.promise
-      if (decision.optionId !== 'allow-once') throw new Error('Host message permission was denied.')
-      await runtimeOptions!.sideChat!.sendMessage('trusted-routing-1', {
+      expect(deliverRelay).toHaveBeenCalledWith(
+        'main-session-1',
+        expect.objectContaining({ status: 'queued', delivery: 'next-user-turn' })
+      )
+      const queuedRelay = relay.claim('main-session-1')
+      expect(queuedRelay?.messages).toEqual([
+        expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' })
+      ])
+      queuedRelay?.restore()
+
+      await runtimeOptions?.sideChat?.sendMessage(started.sideSessionId, {
         target: 'main',
-        text: 'Use a black line.'
+        text: 'Keep the labels.'
       })
-      return { stopReason: 'end_turn' as const }
-    })
-    const deleteSession = vi.fn(async () => ({ sessionIds: [] }))
-    const shutdownForQuit = vi.fn(async () => {
-      closeOrder.push('runtime')
-    })
-    const owner = new SideChatRuntimeOwner({
-      appVersion: '0.11.0',
-      configRoot: temporaryRoot,
-      captureTarget: vi.fn(async () => target),
-      resolveTarget: vi.fn(async (_target, context) => {
-        expect(context.forceCodexNativeResponsesCompatibility).toBe(true)
-        expect(context.includeSkillAndConnectorContext).toBe(false)
-        return resolved
-      }),
-      relay,
-      deliverRelay,
-      persistence: createPersistence(),
-      onEvent: vi.fn(),
-      setParentInteractionsPaused,
-      createRuntime: (options) => {
-        runtimeOptions = options
-        return {
-          createSession,
-          sendPrompt,
-          cancelPrompt: vi.fn(async () => ({ stopReason: 'cancelled' })),
-          deleteSession,
-          respondToPermission,
-          shutdownForQuit
-        } as never
-      }
-    })
+      const reconnectedRelay = relay.claim('main-session-1')
+      expect(reconnectedRelay?.messages).toEqual([
+        expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' }),
+        expect.objectContaining({ text: 'Keep the labels.', sideSessionId: started.sideSessionId })
+      ])
+      reconnectedRelay?.restore()
 
-    const started = await owner.start({
-      parentSessionId: 'main-session-1',
-      projectId: 'project-1',
-      text: 'What context do you have?',
-      historyPreamble: 'Main snapshot.'
-    })
+      await owner.closeForParent('main-session-1')
 
-    expect(started).toMatchObject({
-      sideSessionId: expect.stringMatching(/^side-chat-/),
-      frameworkId: 'claude-code',
-      model: 'model-a'
-    })
-    expect(owner.hasForParent('main-session-1')).toBe(true)
-    expect(setParentInteractionsPaused).toHaveBeenCalledWith('main-session-1', true)
-    expect(runtimeOptions?.sessionCapabilityPolicy).toMatchObject({ role: 'side-chat' })
-    expect(sendPrompt).toHaveBeenCalledWith({
-      sessionId: 'side-session-1',
-      text: 'What context do you have?',
-      historyPreamble: 'Main snapshot.',
-      resumeFallback: { historyPreamble: expect.stringContaining('Main snapshot.') }
-    })
-    expect(registerHostMessageSession).toHaveBeenCalledWith(
-      'provider-session-1',
-      [expect.objectContaining({ name: 'send_message' })],
-      { failClosedUnknownKeys: true }
-    )
-    expect(respondToPermission).toHaveBeenCalledWith({
-      requestId: 'host-message-permission',
-      optionId: 'allow-once'
-    })
-    expect(deliverRelay).toHaveBeenCalledWith(
-      'main-session-1',
-      expect.objectContaining({ status: 'queued', delivery: 'next-user-turn' })
-    )
-    const queuedRelay = relay.claim('main-session-1')
-    expect(queuedRelay?.messages).toEqual([
-      expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' })
-    ])
-    queuedRelay?.restore()
-
-    await runtimeOptions?.sideChat?.sendMessage(started.sideSessionId, {
-      target: 'main',
-      text: 'Keep the labels.'
-    })
-    const reconnectedRelay = relay.claim('main-session-1')
-    expect(reconnectedRelay?.messages).toEqual([
-      expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' }),
-      expect.objectContaining({ text: 'Keep the labels.', sideSessionId: started.sideSessionId })
-    ])
-    reconnectedRelay?.restore()
-
-    await owner.closeForParent('main-session-1')
-
-    expect(unregisterHostMessageSession).toHaveBeenCalledWith('provider-session-1')
-    expect(closeOrder).toEqual(['runtime', 'scope'])
-    expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'side-session-1' })
-    expect(shutdownForQuit).toHaveBeenCalledOnce()
-    expect(owner.hasForParent('main-session-1')).toBe(false)
-    expect(setParentInteractionsPaused).toHaveBeenLastCalledWith('main-session-1', false)
-    await expect(stat(join(temporaryRoot, 'runtime-support', 'side-chat'))).resolves.toBeDefined()
-    expect(relay.claim('main-session-1')?.messages).toEqual([
-      expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' }),
-      expect.objectContaining({ text: 'Keep the labels.', sideSessionId: started.sideSessionId })
-    ])
-  })
+      if (subscription) expect(unregisterHostMessageSession).not.toHaveBeenCalled()
+      else expect(unregisterHostMessageSession).toHaveBeenCalledWith('provider-session-1')
+      expect(closeOrder).toEqual(subscription ? ['runtime'] : ['runtime', 'scope'])
+      expect(deleteSession).toHaveBeenCalledWith({ sessionId: 'side-session-1' })
+      expect(shutdownForQuit).toHaveBeenCalledOnce()
+      expect(owner.hasForParent('main-session-1')).toBe(false)
+      expect(setParentInteractionsPaused).toHaveBeenLastCalledWith('main-session-1', false)
+      await expect(stat(join(temporaryRoot, 'runtime-support', 'side-chat'))).resolves.toBeDefined()
+      expect(relay.claim('main-session-1')?.messages).toEqual([
+        expect.objectContaining({ text: 'Use a black line.', sideSessionId: 'trusted-routing-1' }),
+        expect.objectContaining({ text: 'Keep the labels.', sideSessionId: started.sideSessionId })
+      ])
+    }
+  )
 
   it('coalesces streamed transcript chunks into the latest durable projection', async () => {
     temporaryRoot = await mkdtemp(join(tmpdir(), 'open-science-side-chat-coalesce-'))

--- a/src/main/side-chat/runtime-owner.ts
+++ b/src/main/side-chat/runtime-owner.ts
@@ -13,6 +13,7 @@ import type { AcpCreateSessionResponse } from '../../shared/acp'
 import { isCurrentInFlight } from '../../shared/in-flight-promise'
 import type { ResolvedReasoningEffort } from '../../shared/reasoning-effort'
 import type { PersistedSideChat } from '../../shared/session-persistence'
+import { isCodexSubscriptionProviderId } from '../../shared/settings'
 import {
   SIDE_CHAT_MESSAGE_LIMIT,
   type SideChatEntry,
@@ -101,7 +102,7 @@ type SideChatRuntimeOwnerOptions = Readonly<{
     context: {
       systemPromptAppends: string[]
       includeSkillAndConnectorContext: false
-      forceCodexNativeResponsesCompatibility: true
+      forceCodexNativeResponsesCompatibility: boolean
     }
   ) => Promise<ResolvedAgentBackend>
   relay: SideChatRelayOwner
@@ -431,7 +432,10 @@ class SideChatRuntimeOwner {
         let resolved = await this.options.resolveTarget(target, {
           systemPromptAppends: [SIDE_CHAT_SYSTEM_PROMPT],
           includeSkillAndConnectorContext: false,
-          forceCodexNativeResponsesCompatibility: true
+          // Subscription authentication uses native Codex; API-key routes still need the
+          // compatibility bridge to enforce their host-message-only tool surface.
+          forceCodexNativeResponsesCompatibility:
+            target.frameworkId !== 'codex' || !isCodexSubscriptionProviderId(target.providerId)
         })
         resolved = await prepareSideChatBackend(resolved, profileRoot)
         const bridge = resolved.responsesBridgeLease
@@ -995,7 +999,10 @@ class SideChatRuntimeOwner {
         let resolved = await this.options.resolveTarget(target, {
           systemPromptAppends: [SIDE_CHAT_SYSTEM_PROMPT],
           includeSkillAndConnectorContext: false,
-          forceCodexNativeResponsesCompatibility: true
+          // Subscription authentication uses native Codex; API-key routes still need the
+          // compatibility bridge to enforce their host-message-only tool surface.
+          forceCodexNativeResponsesCompatibility:
+            target.frameworkId !== 'codex' || !isCodexSubscriptionProviderId(target.providerId)
         })
         resolved = await prepareSideChatBackend(resolved, profileRoot)
         const bridge = resolved.responsesBridgeLease


### PR DESCRIPTION
## Problem

A Codex subscription resolves for Main but cannot start Side chat: Side chat forces the API-key Responses compatibility bridge, whose resolver rejects subscription authentication with an artifact-reconstruction error. Dormant Side chats hit the same rejection when sending a follow-up.

## Proposed change

Use the existing native restricted Codex route for subscription targets during startup, restoration and reconnect. Keep forced compatibility for API-key routes and preserve the reconstruction guard.

## Scope and non-goals

No schema, new persisted field/state, transcript migration, or UI layout change. Uses existing app-owned Side chat credential projection and cleanup. No global credential access or new proxy. The originally reported generic `RequestError: Internal error` has not been reproduced; this addresses the independently reproduced current-code subscription blocker.

## Acceptance criteria and validation

Startup/restoration integration cases failed on unchanged production code with the same resolver rejection and pass after the change. Existing tests now cover native subscription and other frameworks' host-message permission, shell denial, relay and cleanup.

- Startup, restoration, auth refresh and tool restrictions -> backend-resolver and runtime-owner tests.
- Auth projection, file handling and transport configuration -> codex-auth and codex framework tests.
- MCP capability boundaries and sibling restricted consumers -> session-capability-owner, host-message-mcp-server and restricted-inference-runner tests.
- Protocol identity, replay, lifecycle and relay consumers -> ACP runtime/coordinator, Side chat IPC/main-prompt-relay and side-chat-relay-owner tests.

Final focused command: `node ../../node_modules/vitest/vitest.mjs run src/main/side-chat src/main/settings/backend-resolver.test.ts src/main/settings/codex-auth.test.ts src/main/agent-framework/codex.test.ts src/main/acp/restricted-inference-runner.test.ts src/main/acp/session-capability-owner.test.ts src/main/acp/side-chat-relay-owner.test.ts src/main/acp/runtime.test.ts src/main/acp/runtime-coordinator.test.ts --maxWorkers=2` (from the worktree).

All 1,070 tests in the focused set passed after the last material edit.

Node typecheck including notebook-network-sandbox, full lint, formatting and diff checks pass. No renderer/type/IPC shape changes; renderer checks and screenshots are not relevant to this patch. No migration is introduced. Full local npm test was explicitly excluded by the maintainer. The impact classifier reports unknown Side chat module ownership, so full/platform CI remains required. No live paid provider or packaged native-binary run was performed.

## Review focus

Native subscription must retain the restricted profile and host-message-only MCP capability. API-key Codex must keep its bridge enforcement. Credential refresh stays inside the existing Side chat profile. No external authentication logout or account-wide mutation is added.
