### PR TITLE
fix(composer): preserve copied message references on paste

### DIFF
--- a/e2e/browser/fixture/message-clipboard.html
+++ b/e2e/browser/fixture/message-clipboard.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Message clipboard test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/message-clipboard.tsx"></script>
+  </body>
+</html>

--- a/e2e/browser/fixture/message-clipboard.tsx
+++ b/e2e/browser/fixture/message-clipboard.tsx
@@ -48,7 +48,7 @@ const parts: NonNullable<ChatMessage['parts']> = [
     sourceFileId: 'csv-file',
     versionId: 'csv-version',
     source: 'upload',
-    name: '对角线火山图.csv',
+    name: 'volcano-plot.csv',
     path: 'uploads/plot.csv',
     mimeType: 'text/csv'
   },
@@ -59,10 +59,10 @@ const parts: NonNullable<ChatMessage['parts']> = [
     sourceFileId: 'xlsx-file',
     versionId: 'xlsx-version',
     source: 'upload',
-    name: '对角线火山图-差异分析.xlsx',
+    name: 'volcano-plot-differential-analysis.xlsx',
     path: 'uploads/analysis.xlsx'
   },
-  { type: 'text', text: '\n用 R 绘制对角线火山图' }
+  { type: 'text', text: '\nCreate a volcano plot in R' }
 ]
 const message: ChatMessage = {
   id: 'message',

--- a/e2e/browser/fixture/message-clipboard.tsx
+++ b/e2e/browser/fixture/message-clipboard.tsx
@@ -1,0 +1,168 @@
+import '@/assets/main.css'
+import { useRef, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import { initI18n } from '@/i18n'
+import {
+  MessageScrollerProvider,
+  MessageScroller,
+  MessageScrollerViewport,
+  MessageScrollerContent
+} from '@/components/ui/message-scroller'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { WorkspaceMessageItem } from '@/pages/workspace/WorkspaceMessageItem'
+import { ComposerEditor } from '@/pages/workspace/composer/ComposerEditor'
+import {
+  docToText,
+  emptyDoc,
+  type ComposerDoc,
+  type ComposerCaretPosition
+} from '@/pages/workspace/composer/composer-doc'
+import {
+  useWorkspaceComposerUploadController,
+  type ComposerDraft
+} from '@/pages/workspace/workspace-composer-upload-controller'
+import { useSettingsStore } from '@/stores/settings-store'
+import type { ChatMessage } from '@/stores/session-store'
+import type { Annotation } from '../../../src/shared/annotations'
+import type { SessionPdfContextSource } from '../../../src/shared/session-persistence'
+
+initI18n('en')
+useSettingsStore.setState({ skillsLoaded: true })
+const noop = (): void => undefined
+// Only external effects are stubbed. Copy, paste, rendering and draft undo are production code.
+const unavailable = async (): Promise<never> => {
+  throw new Error('Not used by the clipboard fixture')
+}
+const uploadApi = {
+  beginTransfer: unavailable,
+  appendTransfer: unavailable,
+  finishTransfer: unavailable,
+  abortTransfer: unavailable,
+  getTransferStatus: unavailable,
+  deleteUpload: unavailable
+}
+const parts: NonNullable<ChatMessage['parts']> = [
+  {
+    type: 'artifact',
+    id: 'csv-file',
+    sourceFileId: 'csv-file',
+    versionId: 'csv-version',
+    source: 'upload',
+    name: '对角线火山图.csv',
+    path: 'uploads/plot.csv',
+    mimeType: 'text/csv'
+  },
+  { type: 'text', text: ' ' },
+  {
+    type: 'artifact',
+    id: 'xlsx-file',
+    sourceFileId: 'xlsx-file',
+    versionId: 'xlsx-version',
+    source: 'upload',
+    name: '对角线火山图-差异分析.xlsx',
+    path: 'uploads/analysis.xlsx'
+  },
+  { type: 'text', text: '\n用 R 绘制对角线火山图' }
+]
+const message: ChatMessage = {
+  id: 'message',
+  role: 'user',
+  content: docToText({ nodes: parts }),
+  parts,
+  status: 'complete',
+  eventIds: [],
+  createdAt: 1788940800000,
+  updatedAt: 1788940800000
+}
+const initialDraft: ComposerDraft = {
+  doc: emptyDoc,
+  annotations: [],
+  attachments: [],
+  attachmentTransfers: [],
+  automaticReadingEnabled: false
+}
+
+export function ClipboardFixture(): React.JSX.Element {
+  const [doc, setDoc] = useState(emptyDoc)
+  const [caretRequest, setCaretRequest] = useState<{
+    key: number
+    position: ComposerCaretPosition
+  }>()
+  const docRef = useRef<ComposerDoc>(emptyDoc)
+  const activeDraftKeyRef = useRef('draft')
+  const draftsRef = useRef<Record<string, ComposerDraft>>({ draft: initialDraft })
+  const annotationsRef = useRef<Annotation[]>([])
+  const readingContextSourcesRef = useRef<SessionPdfContextSource[]>([])
+  const automaticReadingEnabledRef = useRef(false)
+  const controller = useWorkspaceComposerUploadController({
+    initialDraft,
+    activeDraftKeyRef,
+    docRef,
+    draftsRef,
+    annotationsRef,
+    readingContextSourcesRef,
+    automaticReadingEnabledRef,
+    setActiveDoc: (next) => {
+      docRef.current = next
+      setDoc(next)
+    },
+    setActiveAnnotations: noop,
+    clearHistory: noop,
+    markChanged: noop,
+    requestCaret: (position) =>
+      setCaretRequest((previous) => ({ key: (previous?.key ?? 0) + 1, position })),
+    canStageAttachments: false,
+    supportsImageInput: false,
+    uploads: uploadApi,
+    restoreReadingContextSources: noop,
+    setActiveAutomaticReadingEnabled: noop
+  })
+  return (
+    <TooltipProvider>
+      <main className="mx-auto flex min-h-screen max-w-4xl flex-col gap-12 px-8 py-12">
+        <header className="text-sm text-muted-foreground">
+          Open Science · Message clipboard browser test
+        </header>
+        <MessageScrollerProvider>
+          <div className="h-56">
+            <MessageScroller>
+              <MessageScrollerViewport>
+                <MessageScrollerContent>
+                  <WorkspaceMessageItem
+                    message={message}
+                    projectId="project"
+                    onPreviewArtifact={noop}
+                    onPreviewUploadAttachment={noop}
+                    onOpenSkillMention={noop}
+                    onPreviewMentionArtifact={noop}
+                  />
+                </MessageScrollerContent>
+              </MessageScrollerViewport>
+            </MessageScroller>
+          </div>
+        </MessageScrollerProvider>
+        <section className="rounded-2xl border border-border bg-bg-000 p-5 shadow-sm">
+          <ComposerEditor
+            doc={doc}
+            onDocChange={controller.actions.changeDoc}
+            onSubmit={noop}
+            onPaste={noop}
+            placeholder="Ask anything"
+            ariaLabel="Ask anything"
+            onUndo={controller.actions.undo}
+            onRedo={controller.actions.redo}
+            caretRequest={caretRequest}
+            mentionPreviewContext={{
+              projectId: new URLSearchParams(location.search).get('project') ?? 'project',
+              sessionId: 'target'
+            }}
+          />
+        </section>
+        <output hidden data-testid="draft">
+          {JSON.stringify(doc)}
+        </output>
+      </main>
+    </TooltipProvider>
+  )
+}
+createRoot(document.getElementById('root')!).render(<ClipboardFixture />)

--- a/e2e/browser/message-clipboard.spec.ts
+++ b/e2e/browser/message-clipboard.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from '@playwright/test'
+
+// The operating-system clipboard is shared across browser contexts.
+test.describe.configure({ mode: 'serial' })
+
+test('copies file references through the system clipboard, replaces selection and supports undo', async ({
+  page,
+  context
+}, testInfo) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+  await page.goto('/message-clipboard.html')
+  const editor = page.getByRole('textbox', { name: 'Ask anything' })
+  await page.getByRole('button', { name: 'Copy message', exact: true }).click()
+  await expect(page.getByRole('button', { name: 'Copied', exact: true })).toBeVisible()
+  await editor.fill('replace me')
+  await editor.press('ControlOrMeta+A')
+  await editor.press('ControlOrMeta+V')
+  await expect(editor.locator('[data-mention-type="artifact"]')).toHaveCount(2)
+  const draft = await page.getByTestId('draft').textContent()
+  expect(
+    JSON.parse(draft!).nodes.filter((node: { type: string }) => node.type === 'artifact')
+  ).toMatchObject([
+    { id: 'csv-file', versionId: 'csv-version' },
+    { id: 'xlsx-file', versionId: 'xlsx-version' }
+  ])
+  await editor.press('ControlOrMeta+Z')
+  await expect(editor).toHaveText('replace me')
+  await editor.press('ControlOrMeta+Shift+Z')
+  await expect(editor.locator('[data-mention-type="artifact"]')).toHaveCount(2)
+  await page.screenshot({ path: testInfo.outputPath('restored-references.png'), fullPage: true })
+  await editor.press('End')
+  await editor.pressSequentially(' continued')
+  await expect(editor).toContainText('continued')
+  await expect(editor.locator('[data-mention-type="artifact"]')).toHaveCount(2)
+})
+
+test('pastes readable text into another Project', async ({ page, context }) => {
+  await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+  await page.goto('/message-clipboard.html?project=other')
+  await page.getByRole('button', { name: 'Copy message', exact: true }).click()
+  await expect(page.getByRole('button', { name: 'Copied', exact: true })).toBeVisible()
+  const editor = page.getByRole('textbox', { name: 'Ask anything' })
+  await editor.click()
+  await editor.press('ControlOrMeta+V')
+  await expect(editor).toContainText('@对角线火山图.csv')
+  await expect(editor.locator('[data-mention-type]')).toHaveCount(0)
+})

--- a/e2e/browser/message-clipboard.spec.ts
+++ b/e2e/browser/message-clipboard.spec.ts
@@ -42,6 +42,6 @@ test('pastes readable text into another Project', async ({ page, context }) => {
   const editor = page.getByRole('textbox', { name: 'Ask anything' })
   await editor.click()
   await editor.press('ControlOrMeta+V')
-  await expect(editor).toContainText('@对角线火山图.csv')
+  await expect(editor).toContainText('@volcano-plot.csv')
   await expect(editor.locator('[data-mention-type]')).toHaveCount(0)
 })

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -12,6 +12,8 @@ import type { ChatMessage } from '@/stores/session-store'
 import type { SendEditedMessage } from './workspace-edited-message'
 import type { EditAnnotationTarget } from './WorkspaceMessageItem'
 import type { Annotation, TextAnnotation } from '../../../../shared/annotations'
+import { ComposerEditor } from './composer/ComposerEditor'
+import { domToDoc, docToMessageParts, emptyDoc } from './composer/composer-doc'
 import { TooltipProvider } from '@/components/ui/tooltip'
 import { WorkspaceMessageItem as MessageItem } from './WorkspaceMessageItem'
 
@@ -974,6 +976,85 @@ describe('WorkspaceMessageItem user message actions', () => {
     await click(editButton)
     expect(getEditor()).toBeNull()
     expect(onSendEditedMessage).not.toHaveBeenCalled()
+  })
+
+  it('preserves file identities when a copied message is pasted into Composer', async () => {
+    const clipboard = new Map<string, string>()
+    vi.stubGlobal(
+      'ClipboardItem',
+      class {
+        constructor(readonly data: Record<string, Blob>) {}
+      }
+    )
+    const readBlob = (blob: Blob): Promise<string> =>
+      new Promise((resolve) => {
+        const reader = new FileReader()
+        reader.onload = () => resolve(String(reader.result))
+        reader.readAsText(blob)
+      })
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: async (text: string) => {
+          clipboard.set('text/plain', text)
+        },
+        write: async (items: { data: Record<string, Blob> }[]) => {
+          for (const [type, blob] of Object.entries(items[0].data)) {
+            clipboard.set(type, await readBlob(blob))
+          }
+        }
+      }
+    })
+    const parts: NonNullable<ChatMessage['parts']> = [
+      {
+        type: 'artifact',
+        id: 'upload-1',
+        sourceFileId: 'file-1',
+        versionId: 'version-1',
+        name: '对角线火山图.csv',
+        path: 'uploads/plot.csv',
+        source: 'upload',
+        mimeType: 'text/csv'
+      },
+      { type: 'text', text: ' 用 R 绘图' }
+    ]
+    try {
+      await renderItem(createMessage({ content: '@对角线火山图.csv 用 R 绘图', parts }))
+      await click(getButton('Copy message'))
+      await act(async () => {
+        await vi.waitFor(() => expect(clipboard.has('text/html')).toBe(true))
+      })
+      await act(async () => {
+        root.render(
+          <ComposerEditor
+            doc={emptyDoc}
+            onDocChange={noop}
+            onSubmit={noop}
+            onPaste={noop}
+            placeholder="Ask anything"
+            ariaLabel="Ask anything"
+            mentionPreviewContext={{ sessionId: 'target-session', projectId: 'project-1' }}
+          />
+        )
+      })
+      const composer = container.querySelector<HTMLElement>('[role="textbox"]')!
+      composer.focus()
+      const range = document.createRange()
+      range.selectNodeContents(composer)
+      window.getSelection()?.removeAllRanges()
+      window.getSelection()?.addRange(range)
+      await act(async () => {
+        const paste = new Event('paste', { bubbles: true, cancelable: true })
+        Object.defineProperty(paste, 'clipboardData', {
+          value: { files: [], getData: (type: string) => clipboard.get(type) ?? '' }
+        })
+        composer.dispatchEvent(paste)
+      })
+      expect(composer.querySelector('[data-mention-type="artifact"]')).not.toBeNull()
+      expect(docToMessageParts(domToDoc(composer))).toEqual(parts)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 
   it('opens an inline editor prefilled from the message, restoring mention chips', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -1011,15 +1011,15 @@ describe('WorkspaceMessageItem user message actions', () => {
         id: 'upload-1',
         sourceFileId: 'file-1',
         versionId: 'version-1',
-        name: '对角线火山图.csv',
+        name: 'volcano-plot.csv',
         path: 'uploads/plot.csv',
         source: 'upload',
         mimeType: 'text/csv'
       },
-      { type: 'text', text: ' 用 R 绘图' }
+      { type: 'text', text: ' Plot in R' }
     ]
     try {
-      await renderItem(createMessage({ content: '@对角线火山图.csv 用 R 绘图', parts }))
+      await renderItem(createMessage({ content: '@volcano-plot.csv Plot in R', parts }))
       await click(getButton('Copy message'))
       await act(async () => {
         await vi.waitFor(() => expect(clipboard.has('text/html')).toBe(true))

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -49,6 +49,7 @@ import { getUploadedAttachmentName } from '../../../../shared/uploads'
 
 import { ArtifactPreview } from './artifact-preview'
 import { ComposerEditor } from './composer/ComposerEditor'
+import { copyMessageToClipboard } from './composer/message-clipboard'
 import { EditMessageConfirmDialog } from './EditMessageConfirmDialog'
 import { ExtensionPreservingFileName } from './ExtensionPreservingFileName'
 import { providerKindKey } from '../settings/provider-form-value'
@@ -1464,7 +1465,11 @@ const WorkspaceMessageItemImpl = ({
 
   // Copies the message text and briefly swaps the icon to confirm the clipboard write succeeded.
   const handleCopyMessage = (): void => {
-    void navigator.clipboard.writeText(liveMessageContent).then(() => {
+    void copyMessageToClipboard(
+      liveMessageContent,
+      message.role === 'user' ? message.parts : undefined,
+      projectId
+    ).then(() => {
       setCopied(true)
       if (copyResetTimeoutRef.current !== null) window.clearTimeout(copyResetTimeoutRef.current)
       copyResetTimeoutRef.current = window.setTimeout(() => setCopied(false), 2000)

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -1595,3 +1595,104 @@ describe('ComposerEditor', () => {
     })
   })
 })
+
+describe('structured message paste', () => {
+  const fragment = [{ type: 'skill' as const, id: 'lit', name: 'Literature' }]
+  const pasteSkill = (): void => {
+    const element = document.createElement('span')
+    element.setAttribute(
+      'data-open-science-message',
+      JSON.stringify({
+        version: 1,
+        origin: location.origin,
+        projectId: 'default',
+        parts: fragment
+      })
+    )
+    const paste = new Event('paste', { bubbles: true, cancelable: true })
+    Object.defineProperty(paste, 'clipboardData', {
+      value: {
+        files: [],
+        getData: (type: string) => (type === 'text/html' ? element.outerHTML : '/Literature')
+      }
+    })
+    act(() => {
+      editor().dispatchEvent(paste)
+    })
+  }
+  const selectContents = (): void => {
+    editor().focus()
+    const range = document.createRange()
+    range.selectNodeContents(editor())
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+  }
+
+  it('preserves the selection while the Skill catalog loads, then restores the Skill on retry', async () => {
+    const loadSkills = vi.fn(async () => {
+      useSettingsStore.setState({ skillsLoaded: true, skills: seedSkills })
+    })
+    useSettingsStore.setState({ skillsLoaded: false, skills: [], loadSkills })
+    const onDocChange = vi.fn()
+    renderEditor({ doc: { nodes: [{ type: 'text', text: 'keep this' }] }, onDocChange })
+    selectContents()
+    await act(async () => {
+      pasteSkill()
+    })
+    expect(editor().textContent).toBe('keep this')
+    expect(onDocChange).not.toHaveBeenCalled()
+    expect(loadSkills).toHaveBeenCalledOnce()
+    expect(document.body.textContent).toContain('Skills are loading. Paste again shortly.')
+    pasteSkill()
+    expect(domToDoc(editor())).toEqual({ nodes: fragment })
+    expect(onDocChange).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the draft on catalog failure and hides its notice in a different Session', async () => {
+    const loadSkills = vi.fn().mockRejectedValue(new Error('offline'))
+    useSettingsStore.setState({ skillsLoaded: false, skills: [], loadSkills })
+    const doc: ComposerDoc = { nodes: [{ type: 'text', text: 'keep this' }] }
+    renderEditor({ doc, mentionPreviewContext: { sessionId: 'first', projectId: 'default' } })
+    selectContents()
+    await act(async () => {
+      pasteSkill()
+    })
+    expect(editor().textContent).toBe('keep this')
+    expect(document.body.textContent).toContain('Could not load Skills. Try pasting again.')
+    renderEditor({ doc, mentionPreviewContext: { sessionId: 'second', projectId: 'default' } })
+    expect(document.body.textContent).not.toContain('Could not load Skills. Try pasting again.')
+  })
+
+  it('replaces a selected Skill without counting it against the new paste', () => {
+    useSettingsStore.setState({ skillsLoaded: true })
+    const onDocChange = vi.fn()
+    renderEditor({
+      doc: { nodes: [{ type: 'skill', id: 'mpnn', name: 'ProteinMPNN' }] },
+      onDocChange
+    })
+    selectContents()
+    pasteSkill()
+    expect(domToDoc(editor())).toEqual({ nodes: fragment })
+    expect(onDocChange).toHaveBeenCalledWith(
+      { nodes: fragment },
+      expect.objectContaining({ nodeIndex: 0 })
+    )
+  })
+
+  it('preserves surrounding text and inserts at the selected range', () => {
+    useSettingsStore.setState({ skillsLoaded: true })
+    renderEditor({ doc: { nodes: [{ type: 'text', text: 'before replace after' }] } })
+    editor().focus()
+    const range = document.createRange()
+    range.setStart(editor().firstChild!, 7)
+    range.setEnd(editor().firstChild!, 14)
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+    pasteSkill()
+    expect(domToDoc(editor()).nodes).toEqual([
+      { type: 'text', text: 'before ' },
+      ...fragment,
+      { type: 'text', text: ' after' }
+    ])
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -5,6 +5,8 @@ import type { SkillView } from '../../../../../shared/settings'
 import { resolveLocalPath } from '../../../../../shared/local-fs'
 import { cn } from '@/lib/utils'
 import { useGrantedFoldersStore } from '@/stores/granted-folders-store'
+import { useSettingsStore } from '@/stores/settings-store'
+import { constrainMessageClipboard, readMessageClipboard } from './message-clipboard'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
@@ -457,6 +459,7 @@ export const ComposerEditor = ({
   const { t } = useTranslation()
 
   const editorRef = useRef<HTMLDivElement>(null)
+  const [pasteStatus, setPasteStatus] = useState<{ scope: string; message: string }>()
   const historyDescriptionId = useId()
   const historyStatusId = useId()
   const mentionListboxId = useId()
@@ -494,6 +497,7 @@ export const ComposerEditor = ({
     disabled: disabled || docSessionCount(doc) >= MAX_COMPOSER_SESSION_MENTIONS
   })
   const activeProjectId = useNavigationStore((state) => state.activeProjectId)
+  const pasteScope = `${mentionPreviewContext?.projectId ?? activeProjectId}:${mentionPreviewContext?.sessionId ?? ''}`
   const mentionPopupOpen = mention.active || artifactMention.active || sessionMention.active
   const undoCaretRef = useRef<ComposerCaretPosition | undefined>(undefined)
 
@@ -755,11 +759,61 @@ export const ComposerEditor = ({
   }
 
   const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>): void => {
+    setPasteStatus(undefined)
     const activeRoot = editorRef.current
     undoCaretRef.current = activeRoot ? currentCaretPosition(activeRoot) : undefined
     // Forward first so the panel can route file attachments to its intake.
     onPaste(event)
     if (disabled || event.isDefaultPrevented()) return
+    const messageFragment = readMessageClipboard(
+      event.clipboardData?.getData('text/html') ?? '',
+      event.clipboardData?.getData('text/plain') ?? '',
+      mentionPreviewContext?.projectId ?? activeProjectId
+    )
+    const selected = activeRoot ? selectedRangeIn(activeRoot) : undefined
+    if (messageFragment && activeRoot && selected) {
+      event.preventDefault()
+      const catalog = useSettingsStore.getState()
+      if (messageFragment.nodes.some((node) => node.type === 'skill') && !catalog.skillsLoaded) {
+        setPasteStatus({
+          scope: pasteScope,
+          message: t('Skills are loading. Paste again shortly.')
+        })
+        void catalog.loadSkills().catch(() => {
+          setPasteStatus({
+            scope: pasteScope,
+            message: t('Could not load Skills. Try pasting again.')
+          })
+        })
+        return
+      }
+      const { selection, range } = selected
+      range.deleteContents()
+      const skills = useSettingsStore
+        .getState()
+        .skills.filter(
+          (skill) =>
+            skill.available !== false &&
+            (allowedSkillIds ? allowedSkillIds.includes(skill.id) : skill.enabled)
+        )
+      const fragment = constrainMessageClipboard(
+        messageFragment,
+        domToDoc(activeRoot),
+        new Set(skills.map((skill) => skill.id))
+      )
+      const staging = document.createElement('div')
+      applyDocToDom(staging, fragment)
+      const inserted = document.createDocumentFragment()
+      inserted.append(...staging.childNodes)
+      const last = inserted.lastChild
+      range.insertNode(inserted)
+      if (last) range.setStartAfter(last)
+      range.collapse(true)
+      selection.removeAllRanges()
+      selection.addRange(range)
+      emitDocFromDom()
+      return
+    }
     const internalFragment = parseComposerClipboardFragment(
       event.clipboardData?.getData(PASTED_TEXT_CLIPBOARD_TYPE) ?? ''
     )
@@ -913,6 +967,11 @@ export const ComposerEditor = ({
           emitDocFromDom()
         }}
       />
+      {pasteStatus?.scope === pasteScope ? (
+        <div role="status" className="text-xs text-muted-foreground">
+          {pasteStatus.message}
+        </div>
+      ) : null}
       <span id={historyDescriptionId} className="sr-only">
         {t('At the start of the input, use Up and Down Arrow to browse prompt history.')}
       </span>

--- a/src/renderer/src/pages/workspace/composer/message-clipboard.test.ts
+++ b/src/renderer/src/pages/workspace/composer/message-clipboard.test.ts
@@ -104,6 +104,19 @@ describe('message clipboard', () => {
     expect(writeText).not.toHaveBeenCalled()
   })
 
+  it('accepts native clipboard newline conversion without changing reference identities', async () => {
+    const multiline = [...parts, { type: 'text' as const, text: '\nsecond line\nthird line' }]
+    const sourceText = docToText(docFromMessageParts(multiline))
+    await copyMessageToClipboard(sourceText, multiline, 'project')
+    expect(
+      readMessageClipboard(
+        clipboard.get('text/html')!,
+        sourceText.replaceAll('\n', '\r\n'),
+        'project'
+      )
+    ).toEqual(docFromMessageParts(multiline))
+  })
+
   it('does not restore references across projects, origins, or mismatched text', async () => {
     await copyMessageToClipboard(text, parts, 'project')
     const html = clipboard.get('text/html')!

--- a/src/renderer/src/pages/workspace/composer/message-clipboard.test.ts
+++ b/src/renderer/src/pages/workspace/composer/message-clipboard.test.ts
@@ -23,7 +23,7 @@ const parts: MessagePart[] = [
     sourceFileId: 'file',
     versionId: 'v1',
     source: 'upload',
-    name: '数据.csv',
+    name: 'data.csv',
     path: 'uploads/data.csv'
   },
   {
@@ -31,7 +31,7 @@ const parts: MessagePart[] = [
     id: 'artifact',
     versionId: 'v2',
     source: 'artifact',
-    name: '结果.xlsx',
+    name: 'results.xlsx',
     path: 'artifacts/result.xlsx'
   },
   {

--- a/src/renderer/src/pages/workspace/composer/message-clipboard.test.ts
+++ b/src/renderer/src/pages/workspace/composer/message-clipboard.test.ts
@@ -1,0 +1,189 @@
+// @vitest-environment jsdom
+import { Blob as NodeBlob } from 'node:buffer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { MessagePart } from '../../../../../shared/session-persistence'
+import {
+  constrainMessageClipboard,
+  copyMessageToClipboard,
+  readMessageClipboard
+} from './message-clipboard'
+import {
+  docFromMessageParts,
+  docToText,
+  emptyDoc,
+  MAX_COMPOSER_ARTIFACT_MENTIONS,
+  MAX_COMPOSER_SESSION_MENTIONS
+} from './composer-doc'
+
+const parts: MessagePart[] = [
+  { type: 'text', text: 'Analyze <data> & ' },
+  {
+    type: 'artifact',
+    id: 'upload',
+    sourceFileId: 'file',
+    versionId: 'v1',
+    source: 'upload',
+    name: '数据.csv',
+    path: 'uploads/data.csv'
+  },
+  {
+    type: 'artifact',
+    id: 'artifact',
+    versionId: 'v2',
+    source: 'artifact',
+    name: '结果.xlsx',
+    path: 'artifacts/result.xlsx'
+  },
+  {
+    type: 'artifact',
+    id: 'linked',
+    source: 'linked-folder',
+    name: 'local.csv',
+    rootId: 'granted-root',
+    relativePath: 'data/local.csv'
+  },
+  { type: 'skill', id: 'skill', name: 'analysis' },
+  { type: 'session', sessionId: 'session', title: 'Previous work' },
+  { type: 'literature-scope', scope: 'project' },
+  { type: 'literature-scope', scope: 'collection', collectionId: 'collection', name: 'Reading' },
+  {
+    type: 'literature',
+    itemId: 'paper',
+    metadataRevision: 2,
+    item: {
+      itemType: 'journalArticle',
+      title: 'Research',
+      abstract: '',
+      issuedText: '',
+      containerTitle: '',
+      shortTitle: '',
+      language: '',
+      rights: '',
+      url: '',
+      extra: '',
+      typeFields: {},
+      creators: [],
+      identifiers: []
+    }
+  }
+]
+const text = docToText(docFromMessageParts(parts))
+let clipboard: Map<string, string>
+let writeText: ReturnType<typeof vi.fn>
+let write: ReturnType<typeof vi.fn>
+
+beforeEach(() => {
+  clipboard = new Map()
+  vi.stubGlobal('Blob', NodeBlob)
+  vi.stubGlobal(
+    'ClipboardItem',
+    class {
+      constructor(readonly data: Record<string, Blob>) {}
+    }
+  )
+  writeText = vi.fn(async (value: string) => {
+    clipboard.set('text/plain', value)
+  })
+  write = vi.fn(async (items: { data: Record<string, Blob> }[]) => {
+    for (const [type, blob] of Object.entries(items[0].data)) clipboard.set(type, await blob.text())
+  })
+  Object.defineProperty(navigator, 'clipboard', {
+    configurable: true,
+    value: { write, writeText }
+  })
+})
+afterEach(() => vi.unstubAllGlobals())
+
+describe('message clipboard', () => {
+  it('round-trips inline references while preserving readable external text', async () => {
+    await copyMessageToClipboard(text, parts, 'project')
+    expect(clipboard.get('text/plain')).toBe(text)
+    expect(readMessageClipboard(clipboard.get('text/html')!, text, 'project')).toEqual(
+      docFromMessageParts(parts)
+    )
+    expect(writeText).not.toHaveBeenCalled()
+  })
+
+  it('does not restore references across projects, origins, or mismatched text', async () => {
+    await copyMessageToClipboard(text, parts, 'project')
+    const html = clipboard.get('text/html')!
+    expect(readMessageClipboard(html, text, 'other')).toBeUndefined()
+    expect(readMessageClipboard(html, text, undefined)).toBeUndefined()
+    expect(readMessageClipboard(html, 'different text', 'project')).toBeUndefined()
+    const template = document.createElement('template')
+    template.innerHTML = html
+    const element = template.content.firstElementChild!
+    const value = JSON.parse(element.getAttribute('data-open-science-message')!)
+    value.origin = 'https://other.example'
+    element.setAttribute('data-open-science-message', JSON.stringify(value))
+    expect(readMessageClipboard(element.outerHTML, text, 'project')).toBeUndefined()
+  })
+
+  it.each([
+    'not JSON',
+    JSON.stringify({ version: 2, origin: location.origin, projectId: 'project', parts }),
+    JSON.stringify({
+      version: 1,
+      origin: location.origin,
+      projectId: 'project',
+      parts: [...parts, { type: 'unknown' }]
+    }),
+    JSON.stringify({
+      version: 1,
+      origin: location.origin,
+      projectId: 'project',
+      parts: [{ type: 'artifact', id: 'x' }]
+    })
+  ])('rejects malformed or unsupported metadata', (value) => {
+    const element = document.createElement('span')
+    element.setAttribute('data-open-science-message', value)
+    expect(readMessageClipboard(element.outerHTML, text, 'project')).toBeUndefined()
+  })
+
+  it('falls back to text when rich clipboard writes fail or the host lacks support', async () => {
+    write.mockRejectedValueOnce(new Error('unsupported'))
+    await copyMessageToClipboard(text, parts, 'project')
+    expect(writeText).toHaveBeenCalledWith(text)
+    vi.stubGlobal('ClipboardItem', undefined)
+    await copyMessageToClipboard(text, parts, 'project')
+    expect(writeText).toHaveBeenCalledTimes(2)
+  })
+
+  it('keeps historical text-only messages and inconsistent parts as text', async () => {
+    await copyMessageToClipboard('@data.csv', undefined, 'project')
+    await copyMessageToClipboard('changed', parts, 'project')
+    await copyMessageToClipboard(text, parts, undefined)
+    expect(write).not.toHaveBeenCalled()
+    expect(writeText).toHaveBeenCalledTimes(3)
+  })
+
+  it('propagates a failed plain copy so the UI cannot claim success', async () => {
+    writeText.mockRejectedValueOnce(new Error('denied'))
+    await expect(copyMessageToClipboard('plain', undefined, 'project')).rejects.toThrow('denied')
+  })
+
+  it('keeps reference caps and allows only one available Skill without losing labels', () => {
+    const artifact = parts[1]
+    const session = parts[5]
+    const remaining = docFromMessageParts([
+      ...Array.from({ length: MAX_COMPOSER_ARTIFACT_MENTIONS }, () => artifact),
+      ...Array.from({ length: MAX_COMPOSER_SESSION_MENTIONS }, () => session),
+      { type: 'skill', id: 'existing', name: 'existing' }
+    ])
+    const result = constrainMessageClipboard(
+      docFromMessageParts(parts),
+      remaining,
+      new Set(['skill'])
+    )
+    expect(result.nodes.every((node) => node.type === 'text')).toBe(true)
+    expect(docToText(result)).toBe(text)
+    const skills = docFromMessageParts([
+      { type: 'skill', id: 'unavailable', name: 'unavailable' },
+      { type: 'skill', id: 'skill', name: 'analysis' },
+      { type: 'skill', id: 'skill', name: 'analysis' }
+    ])
+    expect(
+      constrainMessageClipboard(skills, emptyDoc, new Set(['skill'])).nodes.map((node) => node.type)
+    ).toEqual(['text', 'skill', 'text'])
+  })
+})

--- a/src/renderer/src/pages/workspace/composer/message-clipboard.ts
+++ b/src/renderer/src/pages/workspace/composer/message-clipboard.ts
@@ -1,0 +1,115 @@
+import { sanitizeMessageParts, type MessagePart } from '../../../../../shared/session-persistence'
+import {
+  docArtifactCount,
+  docFromMessageParts,
+  docSessionCount,
+  docToText,
+  MAX_COMPOSER_ARTIFACT_MENTIONS,
+  MAX_COMPOSER_SESSION_MENTIONS,
+  type ComposerDoc
+} from './composer-doc'
+
+const MESSAGE_ATTRIBUTE = 'data-open-science-message'
+
+// HTML is the interoperable clipboard carrier; its markup is never inserted into the editor.
+// The plain representation remains useful in other apps and when rich clipboard writes fail.
+export const copyMessageToClipboard = async (
+  text: string,
+  parts: readonly MessagePart[] | undefined,
+  projectId: string | undefined
+): Promise<void> => {
+  const clipboard = navigator.clipboard
+  if (
+    projectId &&
+    parts?.some((part) => part.type !== 'text') &&
+    docToText(docFromMessageParts([...parts])).trim() === text.trim() &&
+    clipboard.write &&
+    typeof ClipboardItem !== 'undefined'
+  ) {
+    const element = document.createElement('span')
+    element.setAttribute(
+      MESSAGE_ATTRIBUTE,
+      JSON.stringify({ version: 1, origin: location.origin, projectId, parts })
+    )
+    element.textContent = text
+    try {
+      await clipboard.write([
+        new ClipboardItem({
+          'text/plain': new Blob([text], { type: 'text/plain' }),
+          'text/html': new Blob([element.outerHTML], { type: 'text/html' })
+        })
+      ])
+      return
+    } catch {
+      // Match other rich clipboard surfaces: retain a usable plain-text copy on unsupported hosts.
+    }
+  }
+  await clipboard.writeText(text)
+}
+
+export const readMessageClipboard = (
+  html: string,
+  text: string,
+  projectId: string | undefined
+): ComposerDoc | undefined => {
+  if (!projectId || !html || html.length > 1_000_000) return undefined
+  try {
+    // Template contents stay inert, including images, scripts, and event attributes.
+    const template = document.createElement('template')
+    template.innerHTML = html
+    const elements = template.content.querySelectorAll(`[${MESSAGE_ATTRIBUTE}]`)
+    if (elements.length !== 1) return undefined
+    const parsed: unknown = JSON.parse(elements[0].getAttribute(MESSAGE_ATTRIBUTE) ?? '')
+    if (!parsed || typeof parsed !== 'object') return undefined
+    const candidate = parsed as {
+      version?: unknown
+      origin?: unknown
+      projectId?: unknown
+      parts?: unknown
+    }
+    if (
+      candidate.version !== 1 ||
+      candidate.origin !== location.origin ||
+      candidate.projectId !== projectId ||
+      !Array.isArray(candidate.parts)
+    )
+      return undefined
+    const parts = sanitizeMessageParts(candidate.parts)
+    if (parts.length !== candidate.parts.length) return undefined
+    const doc = docFromMessageParts(parts)
+    if (!parts.some((part) => part.type !== 'text') || docToText(doc).trim() !== text.trim()) {
+      return undefined
+    }
+    return doc
+  } catch {
+    return undefined
+  }
+}
+
+// Apply the same caps as mention pickers to the draft remaining after selection replacement.
+// Unavailable Skills and overflow references retain their readable label instead of disappearing.
+export const constrainMessageClipboard = (
+  fragment: ComposerDoc,
+  remaining: ComposerDoc,
+  allowedSkillIds: ReadonlySet<string>
+): ComposerDoc => {
+  let hasSkill = remaining.nodes.some((node) => node.type === 'skill')
+  let artifacts = docArtifactCount(remaining)
+  let sessions = docSessionCount(remaining)
+  return {
+    nodes: fragment.nodes.map((node) => {
+      let allowed = true
+      if (node.type === 'skill') {
+        allowed = !hasSkill && allowedSkillIds.has(node.id)
+        if (allowed) hasSkill = true
+      } else if (node.type === 'session') {
+        allowed = sessions < MAX_COMPOSER_SESSION_MENTIONS
+        if (allowed) sessions++
+      } else if (docArtifactCount({ nodes: [node] }) > 0) {
+        allowed = artifacts < MAX_COMPOSER_ARTIFACT_MENTIONS
+        if (allowed) artifacts++
+      }
+      return allowed ? node : { type: 'text', text: docToText({ nodes: [node] }) }
+    })
+  }
+}

--- a/src/renderer/src/pages/workspace/composer/message-clipboard.ts
+++ b/src/renderer/src/pages/workspace/composer/message-clipboard.ts
@@ -11,6 +11,9 @@ import {
 
 const MESSAGE_ATTRIBUTE = 'data-open-science-message'
 
+// Native clipboards may translate line endings (notably CRLF on Windows).
+const normalizeClipboardText = (text: string): string => text.replace(/\r\n?/g, '\n').trim()
+
 // HTML is the interoperable clipboard carrier; its markup is never inserted into the editor.
 // The plain representation remains useful in other apps and when rich clipboard writes fail.
 export const copyMessageToClipboard = async (
@@ -22,7 +25,8 @@ export const copyMessageToClipboard = async (
   if (
     projectId &&
     parts?.some((part) => part.type !== 'text') &&
-    docToText(docFromMessageParts([...parts])).trim() === text.trim() &&
+    normalizeClipboardText(docToText(docFromMessageParts([...parts]))) ===
+      normalizeClipboardText(text) &&
     clipboard.write &&
     typeof ClipboardItem !== 'undefined'
   ) {
@@ -77,7 +81,10 @@ export const readMessageClipboard = (
     const parts = sanitizeMessageParts(candidate.parts)
     if (parts.length !== candidate.parts.length) return undefined
     const doc = docFromMessageParts(parts)
-    if (!parts.some((part) => part.type !== 'text') || docToText(doc).trim() !== text.trim()) {
+    if (
+      !parts.some((part) => part.type !== 'text') ||
+      normalizeClipboardText(docToText(doc)) !== normalizeClipboardText(text)
+    ) {
       return undefined
     }
     return doc

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -104,6 +104,8 @@
     "Your unsaved changes will be lost.": "Ihre ungespeicherten Änderungen gehen verloren."
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "Fähigkeiten werden geladen. Fügen Sie den Inhalt gleich erneut ein.",
+    "Could not load Skills. Try pasting again.": "Fähigkeiten konnten nicht geladen werden. Versuchen Sie erneut, den Inhalt einzufügen.",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Diese TIFF-Datei überschreitet die Vorschaugrenze von {{limit}} MiB. Laden Sie sie herunter oder öffnen Sie sie extern.",
     "Shared content": "Gemeinsame Inhalte",
     "Literature settings and tasks": "Literatureinstellungen und Aufgaben",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -105,6 +105,8 @@
     "Your unsaved changes will be lost.": "Se perderán los cambios sin guardar."
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "Se están cargando las Habilidades. Vuelva a pegar el contenido en breve.",
+    "Could not load Skills. Try pasting again.": "No se pudieron cargar las Habilidades. Intente pegar el contenido de nuevo.",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Este archivo TIFF supera el límite de vista previa de {{limit}} MiB. Descárguelo o ábralo en una aplicación externa.",
     "Shared content": "Contenido compartido",
     "Literature settings and tasks": "Configuración y tareas bibliográficas",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -105,6 +105,8 @@
     "Your unsaved changes will be lost.": "Vos modifications non enregistrées seront perdues."
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "Chargement des Compétences. Collez à nouveau dans un instant.",
+    "Could not load Skills. Try pasting again.": "Impossible de charger les Compétences. Essayez de coller à nouveau.",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Ce fichier TIFF dépasse la limite d’aperçu de {{limit}} Mio. Téléchargez-le ou ouvrez-le dans une application externe.",
     "Shared content": "Contenu partagé",
     "Literature settings and tasks": "Paramètres et tâches bibliographiques",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -103,6 +103,8 @@
     "Your unsaved changes will be lost.": "保存されていない変更は失われます。"
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "スキルを読み込んでいます。少し待ってから再度貼り付けてください。",
+    "Could not load Skills. Try pasting again.": "スキルを読み込めませんでした。もう一度貼り付けてください。",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "このTIFFはプレビューの上限（{{limit}} MiB）を超えています。ダウンロードするか、外部アプリで開いてください。",
     "Shared content": "共有コンテンツ",
     "Literature settings and tasks": "文献の設定とタスク",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -103,6 +103,8 @@
     "Your unsaved changes will be lost.": "저장하지 않은 변경 사항이 사라집니다."
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "스킬을 불러오는 중입니다. 잠시 후 다시 붙여넣으세요.",
+    "Could not load Skills. Try pasting again.": "스킬을 불러오지 못했습니다. 다시 붙여넣으세요.",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "이 TIFF는 미리보기 제한인 {{limit}} MiB를 초과합니다. 다운로드하거나 외부 앱에서 여세요.",
     "Shared content": "공유 콘텐츠",
     "Literature settings and tasks": "문헌 설정 및 작업",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -106,6 +106,8 @@
     "Your unsaved changes will be lost.": "Несохранённые изменения будут потеряны."
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "Навыки загружаются. Повторите вставку через некоторое время.",
+    "Could not load Skills. Try pasting again.": "Не удалось загрузить Навыки. Повторите вставку.",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "Этот TIFF превышает ограничение предпросмотра в {{limit}} МиБ. Скачайте его или откройте во внешнем приложении.",
     "Shared content": "Общее содержимое",
     "Literature settings and tasks": "Настройки и задачи литературы",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -103,6 +103,8 @@
     "Your unsaved changes will be lost.": "未保存的更改将会丢失。"
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "正在加载技能，请稍后再次粘贴。",
+    "Could not load Skills. Try pasting again.": "无法加载技能，请尝试再次粘贴。",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "此 TIFF 超过 {{limit}} MiB 的预览限制。请下载或使用外部应用打开。",
     "Shared content": "共享内容",
     "Literature settings and tasks": "文献配置与任务",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -103,6 +103,8 @@
     "Your unsaved changes will be lost.": "未儲存的變更將會遺失。"
   },
   "renderer": {
+    "Skills are loading. Paste again shortly.": "正在載入技能，請稍後再次貼上。",
+    "Could not load Skills. Try pasting again.": "無法載入技能，請嘗試再次貼上。",
     "This TIFF exceeds the {{limit}} MiB preview limit. Download it or open it externally.": "此 TIFF 超過 {{limit}} MiB 的預覽限制。請下載或使用外部應用程式開啟。",
     "Shared content": "共用內容",
     "Literature settings and tasks": "文獻設定與任務",


### PR DESCRIPTION
## Problem

The message Copy button writes only plain text. Pasting a prompt containing file or other inline references into Composer therefore loses their identities and turns the chips into inert labels.

## Proposed change

Copy readable plain text together with structured message parts in a standard HTML clipboard representation. Composer validates the payload, origin, Project and text, then rebuilds the existing document nodes at the selection. It preserves immutable file identities/versions, mention limits, Skill availability and draft undo/redo. Text comparison tolerates native CRLF/LF conversion as described by the [Clipboard specification](https://www.w3.org/TR/clipboard-apis/#write-content-to-the-clipboard). HTML is parsed inertly and never inserted into the editor.

If the Skill catalog is still loading, preserve the draft and selection, load the catalog and show a localized retry hint. Unsupported rich clipboard writes fall back to plain text.

## Scope and non-goals

- Same-Project inline file, Skill, Session, literature and literature-scope references. Other Projects/origins receive plain text.
- Do not copy standalone attachments, images or annotations. Do not guess file identities from names.
- Historical compatibility: messages retaining structured parts work without migration; text-only history remains text.
- State: no new enum values; only component-local, scope-limited paste feedback.
- Persistence: no schema, durable message format or migration change. Resent references use existing MessagePart persistence and runtime validation.

## Acceptance criteria and validation

Checks ran after the final material implementation changes. The final browser spec runs serially because the system clipboard is shared.

| Behavior / risk | Project-owned check | Result |
| --- | --- | --- |
| Copy button -> Composer, identities, malformed payloads, scope, caps, delayed/failed Skill loading, selection replacement, existing document behavior | `npx vitest run src/renderer/src/pages/workspace/composer/message-clipboard.test.ts src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx src/renderer/src/pages/workspace/composer/composer-doc.test.ts src/renderer/src/pages/workspace/workspace-composer-controller.test.ts src/renderer/src/i18n/resources.test.ts` | Passed |
| Workspace draft, history, queue and conversation consumers | `npm run test:module -- workspace_page` | 31 files / 883 tests passed |
| Conversation and sent mention consumers | Targeted ComposerEditor, ConversationPanel interaction and WorkspaceMessageItem mention suites | 3 files / 244 tests passed |
| Real system clipboard, selection replacement, typing, undo/redo and cross-Project text fallback | `npm run test:e2e:browser -- e2e/browser/message-clipboard.spec.ts` | Same 2 specs passed using installed Google Chrome through a local config; pinned Playwright Chromium is not installed locally |
| Renderer types and coding standards | `npm run typecheck:web`; `npm run lint`; `git diff --check` | Passed |
| Final impact selection | `npm run test:affected:explain -- --base origin/main --head HEAD` | Classifier selects full CI because the new browser fixture/spec paths have no dedicated ownership rule |

Per maintainer request, local verification is module/behavior-scoped rather than a complete `npm test`; exact-head PR CI remains authoritative. Independent review confirmed the final behavior-to-check mapping. A successful browser screenshot is emitted as `restored-references.png`.

## Review focus

- Clipboard is untrusted input; shared sanitization and existing runtime authorization remain in place.
- Validate supported reference round-trips without broadening plain-text paste into name-based matching.
- No ACP/runtime protocol, persistence or Node implementation changed, so local provider/model and migration matrices were not repeated.
- Remaining platform risk: native Electron, Windows/Linux and non-Chromium clipboard behavior were not exercised locally. The full authenticated Web instance encountered an unrelated event-recovery blocker; real clipboard verification used production message/editor/undo components in the project browser fixture, not a mocked clipboard.
