### PR TITLE
fix(trust-boundaries): preserve preview and response ownership

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -79,11 +79,22 @@ Project, session, Notebook, artifact, and log content remain user-readable local
 and rely on operating-system account isolation and filesystem protection. Use full-disk
 encryption when the device or research data requires protection at rest.
 
-Open Science's credential stores protect API keys, Connector secrets and OAuth state,
-GitHub tokens, and compute passwords with Electron `safeStorage`, backed by the operating
-system's secure storage. Those stores reject new secret writes when a secure backend is
-unavailable, including Linux's unprotected `basic_text` backend. The renderer receives
-masked or non-secret projections rather than plaintext credential values.
+By default, Open Science protects API keys, Connector secrets and OAuth state, GitHub
+tokens, and compute passwords with Electron `safeStorage`, backed by the operating
+system's secure storage. OS mode rejects new secret writes when a secure backend is
+unavailable, including Linux's unprotected `basic_text` backend.
+
+The Linux headless backend also accepts an explicit `--credential-store=file` option.
+For settings credentials, this stores reversible `file:v1:` base64 values in private
+files; base64 is not encryption. This mode relies on operating-system account and
+filesystem protection and is never selected automatically because a vault is unavailable.
+Compute passwords still require their separate secure vault and do not use this fallback.
+The renderer receives masked or non-secret projections in either mode.
+
+Existing `enc:` values still require the OS vault. `file:v1:` values are readable only
+in explicit file mode. Legacy `plain:` values remain readable when file mode is selected
+or a secure OS vault is available; new writes never create legacy references. Selecting
+a mode does not migrate or re-encrypt existing credentials.
 
 Codex subscription authentication uses an app-owned `codex-subscription/auth.json` file
 under the configuration root and relies on operating-system account and filesystem

--- a/src/main/acp/file-reference-resolver.test.ts
+++ b/src/main/acp/file-reference-resolver.test.ts
@@ -1,4 +1,15 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, symlink, writeFile } from 'node:fs/promises'
+import { writeFileSync } from 'node:fs'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rename,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -13,7 +24,20 @@ import { createManagedFileReferenceResolver } from './file-reference-resolver'
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:fs/promises')>()
-  return { ...actual, stat: vi.fn(actual.stat) }
+  return { ...actual, stat: vi.fn(actual.stat), realpath: vi.fn(actual.realpath) }
+})
+
+const copying = vi.hoisted(() => ({ path: '', mutate: undefined as (() => void) | undefined }))
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs')>()
+  return {
+    ...actual,
+    createReadStream: (...args: Parameters<typeof actual.createReadStream>) => {
+      const stream = actual.createReadStream(...args)
+      if (args[0] === copying.path) stream.once('data', () => copying.mutate?.())
+      return stream
+    }
+  }
 })
 
 let root: string | undefined
@@ -623,7 +647,7 @@ describe('managed file reference resolver', () => {
     resolver.clear()
   })
 
-  it('bounds the bytes actually copied into a read-only snapshot', async () => {
+  it('rejects a file that grows after inspection and refunds the snapshot budget', async () => {
     root = await mkdtemp(join(tmpdir(), 'file-reference-resolver-'))
     const sourcePath = join(root, 'growing.txt')
     await writeFile(sourcePath, '1234')
@@ -646,7 +670,7 @@ describe('managed file reference resolver', () => {
       return beforeGrowth
     })
 
-    await expect(resolver.resolve(context, reference)).rejects.toThrow(/Session storage limit/i)
+    await expect(resolver.resolve(context, reference)).rejects.toThrow(/file changed/i)
 
     await writeFile(sourcePath, '12345')
     await expect(resolver.resolve(context, reference)).resolves.toMatchObject({ size: 5 })
@@ -779,3 +803,150 @@ it.skipIf(process.platform === 'win32')(
     }
   }
 )
+
+describe('TB-03 linked-folder snapshot identity', () => {
+  it.each(['after-realpath', 'after-stat', 'parent-after-stat'] as const)(
+    'rejects outside snapshot content with a replacement %s',
+    async (stage) => {
+      root = await mkdtemp(join(tmpdir(), 'linked-snapshot-race-'))
+      const granted = join(root, 'granted')
+      const outsideDirectory = join(root, 'outside')
+      await mkdir(granted)
+      await mkdir(outsideDirectory)
+      const source = join(granted, 'study.txt')
+      const outside = join(outsideDirectory, 'study.txt')
+      await writeFile(source, 'approved-content')
+      await writeFile(outside, 'outside-secret!!')
+      const canonicalSource = await realpath(source)
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      let substituted = false
+      const substitute = async (): Promise<void> => {
+        substituted = true
+        if (stage === 'parent-after-stat') {
+          await rename(granted, join(root!, 'original-directory'))
+          await symlink(outsideDirectory, granted, 'junction')
+        } else {
+          await rename(source, join(granted, 'original.txt'))
+          await symlink(outside, source)
+        }
+      }
+      vi.mocked(stat).mockImplementation(async (...args) => {
+        const result = await actual.stat(...args)
+        if (args[0] === canonicalSource && !substituted && stage !== 'after-realpath')
+          await substitute()
+        return result
+      })
+      vi.mocked(realpath).mockImplementation(async (...args) => {
+        const result = await actual.realpath(...args)
+        if (args[0] === source && !substituted && stage === 'after-realpath') await substitute()
+        return result
+      })
+      const resolver = createManagedFileReferenceResolver({
+        grantedRoots: { resolveRoot: async () => ({ path: granted, access: 'ro' }) }
+      })
+      try {
+        const result = await resolver
+          .resolve(
+            { projectId: 'default-project', sessionId: 'session-race' },
+            {
+              id: 'linked-race',
+              name: 'study.txt',
+              source: 'linked-folder',
+              rootId: 'root-1',
+              relativePath: 'study.txt',
+              mimeType: 'text/plain'
+            }
+          )
+          .then(
+            async (resolved) => readFile(resolved.absolutePath, 'utf8'),
+            () => undefined
+          )
+        expect(substituted).toBe(true)
+        expect(
+          [undefined, 'approved-content'],
+          'snapshot must reject the replacement or retain the approved file'
+        ).toContain(result)
+      } finally {
+        resolver.clear()
+        vi.mocked(stat).mockImplementation(actual.stat)
+        vi.mocked(realpath).mockImplementation(actual.realpath)
+      }
+    }
+  )
+})
+
+describe('TB-03 snapshot completion', () => {
+  it('rejects a same-size source mutation during copying and refunds its budget', async () => {
+    root = await mkdtemp(join(tmpdir(), 'linked-copy-change-'))
+    const path = join(root, 'data.txt')
+    const original = 'a'.repeat(128 * 1024)
+    await writeFile(path, original)
+    copying.path = await realpath(path)
+    let mutated = false
+    copying.mutate = () => {
+      mutated = true
+      writeFileSync(path, 'b'.repeat(original.length))
+    }
+    const resolver = createManagedFileReferenceResolver({
+      grantedRoots: { resolveRoot: async () => ({ path: root!, access: 'ro' }) },
+      readOnlyProjectionMaxSessionBytes: original.length
+    })
+    const context = { projectId: 'project', sessionId: 'session' }
+    const reference = {
+      id: 'file',
+      name: 'data.txt',
+      source: 'linked-folder' as const,
+      rootId: 'root',
+      relativePath: 'data.txt'
+    }
+    try {
+      await expect(resolver.resolve(context, reference)).rejects.toThrow(/file changed/i)
+      expect(mutated).toBe(true)
+      copying.path = ''
+      copying.mutate = undefined
+      await expect(resolver.resolve(context, reference)).resolves.toMatchObject({
+        size: original.length
+      })
+    } finally {
+      copying.path = ''
+      copying.mutate = undefined
+      resolver.clear()
+    }
+  })
+
+  it.each(['remove', 'change-access'] as const)(
+    'rejects a root %s before snapshot copying',
+    async (change) => {
+      root = await mkdtemp(join(tmpdir(), 'linked-root-change-'))
+      const path = join(root, 'data.txt')
+      await writeFile(path, 'approved')
+      let grant: { path: string; access: 'ro' | 'rw' } | undefined = { path: root, access: 'ro' }
+      const actual = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      vi.mocked(stat).mockImplementationOnce(async (...args) => {
+        const result = await actual.stat(...args)
+        grant = change === 'remove' ? undefined : { path: root!, access: 'rw' }
+        return result
+      })
+      const resolver = createManagedFileReferenceResolver({
+        grantedRoots: { resolveRoot: async () => grant }
+      })
+      try {
+        await expect(
+          resolver.resolve(
+            { projectId: 'project', sessionId: 'session' },
+            {
+              id: 'file',
+              name: 'data.txt',
+              source: 'linked-folder',
+              rootId: 'root',
+              relativePath: 'data.txt'
+            }
+          )
+        ).rejects.toThrow(/reference changed/i)
+      } finally {
+        resolver.clear()
+        vi.mocked(stat).mockImplementation(actual.stat)
+      }
+    }
+  )
+})

--- a/src/main/acp/file-reference-resolver.ts
+++ b/src/main/acp/file-reference-resolver.ts
@@ -1,5 +1,5 @@
-import { createReadStream, createWriteStream, rmSync } from 'node:fs'
-import { mkdtemp, realpath, rm, stat } from 'node:fs/promises'
+import { constants, createReadStream, createWriteStream, rmSync, type Stats } from 'node:fs'
+import { mkdtemp, open, realpath, rm, stat, type FileHandle } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, isAbsolute, join, relative, sep } from 'node:path'
 import { Transform } from 'node:stream'
@@ -84,19 +84,37 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
     connectionGeneration: number,
     sessionId: string,
     sourcePath: string,
-    sourceSize: number
+    sourceInfo: Stats,
+    validateSource: () => Promise<void>
   ): Promise<string> {
     const generation = this.generation
     const sessionGeneration = this.sessionGenerations.get(sessionId) ?? 0
     const connectionProjectionGeneration = this.connectionGenerations.get(connectionGeneration) ?? 0
     const scopeKey = this.scopeKey(connectionGeneration, sessionId)
     const sessionBytes = this.bytesByScope.get(scopeKey) ?? 0
-    if (sourceSize > this.maxSessionBytes - sessionBytes) {
+    if (sourceInfo.size > this.maxSessionBytes - sessionBytes) {
       throw new Error('Read-only linked-folder snapshots exceed the Session storage limit.')
     }
     let copiedBytes = 0
     let directory: string | undefined
+    let sourceHandle: FileHandle | undefined
+    const assertUnchanged = (current: Stats): void => {
+      if (
+        !current.isFile() ||
+        current.dev !== sourceInfo.dev ||
+        current.ino !== sourceInfo.ino ||
+        current.size !== sourceInfo.size ||
+        current.mtimeMs !== sourceInfo.mtimeMs ||
+        current.ctimeMs !== sourceInfo.ctimeMs
+      ) {
+        throw new Error('Linked-folder file changed while preparing its snapshot.')
+      }
+    }
     try {
+      sourceHandle = await open(sourcePath, constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0))
+      assertUnchanged(await sourceHandle.stat())
+      await validateSource()
+      assertUnchanged(await stat(sourcePath))
       directory = await mkdtemp(join(tmpdir(), 'open-science-linked-ro-'))
       if (
         !this.isCurrent(
@@ -119,7 +137,7 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
 
       const snapshotPath = join(directory, basename(sourcePath))
       await pipeline(
-        createReadStream(sourcePath),
+        createReadStream(sourcePath, { fd: sourceHandle.fd, autoClose: false }),
         new Transform({
           transform: (chunk: Buffer, _encoding, callback) => {
             if (
@@ -148,6 +166,8 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
         }),
         createWriteStream(snapshotPath, { flags: 'wx' })
       )
+      assertUnchanged(await sourceHandle.stat())
+      await validateSource()
       if (
         !this.isCurrent(
           connectionGeneration,
@@ -180,6 +200,8 @@ class ReadOnlyLinkedFileProjection implements FileReferenceResolverLifecycle {
       }
       this.deleteScopeIfEmpty(scopeKey)
       throw error
+    } finally {
+      await sourceHandle?.close()
     }
   }
 
@@ -489,7 +511,21 @@ export const createManagedFileReferenceResolver = (dependencies: {
                   connectionGeneration,
                   sessionId,
                   resolvedFile,
-                  fileInfo.size
+                  fileInfo,
+                  async () => {
+                    const current = await dependencies.grantedRoots!.resolveRoot(reference.rootId)
+                    if (
+                      !current ||
+                      current.path !== root.path ||
+                      current.access !== root.access ||
+                      (await realpath(root.path)) !== resolvedRoot ||
+                      (await realpath(resolvedFile)) !== resolvedFile
+                    ) {
+                      throw new Error(
+                        'Linked-folder reference changed while preparing its snapshot.'
+                      )
+                    }
+                  }
                 )
               : resolvedFile,
           name: reference.name,

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -1,3 +1,6 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const routerFactoryControl = vi.hoisted(() => ({
@@ -35,6 +38,11 @@ import {
   type ApplicationInvocation
 } from './application-command-router'
 import { createCallerContext } from './caller-context'
+import { ApplicationCallerLeaseRegistry } from './caller-lifecycle'
+import { createManagedPreviewOwnerRegistry } from './managed-preview-ipc'
+import { ManagedPreviewResources } from './managed-preview-resources'
+import { LocalFsService } from './local-fs/service'
+import type { ManagedPreviewResource, ManagedPreviewRangeResult } from '../shared/preview-resources'
 
 const EMPTY_OWNER = Object.freeze({})
 const unexpectedCommand = defineApplicationCommand<'test:unexpected', readonly [], void>(
@@ -624,4 +632,81 @@ it('validates bounded reference exports through the shared Web command boundary'
   ).resolves.toEqual(exported)
   expect(exportRecord).toHaveBeenCalledWith({ itemId: 'reference' })
   composition.dispose()
+})
+
+describe('TB-01 remote preview admission', () => {
+  it.each([
+    ['remote', 'local'],
+    ['local', 'local'],
+    ['remote', 'literature'],
+    ['remote', 'notebook-input']
+  ] as const)('enforces %s caller admission for %s preview sources', async (surface, source) => {
+    const location = surface === 'remote' ? 'remote' : 'local'
+    const directory = await mkdtemp(join(tmpdir(), 'preview-admission-'))
+    const path = join(directory, 'outside-project.txt')
+    const content = 'host-only-test-content'
+    await writeFile(path, content)
+    const localFs = new LocalFsService()
+    const resolvePath = vi.fn(async (_source, request) => localFs.resolveFilePath(request))
+    const trustedLease = {
+      path,
+      size: content.length,
+      versionToken: 1,
+      snapshot: { dev: 1n, ino: 1n, size: BigInt(content.length), mtimeNs: 1n },
+      read: vi.fn(),
+      readRange: async (begin: number, end: number) => Buffer.from(content).subarray(begin, end),
+      verifyUnchanged: async () => undefined,
+      close: async () => undefined
+    }
+    const resources = new ManagedPreviewResources({
+      resolvePath,
+      openLiterature: async () => trustedLease,
+      openNotebookInput: async () => trustedLease
+    })
+    const owners = createManagedPreviewOwnerRegistry(resources)
+    const deps = dependencies()
+    const composition = createApplicationCommandComposition({
+      ...deps,
+      dataContent: { ...deps.dataContent, managedPreview: owners }
+    })
+    const leases = new ApplicationCallerLeaseRegistry()
+    const initial = invocation(location)
+    const caller = { ...initial, callerLease: leases.acquire(initial.callerContext).lease }
+    const dispatcher = location === 'remote' ? composition.remoteWeb : composition.localWeb
+    let resource: ManagedPreviewResource | undefined
+    try {
+      const acquired = dispatcher.invoke('preview-resources:acquire', {
+        ...caller,
+        args: [{ source, path }]
+      }) as Promise<ManagedPreviewResource>
+      if (location === 'remote' && source === 'local') {
+        // Capture actual bytes if admission unexpectedly succeeds, without hiding the failed guard.
+        resource = await acquired.catch(() => undefined)
+        if (resource) {
+          const range = (await dispatcher.invoke('preview-resources:read-range', {
+            ...caller,
+            args: [{ resourceId: resource.id, begin: 0, end: content.length }]
+          })) as ManagedPreviewRangeResult
+          expect
+            .soft(Buffer.from(range.data).toString(), 'remote caller received host-only bytes')
+            .not.toBe(content)
+        }
+        await expect.soft(acquired).rejects.toThrow(/local app/)
+        expect.soft(resource, 'remote local-file request must be rejected').toBeUndefined()
+        expect(resolvePath, 'reject before filesystem resolution').not.toHaveBeenCalled()
+      } else {
+        resource = await acquired
+        const range = (await dispatcher.invoke('preview-resources:read-range', {
+          ...caller,
+          args: [{ resourceId: resource.id, begin: 0, end: content.length }]
+        })) as ManagedPreviewRangeResult
+        expect(Buffer.from(range.data).toString()).toBe(content)
+      }
+    } finally {
+      if (resource) owners.release(caller.callerLease, { resourceId: resource.id })
+      leases.dispose()
+      composition.dispose()
+      await rm(directory, { recursive: true, force: true })
+    }
+  })
 })

--- a/src/main/data-content-application-commands.ts
+++ b/src/main/data-content-application-commands.ts
@@ -612,8 +612,12 @@ const registerDataContentApplicationCommands = (
       'preview:save': ({ args }) => dependencies.preview.save(args[0])
     })
     scope.registerGroup(dataContentApplicationCommandGroups[3], {
-      'preview-resources:acquire': ({ args, callerLease }) =>
-        dependencies.managedPreview.acquire(callerLease, args[0]),
+      'preview-resources:acquire': (invocation) => {
+        if (invocation.args[0].source === 'local') {
+          assertLocalCaller(invocation, 'preview-resources:acquire')
+        }
+        return dependencies.managedPreview.acquire(invocation.callerLease, invocation.args[0])
+      },
       'preview-resources:read-range': ({ args, callerLease }) =>
         dependencies.managedPreview.readRange(callerLease, args[0]),
       'preview-resources:release': ({ args, callerLease }) =>

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -2938,6 +2938,63 @@ describe('startWebHttpServer', () => {
     expect(taskContext?.isAuthorizationCurrent()).toBe(false)
   })
 
+  it.each(['success', 'error'] as const)(
+    'TB-05 suppresses a delayed remote %s after revocation',
+    async (outcome) => {
+      let current = true
+      let started!: () => void
+      const entered = new Promise<void>((resolve) => {
+        started = resolve
+      })
+      let finish!: () => void
+      const pending = new Promise<void>((resolve) => {
+        finish = resolve
+      })
+      const invoke = vi.fn(async () => {
+        started()
+        await pending
+        if (outcome === 'error')
+          throw new ApplicationCommandError('command-failed', 'private-result-marker')
+        return { content: 'private-result-marker' }
+      })
+      const server = await startTestWebHttpServer({
+        host: '127.0.0.1',
+        port: 0,
+        token: 'local-token',
+        staticRoot: '/unused',
+        rpc: { channels: () => ['projects:list'], invoke },
+        externalAccess: {
+          authorizeHttp: async () => ({
+            kind: 'authorized',
+            principalId: 'paired-browser',
+            isCurrent: () => current
+          }),
+          authorizeWebSocket: async () => undefined
+        },
+        bootstrap: {
+          appName: 'Open Science',
+          appVersion: '0.0.0',
+          configRoot: '/fake/root',
+          platform: 'test',
+          versions: { electron: '1', chrome: '1', node: '1' }
+        }
+      })
+      servers.push(server)
+      const responsePromise = fetch(`http://127.0.0.1:${server.port}/rpc/projects%3Alist`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ protocolVersion: WEB_RPC_PROTOCOL_VERSION, args: [] })
+      })
+      await entered
+      current = false
+      finish()
+      const response = await responsePromise
+      expect.soft(response.status).toBe(401)
+      expect(await response.text()).not.toContain('private-result-marker')
+      expect(invoke).toHaveBeenCalledOnce()
+    }
+  )
+
   it('keeps host-management RPC local while preserving the local Web client', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -1631,6 +1631,7 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             callerContext,
             parsed.data.args
           )
+          assertExternalAuthorizationCurrent(externalAuthorization)
           json(
             response,
             200,
@@ -1642,6 +1643,11 @@ const startWebHttpServer = async (options: WebServerOptions): Promise<RunningWeb
             MAX_WEB_RPC_RESPONSE_BYTES
           )
         } catch (error) {
+          // A delayed error may carry the same private data as a successful result.
+          if (externalAuthorization && !externalAuthorization.isCurrent()) {
+            webRpcError(response, 401, 'invalid_request', 'Remote access authorization expired.')
+            return
+          }
           log.warn('web rpc rejected', {
             channel,
             surface: callerContext.surface,

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx
@@ -177,6 +177,7 @@ const networkApprovalRequest: AcpPermissionRequest = {
   rawInput: {
     notebookNetworkApproval: {
       hostname: 'data.example.org',
+      runtime: 'python',
       port: 443,
       reason: 'Download the dataset requested in this conversation.'
     }
@@ -288,6 +289,9 @@ describe('PermissionApprovalControls', () => {
     expect(html).toContain('Connect to data.example.org?')
     expect(html).toContain('Network access')
     expect(html).toContain('Notebook code requested access to data.example.org:443.')
+    expect(html).toContain(
+      'Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.'
+    )
     expect(html).toContain('Reason: Download the dataset requested in this conversation.')
     expect(html).toContain('Details')
     expect(html).toContain('Allow once')
@@ -296,6 +300,22 @@ describe('PermissionApprovalControls', () => {
     expect(html).not.toContain('data-testid="extra-option"')
     expect(html).not.toContain('notebookNetworkApproval')
   })
+
+  it.each(['python', 'r', 'repl', 'bash', undefined])(
+    'TB-06 describes the existing %s execution contract',
+    (runtime) => {
+      const request = {
+        ...networkApprovalRequest,
+        rawInput: { notebookNetworkApproval: { hostname: 'data.example.org', runtime } }
+      }
+      const html = renderToStaticMarkup(
+        <PermissionApprovalControls requests={[request]} onRespond={() => undefined} />
+      )
+      expect(html.includes('even if the code changes')).toBe(
+        runtime !== undefined && runtime !== 'bash'
+      )
+    }
+  )
 
   it('renders the Allow button with the conversation copy for the session scope by default', () => {
     const html = renderControls()

--- a/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
+++ b/src/renderer/src/pages/workspace/PermissionApprovalControls.tsx
@@ -422,6 +422,13 @@ const NotebookNetworkApprovalDetail = ({
     <div className="space-y-2 text-xs leading-5 text-muted-foreground">
       <p>{t('Notebook code requested access to {{destination}}.', { destination })}</p>
       {approval.reason ? <p>{t('Reason: {{reason}}', { reason: approval.reason })}</p> : null}
+      {approval.runtime && approval.runtime !== 'bash' ? (
+        <p>
+          {t(
+            'Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.'
+          )}
+        </p>
+      ) : null}
       <button
         type="button"
         aria-expanded={expanded}
@@ -600,13 +607,15 @@ const ScopeDropdown = ({
   available,
   onSelect,
   onClose,
-  portaled
+  portaled,
+  onceDescription
 }: {
   selected: PermissionScope
   available: Set<PermissionScope>
   onSelect: (scope: PermissionScope) => void
   onClose: (restoreTriggerFocus?: boolean) => void
   portaled: boolean
+  onceDescription?: string
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const ref = useRef<HTMLDivElement>(null)
@@ -684,7 +693,9 @@ const ScopeDropdown = ({
           {/* Label column: left-aligned flush to padding so both rows line up */}
           <div className="flex min-w-0 flex-1 flex-col">
             <span className="text-xs font-medium text-foreground">{t(label)}</span>
-            <span className="text-[11px] leading-tight text-muted-foreground">{t(subtitle)}</span>
+            <span className="text-[11px] leading-tight text-muted-foreground">
+              {scope === 'once' && onceDescription ? onceDescription : t(subtitle)}
+            </span>
           </div>
           {/* Check column: right side, fixed slot so selection never shifts the label */}
           <span className="flex w-3.5 shrink-0 justify-center text-primary">
@@ -731,6 +742,7 @@ const PermissionApprovalCard = ({
   onSubmitted
 }: PermissionApprovalCardProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const networkRuntime = getNotebookNetworkApproval(request)?.runtime
   const [scope, setScope] = useState<PermissionScope>('session')
   const [scopeOpen, setScopeOpen] = useState(false)
   const [scopeConfirmation, setScopeConfirmation] = useState<PendingScopeConfirmation | undefined>(
@@ -1085,6 +1097,11 @@ const PermissionApprovalCard = ({
                 onSelect={setScope}
                 onClose={closeScopeMenu}
                 portaled={embedded}
+                onceDescription={
+                  networkRuntime && networkRuntime !== 'bash'
+                    ? t('Next execution in this runtime')
+                    : undefined
+                }
               />
             )}
             <PopoverAnchor asChild>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5024,6 +5024,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Fehlgeschlagen: {{failed}} · Übersprungen: {{skipped}}",
     "You can import unfinished files or close this window.": "Sie können unfertige Dateien importieren oder dieses Fenster schließen.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Neue Compute-Aufträge bleiben möglicherweise in der Warteschlange, weil die gespeicherten Parallelitätsgrenzen nicht überprüft werden konnten. Bewahren Sie die betroffenen Dateien auf, stellen Sie eine gültige Kopie wieder her und prüfen Sie erneut, um die Auftragsvergabe fortzusetzen.",
-    "Recheck saved conversations": "Gespeicherte Konversationen erneut prüfen"
+    "Recheck saved conversations": "Gespeicherte Konversationen erneut prüfen",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Einmal erlauben gilt für die nächste Ausführung in dieser Laufzeitumgebung, auch wenn sich der Code ändert. Während dieser Ausführung sind mehrere Verbindungen zu dieser Domain erlaubt.",
+    "Next execution in this runtime": "Nächste Ausführung in dieser Laufzeitumgebung"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5186,6 +5186,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Fallidos: {{failed}} · Omitidos: {{skipped}}",
     "You can import unfinished files or close this window.": "Puede importar los archivos pendientes o cerrar esta ventana.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Los nuevos trabajos de Compute pueden permanecer en cola porque no se pudieron verificar los límites de concurrencia guardados. Conserve los archivos afectados, restaure una copia válida y vuelva a comprobarlos para reanudar el envío de trabajos.",
-    "Recheck saved conversations": "Volver a comprobar las conversaciones guardadas"
+    "Recheck saved conversations": "Volver a comprobar las conversaciones guardadas",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Permitir una vez se aplica a la siguiente ejecución en este entorno, aunque cambie el código. Permite varias conexiones a este dominio durante esa ejecución.",
+    "Next execution in this runtime": "Siguiente ejecución en este entorno"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5186,6 +5186,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Échecs : {{failed}} · Ignorés : {{skipped}}",
     "You can import unfinished files or close this window.": "Vous pouvez importer les fichiers inachevés ou fermer cette fenêtre.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Les nouvelles tâches Compute peuvent rester en attente, car les limites de simultanéité enregistrées n’ont pas pu être vérifiées. Conservez les fichiers concernés, restaurez une copie valide, puis relancez la vérification pour reprendre l’envoi des tâches.",
-    "Recheck saved conversations": "Revérifier les conversations enregistrées"
+    "Recheck saved conversations": "Revérifier les conversations enregistrées",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Autoriser une fois s’applique à la prochaine exécution dans cet environnement, même si le code change. Plusieurs connexions à ce domaine sont autorisées pendant cette exécution.",
+    "Next execution in this runtime": "Prochaine exécution dans cet environnement"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4870,6 +4870,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "失敗: {{failed}} · スキップ: {{skipped}}",
     "You can import unfinished files or close this window.": "未完了のファイルをインポートするか、このウィンドウを閉じることができます。",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "保存された同時実行数の制限を検証できないため、新しい Compute ジョブがキューに残る場合があります。対象ファイルを保持し、有効なコピーを復元してから再確認すると、ジョブの送信を再開できます。",
-    "Recheck saved conversations": "保存済みの会話を再確認"
+    "Recheck saved conversations": "保存済みの会話を再確認",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "1回のみ許可は、コードが変更されても、このランタイムでの次の実行に適用されます。その実行中は、このドメインへの複数の接続が許可されます。",
+    "Next execution in this runtime": "このランタイムでの次の実行"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4868,6 +4868,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "실패: {{failed}} · 건너뜀: {{skipped}}",
     "You can import unfinished files or close this window.": "미완료 파일을 가져오거나 이 창을 닫을 수 있습니다.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "저장된 동시 실행 제한을 확인할 수 없어 새 Compute 작업이 대기열에 남을 수 있습니다. 영향을 받은 파일을 보존하고 유효한 사본을 복원한 다음 다시 확인하여 작업 전송을 재개하세요.",
-    "Recheck saved conversations": "저장된 대화 다시 확인"
+    "Recheck saved conversations": "저장된 대화 다시 확인",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "한 번 허용은 코드가 변경되어도 이 런타임의 다음 실행에 적용됩니다. 해당 실행 중에는 이 도메인에 여러 번 연결할 수 있습니다.",
+    "Next execution in this runtime": "이 런타임의 다음 실행"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5319,6 +5319,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "Ошибки: {{failed}} · Пропущено: {{skipped}}",
     "You can import unfinished files or close this window.": "Можно импортировать незавершённые файлы или закрыть это окно.",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "Новые задания Compute могут оставаться в очереди, поскольку не удалось проверить сохранённые ограничения параллельного выполнения. Сохраните затронутые файлы, восстановите корректную копию и повторите проверку, чтобы возобновить отправку заданий.",
-    "Recheck saved conversations": "Повторно проверить сохранённые диалоги"
+    "Recheck saved conversations": "Повторно проверить сохранённые диалоги",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Однократное разрешение действует для следующего выполнения в этой среде, даже если код изменится. Во время этого выполнения разрешено несколько подключений к этому домену.",
+    "Next execution in this runtime": "Следующее выполнение в этой среде"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4870,6 +4870,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "失败：{{failed}} · 已跳过：{{skipped}}",
     "You can import unfinished files or close this window.": "您可以导入未完成的文件或关闭此窗口。",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "无法验证已保存的并发限制，新 Compute 任务可能会一直排队。请保留受影响的文件，恢复有效副本后重新检查，以恢复任务派发。",
-    "Recheck saved conversations": "重新检查已保存的对话"
+    "Recheck saved conversations": "重新检查已保存的对话",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "允许一次适用于此运行时的下一次执行，即使代码发生变化也仍然适用。该次执行期间可多次连接此域名。",
+    "Next execution in this runtime": "此运行时的下一次执行"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4870,6 +4870,8 @@
     "Failed: {{failed}} · Skipped: {{skipped}}": "失敗：{{failed}} · 已略過：{{skipped}}",
     "You can import unfinished files or close this window.": "您可以匯入未完成的檔案或關閉此視窗。",
     "New Compute jobs may remain queued because saved concurrency limits could not be verified. Preserve the affected files, recover a valid copy, then recheck to resume dispatch.": "無法驗證已儲存的並行限制，新 Compute 任務可能會持續排隊。請保留受影響的檔案，還原有效副本後重新檢查，以恢復任務派發。",
-    "Recheck saved conversations": "重新檢查已儲存的對話"
+    "Recheck saved conversations": "重新檢查已儲存的對話",
+    "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "允許一次適用於此執行環境的下一次執行，即使程式碼有所變更也仍然適用。該次執行期間可多次連線至此網域。",
+    "Next execution in this runtime": "此執行環境的下一次執行"
   }
 }


### PR DESCRIPTION
## Problem

Remote local-file previews, linked-folder snapshot preparation, and in-flight RPC responses do not consistently preserve their existing caller/source/lifecycle boundaries. Kernel network approvals also leave the scope of one-shot access unclear, and credential storage documentation omits explicit headless file mode.

## Proposed change

- Reject remote local-source preview acquisition at the shared command boundary; preserve local browsing and managed remote previews.
- Copy read-only linked references through the inspected file descriptor, rechecking file observations, path and current grant before returning the snapshot. Preserve existing quotas and cleanup.
- Recheck remote authorization before returning RPC successes or delayed errors. This does not roll back committed operations.
- Explain next-execution scope for Python/R/REPL network access in all eight locales. Preserve Bash's exact-command behavior.
- Document the existing explicit Linux headless credential mode and legacy read policies.

## Scope and non-goals

No database fields, tables, persisted enums, serialized formats, credential conversion or historical migration change. The snapshot remains an existing temporary file; descriptor/observation data are runtime-only. No provider filesystem policy or macOS service policy change. File identity checks address reproduced substitutions and ordinary concurrent changes; they are not a claim of a hostile-filesystem sandbox or recall of delivered snapshots.

## Acceptance criteria and validation

Final focused impact set: **22 test files, 1600 tests passed**, after the final material edit. The same regressions on the unchanged baseline failed identically in two runs: 13 failing regression tests, 5 passing controls. No setup failure is counted as reproduction.

| Behavior | Checks run with `npx vitest run` | Result |
| --- | --- | --- |
| Preview admission and legitimate local/managed access | `src/main/application-command-composition.test.ts`, `src/main/data-content-application-commands.test.ts`, `src/main/managed-preview-ipc.test.ts`, `src/main/managed-preview-resources.test.ts`, `src/main/managed-preview-protocol.test.ts`, `src/renderer/web/bootstrap.test.ts` | Pass |
| Snapshot replacement, mutation, grant changes, quota and lifecycle | `src/main/acp/file-reference-resolver.test.ts`, `src/main/acp/file-reference-resolver.windows-scope.test.ts`, `src/main/acp/prompt-content-owner.test.ts`, `src/main/acp/runtime-base-composition.test.ts` | Pass |
| Shared framework consumers | `src/main/agent-framework/claude-code.test.ts`, `src/main/agent-framework/opencode.test.ts`, `src/main/agent-framework/codex.test.ts` | Pass |
| Response revocation, valid local/remote requests | `src/main/web-service/http-server.test.ts` | Pass |
| Approval scope and localization | `src/main/notebook/network-sandbox-owner.test.ts`, `src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx`, `src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx`, `src/renderer/src/i18n/resources.test.ts` | Pass |
| Documented credential behavior | `src/main/settings/crypto.test.ts`, `src/main/settings/file-credential-storage.test.ts` | Pass |

`npm run typecheck` passed; Web typecheck was rerun after the final copy correction. `npm run lint` and `git diff --check` passed. A real-browser isolated component fixture verified the Chinese explanation, menu scope and unchanged `allow-once` submission; screenshots were delivered locally. Independent read-only review found a Bash copy mismatch, which was reproduced and corrected before the final tests.

The manifest explain path requests full CI because the resolver has no declared module owner. Per maintainer instruction, no full local `npm test` was run. Local validation includes actual macOS filesystem operations and Windows path-contract tests; platform CI is authoritative for native Windows/Linux behavior. No live provider account execution or macOS delegated-service experiment is claimed.

Merge conflict resolution retained both sets of added locale entries. The updated base also contained a duplicate identical `readOnly={saving}` prop; removed the duplicate without changing behavior. Both `PreviewFileSurface.test.tsx` and `PreviewFileSurface.freshness.test.tsx` passed (162 tests), and Web typecheck/lint were rerun.

## Review focus

Admission remains source-sensitive; descriptor cleanup and snapshot quota refund remain intact; current authorization controls response delivery; Bash and kernel one-shot semantics remain distinct. Public resolver and transport data shapes are unchanged.
