### PR TITLE
fix(state-sync): preserve authoritative renderer updates

### DIFF
--- a/src/main/application-events.ts
+++ b/src/main/application-events.ts
@@ -60,6 +60,7 @@ export type ApplicationEventMap = {
   'notebook:available': NotebookAvailableEvent
   'notebook:changed': NotebookChangedEvent
   'notebook-env:progress': ProvisionProgress
+  'runtime:policy-changed': undefined
   'notifications:changed': NotificationInboxChanged
   'background-result-delivery:changed': ProjectBackgroundActivityChangedEvent
   'project:created': Project

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3977,6 +3977,7 @@ const createApplicationModules = async (
   // (getRuntimeRoot(<dataRoot>)); read lazily so a data-root switch is reflected without re-register.
   const runtimeWorkflows = createRuntimeWorkflows({
     settingsService,
+    onPolicyChanged: () => broadcastToRenderers('runtime:policy-changed', undefined),
     ...(notebookNetworkSandbox.supportsWindowsRuntimeAccess
       ? {
           setWindowsRuntimeAccess: (executable: string, authorized: boolean) =>

--- a/src/main/notebook/runtime-application-commands.test.ts
+++ b/src/main/notebook/runtime-application-commands.test.ts
@@ -81,11 +81,11 @@ const install = (
 }
 
 describe('runtime application commands', () => {
-  it('installs the exact 12-command Runtime group', () => {
+  it('installs every Runtime method contract', () => {
     install()
-    const runtimeChannels = RENDERER_CONTRACT_GROUPS.find(
-      (group) => group.capability === 'runtime'
-    )?.contracts.map((contract) => contract.channel)
+    const runtimeChannels = RENDERER_CONTRACT_GROUPS.find((group) => group.capability === 'runtime')
+      ?.contracts.filter((contract) => contract.kind === 'method')
+      .map((contract) => contract.channel)
 
     expect(runtimeChannels).toHaveLength(13)
     expect(runtimeApplicationCommandGroup.commands.map((command) => command.name)).toEqual(

--- a/src/main/notebook/runtime-workflows.test.ts
+++ b/src/main/notebook/runtime-workflows.test.ts
@@ -490,3 +490,16 @@ describe('package-listing workflows', () => {
     expect(counts).toEqual({ '/managed/a': 1, '/usr/bin/python3': null })
   })
 })
+
+it('notifies other clients after committing the environment creation policy', async () => {
+  const settingsService = fakeSettingsService()
+  const onPolicyChanged = vi.fn()
+  const workflows = createRuntimeWorkflows({
+    settingsService,
+    runtimeRoot: () => '/fixture',
+    ...{ onPolicyChanged }
+  })
+  await workflows.setAgentEnvironmentCreationEnabled({ enabled: false })
+  expect(await settingsService.getAgentEnvironmentCreationEnabled()).toBe(false)
+  expect(onPolicyChanged).toHaveBeenCalledOnce()
+})

--- a/src/main/notebook/runtime-workflows.ts
+++ b/src/main/notebook/runtime-workflows.ts
@@ -37,6 +37,7 @@ type RuntimeSettings = {
 
 type RuntimeWorkflowDeps = {
   settingsService: RuntimeSettings
+  onPolicyChanged?: () => void
   // Resolve lazily so a data-root switch reaches discovery immediately.
   runtimeRoot: () => string
   // Called only after disabled state is durable; force chooses stop-now instead of drain-and-close.
@@ -220,7 +221,9 @@ const createRuntimeWorkflows = (deps: RuntimeWorkflowDeps): RuntimeWorkflows => 
       if (typeof request?.enabled !== 'boolean') {
         throw new TypeError('Agent environment creation enabled must be a boolean.')
       }
-      return deps.settingsService.setAgentEnvironmentCreationEnabled(request.enabled)
+      const enabled = await deps.settingsService.setAgentEnvironmentCreationEnabled(request.enabled)
+      deps.onPolicyChanged?.()
+      return enabled
     },
     describeUsage: async (request) =>
       deps.describeRuntimeUsage?.(request.language, request.envId) ?? {

--- a/src/main/renderer-broadcast.test.ts
+++ b/src/main/renderer-broadcast.test.ts
@@ -92,3 +92,27 @@ describe('broadcastToRenderers', () => {
     removeSecond()
   })
 })
+
+it('continues broadcasting when one live window fails during send', () => {
+  const failure = new Error('Object has been destroyed')
+  const failed = {
+    destroyed: false,
+    isDestroyed: () => false,
+    webContents: {
+      send: vi.fn(() => {
+        throw failure
+      })
+    }
+  }
+  const healthy = { destroyed: false, isDestroyed: () => false, webContents: { send: vi.fn() } }
+  windows.push(failed, healthy)
+  const hub = new ApplicationEventHub()
+  const uninstall = installRendererBroadcastEventHub(hub)
+  try {
+    hub.publish('runtime:policy-changed', undefined)
+    expect(healthy.webContents.send).toHaveBeenCalledWith('runtime:policy-changed', undefined)
+  } finally {
+    uninstall()
+    hub.dispose()
+  }
+})

--- a/src/main/renderer-broadcast.ts
+++ b/src/main/renderer-broadcast.ts
@@ -1,5 +1,9 @@
 import { BrowserWindow } from 'electron'
 
+import { createLogger, errorLogFields } from './logger'
+
+const log = createLogger('renderer-broadcast')
+
 import type {
   ApplicationEventChannel,
   ApplicationEventMap,
@@ -21,7 +25,15 @@ const projectToElectron = <Channel extends ApplicationEventChannel>(
   payload: ApplicationEventMap[Channel]
 ): void => {
   for (const window of BrowserWindow.getAllWindows()) {
-    if (!window.isDestroyed()) window.webContents.send(channel, payload)
+    try {
+      if (!window.isDestroyed()) window.webContents.send(channel, payload)
+    } catch (error) {
+      // Destruction can race the liveness check. One failed window must not starve its peers.
+      log.warn('Could not deliver application event to renderer', {
+        channel,
+        ...errorLogFields(error)
+      })
+    }
   }
 }
 

--- a/src/preload/index.test.ts
+++ b/src/preload/index.test.ts
@@ -491,6 +491,7 @@ describe('preload bridge — public surface inventory', () => {
       'runtime.listEnvironments',
       'runtime.listPackageCounts',
       'runtime.listPackages',
+      'runtime.onPolicyChanged',
       'runtime.pickInterpreter',
       'runtime.registerInterpreter',
       'runtime.setAgentEnvironmentCreationEnabled',

--- a/src/renderer/src/pages/literature/LiteratureSources.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureSources.test.tsx
@@ -89,3 +89,21 @@ describe('LiteratureSources', () => {
     expect(screen.getByLabelText('Stored metadata').textContent).toContain('<script>bad</script>')
   })
 })
+
+it('refreshes saved sources while the disclosure stays open', async () => {
+  const listeners = new Set<() => void>()
+  Object.assign(window.api.literature, {
+    onChanged: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  })
+  render(<LiteratureSources itemId="item-1" />)
+  await toggle('Metadata sources')
+  expect(await screen.findByText('Crossref')).not.toBeNull()
+  sources.mockResolvedValue([record, { ...record, id: 'source-2', provider: 'PubMed' }])
+  await act(async () => {
+    for (const listener of listeners) listener()
+  })
+  expect(screen.queryByText('PubMed')).not.toBeNull()
+})

--- a/src/renderer/src/pages/literature/LiteratureSources.tsx
+++ b/src/renderer/src/pages/literature/LiteratureSources.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next'
 
 import { ExternalTextLink } from '@/components/ExternalTextLink'
 import { ErrorNotice } from '@/components/error-notice'
+import { useLiteratureChanges } from './useLiteratureChanges'
 import type { LiteratureSourceRecordView } from '../../../../shared/literature'
 
 const sourceLink = (value: string): string | undefined => {
@@ -62,12 +63,18 @@ const LiteratureSources = ({ itemId }: { itemId: string }): React.JSX.Element =>
   const [attempt, setAttempt] = useState(0)
   const [sources, setSources] = useState<LiteratureSourceRecordView[]>()
   const [failed, setFailed] = useState(false)
+  useLiteratureChanges(() => {
+    if (open) setAttempt((value) => value + 1)
+  })
   useEffect(() => {
     if (!open) return
     let cancelled = false
     void window.api.literature.sources(itemId).then(
       (records) => {
-        if (!cancelled) setSources(records)
+        if (!cancelled) {
+          setSources(records)
+          setFailed(false)
+        }
       },
       () => {
         if (!cancelled) setFailed(true)

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -1334,3 +1334,53 @@ it('ignores a delayed local policy receipt after a newer remote change', async (
   })
   expect(toggle()?.getAttribute('data-state')).toBe('checked')
 })
+
+it('shows the committed policy when the follow-up read fails', async () => {
+  const read = vi.fn().mockResolvedValueOnce(true).mockRejectedValue(new Error('offline'))
+  Object.assign(window.api.runtime, {
+    getAgentEnvironmentCreationEnabled: read,
+    setAgentEnvironmentCreationEnabled: vi.fn().mockResolvedValue(false)
+  })
+  await render()
+  await click(container.querySelector('[aria-label="Let the Agent create environments"]'))
+  expect(
+    container
+      .querySelector('[aria-label="Let the Agent create environments"]')
+      ?.getAttribute('data-state')
+  ).toBe('unchecked')
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+})
+
+it('does not use a stale write fallback after a policy event even when rereading fails', async () => {
+  let finish!: (value: boolean) => void
+  let changed!: () => void
+  const read = vi.fn().mockResolvedValue(true)
+  Object.assign(window.api.runtime, {
+    getAgentEnvironmentCreationEnabled: read,
+    setAgentEnvironmentCreationEnabled: vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finish = resolve
+        })
+    ),
+    onPolicyChanged: (listener: () => void) => {
+      changed = listener
+      return () => undefined
+    }
+  })
+  await render()
+  await click(container.querySelector('[aria-label="Let the Agent create environments"]'))
+  await act(async () => {
+    changed()
+  })
+  read.mockRejectedValue(new Error('offline'))
+  await act(async () => {
+    finish(false)
+  })
+  expect(
+    container
+      .querySelector('[aria-label="Let the Agent create environments"]')
+      ?.getAttribute('data-state')
+  ).toBe('checked')
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+})

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -1281,3 +1281,56 @@ describe('RuntimesPanel packages dialog', () => {
     expect(occurrences(dialog, 'Conda: bio')).toBe(1)
   })
 })
+
+it('refreshes an open panel after another client changes policy and removes its listener', async () => {
+  let policy = true
+  const listeners = new Set<() => void>()
+  Object.assign(window.api.runtime, {
+    getAgentEnvironmentCreationEnabled: vi.fn(async () => policy),
+    onPolicyChanged: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  })
+  await render()
+  const toggle = (): Element | null =>
+    container.querySelector('[aria-label="Let the Agent create environments"]')
+  expect(toggle()?.getAttribute('data-state')).toBe('checked')
+  policy = false
+  await act(async () => {
+    for (const listener of listeners) listener()
+  })
+  expect(toggle()?.getAttribute('data-state')).toBe('unchecked')
+  expect(listEnvironments).toHaveBeenCalledOnce()
+  await act(async () => root.render(null))
+  expect(listeners.size).toBe(0)
+})
+
+it('ignores a delayed local policy receipt after a newer remote change', async () => {
+  let policy = true
+  let finish!: (value: boolean) => void
+  const listeners = new Set<() => void>()
+  Object.assign(window.api.runtime, {
+    getAgentEnvironmentCreationEnabled: vi.fn(async () => policy),
+    setAgentEnvironmentCreationEnabled: vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finish = resolve
+        })
+    ),
+    onPolicyChanged: (listener: () => void) => {
+      listeners.add(listener)
+      return () => listeners.delete(listener)
+    }
+  })
+  await render()
+  const toggle = (): Element | null =>
+    container.querySelector('[aria-label="Let the Agent create environments"]')
+  await click(toggle())
+  policy = true
+  await act(async () => {
+    for (const listener of listeners) listener()
+    finish(false)
+  })
+  expect(toggle()?.getAttribute('data-state')).toBe('checked')
+})

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -110,9 +110,7 @@ const RuntimesPanel = ({
   const setBusy = useRuntimeSettingsStore((state) => state.setBusy)
   const setError = useRuntimeSettingsStore((state) => state.setError)
   const setEnablement = useRuntimeSettingsStore((state) => state.setEnablement)
-  const setAgentEnvironmentCreationEnabled = useRuntimeSettingsStore(
-    (state) => state.setAgentEnvironmentCreationEnabled
-  )
+  const refreshRuntimePolicy = useRuntimeSettingsStore((state) => state.refreshPolicy)
   const updatePackageCount = useRuntimeSettingsStore((state) => state.updatePackageCount)
   const [runtimeAccessMessage, setRuntimeAccessMessage] = useState<Record<string, string>>({})
   const setSandboxAccess = async (
@@ -188,7 +186,9 @@ const RuntimesPanel = ({
   }, [initEnv])
 
   useEffect(() => {
+    const remove = useRuntimeSettingsStore.getState().listen()
     void loadRuntimeSettings().catch(() => undefined)
+    return remove
   }, [loadRuntimeSettings])
 
   // Fetches the open dialog's package list; re-runs on Retry via packagesRetryNonce. A successful
@@ -334,10 +334,12 @@ const RuntimesPanel = ({
     setBusy(true)
     setError(null)
     try {
-      const enabled = await window.api.runtime.setAgentEnvironmentCreationEnabled({
+      await window.api.runtime.setAgentEnvironmentCreationEnabled({
         enabled: !agentEnvironmentCreationEnabled
       })
-      setAgentEnvironmentCreationEnabled(enabled)
+      // The write committed. A stale reply must not replace a newer remote policy; reread it.
+      // Refresh errors already have the panel's retryable load-error surface.
+      await refreshRuntimePolicy().catch(() => undefined)
     } catch (e) {
       setError(e instanceof Error ? e.message : t('Could not change Agent environment creation.'))
     } finally {

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -110,7 +110,9 @@ const RuntimesPanel = ({
   const setBusy = useRuntimeSettingsStore((state) => state.setBusy)
   const setError = useRuntimeSettingsStore((state) => state.setError)
   const setEnablement = useRuntimeSettingsStore((state) => state.setEnablement)
-  const refreshRuntimePolicy = useRuntimeSettingsStore((state) => state.refreshPolicy)
+  const setAgentEnvironmentCreationEnabled = useRuntimeSettingsStore(
+    (state) => state.setAgentEnvironmentCreationEnabled
+  )
   const updatePackageCount = useRuntimeSettingsStore((state) => state.updatePackageCount)
   const [runtimeAccessMessage, setRuntimeAccessMessage] = useState<Record<string, string>>({})
   const setSandboxAccess = async (
@@ -334,12 +336,7 @@ const RuntimesPanel = ({
     setBusy(true)
     setError(null)
     try {
-      await window.api.runtime.setAgentEnvironmentCreationEnabled({
-        enabled: !agentEnvironmentCreationEnabled
-      })
-      // The write committed. A stale reply must not replace a newer remote policy; reread it.
-      // Refresh errors already have the panel's retryable load-error surface.
-      await refreshRuntimePolicy().catch(() => undefined)
+      await setAgentEnvironmentCreationEnabled(!agentEnvironmentCreationEnabled)
     } catch (e) {
       setError(e instanceof Error ? e.message : t('Could not change Agent environment creation.'))
     } finally {

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -75,6 +75,10 @@ beforeAll(async () => {
 // real jsdom window so DOM globals radix relies on (getComputedStyle, etc.) stay intact.
 const installApi = (): void => {
   ;(window as unknown as { api: unknown }).api = {
+    runtime: {
+      onPolicyChanged: vi.fn(() => vi.fn()),
+      getAgentEnvironmentCreationEnabled: vi.fn().mockResolvedValue(true)
+    },
     settings: {
       getSettings: vi.fn().mockResolvedValue({
         claude: {},

--- a/src/renderer/src/pages/workspace/workspace-compute-host-access-controller.test.ts
+++ b/src/renderer/src/pages/workspace/workspace-compute-host-access-controller.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, vi, describe, expect, it } from 'vitest'
 
+import type { PersistedChatSession } from '../../../../shared/session-persistence'
 import { createWorkspaceComputeHostAccessController } from './workspace-compute-host-access-controller'
 
 describe('workspace Compute Host access controller', () => {
@@ -40,5 +41,65 @@ describe('workspace Compute Host access controller', () => {
     controller().setHostSelected('ssh:gamma', true)
     expect(enabledProviderIds).toEqual(['ssh:beta', 'ssh:alpha', 'ssh:gamma'])
     expect(selectedProviderIds).toEqual(['ssh:beta', 'ssh:gamma'])
+  })
+})
+
+describe('overlapping authoritative updates', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+    let resolve!: (v: T) => void
+    const promise = new Promise<T>((a) => {
+      resolve = a
+    })
+    return { promise, resolve }
+  }
+
+  it('preserves newer host authority after a delayed command reply', async () => {
+    const { useSessionStore: store, createInitialSessionState } =
+      await import('../../stores/session-store')
+    const { createWorkspaceComputeHostAccessController } =
+      await import('./workspace-compute-host-access-controller')
+    store.setState(createInitialSessionState())
+    const initial: PersistedChatSession = {
+      id: 'sync-session',
+      projectId: 'p',
+      title: 'Session',
+      cwd: '/fixture',
+      status: 'idle',
+      messages: [],
+      createdAt: 1,
+      updatedAt: 1,
+      revision: 1,
+      enabledComputeHosts: [],
+      selectedComputeHosts: []
+    }
+    store.setState({ sessions: [initial] } as never)
+    const rpc = deferred<typeof initial>()
+    const setError = vi.fn()
+    vi.stubGlobal('window', { api: { compute: { hostEnabledSet: () => rpc.promise } } })
+    createWorkspaceComputeHostAccessController({
+      activeSession: initial,
+      newConversationEnabledComputeHosts: [],
+      newConversationSelectedComputeHosts: [],
+      setNewConversationEnabledComputeHosts: vi.fn(),
+      setNewConversationSelectedComputeHosts: vi.fn(),
+      setError
+    } as never).setHostEnabled('ssh:lab', true)
+    const old = { ...initial, revision: 2, updatedAt: 2, enabledComputeHosts: ['ssh:lab'] }
+    // Same projection used by useLifecycleSync; remote client has since disabled this host.
+    store.getState().applyDurableSessionProjection({
+      source: initial,
+      session: { ...initial, revision: 3, updatedAt: 3 },
+      mode: 'compute-host-access-authority'
+    } as never)
+    rpc.resolve(old)
+    await rpc.promise
+    await Promise.resolve()
+    expect(store.getState().sessions[0]).toMatchObject({
+      revision: 3,
+      updatedAt: 3,
+      enabledComputeHosts: []
+    })
   })
 })

--- a/src/renderer/src/stores/memory-store.test.ts
+++ b/src/renderer/src/stores/memory-store.test.ts
@@ -310,3 +310,43 @@ it('refreshes a visible project name after a project update without a memory rev
     remove()
   }
 })
+
+it('keeps refreshed project metadata after a delayed equal-revision mutation receipt', async () => {
+  const before = {
+    ...snapshot(2),
+    projects: [{ projectId: 'project-a', name: 'Before', archived: false, entries: [] }]
+  }
+  const after = { ...before, projects: [{ ...before.projects[0], name: 'After', archived: true }] }
+  let finish!: (value: MemorySnapshot) => void
+  let updated!: (project: { id: string }) => void
+  setMemoryApi({
+    snapshot: vi.fn().mockResolvedValue(after),
+    setEnabled: vi.fn(
+      () =>
+        new Promise<MemorySnapshot>((resolve) => {
+          finish = resolve
+        })
+    ),
+    onChanged: vi.fn(() => () => undefined)
+  })
+  Object.assign(window.api, {
+    projects: {
+      onUpdated: (listener: typeof updated) => {
+        updated = listener
+        return () => undefined
+      }
+    }
+  })
+  useMemoryStore.setState({ ...before, status: 'ready' })
+  const remove = useMemoryStore.getState().listen()
+  try {
+    const writing = useMemoryStore.getState().setEnabled(false)
+    updated({ id: 'project-a' })
+    await vi.waitFor(() => expect(useMemoryStore.getState().projects).toEqual(after.projects))
+    finish(before)
+    await writing
+    expect(useMemoryStore.getState().projects).toEqual(after.projects)
+  } finally {
+    remove()
+  }
+})

--- a/src/renderer/src/stores/memory-store.test.ts
+++ b/src/renderer/src/stores/memory-store.test.ts
@@ -279,3 +279,34 @@ describe('memory store', () => {
     })
   })
 })
+
+it('refreshes a visible project name after a project update without a memory revision change', async () => {
+  const listeners = new Set<(project: { id: string }) => void>()
+  const before = {
+    ...snapshot(1),
+    projects: [{ projectId: 'project-a', name: 'Before', archived: false, entries: [] }]
+  }
+  const after = { ...before, projects: [{ ...before.projects[0], name: 'After', archived: true }] }
+  setMemoryApi({
+    snapshot: vi.fn().mockResolvedValueOnce(before).mockResolvedValueOnce(after),
+    onChanged: vi.fn(() => () => undefined)
+  })
+  Object.assign(window.api, {
+    projects: {
+      onUpdated: (listener: (project: { id: string }) => void) => {
+        listeners.add(listener)
+        return () => listeners.delete(listener)
+      }
+    }
+  })
+  await useMemoryStore.getState().load()
+  const remove = useMemoryStore.getState().listen()
+  try {
+    for (const listener of listeners) listener({ id: 'project-a' })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(useMemoryStore.getState().projects).toEqual(after.projects)
+  } finally {
+    remove()
+  }
+})

--- a/src/renderer/src/stores/memory-store.ts
+++ b/src/renderer/src/stores/memory-store.ts
@@ -74,6 +74,7 @@ const stateFromSnapshot = (
 }
 
 export const useMemoryStore = create<MemoryStore>((set, get) => {
+  let projectGeneration = 0
   const applySnapshot = (snapshot: MemorySnapshot): boolean => {
     const state = get()
     if (snapshot.revision < state.revision) return false
@@ -84,8 +85,12 @@ export const useMemoryStore = create<MemoryStore>((set, get) => {
   }
 
   const applyMutation = async (operation: () => Promise<MemorySnapshot>): Promise<void> => {
+    const generation = projectGeneration
     try {
-      applySnapshot(await operation())
+      const snapshot = await operation()
+      // Memory revisions do not order project metadata. Read again after a concurrent project event.
+      if (generation !== projectGeneration) await get().load()
+      else applySnapshot(snapshot)
     } catch (error) {
       set({ error: error instanceof Error ? error.message : 'memory' })
       throw error
@@ -143,7 +148,10 @@ export const useMemoryStore = create<MemoryStore>((set, get) => {
         if (revision > get().revision) void get().load()
       })
       const removeProject = window.api.projects?.onUpdated?.(({ id }) => {
-        if (get().projects.some((project) => project.projectId === id)) void get().load()
+        if (get().projects.some((project) => project.projectId === id)) {
+          projectGeneration += 1
+          void get().load()
+        }
       })
       return () => {
         removeMemory()

--- a/src/renderer/src/stores/memory-store.ts
+++ b/src/renderer/src/stores/memory-store.ts
@@ -139,9 +139,16 @@ export const useMemoryStore = create<MemoryStore>((set, get) => {
     clearAll: () => applyMutation(() => window.api.memory.clearAll()),
     listen: () => {
       if (!window.api?.memory) return () => undefined
-      return window.api.memory.onChanged(({ revision }) => {
+      const removeMemory = window.api.memory.onChanged(({ revision }) => {
         if (revision > get().revision) void get().load()
       })
+      const removeProject = window.api.projects?.onUpdated?.(({ id }) => {
+        if (get().projects.some((project) => project.projectId === id)) void get().load()
+      })
+      return () => {
+        removeMemory()
+        removeProject?.()
+      }
     }
   }
 })

--- a/src/renderer/src/stores/runtime-settings-store.test.ts
+++ b/src/renderer/src/stores/runtime-settings-store.test.ts
@@ -268,3 +268,44 @@ it.each([false, true])(
     expect(useRuntimeSettingsStore.getState().error).toBeNull()
   }
 )
+
+it('clears a recovered policy read failure without repeating discovery', async () => {
+  const policy = vi.fn().mockResolvedValue(true)
+  const discovery = vi.fn().mockResolvedValue({ python: [], r: [] })
+  setRuntimeApi({
+    listEnvironments: discovery,
+    getEnablement: vi.fn().mockResolvedValue(enablement),
+    getAgentEnvironmentCreationEnabled: policy
+  })
+  await useRuntimeSettingsStore.getState().load()
+  policy.mockRejectedValueOnce(new Error('offline'))
+  await expect(useRuntimeSettingsStore.getState().refreshPolicy()).rejects.toThrow('offline')
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+  await useRuntimeSettingsStore.getState().refreshPolicy()
+  expect(useRuntimeSettingsStore.getState().error).toBeNull()
+  expect(discovery).toHaveBeenCalledOnce()
+})
+
+it('preserves discovery failure when a failed policy read later recovers', async () => {
+  const policy = vi.fn().mockResolvedValue(true)
+  setRuntimeApi({
+    listEnvironments: vi.fn().mockRejectedValue(new Error('discovery failed')),
+    getEnablement: vi.fn().mockResolvedValue(enablement),
+    getAgentEnvironmentCreationEnabled: policy
+  })
+  await expect(useRuntimeSettingsStore.getState().load()).rejects.toThrow('discovery failed')
+  policy.mockRejectedValueOnce(new Error('offline'))
+  await expect(useRuntimeSettingsStore.getState().refreshPolicy()).rejects.toThrow('offline')
+  await useRuntimeSettingsStore.getState().refreshPolicy()
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+})
+
+it('preserves a newer operation error when a policy read recovers', async () => {
+  const policy = vi.fn().mockResolvedValue(true)
+  setRuntimeApi({ getAgentEnvironmentCreationEnabled: policy })
+  policy.mockRejectedValueOnce(new Error('offline'))
+  await expect(useRuntimeSettingsStore.getState().refreshPolicy()).rejects.toThrow('offline')
+  useRuntimeSettingsStore.getState().setError('Could not register interpreter.')
+  await useRuntimeSettingsStore.getState().refreshPolicy()
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not register interpreter.')
+})

--- a/src/renderer/src/stores/runtime-settings-store.test.ts
+++ b/src/renderer/src/stores/runtime-settings-store.test.ts
@@ -244,3 +244,27 @@ it('retains a newer policy refresh error when older discovery completes', async 
   remove()
   expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
 })
+
+it.each([false, true])(
+  'preserves discovery failures during policy refresh (cached: %s)',
+  async (cached) => {
+    const listEnvironments = vi.fn().mockResolvedValue({ python: [], r: [] })
+    setRuntimeApi({
+      listEnvironments,
+      getEnablement: vi.fn().mockResolvedValue(enablement),
+      getAgentEnvironmentCreationEnabled: vi.fn().mockResolvedValue(true)
+    })
+    if (cached) await useRuntimeSettingsStore.getState().load()
+    listEnvironments.mockRejectedValue(new Error('discovery failed'))
+    await expect(useRuntimeSettingsStore.getState().recheck()).rejects.toThrow('discovery failed')
+    await useRuntimeSettingsStore.getState().refreshPolicy()
+    expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+    if (cached) {
+      await useRuntimeSettingsStore.getState().load()
+      expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+    }
+    listEnvironments.mockResolvedValue({ python: [], r: [] })
+    await useRuntimeSettingsStore.getState().recheck()
+    expect(useRuntimeSettingsStore.getState().error).toBeNull()
+  }
+)

--- a/src/renderer/src/stores/runtime-settings-store.test.ts
+++ b/src/renderer/src/stores/runtime-settings-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { DiscoveredInterpreter, RuntimeEnablement } from '../../../shared/notebook-runtime'
 import { useRuntimeSettingsStore } from './runtime-settings-store'
@@ -101,4 +101,146 @@ describe('runtime settings store', () => {
     expect(useRuntimeSettingsStore.getState().agentEnvironmentCreationEnabled).toBe(false)
     expect(useRuntimeSettingsStore.getState().checkedAt).toBeGreaterThan(1)
   })
+})
+
+describe('overlapping authoritative updates', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('refreshes remote runtime policy when reopening the panel', async () => {
+    const { useRuntimeSettingsStore: store } = await import('./runtime-settings-store')
+    const { NotebookRuntimeSettingsModule } =
+      await import('../../../main/settings/notebook-runtime-settings')
+    let authority = { agentEnvironmentCreationEnabled: true }
+    const owner = new NotebookRuntimeSettingsModule({
+      getSettings: async () => authority,
+      setAgentEnvironmentCreationEnabled: async (enabled: boolean) => {
+        authority = { agentEnvironmentCreationEnabled: enabled }
+        return authority
+      }
+    } as never)
+    store.setState({
+      envs: null,
+      enablement: {},
+      loaded: false,
+      checkedAt: null,
+      busy: false,
+      error: null,
+      packageCounts: {},
+      packageCountsLoaded: {}
+    })
+    const getPolicy = vi.fn(() => owner.getAgentEnvironmentCreationEnabled())
+    vi.stubGlobal('window', {
+      api: {
+        runtime: {
+          listEnvironments: async () => ({ python: [], r: [] }),
+          getEnablement: async () => ({ enabled: {}, installAuthorized: {} }),
+          getAgentEnvironmentCreationEnabled: getPolicy
+        }
+      }
+    })
+    await store.getState().load()
+    await owner.setAgentEnvironmentCreationEnabled(false)
+    await store.getState().load()
+    expect(await owner.getAgentEnvironmentCreationEnabled()).toBe(false)
+    expect(store.getState().agentEnvironmentCreationEnabled).toBe(false)
+    expect(getPolicy).toHaveBeenCalledTimes(2)
+    await store.getState().recheck()
+    expect(store.getState().agentEnvironmentCreationEnabled).toBe(false)
+  })
+})
+
+it('keeps discovery from restoring a policy superseded during Recheck', async () => {
+  let finishDiscovery!: (value: {
+    python: DiscoveredInterpreter[]
+    r: DiscoveredInterpreter[]
+  }) => void
+  let changed!: () => void
+  let policy = true
+  const runtime = {
+    listEnvironments: vi
+      .fn()
+      .mockResolvedValueOnce({ python: [], r: [] })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finishDiscovery = resolve
+          })
+      ),
+    getEnablement: vi.fn().mockResolvedValue(enablement),
+    getAgentEnvironmentCreationEnabled: vi.fn(async () => policy),
+    onPolicyChanged: vi.fn((listener) => {
+      changed = listener
+      return () => undefined
+    })
+  }
+  setRuntimeApi(runtime)
+  await useRuntimeSettingsStore.getState().load()
+  const remove = useRuntimeSettingsStore.getState().listen()
+  const checking = useRuntimeSettingsStore.getState().recheck()
+  await Promise.resolve()
+  policy = false
+  changed()
+  await useRuntimeSettingsStore.getState().refreshPolicy()
+  finishDiscovery({ python: [], r: [] })
+  await checking
+  remove()
+  expect(useRuntimeSettingsStore.getState().agentEnvironmentCreationEnabled).toBe(false)
+  expect(runtime.listEnvironments).toHaveBeenCalledTimes(2)
+})
+
+it('keeps a failed discovery visible when a slower policy read succeeds', async () => {
+  let finish!: (value: boolean) => void
+  setRuntimeApi({
+    listEnvironments: vi.fn().mockRejectedValue(new Error('discovery failed')),
+    getEnablement: vi.fn().mockResolvedValue(enablement),
+    getAgentEnvironmentCreationEnabled: vi.fn(
+      () =>
+        new Promise<boolean>((resolve) => {
+          finish = resolve
+        })
+    )
+  })
+  await expect(useRuntimeSettingsStore.getState().load()).rejects.toThrow('discovery failed')
+  finish(true)
+  await Promise.resolve()
+  await Promise.resolve()
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
+})
+
+it('retains a newer policy refresh error when older discovery completes', async () => {
+  let finish!: (value: { python: DiscoveredInterpreter[]; r: DiscoveredInterpreter[] }) => void
+  let changed!: () => void
+  const policy = vi
+    .fn()
+    .mockResolvedValueOnce(true)
+    .mockResolvedValueOnce(true)
+    .mockRejectedValue(new Error('offline'))
+  setRuntimeApi({
+    listEnvironments: vi
+      .fn()
+      .mockResolvedValueOnce({ python: [], r: [] })
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            finish = resolve
+          })
+      ),
+    getEnablement: vi.fn().mockResolvedValue(enablement),
+    getAgentEnvironmentCreationEnabled: policy,
+    onPolicyChanged: vi.fn((listener) => {
+      changed = listener
+      return () => undefined
+    })
+  })
+  await useRuntimeSettingsStore.getState().load()
+  const remove = useRuntimeSettingsStore.getState().listen()
+  const checking = useRuntimeSettingsStore.getState().recheck()
+  await Promise.resolve()
+  await Promise.resolve()
+  changed()
+  await expect(useRuntimeSettingsStore.getState().refreshPolicy()).rejects.toThrow('offline')
+  finish({ python: [], r: [] })
+  await checking
+  remove()
+  expect(useRuntimeSettingsStore.getState().error).toBe('Could not load runtimes.')
 })

--- a/src/renderer/src/stores/runtime-settings-store.ts
+++ b/src/renderer/src/stores/runtime-settings-store.ts
@@ -80,7 +80,6 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
     // Events and completed writes invalidate any read already in flight. A burst shares one
     // request and gets a trailing read; it never repeats discovery or package inventory.
     policyGeneration += 1
-    set({ error: null })
     // A read can have settled just before this event while its finally cleanup is still queued.
     // Wait through that cleanup before requesting authority again.
     return policyRequest
@@ -129,7 +128,6 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
   const refresh = (force: boolean): Promise<RuntimeRegistrySnapshot> => {
     const state = get()
     if (!force && state.loaded && state.envs) {
-      set({ error: null })
       return readPolicy().then((agentEnvironmentCreationEnabled) => ({
         envs: state.envs!,
         enablement: state.enablement,

--- a/src/renderer/src/stores/runtime-settings-store.ts
+++ b/src/renderer/src/stores/runtime-settings-store.ts
@@ -30,6 +30,7 @@ type RuntimeSettingsState = {
   setError: (error: string | null) => void
   setEnablement: (language: NotebookLanguage, enablement: RuntimeEnablement) => void
   refreshPolicy: () => Promise<boolean>
+  setAgentEnvironmentCreationEnabled: (enabled: boolean) => Promise<void>
   listen: () => () => void
   updatePackageCount: (envId: string, count: number) => void
 }
@@ -204,6 +205,13 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
     setEnablement: (language, enablement) =>
       set((state) => ({ enablement: { ...state.enablement, [language]: enablement } })),
     refreshPolicy,
+    setAgentEnvironmentCreationEnabled: async (enabled) => {
+      const generation = policyGeneration
+      const committed = await window.api.runtime.setAgentEnvironmentCreationEnabled({ enabled })
+      // A receipt is safe only while no policy event has superseded the write's starting point.
+      if (generation === policyGeneration) set({ agentEnvironmentCreationEnabled: committed })
+      await refreshPolicy().catch(() => undefined)
+    },
     listen: () =>
       window.api.runtime.onPolicyChanged?.(() => {
         void refreshPolicy().catch(() => undefined)

--- a/src/renderer/src/stores/runtime-settings-store.ts
+++ b/src/renderer/src/stores/runtime-settings-store.ts
@@ -29,7 +29,8 @@ type RuntimeSettingsState = {
   setBusy: (busy: boolean) => void
   setError: (error: string | null) => void
   setEnablement: (language: NotebookLanguage, enablement: RuntimeEnablement) => void
-  setAgentEnvironmentCreationEnabled: (enabled: boolean) => void
+  refreshPolicy: () => Promise<boolean>
+  listen: () => () => void
   updatePackageCount: (envId: string, count: number) => void
 }
 
@@ -38,19 +39,54 @@ let registryGeneration = 0
 let packageCountGeneration = 0
 const packageCountRequests: Partial<Record<NotebookLanguage, Promise<void>>> = {}
 
-const fetchRegistry = (): Promise<RuntimeRegistrySnapshot> =>
+const fetchRegistry = (): Promise<
+  Omit<RuntimeRegistrySnapshot, 'agentEnvironmentCreationEnabled'>
+> =>
   Promise.all([
     window.api.runtime.listEnvironments(),
     window.api.runtime.getEnablement('python'),
-    window.api.runtime.getEnablement('r'),
-    window.api.runtime.getAgentEnvironmentCreationEnabled()
-  ]).then(([envs, python, r, agentEnvironmentCreationEnabled]) => ({
+    window.api.runtime.getEnablement('r')
+  ]).then(([envs, python, r]) => ({
     envs,
-    enablement: { python, r },
-    agentEnvironmentCreationEnabled
+    enablement: { python, r }
   }))
 
 const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
+  let policyGeneration = 0
+  let policyRequest: Promise<boolean> | undefined
+  const readPolicy = (): Promise<boolean> => {
+    if (policyRequest) return policyRequest
+    const request = (async () => {
+      for (;;) {
+        const generation = policyGeneration
+        try {
+          const enabled = await window.api.runtime.getAgentEnvironmentCreationEnabled()
+          if (generation !== policyGeneration) continue
+          set({ agentEnvironmentCreationEnabled: enabled })
+          return enabled
+        } catch (error) {
+          if (generation !== policyGeneration) continue
+          set({ error: 'Could not load runtimes.' })
+          throw error
+        }
+      }
+    })().finally(() => {
+      if (policyRequest === request) policyRequest = undefined
+    })
+    policyRequest = request
+    return request
+  }
+  const refreshPolicy = (): Promise<boolean> => {
+    // Events and completed writes invalidate any read already in flight. A burst shares one
+    // request and gets a trailing read; it never repeats discovery or package inventory.
+    policyGeneration += 1
+    set({ error: null })
+    // A read can have settled just before this event while its finally cleanup is still queued.
+    // Wait through that cleanup before requesting authority again.
+    return policyRequest
+      ? policyRequest.catch(() => undefined).then(() => readPolicy())
+      : readPolicy()
+  }
   const loadPackageCounts = (snapshot: RuntimeRegistrySnapshot, generation: number): void => {
     for (const language of ['python', 'r'] as const) {
       if (!snapshot.envs[language].some((env) => env.runnable)) {
@@ -93,15 +129,17 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
   const refresh = (force: boolean): Promise<RuntimeRegistrySnapshot> => {
     const state = get()
     if (!force && state.loaded && state.envs) {
-      return Promise.resolve({
-        envs: state.envs,
+      set({ error: null })
+      return readPolicy().then((agentEnvironmentCreationEnabled) => ({
+        envs: state.envs!,
         enablement: state.enablement,
-        agentEnvironmentCreationEnabled: state.agentEnvironmentCreationEnabled
-      })
+        agentEnvironmentCreationEnabled
+      }))
     }
     if (registryRequest) return registryRequest
 
     const generation = ++registryGeneration
+    const policyAtStart = policyGeneration
     if (force) {
       packageCountGeneration += 1
       delete packageCountRequests.python
@@ -111,17 +149,21 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
       busy: state.loaded,
       error: null
     })
-    const request = fetchRegistry().then(
-      (snapshot) => {
+    const request = Promise.all([fetchRegistry(), readPolicy()]).then(
+      ([registry]) => {
+        // Discovery may finish after a newer policy read. Its receipt does not own policy state.
+        const snapshot = {
+          ...registry,
+          agentEnvironmentCreationEnabled: get().agentEnvironmentCreationEnabled
+        }
         if (generation === registryGeneration) {
           set({
             envs: snapshot.envs,
             enablement: snapshot.enablement,
-            agentEnvironmentCreationEnabled: snapshot.agentEnvironmentCreationEnabled,
             loaded: true,
             checkedAt: Date.now(),
             busy: false,
-            error: null,
+            error: policyAtStart === policyGeneration ? null : get().error,
             ...(force ? { packageCounts: {}, packageCountsLoaded: {} } : {})
           })
           loadPackageCounts(snapshot, generation)
@@ -163,8 +205,11 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
     setError: (error) => set({ error }),
     setEnablement: (language, enablement) =>
       set((state) => ({ enablement: { ...state.enablement, [language]: enablement } })),
-    setAgentEnvironmentCreationEnabled: (agentEnvironmentCreationEnabled) =>
-      set({ agentEnvironmentCreationEnabled }),
+    refreshPolicy,
+    listen: () =>
+      window.api.runtime.onPolicyChanged?.(() => {
+        void refreshPolicy().catch(() => undefined)
+      }) ?? (() => undefined),
     updatePackageCount: (envId, count) =>
       set((state) => ({ packageCounts: { ...state.packageCounts, [envId]: count } }))
   }

--- a/src/renderer/src/stores/runtime-settings-store.ts
+++ b/src/renderer/src/stores/runtime-settings-store.ts
@@ -55,6 +55,8 @@ const fetchRegistry = (): Promise<
 const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
   let policyGeneration = 0
   let policyRequest: Promise<boolean> | undefined
+  // undefined means another operation owns the error; null is a policy-only failure.
+  let policyErrorFallback: string | null | undefined
   const readPolicy = (): Promise<boolean> => {
     if (policyRequest) return policyRequest
     const request = (async () => {
@@ -63,10 +65,15 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
         try {
           const enabled = await window.api.runtime.getAgentEnvironmentCreationEnabled()
           if (generation !== policyGeneration) continue
-          set({ agentEnvironmentCreationEnabled: enabled })
+          set({
+            agentEnvironmentCreationEnabled: enabled,
+            ...(policyErrorFallback === undefined ? {} : { error: policyErrorFallback })
+          })
+          policyErrorFallback = undefined
           return enabled
         } catch (error) {
           if (generation !== policyGeneration) continue
+          if (policyErrorFallback === undefined) policyErrorFallback = get().error
           set({ error: 'Could not load runtimes.' })
           throw error
         }
@@ -137,6 +144,7 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
     }
     if (registryRequest) return registryRequest
 
+    policyErrorFallback = undefined
     const generation = ++registryGeneration
     const policyAtStart = policyGeneration
     if (force) {
@@ -171,6 +179,8 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
       },
       (error: unknown) => {
         if (generation === registryGeneration) {
+          // A full load failure still needs Recheck, even if a policy-only read recovers.
+          policyErrorFallback = undefined
           set({
             loaded: true,
             busy: false,
@@ -201,7 +211,10 @@ const useRuntimeSettingsStore = create<RuntimeSettingsState>((set, get) => {
     load: () => refresh(false),
     recheck: () => refresh(true),
     setBusy: (busy) => set({ busy }),
-    setError: (error) => set({ error }),
+    setError: (error) => {
+      policyErrorFallback = undefined
+      set({ error })
+    },
     setEnablement: (language, enablement) =>
       set((state) => ({ enablement: { ...state.enablement, [language]: enablement } })),
     refreshPolicy,

--- a/src/renderer/src/stores/session-store-persistence-owner.ts
+++ b/src/renderer/src/stores/session-store-persistence-owner.ts
@@ -213,9 +213,24 @@ const projectSessionMetadataAuthority = (
   ) {
     return current
   }
-  if (current.archivedAt === incoming.archivedAt && currentRevision === incomingRevision)
+  if (
+    current.archivedAt === incoming.archivedAt &&
+    currentRevision === incomingRevision &&
+    current.enabledComputeHosts === incoming.enabledComputeHosts &&
+    current.selectedComputeHosts === incoming.selectedComputeHosts &&
+    current.computeConcurrencyLimit === incoming.computeConcurrencyLimit
+  )
     return current
-  const projected = { ...current, revision: incomingRevision }
+  // These fields are main-owned in every full durable snapshot, including receipts for other
+  // domains. Project them before advancing the shared revision so a later Host receipt can be
+  // rejected without losing a change already present in the newer snapshot.
+  const projected = {
+    ...current,
+    revision: incomingRevision,
+    enabledComputeHosts: incoming.enabledComputeHosts && [...incoming.enabledComputeHosts],
+    selectedComputeHosts: incoming.selectedComputeHosts && [...incoming.selectedComputeHosts],
+    computeConcurrencyLimit: incoming.computeConcurrencyLimit
+  }
   if (incoming.archivedAt === undefined) delete projected.archivedAt
   else projected.archivedAt = incoming.archivedAt
   return projected
@@ -873,12 +888,17 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
       }
 
       if (mode === 'compute-host-access-authority') {
+        if (sessionRevision(session) < sessionRevision(current)) {
+          if (archive === current) return state
+          return {
+            sessions: state.sessions.map((candidate) =>
+              candidate === current ? archive : candidate
+            )
+          } as Partial<State>
+        }
         const projected: ChatSession = {
           ...archive,
           revision: Math.max(sessionRevision(current), sessionRevision(session)),
-          enabledComputeHosts: session.enabledComputeHosts && [...session.enabledComputeHosts],
-          selectedComputeHosts: session.selectedComputeHosts && [...session.selectedComputeHosts],
-          computeConcurrencyLimit: session.computeConcurrencyLimit,
           updatedAt: Math.max(current.updatedAt, session.updatedAt)
         }
         markExternallyHydratedSession(projected, session)
@@ -1074,6 +1094,9 @@ export const createSessionPersistenceOwner = <State extends SessionStoreData>(
         {
           ...projected,
           archivedAt: archive.archivedAt,
+          enabledComputeHosts: archive.enabledComputeHosts,
+          selectedComputeHosts: archive.selectedComputeHosts,
+          computeConcurrencyLimit: archive.computeConcurrencyLimit,
           branchContextResetRequired: archive.branchContextResetRequired,
           // Whole-Session saves and continuation acknowledgements do not own Delegation policy.
           // Keep the last dedicated mutation result even when a later ordinary projection carries

--- a/src/renderer/src/stores/session-store.archive-order.test.ts
+++ b/src/renderer/src/stores/session-store.archive-order.test.ts
@@ -222,3 +222,48 @@ describe('session deletion fallback', () => {
     }
   )
 })
+
+describe('Compute Host authority across session projections', () => {
+  it.each([
+    'replace-persisted-if-current',
+    'merge-upload-identities',
+    'archive-authority',
+    'runtime-context-authority',
+    'permission-authority',
+    'session-details-authority',
+    'delegated-authority'
+  ] as const)('receives current host fields when %s advances the revision', (mode) => {
+    const store = createSessionStore()
+    store.getState().hydrateSessions([{ ...session, revision: 1 }])
+    const source = store.getState().sessions[0]
+    const committed = {
+      ...session,
+      revision: 3,
+      enabledComputeHosts: ['ssh:current'],
+      selectedComputeHosts: [],
+      computeConcurrencyLimit: 2
+    }
+    store.getState().applyDurableSessionProjection({ source, session: committed, mode })
+    store.getState().renameSession(session.id, 'Unsaved title')
+    store.getState().applyDurableSessionProjection({
+      source,
+      session: {
+        ...session,
+        revision: 2,
+        enabledComputeHosts: ['ssh:old'],
+        selectedComputeHosts: ['ssh:old'],
+        computeConcurrencyLimit: 9
+      },
+      mode: 'compute-host-access-authority'
+    })
+    expect(store.getState().sessions[0]).toMatchObject({
+      revision: 3,
+      title: 'Unsaved title',
+      unsavedTitle: true,
+      messages: session.messages,
+      enabledComputeHosts: ['ssh:current'],
+      selectedComputeHosts: [],
+      computeConcurrencyLimit: 2
+    })
+  })
+})

--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -195,9 +195,7 @@ export const createSettingsPreferencesSlice = ({
           : undefined
       )
       if (!isCurrent) return
-      if (!accepted) {
-        setState({ [field]: confirmedValue } as Partial<SettingsPreferencesState>)
-      }
+      setState({ [field]: confirmedValue } as Partial<SettingsPreferencesState>)
       write.succeed()
     } catch (error) {
       const confirmedValue = write.complete()

--- a/src/renderer/src/stores/settings-preferences-slice.ts
+++ b/src/renderer/src/stores/settings-preferences-slice.ts
@@ -189,8 +189,10 @@ export const createSettingsPreferencesSlice = ({
       const snapshot = await write.run(command)
       const isCurrent = write.isCurrent()
       const accepted = reconcileSnapshot(snapshot) !== false
+      // Reconciliation records normalized defaults and authoritative clears. Do not replace
+      // those with an omitted raw field from an older/untyped snapshot.
       const confirmedValue = write.complete(
-        accepted
+        accepted && snapshot[field] !== undefined
           ? { value: snapshot[field] as unknown as SettingsPreferencesState[Field] }
           : undefined
       )

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -2625,3 +2625,62 @@ describe('settings store: setDefaultPermissionProfile', () => {
     )
   })
 })
+
+describe('overlapping authoritative updates', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+    let resolve!: (v: T) => void
+    const promise = new Promise<T>((a) => {
+      resolve = a
+    })
+    return { promise, resolve }
+  }
+  const settings = (revision: number, notificationsEnabled: boolean): SettingsSnapshot => ({
+    ...snapshot([]),
+    revision,
+    notificationsEnabled
+  })
+
+  it.each(['load', 'provider', 'runtime'] as const)(
+    'preserves the committed preference after an overlapping %s snapshot and event',
+    async (source) => {
+      useSettingsStore.setState({ ...createInitialSettingsState(), isLoaded: true })
+      useSettingsStore.getState().acceptCommittedSnapshot(settings(1, true))
+      const read = deferred<ReturnType<typeof settings>>()
+      const write = deferred<ReturnType<typeof settings>>()
+      vi.stubGlobal('window', {
+        api: {
+          settings: {
+            getSettings: () => read.promise,
+            isEncryptionAvailable: async () => true,
+            setActiveProvider: () => read.promise,
+            detectOpencode: () => read.promise,
+            getPreflight: async () => createInitialSettingsState().preflight,
+            setNotificationsEnabled: () => write.promise
+          }
+        }
+      })
+      const store = useSettingsStore.getState()
+      const loading =
+        source === 'load'
+          ? store.load()
+          : source === 'provider'
+            ? store.setActiveProvider('provider')
+            : store.detectOpencode()
+      const saving = store.setNotificationsEnabled(false)
+      expect(useSettingsStore.getState().notificationsEnabled).toBe(false)
+      read.resolve(settings(1, true))
+      await loading
+      // Production publishes the committed event before returning the command response.
+      useSettingsStore.getState().acceptCommittedSnapshot(settings(2, false))
+      write.resolve(settings(2, false))
+      await saving
+      expect(useSettingsStore.getState()).toMatchObject({
+        settingsSnapshotRevision: 2,
+        notificationsEnabled: false,
+        settingsWriteError: undefined
+      })
+    }
+  )
+})

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -2684,3 +2684,20 @@ describe('overlapping authoritative updates', () => {
     }
   )
 })
+
+it('keeps normalized preference defaults when an untyped receipt omits the field', async () => {
+  useSettingsStore.setState({
+    ...createInitialSettingsState(),
+    isLoaded: true,
+    notificationsEnabled: false
+  })
+  const committed = { ...snapshot([]), revision: 2 }
+  delete (committed as Partial<SettingsSnapshot>).notificationsEnabled
+  vi.stubGlobal('window', { api: { settings: { setNotificationsEnabled: async () => committed } } })
+  try {
+    await useSettingsStore.getState().setNotificationsEnabled(true)
+    expect(useSettingsStore.getState().notificationsEnabled).toBe(true)
+  } finally {
+    vi.unstubAllGlobals()
+  }
+})

--- a/src/renderer/src/stores/settings-store.test.ts
+++ b/src/renderer/src/stores/settings-store.test.ts
@@ -2701,3 +2701,35 @@ it('keeps normalized preference defaults when an untyped receipt omits the field
     vi.unstubAllGlobals()
   }
 })
+
+it.each([
+  ['closePreference', 'setClosePreference'],
+  ['projectFilesFilter', 'setProjectFilesFilter']
+] as const)(
+  'keeps a successful %s clear when transport omits the field',
+  async (field, command) => {
+    useSettingsStore.setState(createInitialSettingsState())
+    const previous: SettingsSnapshot = {
+      ...snapshot([]),
+      revision: 1,
+      closePreference: 'quit',
+      projectFilesFilter: { sourceMode: 'local' }
+    }
+    useSettingsStore.getState().acceptCommittedSnapshot(previous)
+    const cleared = JSON.parse(
+      JSON.stringify({ ...previous, revision: 2, [field]: undefined })
+    ) as SettingsSnapshot
+    expect(Object.hasOwn(cleared, field)).toBe(false)
+    const save = vi.fn().mockResolvedValue(cleared)
+    vi.stubGlobal('window', { api: { settings: { [command]: save } } })
+    try {
+      await useSettingsStore.getState()[command](undefined)
+      expect(save).toHaveBeenCalledOnce()
+      expect(useSettingsStore.getState()[field]).toBeUndefined()
+      expect(useSettingsStore.getState().settingsSnapshotRevision).toBe(2)
+      expect(useSettingsStore.getState().settingsWriteError).toBeUndefined()
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  }
+)

--- a/src/renderer/src/stores/settings-store.ts
+++ b/src/renderer/src/stores/settings-store.ts
@@ -267,11 +267,16 @@ const canApplySnapshot = (state: SettingsStoreData, snapshot: SettingsSnapshot):
 const mergeSnapshot = (
   state: SettingsStoreData,
   snapshot: SettingsSnapshot,
+  writeCoordinator: SettingsWriteCoordinator,
   extra: Partial<SettingsStoreData> = {}
 ): Partial<SettingsStoreData> =>
   canApplySnapshot(state, snapshot)
     ? {
-        ...applySnapshot(snapshot),
+        ...omitInFlightOptimisticPreferences(
+          applySnapshot(snapshot),
+          writeCoordinator.hasPending,
+          writeCoordinator.acceptCommitted
+        ),
         ...(snapshot.revision === undefined ? {} : { settingsSnapshotRevision: snapshot.revision }),
         ...extra
       }
@@ -360,12 +365,13 @@ const createSettingsStoreState = (
     // Resolve browser globals only when an action runs; node-based renderer tests import this store.
     getCommands: () => window.api.settings,
     reconcileSnapshot: (snapshot, runtimePatch = {}) =>
-      set((state) => mergeSnapshot(state, snapshot, runtimePatch))
+      set((state) => mergeSnapshot(state, snapshot, writeCoordinator, runtimePatch))
   }),
   ...createProviderAuthSlice({
     get,
     getCommands: () => window.api.settings,
-    reconcileSnapshot: (snapshot) => set((state) => mergeSnapshot(state, snapshot)),
+    reconcileSnapshot: (snapshot) =>
+      set((state) => mergeSnapshot(state, snapshot, writeCoordinator)),
     refreshPreflight: () => get().refreshPreflight(),
     refreshFrameworkStatus: async (id) => {
       if (id === 'opencode') {
@@ -387,13 +393,7 @@ const createSettingsStoreState = (
     getCommands: () => window.api.settings,
     reconcileSnapshot: (snapshot) => {
       if (!canApplySnapshot(get(), snapshot)) return false
-      set((state) =>
-        omitInFlightOptimisticPreferences(
-          mergeSnapshot(state, snapshot),
-          writeCoordinator.hasPending,
-          writeCoordinator.acceptCommitted
-        )
-      )
+      set((state) => mergeSnapshot(state, snapshot, writeCoordinator))
       return true
     },
     writeCoordinator
@@ -456,7 +456,7 @@ const createSettingsStoreState = (
         // The persisted Settings authority is enough for an existing user to enter Home. Capability
         // probes continue in this same deduplicated pass; first-run onboarding still waits in App.
         set((state) =>
-          mergeSnapshot(state, snapshot, {
+          mergeSnapshot(state, snapshot, writeCoordinator, {
             ...(shouldInitializeRuntime ? { isLoaded: true } : {}),
             loadError: undefined
           })
@@ -529,14 +529,7 @@ const createSettingsStoreState = (
 
   clearSettingsWriteError: () => writeCoordinator.clearFailures(),
   acceptCommittedSnapshot: (snapshot) =>
-    set((state) => {
-      if (!canApplySnapshot(state, snapshot)) return {}
-      return omitInFlightOptimisticPreferences(
-        mergeSnapshot(state, snapshot),
-        writeCoordinator.hasPending,
-        writeCoordinator.acceptCommitted
-      )
-    })
+    set((state) => mergeSnapshot(state, snapshot, writeCoordinator))
 })
 
 export const useSettingsStore = create<SettingsStore>((set, get) =>

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -836,3 +836,30 @@ it('retains a newer event read even when the command reply is still acceptable',
   remove()
   expect(useTagStore.getState().revision).toBe(3)
 })
+
+it('keeps a committed mutation ready when an earlier load rejects', async () => {
+  let rejectRead!: (error: Error) => void
+  const tag = {
+    id: 'custom-tag',
+    name: 'Original',
+    iconKey: 'tag' as const,
+    colorKey: 'gray' as const,
+    createdAt: 1,
+    updatedAt: 1
+  }
+  setTagsApi({
+    snapshot: vi.fn(
+      () =>
+        new Promise<TagSnapshot>((_, reject) => {
+          rejectRead = reject
+        })
+    ),
+    delete: vi.fn().mockResolvedValue(favoriteSnapshot(2))
+  })
+  useTagStore.setState({ ...favoriteSnapshot(1), tags: [tag], status: 'ready' })
+  const reading = useTagStore.getState().load()
+  await useTagStore.getState().delete(tag.id)
+  rejectRead(new Error('earlier read failed'))
+  await reading
+  expect(useTagStore.getState()).toMatchObject({ revision: 2, status: 'ready', error: undefined })
+})

--- a/src/renderer/src/stores/tag-store.test.ts
+++ b/src/renderer/src/stores/tag-store.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { TagSnapshot } from '../../../shared/tags'
 import { createInitialTagState, useTagStore } from './tag-store'
@@ -709,4 +709,130 @@ describe('tag store', () => {
       expect(useTagStore.getState().tags).toEqual(tags)
     }
   )
+})
+
+describe('overlapping authoritative updates', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  const deferred = <T>(): { promise: Promise<T>; resolve: (value: T) => void } => {
+    let resolve!: (v: T) => void
+    const promise = new Promise<T>((a) => {
+      resolve = a
+    })
+    return { promise, resolve }
+  }
+  const tag = (revision: number, name: string): TagSnapshot => ({
+    revision,
+    tags: [
+      { id: 'tag-1', name, iconKey: 'tag', colorKey: 'gray', createdAt: 1, updatedAt: revision }
+    ],
+    assignments: []
+  })
+
+  it.each(['create', 'update', 'delete', 'reorder', 'setAssignment'] as const)(
+    'keeps the newer event read after a stale %s reply',
+    async (operation) => {
+      useTagStore.setState({
+        ...createInitialTagState(),
+        ...tag(1, 'initial'),
+        status: 'ready'
+      } as never)
+      const write = deferred<ReturnType<typeof tag>>()
+      const read = deferred<ReturnType<typeof tag>>()
+      const intermediate = deferred<ReturnType<typeof tag>>()
+      let changed!: (event: { revision: number }) => void
+      vi.stubGlobal('window', {
+        api: {
+          tags: {
+            [operation]: () => write.promise,
+            snapshot: vi
+              .fn()
+              .mockReturnValueOnce(intermediate.promise)
+              .mockReturnValueOnce(read.promise),
+            onChanged: (fn: (event: { revision: number }) => void) => {
+              changed = fn
+              return () => {}
+            }
+          }
+        }
+      })
+      const store = useTagStore.getState()
+      const saving =
+        operation === 'create'
+          ? store.create({ name: 'local', iconKey: 'tag', colorKey: 'gray' })
+          : operation === 'update'
+            ? store.update({
+                id: 'tag-1',
+                name: 'local',
+                iconKey: 'tag',
+                colorKey: 'gray',
+                expectedUpdatedAt: 1
+              })
+            : operation === 'delete'
+              ? store.delete('tag-1')
+              : operation === 'reorder'
+                ? store.reorder({ tagIds: ['tag-1'] })
+                : store.setAssignment({
+                    tagId: 'tag-1',
+                    resourceType: 'catalog.skill',
+                    resourceId: 'skill-1',
+                    assigned: true
+                  })
+      const remove = useTagStore.getState().listen()
+      changed({ revision: 3 })
+      intermediate.resolve(tag(3, 'remote-3'))
+      await intermediate.promise
+      await Promise.resolve()
+      expect(useTagStore.getState().revision).toBe(3)
+      changed({ revision: 4 })
+      write.resolve(tag(2, 'local'))
+      await saving
+      read.resolve(tag(4, 'remote-4'))
+      await read.promise
+      await Promise.resolve()
+      expect(useTagStore.getState()).toMatchObject({
+        revision: 4,
+        tags: [{ name: 'remote-4' }],
+        status: 'ready'
+      })
+      remove()
+    }
+  )
+})
+
+it('retains a newer event read even when the command reply is still acceptable', async () => {
+  let changed!: (event: { revision: number }) => void
+  let resolveRead!: (snapshot: TagSnapshot) => void
+  let resolveWrite!: (snapshot: TagSnapshot) => void
+  setTagsApi({
+    onChanged: vi.fn((listener) => {
+      changed = listener
+      return () => undefined
+    }),
+    update: vi.fn(
+      () =>
+        new Promise<TagSnapshot>((resolve) => {
+          resolveWrite = resolve
+        })
+    ),
+    snapshot: vi.fn(
+      () =>
+        new Promise<TagSnapshot>((resolve) => {
+          resolveRead = resolve
+        })
+    )
+  })
+  useTagStore.setState({ ...favoriteSnapshot(1), status: 'ready' })
+  const remove = useTagStore.getState().listen()
+  const saving = useTagStore
+    .getState()
+    .update({ id: 'custom', name: 'local', iconKey: 'tag', colorKey: 'gray', expectedUpdatedAt: 1 })
+  changed({ revision: 3 })
+  resolveWrite(favoriteSnapshot(2))
+  await saving
+  resolveRead(favoriteSnapshot(3))
+  await Promise.resolve()
+  await Promise.resolve()
+  remove()
+  expect(useTagStore.getState().revision).toBe(3)
 })

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -98,8 +98,12 @@ const stateFromSnapshot = (snapshot: TagSnapshot): Pick<TagStore, keyof TagSnaps
 const stateFromMutationSnapshot = (
   snapshot: TagSnapshot,
   currentRevision: number
-): Partial<Pick<TagStore, keyof TagSnapshot | 'status'>> =>
-  snapshot.revision < currentRevision ? { status: 'ready' } : stateFromSnapshot(snapshot)
+): Partial<Pick<TagStore, keyof TagSnapshot | 'status' | 'error'>> => {
+  if (snapshot.revision < currentRevision) return {}
+  // Keep event-triggered reads alive even if this receipt is newer than the displayed state.
+  // load() already rejects a snapshot older than an accepted command result.
+  return { ...stateFromSnapshot(snapshot), error: undefined }
+}
 
 export const useTagStore = create<TagStore>((set, get) => ({
   ...createInitialTagState(),
@@ -134,8 +138,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
   },
   create: async (request) => {
     const snapshot = await window.api.tags.create(request)
-    loadSequence += 1
-    set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
+    set((state) => stateFromMutationSnapshot(snapshot, state.revision))
     const requestedNameKey = request.name
       .normalize('NFKC')
       .trim()
@@ -151,13 +154,11 @@ export const useTagStore = create<TagStore>((set, get) => ({
   },
   update: async (request) => {
     const snapshot = await window.api.tags.update(request)
-    loadSequence += 1
-    set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
+    set((state) => stateFromMutationSnapshot(snapshot, state.revision))
   },
   delete: async (id) => {
     const snapshot = await window.api.tags.delete({ id })
-    loadSequence += 1
-    set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
+    set((state) => stateFromMutationSnapshot(snapshot, state.revision))
   },
   reorder: async (request) => {
     const revision = get().revision
@@ -175,8 +176,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
     const optimistic = get().tags
     try {
       const snapshot = await window.api.tags.reorder(request)
-      loadSequence += 1
-      set((state) => ({ ...stateFromMutationSnapshot(snapshot, state.revision), error: undefined }))
+      set((state) => stateFromMutationSnapshot(snapshot, state.revision))
     } catch (error) {
       const restored = rollbackProjection(failedTagProjections, optimistic, before)
       if (get().revision === revision && get().tags === optimistic) set({ tags: restored })
@@ -197,11 +197,9 @@ export const useTagStore = create<TagStore>((set, get) => ({
       const snapshot = await window.api.tags.setAssignment(request)
       pendingAssignments.delete(sequence)
       settledAssignments.set(key, Math.max(sequence, settledAssignments.get(key) ?? 0))
-      loadSequence += 1
       set((state) => ({
         assignments: projectAssignments(state.tags),
-        ...stateFromMutationSnapshot(snapshot, state.revision),
-        error: undefined
+        ...stateFromMutationSnapshot(snapshot, state.revision)
       }))
     } catch (error) {
       pendingAssignments.delete(sequence)

--- a/src/renderer/src/stores/tag-store.ts
+++ b/src/renderer/src/stores/tag-store.ts
@@ -122,6 +122,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
       return
     }
     const sequence = ++loadSequence
+    const revision = get().revision
     set({ status: 'loading', error: undefined })
     try {
       const snapshot = await window.api.tags.snapshot()
@@ -132,7 +133,7 @@ export const useTagStore = create<TagStore>((set, get) => ({
       }
       set({ ...stateFromSnapshot(snapshot), error: undefined })
     } catch {
-      if (sequence !== loadSequence) return
+      if (sequence !== loadSequence || revision !== get().revision) return
       set({ status: 'error', error: 'load' })
     }
   },

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -1612,6 +1612,10 @@ export const RENDERER_API_CONTRACT = Object.freeze({
   'runtime.listPackages': callable<
     (language: NotebookLanguage, envId: string) => Promise<EnvPackage[]>
   >()('runtime', ['runtime:list-packages', WEB, RUNTIME_LANGUAGE_ENV]),
+  'runtime.onPolicyChanged': callable<(listener: () => void) => RemoveListener>()('runtime', [
+    'runtime:policy-changed',
+    EVENT
+  ]),
   'runtime.pickInterpreter': callable<() => Promise<string | null>>()('runtime', [
     'runtime:pick-interpreter',
     LOCAL

--- a/src/shared/web-api-map.generated.ts
+++ b/src/shared/web-api-map.generated.ts
@@ -383,6 +383,7 @@ export const WEB_EVENT_CHANNELS = {
   'reviewer.onFixLoopStart': 'reviewer:fix-loop-start',
   'reviewer.onSuppressNextAutoReview': 'reviewer:suppress-next-auto-review',
   'reviewer.onUpdated': 'reviewer:updated',
+  'runtime.onPolicyChanged': 'runtime:policy-changed',
   'sessions.onCreated': 'session:created',
   'sessions.onDeleted': 'session:deleted',
   'sessions.onFlushAborted': 'sessions:flush-aborted',


### PR DESCRIPTION
## Problem

Delayed settings, tag and Compute Host replies can leave the renderer showing older values after a successful commit or newer event. Runtime policy remains cached across panel reopen, and open Memory/Literature secondary views miss relevant changes. A failed Electron window send also stops delivery to later windows.

## Proposed change

- Apply Settings snapshots through the existing pending-preference guard and settle the current write against accepted authority.
- Keep Tag event reads alive across mutation receipts; old read failures do not overwrite newer committed authority.
- Project main-owned Compute Host fields with full durable Session authority before advancing its shared revision, preserving local content and rejecting older Host receipts.
- Refresh runtime policy separately from discovery/package counts and notify open clients after commit. A local write uses its successful receipt only if no policy event has superseded its starting generation, then rereads authority. Read failures remain visible; stale receipts cannot override later events. Policy reads clear only their own recovered errors; a private renderer-only fallback remembers the previous error. Full-load failures and newer operation errors retain ownership and cannot be cleared by policy recovery.
- Reuse project/Literature subscriptions for derived views. A renderer-only project event counter makes Memory reread after a mutation overlapping a project update, since Memory revision does not order project metadata. Isolate and log each Electron window delivery failure.

## Scope and non-goals

No database/schema changes, migrations, new persisted fields, historical data repair, or new status enum. Existing unversioned Session ordering and optional-field defaults are preserved. Runtime policy adds an in-memory read generation and one event in the existing transport catalog. Interpreter discovery and package caches remain intact. No global sync framework, persistent event log, authorization changes, or universal save/conflict UI.

## Acceptance criteria and validation

Twenty-four correct-behavior regressions failed twice on unchanged production code, exclusively at assertions matching stale values/missing refresh/delivery. They pass with the fixes. Tests use existing Store, controller, component and workflow boundaries; the runtime workflow gains its production notification callback as an injectable port.

| Behavior | Check | Result |
| --- | --- | --- |
| Store ordering, Session persistence/consumer preservation, policy notification, derived-view refresh, Electron/Web contracts | Explicit 41-file command below | 1,524 passed |
| Omitted preference fields retain normalized defaults | Six Settings suites, including store, preference, coordinator, provider, runtime and architecture checks | 233 passed after follow-up |
| Runtime consumers and branch/event handling | `RUN_COMPUTE_JOBS=0 npm run test:module -- workspace_runtime` | 527 passed |
| Main, renderer and sandbox types | `npm run typecheck` | Passed |
| Source conventions | `npm run lint` | Passed |
| Generated transport map | `npm run check:web-api-map` | Passed |

The 41-file suite, typechecks and lint ran after the main implementation. A final preference-default follow-up passed the six Settings suites (233 tests), renderer typecheck and lint after its last edit; it preserves the existing normalized defaults when an older/untyped receipt omits a field. The workspace runtime consumer suite ran after the last Session edit; the later edit only preserved runtime-settings load errors and is covered by the final 41-file run.

The classifier requests full validation because the application-event catalog is not assigned to a module. Per maintainer instruction, complete local tests were not run; required PR CI is authoritative for full portable/platform verification. The local set includes transport adapters because an event was added, Session persistence and runtime consumers because shared authority projection changed, and relevant panel consumers. Protocol/framework implementations and persisted formats are unchanged; no real model, SSH, installation, migration or restart operation was performed.

Browser verification used production React components with a fixture transport in two isolated ego-browser tabs. A second tab changed policy, renamed a project and added a literature source; the first updated without reopening. Local screenshots were captured. This is component/browser evidence, not an actual Electron/Web end-to-end transport test. Natural window-destruction timing remains unverified; the delivery failure was deterministically injected.

## Review focus

Check full-Session Host ownership when unrelated projections advance revision, optimistic write settlement under concurrent input, policy invalidation during discovery, and listener cleanup. Independent PR review and required CI remain pending.

<details>
<summary>Exact focused test command</summary>

```sh
RUN_COMPUTE_JOBS=0 npm test -- \
  src/main/application-event-flow.test.ts \
  src/main/application-events.test.ts \
  src/main/compute/application-commands.test.ts \
  src/main/notebook/runtime-ipc.test.ts \
  src/main/notebook/runtime-workflows.test.ts \
  src/main/renderer-broadcast.test.ts \
  src/main/session-persistence/coordinator.test.ts \
  src/main/session-persistence/renderer-save-options.test.ts \
  src/main/settings/notebook-runtime-settings.test.ts \
  src/main/settings/settings-snapshot-commit-owner.test.ts \
  src/main/web-service/application-event-projections.test.ts \
  src/main/web-service/internal-web-event-stream.test.ts \
  src/preload/electron-renderer-contract-adapter.test.ts \
  src/preload/index.test.ts \
  src/renderer/src/hooks/useLifecycleSync.test.tsx \
  src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx \
  src/renderer/src/lib/session-persistence/session-persistence.test.ts \
  src/renderer/src/pages/literature/LiteratureDetailController.test.ts \
  src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx \
  src/renderer/src/pages/literature/LiteratureSources.test.tsx \
  src/renderer/src/pages/literature/useLiteratureChanges.test.tsx \
  src/renderer/src/pages/settings/MemoryPanel.render.test.tsx \
  src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx \
  src/renderer/src/pages/workspace/workspace-compute-host-access-controller.test.ts \
  src/renderer/src/stores/memory-store.test.ts \
  src/renderer/src/stores/runtime-settings-store.test.ts \
  src/renderer/src/stores/session-store.archive-order.test.ts \
  src/renderer/src/stores/session-store.test.ts \
  src/renderer/src/stores/settings-preferences-slice.test.ts \
  src/renderer/src/stores/settings-provider-auth-slice.test.ts \
  src/renderer/src/stores/settings-runtime-slice.test.ts \
  src/renderer/src/stores/settings-store.architecture.test.ts \
  src/renderer/src/stores/settings-store.test.ts \
  src/renderer/src/stores/settings-write-coordinator.test.ts \
  src/renderer/src/stores/tag-store.test.ts \
  src/renderer/web/api-installer.test.ts \
  src/renderer/web/bootstrap.test.ts \
  src/shared/renderer-contract-catalog.test.ts \
  src/shared/renderer-surface-inventory.test.ts \
  src/shared/renderer-surface-matrix.test.ts \
  src/shared/web-rpc-contract.test.ts \
  --maxWorkers=4
```
</details>

### Final focused evidence

- Policy error recovery: the new public-store reproduction failed twice on unchanged production code because a successful retry left the stale error visible. After the final material edit, `npm test -- src/renderer/src/stores/runtime-settings-store.test.ts src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx` passed (3 files, 174 tests), covering recovery without rediscovery, preservation of discovery failures, newer operation errors, and existing event/receipt races. Renderer typechecking and lint passed. A real-component browser fixture confirmed the error appears during a failed policy event read and disappears on a later successful event read; the recovered screenshot is retained locally. The fallback is private in-memory bookkeeping, not a public field, enum, or persisted format.

- Memory project-metadata races and Runtime committed-write/read-failure behavior: two new public store/component regressions failed twice on the preceding production code, at the reported stale-value assertions. After the final material edit, `npm test -- src/renderer/src/stores/memory-store.test.ts src/renderer/src/stores/runtime-settings-store.test.ts src/renderer/src/pages/settings/MemoryPanel.render.test.tsx src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx src/renderer/src/pages/settings/SettingsPage.render.test.tsx` passed (5 files, 204 tests). This includes the guard against using a stale receipt after a newer event when rereading fails. Renderer typechecking and lint passed.
- Tag stale-read errors and policy-only error preservation: public-store regressions failed twice before the fixes; the relevant store/panel set passed 227 tests. These paths remain unchanged by the final edit, and the Runtime/Settings consumers were rerun above.
- Optional preference clears: the review scenario was not reproducible. JSON-round-tripped responses completely omit each cleared field; both new public-store tests pass on unchanged production code. `applySnapshot` projects the optional field as `undefined`, and `acceptCommitted` records it before pending fields are omitted from the visible patch. The Settings store/preferences/coordinator set passed 145 tests, including normalized defaults and stale receipt handling.
- CI fixture/contracts: Settings rendering now supplies the Runtime policy API, and the command inventory compares method contracts rather than events. The affected Runtime/Settings suites passed 172 tests.
- Windows legacy-path timeout: local integration tests and the unchanged-head [Windows core rerun](https://github.com/aipoch/open-science/actions/runs/34360987414/job/102504751565) passed with the existing runner and timeout settings. No path code or timeout budget was changed; the original timeout cause remains unproven.

The final browser screenshot uses the production Runtime panel with a local fault-injection transport: a successful write is followed by a failed policy read, and the settled switch matches the saved value while the retryable error remains visible. Cross-event uncertainty intentionally requires a successful reread or Recheck rather than trusting an unversioned receipt. No new persistent fields, enum values, schema, or historical-data compatibility requirements were introduced. Final-head CI and independent review remain authoritative.

