### PR TITLE
fix(notebook): restore Windows kernel ownership persistence

### DIFF
--- a/resources/notebook/kernel_process_host.js
+++ b/resources/notebook/kernel_process_host.js
@@ -24,7 +24,7 @@ try {
   const updated = { ...record, pid: process.pid, commandIdentityMarker: receiptId }
   const temporary = `${activePath}.${process.pid}.tmp`
   fs.writeFileSync(temporary, `${JSON.stringify(updated, null, 2)}\n`, { mode: 0o600 })
-  const descriptor = fs.openSync(temporary, 'r')
+  const descriptor = fs.openSync(temporary, 'r+')
   try {
     fs.fsyncSync(descriptor)
   } finally {

--- a/src/main/notebook/kernel-process-lifecycle.test.ts
+++ b/src/main/notebook/kernel-process-lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process'
-import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -31,6 +31,54 @@ describe('KernelProcessLifecycleOwner', () => {
     vi.restoreAllMocks()
     if (root) await rm(root, { recursive: true, force: true })
     root = undefined
+  })
+
+  it('does not fence admission on unpublished temporary records left by a failed write', async () => {
+    root = await mkdtemp(join(tmpdir(), 'kernel-process-temporary-'))
+    const owner = new KernelProcessLifecycleOwner({ storageRoot: root })
+    const scope = { laneKey: 'lane', processKey: 'python:default-python', kernelEpochId: 'epoch' }
+    const intent = owner.beginSpawn(scope)
+    await writeFile(`${intent.path}.123-test.tmp`, JSON.stringify(intent.record))
+    owner.abandonSpawn(intent)
+    const restarted = new KernelProcessLifecycleOwner({ storageRoot: root })
+    await restarted.ensureReady()
+    const retried = restarted.beginSpawn(scope)
+    expect(retried.record.processKey).toBe('python:default-python')
+    expect(() => restarted.beginSpawn(scope)).toThrow('KERNEL_STARTUP_FENCE')
+  })
+
+  it('allows the real process host to publish its receipt and execute code', async () => {
+    root = await mkdtemp(join(tmpdir(), 'kernel-process-host-execution-'))
+    const owner = new KernelProcessLifecycleOwner({ storageRoot: root })
+    const intent = owner.beginSpawn({
+      laneKey: 'lane',
+      processKey: 'python:default-python',
+      kernelEpochId: 'epoch'
+    })
+    const host = spawn(
+      process.execPath,
+      [
+        join(__dirname, '../../../resources/notebook/kernel_process_host.js'),
+        intent.path,
+        intent.record.receiptId,
+        process.execPath,
+        '-e',
+        'process.stdout.write("42")'
+      ],
+      { env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }, windowsHide: true }
+    )
+    let output = ''
+    host.stdout.on('data', (chunk) => {
+      output += chunk.toString()
+    })
+    const exitCode = await new Promise<number | null>((resolve, reject) => {
+      host.once('error', reject)
+      host.once('close', resolve)
+    })
+    expect(exitCode).toBe(0)
+    expect(output).toBe('42')
+    const record = JSON.parse(await readFile(intent.activePath(host.pid!), 'utf8'))
+    expect(record.pid).toBe(host.pid)
   })
 
   it('reaps a verified stale owner before opening process admission', async () => {

--- a/src/main/notebook/kernel-process-lifecycle.windows-posix.ts
+++ b/src/main/notebook/kernel-process-lifecycle.windows-posix.ts
@@ -80,17 +80,24 @@ const writeRecordSync = (path: string, record: KernelProcessRecord): void => {
   const directory = dirname(path)
   mkdirSync(directory, { recursive: true })
   const temporary = `${path}.${process.pid}-${randomUUID()}.tmp`
-  writeFileSync(temporary, `${JSON.stringify(record, null, 2)}\n`, {
-    encoding: 'utf8',
-    mode: 0o600
-  })
-  const file = openSync(temporary, 'r')
   try {
-    fsyncSync(file)
-  } finally {
-    closeSync(file)
+    // Windows requires a writable handle for fsync (FlushFileBuffers).
+    const file = openSync(temporary, 'wx', 0o600)
+    try {
+      writeFileSync(file, `${JSON.stringify(record, null, 2)}\n`, 'utf8')
+      fsyncSync(file)
+    } finally {
+      closeSync(file)
+    }
+    renameSync(temporary, path)
+  } catch (error) {
+    try {
+      rmSync(temporary, { force: true })
+    } catch {
+      // Preserve the original write failure; the published receipt remains authoritative.
+    }
+    throw error
   }
-  renameSync(temporary, path)
 }
 
 const decodeRecord = (contents: string): KernelProcessRecord | undefined => {
@@ -263,7 +270,12 @@ class KernelProcessLifecycleOwner {
   ): KernelProcessSpawnIntent {
     const prefix = recordFilePrefix(scope)
     mkdirSync(this.directory, { recursive: true })
-    if (readdirSync(this.directory).some((name) => name.startsWith(`${prefix}.`))) {
+    // Unpublished .tmp writes cannot authorize a host; recovery only reads published JSON receipts.
+    if (
+      readdirSync(this.directory).some(
+        (name) => name.startsWith(`${prefix}.`) && name.endsWith('.json')
+      )
+    ) {
       throw new Error(
         `KERNEL_STARTUP_FENCE: ${scope.processKey} still has durable process ownership.`
       )


### PR DESCRIPTION
## Problem

Windows Notebook kernel startup fails with `EPERM: operation not permitted, fsync` because ownership records are flushed through read-only file handles. The unpublished temporary file then causes subsequent attempts to fail with `KERNEL_STARTUP_FENCE`. The process host has the same read-only flush bug. This code was introduced in #2325.

## Proposed change

Use a writable handle when persisting the owner record and when flushing the process host receipt. Remove the current temporary write on publication failure. Match admission against published JSON receipts, consistently with recovery, so historical unpublished `.tmp` debris does not permanently block the lane.

## Scope and non-goals

The Notebook lifecycle owner remains responsible for pending/active receipts, process identity verification, and crash recovery. Published receipts still fence admission, and unverifiable ownership still fails closed. Record version, process termination, uninstall behavior, and WSL2 routing are unchanged; no user data cleanup or schema migration is required.

## Acceptance criteria and validation

All checks below ran after the last material edit. An independent gpt-5.6-sol (medium) subagent reviewed the final three-file diff and confirmed the Test Impact Set covers its persistence, admission, host, and consumer behavior.

| Behavior | Command / check | Result |
| --- | --- | --- |
| Windows failure and retry | Independent Node 22.3.0 harness using the exact pre-fix module from a7350344 versus the fixed module | Original: EPERM on first spawn, KERNEL_STARTUP_FENCE on retry. Fixed: durable pending receipt and successful retry with only historical tmp debris. |
| Host activation and admission protection | Independent Node 22.3.0 real-host execution and pending/active receipt checks | Original host exits 125 without executing; fixed host exits 0 and prints 42. Real pending and active receipts still fence admission. |
| Lifecycle owner and kernel executor consumer | `npx vitest run src/main/notebook/kernel-process-lifecycle.test.ts src/main/notebook/kernel-executor.test.ts` | 2 files passed; 38 tests passed, 79 skipped, 0 failed on Windows / Node 24.19.0. Lifecycle: 11 passed / 2 skipped; executor: 27 passed / 77 skipped. |
| Main-process and sandbox types | `npm run typecheck:node` | Passed on Node 22 after generating a worktree-local Prisma client and supplying the already-installed matching citeme-engine-wasm dependency. |
| Source style | `npm run lint` | Passed. |
| Patch whitespace | `git diff HEAD^ --check` | Passed. |

The executor consumer suite is included because the lifecycle owner controls its durable process admission and shutdown receipts. Test skips follow existing platform/runtime availability gates; Windows process recovery ran. The local shared Vitest setup failed to load under Node 22 with ERR_REQUIRE_ESM, so the project tests used Node 24 while the exact Windows bug and host regression were independently exercised directly under Node 22. These are targeted checks, not a full-suite claim.

## Review focus

Check the distinction between unpublished temporary writes and authoritative pending/active receipts, and preservation of fail-closed recovery. No renderer/API interface changed, so renderer checks were excluded. Windows is the affected platform; Linux/macOS and full interactive Electron Notebook execution were not run locally and remain CI/manual coverage.

