### PR TITLE
feat(cli): add JSON readiness projection for headless environments

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -88,9 +88,11 @@ open-science doctor --json
 ```
 
 The command prints one JSON object. `ready` requires both the selected Agent runtime and active
-provider to be ready. `checks.skills.enabled` contains the sorted IDs of enabled, available Skills;
+provider to be ready. A check is `missing` when its resource is absent and `not_ready` when it is
+configured but unusable; provider failures may include a stable `reason`, such as
+`credential_invalid`. `checks.skills.enabled` contains the sorted IDs of enabled, available Skills;
 Skills do not block overall readiness. `next` contains stable action codes such as
-`runtime_missing` and `provider_missing`, never commands that may not exist. A completed inspection
+`runtime_missing` and `provider_not_ready`, never commands that may not exist. A completed inspection
 exits with code `0` even when `ready` is false; connection and command failures keep the existing
 nonzero CLI error codes.
 

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -90,8 +90,13 @@ open-science doctor --json
 The command prints one JSON object. `ready` requires both the selected Agent runtime and active
 provider to be ready. A check is `missing` when its resource is absent and `not_ready` when it is
 configured but unusable; provider failures may include a stable `reason`, such as
-`credential_invalid`. `checks.skills.enabled` contains the sorted IDs of enabled, available Skills;
-Skills do not block overall readiness. `next` contains stable action codes such as
+`credential_invalid`.
+
+Codex credential inspection checks supported material in the app-owned `auth.json` without launching
+Codex or validating expiry/revocation remotely; historical provider validation remains a separate gate.
+
+`checks.skills.enabled` contains the sorted IDs of enabled, available Skills; Skills do not block
+overall readiness. `next` contains stable action codes such as
 `runtime_missing` and `provider_not_ready`, never commands that may not exist. A completed inspection
 exits with code `0` even when `ready` is false; connection and command failures keep the existing
 nonzero CLI error codes.

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -78,6 +78,22 @@ Among lifecycle commands, `status`, `stop`, and `update` support `--json`. `star
 it; run `start --no-open` followed by `status --json` for machine-readable startup status. Errors
 with `--json` are reported on stderr as a JSON error object with a nonzero exit code.
 
+## Readiness checks
+
+Inspect the running service without changing runtime, provider, credential, onboarding, or Skill
+settings:
+
+```bash
+open-science doctor --json
+```
+
+The command prints one JSON object. `ready` requires both the selected Agent runtime and active
+provider to be ready. `checks.skills.enabled` contains the sorted IDs of enabled, available Skills;
+Skills do not block overall readiness. `next` contains stable action codes such as
+`runtime_missing` and `provider_missing`, never commands that may not exist. A completed inspection
+exits with code `0` even when `ready` is false; connection and command failures keep the existing
+nonzero CLI error codes.
+
 ## Application updates
 
 Check, download, and apply an Open Science application update without opening the browser or desktop

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -34,6 +34,7 @@ Commands:
   status      Show backend status
   url         Print the authenticated web URL
   update      Check, download, and apply an application update
+  doctor --json  Inspect headless readiness
   codex login [--force]
   connector list | show <id> | enable <id> | disable <id>
   connector add | update <id>      Read configuration JSON from stdin
@@ -146,6 +147,7 @@ const VALUE_OPTIONS = {
 }
 
 const TASK_COMMANDS = new Set([
+  'doctor',
   'project',
   'run',
   'session',
@@ -168,6 +170,7 @@ const GROUP_COMMANDS = new Set([
 // Project create, update, and session-defaults intentionally remain unbounded because their
 // positional Project names may contain multiple unquoted words.
 const POSITIONAL_LIMITS = new Map([
+  ['doctor', 0],
   ['connector list', 0],
   ['connector show', 1],
   ['connector enable', 1],
@@ -378,6 +381,9 @@ export const parseCliArgs = (argv) => {
   }
   if (options.json && options.jsonl) {
     throw new CliUsageError('Use only one of --json or --jsonl.')
+  }
+  if (command === 'doctor' && !options.json) {
+    throw new CliUsageError('doctor requires --json.')
   }
   if (options.json && (command === 'start' || command === 'url')) {
     throw new CliUsageError(`--json is not supported for ${command}.`)
@@ -1438,6 +1444,11 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
   const deps = { ...TASK_DEPS, ...dependencies }
   const { command, subcommand, positionals = [], options } = parsed
   const client = await deps.connect({ configRoot: options.configRoot })
+
+  if (command === 'doctor') {
+    deps.log(JSON.stringify(await client.doctor()))
+    return
+  }
 
   if (command === 'connector' || command === 'credential') {
     const id = positionals[0]

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -39,10 +39,10 @@ describe('task CLI', () => {
       checks: {
         daemon: { status: 'ready' },
         runtime: { status: 'missing', framework: 'codex' },
-        provider: { status: 'missing' },
+        provider: { status: 'not_ready', reason: 'credential_invalid' },
         skills: { status: 'ready', enabled: ['literature-review'] }
       },
-      next: [{ code: 'runtime_missing' }, { code: 'provider_missing' }]
+      next: [{ code: 'runtime_missing' }, { code: 'provider_not_ready' }]
     }
     const log = vi.fn()
 

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -29,6 +29,32 @@ const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
 ]
 
 describe('task CLI', () => {
+  it('requires JSON output for doctor', () => {
+    expect(() => parseCliArgs(['doctor'])).toThrow('doctor requires --json.')
+  })
+
+  it('prints the doctor readiness contract as valid JSON', async () => {
+    const report = {
+      ready: false,
+      checks: {
+        daemon: { status: 'ready' },
+        runtime: { status: 'missing', framework: 'codex' },
+        provider: { status: 'missing' },
+        skills: { status: 'ready', enabled: ['literature-review'] }
+      },
+      next: [{ code: 'runtime_missing' }, { code: 'provider_missing' }]
+    }
+    const log = vi.fn()
+
+    await runTaskCommand(parseCliArgs(['doctor', '--json']), {
+      connect: vi.fn().mockResolvedValue({ doctor: vi.fn().mockResolvedValue(report) }),
+      log,
+      stdinIsTTY: true
+    })
+
+    expect(JSON.parse(log.mock.calls[0][0])).toEqual(report)
+  })
+
   it('rejects ports that are not complete decimal values', () => {
     expect(() => parseCliArgs(['start', '--port', '44100xyz'])).toThrow('Invalid port: 44100xyz')
     expect(() => parseCliArgs(['start', '--port', '0'])).toThrow('Invalid port: 0')

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -55,6 +55,7 @@ describe('OpenScienceClient', () => {
     expect(Object.getOwnPropertyNames(OpenScienceClient.prototype).sort()).toEqual(
       [
         'constructor',
+        'doctor',
         'health',
         'listConnectors',
         'getConnector',
@@ -92,7 +93,7 @@ describe('OpenScienceClient', () => {
     )
   })
 
-  it('uses versioned endpoints for Session, Project-default, and Agent-routing configuration', async () => {
+  it('uses versioned endpoints for Doctor, Session, Project-default, and Agent-routing reads', async () => {
     const fetch = vi.fn().mockImplementation(async () => response(200, { data: { ok: true } }))
     const client = new OpenScienceClient({
       baseUrl: 'http://127.0.0.1:44100',
@@ -100,6 +101,7 @@ describe('OpenScienceClient', () => {
       fetch
     })
 
+    await client.doctor()
     await client.getProjectSessionDefaults('project/1')
     await client.updateProjectSessionDefaults('project/1', {
       expectedUpdatedAt: 2,
@@ -114,6 +116,7 @@ describe('OpenScienceClient', () => {
     await client.updateAgentRouting({ framework: 'codex' })
 
     expect(fetch.mock.calls.map(([url]) => url)).toEqual([
+      'http://127.0.0.1:44100/api/v1/doctor',
       'http://127.0.0.1:44100/api/v1/projects/project%2F1/session-defaults',
       'http://127.0.0.1:44100/api/v1/projects/project%2F1/session-defaults',
       'http://127.0.0.1:44100/api/v1/sessions/session%2F1/config',
@@ -122,6 +125,7 @@ describe('OpenScienceClient', () => {
       'http://127.0.0.1:44100/api/v1/settings/agent-routing'
     ])
     expect(fetch.mock.calls.map(([, options]) => options?.method ?? 'GET')).toEqual([
+      'GET',
       'GET',
       'PATCH',
       'GET',

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -200,15 +200,28 @@ export type DelegationPolicy = 'allow' | 'deny'
 export type TurnIntent = 'plan-first'
 export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 export type AgentFramework = 'claude-code' | 'opencode' | 'codex' | 'codebuddy'
+export type ReadinessStatus = 'ready' | 'missing' | 'not_ready'
+export type ProviderReadinessReason =
+  | 'credential_invalid'
+  | 'network'
+  | 'model-not-found'
+  | 'bad-url'
+  | 'timeout'
+  | 'incompatible'
+  | 'server-error'
+  | 'unknown'
 export type DoctorReport = {
   ready: boolean
   checks: {
     daemon: { status: 'ready' }
-    runtime: { status: 'ready' | 'missing'; framework: AgentFramework }
-    provider: { status: 'ready' | 'missing' }
+    runtime: { status: ReadinessStatus; framework: AgentFramework }
+    provider:
+      { status: 'ready' | 'missing' } | { status: 'not_ready'; reason?: ProviderReadinessReason }
     skills: { status: 'ready'; enabled: string[] }
   }
-  next: Array<{ code: 'runtime_missing' | 'provider_missing' }>
+  next: Array<{
+    code: 'runtime_missing' | 'runtime_not_ready' | 'provider_missing' | 'provider_not_ready'
+  }>
 }
 export type AgentConfiguration = {
   providerId: string

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -200,6 +200,16 @@ export type DelegationPolicy = 'allow' | 'deny'
 export type TurnIntent = 'plan-first'
 export type ReasoningEffort = 'default' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 export type AgentFramework = 'claude-code' | 'opencode' | 'codex' | 'codebuddy'
+export type DoctorReport = {
+  ready: boolean
+  checks: {
+    daemon: { status: 'ready' }
+    runtime: { status: 'ready' | 'missing'; framework: AgentFramework }
+    provider: { status: 'ready' | 'missing' }
+    skills: { status: 'ready'; enabled: string[] }
+  }
+  next: Array<{ code: 'runtime_missing' | 'provider_missing' }>
+}
 export type AgentConfiguration = {
   providerId: string
   model?: string
@@ -457,6 +467,7 @@ export class OpenScienceClient {
     requestTimeoutMs?: number
   })
   health(options?: RequestOptions): Promise<unknown>
+  doctor(options?: RequestOptions): Promise<DoctorReport>
   listConnectors(options?: RequestOptions): Promise<ConnectorsSnapshot>
   getConnector(
     id: string,

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -179,6 +179,10 @@ export class OpenScienceClient {
     )
   }
 
+  doctor(options) {
+    return this.request('/api/v1/doctor', { ...options, method: 'GET' })
+  }
+
   listConnectors(options) {
     return this.request(`/api/v1/connectors`, { ...options, method: 'GET' })
   }

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -308,6 +308,8 @@ describe('application command composition', () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
+      'settings:get-preflight',
+      'settings:list-skills',
       'settings:list-connectors',
       'settings:get-connector-detail',
       'settings:set-connector-enabled',
@@ -607,6 +609,33 @@ it('routes Task Connector reads to the existing Settings owner without adding We
   expect(listConnectors).toHaveBeenCalledOnce()
   expect(composition.localWeb.commandNames()).not.toContain('settings:test-custom-server')
   expect(composition.remoteWeb.commandNames()).not.toContain('settings:test-custom-server')
+  composition.dispose()
+})
+
+it('routes Task doctor prerequisites to the existing Settings owners', async () => {
+  const preflight = {
+    claudeReady: false,
+    opencodeReady: false,
+    codebuddyReady: false,
+    codexReady: true,
+    agentFrameworkId: 'codex',
+    agentReady: true,
+    activeProviderReady: true
+  }
+  const skills = [{ id: 'literature-review' }]
+  const getPreflight = vi.fn(async () => preflight)
+  const listSkills = vi.fn(async () => skills)
+  const composition = createApplicationCommandComposition({
+    ...dependencies(),
+    settingsCore: { service: { getPreflight, listSkills } } as never
+  })
+
+  await expect(composition.task.invoke('settings:get-preflight', invocation())).resolves.toEqual(
+    preflight
+  )
+  await expect(composition.task.invoke('settings:list-skills', invocation())).resolves.toEqual(
+    skills
+  )
   composition.dispose()
 })
 

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -159,6 +159,8 @@ const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
 ])
 
 const TASK_COMMAND_NAMES = Object.freeze([
+  'settings:get-preflight',
+  'settings:list-skills',
   'settings:list-connectors',
   'settings:get-connector-detail',
   'settings:set-connector-enabled',

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -6338,11 +6338,12 @@ describe('notebook runtime service', () => {
     let maxConcurrent = 0
     const releases: Array<() => void> = []
     const executedCodes: string[] = []
+    const repository = new NotebookRunRepository(root)
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
       projectId: 'default-project',
-      repository: new NotebookRunRepository(root),
+      repository,
       executorFactory: () => ({
         execute: async (request): Promise<NotebookExecutionResult> => {
           executedCodes.push(request.code)
@@ -6387,20 +6388,32 @@ describe('notebook runtime service', () => {
     // Wait until the first run has actually entered the executor and is holding the single slot.
     await vi.waitFor(() => expect(releases).toHaveLength(1))
 
-    const second = submit("print('b')")
-    // Give the second run a chance to (wrongly) reach the executor while the first is in flight.
-    await new Promise((resolve) => setTimeout(resolve, 20))
-
-    // With serialization the second run is still queued, so only the first has entered the executor.
-    expect(releases).toHaveLength(1)
-    const queuedState = await service.state({
-      projectId: 'default-project',
-      sessionId: 'session-1',
-      workspaceCwd: '/workspace'
+    // Exercise slow durable admission instead of assuming it completes within a fixed sleep.
+    const appendRun = repository.appendOrGetRun.bind(repository)
+    vi.spyOn(repository, 'appendOrGetRun').mockImplementationOnce(async (input) => {
+      await new Promise((resolve) => setTimeout(resolve, 1250))
+      return appendRun(input)
     })
-    expect(queuedState.runs).toEqual(
-      expect.arrayContaining([expect.objectContaining({ script: "print('b')", status: 'queued' })])
+
+    const second = submit("print('b')")
+    // Observe durable admission before asserting that the second run cannot enter the executor.
+    const queuedState = await vi.waitFor(
+      async () => {
+        const state = await service.state({
+          projectId: 'default-project',
+          sessionId: 'session-1',
+          workspaceCwd: '/workspace'
+        })
+        expect(state.runs).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ script: "print('b')", status: 'queued' })
+          ])
+        )
+        return state
+      },
+      { timeout: 5000 }
     )
+    expect(releases).toHaveLength(1)
     const queuedCell = queuedState.cells.find((cell) => cell.code === "print('b')")
     expect(queuedCell).toBeDefined()
     await expect(

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -537,6 +537,28 @@ describe('AgentRuntimeManager', () => {
     expect(providers.isProviderKeyUsable).toHaveBeenCalledWith(storedProvider)
   })
 
+  it('projects a never-validated missing app credential as credential_invalid', async () => {
+    await repository.upsertProvider({
+      id: 'provider-a',
+      type: 'custom',
+      name: 'Provider A',
+      model: 'model-a',
+      apiEndpoints: ['anthropic'],
+      keyRef: 'missing-key'
+    })
+    await repository.setActiveProvider('provider-a', 'model-a')
+    const providers: ProviderPreflightAccess = {
+      resolveProviderApiEndpoints: vi.fn().mockReturnValue(['anthropic']),
+      resolveActiveModel: vi.fn().mockReturnValue('model-a'),
+      isProviderKeyUsable: vi.fn().mockResolvedValue(false)
+    }
+
+    await expect(manager.getPreflight(providers)).resolves.toMatchObject({
+      providerReadiness: { status: 'not_ready', reason: 'credential_invalid' }
+    })
+    expect(providers.isProviderKeyUsable).toHaveBeenCalledOnce()
+  })
+
   it('fails Codex preflight when the installed ACP adapter is below the supported version', async () => {
     inventory.codexAdapter.set(managedAdapterPath, 'codex-acp 1.1.4')
     inventory.codexNative.set(managedCodexPath, 'codex-cli 0.144.6')

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -14,7 +14,7 @@ import type {
   InstallCodeBuddyRequest,
   InstallCodexRequest,
   InstallOpencodeRequest,
-  Preflight,
+  ReadinessPreflight,
   ValidateProviderResult
 } from '../../shared/settings'
 import {
@@ -433,7 +433,7 @@ export class AgentRuntimeManager {
       options.resolveCodexProxyEnvironment ?? resolveSystemProxyEnvironment
   }
 
-  async getPreflight(providers: ProviderPreflightAccess): Promise<Preflight> {
+  async getPreflight(providers: ProviderPreflightAccess): Promise<ReadinessPreflight> {
     return this.trackDetection(async (signal) => {
       const settings = await this.repository.getSettings()
       signal.throwIfAborted()
@@ -458,18 +458,16 @@ export class AgentRuntimeManager {
       const activeEndpoints = activeProvider
         ? providers.resolveProviderApiEndpoints(activeProvider, activeModel)
         : undefined
-      const activeProviderCompatible =
-        activeProvider && configuredModelAvailable
-          ? isProviderUsableByFramework(
-              { apiEndpoints: activeEndpoints, type: activeProvider.type },
-              framework
-            ) &&
-            (framework.id !== 'codex' || isModelBridgeSupported(activeProvider, activeModel))
-          : false
-      const activeProviderKeyUsable =
-        activeProvider && activeProvider.lastValidatedAt !== undefined
-          ? await providers.isProviderKeyUsable(activeProvider)
-          : false
+      const activeProviderCompatible = activeProvider
+        ? isProviderUsableByFramework(
+            { apiEndpoints: activeEndpoints, type: activeProvider.type },
+            framework
+          ) &&
+          (framework.id !== 'codex' || isModelBridgeSupported(activeProvider, activeModel))
+        : false
+      const activeProviderKeyUsable = activeProvider
+        ? await providers.isProviderKeyUsable(activeProvider)
+        : false
       const activeValidationTarget = activeProvider
         ? {
             model: activeModel,
@@ -497,6 +495,7 @@ export class AgentRuntimeManager {
         isProviderKeyUsable: (provider) =>
           provider.id === activeProvider?.id && activeProviderKeyUsable,
         activeProviderCompatible,
+        activeProviderModelAvailable: configuredModelAvailable,
         activeValidationTarget
       })
     })

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -13,6 +13,7 @@ import {
   createCodexAuthEnvironment,
   ensureCodexAuthHome,
   importCodexAuthentication,
+  inspectAppOwnedCodexAuthentication,
   projectSafeCodexProviderRoute,
   resolveEffectiveCodexSubscriptionTransport,
   type CodexAuthSession
@@ -34,6 +35,89 @@ const session = (overrides: Partial<CodexAuthSession> = {}): CodexAuthSession =>
 
 const autoTransportConfig = (prefix: string[] = []): string =>
   [...prefix, 'cli_auth_credentials_store = "file"', ''].join('\n')
+
+describe('inspectAppOwnedCodexAuthentication', () => {
+  it('reports a missing credential without creating the app-owned home', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-missing-'))
+    const home = codexSubscriptionStorageDir(root)
+    try {
+      await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({ state: 'missing' })
+      expect(existsSync(home)).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports a stored credential without changing auth or config files', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-present-'))
+    const home = codexSubscriptionStorageDir(root)
+    const authPath = join(home, 'auth.json')
+    const configPath = join(home, 'config.toml')
+    try {
+      await mkdir(home, { recursive: true })
+      await writeFile(authPath, '{"tokens":{"access_token":"secret"}}')
+      await writeFile(configPath, 'model = "account-default"\n')
+      const before = {
+        auth: await stat(authPath),
+        config: await stat(configPath)
+      }
+
+      await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({ state: 'present' })
+
+      expect(await readFile(authPath, 'utf8')).toBe('{"tokens":{"access_token":"secret"}}')
+      expect(await readFile(configPath, 'utf8')).toBe('model = "account-default"\n')
+      expect(await stat(authPath)).toMatchObject({
+        mode: before.auth.mode,
+        size: before.auth.size,
+        mtimeMs: before.auth.mtimeMs
+      })
+      expect(await stat(configPath)).toMatchObject({
+        mode: before.config.mode,
+        size: before.config.size,
+        mtimeMs: before.config.mtimeMs
+      })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports malformed credentials without rewriting them or creating config.toml', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-invalid-'))
+    const home = codexSubscriptionStorageDir(root)
+    const authPath = join(home, 'auth.json')
+    const configPath = join(home, 'config.toml')
+    try {
+      await mkdir(home, { recursive: true })
+      await writeFile(authPath, '{not-json')
+      const before = await stat(authPath)
+
+      await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({ state: 'invalid' })
+
+      expect(await readFile(authPath, 'utf8')).toBe('{not-json')
+      expect(await stat(authPath)).toMatchObject({
+        mode: before.mode,
+        size: before.size,
+        mtimeMs: before.mtimeMs
+      })
+      expect(existsSync(configPath)).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('reports credential read failures without throwing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-unreadable-'))
+    const authPath = join(codexSubscriptionStorageDir(root), 'auth.json')
+    try {
+      await mkdir(authPath, { recursive: true })
+      await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({
+        state: 'unreadable'
+      })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+})
 
 describe('resolveEffectiveCodexSubscriptionTransport', () => {
   it('retains learned HTTPS only while the preference is Auto', () => {

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -36,6 +36,16 @@ const session = (overrides: Partial<CodexAuthSession> = {}): CodexAuthSession =>
 const autoTransportConfig = (prefix: string[] = []): string =>
   [...prefix, 'cli_auth_credentials_store = "file"', ''].join('\n')
 
+const storedChatGptAuth = JSON.stringify({
+  auth_mode: 'chatgpt',
+  tokens: {
+    id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature',
+    access_token: 'access',
+    refresh_token: 'refresh'
+  },
+  last_refresh: '2026-09-11T00:00:00Z'
+})
+
 describe('inspectAppOwnedCodexAuthentication', () => {
   it('reports a missing credential without creating the app-owned home', async () => {
     const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-missing-'))
@@ -55,7 +65,7 @@ describe('inspectAppOwnedCodexAuthentication', () => {
     const configPath = join(home, 'config.toml')
     try {
       await mkdir(home, { recursive: true })
-      await writeFile(authPath, '{"tokens":{"access_token":"secret"}}')
+      await writeFile(authPath, storedChatGptAuth)
       await writeFile(configPath, 'model = "account-default"\n')
       const before = {
         auth: await stat(authPath),
@@ -64,7 +74,7 @@ describe('inspectAppOwnedCodexAuthentication', () => {
 
       await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({ state: 'present' })
 
-      expect(await readFile(authPath, 'utf8')).toBe('{"tokens":{"access_token":"secret"}}')
+      expect(await readFile(authPath, 'utf8')).toBe(storedChatGptAuth)
       expect(await readFile(configPath, 'utf8')).toBe('model = "account-default"\n')
       expect(await stat(authPath)).toMatchObject({
         mode: before.auth.mode,
@@ -76,6 +86,64 @@ describe('inspectAppOwnedCodexAuthentication', () => {
         size: before.config.size,
         mtimeMs: before.config.mtimeMs
       })
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    '{}',
+    'null',
+    '[]',
+    '"credential"',
+    '{"tokens":{}}',
+    '{"tokens":null}',
+    '{"tokens":[]}',
+    '{"tokens":123}',
+    '{"tokens":{"access_token":""}}',
+    '{"tokens":{"access_token":"secret"}}',
+    '{"tokens":{"id_token":"id","access_token":"secret","refresh_token":"refresh"}}',
+    '{"tokens":{"id_token":"id","access_token":"secret","refresh_token":"refresh"},"last_refresh":"2026-09-11T00:00:00Z"}',
+    '{"tokens":{"id_token":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature","access_token":"secret","refresh_token":"refresh"},"last_refresh":"2026-09-11"}',
+    '{"tokens":{"access_token":"   "}}',
+    '{"OPENAI_API_KEY":""}',
+    '{"OPENAI_API_KEY":123}',
+    '{"auth_mode":"personalAccessToken","personal_access_token":""}',
+    '{"auth_mode":"agentIdentity","agent_identity":"secret"}',
+    '{"auth_mode":"agentIdentity","agent_identity":{}}',
+    '{"auth_mode":"agentIdentity","agent_identity":{"agent_runtime_id":"runtime","agent_private_key":"secret"}}',
+    '{"auth_mode":"bedrockApiKey","bedrock_api_key":{"api_key":"","region":"us-east-1"}}'
+  ])('reports empty credential material as invalid: %s', async (content) => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-empty-'))
+    const home = codexSubscriptionStorageDir(root)
+    const authPath = join(home, 'auth.json')
+    try {
+      await mkdir(home, { recursive: true })
+      await writeFile(authPath, content)
+
+      await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({ state: 'invalid' })
+      expect(await readFile(authPath, 'utf8')).toBe(content)
+      expect(existsSync(join(home, 'config.toml'))).toBe(false)
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it.each([
+    '{"OPENAI_API_KEY":"secret"}',
+    '{"auth_mode":"apikey","OPENAI_API_KEY":"secret"}',
+    '{"auth_mode":"personalAccessToken","personal_access_token":"secret"}',
+    '{"auth_mode":"agentIdentity","agent_identity":"eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature"}',
+    '{"auth_mode":"agentIdentity","agent_identity":{"agent_runtime_id":"runtime","agent_private_key":"secret","account_id":"account","chatgpt_user_id":"user","plan_type":"pro","chatgpt_account_is_fedramp":false}}',
+    '{"auth_mode":"bedrockApiKey","bedrock_api_key":{"api_key":"secret","region":"us-east-1"}}'
+  ])('recognizes supported stored credential material: %s', async (content) => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-inspect-api-key-'))
+    const home = codexSubscriptionStorageDir(root)
+    try {
+      await mkdir(home, { recursive: true })
+      await writeFile(join(home, 'auth.json'), content)
+
+      await expect(inspectAppOwnedCodexAuthentication(root)).resolves.toEqual({ state: 'present' })
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -628,6 +628,28 @@ type CodexAuthenticationSnapshot = Readonly<{
   providerRoute?: ImportedCodexProviderRoute
 }>
 
+export type CodexStoredAuthInspection =
+  { state: 'present' } | { state: 'missing' } | { state: 'invalid' } | { state: 'unreadable' }
+
+export const inspectAppOwnedCodexAuthentication = async (
+  storageRoot: string
+): Promise<CodexStoredAuthInspection> => {
+  try {
+    const content = await readFile(
+      join(codexSubscriptionStorageDir(storageRoot), 'auth.json'),
+      'utf8'
+    )
+    const parsed = JSON.parse(content) as unknown
+    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
+      ? { state: 'present' }
+      : { state: 'invalid' }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { state: 'missing' }
+    if (error instanceof SyntaxError) return { state: 'invalid' }
+    return { state: 'unreadable' }
+  }
+}
+
 const readCodexAuthenticationSnapshot = async (
   sourceHome: string,
   required: boolean

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -631,6 +631,72 @@ type CodexAuthenticationSnapshot = Readonly<{
 export type CodexStoredAuthInspection =
   { state: 'present' } | { state: 'missing' } | { state: 'invalid' } | { state: 'unreadable' }
 
+const isJsonObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value)
+
+const isNonEmptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.trim() !== ''
+
+const isRfc3339 = (value: unknown): value is string =>
+  isNonEmptyString(value) &&
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/.test(value) &&
+  !Number.isNaN(Date.parse(value))
+
+const isJwt = (value: unknown): value is string => {
+  if (!isNonEmptyString(value)) return false
+  const parts = value.split('.')
+  if (parts.length !== 3 || parts.some((part) => part === '')) return false
+  try {
+    return isJsonObject(JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8')))
+  } catch {
+    return false
+  }
+}
+
+const hasCodexCredentialMaterial = (value: unknown): boolean => {
+  if (!isJsonObject(value)) return false
+  const auth = value
+  const inferredMode =
+    typeof auth.personal_access_token === 'string'
+      ? 'personalAccessToken'
+      : isJsonObject(auth.bedrock_api_key)
+        ? 'bedrockApiKey'
+        : typeof auth.OPENAI_API_KEY === 'string'
+          ? 'apikey'
+          : 'chatgpt'
+  const mode = auth.auth_mode ?? inferredMode
+
+  if (mode === 'apikey') return isNonEmptyString(auth.OPENAI_API_KEY)
+  if (mode === 'personalAccessToken') return isNonEmptyString(auth.personal_access_token)
+  if (mode === 'agentIdentity') {
+    if (isJwt(auth.agent_identity)) return true
+    return (
+      isJsonObject(auth.agent_identity) &&
+      isNonEmptyString(auth.agent_identity.agent_runtime_id) &&
+      isNonEmptyString(auth.agent_identity.agent_private_key) &&
+      isNonEmptyString(auth.agent_identity.account_id) &&
+      isNonEmptyString(auth.agent_identity.chatgpt_user_id) &&
+      isNonEmptyString(auth.agent_identity.plan_type) &&
+      typeof auth.agent_identity.chatgpt_account_is_fedramp === 'boolean'
+    )
+  }
+  if (mode === 'bedrockApiKey') {
+    return (
+      isJsonObject(auth.bedrock_api_key) &&
+      isNonEmptyString(auth.bedrock_api_key.api_key) &&
+      isNonEmptyString(auth.bedrock_api_key.region)
+    )
+  }
+  if (mode !== 'chatgpt' && mode !== 'chatgptAuthTokens') return false
+  return (
+    isJsonObject(auth.tokens) &&
+    isJwt(auth.tokens.id_token) &&
+    isNonEmptyString(auth.tokens.access_token) &&
+    isNonEmptyString(auth.tokens.refresh_token) &&
+    isRfc3339(auth.last_refresh)
+  )
+}
+
 export const inspectAppOwnedCodexAuthentication = async (
   storageRoot: string
 ): Promise<CodexStoredAuthInspection> => {
@@ -640,9 +706,7 @@ export const inspectAppOwnedCodexAuthentication = async (
       'utf8'
     )
     const parsed = JSON.parse(content) as unknown
-    return typeof parsed === 'object' && parsed !== null && !Array.isArray(parsed)
-      ? { state: 'present' }
-      : { state: 'invalid' }
+    return hasCodexCredentialMaterial(parsed) ? { state: 'present' } : { state: 'invalid' }
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { state: 'missing' }
     if (error instanceof SyntaxError) return { state: 'invalid' }

--- a/src/main/settings/preflight.test.ts
+++ b/src/main/settings/preflight.test.ts
@@ -32,6 +32,7 @@ const run = (overrides: Partial<PreflightInput> = {}): ReturnType<typeof compute
     agentFrameworkId: 'claude-code',
     isProviderKeyUsable: alwaysUsable,
     activeProviderCompatible: true,
+    activeProviderModelAvailable: true,
     ...overrides
   })
 
@@ -44,18 +45,24 @@ describe('computePreflight', () => {
       codexReady: false,
       agentFrameworkId: 'claude-code',
       agentReady: true,
-      activeProviderReady: true
+      activeProviderReady: true,
+      runtimeReadiness: { status: 'ready' },
+      providerReadiness: { status: 'ready' }
     })
   })
 
   it('is not claude-ready when the recorded path no longer exists', () => {
-    expect(run({ claudePathExists: false }).claudeReady).toBe(false)
+    expect(run({ claudePathExists: false })).toMatchObject({
+      claudeReady: false,
+      runtimeReadiness: { status: 'not_ready' }
+    })
   })
 
   it('is not claude-ready when no path was ever recorded', () => {
-    expect(
-      run({ settings: baseSettings({ claude: {} }), claudePathExists: false }).claudeReady
-    ).toBe(false)
+    expect(run({ settings: baseSettings({ claude: {} }), claudePathExists: false })).toMatchObject({
+      claudeReady: false,
+      runtimeReadiness: { status: 'missing' }
+    })
   })
 
   it('tracks opencode readiness from its own stored path', () => {
@@ -108,7 +115,10 @@ describe('computePreflight', () => {
       providers: [{ ...customProvider, lastValidatedAt: undefined }]
     })
 
-    expect(run({ settings }).activeProviderReady).toBe(false)
+    expect(run({ settings })).toMatchObject({
+      activeProviderReady: false,
+      providerReadiness: { status: 'not_ready' }
+    })
   })
 
   it('is not provider-ready when only another model target was validated', () => {
@@ -137,16 +147,22 @@ describe('computePreflight', () => {
         {
           ...customProvider,
           lastValidatedAt: 100,
-          lastValidationFailure: { at: 200, category: 'auth' }
+          lastValidationFailure: { at: 200, category: 'network' }
         }
       ]
     })
 
-    expect(run({ settings }).activeProviderReady).toBe(false)
+    expect(run({ settings })).toMatchObject({
+      activeProviderReady: false,
+      providerReadiness: { status: 'not_ready', reason: 'network' }
+    })
   })
 
   it('is not provider-ready when the active provider key is unusable', () => {
-    expect(run({ isProviderKeyUsable: () => false }).activeProviderReady).toBe(false)
+    expect(run({ isProviderKeyUsable: () => false })).toMatchObject({
+      activeProviderReady: false,
+      providerReadiness: { status: 'not_ready', reason: 'credential_invalid' }
+    })
   })
 
   it('is not provider-ready when the active provider is incompatible with the framework', () => {

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -3,7 +3,7 @@ import {
   providerValidationSucceeded,
   type AgentFrameworkId,
   type ProviderValidationTarget,
-  type Preflight
+  type ReadinessPreflight
 } from '../../shared/settings'
 import type { StoredProvider, StoredSettings } from './types'
 
@@ -27,6 +27,7 @@ export type PreflightInput = {
   // Whether the active provider can actually drive the selected framework (endpoint + provider-type
   // compatibility). Resolved by the caller, which has the vendor registry to derive official apiTypes.
   activeProviderCompatible: boolean
+  activeProviderModelAvailable: boolean
   activeValidationTarget?: ProviderValidationTarget
 }
 
@@ -42,8 +43,9 @@ const computePreflight = ({
   agentFrameworkId,
   isProviderKeyUsable,
   activeProviderCompatible,
+  activeProviderModelAvailable,
   activeValidationTarget
-}: PreflightInput): Preflight => {
+}: PreflightInput): ReadinessPreflight => {
   const claudeReady = Boolean(settings.claude?.resolvedPath) && claudePathExists
   const opencodeReady = Boolean(settings.opencodePath) && opencodePathExists
   const codebuddyReady = Boolean(settings.codebuddyPath) && codebuddyPathExists
@@ -55,6 +57,19 @@ const computePreflight = ({
     codebuddy: codebuddyReady
   }
   const agentReady = readyByFramework[agentFrameworkId]
+  const runtimeConfiguredByFramework: Record<AgentFrameworkId, boolean> = {
+    'claude-code': Boolean(settings.claude?.resolvedPath),
+    opencode: Boolean(settings.opencodePath),
+    codex: Boolean(settings.codex?.resolvedPath),
+    codebuddy: Boolean(settings.codebuddyPath)
+  }
+  const runtimeReadiness = {
+    status: agentReady
+      ? ('ready' as const)
+      : runtimeConfiguredByFramework[agentFrameworkId]
+        ? ('not_ready' as const)
+        : ('missing' as const)
+  }
 
   const activeProvider = settings.activeProviderId
     ? settings.providers.find((provider) => provider.id === settings.activeProviderId)
@@ -62,15 +77,44 @@ const computePreflight = ({
 
   // "Ready" also requires the active provider to be able to drive the selected framework, so an
   // incompatible pair (e.g. OpenCode + a Codex-only provider) is never marked ready.
+  const activeProviderValidationFailed = Boolean(
+    activeProvider && providerValidationFailed(activeProvider, activeValidationTarget)
+  )
+  const validationFailureCategory = activeProviderValidationFailed
+    ? activeProvider?.lastValidationFailure?.category
+    : undefined
+  const validationFailureReason =
+    validationFailureCategory === 'auth'
+      ? ('credential_invalid' as const)
+      : validationFailureCategory === 'ok'
+        ? undefined
+        : validationFailureCategory
+  const activeProviderKeyUsable = Boolean(activeProvider && isProviderKeyUsable(activeProvider))
   const activeProviderReady = Boolean(
     activeProvider &&
     (activeValidationTarget
       ? providerValidationSucceeded(activeProvider, activeValidationTarget)
       : activeProvider.lastValidatedAt !== undefined &&
         !providerValidationFailed(activeProvider)) &&
-    isProviderKeyUsable(activeProvider) &&
+    activeProviderKeyUsable &&
+    activeProviderModelAvailable &&
     activeProviderCompatible
   )
+  const providerReason =
+    activeProvider && (validationFailureReason === 'credential_invalid' || !activeProviderKeyUsable)
+      ? ('credential_invalid' as const)
+      : activeProvider && validationFailureReason
+        ? validationFailureReason
+        : activeProvider && !activeProviderModelAvailable
+          ? ('model-not-found' as const)
+          : activeProvider && !activeProviderCompatible
+            ? ('incompatible' as const)
+            : undefined
+  const providerReadiness = activeProviderReady
+    ? ({ status: 'ready' } as const)
+    : !activeProvider
+      ? ({ status: 'missing' } as const)
+      : ({ status: 'not_ready', ...(providerReason ? { reason: providerReason } : {}) } as const)
 
   return {
     claudeReady,
@@ -79,7 +123,9 @@ const computePreflight = ({
     codexReady,
     agentFrameworkId,
     agentReady,
-    activeProviderReady
+    activeProviderReady,
+    runtimeReadiness,
+    providerReadiness
   }
 }
 

--- a/src/main/settings/preflight.ts
+++ b/src/main/settings/preflight.ts
@@ -21,7 +21,8 @@ export type PreflightInput = {
   codexPathExists: boolean
   // The selected framework, resolved (default applied) by the caller.
   agentFrameworkId: AgentFrameworkId
-  // Whether a provider's credentials are usable (codex subscriptions always; custom must decrypt).
+  // Whether a provider's current credentials are usable (subscription auth is checked by its owner;
+  // custom credentials must still decrypt).
   isProviderKeyUsable: (provider: StoredProvider) => boolean
   // Whether the active provider can actually drive the selected framework (endpoint + provider-type
   // compatibility). Resolved by the caller, which has the vendor registry to derive official apiTypes.

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -147,7 +147,15 @@ describe('ProviderAuthLifecycleOwner', () => {
   }
 
   const storeAppCodexAuth = async (
-    content = '{"tokens":{"access_token":"secret"}}'
+    content = JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: {
+        id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature',
+        access_token: 'access',
+        refresh_token: 'refresh'
+      },
+      last_refresh: '2026-09-11T00:00:00Z'
+    })
   ): Promise<void> => {
     const home = join(dir, 'codex-subscription')
     await mkdir(home, { recursive: true })

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -1,4 +1,5 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -63,6 +64,7 @@ describe('ProviderAuthLifecycleOwner', () => {
   let claudeIsolatedAuth: ClaudeIsolatedAuthControllerPort
   let claudeSharedAuth: ClaudeSharedAuthControllerPort
   let runClaudeSubscriptionProbe: ProviderAuthLifecycleOwnerOptions['runClaudeSubscriptionProbe']
+  let resolveCodexExecutable: ProviderAuthLifecycleOwnerOptions['resolveCodexExecutable']
   let owner: InstanceType<typeof ProviderAuthLifecycleOwner>
 
   beforeEach(async () => {
@@ -108,13 +110,14 @@ describe('ProviderAuthLifecycleOwner', () => {
       cancelLogin: vi.fn()
     }
     runClaudeSubscriptionProbe = vi.fn(async () => ({ ok: true, category: 'ok' as const }))
+    resolveCodexExecutable = vi.fn(async () => '/codex-acp')
     const projection = new ProviderRuntimeProjectionOwner()
     owner = new ProviderAuthLifecycleOwner({
       repository,
       storageRoot: dir,
       userClaudeDir: join(dir, 'user-claude'),
       userCodexDir: join(dir, 'user-codex'),
-      resolveCodexExecutable: vi.fn(async () => '/codex-acp'),
+      resolveCodexExecutable,
       resolveCodexProxyEnvironment: vi.fn(async () => undefined),
       runClaudeSubscriptionProbe,
       resolveProvider: (provider, model) => projection.resolveProvider(provider, model),
@@ -143,30 +146,85 @@ describe('ProviderAuthLifecycleOwner', () => {
     return (await repository.getSettings()).providers[0]
   }
 
+  const storeAppCodexAuth = async (
+    content = '{"tokens":{"access_token":"secret"}}'
+  ): Promise<void> => {
+    const home = join(dir, 'codex-subscription')
+    await mkdir(home, { recursive: true })
+    await writeFile(join(home, 'auth.json'), content)
+  }
+
   it('accepts a valid app-owned Codex credential', async () => {
+    await storeAppCodexAuth()
     const stored = await storeCodexProvider('isolated')
 
     await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
-    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+    expect(codexAuth.getStatus).not.toHaveBeenCalled()
+    expect(resolveCodexExecutable).not.toHaveBeenCalled()
+  })
+
+  it('does not resolve the Codex executable while inspecting stored credentials', async () => {
+    await storeAppCodexAuth()
+    const stored = await storeCodexProvider('isolated')
+    const projection = new ProviderRuntimeProjectionOwner()
+    const runtimeResolver = vi.fn(async () => {
+      throw new Error('Codex runtime missing')
+    })
+    const defaultAuthOwner = new ProviderAuthLifecycleOwner({
+      repository,
+      storageRoot: dir,
+      userClaudeDir: join(dir, 'user-claude'),
+      userCodexDir: join(dir, 'user-codex'),
+      resolveCodexExecutable: runtimeResolver,
+      resolveCodexProxyEnvironment: vi.fn(async () => undefined),
+      runClaudeSubscriptionProbe,
+      resolveProvider: (provider, model) => projection.resolveProvider(provider, model),
+      claudeIsolatedAuth,
+      claudeSharedAuth
+    })
+
+    await expect(defaultAuthOwner.isProviderKeyUsable(stored)).resolves.toBe(true)
+    expect(runtimeResolver).not.toHaveBeenCalled()
   })
 
   it('rejects a missing app-owned Codex credential', async () => {
-    vi.mocked(codexAuth.getStatus).mockResolvedValueOnce({
-      mode: 'isolated',
-      supported: true,
-      authenticated: false
-    })
     const stored = await storeCodexProvider('isolated')
 
     await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(false)
-    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+    expect(existsSync(join(dir, 'codex-subscription'))).toBe(false)
+    expect(codexAuth.getStatus).not.toHaveBeenCalled()
+    expect(resolveCodexExecutable).not.toHaveBeenCalled()
+  })
+
+  it('rejects a malformed app-owned Codex credential', async () => {
+    await storeAppCodexAuth('{not-json')
+    const stored = await storeCodexProvider('isolated')
+
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(false)
+    expect(codexAuth.getStatus).not.toHaveBeenCalled()
+    expect(resolveCodexExecutable).not.toHaveBeenCalled()
+  })
+
+  it('rejects an unreadable app-owned Codex credential', async () => {
+    await mkdir(join(dir, 'codex-subscription', 'auth.json'), { recursive: true })
+    const stored = await storeCodexProvider('isolated')
+
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(false)
+    expect(codexAuth.getStatus).not.toHaveBeenCalled()
   })
 
   it('keeps imported app-owned Codex credentials usable after external logout', async () => {
+    await storeAppCodexAuth()
+    vi.mocked(codexAuth.getStatus).mockResolvedValueOnce({
+      mode: 'shared',
+      supported: true,
+      authenticated: false
+    })
     const stored = await storeCodexProvider('imported')
 
     await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
-    expect(codexAuth.getStatus).toHaveBeenCalledWith('shared')
+    expect(codexAuth.getStatus).not.toHaveBeenCalled()
+    expect(resolveCodexExecutable).not.toHaveBeenCalled()
   })
 
   it('coalesces shared status reads and invalidates them across logout and login', async () => {

--- a/src/main/settings/provider-auth-lifecycle.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.test.ts
@@ -129,6 +129,46 @@ describe('ProviderAuthLifecycleOwner', () => {
     await rm(dir, { recursive: true, force: true })
   })
 
+  const storeCodexProvider = async (
+    authMode: 'isolated' | 'imported'
+  ): Promise<Awaited<ReturnType<typeof repository.getSettings>>['providers'][number]> => {
+    await repository.deleteProvider(CLAUDE_SHARED_PROVIDER_ID)
+    await repository.upsertProvider({
+      id: CODEX_SUBSCRIPTION_PROVIDER_ID,
+      type: 'codex-isolated',
+      codexAuthMode: authMode,
+      name: 'Codex subscription',
+      apiEndpoints: ['responses']
+    })
+    return (await repository.getSettings()).providers[0]
+  }
+
+  it('accepts a valid app-owned Codex credential', async () => {
+    const stored = await storeCodexProvider('isolated')
+
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
+    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+  })
+
+  it('rejects a missing app-owned Codex credential', async () => {
+    vi.mocked(codexAuth.getStatus).mockResolvedValueOnce({
+      mode: 'isolated',
+      supported: true,
+      authenticated: false
+    })
+    const stored = await storeCodexProvider('isolated')
+
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(false)
+    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+  })
+
+  it('keeps imported app-owned Codex credentials usable after external logout', async () => {
+    const stored = await storeCodexProvider('imported')
+
+    await expect(owner.isProviderKeyUsable(stored)).resolves.toBe(true)
+    expect(codexAuth.getStatus).toHaveBeenCalledWith('shared')
+  })
+
   it('coalesces shared status reads and invalidates them across logout and login', async () => {
     const stored = (await repository.getSettings()).providers[0]
     const firstStatus = deferred<ClaudeSharedAuthStatus>()

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -17,6 +17,7 @@ import {
   CodexAuthController,
   ensureCodexAuthHome,
   importCodexAuthentication,
+  inspectAppOwnedCodexAuthentication,
   openCodexAuthSession,
   resolveEffectiveCodexSubscriptionTransport,
   type CodexAuthControllerPort,
@@ -525,8 +526,9 @@ class ProviderAuthLifecycleOwner {
 
   async isProviderKeyUsable(provider: StoredProvider): Promise<boolean> {
     if (isCodexSubscriptionProvider(provider.type)) {
-      const mode = resolveCodexSubscriptionType(provider) === 'codex-shared' ? 'shared' : 'isolated'
-      return (await this.codexAuth.getStatus(mode)).authenticated
+      return (
+        (await inspectAppOwnedCodexAuthentication(this.options.storageRoot)).state === 'present'
+      )
     }
     if (provider.type === 'claude-shared') {
       if (provider.disconnectedAt !== undefined) return false

--- a/src/main/settings/provider-auth-lifecycle.ts
+++ b/src/main/settings/provider-auth-lifecycle.ts
@@ -524,7 +524,10 @@ class ProviderAuthLifecycleOwner {
   }
 
   async isProviderKeyUsable(provider: StoredProvider): Promise<boolean> {
-    if (isCodexSubscriptionProvider(provider.type)) return true
+    if (isCodexSubscriptionProvider(provider.type)) {
+      const mode = resolveCodexSubscriptionType(provider) === 'codex-shared' ? 'shared' : 'isolated'
+      return (await this.codexAuth.getStatus(mode)).authenticated
+    }
     if (provider.type === 'claude-shared') {
       if (provider.disconnectedAt !== undefined) return false
       return this.getClaudeSharedAuthStatus()

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2162,7 +2162,9 @@ describe('SettingsService: preflight & spawn config', () => {
       codebuddyReady: false,
       agentFrameworkId: 'claude-code',
       agentReady: true,
-      activeProviderReady: true
+      activeProviderReady: true,
+      runtimeReadiness: { status: 'ready' },
+      providerReadiness: { status: 'ready' }
     })
   })
 
@@ -2185,7 +2187,10 @@ describe('SettingsService: preflight & spawn config', () => {
       lastValidatedAt: 1
     })
 
-    await expect(service.getPreflight()).resolves.toMatchObject({ activeProviderReady: false })
+    await expect(service.getPreflight()).resolves.toMatchObject({
+      activeProviderReady: false,
+      providerReadiness: { status: 'not_ready', reason: 'model-not-found' }
+    })
   })
 
   it('closes the provider gate when the active shared Claude session is signed out', async () => {
@@ -2901,8 +2906,19 @@ describe('SettingsService: preflight & spawn config', () => {
     await mkdir(dirname(adapterPath), { recursive: true })
     await writeFile(adapterPath, MANAGED_CODEX_ADAPTER_FIXTURE, 'utf8')
     await chmod(adapterPath, 0o755)
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: false
+      }),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
     const service = createService(undefined, {
-      codexDetected: { path: adapterPath, version: 'codex-acp 1.6.2' }
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.6.2' },
+      codexAuth
     })
     await repository.setCodexInfo({
       resolvedPath: adapterPath,
@@ -2920,7 +2936,11 @@ describe('SettingsService: preflight & spawn config', () => {
     })
     await service.setActiveProvider(CODEX_SHARED_PROVIDER_ID, 'gpt-5.6-terra')
 
-    expect(await service.getPreflight()).toMatchObject({ activeProviderReady: false })
+    expect(await service.getPreflight()).toMatchObject({
+      activeProviderReady: false,
+      providerReadiness: { status: 'not_ready', reason: 'credential_invalid' }
+    })
+    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
     const migratedProviders = (await repository.getSettings()).providers
 
     expect(migratedProviders).toEqual([

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2937,8 +2937,19 @@ describe('SettingsService: preflight & spawn config', () => {
     await mkdir(dirname(adapterPath), { recursive: true })
     await writeFile(adapterPath, MANAGED_CODEX_ADAPTER_FIXTURE, 'utf8')
     await chmod(adapterPath, 0o755)
+    const codexAuth: CodexAuthControllerPort = {
+      getStatus: vi.fn().mockResolvedValue({
+        mode: 'isolated',
+        supported: true,
+        authenticated: true
+      }),
+      loginIsolated: vi.fn(),
+      cancelLogin: vi.fn(),
+      logoutIsolated: vi.fn()
+    }
     const service = createService(undefined, {
       codexDetected: { path: adapterPath, version: 'codex-acp 1.6.2' },
+      codexAuth,
       resolveCodexProxyEnvironment: () =>
         Promise.resolve({
           HTTP_PROXY: 'http://proxy.example.test:3128',

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2509,6 +2509,15 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(await readFile(adapterPath, 'utf8')).toBe(MANAGED_CODEX_ADAPTER_FIXTURE)
     expect(await readFile(authPath, 'utf8')).toBe(authContent)
     expect(await readFile(configPath, 'utf8')).toBe('model = "account-default"\n')
+
+    await writeFile(authPath, '{}')
+    await expect(service.getPreflight()).resolves.toMatchObject({
+      activeProviderReady: false,
+      providerReadiness: { status: 'not_ready', reason: 'credential_invalid' }
+    })
+    expect(await readFile(authPath, 'utf8')).toBe('{}')
+    expect(await readFile(adapterPath, 'utf8')).toBe(MANAGED_CODEX_ADAPTER_FIXTURE)
+    expect(await readFile(configPath, 'utf8')).toBe('model = "account-default"\n')
   })
 
   it('detects Codex and exposes readiness for its selected adapter', async () => {

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -3053,7 +3053,18 @@ describe('SettingsService: preflight & spawn config', () => {
     await service.setActiveProvider(CODEX_ISOLATED_PROVIDER_ID, 'gpt-5.6-terra')
     const authHome = codexSubscriptionStorageDir(storageRoot)
     await mkdir(authHome, { recursive: true })
-    await writeFile(join(authHome, 'auth.json'), '{"tokens":{"access_token":"app-owned"}}')
+    await writeFile(
+      join(authHome, 'auth.json'),
+      JSON.stringify({
+        auth_mode: 'chatgpt',
+        tokens: {
+          id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature',
+          access_token: 'app-owned',
+          refresh_token: 'refresh'
+        },
+        last_refresh: '2026-09-11T00:00:00Z'
+      })
+    )
     const configPath = join(storageRoot, 'codex', 'config.toml')
     await mkdir(dirname(configPath), { recursive: true })
     await writeFile(

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs'
 import {
   chmod,
   mkdir,
@@ -31,6 +32,7 @@ import type { UserSkillRepository as UserSkillRepositoryType } from '../skills/u
 import type { SystemProxyEnvironment } from './system-proxy'
 import type { AgentBackendResolutionContext } from './backend-resolver'
 import type { Logger } from '../logger'
+import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import type { SettingsServiceOptions } from './service'
 import { SettingsInstallCoordinator } from './settings-install-coordinator'
 
@@ -2466,6 +2468,49 @@ describe('SettingsService: preflight & spawn config', () => {
     }
   })
 
+  it('returns structured Codex readiness without starting auth when the runtime is incomplete', async () => {
+    const adapterPath = join(storageRoot, 'bin', 'codex-acp')
+    const authHome = codexSubscriptionStorageDir(storageRoot)
+    const authPath = join(authHome, 'auth.json')
+    const configPath = join(authHome, 'config.toml')
+    await mkdir(dirname(adapterPath), { recursive: true })
+    await mkdir(authHome, { recursive: true })
+    await writeFile(adapterPath, MANAGED_CODEX_ADAPTER_FIXTURE, 'utf8')
+    const authContent = JSON.stringify({
+      auth_mode: 'chatgpt',
+      tokens: {
+        id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature',
+        access_token: 'app-owned',
+        refresh_token: 'refresh'
+      },
+      last_refresh: '2026-09-11T00:00:00Z'
+    })
+    await writeFile(authPath, authContent)
+    await writeFile(configPath, 'model = "account-default"\n')
+    const service = createService(undefined, {
+      codexDetected: { path: adapterPath, version: 'codex-acp 1.6.2' },
+      managedCodexAdapterPath: adapterPath
+    })
+    await repository.setCodexInfo({ resolvedPath: adapterPath, version: '1.6.2' })
+    await repository.setAgentFramework('codex')
+    await repository.upsertProvider({
+      id: CODEX_ISOLATED_PROVIDER_ID,
+      type: 'codex-isolated',
+      name: 'codex-isolated',
+      apiEndpoints: ['responses'],
+      lastValidatedAt: 100
+    })
+    await service.setActiveProvider(CODEX_ISOLATED_PROVIDER_ID, 'gpt-5.6-terra')
+
+    await expect(service.getPreflight()).resolves.toMatchObject({
+      runtimeReadiness: { status: 'not_ready' },
+      providerReadiness: { status: 'ready' }
+    })
+    expect(await readFile(adapterPath, 'utf8')).toBe(MANAGED_CODEX_ADAPTER_FIXTURE)
+    expect(await readFile(authPath, 'utf8')).toBe(authContent)
+    expect(await readFile(configPath, 'utf8')).toBe('model = "account-default"\n')
+  })
+
   it('detects Codex and exposes readiness for its selected adapter', async () => {
     const adapterPath = '/data/codex-managed/adapter/dist/index.js'
     const nativePath = '/data/codex-managed/codex/vendor/target/bin/codex'
@@ -2935,12 +2980,14 @@ describe('SettingsService: preflight & spawn config', () => {
       lastValidatedAt: 100
     })
     await service.setActiveProvider(CODEX_SHARED_PROVIDER_ID, 'gpt-5.6-terra')
+    const authHome = codexSubscriptionStorageDir(storageRoot)
 
     expect(await service.getPreflight()).toMatchObject({
       activeProviderReady: false,
       providerReadiness: { status: 'not_ready', reason: 'credential_invalid' }
     })
-    expect(codexAuth.getStatus).toHaveBeenCalledWith('isolated')
+    expect(codexAuth.getStatus).not.toHaveBeenCalled()
+    expect(existsSync(authHome)).toBe(false)
     const migratedProviders = (await repository.getSettings()).providers
 
     expect(migratedProviders).toEqual([
@@ -2995,6 +3042,9 @@ describe('SettingsService: preflight & spawn config', () => {
       lastValidatedAt: 100
     })
     await service.setActiveProvider(CODEX_ISOLATED_PROVIDER_ID, 'gpt-5.6-terra')
+    const authHome = codexSubscriptionStorageDir(storageRoot)
+    await mkdir(authHome, { recursive: true })
+    await writeFile(join(authHome, 'auth.json'), '{"tokens":{"access_token":"app-owned"}}')
     const configPath = join(storageRoot, 'codex', 'config.toml')
     await mkdir(dirname(configPath), { recursive: true })
     await writeFile(

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -32,7 +32,7 @@ import type {
   InstallCodeBuddyRequest,
   InstallCodexRequest,
   InstallOpencodeRequest,
-  Preflight,
+  ReadinessPreflight,
   RefreshProviderModelsRequest,
   RefreshProviderModelsResult,
   ResolveSkillDocumentRequest,
@@ -1112,7 +1112,7 @@ class SettingsService {
     return this.skills.importAgentHomeSkills(request)
   }
   // Computes the startup gates from a fresh or immediate startup-chain runtime probe.
-  async getPreflight(): Promise<Preflight> {
+  async getPreflight(): Promise<ReadinessPreflight> {
     return this.runtimeManager.getPreflight(this.providers)
   }
 

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -2995,6 +2995,61 @@ describe('startWebHttpServer', () => {
     }
   )
 
+  it('rejects a delayed doctor result after remote authorization is revoked', async () => {
+    let current = true
+    let markDoctorStarted!: () => void
+    const doctorStarted = new Promise<void>((resolve) => {
+      markDoctorStarted = resolve
+    })
+    let finishDoctor!: () => void
+    const doctorPending = new Promise<void>((resolve) => {
+      finishDoctor = resolve
+    })
+    const doctor = vi.fn(async () => {
+      markDoctorStarted()
+      await doctorPending
+      return { ready: true, checks: {}, next: [], private: 'private-result-marker' }
+    })
+    const server = await startTestWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'local-token',
+      staticRoot: '/unused',
+      rpc: { channels: () => [], invoke: vi.fn() },
+      tasks: {
+        runWithCallerContext: (_context: CallerContext, operation: () => unknown) => operation(),
+        subscribeProgress: () => () => undefined,
+        doctor
+      } as never,
+      externalAccess: {
+        authorizeHttp: async () => ({
+          kind: 'authorized' as const,
+          principalId: 'paired-browser',
+          isCurrent: () => current
+        }),
+        authorizeWebSocket: async () => undefined
+      },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: '0.0.0',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    })
+    servers.push(server)
+
+    const responsePromise = fetch(`http://127.0.0.1:${server.port}/api/v1/doctor`)
+    await doctorStarted
+    current = false
+    finishDoctor()
+
+    const response = await responsePromise
+    expect(response.status).toBe(401)
+    expect(await response.text()).not.toContain('private-result-marker')
+    expect(doctor).toHaveBeenCalledOnce()
+  })
+
   it('keeps host-management RPC local while preserving the local Web client', async () => {
     const staticRoot = await mkdtemp(join(tmpdir(), 'open-science-web-static-'))
     roots.push(staticRoot)

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -3955,6 +3955,16 @@ describe('startWebHttpServer', () => {
       ((event: import('../../shared/task-api').TaskRunProgressEvent) => void) | undefined
     const tasks = {
       runWithCallerContext: runWithCapturedCallerContext,
+      doctor: vi.fn().mockResolvedValue({
+        ready: false,
+        checks: {
+          daemon: { status: 'ready' },
+          runtime: { status: 'missing', framework: 'codex' },
+          provider: { status: 'ready' },
+          skills: { status: 'ready', enabled: ['literature-review'] }
+        },
+        next: [{ code: 'runtime_missing' }]
+      }),
       subscribeProgress: vi.fn((listener) => {
         publishProgress = listener
         return () => {
@@ -4064,6 +4074,21 @@ describe('startWebHttpServer', () => {
     servers.push(server)
     const base = `http://127.0.0.1:${server.port}`
     const headers = { authorization: 'Bearer test-token' }
+
+    const doctor = await fetch(`${base}/api/v1/doctor`, { headers })
+    expect(doctor.status).toBe(200)
+    expect(await doctor.json()).toEqual({
+      data: {
+        ready: false,
+        checks: {
+          daemon: { status: 'ready' },
+          runtime: { status: 'missing', framework: 'codex' },
+          provider: { status: 'ready' },
+          skills: { status: 'ready', enabled: ['literature-review'] }
+        },
+        next: [{ code: 'runtime_missing' }]
+      }
+    })
 
     const progressSocket = new WebSocket(
       `${base.replace('http:', 'ws:')}/api/v1/events?token=test-token`

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -991,7 +991,9 @@ const handleTaskApiRequest = async (
       await waitUntilTasksReady?.()
       if (url.pathname === '/api/v1/doctor' && request.method === 'GET' && tasks.doctor) {
         assertExternalAuthorizationCurrent(externalAuthorization)
-        json(response, 200, { data: await tasks.doctor() })
+        const data = await tasks.doctor()
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data })
         return true
       }
       const connectorMatch = url.pathname.match(

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -168,6 +168,7 @@ type WebServerOptions = {
         | 'updateCredential'
         | 'getAgentRouting'
         | 'updateAgentRouting'
+        | 'doctor'
       >
     >
   waitUntilTasksReady?: () => Promise<void>
@@ -988,6 +989,11 @@ const handleTaskApiRequest = async (
   tasks.runWithCallerContext(callerContext, async () => {
     try {
       await waitUntilTasksReady?.()
+      if (url.pathname === '/api/v1/doctor' && request.method === 'GET' && tasks.doctor) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: await tasks.doctor() })
+        return true
+      }
       const connectorMatch = url.pathname.match(
         /^\/api\/v1\/connectors(?:\/([^/]+)(?:\/(enabled|test))?)?$/
       )

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -237,6 +237,69 @@ const createComputePreferenceHarness = (
 }
 
 describe('HeadlessTaskApi adapter', () => {
+  it('projects read-only readiness checks and stable next-action codes', async () => {
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'settings:get-preflight') {
+        return {
+          claudeReady: true,
+          opencodeReady: true,
+          codebuddyReady: true,
+          codexReady: false,
+          agentFrameworkId: 'codex',
+          agentReady: false,
+          activeProviderReady: false
+        }
+      }
+      if (channel === 'settings:list-skills') {
+        return [
+          {
+            id: 'writing',
+            name: 'writing',
+            displayName: 'Writing',
+            description: 'Write reports.',
+            source: 'featured',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            enabled: true
+          },
+          {
+            id: 'literature-review',
+            name: 'literature-review',
+            displayName: 'Literature Review',
+            description: 'Review literature.',
+            source: 'featured',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            enabled: true,
+            available: true
+          },
+          {
+            id: 'unavailable',
+            name: 'unavailable',
+            displayName: 'Unavailable',
+            description: 'Unavailable skill.',
+            source: 'personal',
+            updatedAt: '2026-01-01T00:00:00.000Z',
+            enabled: true,
+            available: false,
+            availability: 'identity-conflict'
+          }
+        ]
+      }
+      throw new Error(`Unexpected Task command: ${channel}`)
+    })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+
+    await expect(api.doctor()).resolves.toEqual({
+      ready: false,
+      checks: {
+        daemon: { status: 'ready' },
+        runtime: { status: 'missing', framework: 'codex' },
+        provider: { status: 'missing' },
+        skills: { status: 'ready', enabled: ['literature-review', 'writing'] }
+      },
+      next: [{ code: 'runtime_missing' }, { code: 'provider_missing' }]
+    })
+  })
+
   it('routes Project Session defaults through the Task-only persistence command', async () => {
     const invoke = vi.fn(
       async (channel: string, _callerContext: CallerContext, args: unknown[]) => {

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -247,7 +247,9 @@ describe('HeadlessTaskApi adapter', () => {
           codexReady: false,
           agentFrameworkId: 'codex',
           agentReady: false,
-          activeProviderReady: false
+          activeProviderReady: false,
+          runtimeReadiness: { status: 'missing' },
+          providerReadiness: { status: 'missing' }
         }
       }
       if (channel === 'settings:list-skills') {
@@ -297,6 +299,38 @@ describe('HeadlessTaskApi adapter', () => {
         skills: { status: 'ready', enabled: ['literature-review', 'writing'] }
       },
       next: [{ code: 'runtime_missing' }, { code: 'provider_missing' }]
+    })
+  })
+
+  it('distinguishes configured but unusable runtime and provider state', async () => {
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'settings:get-preflight') {
+        return {
+          claudeReady: false,
+          opencodeReady: false,
+          codebuddyReady: false,
+          codexReady: false,
+          agentFrameworkId: 'codex',
+          agentReady: false,
+          activeProviderReady: false,
+          runtimeReadiness: { status: 'not_ready' },
+          providerReadiness: { status: 'not_ready', reason: 'credential_invalid' }
+        }
+      }
+      if (channel === 'settings:list-skills') return []
+      throw new Error(`Unexpected Task command: ${channel}`)
+    })
+    const api = new HeadlessTaskApi({ commands: commandsFrom(invoke), agent: createAgent() })
+
+    await expect(api.doctor()).resolves.toEqual({
+      ready: false,
+      checks: {
+        daemon: { status: 'ready' },
+        runtime: { status: 'not_ready', framework: 'codex' },
+        provider: { status: 'not_ready', reason: 'credential_invalid' },
+        skills: { status: 'ready', enabled: [] }
+      },
+      next: [{ code: 'runtime_not_ready' }, { code: 'provider_not_ready' }]
     })
   })
 

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -20,6 +20,8 @@ import type {
   UpdateDeviceCredentialRequest,
   DeviceCredentialsSnapshot,
   CreateDeviceCredentialResult,
+  Preflight,
+  SkillView,
   SettingsSnapshot
 } from '../../shared/settings'
 import type {
@@ -28,6 +30,7 @@ import type {
   StartTaskRunRequest,
   TaskProject,
   TaskAgentRouting,
+  TaskDoctorReport,
   TaskProjectSessionDefaults,
   TaskPlanResponseRequest,
   TaskRun,
@@ -227,6 +230,35 @@ class HeadlessTaskApi {
 
   listProjects(): Promise<TaskProject[]> {
     return this.runner.listProjects()
+  }
+
+  async doctor(): Promise<TaskDoctorReport> {
+    const [preflight, skills] = await Promise.all([
+      this.invoke('settings:get-preflight') as Promise<Preflight>,
+      this.invoke('settings:list-skills') as Promise<SkillView[]>
+    ])
+    const next: TaskDoctorReport['next'][number][] = []
+    if (!preflight.agentReady) next.push({ code: 'runtime_missing' })
+    if (!preflight.activeProviderReady) next.push({ code: 'provider_missing' })
+    return {
+      ready: preflight.agentReady && preflight.activeProviderReady,
+      checks: {
+        daemon: { status: 'ready' },
+        runtime: {
+          status: preflight.agentReady ? 'ready' : 'missing',
+          framework: preflight.agentFrameworkId
+        },
+        provider: { status: preflight.activeProviderReady ? 'ready' : 'missing' },
+        skills: {
+          status: 'ready',
+          enabled: skills
+            .filter((skill) => skill.enabled && skill.available !== false)
+            .map((skill) => skill.id)
+            .sort()
+        }
+      },
+      next
+    }
   }
 
   createProject(request: CreateTaskProjectRequest): Promise<TaskProject> {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -20,7 +20,7 @@ import type {
   UpdateDeviceCredentialRequest,
   DeviceCredentialsSnapshot,
   CreateDeviceCredentialResult,
-  Preflight,
+  ReadinessPreflight,
   SkillView,
   SettingsSnapshot
 } from '../../shared/settings'
@@ -234,21 +234,26 @@ class HeadlessTaskApi {
 
   async doctor(): Promise<TaskDoctorReport> {
     const [preflight, skills] = await Promise.all([
-      this.invoke('settings:get-preflight') as Promise<Preflight>,
+      this.invoke('settings:get-preflight') as Promise<ReadinessPreflight>,
       this.invoke('settings:list-skills') as Promise<SkillView[]>
     ])
+    const { runtimeReadiness, providerReadiness } = preflight
     const next: TaskDoctorReport['next'][number][] = []
-    if (!preflight.agentReady) next.push({ code: 'runtime_missing' })
-    if (!preflight.activeProviderReady) next.push({ code: 'provider_missing' })
+    if (runtimeReadiness.status !== 'ready') {
+      next.push({ code: `runtime_${runtimeReadiness.status}` })
+    }
+    if (providerReadiness.status !== 'ready') {
+      next.push({ code: `provider_${providerReadiness.status}` })
+    }
     return {
-      ready: preflight.agentReady && preflight.activeProviderReady,
+      ready: runtimeReadiness.status === 'ready' && providerReadiness.status === 'ready',
       checks: {
         daemon: { status: 'ready' },
         runtime: {
-          status: preflight.agentReady ? 'ready' : 'missing',
+          status: runtimeReadiness.status,
           framework: preflight.agentFrameworkId
         },
-        provider: { status: preflight.activeProviderReady ? 'ready' : 'missing' },
+        provider: providerReadiness,
         skills: {
           status: 'ready',
           enabled: skills

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -669,9 +669,16 @@ export type AppIconPreview = AppIconVariantInfo & {
   previewDataUrl: string
 }
 
-// The hard startup gates. Kept as plain booleans so the wizard can target the first unmet step.
-// Per-framework readiness is exposed alongside `agentReady`, which reflects the currently-selected
-// framework — the gate a session actually depends on.
+export type ReadinessStatus = 'ready' | 'missing' | 'not_ready'
+
+export type ProviderReadinessReason =
+  'credential_invalid' | Exclude<ValidationCategory, 'ok' | 'auth'>
+
+export type ProviderReadiness =
+  { status: 'ready' | 'missing' } | { status: 'not_ready'; reason?: ProviderReadinessReason }
+
+// The hard startup gates. The booleans keep the wizard's existing gate contract; the structured
+// projections distinguish absent resources from configured resources that cannot currently run.
 export type Preflight = {
   claudeReady: boolean
   opencodeReady: boolean
@@ -681,6 +688,11 @@ export type Preflight = {
   agentFrameworkId: AgentFrameworkId
   agentReady: boolean
   activeProviderReady: boolean
+}
+
+export type ReadinessPreflight = Preflight & {
+  runtimeReadiness: { status: ReadinessStatus }
+  providerReadiness: ProviderReadiness
 }
 
 // A provider draft as entered in the renderer form. The plaintext `key` is present only when the user

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -18,6 +18,17 @@ import type {
   SubagentModelConfiguration
 } from './settings'
 
+export type TaskDoctorReport = Readonly<{
+  ready: boolean
+  checks: Readonly<{
+    daemon: Readonly<{ status: 'ready' }>
+    runtime: Readonly<{ status: 'ready' | 'missing'; framework: AgentFrameworkId }>
+    provider: Readonly<{ status: 'ready' | 'missing' }>
+    skills: Readonly<{ status: 'ready'; enabled: string[] }>
+  }>
+  next: ReadonlyArray<Readonly<{ code: 'runtime_missing' | 'provider_missing' }>>
+}>
+
 export const TASK_EVENT_STREAM_PROTOCOL_VERSION = 1 as const
 
 export type TaskRunStatus = 'running' | 'completed' | 'failed' | 'cancelled'

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -14,6 +14,8 @@ import type { DelegationPolicy, PersistedSessionStatus } from './session-persist
 import type { ActivePlanProjection } from './session-plan/contract'
 import type {
   AgentFrameworkId,
+  ProviderReadinessReason,
+  ReadinessStatus,
   ReviewerModelConfiguration,
   SubagentModelConfiguration
 } from './settings'
@@ -22,11 +24,17 @@ export type TaskDoctorReport = Readonly<{
   ready: boolean
   checks: Readonly<{
     daemon: Readonly<{ status: 'ready' }>
-    runtime: Readonly<{ status: 'ready' | 'missing'; framework: AgentFrameworkId }>
-    provider: Readonly<{ status: 'ready' | 'missing' }>
+    runtime: Readonly<{ status: ReadinessStatus; framework: AgentFrameworkId }>
+    provider: Readonly<
+      { status: 'ready' | 'missing' } | { status: 'not_ready'; reason?: ProviderReadinessReason }
+    >
     skills: Readonly<{ status: 'ready'; enabled: string[] }>
   }>
-  next: ReadonlyArray<Readonly<{ code: 'runtime_missing' | 'provider_missing' }>>
+  next: ReadonlyArray<
+    Readonly<{
+      code: 'runtime_missing' | 'runtime_not_ready' | 'provider_missing' | 'provider_not_ready'
+    }>
+  >
 }>
 
 export const TASK_EVENT_STREAM_PROTOCOL_VERSION = 1 as const


### PR DESCRIPTION
## Summary

Add JSON-only `open-science doctor --json`, `OpenScienceClient.doctor()`, and authenticated `GET /api/v1/doctor` so headless callers can inspect selected runtime/provider readiness and enabled, available Skills.

Distinguish absent resources (`missing`) from configured but unusable resources (`not_ready`) and return stable next-action codes. Codex inspection requires nonempty locally stored API-key or access-token material: an empty `auth.json` object no longer passes because a provider validated previously. Inspection does not launch/repair Codex or normalize its credential configuration; remote token expiry/revocation validation remains outside this local check. Authorization is revalidated after asynchronous inspection before returning results.

## Architecture and scope

CLI → OpenScienceClient → Task HTTP API → HeadlessTaskApi → existing Settings preflight and Skill catalog owners.

No new runtime installation, onboarding mutation, automatic fix command, credential storage, or database migration. Related to #1987; this is a diagnostic slice, not complete first-run bootstrap.

The follow-up merges current main while preserving the original contributor commits and both Settings test changes.

## Compatibility and persistence

- Public doctor states: `ready`, `missing`, `not_ready`; next codes: `runtime_missing`, `runtime_not_ready`, `provider_missing`, `provider_not_ready`. Provider failures can include a reason.
- Existing renderer preflight boolean contract remains available.
- No historical data migration, stored-field addition, or credential rewrite. Local inspection recognizes API-key/access-token material with or without an auth-mode field.
- No new states were introduced by the final credential-validation fix.

## Validation

After the final source edit:

- Credential inspection, shared readiness, and doctor CLI/SDK/Task composition → `npm test -- packages/open-science/cli.test.ts packages/open-science/client.test.ts src/main/web-service/task-api.test.ts src/main/application-command-composition.test.ts src/main/settings/preflight.test.ts src/main/settings/provider-auth-lifecycle.test.ts src/main/settings/agent-runtime-manager.test.ts src/main/settings/service.test.ts src/main/settings/codex-auth.test.ts` → **576 passed**.
- Authenticated HTTP doctor and revocation during inspection → `npm test -- src/main/web-service/http-server.test.ts -t 'rejects a delayed doctor result|serves the versioned task API'` → **2 passed**, 63 unrelated tests skipped.
- `npm run lint` and `git diff --cached --check` → **passed**.
- `npm run typecheck:node` and `npm run typecheck:web` → **blocked by missing local `reflect-metadata` and `@peculiar/x509` dependencies** in unchanged Notebook network gateway code; not reported as passed.

The new credential-free fixtures failed before the fix and passed afterward. Independent review found no blocking issue in the final fix or conflict resolution. The change affects the common Settings preflight consumed by doctor and the renderer; owner and consumer checks are included. It adds no ACP wire behavior, platform path semantics, or persisted format, so no extra local protocol/platform migration matrix was introduced. Full portable and platform verification is delegated to the required CI on the updated head; prior-head green results are not reused.
