### PR TITLE
fix(lifecycle): recover interrupted data cleanup independently

### DIFF
--- a/packages/safe-file-publisher-native/index.d.ts
+++ b/packages/safe-file-publisher-native/index.d.ts
@@ -11,3 +11,11 @@ export type StoragePathCapabilities = {
 }
 
 export function inspectPath(path: string): StoragePathCapabilities
+
+export function removeAnchoredFile(
+  rootPath: string,
+  relativeParentPath: string,
+  filename: string,
+  parentDev: bigint,
+  parentIno: bigint
+): void

--- a/packages/safe-file-publisher-native/index.d.ts
+++ b/packages/safe-file-publisher-native/index.d.ts
@@ -17,5 +17,18 @@ export function removeAnchoredFile(
   relativeParentPath: string,
   filename: string,
   parentDev: bigint,
+  parentIno: bigint,
+  fileDev: bigint,
+  fileIno: bigint,
+  fileSize: bigint,
+  fileMtimeNs: bigint,
+  quarantineName: string
+): void
+
+export function recoverAnchoredRemoval(
+  rootPath: string,
+  relativeParentPath: string,
+  quarantineName: string,
+  parentDev: bigint,
   parentIno: bigint
 ): void

--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -639,12 +639,21 @@ bool MatchesRemovalFile(const struct stat& info, const RemovalReceipt& receipt) 
       modified.tv_sec * INT64_C(1000000000) + modified.tv_nsec == receipt.mtime;
 }
 
-// Both names are relative to held directories. Never overwrite a concurrently installed leaf.
-int MoveRemovalFile(int from, const char* source, int to, const char* destination) {
+// Both names are relative to held directories. Only capture targets the private, locked quarantine.
+int MoveRemovalFile(int from, const char* source, int to, const char* destination,
+                    bool private_destination = false) {
 #ifdef __APPLE__
   return renameatx_np(from, source, to, destination, RENAME_EXCL);
 #else
-  return static_cast<int>(syscall(SYS_renameat2, from, source, to, destination, RENAME_NOREPLACE));
+  if (syscall(SYS_renameat2, from, source, to, destination, RENAME_NOREPLACE) == 0) return 0;
+  if (errno != ENOSYS && errno != EOPNOTSUPP && errno != EINVAL) return -1;
+  // FinishRemoval already observed an absent payload while holding the quarantine lock. Its
+  // single writer can use ordinary rename here; no public source name is ever unlinked.
+  if (private_destination) return renameat(from, source, to, destination);
+  // Restore without replacing a public name. Make its link durable before unlinking the private
+  // payload. An interruption leaves both copies and the existing receipt's conflict barrier.
+  if (linkat(from, source, to, destination, 0) != 0 || fsync(to) != 0) return -1;
+  return unlinkat(from, source, 0);
 #endif
 }
 
@@ -713,7 +722,7 @@ int FinishRemoval(int parent, int quarantine, const std::string& directory, cons
     if (errno != ENOENT) return -1;
     if (fstatat(parent, receipt.name.c_str(), &source, AT_SYMLINK_NOFOLLOW) == 0) {
       if (!MatchesRemovalFile(source, receipt)) { errno = ESTALE; return -1; }
-      if (MoveRemovalFile(parent, receipt.name.c_str(), quarantine, "payload") != 0) return -1;
+      if (MoveRemovalFile(parent, receipt.name.c_str(), quarantine, "payload", true) != 0) return -1;
       // The receipt is already durable. Make capture durable before destroying its only copy.
       if (fsync(quarantine) != 0 || fsync(parent) != 0) return -1;
       if (fstatat(quarantine, "payload", &payload, AT_SYMLINK_NOFOLLOW) != 0) return -1;

--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -1,6 +1,8 @@
 #include <node_api.h>
 
 #include <cerrno>
+#include <charconv>
+#include <sstream>
 #include <cstddef>
 #include <cstring>
 #include <limits>
@@ -13,6 +15,7 @@
 #else
 #include <fcntl.h>
 #include <sys/stat.h>
+#include <sys/file.h>
 #include <unistd.h>
 #ifdef __linux__
 #include <sys/syscall.h>
@@ -391,6 +394,10 @@ const char* PosixErrorCode(int error) {
       return "EPERM";
     case ELOOP:
       return "ELOOP";
+    case ESTALE:
+      return "ESTALE";
+    case EINVAL:
+      return "EINVAL";
     default:
       return "EIO";
   }
@@ -564,23 +571,220 @@ napi_value PublishNoReplace(napi_env env, napi_callback_info info) {
 #endif
 }
 
+bool IsRemovalDirectory(const std::string& name) {
+  const std::string prefix = ".publication-recovery-";
+  if (name.size() != prefix.size() + 36 || name.compare(0, prefix.size(), prefix) != 0) return false;
+  const std::string id = name.substr(prefix.size());
+  for (size_t i = 0; i < id.size(); ++i) {
+    if (i == 8 || i == 13 || i == 18 || i == 23) {
+      if (id[i] != '-') return false;
+    } else if (!((id[i] >= '0' && id[i] <= '9') || (id[i] >= 'a' && id[i] <= 'f'))) return false;
+  }
+  return id[14] == '4' && (id[19] == '8' || id[19] == '9' || id[19] == 'a' || id[19] == 'b');
+}
+
+bool IsPublicationTemporary(const std::string& name) {
+  if (name.size() != 105 || name[64] != '.' || name.substr(101) != ".tmp") return false;
+  for (size_t i = 0; i < 64; ++i) {
+    if (!((name[i] >= '0' && name[i] <= '9') || (name[i] >= 'a' && name[i] <= 'f'))) return false;
+  }
+  return IsRemovalDirectory(".publication-recovery-" + name.substr(65, 36));
+}
+
+#ifndef _WIN32
+struct RemovalFd {
+  int value;
+  explicit RemovalFd(int fd) : value(fd) {}
+  ~RemovalFd() { if (value >= 0) close(value); }
+  RemovalFd(const RemovalFd&) = delete;
+  RemovalFd& operator=(const RemovalFd&) = delete;
+};
+
+struct RemovalReceipt {
+  std::string name;
+  uint64_t parent_dev, parent_ino, dev, ino, size;
+  int64_t mtime;
+};
+
+int OpenRemovalParent(const std::string& root, const std::vector<std::string>& components,
+                      uint64_t dev, uint64_t ino) {
+  int parent = open(root.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (parent < 0) return -1;
+  for (const auto& component : components) {
+    const int next = openat(parent, component.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    const int error = errno;
+    close(parent);
+    if (next < 0) { errno = error; return -1; }
+    parent = next;
+  }
+  struct stat info {};
+  if (fstat(parent, &info) != 0 || static_cast<uint64_t>(info.st_dev) != dev ||
+      static_cast<uint64_t>(info.st_ino) != ino) {
+    close(parent);
+    errno = ESTALE;
+    return -1;
+  }
+  return parent;
+}
+
+bool MatchesRemovalFile(const struct stat& info, const RemovalReceipt& receipt) {
+#ifdef __APPLE__
+  const auto modified = info.st_mtimespec;
+#else
+  const auto modified = info.st_mtim;
+#endif
+  return S_ISREG(info.st_mode) && static_cast<uint64_t>(info.st_dev) == receipt.dev &&
+      static_cast<uint64_t>(info.st_ino) == receipt.ino &&
+      static_cast<uint64_t>(info.st_size) == receipt.size &&
+      modified.tv_sec * INT64_C(1000000000) + modified.tv_nsec == receipt.mtime;
+}
+
+// Both names are relative to held directories. Never overwrite a concurrently installed leaf.
+int MoveRemovalFile(int from, const char* source, int to, const char* destination) {
+#ifdef __APPLE__
+  return renameatx_np(from, source, to, destination, RENAME_EXCL);
+#else
+  return static_cast<int>(syscall(SYS_renameat2, from, source, to, destination, RENAME_NOREPLACE));
+#endif
+}
+
+template <typename T>
+bool ReadRemovalNumber(std::istringstream& stream, T* value) {
+  std::string line;
+  if (!std::getline(stream, line)) return false;
+  const auto parsed = std::from_chars(line.data(), line.data() + line.size(), *value);
+  return parsed.ec == std::errc() && parsed.ptr == line.data() + line.size() &&
+      line == std::to_string(*value);
+}
+
+int ReadRemovalReceipt(int directory, RemovalReceipt* receipt) {
+  RemovalFd file(openat(directory, "receipt", O_RDONLY | O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC));
+  if (file.value < 0) return -1;
+  struct stat info {};
+  if (fstat(file.value, &info) != 0 || !S_ISREG(info.st_mode) || info.st_size <= 0 || info.st_size > 4096) {
+    errno = EINVAL;
+    return -1;
+  }
+  std::string bytes(static_cast<size_t>(info.st_size), '\0');
+  size_t offset = 0;
+  while (offset < bytes.size()) {
+    const auto count = read(file.value, &bytes[offset], bytes.size() - offset);
+    if (count < 0 && errno == EINTR) continue;
+    if (count <= 0) { errno = EINVAL; return -1; }
+    offset += count;
+  }
+  std::istringstream stream(bytes);
+  std::string version, extra;
+  if (!std::getline(stream, version) || version != "publication-removal-v1" ||
+      !std::getline(stream, receipt->name) || !IsPublicationTemporary(receipt->name) ||
+      receipt->name.find('\0') != std::string::npos || receipt->name.find('\r') != std::string::npos ||
+      !ReadRemovalNumber(stream, &receipt->parent_dev) || !ReadRemovalNumber(stream, &receipt->parent_ino) ||
+      !ReadRemovalNumber(stream, &receipt->dev) || !ReadRemovalNumber(stream, &receipt->ino) ||
+      !ReadRemovalNumber(stream, &receipt->size) || !ReadRemovalNumber(stream, &receipt->mtime) ||
+      std::getline(stream, extra)) {
+    errno = EINVAL;
+    return -1;
+  }
+  return 0;
+}
+
+int WriteRemovalReceipt(int directory, const RemovalReceipt& receipt) {
+  const std::string bytes = "publication-removal-v1\n" + receipt.name + "\n" +
+      std::to_string(receipt.parent_dev) + "\n" + std::to_string(receipt.parent_ino) + "\n" +
+      std::to_string(receipt.dev) + "\n" + std::to_string(receipt.ino) + "\n" +
+      std::to_string(receipt.size) + "\n" + std::to_string(receipt.mtime) + "\n";
+  RemovalFd file(openat(directory, "receipt", O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW | O_CLOEXEC, 0600));
+  if (file.value < 0) return -1;
+  size_t offset = 0;
+  while (offset < bytes.size()) {
+    const auto count = write(file.value, bytes.data() + offset, bytes.size() - offset);
+    if (count < 0 && errno == EINTR) continue;
+    if (count <= 0) return -1;
+    offset += count;
+  }
+  return fsync(file.value);
+}
+
+int FinishRemoval(int parent, int quarantine, const std::string& directory, const RemovalReceipt& receipt) {
+  struct stat parent_info {}, payload {}, source {};
+  if (fstat(parent, &parent_info) != 0 || static_cast<uint64_t>(parent_info.st_dev) != receipt.parent_dev ||
+      static_cast<uint64_t>(parent_info.st_ino) != receipt.parent_ino) { errno = ESTALE; return -1; }
+  if (fstatat(quarantine, "payload", &payload, AT_SYMLINK_NOFOLLOW) != 0) {
+    if (errno != ENOENT) return -1;
+    if (fstatat(parent, receipt.name.c_str(), &source, AT_SYMLINK_NOFOLLOW) == 0) {
+      if (!MatchesRemovalFile(source, receipt)) { errno = ESTALE; return -1; }
+      if (MoveRemovalFile(parent, receipt.name.c_str(), quarantine, "payload") != 0) return -1;
+      // The receipt is already durable. Make capture durable before destroying its only copy.
+      if (fsync(quarantine) != 0 || fsync(parent) != 0) return -1;
+      if (fstatat(quarantine, "payload", &payload, AT_SYMLINK_NOFOLLOW) != 0) return -1;
+    } else if (errno != ENOENT) return -1;
+    else {
+      // A completed unlink, or a candidate removed before capture. Never follow other names.
+      if (unlinkat(quarantine, "receipt", 0) != 0 || fsync(quarantine) != 0) return -1;
+      if (unlinkat(parent, directory.c_str(), AT_REMOVEDIR) != 0) return -1;
+      return fsync(parent);
+    }
+  }
+  if (fstatat(parent, receipt.name.c_str(), &source, AT_SYMLINK_NOFOLLOW) == 0) {
+    errno = EEXIST;
+    return -1; // Preserve both copies and the receipt; do not admit the reused name on another sweep.
+  }
+  if (errno != ENOENT) return -1;
+  if (!MatchesRemovalFile(payload, receipt)) {
+    // Restore without replacement, but retain the receipt as a conflict barrier on later sweeps.
+    if (MoveRemovalFile(quarantine, "payload", parent, receipt.name.c_str()) == 0) {
+      if (fsync(parent) != 0 || fsync(quarantine) != 0) return -1;
+    }
+    errno = ESTALE;
+    return -1;
+  }
+  // Only this owner writes the private, locked quarantine. No unlink is performed in the public
+  // source directory, so replacing the source leaf cannot redirect this removal.
+  if (unlinkat(quarantine, "payload", 0) != 0 || fsync(quarantine) != 0 ||
+      unlinkat(quarantine, "receipt", 0) != 0 || fsync(quarantine) != 0) return -1;
+  if (unlinkat(parent, directory.c_str(), AT_REMOVEDIR) != 0) return -1;
+  return fsync(parent);
+}
+
+int OpenRemovalQuarantine(int parent, const std::string& directory) {
+  const int fd = openat(parent, directory.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (fd < 0) return -1;
+  struct stat info {};
+  if (fstat(fd, &info) != 0 || info.st_uid != geteuid() || (info.st_mode & 0077) != 0 ||
+      flock(fd, LOCK_EX | LOCK_NB) != 0) {
+    close(fd);
+    errno = EPERM;
+    return -1;
+  }
+  return fd;
+}
+#endif
+
 // Bind deletion to an opened parent, not a path checked earlier by JavaScript.
 napi_value RemoveAnchoredFile(napi_env env, napi_callback_info info) {
-  size_t argc = 5;
-  napi_value argv[5];
-  std::string root, relative_parent, filename;
+  size_t argc = 10;
+  napi_value argv[10];
+  std::string root, relative_parent, filename, quarantine;
   std::vector<std::string> components;
   uint64_t expected_dev = 0, expected_ino = 0;
-  bool dev_lossless = false, ino_lossless = false;
-  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc != 5 ||
+  uint64_t file_dev = 0, file_ino = 0, file_size = 0;
+  int64_t file_mtime = 0;
+  bool dev_lossless = false, ino_lossless = false, file_dev_ok = false, file_ino_ok = false, size_ok = false, time_ok = false;
+  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc != 10 ||
       !ReadString(env, argv[0], &root) || !ReadString(env, argv[1], &relative_parent) ||
       !ReadString(env, argv[2], &filename) || root.empty() ||
       root.find('\0') != std::string::npos || relative_parent.find('\0') != std::string::npos ||
-      filename.find('\0') != std::string::npos ||
+      filename.find('\0') != std::string::npos || filename.find_first_of("\r\n") != std::string::npos ||
       !SplitRelativePath(relative_parent, &components) || !IsSimpleName(filename) ||
       napi_get_value_bigint_uint64(env, argv[3], &expected_dev, &dev_lossless) != napi_ok ||
       napi_get_value_bigint_uint64(env, argv[4], &expected_ino, &ino_lossless) != napi_ok ||
-      !dev_lossless || !ino_lossless) {
+      !dev_lossless || !ino_lossless ||
+      napi_get_value_bigint_uint64(env, argv[5], &file_dev, &file_dev_ok) != napi_ok ||
+      napi_get_value_bigint_uint64(env, argv[6], &file_ino, &file_ino_ok) != napi_ok ||
+      napi_get_value_bigint_uint64(env, argv[7], &file_size, &size_ok) != napi_ok ||
+      napi_get_value_bigint_int64(env, argv[8], &file_mtime, &time_ok) != napi_ok ||
+      !file_dev_ok || !file_ino_ok || !size_ok || !time_ok ||
+      !ReadString(env, argv[9], &quarantine) || !IsRemovalDirectory(quarantine)) {
     return ThrowError(env, "Invalid anchored removal arguments.", "EINVAL");
   }
 #ifdef _WIN32
@@ -649,6 +853,17 @@ napi_value RemoveAnchoredFile(napi_env env, napi_callback_info info) {
   const bool safe = GetFileInformationByHandle(file, &attributes) &&
       (attributes.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) == 0 &&
       SamePath(ParentPath(HandlePath(file)), path);
+  const uint64_t modified = (static_cast<uint64_t>(attributes.ftLastWriteTime.dwHighDateTime) << 32) |
+      attributes.ftLastWriteTime.dwLowDateTime;
+  const bool matches = safe && attributes.dwVolumeSerialNumber == file_dev &&
+      ((static_cast<uint64_t>(attributes.nFileIndexHigh) << 32) | attributes.nFileIndexLow) == file_ino &&
+      ((static_cast<uint64_t>(attributes.nFileSizeHigh) << 32) | attributes.nFileSizeLow) == file_size &&
+      (static_cast<int64_t>(modified) - INT64_C(116444736000000000)) * 100 == file_mtime;
+  if (!matches) {
+    CloseHandle(file);
+    close_directories();
+    return ThrowError(env, "Removal file changed.", "ESTALE");
+  }
   FILE_DISPOSITION_INFO disposition{TRUE};
   const bool removed = safe && SetFileInformationByHandle(file, FileDispositionInfo,
       &disposition, sizeof(disposition));
@@ -657,38 +872,61 @@ napi_value RemoveAnchoredFile(napi_env env, napi_callback_info info) {
   close_directories();
   if (!removed) return ThrowError(env, "Anchored removal failed.", safe ? WindowsErrorCode(error) : "ELOOP");
 #else
-  int parent = open(root.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-  if (parent < 0) return ThrowError(env, "Could not anchor the storage root.", PosixErrorCode(errno));
-  for (const auto& component : components) {
-    const int next = openat(parent, component.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
-    const int error = errno;
-    close(parent);
-    if (next < 0) return ThrowError(env, "Could not anchor the removal directory.", PosixErrorCode(error));
-    parent = next;
-  }
-  struct stat directory_info {};
-  if (fstat(parent, &directory_info) != 0 ||
-      static_cast<uint64_t>(directory_info.st_dev) != expected_dev ||
-      static_cast<uint64_t>(directory_info.st_ino) != expected_ino) {
-    close(parent);
-    return ThrowError(env, "Removal directory changed.", "ESTALE");
-  }
-  struct stat file_info {};
-  const int inspected = fstatat(parent, filename.c_str(), &file_info, AT_SYMLINK_NOFOLLOW);
-  const int inspection_error = errno;
-  if (inspected != 0 || !S_ISREG(file_info.st_mode)) {
-    close(parent);
-    return ThrowError(env, "Unsafe removal file.", inspected != 0 ? PosixErrorCode(inspection_error) : "ELOOP");
-  }
-  // unlinkat never follows a replacement leaf symlink and never removes a directory.
-  const int removed = unlinkat(parent, filename.c_str(), 0);
-  const int error = errno;
-  close(parent);
-  if (removed != 0) return ThrowError(env, "Anchored removal failed.", PosixErrorCode(error));
+  RemovalFd parent(OpenRemovalParent(root, components, expected_dev, expected_ino));
+  if (parent.value < 0) return ThrowError(env, "Could not anchor removal parent.", PosixErrorCode(errno));
+  if (mkdirat(parent.value, quarantine.c_str(), 0700) != 0)
+    return ThrowError(env, "Could not create removal quarantine.", PosixErrorCode(errno));
+  RemovalFd held(OpenRemovalQuarantine(parent.value, quarantine));
+  if (held.value < 0) return ThrowError(env, "Unsafe removal quarantine.", PosixErrorCode(errno));
+  const RemovalReceipt receipt{filename, expected_dev, expected_ino, file_dev, file_ino, file_size, file_mtime};
+  if (WriteRemovalReceipt(held.value, receipt) != 0 || fsync(held.value) != 0 || fsync(parent.value) != 0 ||
+      FinishRemoval(parent.value, held.value, quarantine, receipt) != 0)
+    return ThrowError(env, "Publication quarantine requires recovery: " + quarantine, PosixErrorCode(errno));
 #endif
   napi_value undefined;
   napi_get_undefined(env, &undefined);
   return undefined;
+}
+
+napi_value RecoverAnchoredRemoval(napi_env env, napi_callback_info info) {
+  size_t argc = 5;
+  napi_value argv[5];
+  std::string root, relative_parent, directory;
+  std::vector<std::string> components;
+  uint64_t dev = 0, ino = 0;
+  bool dev_ok = false, ino_ok = false;
+  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc != 5 ||
+      !ReadString(env, argv[0], &root) || root.empty() || root.find('\0') != std::string::npos ||
+      !ReadString(env, argv[1], &relative_parent) || relative_parent.find('\0') != std::string::npos ||
+      !SplitRelativePath(relative_parent, &components) || !ReadString(env, argv[2], &directory) ||
+      !IsRemovalDirectory(directory) ||
+      napi_get_value_bigint_uint64(env, argv[3], &dev, &dev_ok) != napi_ok ||
+      napi_get_value_bigint_uint64(env, argv[4], &ino, &ino_ok) != napi_ok || !dev_ok || !ino_ok)
+    return ThrowError(env, "Invalid removal recovery arguments.", "EINVAL");
+#ifdef _WIN32
+  // Windows deletes an identity-checked open handle directly. A transferred POSIX receipt cannot
+  // prove identity on this volume; preserve it rather than guessing ownership after migration.
+  return ThrowError(env, "POSIX publication quarantine requires its original filesystem.", "ENOTSUP");
+#else
+  RemovalFd parent(OpenRemovalParent(root, components, dev, ino));
+  if (parent.value < 0) return ThrowError(env, "Could not anchor recovery parent.", PosixErrorCode(errno));
+  RemovalFd held(OpenRemovalQuarantine(parent.value, directory));
+  if (held.value < 0) return ThrowError(env, "Unsafe recovery quarantine.", PosixErrorCode(errno));
+  RemovalReceipt receipt{};
+  if (ReadRemovalReceipt(held.value, &receipt) != 0) {
+    if (errno != ENOENT || unlinkat(parent.value, directory.c_str(), AT_REMOVEDIR) != 0)
+      return ThrowError(env, "Unrecognized publication recovery receipt.", PosixErrorCode(errno));
+    if (fsync(parent.value) != 0) return ThrowError(env, "Could not sync recovery directory.", PosixErrorCode(errno));
+  } else if (components.size() != 3 || components[0] != "content" || components[1] != "blobs" ||
+             components[2] != receipt.name.substr(0, 2)) {
+    return ThrowError(env, "Recovery receipt is outside the publication namespace.", "EINVAL");
+  } else if (FinishRemoval(parent.value, held.value, directory, receipt) != 0) {
+    return ThrowError(env, "Publication quarantine requires recovery: " + directory, PosixErrorCode(errno));
+  }
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+#endif
 }
 
 napi_value Init(napi_env env, napi_value exports) {
@@ -703,6 +941,9 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_value remove;
   napi_create_function(env, "removeAnchoredFile", NAPI_AUTO_LENGTH, RemoveAnchoredFile, nullptr, &remove);
   napi_set_named_property(env, exports, "removeAnchoredFile", remove);
+  napi_value recover;
+  napi_create_function(env, "recoverAnchoredRemoval", NAPI_AUTO_LENGTH, RecoverAnchoredRemoval, nullptr, &recover);
+  napi_set_named_property(env, exports, "recoverAnchoredRemoval", recover);
   return exports;
 }
 

--- a/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
+++ b/packages/safe-file-publisher-native/src/safe_file_publisher_native.cc
@@ -564,6 +564,133 @@ napi_value PublishNoReplace(napi_env env, napi_callback_info info) {
 #endif
 }
 
+// Bind deletion to an opened parent, not a path checked earlier by JavaScript.
+napi_value RemoveAnchoredFile(napi_env env, napi_callback_info info) {
+  size_t argc = 5;
+  napi_value argv[5];
+  std::string root, relative_parent, filename;
+  std::vector<std::string> components;
+  uint64_t expected_dev = 0, expected_ino = 0;
+  bool dev_lossless = false, ino_lossless = false;
+  if (napi_get_cb_info(env, info, &argc, argv, nullptr, nullptr) != napi_ok || argc != 5 ||
+      !ReadString(env, argv[0], &root) || !ReadString(env, argv[1], &relative_parent) ||
+      !ReadString(env, argv[2], &filename) || root.empty() ||
+      root.find('\0') != std::string::npos || relative_parent.find('\0') != std::string::npos ||
+      filename.find('\0') != std::string::npos ||
+      !SplitRelativePath(relative_parent, &components) || !IsSimpleName(filename) ||
+      napi_get_value_bigint_uint64(env, argv[3], &expected_dev, &dev_lossless) != napi_ok ||
+      napi_get_value_bigint_uint64(env, argv[4], &expected_ino, &ino_lossless) != napi_ok ||
+      !dev_lossless || !ino_lossless) {
+    return ThrowError(env, "Invalid anchored removal arguments.", "EINVAL");
+  }
+#ifdef _WIN32
+  // Denying delete sharing pins every directory while the child is opened. OPEN_REPARSE_POINT
+  // rejects junctions at every level; deletion then targets the opened file handle itself.
+  std::wstring path = Utf8ToWide(root);
+  std::vector<HANDLE> directories;
+  auto close_directories = [&]() {
+    for (HANDLE handle : directories) CloseHandle(handle);
+  };
+  for (size_t index = 0; index <= components.size(); ++index) {
+    const std::wstring previous_parent = path;
+    if (index != 0) {
+      if (path.back() != L'\\' && path.back() != L'/') path.push_back(L'\\');
+      const auto component = Utf8ToWide(components[index - 1]);
+      if (component.empty()) {
+        close_directories();
+        return ThrowError(env, "Invalid removal directory.", "EINVAL");
+      }
+      path.append(component);
+    }
+    HANDLE handle = CreateFileW(path.c_str(), FILE_READ_ATTRIBUTES | FILE_TRAVERSE,
+        FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT, nullptr);
+    if (handle == INVALID_HANDLE_VALUE) {
+      const DWORD error = GetLastError();
+      close_directories();
+      return ThrowError(env, "Could not anchor the removal directory.", WindowsErrorCode(error));
+    }
+    directories.push_back(handle);
+    BY_HANDLE_FILE_INFORMATION attributes{};
+    if (!GetFileInformationByHandle(handle, &attributes) ||
+        (attributes.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) == 0 ||
+        (attributes.dwFileAttributes & FILE_ATTRIBUTE_REPARSE_POINT) != 0 || IsRemoteHandle(handle)) {
+      close_directories();
+      return ThrowError(env, "Unsafe removal directory.", "ELOOP");
+    }
+    if (index == components.size() &&
+        (attributes.dwVolumeSerialNumber != expected_dev ||
+         ((static_cast<uint64_t>(attributes.nFileIndexHigh) << 32) |
+          attributes.nFileIndexLow) != expected_ino)) {
+      close_directories();
+      return ThrowError(env, "Removal directory changed.", "ESTALE");
+    }
+    const auto anchored = HandlePath(handle);
+    if (anchored.empty() || (index != 0 && !SamePath(ParentPath(anchored), previous_parent))) {
+      close_directories();
+      return ThrowError(env, "Removal directory escaped its parent.", "ELOOP");
+    }
+    path = anchored;
+  }
+  const auto name = Utf8ToWide(filename);
+  if (name.empty()) {
+    close_directories();
+    return ThrowError(env, "Invalid removal filename.", "EINVAL");
+  }
+  HANDLE file = CreateFileW((path + L"\\" + name).c_str(), DELETE | FILE_READ_ATTRIBUTES,
+      FILE_SHARE_READ | FILE_SHARE_WRITE, nullptr, OPEN_EXISTING,
+      FILE_FLAG_OPEN_REPARSE_POINT | FILE_FLAG_BACKUP_SEMANTICS, nullptr);
+  if (file == INVALID_HANDLE_VALUE) {
+    const DWORD error = GetLastError();
+    close_directories();
+    return ThrowError(env, "Could not open the removal file.", WindowsErrorCode(error));
+  }
+  BY_HANDLE_FILE_INFORMATION attributes{};
+  const bool safe = GetFileInformationByHandle(file, &attributes) &&
+      (attributes.dwFileAttributes & (FILE_ATTRIBUTE_DIRECTORY | FILE_ATTRIBUTE_REPARSE_POINT)) == 0 &&
+      SamePath(ParentPath(HandlePath(file)), path);
+  FILE_DISPOSITION_INFO disposition{TRUE};
+  const bool removed = safe && SetFileInformationByHandle(file, FileDispositionInfo,
+      &disposition, sizeof(disposition));
+  const DWORD error = GetLastError();
+  CloseHandle(file);
+  close_directories();
+  if (!removed) return ThrowError(env, "Anchored removal failed.", safe ? WindowsErrorCode(error) : "ELOOP");
+#else
+  int parent = open(root.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+  if (parent < 0) return ThrowError(env, "Could not anchor the storage root.", PosixErrorCode(errno));
+  for (const auto& component : components) {
+    const int next = openat(parent, component.c_str(), O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC);
+    const int error = errno;
+    close(parent);
+    if (next < 0) return ThrowError(env, "Could not anchor the removal directory.", PosixErrorCode(error));
+    parent = next;
+  }
+  struct stat directory_info {};
+  if (fstat(parent, &directory_info) != 0 ||
+      static_cast<uint64_t>(directory_info.st_dev) != expected_dev ||
+      static_cast<uint64_t>(directory_info.st_ino) != expected_ino) {
+    close(parent);
+    return ThrowError(env, "Removal directory changed.", "ESTALE");
+  }
+  struct stat file_info {};
+  const int inspected = fstatat(parent, filename.c_str(), &file_info, AT_SYMLINK_NOFOLLOW);
+  const int inspection_error = errno;
+  if (inspected != 0 || !S_ISREG(file_info.st_mode)) {
+    close(parent);
+    return ThrowError(env, "Unsafe removal file.", inspected != 0 ? PosixErrorCode(inspection_error) : "ELOOP");
+  }
+  // unlinkat never follows a replacement leaf symlink and never removes a directory.
+  const int removed = unlinkat(parent, filename.c_str(), 0);
+  const int error = errno;
+  close(parent);
+  if (removed != 0) return ThrowError(env, "Anchored removal failed.", PosixErrorCode(error));
+#endif
+  napi_value undefined;
+  napi_get_undefined(env, &undefined);
+  return undefined;
+}
+
 napi_value Init(napi_env env, napi_value exports) {
   napi_value publish;
   napi_create_function(
@@ -573,6 +700,9 @@ napi_value Init(napi_env env, napi_value exports) {
   napi_create_function(
       env, "inspectPath", NAPI_AUTO_LENGTH, InspectPath, nullptr, &inspect_path);
   napi_set_named_property(env, exports, "inspectPath", inspect_path);
+  napi_value remove;
+  napi_create_function(env, "removeAnchoredFile", NAPI_AUTO_LENGTH, RemoveAnchoredFile, nullptr, &remove);
+  napi_set_named_property(env, exports, "removeAnchoredFile", remove);
   return exports;
 }
 

--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -955,6 +955,7 @@
       "testFiles": {
         "owner": [
           "src/main/projects/deletion-coordinator.test.ts",
+          "src/main/projects/data-lifecycle-regressions.integration.test.ts",
           "src/main/projects/preview-repository.test.ts",
           "src/main/projects/project-owned-data.catalog.architecture.test.ts",
           "src/main/projects/project-runtime-quiescence-owner.test.ts",

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -55,6 +55,12 @@ describe('production application command wiring', () => {
     )
   })
 
+  it('routes background deletion through the tested owner recovery sequence', () => {
+    expect(compact(ipcSource)).toContain(
+      'recoverDeletionWork({ recoverOrphanJobs: () => jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive), replaySessionProjection: () => sessionRepository.reconcilePendingSessionProjection(), recoverProjects: () => projectDeletionCoordinator.recoverPendingDeletions() })'
+    )
+  })
+
   it('restores durable deletion barriers before managed file version recovery', () => {
     const deletionBarrierRestore = ipcSource.indexOf(
       'projectDeletionCoordinator.restorePendingDeletionBarriers()'

--- a/src/main/compute/compute-service.architecture.test.ts
+++ b/src/main/compute/compute-service.architecture.test.ts
@@ -302,15 +302,15 @@ describe('Compute service architecture', () => {
       'await deletionOwner.reconcileProjectOrphanJobs(projectId, isComputeJobOwnerLive)'
     )
     const backgroundOrphanRecovery = source.indexOf(
-      'await jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive)',
+      'recoverOrphanJobs: () => jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive)',
       backgroundRecovery
     )
     const backgroundSessionRecovery = source.indexOf(
-      'await sessionRepository.reconcilePendingSessionProjection()',
+      'replaySessionProjection: () => sessionRepository.reconcilePendingSessionProjection()',
       backgroundOrphanRecovery
     )
     const backgroundProjectRecovery = source.indexOf(
-      'await projectDeletionCoordinator.recoverPendingDeletions()',
+      'recoverProjects: () => projectDeletionCoordinator.recoverPendingDeletions()',
       backgroundSessionRecovery
     )
     const committedDeletionWake = source.indexOf(

--- a/src/main/compute/job-deletion-owner.test.ts
+++ b/src/main/compute/job-deletion-owner.test.ts
@@ -94,7 +94,9 @@ const createHarness = (jobs: ComputeJob[]) => {
     })
   }
   const jobRepository = {
-    findByOwner: vi.fn(async () => jobs),
+    findByOwner: vi.fn<(owner: { projectId: string; sessionId?: string }) => Promise<ComputeJob[]>>(
+      async () => jobs
+    ),
     listOwners: vi.fn(async () => [{ projectId: 'project-1', sessionId: 'session-1' }]),
     get: vi.fn(
       async (jobId: string) => jobs.find((candidate) => candidate.job_id === jobId) ?? null
@@ -627,6 +629,56 @@ describe('ComputeJobDeletionOwner', () => {
     expect(harness.lifecycle.abortOwnerDeletion).not.toHaveBeenCalled()
     expect(harness.queueManager.resumeOwner).not.toHaveBeenCalled()
     expect(harness.runtime.resume).toHaveBeenCalledOnce()
+  })
+
+  it.each(['project-1', 'project-2'])(
+    'isolates failed session cleanup from another session in %s and retries the original owner',
+    async (projectId) => {
+      const harness = createHarness([job()])
+      harness.jobRepository.findByOwner.mockImplementation(async (scope) =>
+        scope.sessionId === 'session-1' ? [job()] : []
+      )
+      harness.runner.run.mockRejectedValueOnce(new Error('offline'))
+      await harness.owner.prepareSessionJobDeletion('project-1', 'session-1')
+      await expect(
+        harness.owner.commitSessionJobDeletion('project-1', 'session-1')
+      ).rejects.toThrow('offline')
+      await harness.owner.prepareSessionJobDeletion(projectId, 'session-2')
+      await harness.owner.commitSessionJobDeletion(projectId, 'session-2')
+      expect(harness.lifecycle.deleteOwnerRows).toHaveBeenCalledExactlyOnceWith({
+        projectId,
+        sessionId: 'session-2'
+      })
+      expect(harness.lifecycle.abortOwnerDeletion).not.toHaveBeenCalled()
+      await harness.owner.commitSessionJobDeletion('project-1', 'session-1')
+      expect(harness.lifecycle.deleteOwnerRows).toHaveBeenLastCalledWith({
+        projectId: 'project-1',
+        sessionId: 'session-1'
+      })
+      expect(harness.runner.run).toHaveBeenCalledTimes(2)
+    }
+  )
+
+  it('continues orphan recovery after one owner fails and preserves its retry plan', async () => {
+    const harness = createHarness([job()])
+    harness.jobRepository.listOwners.mockResolvedValue([
+      { projectId: 'project-1', sessionId: 'session-1' },
+      { projectId: 'project-2', sessionId: 'session-2' }
+    ])
+    harness.jobRepository.findByOwner.mockImplementation(async (scope) =>
+      scope.projectId === 'project-1' ? [job()] : []
+    )
+    harness.runner.run.mockRejectedValueOnce(new Error('offline'))
+    await expect(harness.owner.reconcileOrphanJobs(async () => false)).rejects.toThrow()
+    expect(harness.lifecycle.deleteOwnerRows).toHaveBeenCalledExactlyOnceWith({
+      projectId: 'project-2',
+      sessionId: 'session-2'
+    })
+    await harness.owner.commitSessionJobDeletion('project-1', 'session-1')
+    expect(harness.lifecycle.deleteOwnerRows).toHaveBeenLastCalledWith({
+      projectId: 'project-1',
+      sessionId: 'session-1'
+    })
   })
 
   it('recovers a retained child Session plan before preparing its parent Project', async () => {

--- a/src/main/compute/job-deletion-owner.ts
+++ b/src/main/compute/job-deletion-owner.ts
@@ -158,7 +158,7 @@ const cleanupCommand = (
 class ComputeJobDeletionOwner {
   private operationQueue: Promise<unknown> = Promise.resolve()
   private runtime: ComputeJobRuntimePause | undefined
-  private preparedDeletion: PreparedOwnerDeletion | undefined
+  private readonly preparedDeletions = new Map<string, PreparedOwnerDeletion>()
   private readonly armedOwners = new Map<string, ComputeJobOwner>()
   private readonly retainedOwners = new Set<string>()
   private readonly dispatchTracker: Pick<DispatchTracker, 'waitFor'>
@@ -342,8 +342,8 @@ class ComputeJobDeletionOwner {
   private async prepareOwnerWhenAvailable(owner: ComputeJobOwner): Promise<void> {
     while (true) {
       const decision = await this.enqueue(async () => {
-        const prepared = this.preparedDeletion
-        if (prepared && !this.sameOwner(prepared.owner, owner)) {
+        const prepared = this.overlappingPlan(owner)
+        if (prepared) {
           return { status: 'wait' as const, outcome: prepared.outcome }
         }
         await this.prepareOwner(owner)
@@ -358,6 +358,15 @@ class ComputeJobDeletionOwner {
 
   private sameOwner(left: ComputeJobOwner, right: ComputeJobOwner): boolean {
     return left.projectId === right.projectId && left.sessionId === right.sessionId
+  }
+
+  private overlappingPlan(owner: ComputeJobOwner): PreparedOwnerDeletion | undefined {
+    return [...this.preparedDeletions.values()].find(
+      (plan) =>
+        !this.sameOwner(plan.owner, owner) &&
+        plan.owner.projectId === owner.projectId &&
+        (plan.owner.sessionId === undefined || owner.sessionId === undefined)
+    )
   }
 
   private ownerKey(owner: ComputeJobOwner): string {
@@ -409,9 +418,9 @@ class ComputeJobDeletionOwner {
   }
 
   private async prepareOwner(owner: ComputeJobOwner): Promise<void> {
-    if (this.preparedDeletion) {
-      if (this.sameOwner(this.preparedDeletion.owner, owner)) return
-      throw new Error('Another Compute Job owner deletion is already prepared.')
+    if (this.preparedDeletions.has(this.ownerKey(owner))) return
+    if (this.overlappingPlan(owner)) {
+      throw new Error('An overlapping Compute Job owner deletion is already prepared.')
     }
 
     await this.armOwner(owner, false)
@@ -443,7 +452,12 @@ class ComputeJobDeletionOwner {
       const outcome = new Promise<PreparedDeletionOutcome>((resolve) => {
         settleOutcome = resolve
       })
-      this.preparedDeletion = { owner, remoteCleanups, outcome, settleOutcome }
+      this.preparedDeletions.set(this.ownerKey(owner), {
+        owner,
+        remoteCleanups,
+        outcome,
+        settleOutcome
+      })
     } catch (error) {
       if (!this.retainedOwners.has(this.ownerKey(owner))) {
         await this.releaseOwnerBarrier(owner)
@@ -453,7 +467,7 @@ class ComputeJobDeletionOwner {
   }
 
   private async commitOwner(owner: ComputeJobOwner): Promise<void> {
-    const prepared = this.preparedDeletion
+    const prepared = this.preparedDeletions.get(this.ownerKey(owner))
     if (!prepared || !this.sameOwner(prepared.owner, owner)) {
       throw new Error('Compute Job owner deletion is not prepared.')
     }
@@ -466,22 +480,22 @@ class ComputeJobDeletionOwner {
       prepared.settleOutcome({ status: 'retained', error })
       throw error
     }
-    this.preparedDeletion = undefined
+    this.preparedDeletions.delete(this.ownerKey(owner))
     prepared.settleOutcome({ status: 'released' })
     this.releaseCommittedOwnerBarriers(owner)
   }
 
   private async abortOwner(owner: ComputeJobOwner): Promise<void> {
-    if (this.preparedDeletion && !this.sameOwner(this.preparedDeletion.owner, owner)) {
+    if (this.overlappingPlan(owner)) {
       // A parent Project abort can race a retained child Session cleanup plan. The parent never
       // armed a new barrier because prepareOwner rejected before armOwner, so leave the child plan
       // and any restored durable Project barrier untouched for the next recovery attempt.
       return
     }
-    const prepared = this.preparedDeletion
+    const prepared = this.preparedDeletions.get(this.ownerKey(owner))
     await this.releaseOwnerBarrier(owner)
     if (prepared) {
-      this.preparedDeletion = undefined
+      this.preparedDeletions.delete(this.ownerKey(owner))
       prepared.settleOutcome({ status: 'released' })
     }
   }
@@ -493,26 +507,28 @@ class ComputeJobDeletionOwner {
     const owners = (await this.deps.jobRepository.listOwners()).filter(
       (owner) => projectId === undefined || owner.projectId === projectId
     )
-    const prepared = this.preparedDeletion?.owner
-    if (prepared?.sessionId !== undefined) {
-      const preparedIndex = owners.findIndex((owner) => this.sameOwner(owner, prepared))
-      if (preparedIndex > 0) owners.unshift(...owners.splice(preparedIndex, 1))
-    }
+    const failures: unknown[] = []
     for (const owner of owners) {
-      const liveness = await isOwnerLive(owner)
-      if (liveness === 'unknown') continue
-      if (liveness) {
-        const key = this.ownerKey(owner)
-        if (
-          this.retainedOwners.has(key) &&
-          (!this.preparedDeletion || !this.sameOwner(this.preparedDeletion.owner, owner))
-        ) {
-          await this.releaseOwnerBarrier(owner)
+      try {
+        const liveness = await isOwnerLive(owner)
+        if (liveness === 'unknown') continue
+        if (liveness) {
+          const key = this.ownerKey(owner)
+          if (this.retainedOwners.has(key) && !this.preparedDeletions.has(key)) {
+            await this.releaseOwnerBarrier(owner)
+          }
+          continue
         }
-        continue
+        await this.prepareOwner(owner)
+        await this.commitOwner(owner)
+      } catch (error) {
+        failures.push(error)
       }
-      await this.prepareOwner(owner)
-      await this.commitOwner(owner)
+    }
+    if (failures.length > 0) {
+      throw new AggregateError(failures, 'Compute Job owner cleanup failed.', {
+        cause: failures[0]
+      })
     }
   }
 

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -263,7 +263,8 @@ import {
 import { ManagedFileVersionService } from './managed-file-versions/service'
 import {
   ProjectDeletionCoordinator,
-  ProjectDeletionRecoveryLoop
+  ProjectDeletionRecoveryLoop,
+  recoverDeletionWork
 } from './projects/deletion-coordinator'
 import { ProjectRuntimeQuiescenceOwner } from './projects/project-runtime-quiescence-owner'
 import { getProjectDbClient } from './projects/prisma-client'
@@ -3340,14 +3341,12 @@ const createApplicationModules = async (
   // Notebook, Side Chat, and the composed quiescence boundary are all initialized. The bounded
   // durable barrier restoration above still runs early enough to block admission during startup.
   const projectDeletionRecovery = new ProjectDeletionRecoveryLoop(
-    async () => {
-      // A retained child Session plan must finish before its parent Project intent can prepare.
-      await jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive)
-      // Replay a pending Session JSON write from the tombstone before Project recovery removes that
-      // temporary authority. The retained SQLite facts then remain available to historical Usage.
-      await sessionRepository.reconcilePendingSessionProjection()
-      await projectDeletionCoordinator.recoverPendingDeletions()
-    },
+    () =>
+      recoverDeletionWork({
+        recoverOrphanJobs: () => jobDeletionOwner.reconcileOrphanJobs(isComputeJobOwnerLive),
+        replaySessionProjection: () => sessionRepository.reconcilePendingSessionProjection(),
+        recoverProjects: () => projectDeletionCoordinator.recoverPendingDeletions()
+      }),
     {
       onError: (error) =>
         createLogger('compute-job-deletion').error(

--- a/src/main/projects/data-lifecycle-regressions.integration.test.ts
+++ b/src/main/projects/data-lifecycle-regressions.integration.test.ts
@@ -1,0 +1,200 @@
+// Public lifecycle regressions derived from interrupted deletion and publication scenarios.
+import { createHash } from 'node:crypto'
+import { mkdtemp, mkdir, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { expect, it, vi } from 'vitest'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { ProjectRepository } from '../projects/repository'
+import {
+  ProjectDeletionCoordinator,
+  ProjectDeletionRecoveryLoop
+} from '../projects/deletion-coordinator'
+import { LiteratureCatalog } from '../literature/catalog'
+import { literatureItemInputSchema } from '../../shared/literature'
+import { ContentRepository } from '../storage/content-repository'
+import { ComputeJobDeletionOwner } from '../compute/job-deletion-owner'
+
+it('removes deleted projects from literature membership and counts', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'lifecycle-audit-links-'))
+  const client = createProjectDbClient(root)
+  try {
+    await migrateApplicationDatabase(client)
+    const projects = new ProjectRepository(async () => client)
+    const project = await projects.create({ name: 'Audit Project' })
+    const catalog = new LiteratureCatalog(async () => client)
+    const item = await catalog.transact({
+      kind: 'create-item',
+      item: literatureItemInputSchema.parse({
+        title: 'Audit Reference',
+        itemType: 'journalArticle'
+      })
+    })
+    await client.projectLiterature.create({
+      data: { projectId: project.id, itemId: item.id, source: 'user' }
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, {
+      deleteProjectSessions: async () => ({ status: 'completed' }),
+      getProjectSessionDeletionState: async () => 'absent',
+      completeProjectSessionDeletion: async () => undefined,
+      listLegacyProjectSessionTombstones: async () => []
+    })
+    expect(await coordinator.deleteProject(project.id)).toEqual({ status: 'deleted' })
+    expect(await projects.get(project.id)).toBeNull()
+    expect(await client.projectDeletionIntent.count()).toBe(0)
+    expect((await catalog.get(item.id))?.projectIds).not.toContain(project.id)
+    expect((await catalog.search({ scope: 'project-counts' })).entries).not.toContainEqual({
+      projectId: project.id,
+      itemCount: 1
+    })
+  } finally {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+it('removes abandoned publication bytes when sweeping interrupted staging content', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'lifecycle-audit-temp-'))
+  const client = createProjectDbClient(root)
+  try {
+    await migrateApplicationDatabase(client)
+    const bytes = Buffer.from('simulated interrupted content publication')
+    const checksum = createHash('sha256').update(bytes).digest('hex')
+    const id = `sha256:${checksum}:${bytes.length}`
+    const storageKey = `content/blobs/${checksum.slice(0, 2)}/${checksum}`
+    const orphanPath = join(root, `${storageKey}.01234567-89ab-4def-8123-456789abcdef.tmp`)
+    await mkdir(dirname(orphanPath), { recursive: true })
+    await writeFile(orphanPath, bytes)
+    await client.contentBlob.create({
+      data: {
+        id,
+        storageKey,
+        checksum,
+        sizeBytes: BigInt(bytes.length),
+        state: 'staging',
+        createdAt: new Date(1)
+      }
+    })
+    const content = new ContentRepository({ storageRoot: root, getClient: async () => client })
+    expect((await content.sweep({ createdBefore: new Date() })).removedIds).toContain(id)
+    expect(await client.contentBlob.count()).toBe(0)
+    await expect(readFile(orphanPath)).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await content.sweep({ createdBefore: new Date() })).toEqual({
+      removedIds: [],
+      retainedIds: [],
+      failedIds: []
+    })
+    await expect(readFile(orphanPath)).rejects.toMatchObject({ code: 'ENOENT' })
+  } finally {
+    await client.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+})
+
+it('allows unrelated session deletion after another owner fails remote cleanup', async () => {
+  const job = {
+    job_id: 'audit-job',
+    provider_id: 'audit-host',
+    project_id: 'project-a',
+    session_id: 'session-a',
+    status: 'success',
+    execution_mode: 'direct_ssh',
+    harvested_at: 1,
+    remote_workdir: '/scratch/.openscience/jobs/audit-job'
+  }
+  const findByOwner = vi.fn(async (owner: { projectId: string; sessionId?: string }) =>
+    owner.projectId === 'project-a' ? [job] : []
+  )
+  const begin = vi.fn(async () => undefined)
+  const deleteRows = vi.fn(async () => undefined)
+  const owner = new ComputeJobDeletionOwner({
+    jobRepository: {
+      findByOwner,
+      listOwners: async () => [],
+      get: async () => null,
+      settleRemoteCleanup: vi.fn()
+    },
+    lifecycle: {
+      beginOwnerDeletion: begin,
+      deleteOwnerRows: deleteRows,
+      abortOwnerDeletion: async () => undefined
+    },
+    hostRepository: { get: async () => ({ scratchRoot: '/scratch' }) },
+    connectionBroker: {
+      acquire: async () => ({
+        run: async () => {
+          throw new Error('host-a offline')
+        }
+      })
+    },
+    dispatchTracker: { waitFor: async () => undefined },
+    queueManager: { pauseOwner: async () => undefined, resumeOwner: () => undefined }
+  } as never)
+  await owner.prepareSessionJobDeletion('project-a', 'session-a')
+  await expect(owner.commitSessionJobDeletion('project-a', 'session-a')).rejects.toThrow(
+    'host-a offline'
+  )
+  await expect(owner.prepareSessionJobDeletion('project-b', 'session-b')).resolves.toBeUndefined()
+  expect(begin).toHaveBeenCalledTimes(2)
+  expect(findByOwner).toHaveBeenCalledWith({ projectId: 'project-b', sessionId: 'session-b' })
+  expect(deleteRows).not.toHaveBeenCalled()
+})
+
+it('automatically retries a durable deletion after transient failure before metadata commit', async () => {
+  vi.useFakeTimers()
+  let projectExists = true
+  const intents = new Set<string>()
+  const deleteSessions = vi
+    .fn()
+    .mockRejectedValueOnce(new Error('transient session cleanup failure'))
+    .mockResolvedValue({ status: 'completed' })
+  const coordinator = new ProjectDeletionCoordinator(
+    {
+      exists: async () => projectExists,
+      delete: async () => {
+        projectExists = false
+        return undefined
+      },
+      createDeletionIntent: async (id: string) => {
+        intents.add(id)
+      },
+      deleteDeletionIntent: async (id: string) => {
+        intents.delete(id)
+      },
+      listDeletionIntents: async () => [...intents],
+      listDeletionCleanupProjects: async () => [...intents].map((projectId) => ({ projectId }))
+    },
+    {
+      deleteProjectSessions: deleteSessions,
+      getProjectSessionDeletionState: async () => 'absent',
+      completeProjectSessionDeletion: async () => undefined,
+      listLegacyProjectSessionTombstones: async () => []
+    },
+    undefined,
+    undefined,
+    undefined,
+    undefined,
+    {
+      publish: (channel: string, payload: { status?: string }) => {
+        // Production wakes recovery on the post-commit cleanup-pending event.
+        if (channel === 'project:deleted' && payload.status === 'cleanup-pending') loop.wake()
+      }
+    } as never
+  )
+  const loop = new ProjectDeletionRecoveryLoop(() => coordinator.recoverPendingDeletions())
+  coordinator.setRecoveryLoop(loop)
+  try {
+    loop.start()
+    await vi.advanceTimersByTimeAsync(0)
+    await expect(coordinator.deleteProject('project-a')).rejects.toThrow(
+      'transient session cleanup failure'
+    )
+    await vi.advanceTimersByTimeAsync(60_000)
+    expect(deleteSessions).toHaveBeenCalledTimes(2)
+    expect(intents.size).toBe(0)
+    expect(await coordinator.listDeletionCleanup()).toEqual([])
+  } finally {
+    await loop.stop()
+    vi.useRealTimers()
+  }
+})

--- a/src/main/projects/deletion-coordinator.test.ts
+++ b/src/main/projects/deletion-coordinator.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   ProjectDeletionRecoveryLoop,
+  recoverDeletionWork,
   ProjectDeletionCoordinator,
   type ProjectDeletionRepository,
   type ProjectSessionDeletion
@@ -39,6 +40,158 @@ describe('ProjectDeletionCoordinator', () => {
     } finally {
       blocked.resolve()
       await deletion
+    }
+  })
+
+  it('continues project recovery after unrelated remote cleanup fails', async () => {
+    const offline = new Error('remote host offline')
+    const order: string[] = []
+    await expect(
+      recoverDeletionWork({
+        recoverOrphanJobs: async () => {
+          order.push('jobs')
+          throw offline
+        },
+        replaySessionProjection: async () => {
+          order.push('projection')
+        },
+        recoverProjects: async () => {
+          order.push('projects')
+        }
+      })
+    ).rejects.toBe(offline)
+    expect(order).toEqual(['jobs', 'projection', 'projects'])
+  })
+
+  it('does not remove project authority when pending Session projection replay fails', async () => {
+    const recoverProjects = vi.fn()
+    await expect(
+      recoverDeletionWork({
+        recoverOrphanJobs: async () => undefined,
+        replaySessionProjection: async () => {
+          throw new Error('projection unavailable')
+        },
+        recoverProjects
+      })
+    ).rejects.toThrow('projection unavailable')
+    expect(recoverProjects).not.toHaveBeenCalled()
+  })
+
+  it.each(['quiesce', 'sessions', 'permissions', 'metadata'] as const)(
+    'automatically retries durable foreground failure during %s',
+    async (stage) => {
+      vi.useFakeTimers()
+      const projects = createProjects()
+      const intents = new Set<string>()
+      projects.createDeletionIntent = vi.fn(async (id) => {
+        intents.add(id)
+      })
+      projects.deleteDeletionIntent = vi.fn(async (id) => {
+        intents.delete(id)
+      })
+      projects.listDeletionIntents = vi.fn(async () => [...intents])
+      const sessions = createSessions()
+      const lifecycle = { beforeProjectDelete: vi.fn().mockResolvedValue(undefined) }
+      const permissions = { prune: vi.fn().mockResolvedValue(undefined) }
+      const failure = {
+        quiesce: lifecycle.beforeProjectDelete,
+        sessions: vi.mocked(sessions.deleteProjectSessions),
+        permissions: permissions.prune,
+        metadata: vi.mocked(projects.delete)
+      }[stage]
+      failure.mockRejectedValueOnce(new Error('transient'))
+      const coordinator = new ProjectDeletionCoordinator(
+        projects,
+        sessions,
+        undefined,
+        undefined,
+        permissions,
+        lifecycle
+      )
+      const loop = new ProjectDeletionRecoveryLoop(() => coordinator.recoverPendingDeletions())
+      coordinator.setRecoveryLoop(loop)
+      try {
+        loop.start()
+        await vi.advanceTimersByTimeAsync(0)
+        await expect(coordinator.deleteProject('project-1')).rejects.toThrow('transient')
+        await vi.advanceTimersByTimeAsync(60_000)
+        expect(intents.size).toBe(0)
+        expect(failure).toHaveBeenCalledTimes(2)
+      } finally {
+        await loop.stop()
+      }
+    }
+  )
+
+  it('does not wake recovery when intent creation fails and the fence is rolled back', async () => {
+    const projects = createProjects()
+    vi.mocked(projects.createDeletionIntent).mockRejectedValueOnce(
+      new Error('database unavailable')
+    )
+    const lifecycle = { beforeProjectDelete: vi.fn(), abortProjectDeletion: vi.fn() }
+    const coordinator = new ProjectDeletionCoordinator(
+      projects,
+      createSessions(),
+      undefined,
+      undefined,
+      undefined,
+      lifecycle
+    )
+    const loop = new ProjectDeletionRecoveryLoop(async () => undefined)
+    const wake = vi.spyOn(loop, 'wake')
+    coordinator.setRecoveryLoop(loop)
+    await expect(coordinator.deleteProject('project-1')).rejects.toThrow('database unavailable')
+    expect(lifecycle.abortProjectDeletion).toHaveBeenCalledWith('project-1')
+    expect(wake).not.toHaveBeenCalled()
+  })
+
+  it('schedules persistent foreground failures with accurate counts instead of spinning', async () => {
+    vi.useFakeTimers()
+    const projects = createProjects()
+    const intents = new Set<string>()
+    projects.createDeletionIntent = vi.fn(async (id) => {
+      intents.add(id)
+    })
+    projects.listDeletionIntents = vi.fn(async () => [...intents])
+    projects.listDeletionCleanupProjects = vi.fn(async () =>
+      [...intents].map((projectId) => ({ projectId }))
+    )
+    const sessions = createSessions({
+      deleteProjectSessions: vi.fn().mockRejectedValue(new Error('offline'))
+    })
+    const coordinator = new ProjectDeletionCoordinator(projects, sessions)
+    const loop = new ProjectDeletionRecoveryLoop(
+      () =>
+        recoverDeletionWork({
+          recoverOrphanJobs: async () => {
+            throw new Error('remote offline')
+          },
+          replaySessionProjection: async () => undefined,
+          recoverProjects: () => coordinator.recoverPendingDeletions()
+        }),
+      { retryDelayMs: 1_000 }
+    )
+    coordinator.setRecoveryLoop(loop)
+    try {
+      loop.start()
+      await vi.advanceTimersByTimeAsync(0)
+      await expect(coordinator.deleteProject('project-1')).rejects.toThrow('offline')
+      await vi.advanceTimersByTimeAsync(0)
+      expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
+      expect(await coordinator.listDeletionCleanup()).toEqual([
+        {
+          projectId: 'project-1',
+          phase: 'retry-scheduled',
+          failureCount: 1,
+          nextRetryAt: Date.now() + 1_000
+        }
+      ])
+      await vi.advanceTimersByTimeAsync(999)
+      expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(2)
+      await vi.advanceTimersByTimeAsync(1)
+      expect(sessions.deleteProjectSessions).toHaveBeenCalledTimes(3)
+    } finally {
+      await loop.stop()
     }
   })
 

--- a/src/main/projects/deletion-coordinator.ts
+++ b/src/main/projects/deletion-coordinator.ts
@@ -84,6 +84,30 @@ class ProjectDeletionRecoveryError extends AggregateError {
   }
 }
 
+// Production recovery order: finish retained child jobs, replay Session projection authority,
+// then remove Project tombstones. Kept callable without booting Electron or other runtimes.
+const recoverDeletionWork = async (owners: {
+  recoverOrphanJobs(): Promise<void>
+  replaySessionProjection(): Promise<void>
+  recoverProjects(): Promise<void>
+}): Promise<void> => {
+  const failures: unknown[] = []
+  try {
+    await owners.recoverOrphanJobs()
+  } catch (error) {
+    failures.push(error)
+  }
+  try {
+    // Projection replay is still a prerequisite: do not remove its tombstone on replay failure.
+    await owners.replaySessionProjection()
+    await owners.recoverProjects()
+  } catch (error) {
+    failures.push(error)
+  }
+  if (failures.length === 1) throw failures[0]
+  if (failures.length > 1) throw new AggregateError(failures, 'Deletion recovery failed.')
+}
+
 class ProjectDeletionRecoveryLoop {
   private readonly retryDelayMs: number
   private readonly onError: (error: unknown) => void
@@ -175,8 +199,14 @@ class ProjectDeletionRecoveryLoop {
           this.running = false
           const rerunRequested = this.rerunRequested
           this.rerunRequested = false
-          if (error instanceof ProjectDeletionRecoveryError) {
-            const failedProjectIds = new Set(error.failures.map(({ projectId }) => projectId))
+          const projectFailures = [
+            error,
+            ...(error instanceof AggregateError ? error.errors : [])
+          ].flatMap((failure) =>
+            failure instanceof ProjectDeletionRecoveryError ? failure.failures : []
+          )
+          if (projectFailures.length > 0) {
+            const failedProjectIds = new Set(projectFailures.map(({ projectId }) => projectId))
             for (const projectId of this.failureCounts.keys()) {
               if (!failedProjectIds.has(projectId)) this.failureCounts.delete(projectId)
             }
@@ -252,11 +282,14 @@ class ProjectDeletionCoordinator {
   deleteProject(projectId: string): Promise<ProjectDeletionOutcome> {
     const generation = ++this.operationGeneration
     this.isRecoveryComplete = false
-    return this.enqueueProjectOperation(projectId, () =>
+    let intentCreated = false
+    const operation = this.enqueueProjectOperation(projectId, () =>
       withDataRootWrite(async () => {
         const recoveryComplete = await this.waitForProjectOperationsNow([projectId], projectId)
         try {
-          const outcome = await this.runDeletion(projectId)
+          const outcome = await this.runDeletion(projectId, () => {
+            intentCreated = true
+          })
           // Preserve sticky completion only when scoped admission did not suppress failures owned by
           // other Projects and no newer deletion started during this operation.
           this.isRecoveryComplete =
@@ -269,6 +302,16 @@ class ProjectDeletionCoordinator {
           throw error
         }
       })
+    )
+    return operation.then(
+      (outcome) => {
+        if (outcome.status === 'cleanup-pending') this.recoveryLoop?.wake()
+        return outcome
+      },
+      (error: unknown) => {
+        if (intentCreated) this.recoveryLoop?.wake()
+        throw error
+      }
     )
   }
 
@@ -363,10 +406,14 @@ class ProjectDeletionCoordinator {
   // retry authority before any destructive runtime cleanup. Once the intent exists, every failure
   // remains fail-closed: the Project may still be visible, but recovery retains the fence and replays
   // quiescence before continuing durable deletion.
-  private async runDeletion(projectId: string): Promise<ProjectDeletionOutcome> {
+  private async runDeletion(
+    projectId: string,
+    onIntentCreated: () => void
+  ): Promise<ProjectDeletionOutcome> {
     if (!(await this.projects.exists(projectId))) return { status: 'deleted' }
 
     await this.createDeletionIntentWithFence(projectId)
+    onIntentCreated()
     await this.lifecycle?.beforeProjectDelete(projectId)
     await this.sessions.deleteProjectSessions(projectId)
     const attempt = await this.finishDeletion(projectId)
@@ -564,7 +611,7 @@ class ProjectDeletionCoordinator {
   }
 }
 
-export { ProjectDeletionCoordinator, ProjectDeletionRecoveryLoop }
+export { ProjectDeletionCoordinator, ProjectDeletionRecoveryLoop, recoverDeletionWork }
 export type {
   ProjectDeletionRecoveryLoopOptions,
   ProjectDeletionRepository,

--- a/src/main/storage/content-repository.test.ts
+++ b/src/main/storage/content-repository.test.ts
@@ -19,10 +19,16 @@ import type { PrismaClient } from '@prisma/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { literatureItemInputSchema } from '../../shared/literature'
+import { removeAnchoredFile } from '../uploads/atomic-no-replace-publisher'
 import { LiteratureCatalog } from '../literature/catalog'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { markContentBlobAvailable, registerContentBlob } from './content-blob-registry'
 import { ContentRepository, resolveContentStorageKey } from './content-repository'
+
+vi.mock('../uploads/atomic-no-replace-publisher', async (importOriginal) => {
+  const original = await importOriginal<typeof import('../uploads/atomic-no-replace-publisher')>()
+  return { ...original, removeAnchoredFile: vi.fn(original.removeAnchoredFile) }
+})
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs/promises')>()
@@ -54,6 +60,15 @@ describe('content repository', () => {
     const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
     vi.mocked(copyFile).mockReset().mockImplementation(fs.copyFile)
     vi.mocked(lstat).mockReset().mockImplementation(fs.lstat)
+    vi.mocked(removeAnchoredFile)
+      .mockReset()
+      .mockImplementation(
+        (
+          await vi.importActual<typeof import('../uploads/atomic-no-replace-publisher')>(
+            '../uploads/atomic-no-replace-publisher'
+          )
+        ).removeAnchoredFile
+      )
     await client?.$disconnect()
     if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   })
@@ -872,7 +887,9 @@ describe('content repository', () => {
         createdAt: new Date(1)
       }
     })
-    vi.mocked(rm).mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'EACCES' }))
+    vi.mocked(removeAnchoredFile).mockImplementationOnce(() => {
+      throw Object.assign(new Error('denied'), { code: 'EACCES' })
+    })
     await expect(repository.sweep({ createdBefore: new Date() })).rejects.toMatchObject({
       code: 'EACCES'
     })
@@ -893,6 +910,33 @@ describe('content repository', () => {
     await symlink(outside, join(blobs, 'aa'), process.platform === 'win32' ? 'junction' : 'dir')
     await repository.sweep({ createdBefore: new Date() })
     expect(await readFile(join(outside, filename), 'utf8')).toBe('keep')
+  })
+
+  it('preserves outside bytes when a publication parent is swapped after the final path check', async () => {
+    const repository = await createRepository()
+    const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+    const outside = join(storageRoot!, 'outside')
+    const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+    const temporary = join(directory, filename)
+    await mkdir(directory, { recursive: true })
+    await mkdir(outside)
+    await writeFile(temporary, 'owned')
+    await writeFile(join(outside, filename), 'outside user bytes')
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let checks = 0
+    vi.mocked(lstat).mockImplementation((...args) => {
+      if (String(args[0]) !== temporary || ++checks !== 2) return fs.lstat(...args)
+      return (async () => {
+        const current = await fs.lstat(temporary)
+        await rename(directory, `${directory}-held`)
+        await symlink(outside, directory, process.platform === 'win32' ? 'junction' : 'dir')
+        return current
+      })() as ReturnType<typeof lstat>
+    })
+    const result = await repository.sweep({ createdBefore: new Date(0) }).catch((error) => error)
+    expect(await readFile(join(outside, filename), 'utf8')).toBe('outside user bytes')
+    expect(result).toBeInstanceOf(Error)
+    expect(await readFile(join(`${directory}-held`, filename), 'utf8')).toBe('owned')
   })
 
   it('refuses a replaced publication directory before unlinking a same-named file', async () => {

--- a/src/main/storage/content-repository.test.ts
+++ b/src/main/storage/content-repository.test.ts
@@ -1,5 +1,17 @@
 import { createHash } from 'node:crypto'
-import { mkdir, mkdtemp, readFile, rm, writeFile, stat, rename } from 'node:fs/promises'
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+  stat,
+  rename,
+  copyFile,
+  readdir,
+  symlink,
+  lstat
+} from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 
@@ -14,7 +26,13 @@ import { ContentRepository, resolveContentStorageKey } from './content-repositor
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs/promises')>()
-  return { ...original, rm: vi.fn(original.rm), stat: vi.fn(original.stat) }
+  return {
+    ...original,
+    rm: vi.fn(original.rm),
+    stat: vi.fn(original.stat),
+    copyFile: vi.fn(original.copyFile),
+    lstat: vi.fn(original.lstat)
+  }
 })
 
 const sha256 = (content: Buffer): string => createHash('sha256').update(content).digest('hex')
@@ -33,6 +51,9 @@ describe('content repository', () => {
     vi.mocked(rm).mockImplementation(
       (await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')).rm
     )
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    vi.mocked(copyFile).mockReset().mockImplementation(fs.copyFile)
+    vi.mocked(lstat).mockReset().mockImplementation(fs.lstat)
     await client?.$disconnect()
     if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   })
@@ -760,6 +781,146 @@ describe('content repository', () => {
       ).resolves.toBe('kept')
     }
   )
+
+  it.each(['staging', 'available', 'missing'] as const)(
+    'recovers abandoned publication files with %s authority and preserves the published file',
+    async (state) => {
+      const repository = await createRepository()
+      const bytes = Buffer.from('interrupted publication')
+      const checksum = sha256(bytes)
+      const storageKey = `content/blobs/${checksum.slice(0, 2)}/${checksum}`
+      const destination = join(storageRoot!, storageKey)
+      const temporary = `${destination}.01234567-89ab-4def-8123-456789abcdef.tmp`
+      await mkdir(dirname(destination), { recursive: true })
+      await writeFile(destination, bytes)
+      await writeFile(temporary, bytes.subarray(0, 4))
+      await writeFile(`${destination}.unknown.tmp`, bytes)
+      if (state !== 'missing')
+        await client!.contentBlob.create({
+          data: {
+            id: `sha256:${checksum}:${bytes.length}`,
+            checksum,
+            storageKey,
+            sizeBytes: BigInt(bytes.length),
+            state
+          }
+        })
+      // A targeted deletion owns no unrelated temporary files, even if their row is absent.
+      await repository.sweep({ contentIds: ['unrelated'], createdBefore: new Date(0) })
+      expect(await readFile(temporary)).toEqual(bytes.subarray(0, 4))
+      // No row is old enough to be deleted; temporary recovery is independently discoverable.
+      await repository.sweep({ createdBefore: new Date(0) })
+      await expect(readFile(temporary)).rejects.toMatchObject({ code: 'ENOENT' })
+      expect(await readFile(destination)).toEqual(bytes)
+      expect(await readFile(`${destination}.unknown.tmp`)).toEqual(bytes)
+      await repository.sweep({ createdBefore: new Date(0) })
+    }
+  )
+
+  it('preserves a currently copying publication across repository instances', async () => {
+    const repository = await createRepository()
+    const sourcePath = join(storageRoot!, 'source.pdf')
+    await writeFile(sourcePath, 'active publication')
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let release!: () => void
+    const held = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    let copied!: () => void
+    const ready = new Promise<void>((resolve) => {
+      copied = resolve
+    })
+    let temporary = ''
+    vi.mocked(copyFile).mockImplementationOnce(async (source, destination) => {
+      await fs.copyFile(source, destination)
+      temporary = String(destination)
+      copied()
+      await held
+    })
+    const publication = repository.publish({ sourcePath })
+    try {
+      await ready
+      const sweeper = new ContentRepository({
+        storageRoot: storageRoot!,
+        getClient: async () => client!
+      })
+      await sweeper.sweep({ createdBefore: new Date(0) })
+      expect(await readFile(temporary, 'utf8')).toBe('active publication')
+    } finally {
+      release()
+    }
+    const content = await publication
+    expect(await repository.verify(content.id)).toMatchObject({ state: 'available' })
+  })
+
+  it('retains interrupted publication authority when unlink fails and recovers on retry', async () => {
+    const repository = await createRepository()
+    const bytes = Buffer.from('retry publication')
+    const checksum = sha256(bytes)
+    const id = `sha256:${checksum}:${bytes.length}`
+    const storageKey = `content/blobs/${checksum.slice(0, 2)}/${checksum}`
+    const temporary = join(storageRoot!, `${storageKey}.01234567-89ab-4def-8123-456789abcdef.tmp`)
+    await mkdir(dirname(temporary), { recursive: true })
+    await writeFile(temporary, bytes)
+    await client!.contentBlob.create({
+      data: {
+        id,
+        storageKey,
+        checksum,
+        sizeBytes: BigInt(bytes.length),
+        state: 'staging',
+        createdAt: new Date(1)
+      }
+    })
+    vi.mocked(rm).mockRejectedValueOnce(Object.assign(new Error('denied'), { code: 'EACCES' }))
+    await expect(repository.sweep({ createdBefore: new Date() })).rejects.toMatchObject({
+      code: 'EACCES'
+    })
+    expect(await client!.contentBlob.findUnique({ where: { id } })).not.toBeNull()
+    expect(await readFile(temporary)).toEqual(bytes)
+    expect((await repository.sweep({ createdBefore: new Date() })).removedIds).toEqual([id])
+    await expect(readFile(temporary)).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('does not traverse a symlinked publication prefix', async () => {
+    const repository = await createRepository()
+    const outside = join(storageRoot!, 'unowned')
+    const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+    await mkdir(outside)
+    await writeFile(join(outside, filename), 'keep')
+    const blobs = join(storageRoot!, 'content', 'blobs')
+    await mkdir(blobs, { recursive: true })
+    await symlink(outside, join(blobs, 'aa'), process.platform === 'win32' ? 'junction' : 'dir')
+    await repository.sweep({ createdBefore: new Date() })
+    expect(await readFile(join(outside, filename), 'utf8')).toBe('keep')
+  })
+
+  it('refuses a replaced publication directory before unlinking a same-named file', async () => {
+    const repository = await createRepository()
+    const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+    const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+    const temporary = join(directory, filename)
+    await mkdir(directory, { recursive: true })
+    await writeFile(temporary, 'old')
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let replaced = false
+    vi.mocked(lstat).mockImplementation((...args) => {
+      if (String(args[0]) !== temporary || replaced) return fs.lstat(...args)
+      replaced = true
+      return (async () => {
+        const original = await fs.lstat(temporary)
+        await rename(directory, `${directory}-retained`)
+        await mkdir(directory)
+        await writeFile(temporary, 'new user data')
+        return original
+      })() as ReturnType<typeof lstat>
+    })
+    await expect(repository.sweep({ createdBefore: new Date() })).rejects.toThrow(
+      'directory changed'
+    )
+    expect(await readFile(temporary, 'utf8')).toBe('new user data')
+    expect(await readdir(`${directory}-retained`)).toEqual([filename])
+  })
 
   it('rejects traversal and platform-specific absolute storage keys', () => {
     expect(() => resolveContentStorageKey('/data', '../outside')).toThrow(/invalid/i)

--- a/src/main/storage/content-repository.test.ts
+++ b/src/main/storage/content-repository.test.ts
@@ -912,6 +912,193 @@ describe('content repository', () => {
     expect(await readFile(join(outside, filename), 'utf8')).toBe('keep')
   })
 
+  it
+    .skipIf(process.platform === 'win32')
+    .each(['before receipt', 'before move', 'after move', 'after unlink'])(
+    'recovers an interrupted publication quarantine %s',
+    async (boundary) => {
+      const repository = await createRepository()
+      const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+      const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+      const temporary = join(directory, filename)
+      await mkdir(directory, { recursive: true })
+      await writeFile(temporary, 'interrupted publication')
+      const parent = await lstat(directory, { bigint: true })
+      const file = await lstat(temporary, { bigint: true })
+      const quarantine = join(
+        directory,
+        '.publication-recovery-01234567-89ab-4def-8123-456789abcdef'
+      )
+      await mkdir(quarantine, { mode: 0o700 })
+      if (boundary !== 'before receipt')
+        await writeFile(
+          join(quarantine, 'receipt'),
+          [
+            'publication-removal-v1',
+            filename,
+            parent.dev,
+            parent.ino,
+            file.dev,
+            file.ino,
+            file.size,
+            file.mtimeNs,
+            ''
+          ].join('\n'),
+          { mode: 0o600 }
+        )
+      if (boundary === 'after move' || boundary === 'after unlink')
+        await rename(temporary, join(quarantine, 'payload'))
+      if (boundary === 'after unlink') await rm(join(quarantine, 'payload'))
+      await repository.sweep({ createdBefore: new Date(0) })
+      await expect(lstat(quarantine)).rejects.toMatchObject({ code: 'ENOENT' })
+      await expect(readFile(temporary)).rejects.toMatchObject({ code: 'ENOENT' })
+      expect(await readdir(directory)).toEqual([])
+    }
+  )
+
+  it
+    .skipIf(process.platform === 'win32')
+    .each(['reused source', 'captured replacement', 'modified payload'])(
+    'retains conflicting quarantine bytes across repeated sweeps: %s',
+    async (conflict) => {
+      const repository = await createRepository()
+      const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+      const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+      const temporary = join(directory, filename)
+      await mkdir(directory, { recursive: true })
+      await writeFile(temporary, 'original')
+      const parent = await lstat(directory, { bigint: true })
+      const file = await lstat(temporary, { bigint: true })
+      const quarantine = join(
+        directory,
+        '.publication-recovery-01234567-89ab-4def-8123-456789abcdef'
+      )
+      await mkdir(quarantine, { mode: 0o700 })
+      await writeFile(
+        join(quarantine, 'receipt'),
+        [
+          'publication-removal-v1',
+          filename,
+          parent.dev,
+          parent.ino,
+          file.dev,
+          file.ino,
+          file.size,
+          file.mtimeNs,
+          ''
+        ].join('\n'),
+        { mode: 0o600 }
+      )
+      await rename(temporary, join(quarantine, 'payload'))
+      if (conflict === 'reused source') {
+        await writeFile(temporary, 'replacement user bytes')
+      } else {
+        if (conflict === 'captured replacement')
+          await rename(join(quarantine, 'payload'), `${temporary}-held`)
+        await writeFile(join(quarantine, 'payload'), 'replacement user bytes')
+      }
+      for (let attempt = 0; attempt < 2; attempt++) {
+        const result = await repository
+          .sweep({ createdBefore: new Date(0) })
+          .catch((error) => error)
+        expect(await readFile(temporary, 'utf8')).toBe('replacement user bytes')
+        if (conflict === 'reused source')
+          expect(await readFile(join(quarantine, 'payload'), 'utf8')).toBe('original')
+        else
+          await expect(lstat(join(quarantine, 'payload'))).rejects.toMatchObject({ code: 'ENOENT' })
+        if (conflict === 'captured replacement')
+          expect(await readFile(`${temporary}-held`, 'utf8')).toBe('original')
+        expect(result).toBeInstanceOf(Error)
+      }
+    }
+  )
+
+  it('rejects a receipt that names published content instead of a publication temporary', async () => {
+    const repository = await createRepository()
+    const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+    const filename = 'a'.repeat(64)
+    const quarantine = join(directory, '.publication-recovery-01234567-89ab-4def-8123-456789abcdef')
+    await mkdir(quarantine, { recursive: true, mode: 0o700 })
+    await writeFile(join(directory, filename), 'published bytes')
+    const parent = await lstat(directory, { bigint: true })
+    const file = await lstat(join(directory, filename), { bigint: true })
+    await writeFile(
+      join(quarantine, 'receipt'),
+      [
+        'publication-removal-v1',
+        filename,
+        parent.dev,
+        parent.ino,
+        file.dev,
+        file.ino,
+        file.size,
+        file.mtimeNs,
+        ''
+      ].join('\n'),
+      { mode: 0o600 }
+    )
+    const result = await repository.sweep({ createdBefore: new Date(0) }).catch((error) => error)
+    expect(await readFile(join(directory, filename), 'utf8')).toBe('published bytes')
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it('retains files when a quarantine receipt is malformed or belongs to another platform', async () => {
+    const repository = await createRepository()
+    const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+    const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+    const quarantine = join(directory, '.publication-recovery-01234567-89ab-4def-8123-456789abcdef')
+    await mkdir(quarantine, { recursive: true, mode: 0o700 })
+    await writeFile(join(quarantine, 'receipt'), 'incomplete receipt')
+    await writeFile(join(directory, filename), 'keep')
+    const result = await repository.sweep({ createdBefore: new Date(0) }).catch((error) => error)
+    expect(await readFile(join(directory, filename), 'utf8')).toBe('keep')
+    expect(await readFile(join(quarantine, 'receipt'), 'utf8')).toBe('incomplete receipt')
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it('refuses to follow a linked publication quarantine', async () => {
+    const repository = await createRepository()
+    const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+    const outside = join(storageRoot!, 'outside')
+    const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+    await mkdir(directory, { recursive: true })
+    await mkdir(outside, { mode: 0o700 })
+    await writeFile(join(outside, 'payload'), 'keep outside')
+    await writeFile(join(directory, filename), 'keep source')
+    await symlink(
+      outside,
+      join(directory, '.publication-recovery-01234567-89ab-4def-8123-456789abcdef'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    const result = await repository.sweep({ createdBefore: new Date(0) }).catch((error) => error)
+    expect(await readFile(join(outside, 'payload'), 'utf8')).toBe('keep outside')
+    expect(await readFile(join(directory, filename), 'utf8')).toBe('keep source')
+    expect(result).toBeInstanceOf(Error)
+  })
+
+  it('preserves a replacement file installed after the final publication check', async () => {
+    const repository = await createRepository()
+    const directory = join(storageRoot!, 'content', 'blobs', 'aa')
+    const filename = `${'a'.repeat(64)}.01234567-89ab-4def-8123-456789abcdef.tmp`
+    const temporary = join(directory, filename)
+    await mkdir(directory, { recursive: true })
+    await writeFile(temporary, 'interrupted publication')
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let checks = 0
+    vi.mocked(lstat).mockImplementation((...args) => {
+      if (String(args[0]) !== temporary || ++checks !== 2) return fs.lstat(...args)
+      return (async () => {
+        const current = await fs.lstat(...args)
+        await rename(temporary, `${temporary}-held`)
+        await writeFile(temporary, 'replacement user bytes')
+        return current
+      })() as ReturnType<typeof lstat>
+    })
+    const result = await repository.sweep({ createdBefore: new Date(0) }).catch((error) => error)
+    expect(await readFile(temporary, 'utf8')).toBe('replacement user bytes')
+    expect(result).toBeInstanceOf(Error)
+  })
+
   it('preserves outside bytes when a publication parent is swapped after the final path check', async () => {
     const repository = await createRepository()
     const directory = join(storageRoot!, 'content', 'blobs', 'aa')
@@ -927,7 +1114,7 @@ describe('content repository', () => {
     vi.mocked(lstat).mockImplementation((...args) => {
       if (String(args[0]) !== temporary || ++checks !== 2) return fs.lstat(...args)
       return (async () => {
-        const current = await fs.lstat(temporary)
+        const current = await fs.lstat(...args)
         await rename(directory, `${directory}-held`)
         await symlink(outside, directory, process.platform === 'win32' ? 'junction' : 'dir')
         return current
@@ -952,7 +1139,7 @@ describe('content repository', () => {
       if (String(args[0]) !== temporary || replaced) return fs.lstat(...args)
       replaced = true
       return (async () => {
-        const original = await fs.lstat(temporary)
+        const original = await fs.lstat(...args)
         await rename(directory, `${directory}-retained`)
         await mkdir(directory)
         await writeFile(temporary, 'new user data')

--- a/src/main/storage/content-repository.ts
+++ b/src/main/storage/content-repository.ts
@@ -1,7 +1,9 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { createReadStream } from 'node:fs'
+import { type BigIntStats, createReadStream } from 'node:fs'
 import { copyFile, link, lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
+
+import { removeAnchoredFile } from '../uploads/atomic-no-replace-publisher'
 
 import type { PrismaClient } from '@prisma/client'
 import { NodeVersionFileOperator } from '../managed-file-versions/version-file-operator'
@@ -545,9 +547,9 @@ class ContentRepository {
   private async sweepPublicationFiles(): Promise<void> {
     const root = resolve(this.options.storageRoot)
     const directories = [root, join(root, 'content'), join(root, 'content', 'blobs')]
-    const snapshots: Awaited<ReturnType<typeof lstat>>[] = []
+    const snapshots: BigIntStats[] = []
     for (const directory of directories) {
-      const snapshot = await lstat(directory).catch((error: unknown) => {
+      const snapshot = await lstat(directory, { bigint: true }).catch((error: unknown) => {
         if (missingFile(error)) return undefined
         throw error
       })
@@ -561,7 +563,7 @@ class ContentRepository {
     for (const prefix of await readdir(blobsRoot)) {
       if (!/^[a-f0-9]{2}$/.test(prefix)) continue
       const directory = join(blobsRoot, prefix)
-      const snapshot = await lstat(directory)
+      const snapshot = await lstat(directory, { bigint: true })
       if (!snapshot.isDirectory() || snapshot.isSymbolicLink()) continue
       for (const filename of await readdir(directory)) {
         const match = publicationFilename.exec(filename)
@@ -574,7 +576,7 @@ class ContentRepository {
           // remove a same-named file, and never recursively remove an unexpected directory.
           for (const [index, path] of [...directories, directory].entries()) {
             const expected = [...snapshots, snapshot][index]
-            const current = await lstat(path)
+            const current = await lstat(path, { bigint: true })
             if (
               !current.isDirectory() ||
               current.isSymbolicLink() ||
@@ -592,7 +594,9 @@ class ContentRepository {
             fileFingerprint(current) !== fileFingerprint(file)
           )
             continue
-          if (!activePublicationFiles.has(filename)) await rm(temporary, { force: true })
+          if (!activePublicationFiles.has(filename)) {
+            removeAnchoredFile(root, relative(root, directory), filename, snapshot)
+          }
         } catch (error) {
           // Another sweep or publisher can have removed this exact temporary file already.
           if (!missingFile(error)) throw error

--- a/src/main/storage/content-repository.ts
+++ b/src/main/storage/content-repository.ts
@@ -1,7 +1,7 @@
 import { createHash, randomUUID } from 'node:crypto'
 import { createReadStream } from 'node:fs'
-import { copyFile, link, mkdir, rename, rm, stat } from 'node:fs/promises'
-import { dirname, isAbsolute, relative, resolve, sep } from 'node:path'
+import { copyFile, link, lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
+import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
 import type { PrismaClient } from '@prisma/client'
 import { NodeVersionFileOperator } from '../managed-file-versions/version-file-operator'
@@ -106,6 +106,11 @@ const contentLifecycles = new Map<string, Promise<void>>()
 // Reservations bridge publication and reference insertion without holding a database transaction.
 // All content publishers and sweepers in the application process share these counts.
 const pendingContentReferences = new Map<string, number>()
+// UUID filenames identify attempts independently of partially copied lengths and root aliases.
+// All application publishers share this set, just as they share content lifecycle reservations.
+const activePublicationFiles = new Set<string>()
+const publicationFilename =
+  /^([a-f0-9]{64})\.[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}\.tmp$/
 const contentLifecycleKey = (storageRoot: string, contentId: string): string =>
   JSON.stringify([resolve(storageRoot), contentId])
 
@@ -210,6 +215,7 @@ class ContentRepository {
         const destination = resolveContentStorageKey(this.options.storageRoot, storageKey)
         await mkdir(dirname(destination), { recursive: true })
         const temporary = `${destination}.${randomUUID()}.tmp`
+        activePublicationFiles.add(basename(temporary))
         try {
           await copyFile(request.sourcePath, temporary)
           const copied = await stat(temporary)
@@ -226,7 +232,11 @@ class ContentRepository {
             }
           })
         } finally {
-          await rm(temporary, { force: true })
+          try {
+            await rm(temporary, { force: true })
+          } finally {
+            activePublicationFiles.delete(basename(temporary))
+          }
         }
 
         const destinationFile = await stat(destination)
@@ -475,6 +485,10 @@ class ContentRepository {
     if (request.contentIds?.length === 0) {
       return { removedIds: [], retainedIds: [], failedIds: [] }
     }
+    // Only a whole-repository sweep owns historical attempts without a database row. A targeted
+    // cleanup must not touch another owner's publication files. Scan first so unlink failures do
+    // not discard staging authority; files without rows remain discoverable on the next sweep.
+    if (!request.contentIds) await this.sweepPublicationFiles()
     const candidateWhere = {
       createdAt: { lt: request.createdBefore },
       ...(request.contentIds ? { id: { in: [...new Set(request.contentIds)] } } : {})
@@ -526,6 +540,65 @@ class ContentRepository {
       }
     }
     return receipt
+  }
+
+  private async sweepPublicationFiles(): Promise<void> {
+    const root = resolve(this.options.storageRoot)
+    const directories = [root, join(root, 'content'), join(root, 'content', 'blobs')]
+    const snapshots: Awaited<ReturnType<typeof lstat>>[] = []
+    for (const directory of directories) {
+      const snapshot = await lstat(directory).catch((error: unknown) => {
+        if (missingFile(error)) return undefined
+        throw error
+      })
+      if (!snapshot) return
+      if (!snapshot.isDirectory() || snapshot.isSymbolicLink()) {
+        throw new Error('Unsafe content publication directory.')
+      }
+      snapshots.push(snapshot)
+    }
+    const blobsRoot = directories[2]
+    for (const prefix of await readdir(blobsRoot)) {
+      if (!/^[a-f0-9]{2}$/.test(prefix)) continue
+      const directory = join(blobsRoot, prefix)
+      const snapshot = await lstat(directory)
+      if (!snapshot.isDirectory() || snapshot.isSymbolicLink()) continue
+      for (const filename of await readdir(directory)) {
+        const match = publicationFilename.exec(filename)
+        if (!match || !match[1].startsWith(prefix) || activePublicationFiles.has(filename)) continue
+        const temporary = join(directory, filename)
+        try {
+          const file = await lstat(temporary)
+          if (!file.isFile() || file.isSymbolicLink()) continue
+          // A replaced directory invalidates the enumeration. Never follow its replacement to
+          // remove a same-named file, and never recursively remove an unexpected directory.
+          for (const [index, path] of [...directories, directory].entries()) {
+            const expected = [...snapshots, snapshot][index]
+            const current = await lstat(path)
+            if (
+              !current.isDirectory() ||
+              current.isSymbolicLink() ||
+              current.dev !== expected.dev ||
+              current.ino !== expected.ino ||
+              current.birthtimeMs !== expected.birthtimeMs
+            ) {
+              throw new Error('Content publication directory changed during recovery.')
+            }
+          }
+          const current = await lstat(temporary)
+          if (
+            !current.isFile() ||
+            current.isSymbolicLink() ||
+            fileFingerprint(current) !== fileFingerprint(file)
+          )
+            continue
+          if (!activePublicationFiles.has(filename)) await rm(temporary, { force: true })
+        } catch (error) {
+          // Another sweep or publisher can have removed this exact temporary file already.
+          if (!missingFile(error)) throw error
+        }
+      }
+    }
   }
 
   // Caller holds the content lifecycle lock through claim, unlink and authority removal.

--- a/src/main/storage/content-repository.ts
+++ b/src/main/storage/content-repository.ts
@@ -3,7 +3,7 @@ import { type BigIntStats, createReadStream } from 'node:fs'
 import { copyFile, link, lstat, mkdir, readdir, rename, rm, stat } from 'node:fs/promises'
 import { basename, dirname, isAbsolute, join, relative, resolve, sep } from 'node:path'
 
-import { removeAnchoredFile } from '../uploads/atomic-no-replace-publisher'
+import { recoverAnchoredRemoval, removeAnchoredFile } from '../uploads/atomic-no-replace-publisher'
 
 import type { PrismaClient } from '@prisma/client'
 import { NodeVersionFileOperator } from '../managed-file-versions/version-file-operator'
@@ -99,7 +99,7 @@ const pathAlreadyExists = (error: unknown): boolean =>
   'code' in error &&
   (error as { code?: unknown }).code === 'EEXIST'
 
-const fileFingerprint = (file: Awaited<ReturnType<typeof stat>>): string =>
+const fileFingerprint = (file: Awaited<ReturnType<typeof stat>> | BigIntStats): string =>
   [file.dev, file.ino, file.size, file.mtimeMs, file.ctimeMs].join(':')
 
 // Different repositories share the same immutable files. Keep a sweep's claim and unlink
@@ -565,12 +565,28 @@ class ContentRepository {
       const directory = join(blobsRoot, prefix)
       const snapshot = await lstat(directory, { bigint: true })
       if (!snapshot.isDirectory() || snapshot.isSymbolicLink()) continue
-      for (const filename of await readdir(directory)) {
+      const entries = await readdir(directory)
+      // Recover receipts before admitting source names: a conflict receipt protects a replaced
+      // source from being mistaken for a fresh orphan on every later sweep.
+      for (const entry of entries) {
+        if (
+          !/^\.publication-recovery-[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89ab][a-f0-9]{3}-[a-f0-9]{12}$/.test(
+            entry
+          )
+        )
+          continue
+        try {
+          recoverAnchoredRemoval(root, relative(root, directory), entry, snapshot)
+        } catch (error) {
+          if (!missingFile(error)) throw error
+        }
+      }
+      for (const filename of entries) {
         const match = publicationFilename.exec(filename)
         if (!match || !match[1].startsWith(prefix) || activePublicationFiles.has(filename)) continue
         const temporary = join(directory, filename)
         try {
-          const file = await lstat(temporary)
+          const file = await lstat(temporary, { bigint: true })
           if (!file.isFile() || file.isSymbolicLink()) continue
           // A replaced directory invalidates the enumeration. Never follow its replacement to
           // remove a same-named file, and never recursively remove an unexpected directory.
@@ -587,7 +603,7 @@ class ContentRepository {
               throw new Error('Content publication directory changed during recovery.')
             }
           }
-          const current = await lstat(temporary)
+          const current = await lstat(temporary, { bigint: true })
           if (
             !current.isFile() ||
             current.isSymbolicLink() ||
@@ -595,7 +611,7 @@ class ContentRepository {
           )
             continue
           if (!activePublicationFiles.has(filename)) {
-            removeAnchoredFile(root, relative(root, directory), filename, snapshot)
+            removeAnchoredFile(root, relative(root, directory), filename, snapshot, file)
           }
         } catch (error) {
           // Another sweep or publisher can have removed this exact temporary file already.

--- a/src/main/uploads/atomic-no-replace-publisher.test.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.test.ts
@@ -79,15 +79,16 @@ describe.skipIf(!nativeBindingAvailable)('anchored publication removal', () => {
     const identity = await lstat(parent, { bigint: true })
     await writeFile(join(parent, 'attempt.tmp'), 'interrupted')
     await writeFile(join(parent, 'published'), 'keep')
-    removeAnchoredFile(cleanupRoot, 'content', 'attempt.tmp', identity)
+    const file = await lstat(join(parent, 'attempt.tmp'), { bigint: true })
+    removeAnchoredFile(cleanupRoot, 'content', 'attempt.tmp', identity, file)
     await expect(readFile(join(parent, 'attempt.tmp'))).rejects.toMatchObject({ code: 'ENOENT' })
     expect(await readFile(join(parent, 'published'), 'utf8')).toBe('keep')
     await rename(parent, `${parent}-held`)
     await mkdir(parent)
     await writeFile(join(parent, 'attempt.tmp'), 'replacement')
-    expect(() => removeAnchoredFile(cleanupRoot!, 'content', 'attempt.tmp', identity)).toThrow(
-      expect.objectContaining({ code: 'ESTALE' })
-    )
+    expect(() =>
+      removeAnchoredFile(cleanupRoot!, 'content', 'attempt.tmp', identity, file)
+    ).toThrow(expect.objectContaining({ code: 'ESTALE' }))
     expect(await readFile(join(parent, 'attempt.tmp'), 'utf8')).toBe('replacement')
   })
 
@@ -104,7 +105,7 @@ describe.skipIf(!nativeBindingAvailable)('anchored publication removal', () => {
       await rename(target, `${target}-held`)
       await symlink(`${target}-held`, target, process.platform === 'win32' ? 'junction' : 'dir')
       expect(() =>
-        removeAnchoredFile(root, join('content', 'blobs'), 'attempt.tmp', identity)
+        removeAnchoredFile(root, join('content', 'blobs'), 'attempt.tmp', identity, identity)
       ).toThrow()
       expect(await readFile(join(parent, 'attempt.tmp'), 'utf8')).toBe('keep')
     }
@@ -115,9 +116,9 @@ describe.skipIf(!nativeBindingAvailable)('anchored publication removal', () => {
     const identity = await lstat(cleanupRoot, { bigint: true })
     await mkdir(join(cleanupRoot, 'nested'))
     await writeFile(join(cleanupRoot, 'nested', 'keep'), 'keep')
-    expect(() => removeAnchoredFile(cleanupRoot!, '..', 'anything', identity)).toThrow()
-    expect(() => removeAnchoredFile(cleanupRoot!, '', '../anything', identity)).toThrow()
-    expect(() => removeAnchoredFile(cleanupRoot!, '', 'nested', identity)).toThrow()
+    expect(() => removeAnchoredFile(cleanupRoot!, '..', 'anything', identity, identity)).toThrow()
+    expect(() => removeAnchoredFile(cleanupRoot!, '', '../anything', identity, identity)).toThrow()
+    expect(() => removeAnchoredFile(cleanupRoot!, '', 'nested', identity, identity)).toThrow()
     expect(await readFile(join(cleanupRoot, 'nested', 'keep'), 'utf8')).toBe('keep')
   })
 })

--- a/src/main/uploads/atomic-no-replace-publisher.test.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.test.ts
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { createRequire } from 'node:module'
 import { mkdir, mkdtemp, readFile, rm, symlink, writeFile, lstat, rename } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -122,3 +123,103 @@ describe.skipIf(!nativeBindingAvailable)('anchored publication removal', () => {
     expect(await readFile(join(cleanupRoot, 'nested', 'keep'), 'utf8')).toBe('keep')
   })
 })
+
+// Exercise the real addon in a child with only renameat2 denied. No production test hook is needed.
+describe.skipIf(process.platform !== 'linux' || !nativeBindingAvailable)(
+  'publication removal without renameat2',
+  () => {
+    it.each(['ENOSYS', 'EOPNOTSUPP', 'EINVAL'])(
+      'removes and recovers interrupted files when renameat2 returns %s',
+      async (errorCode) => {
+        cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-removal-fallback-'))
+        const launcherSource = join(cleanupRoot, 'restrict-rename.c')
+        const launcher = join(cleanupRoot, 'restrict-rename')
+        await writeFile(
+          launcherSource,
+          `
+#include <errno.h>
+#include <stddef.h>
+#include <linux/filter.h>
+#include <linux/seccomp.h>
+#include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+  struct sock_filter filter[] = {
+    BPF_STMT(BPF_LD | BPF_W | BPF_ABS, offsetof(struct seccomp_data, nr)),
+    BPF_JUMP(BPF_JMP | BPF_JEQ | BPF_K, SYS_renameat2, 0, 1),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ERRNO | ${errorCode}),
+    BPF_STMT(BPF_RET | BPF_K, SECCOMP_RET_ALLOW)
+  };
+  struct sock_fprog program = { sizeof(filter) / sizeof(filter[0]), filter };
+  if (argc < 2 || prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) ||
+      prctl(PR_SET_SECCOMP, SECCOMP_MODE_FILTER, &program)) return 125;
+  execvp(argv[1], &argv[1]);
+  return 126;
+}
+`
+        )
+        execFileSync('cc', [launcherSource, '-o', launcher])
+        const exercise = `
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const binding = require(process.argv[1]);
+const root = process.argv[2];
+const relative = 'content/blobs/aa';
+const parentPath = path.join(root, relative);
+fs.mkdirSync(parentPath, { recursive: true });
+const name = 'a'.repeat(64) + '.01234567-89ab-4def-8123-456789abcdef.tmp';
+const source = path.join(parentPath, name);
+const quarantineName = '.publication-recovery-01234567-89ab-4def-8123-456789abcdef';
+const quarantine = path.join(parentPath, quarantineName);
+const parent = fs.lstatSync(parentPath, { bigint: true });
+fs.writeFileSync(source, 'interrupted');
+let file = fs.lstatSync(source, { bigint: true });
+binding.removeAnchoredFile(root, relative, name, parent.dev, parent.ino,
+  file.dev, file.ino, file.size, file.mtimeNs, quarantineName);
+assert.deepEqual(fs.readdirSync(parentPath), []);
+// Recover both an old receipt awaiting capture and a captured replacement.
+for (const replaced of [false, true]) {
+  fs.writeFileSync(source, 'original');
+  file = fs.lstatSync(source, { bigint: true });
+  fs.mkdirSync(quarantine, { mode: 0o700 });
+  fs.writeFileSync(path.join(quarantine, 'receipt'), [
+    'publication-removal-v1', name, parent.dev, parent.ino,
+    file.dev, file.ino, file.size, file.mtimeNs, ''
+  ].join('\\n'), { mode: 0o600 });
+  if (replaced) {
+    fs.renameSync(source, source + '-held');
+    fs.writeFileSync(path.join(quarantine, 'payload'), 'replacement');
+  }
+  const recover = () => binding.recoverAnchoredRemoval(root, relative, quarantineName,
+    parent.dev, parent.ino);
+  if (replaced) {
+    for (let attempt = 0; attempt < 2; attempt++) {
+      assert.throws(recover, { code: 'ESTALE' });
+      assert.equal(fs.readFileSync(source, 'utf8'), 'replacement');
+      assert.equal(fs.readFileSync(source + '-held', 'utf8'), 'original');
+      assert.equal(fs.existsSync(path.join(quarantine, 'payload')), false);
+      assert.equal(fs.existsSync(path.join(quarantine, 'receipt')), true);
+    }
+  } else {
+    recover();
+    assert.deepEqual(fs.readdirSync(parentPath), []);
+  }
+}
+`
+        execFileSync(
+          launcher,
+          [
+            process.execPath,
+            '-e',
+            exercise,
+            require.resolve('@aipoch/safe-file-publisher-native'),
+            cleanupRoot
+          ],
+          { encoding: 'utf8' }
+        )
+      }
+    )
+  }
+)

--- a/src/main/uploads/atomic-no-replace-publisher.test.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.test.ts
@@ -1,10 +1,10 @@
 import { createRequire } from 'node:module'
-import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile, lstat, rename } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { publishNoReplace } from './atomic-no-replace-publisher'
+import { publishNoReplace, removeAnchoredFile } from './atomic-no-replace-publisher'
 
 const require = createRequire(import.meta.url)
 const nativeBindingAvailable = (() => {
@@ -67,5 +67,57 @@ describe.skipIf(!nativeBindingAvailable)('atomic no-replace publisher', () => {
     await expect(readFile(join(outsideParent, 'content'))).rejects.toMatchObject({
       code: 'ENOENT'
     })
+  })
+})
+
+// These exercise the real native mutation boundary on each portable CI platform.
+describe('anchored publication removal', () => {
+  it('removes only the named file and rejects a changed parent identity', async () => {
+    cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-removal-'))
+    const parent = join(cleanupRoot, 'content')
+    await mkdir(parent)
+    const identity = await lstat(parent, { bigint: true })
+    await writeFile(join(parent, 'attempt.tmp'), 'interrupted')
+    await writeFile(join(parent, 'published'), 'keep')
+    removeAnchoredFile(cleanupRoot, 'content', 'attempt.tmp', identity)
+    await expect(readFile(join(parent, 'attempt.tmp'))).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readFile(join(parent, 'published'), 'utf8')).toBe('keep')
+    await rename(parent, `${parent}-held`)
+    await mkdir(parent)
+    await writeFile(join(parent, 'attempt.tmp'), 'replacement')
+    expect(() => removeAnchoredFile(cleanupRoot!, 'content', 'attempt.tmp', identity)).toThrow(
+      expect.objectContaining({ code: 'ESTALE' })
+    )
+    expect(await readFile(join(parent, 'attempt.tmp'), 'utf8')).toBe('replacement')
+  })
+
+  it.each(['root', 'ancestor', 'parent'] as const)(
+    'refuses a linked %s directory',
+    async (level) => {
+      cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-removal-'))
+      const root = join(cleanupRoot, 'root')
+      const parent = join(root, 'content', 'blobs')
+      await mkdir(parent, { recursive: true })
+      await writeFile(join(parent, 'attempt.tmp'), 'keep')
+      const identity = await lstat(parent, { bigint: true })
+      const target = level === 'root' ? root : level === 'ancestor' ? join(root, 'content') : parent
+      await rename(target, `${target}-held`)
+      await symlink(`${target}-held`, target, process.platform === 'win32' ? 'junction' : 'dir')
+      expect(() =>
+        removeAnchoredFile(root, join('content', 'blobs'), 'attempt.tmp', identity)
+      ).toThrow()
+      expect(await readFile(join(parent, 'attempt.tmp'), 'utf8')).toBe('keep')
+    }
+  )
+
+  it('rejects traversal and directory leaves without removing their contents', async () => {
+    cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-removal-'))
+    const identity = await lstat(cleanupRoot, { bigint: true })
+    await mkdir(join(cleanupRoot, 'nested'))
+    await writeFile(join(cleanupRoot, 'nested', 'keep'), 'keep')
+    expect(() => removeAnchoredFile(cleanupRoot!, '..', 'anything', identity)).toThrow()
+    expect(() => removeAnchoredFile(cleanupRoot!, '', '../anything', identity)).toThrow()
+    expect(() => removeAnchoredFile(cleanupRoot!, '', 'nested', identity)).toThrow()
+    expect(await readFile(join(cleanupRoot, 'nested', 'keep'), 'utf8')).toBe('keep')
   })
 })

--- a/src/main/uploads/atomic-no-replace-publisher.test.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.test.ts
@@ -71,7 +71,7 @@ describe.skipIf(!nativeBindingAvailable)('atomic no-replace publisher', () => {
 })
 
 // These exercise the real native mutation boundary on each portable CI platform.
-describe('anchored publication removal', () => {
+describe.skipIf(!nativeBindingAvailable)('anchored publication removal', () => {
   it('removes only the named file and rejects a changed parent identity', async () => {
     cleanupRoot = await mkdtemp(join(tmpdir(), 'safe-file-removal-'))
     const parent = join(cleanupRoot, 'content')

--- a/src/main/uploads/atomic-no-replace-publisher.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.ts
@@ -1,14 +1,7 @@
 import { createRequire } from 'node:module'
 import { isAbsolute, relative, sep } from 'node:path'
 
-type NativePublisherBinding = {
-  publishNoReplace: (
-    rootPath: string,
-    relativeParentPath: string,
-    sourceName: string,
-    destinationName: string
-  ) => void
-}
+type NativePublisherBinding = typeof import('@aipoch/safe-file-publisher-native')
 
 const require = createRequire(import.meta.url)
 let binding: NativePublisherBinding | undefined
@@ -35,4 +28,13 @@ export const publishNoReplace = (
     throw error
   }
   loadBinding().publishNoReplace(rootPath, relativeParentPath, sourceName, destinationName)
+}
+
+export const removeAnchoredFile = (
+  rootPath: string,
+  relativeParentPath: string,
+  filename: string,
+  parent: { dev: bigint; ino: bigint }
+): void => {
+  loadBinding().removeAnchoredFile(rootPath, relativeParentPath, filename, parent.dev, parent.ino)
 }

--- a/src/main/uploads/atomic-no-replace-publisher.ts
+++ b/src/main/uploads/atomic-no-replace-publisher.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+import type { BigIntStats } from 'node:fs'
 import { createRequire } from 'node:module'
 import { isAbsolute, relative, sep } from 'node:path'
 
@@ -34,7 +36,34 @@ export const removeAnchoredFile = (
   rootPath: string,
   relativeParentPath: string,
   filename: string,
+  parent: { dev: bigint; ino: bigint },
+  file: Pick<BigIntStats, 'dev' | 'ino' | 'size' | 'mtimeNs'>
+): void => {
+  loadBinding().removeAnchoredFile(
+    rootPath,
+    relativeParentPath,
+    filename,
+    parent.dev,
+    parent.ino,
+    file.dev,
+    file.ino,
+    file.size,
+    file.mtimeNs,
+    `.publication-recovery-${randomUUID()}`
+  )
+}
+
+export const recoverAnchoredRemoval = (
+  rootPath: string,
+  relativeParentPath: string,
+  quarantineName: string,
   parent: { dev: bigint; ino: bigint }
 ): void => {
-  loadBinding().removeAnchoredFile(rootPath, relativeParentPath, filename, parent.dev, parent.ino)
+  loadBinding().recoverAnchoredRemoval(
+    rootPath,
+    relativeParentPath,
+    quarantineName,
+    parent.dev,
+    parent.ino
+  )
 }

--- a/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
+++ b/src/renderer/src/pages/workspace/PreviewFileSurface.tsx
@@ -1641,7 +1641,6 @@ const PreviewFileSurface = forwardRef<PreviewFileSurfaceHandle, PreviewFileSurfa
                         autoFocus
                         aria-label={t('Edit {{name}} source', { name: resolvedPreviewItem.name })}
                         className="min-h-0 flex-1 resize-none bg-bg-000 p-4 font-mono text-sm leading-6 text-text-000 outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring"
-                        readOnly={saving}
                         value={draft}
                         onChange={(event) => setDraft(event.target.value)}
                       />


### PR DESCRIPTION
## Problem

Interrupted content publication can leave temporary bytes after its staging row is swept. A retained remote cleanup failure can also block an unrelated Session deletion, and a new Project deletion that fails before metadata commit does not wake idle recovery.

## Changes

- Keep Compute deletion plans per owner, preserving parent/child exclusion while allowing unrelated owners to progress. Recover independent owners before reporting aggregate failures.
- Wake existing recovery after a durable foreground deletion fails. Preserve Session projection-before-Project-removal ordering and per-Project retry accounting when independent remote recovery fails.
- Recover recognized publication temporaries during full ContentRepository sweeps, including historical files without database rows. Protect active publishers and existing shared references; targeted sweeps keep their existing scope.
- On POSIX, atomically capture a candidate into a private, locked per-attempt quarantine and verify its identity after capture. Delete only the verified private payload. Recover receipts before scanning source names so conflicts remain protected across retries. Windows verifies identity on the opened file handle and deletes through that same handle.

## Persistence and compatibility

No database columns, tables, migrations, public enum values, UI or interaction changes. Existing deletion intents/job rows remain authority; Compute plans and active publication tracking remain in memory.

The approved persistence addition is limited to POSIX publication recovery: `content/blobs/<prefix>/.publication-recovery-<UUID>/receipt` and an optional `payload`. The versioned receipt records the original temporary basename, parent and file device/inode, size, and modification time in nanoseconds. The receipt and directories are synced before capture; capture, payload deletion and receipt retirement are synced in order. Recovery covers interruption before receipt creation, before capture, after capture and after unlink. On Linux without `RENAME_NOREPLACE`, capture uses `renameat` into the locked, previously empty private destination. Restore creates a non-replacing hard link, syncs the public parent, then unlinks only the private payload. An interrupted restore preserves both aliases behind the existing receipt barrier; no new persisted format is needed.

A reused source name retains both files and the receipt. A captured file with a mismatched identity is restored without overwriting another file, while its receipt remains a conflict barrier. Unknown names, malformed receipts, symlinked directories and references to published content are not deleted. Errors retain evidence and identify the quarantine requiring attention; nothing is recursively erased.

Historical rowless temporaries retain the approved bounded filename/root admission. Receipts are tied to the original filesystem identity: copied/rebound identities fail closed, and POSIX receipts transferred to Windows are retained rather than guessed or migrated. There is no automatic identity-rebinding migration or new recovery UI. The private quarantine follows the existing application single-writer contract; this is not a promise against deliberate same-account rewriting of private receipts or secure media erasure.

## Verification

The public source-replacement regression failed twice before the fix by observing missing replacement bytes. The extended crash-state and conflict cases also failed twice on the earlier implementation; fixed storage/native/integration checks pass 54 tests on macOS; three Linux-only syscall-failure cases are skipped there and exercised separately on real Linux. Recovery fixtures model persisted interruption boundaries; no actual power-loss or process-kill experiment is claimed.

Final local Test Impact Set: the repository-declared `project_lifecycle`, `compute_service` and `upload_repository` plans plus ContentRepository, native publication, user-file publisher, Notebook save, provenance, PDF acquisition/attachment and wiring/manifest consumers. Across 102 selected files: 3446 passed, 9 conditional skips, zero failures. Skips cover five real-SSH opt-in scenarios, a Windows-only SSH helper and the three Linux-only syscall-failure cases.

The Linux compatibility regression runs the real native removal/recovery API in a seccomp-restricted child, forcing ENOSYS, EOPNOTSUPP and EINVAL from renameat2. Each case failed twice before the fix and passed twice afterward on ARM64 Linux with Node 20.19.4, using offline cached containers. It also covers existing receipt recovery and repeated preservation of captured replacement bytes. CI supplies Node 22 platform validation. No production test hook was added.

The native macOS rebuild, Node/sandbox typechecks, global lint and module/consumer suite run after the Linux fallback change. Renderer typechecks, the application build and three no-retry repetitions of the formerly flaky macOS startup/exit scenario passed before this Linux-only follow-up; renderer behavior and the macOS mutation primitive are unchanged. Full local `npm test` was explicitly excluded by the maintainer; PR CI remains the complete/platform validation authority. Native tests retain the existing availability guard, and skips are never treated as platform evidence. Required checks and independent review must pass before merge.
