### PR TITLE
fix(notebook): authorize configured package mirrors

### DIFF
--- a/src/main/notebook/network-sandbox-owner.test.ts
+++ b/src/main/notebook/network-sandbox-owner.test.ts
@@ -196,6 +196,55 @@ describe('NotebookNetworkSandboxOwner', () => {
     wrapped.cleanup()
   })
 
+  it('scopes derived package mirror access to the installer process', async () => {
+    const requestDecision = vi.fn()
+    const owner = new NotebookNetworkSandboxOwner({
+      resourceRoot: '/resources',
+      getSettings: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      persistAlwaysAllow: vi.fn(),
+      requestDecision,
+      platform: 'linux'
+    })
+    const invocation = {
+      executable: '/usr/bin/python',
+      args: ['script.py'],
+      env: { PATH: '/usr/bin' },
+      cwd: '/workspace',
+      commandText: 'python script.py',
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      runtime: 'python' as const,
+      filesystem: {
+        readOnlyRoots: ['/usr/bin'],
+        readWriteRoots: ['/workspace'],
+        deniedReadRoots: [],
+        deniedWriteRoots: []
+      }
+    }
+
+    const installer = await owner.wrap({
+      ...invocation,
+      allowedNetworkHosts: ['packages.example.org']
+    })
+    const installerRequest = backend.request!
+    const notebook = await owner.wrap(invocation)
+    const notebookRequest = backend.request!
+
+    const endInstaller = installer.beginExecution?.()
+    await expect(installerRequest({ host: 'packages.example.org', port: 443 })).resolves.toBe(true)
+    await expect(installerRequest({ host: 'redirect.example.org', port: 443 })).resolves.toBe(false)
+    endInstaller?.()
+    const endNotebook = notebook.beginExecution?.()
+    await expect(notebookRequest({ host: 'packages.example.org', port: 443 })).resolves.toBe(false)
+    endNotebook?.()
+    expect(requestDecision).not.toHaveBeenCalled()
+    expect(backend.updatePolicy).not.toHaveBeenCalled()
+
+    installer.cleanup()
+    notebook.cleanup()
+    await owner.dispose()
+  })
+
   it('applies allow-once to every matching connection in the next command only', async () => {
     const requestDecision = vi.fn().mockResolvedValue('allowOnce')
     const persistAlwaysAllow = vi.fn()

--- a/src/main/notebook/network-sandbox-owner.ts
+++ b/src/main/notebook/network-sandbox-owner.ts
@@ -201,6 +201,12 @@ class NotebookNetworkSandboxOwner implements NotebookProcessSandbox {
     }
     let activeExecutionGrants: ReadonlySet<string> = new Set()
     let executionActive = false
+    const allowedNetworkHosts = new Set(
+      (invocation.allowedNetworkHosts ?? []).flatMap((host) => {
+        const normalized = validateCustomAllowedDomain(host)
+        return normalized.ok ? [normalized.hostname] : []
+      })
+    )
     let wrapped: Awaited<ReturnType<NotebookNetworkSandbox['wrap']>>
     try {
       wrapped = await this.sandbox!.wrap({
@@ -247,6 +253,7 @@ class NotebookNetworkSandboxOwner implements NotebookProcessSandbox {
             invocation.commandText,
             executionActive,
             activeExecutionGrants,
+            allowedNetworkHosts,
             request
           )
       })
@@ -655,11 +662,13 @@ class NotebookNetworkSandboxOwner implements NotebookProcessSandbox {
     commandText: string,
     executionActive: boolean,
     commandGrants: ReadonlySet<string>,
+    allowedNetworkHosts: ReadonlySet<string>,
     request: { host: string; signal: AbortSignal }
   ): Promise<boolean> {
     if (request.signal.aborted) return Promise.resolve(false)
     const normalized = validateCustomAllowedDomain(request.host)
     if (!normalized.ok || !executionActive) return Promise.resolve(false)
+    if (allowedNetworkHosts.has(normalized.hostname)) return Promise.resolve(true)
     if (commandGrants.has(normalized.hostname)) return Promise.resolve(true)
     const key = blockedDestinationKey(sessionId, normalized.hostname)
     const runtimes = this.blockedDestinationCommands.get(key) ?? new Map()

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -54,7 +54,7 @@ type NotebookPackageMutationOwnerOptions = {
     request: NotebookPackageAdmittedTarget['request'],
     deps?: Partial<InstallDeps>
   ) => Promise<InstallResult>
-  packageSpawn?: (target: NotebookPackageAdmittedTarget) => InstallSpawn
+  packageSpawn?: (target: NotebookPackageAdmittedTarget, mirror: PackageMirror) => InstallSpawn
   micromambaRunner?: Pick<MicromambaRunner, 'resolve'>
   recheckRepair: (
     target: NotebookPackageAdmittedTarget
@@ -144,7 +144,9 @@ class NotebookPackageMutationOwner {
           try {
             try {
               installResult = await this.options.installPackages(request, {
-                ...(this.options.packageSpawn ? { spawn: this.options.packageSpawn(target) } : {}),
+                ...(this.options.packageSpawn
+                  ? { spawn: this.options.packageSpawn(target, mirror) }
+                  : {}),
                 micromambaRunner: this.options.micromambaRunner,
                 storageRoot: this.options.storageRoot,
                 condaChannel: mirror.condaChannel,

--- a/src/main/notebook/package-operations.test.ts
+++ b/src/main/notebook/package-operations.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { NotebookLanguage } from '../../shared/notebook'
+import type { PackageMirror } from '../../shared/mirror'
 import { createRootNotebookLane } from './lane-identity'
 import { NotebookPackageOperations } from './package-operations'
 import { installPackages } from './package-manager'
@@ -407,6 +408,38 @@ describe('NotebookPackageOperations', () => {
     )
     expect(options.environmentOperations.recommendRestart).toHaveBeenCalledWith('r', 'default-r')
     expect(options.notifyChanged).toHaveBeenCalledWith(activeSession)
+  })
+
+  it('passes the current mirror to the installer sandbox without retaining replaced or cleared mirrors', async () => {
+    let configuredMirror: PackageMirror = { pypiIndex: 'https://packages.example.org/simple' }
+    const packageSpawn = vi.fn(() => vi.fn())
+    const { owner } = harness(session('session-1'), {
+      resolvePackageMirror: vi.fn(() => configuredMirror),
+      mirrorProbe: { candidates: [] },
+      packageSpawn
+    })
+
+    await owner.manage({ language: 'python', packages: ['numpy'], usePip: true })
+    configuredMirror = { pypiIndex: 'https://new-packages.example.org/simple' }
+    await owner.manage({ language: 'python', packages: ['pandas'], usePip: true })
+    configuredMirror = {}
+    await owner.manage({ language: 'python', packages: ['scipy'], usePip: true })
+
+    expect(packageSpawn).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ request: expect.objectContaining({ packages: ['numpy'] }) }),
+      { pypiIndex: 'https://packages.example.org/simple' }
+    )
+    expect(packageSpawn).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ request: expect.objectContaining({ packages: ['pandas'] }) }),
+      { pypiIndex: 'https://new-packages.example.org/simple' }
+    )
+    expect(packageSpawn).toHaveBeenNthCalledWith(
+      3,
+      expect.objectContaining({ request: expect.objectContaining({ packages: ['scipy'] }) }),
+      {}
+    )
   })
 
   it('returns an explicit target receipt when the admitted installer throws', async () => {

--- a/src/main/notebook/package-operations.ts
+++ b/src/main/notebook/package-operations.ts
@@ -91,7 +91,7 @@ type NotebookPackageOperationsOptions = {
     'inspectPackages' | 'markPackageMutationDirty' | 'refreshAfterPackageMutation'
   >
   installPackages: (request: InstallRequest, deps?: Partial<InstallDeps>) => Promise<InstallResult>
-  packageSpawn?: (target: NotebookPackageAdmittedTarget) => InstallSpawn
+  packageSpawn?: (target: NotebookPackageAdmittedTarget, mirror: PackageMirror) => InstallSpawn
   micromambaRunner?: Pick<MicromambaRunner, 'resolve'>
   retainWorkingCache?: MicromambaWorkingCacheRetainer
   createEnvironmentCaptureTarget: (

--- a/src/main/notebook/package-process-sandbox.test.ts
+++ b/src/main/notebook/package-process-sandbox.test.ts
@@ -160,6 +160,73 @@ describe('sandboxedPackageSpawn', () => {
     expect(cleanup).toHaveBeenCalledOnce()
   })
 
+  it('grants only the configured package mirror hostnames to the installer', async () => {
+    const processSandbox: NotebookProcessSandbox = {
+      wrap: vi.fn(async (invocation) => ({
+        executable: invocation.executable,
+        args: invocation.args,
+        env: invocation.env,
+        annotateStderr: (stderr: string) => stderr,
+        cleanup: vi.fn()
+      }))
+    }
+    const spawn = sandboxedPackageSpawn({
+      processSandbox,
+      request: { language: 'python', packages: ['example'] },
+      mirror: {
+        condaChannel: 'https://CONDA.example.org/channels/conda-forge/',
+        pypiIndex: 'https://pypi.example.org/simple',
+        cranMirror: 'https://cran.example.org/CRAN/'
+      },
+      runtimeRoot: process.cwd(),
+      storageRoot: process.cwd()
+    })
+
+    await spawn(process.execPath, ['-e', 'process.exit(0)'], process.env)
+
+    expect(processSandbox.wrap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        allowedNetworkHosts: ['conda.example.org', 'pypi.example.org', 'cran.example.org']
+      })
+    )
+  })
+
+  it.each([
+    ['leading whitespace', ' https://packages.example.org/simple', []],
+    ['trailing whitespace', 'https://packages.example.org/simple ', []],
+    ['embedded ASCII whitespace', 'https://packages.exa\tmple.org/simple', []],
+    ['embedded ASCII control', 'https://packages.example.org/sim\nple', []],
+    ['non-HTTP protocol', 'ftp://packages.example.org/simple', []],
+    ['URL userinfo', 'https://user:secret@packages.example.org/simple', []],
+    ['localhost', 'https://localhost/simple', []],
+    ['IPv4 address', 'https://127.0.0.1/simple', []],
+    ['IPv6 address', 'https://[::1]/simple', []],
+    ['valid IDN', 'https://例子.测试/simple', ['xn--fsqu00a.xn--0zwm56d']]
+  ] as const)('derives safe exact mirror hosts for %s', async (_label, pypiIndex, expected) => {
+    const processSandbox: NotebookProcessSandbox = {
+      wrap: vi.fn(async (invocation) => ({
+        executable: invocation.executable,
+        args: invocation.args,
+        env: invocation.env,
+        annotateStderr: (stderr: string) => stderr,
+        cleanup: vi.fn()
+      }))
+    }
+    const spawn = sandboxedPackageSpawn({
+      processSandbox,
+      request: { language: 'python', packages: ['example'] },
+      mirror: { pypiIndex },
+      runtimeRoot: process.cwd(),
+      storageRoot: process.cwd()
+    })
+
+    await spawn(process.execPath, ['-e', 'process.exit(0)'], process.env)
+
+    expect(processSandbox.wrap).toHaveBeenCalledWith(
+      expect.objectContaining({ allowedNetworkHosts: expected })
+    )
+  })
+
   it('forwards installer deadlines and cleans up only after the child is stopped', async () => {
     const endExecution = vi.fn()
     const cleanup = vi.fn()

--- a/src/main/notebook/package-process-sandbox.ts
+++ b/src/main/notebook/package-process-sandbox.ts
@@ -11,6 +11,8 @@ import {
 } from 'node:fs'
 import { delimiter, dirname, isAbsolute, join, relative, resolve, win32 } from 'node:path'
 
+import type { PackageMirror } from '../../shared/mirror'
+import { validateCustomAllowedDomain } from '../../shared/notebook-network'
 import { defaultSpawn, type InstallRequest, type InstallSpawn } from './package-manager'
 import { buildNotebookKernelEnvironment } from './process-environment'
 import type { NotebookProcessSandbox } from './process-sandbox'
@@ -20,9 +22,31 @@ type PackageProcessSandboxOptions = Readonly<{
   request: InstallRequest
   runtimeRoot: string
   storageRoot: string
+  mirror?: PackageMirror
   interpreter?: Readonly<{ command: string; condaPrefix?: string }>
   platform?: NodeJS.Platform
 }>
+
+const packageMirrorHosts = (mirror: PackageMirror | undefined): string[] => {
+  const hosts = [mirror?.condaChannel, mirror?.pypiIndex, mirror?.cranMirror].flatMap((value) => {
+    const hasAsciiWhitespaceOrControl = [...(value ?? '')].some((character) => {
+      const codePoint = character.codePointAt(0) ?? 0
+      return codePoint <= 0x20 || codePoint === 0x7f
+    })
+    if (!value || hasAsciiWhitespaceOrControl) return []
+    try {
+      const url = new URL(value)
+      if ((url.protocol !== 'https:' && url.protocol !== 'http:') || url.username || url.password) {
+        return []
+      }
+      const normalized = validateCustomAllowedDomain(url.hostname)
+      return normalized.ok ? [normalized.hostname] : []
+    } catch {
+      return []
+    }
+  })
+  return [...new Set(hosts)]
+}
 
 const PACKAGE_ENV_KEYS = [
   'CONDA_PKGS_DIRS',
@@ -177,6 +201,7 @@ export const sandboxedPackageSpawn =
       sessionId: request.sessionId ?? 'notebook-package-manager',
       projectId: request.projectId ?? 'notebook-package-manager',
       runtime: request.language,
+      allowedNetworkHosts: packageMirrorHosts(options.mirror),
       signal: spawnOptions?.signal,
       filesystem: {
         readOnlyRoots: [...absolutePath(dirname(command)), ...absolutePath(request.workspaceCwd)],

--- a/src/main/notebook/process-sandbox.ts
+++ b/src/main/notebook/process-sandbox.ts
@@ -7,6 +7,8 @@ export type NotebookSandboxInvocation = Readonly<{
   sessionId: string
   projectId: string
   runtime: 'python' | 'r' | 'repl' | 'bash'
+  /** Exact public hostnames granted only to this wrapped process. */
+  allowedNetworkHosts?: readonly string[]
   localRpcSocketPath?: string
   inheritedFileDescriptorCount?: number
   filesystem: Readonly<{

--- a/src/main/notebook/runtime-service.ts
+++ b/src/main/notebook/runtime-service.ts
@@ -604,10 +604,11 @@ class NotebookRuntimeService {
       installPackages: options.installPackagesImpl ?? installPackagesDefault,
       ...(options.processSandbox
         ? {
-            packageSpawn: (target) =>
+            packageSpawn: (target, mirror) =>
               sandboxedPackageSpawn({
                 processSandbox: options.processSandbox!,
                 request: target.request,
+                mirror,
                 runtimeRoot,
                 storageRoot: options.dataRoot,
                 interpreter: target.interpreter


### PR DESCRIPTION
## Problem

Manage Packages uses the current effective conda, PyPI, or CRAN mirror configuration, but the Notebook network policy previously derived trusted domains only from the built-in mirror catalog. A valid user-configured mirror could therefore be selected for dependency installation and still be blocked until the user separately approved the same domain.

## Proposed change

- Derive normalized, exact hostnames from the effective `PackageMirror` used by each package operation.
- Pass those hostnames to the Notebook sandbox as invocation-local grants for the installer process.
- Activate the grants only for the wrapped process execution and remove them during cleanup.
- Reject unsafe mirror URL input, including ASCII whitespace or control characters, non-HTTP(S) schemes, user information, localhost, and IP literals; normalize internationalized domains to their ASCII form.
- Keep redirect destinations subject to the existing network approval flow.

## Scope and non-goals

- Do not persist derived mirror hosts in `NotebookNetworkSettings.allowedDomains`.
- Do not grant mirror access to ordinary Notebook Python, R, Bash, or REPL execution.
- Do not auto-authorize cross-domain redirects.
- Do not add new mirror providers or change the Manage Packages UI.
- Do not change schemas, migrations, dependencies, renderer strings, wire formats, or documentation.

## Acceptance criteria and validation

The checks below ran after the last material edit. Independent Standards and Spec reviews confirmed that this mapping covers the final state and reported no actionable findings.

- Configured conda, PyPI, and CRAN hosts are available to the installer process; replacement and clearing do not leave stale access -> `npx vitest run src/main/notebook/package-process-sandbox.test.ts src/main/notebook/network-sandbox-owner.test.ts src/main/notebook/package-operations.test.ts src/main/notebook/runtime-service.test.ts` -> 433 tests passed.
- Unsafe mirror URLs are rejected and internationalized hostnames are normalized -> the targeted Vitest command above -> passed.
- Ordinary Notebook execution and cross-domain redirects retain the existing denial or approval behavior -> the targeted Vitest command above -> passed.
- Main-process, sandbox, and web types remain valid -> `npm run typecheck` -> passed.
- Repository lint rules remain satisfied -> `npm run lint` -> passed.
- The impact classifier selected the full fallback because the changed process-sandbox interface has no mapped module owner -> CI `Full portable tests (Ubuntu, shard 1/3-3/3)` -> all passed.
- Platform-sensitive Notebook isolation remains valid -> CI `Linux Notebook isolation` and `Windows core` -> passed.

Local full-suite note: `npm test` reported 28,597 passed, 305 skipped, and one shared-interpreter timing test failure under full-suite load; that exact test passed on isolated rerun. The authoritative CI portable shards passed. The initial Windows E2E run has two unrelated tests that passed on retry but failed their jobs because the suite uses `--fail-on-flaky-tests`; rerunning failed upstream jobs requires repository Actions permission that the PR author token does not have.

Uncovered risk: this change does not perform a live installation against every public mirror. URL boundary behavior and process-scoped authorization are covered with deterministic tests, while platform execution is covered by the selected CI lanes.

## Review focus

- Confirm that mirror access exists only for the current Manage Packages process and never mutates global or persisted network policy.
- Check the hostname parsing boundary, especially malformed input, user information, localhost and IP rejection, and IDN normalization.
- Verify that every package-manager spawn receives the current effective mirror snapshot, including fallback paths, with no stale grant after update or clear.
