### PR TITLE
fix(notebook): retry incomplete runtime recovery safely

### DIFF
--- a/src/main/notebook/recovery-coordinator.test.ts
+++ b/src/main/notebook/recovery-coordinator.test.ts
@@ -1,3 +1,5 @@
+import * as filesystem from 'node:fs/promises'
+import * as runtimePaths from './runtime-paths'
 import { existsSync } from 'node:fs'
 import { chmod, lstat, mkdir, mkdtemp, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -7,6 +9,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { operationJournalPath, RuntimeOperationJournal } from './operation-journal'
 import { NotebookRecoveryCoordinator } from './recovery-coordinator'
 import { DEFAULT_PY_ENV, DEFAULT_R_ENV, envPrefix, pythonBin, rBin } from './runtime-paths'
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, rm: vi.fn(actual.rm) }
+})
 
 let root: string | undefined
 
@@ -565,3 +572,122 @@ describe('NotebookRecoveryCoordinator', () => {
     await expect(coordinator.recover()).rejects.toThrow(/disposed/)
   })
 })
+
+it('blocks an interrupted install until its failed repair marker can be committed', async () => {
+  const runtimeRoot = await createRuntimeRoot()
+  const prefix = envPrefix(runtimeRoot, DEFAULT_PY_ENV)
+  const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+  await journal.begin({
+    operationId: 'repair-write-failure',
+    kind: 'install',
+    runtimeId: DEFAULT_PY_ENV,
+    phase: 'install-python',
+    startedAt: 100,
+    targetPath: prefix
+  })
+  const failure = Object.assign(new Error('repair registry write denied'), { code: 'EACCES' })
+  const marker = vi.spyOn(runtimePaths, 'addRepairRequired').mockImplementationOnce(() => {
+    throw failure
+  })
+  const recovery = new NotebookRecoveryCoordinator(runtimeRoot)
+  try {
+    await recovery.recover()
+    expect(marker).toHaveBeenCalledTimes(1)
+    expect(await journal.pending()).toHaveLength(1)
+    expect(
+      runtimePaths.isRepairRequired(
+        runtimeRoot,
+        runtimePaths.managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')
+      )
+    ).toBe(false)
+    expect(recovery.isPrefixBlocked(prefix)).toBe(true)
+    await recovery.ensureReady()
+    expect(await journal.pending()).toHaveLength(0)
+    expect(
+      runtimePaths.isRepairRequired(
+        runtimeRoot,
+        runtimePaths.managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')
+      )
+    ).toBe(true)
+    expect(recovery.isPrefixBlocked(prefix)).toBe(false)
+  } finally {
+    marker.mockRestore()
+  }
+})
+
+it.each(['python', 'r', 'external'] as const)(
+  'retains only the affected %s install identity when journal completion fails',
+  async (kind) => {
+    const runtimeRoot = await createRuntimeRoot()
+    const language = kind === 'r' ? 'r' : 'python'
+    const runtimeId =
+      kind === 'external' ? join(runtimeRoot, 'external-python') : `analysis-${kind}`
+    const prefix = kind === 'external' ? undefined : envPrefix(runtimeRoot, runtimeId)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'incomplete-commit',
+      kind: 'install',
+      runtimeId,
+      phase: `install-${language}`,
+      startedAt: 100,
+      ...(prefix ? { targetPath: prefix } : {})
+    })
+    const complete = vi.spyOn(journal, 'complete').mockRejectedValueOnce(new Error('commit EIO'))
+    const recovery = new NotebookRecoveryCoordinator(runtimeRoot)
+    try {
+      await recovery.recover()
+      expect(await journal.pending()).toHaveLength(1)
+      expect.soft(recovery.isRuntimeIdBlocked(runtimeId)).toBe(true)
+      if (prefix) expect.soft(recovery.isPrefixBlocked(prefix)).toBe(true)
+      expect(recovery.isPrefixBlocked(envPrefix(runtimeRoot, 'unrelated'))).toBe(false)
+      expect(recovery.isRuntimeIdBlocked('unrelated')).toBe(false)
+      await recovery.ensureReady()
+      expect(await journal.pending()).toEqual([])
+      expect(recovery.isRuntimeIdBlocked(runtimeId)).toBe(false)
+    } finally {
+      complete.mockRestore()
+    }
+  }
+)
+
+it.each(['download', 'materialize'] as const)(
+  'blocks and retries an interrupted %s after its cleanup fails',
+  async (kind) => {
+    const runtimeRoot = await createRuntimeRoot()
+    const targetPath =
+      kind === 'download'
+        ? join(runtimeRoot, 'packs', '.incoming-test')
+        : envPrefix(runtimeRoot, 'analysis')
+    await mkdir(targetPath, { recursive: true })
+    const canonicalTargetPath = await filesystem.realpath(targetPath)
+    const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+    await journal.begin({
+      operationId: 'cleanup-failure',
+      kind,
+      runtimeId: 'analysis',
+      phase: kind === 'download' ? 'download' : 'create-python',
+      startedAt: 100,
+      targetPath
+    })
+    const { rm: remove } =
+      await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    const failure = vi.spyOn(filesystem, 'rm').mockImplementation(async (path, options) => {
+      if (path === targetPath || path === canonicalTargetPath)
+        throw Object.assign(new Error('cleanup denied'), { code: 'EACCES' })
+      return remove(path, options)
+    })
+    const recovery = new NotebookRecoveryCoordinator(runtimeRoot)
+    try {
+      await recovery.recover()
+      expect(await journal.pending()).toHaveLength(1)
+      expect(recovery.isPrefixBlocked(targetPath)).toBe(true)
+      expect(recovery.isPrefixBlocked(envPrefix(runtimeRoot, 'unrelated'))).toBe(false)
+      failure.mockRestore()
+      await recovery.ensureReady()
+      expect(await journal.pending()).toEqual([])
+      expect(recovery.isPrefixBlocked(targetPath)).toBe(false)
+    } finally {
+      failure.mockRestore()
+    }
+  }
+)

--- a/src/main/notebook/recovery-coordinator.ts
+++ b/src/main/notebook/recovery-coordinator.ts
@@ -309,8 +309,12 @@ export class NotebookRecoveryCoordinator {
         publishedArchiveRecords.push(record)
       },
       deferArchiveCompletion: true,
-      onRetained: () => {
+      onRetained: (record) => {
         recoveryIncomplete = true
+        // A failed repair or journal commit is no safer than an unconfirmed writer. Keep the
+        // existing admission block until the retained operation can be reconciled durably.
+        if (record.kind === 'install') nextStartupBlockedRuntimeIds.add(record.runtimeId)
+        if (record.targetPath) nextStartupBlockedPrefixes.add(record.targetPath)
       }
     })
 

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -15494,3 +15494,85 @@ describe('v4 runtime bindings & agent tools', () => {
     60_000
   )
 })
+
+it('retries Notebook lifecycle recovery after a transient repository failure', async () => {
+  const root = await createStorageRoot()
+  const repository = new NotebookRunRepository(root)
+  const recover = vi
+    .spyOn(repository, 'recoverAllRunLifecycles')
+    .mockRejectedValueOnce(new Error('transient EIO'))
+    .mockResolvedValue([])
+  const service = new NotebookRuntimeService({
+    dataRoot: root,
+    repository,
+    projectId: 'recovery-project',
+    configRoot: root
+  })
+  try {
+    await expect(service.recoverInterruptedOperations()).rejects.toThrow('transient EIO')
+    await expect(service.recoverInterruptedOperations()).resolves.toBeUndefined()
+    await expect(service.ensureRecovered()).resolves.toBeUndefined()
+    expect(recover).toHaveBeenCalledTimes(2)
+  } finally {
+    await service.dispose()
+  }
+})
+
+it('keeps a failed recovery round joined until its other owners finish', async () => {
+  const root = await createStorageRoot()
+  const runtimeRoot = getRuntimeRoot(root)
+  const journal = RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot))
+  await journal.begin({
+    operationId: 'slow-recovery',
+    kind: 'install',
+    runtimeId: 'analysis',
+    phase: 'install-python',
+    startedAt: 100,
+    targetPath: envPrefix(runtimeRoot, 'analysis')
+  })
+  const repository = new NotebookRunRepository(root)
+  const recover = vi
+    .spyOn(repository, 'recoverAllRunLifecycles')
+    .mockRejectedValueOnce(new Error('transient EIO'))
+    .mockResolvedValue([])
+  const originalComplete = journal.complete.bind(journal)
+  const entered = createDeferred<void>()
+  const release = createDeferred<void>()
+  const complete = vi.spyOn(journal, 'complete').mockImplementationOnce(async (id) => {
+    entered.resolve()
+    await release.promise
+    await originalComplete(id)
+  })
+  const service = new NotebookRuntimeService({
+    configRoot: root,
+    dataRoot: root,
+    repository,
+    projectId: 'recovery-project'
+  })
+  let settled = false
+  const first = service.recoverInterruptedOperations().catch((error: unknown) => {
+    settled = true
+    return error
+  })
+  try {
+    await entered.promise
+    expect.soft(settled).toBe(false)
+    const joined = service.recoverInterruptedOperations().catch((error: unknown) => error)
+    expect(recover).toHaveBeenCalledTimes(1)
+    release.resolve()
+    expect(await first).toMatchObject({ message: 'transient EIO' })
+    expect(await joined).toMatchObject({ message: 'transient EIO' })
+    await expect(
+      Promise.all([service.ensureRecovered(), service.ensureRecovered()])
+    ).resolves.toEqual([undefined, undefined])
+    expect(recover).toHaveBeenCalledTimes(2)
+    await service.ensureRecovered()
+    expect(recover).toHaveBeenCalledTimes(2)
+  } finally {
+    release.resolve()
+    await first
+    await service.dispose()
+    recover.mockRestore()
+    complete.mockRestore()
+  }
+})

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -424,6 +424,7 @@ class NotebookRuntimeService {
   private disposalPromise: Promise<{ reaped: boolean }> | undefined
   private environmentStartupBarrier: Promise<void> = Promise.resolve()
   private runLifecycleRecovery: Promise<void> | undefined
+  private runLifecycleRecoveryFailed = false
   private readonly backgroundRuns = new Map<
     string,
     {
@@ -2044,18 +2045,22 @@ class NotebookRuntimeService {
   // download (staging cleanup), materialize (verify/rebuild the env prefix), and install (flag
   // repair-required) paths all populate the journal, so each reconcile action below is wired to a real effect.
   async recoverInterruptedOperations(): Promise<void> {
+    if (this.runLifecycleRecoveryFailed) {
+      this.runLifecycleRecovery = undefined
+      this.runLifecycleRecoveryFailed = false
+    }
     this.runLifecycleRecovery ??= (async () => {
       // Publish every startup recovery before yielding so new work cannot race any owner.
       const runRecovery = this.repository.recoverAllRunLifecycles()
       const kernelRecovery = this.kernelProcessLifecycle.recover()
       const operationRecovery = this.recoveryCoordinator.recover()
       const shellRecovery = this.shellProcessOwnership.recover()
-      const [, recoveredRuns] = await Promise.all([
-        shellRecovery,
-        runRecovery,
-        kernelRecovery,
-        operationRecovery
-      ])
+      const recoveries = [shellRecovery, runRecovery, kernelRecovery, operationRecovery] as const
+      const [, recoveredRuns] = await Promise.all(recoveries).catch(async (error: unknown) => {
+        // Preserve the first failure, but do not release retry while another owner mutates storage.
+        await Promise.allSettled(recoveries)
+        throw error
+      })
       if (this.options.onBackgroundRunTerminal) {
         await Promise.all(
           recoveredRuns.map(async ({ projectId, sessionId, run }) => {
@@ -2073,7 +2078,10 @@ class NotebookRuntimeService {
           })
         )
       }
-    })()
+    })().catch((error: unknown) => {
+      this.runLifecycleRecoveryFailed = true
+      throw error
+    })
     await this.runLifecycleRecovery
   }
 
@@ -2083,7 +2091,7 @@ class NotebookRuntimeService {
   // startup env gate and UI provision/repair handlers can share the SAME barrier (they touch prefixes
   // too, not just materialize/install).
   async ensureRecovered(): Promise<void> {
-    await this.runLifecycleRecovery
+    if (this.runLifecycleRecovery) await this.recoverInterruptedOperations()
     await this.kernelProcessLifecycle.ensureReady()
     await this.recoveryCoordinator.ensureReady()
   }


### PR DESCRIPTION
## Problem

An interrupted Notebook install can remain in the operation journal after its repair-marker write fails, while the affected environment is admitted as usable. Separately, a transient startup recovery error is cached for the process lifetime, so retry still fails after storage recovers.

## Proposed change

Keep each retained operation's existing runtime/prefix admission block until reconciliation and journal completion succeed. Allow a failed Notebook recovery round to retry, while preserving successful caching and joining concurrent attempts. Preserve the first error and wait for all recovery owners to settle before releasing the retry barrier.

## Scope and non-goals

Only the existing Notebook coordinator/runtime owner and their tests change. No schema migration, persisted field, file-format version, enum value, or renderer interaction is added. The new failure flag is private process memory. Existing operation-journal and repair-registry writes keep their current format; older pending operations are read normally. Recovery settles existing records and does not rerun user cells.

Claude handoff recovery and ambiguous provider acceptance are separate work and are not changed by this PR. No new recovery framework, timer, dependency, or production test seam is introduced.

## Acceptance criteria and validation

Eight regressions failed twice against the unchanged default-branch production files with the expected behavior assertions: missing blocks after repair/commit/cleanup failure, reuse of the stale EIO rejection, and premature release while another owner is still running. The same tests are included in the final targeted command below. Fault injection uses existing repair/repository/filesystem boundaries and real temporary journals; cleanup paths are canonicalized for cross-platform fixtures.

Final evidence mapping (all checks after the last material source/test edit):

| Behavior | Project-owned checks |
| --- | --- |
| Failed repair-marker write; failed journal commit for managed Python/R and external identity; failed download/materialize cleanup; unrelated targets remain available | recovery-coordinator.test.ts, operation-recovery.test.ts, runtime-repair-policy.test.ts |
| Same-process retry, concurrent-round drain, success caching, execution/package consumers | runtime-service.test.ts, package-admission.test.ts, package-operations.test.ts |
| Existing repair/lease/provisioning and unknown-writer protections | runtime-repair.test.ts, environment-operations.test.ts, provisioner.test.ts, kernel-process-lifecycle.test.ts, shell-process-ownership.test.ts |

```sh
./node_modules/.bin/vitest run \
  src/main/notebook/runtime-service.test.ts \
  src/main/notebook/recovery-coordinator.test.ts \
  src/main/notebook/operation-recovery.test.ts \
  src/main/notebook/runtime-repair-policy.test.ts \
  src/main/notebook/runtime-repair.test.ts \
  src/main/notebook/package-admission.test.ts \
  src/main/notebook/package-operations.test.ts \
  src/main/notebook/environment-operations.test.ts \
  src/main/notebook/kernel-process-lifecycle.test.ts \
  src/main/notebook/shell-process-ownership.test.ts \
  src/main/notebook/provisioner.test.ts --maxWorkers=2
npm run typecheck:node
npm run lint
```

Final targeted result: 637 passed, 0 failed, 4 skipped across 11 files. Main/sandbox typechecks, lint and `git diff --check` pass. Native child-process fixtures ran outside the agent execution sandbox after the sandbox was shown to prevent their existing process behavior. The committed-diff `test:affected:explain -- --base abf69398718aad5a8bb6ab05625dfcbca5a81194 --head HEAD` selects full verification because the current manifest has no Notebook module owner. The explicit owner/consumer mapping above supplies local coverage; no complete local test suite was run, as requested by the maintainer; exact-head PR CI is authoritative for portable/platform coverage.

Limitations: local execution is macOS; Linux/Windows-specific skipped fixtures require their native CI lanes. This does not certify power-loss/fsync behavior, actual half-installed interpreter execution, or the complete data-root reconnect UI. No ACP/provider code or subscription interface changes; provider/live-service tests are outside this Notebook patch. Independent review and selected PR CI remain required before marking the patch fully verified.

## Review focus

Check that failed operations remain scoped to their affected identity and that failure retry cannot overlap unfinished recovery owners or bypass admission. Persistence changes are ordering/retry of existing writes, not a new data model.
