### PR TITLE
fix(diagnostics): preserve bounded and recoverable logging

### DIFF
--- a/e2e/message-tool-layout-stability.spec.ts
+++ b/e2e/message-tool-layout-stability.spec.ts
@@ -12,7 +12,8 @@ const TOOL_STATUS_LAYOUT_SHIFT_PROMPT = 'Run the status-bearing layout stability
 const BUFFERED_TEXT_TOOL_LAYOUT_SHIFT_PROMPT =
   'Run the buffered text tool layout stability journey.'
 const TOOL_ORDER_PROMPT = 'Run the ordered slow tool journey.'
-const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 22 bytes; raw output omitted.'
+// The stream byte count includes the fixture's terminating newline.
+const AGENT_STDERR_SUMMARY = 'Agent process stderr: 1 chunk, 23 bytes; raw output omitted.'
 
 // Windows CI stalls the first fake-agent turn when the window is shown from launch. Keep it hidden
 // until that reply arrives, then show it for requestAnimationFrame sampling. macOS already passes

--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -123,6 +123,23 @@ const openCandidate = async (
 }
 
 describe('AcpAgentConnectionAdapter', () => {
+  it('preserves stderr separators and decodes UTF-8 split across byte chunks', async () => {
+    const process = new FakeAgentProcess()
+    const connectionHooks = hooks()
+    const candidate = await openCandidate(process, undefined, connectionHooks)
+    const text = ' apiKey=fictional-token 测试\n'
+    try {
+      for (const byte of Buffer.from(text)) process.stderr.emit('data', Buffer.from([byte]))
+      const decoded = vi
+        .mocked(connectionHooks.onProcessStderr)
+        .mock.calls.map(([part]) => part)
+        .join('')
+      expect(decoded).toBe(text)
+    } finally {
+      await candidate.dispose()
+    }
+  })
+
   it('binds process diagnostics and forwards the process epoch context', async () => {
     const process = new FakeAgentProcess()
     const connectionHooks = hooks()
@@ -133,7 +150,7 @@ describe('AcpAgentConnectionAdapter', () => {
     process.emit('error', error)
     process.emit('exit', 1, 'SIGTERM')
 
-    expect(connectionHooks.onProcessStderr).toHaveBeenCalledWith('provider auth failed', {
+    expect(connectionHooks.onProcessStderr).toHaveBeenCalledWith(' provider auth failed\n', {
       process,
       framework: 'claude-code',
       epoch: 1

--- a/src/main/acp/agent-connection-adapter.test.ts
+++ b/src/main/acp/agent-connection-adapter.test.ts
@@ -140,6 +140,25 @@ describe('AcpAgentConnectionAdapter', () => {
     }
   })
 
+  it.each(['end', 'close'] as const)(
+    'finalizes stderr once when %s arrives first and ignores later data',
+    async (first) => {
+      const process = new FakeAgentProcess()
+      const connectionHooks = { ...hooks(), onProcessStderrEnd: vi.fn() }
+      const candidate = await openCandidate(process, undefined, connectionHooks)
+      try {
+        process.stderr.emit('data', Buffer.from('tail'))
+        process.stderr.emit(first)
+        process.stderr.emit(first === 'end' ? 'close' : 'end')
+        process.stderr.emit('data', Buffer.from('impossible late data'))
+        expect(connectionHooks.onProcessStderrEnd).toHaveBeenCalledOnce()
+        expect(connectionHooks.onProcessStderr).toHaveBeenCalledTimes(1)
+      } finally {
+        await candidate.dispose()
+      }
+    }
+  )
+
   it('binds process diagnostics and forwards the process epoch context', async () => {
     const process = new FakeAgentProcess()
     const connectionHooks = hooks()

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -194,14 +194,19 @@ class AcpAgentConnectionAdapter {
       hooks.onBackendPublished(backendAttempt.publish())
       const stderrDecoder = new StringDecoder('utf8')
       const stderrContext = { process: spawnedProcess, framework, epoch: input.epoch }
+      let stderrEnded = false
       spawnedProcess.stderr.on('data', (data: Buffer) => {
-        hooks.onProcessStderr(stderrDecoder.write(data), stderrContext)
+        if (!stderrEnded) hooks.onProcessStderr(stderrDecoder.write(data), stderrContext)
       })
-      spawnedProcess.stderr.once('end', () => {
+      const finishStderr = (): void => {
+        if (stderrEnded) return
+        stderrEnded = true
         const tail = stderrDecoder.end()
         if (tail) hooks.onProcessStderr(tail, stderrContext)
         hooks.onProcessStderrEnd?.(stderrContext)
-      })
+      }
+      spawnedProcess.stderr.once('end', finishStderr)
+      spawnedProcess.stderr.once('close', finishStderr)
       spawnedProcess.on('error', (error) => {
         hooks.onProcessError(error, {
           process: spawnedProcess,

--- a/src/main/acp/agent-connection-adapter.ts
+++ b/src/main/acp/agent-connection-adapter.ts
@@ -14,6 +14,7 @@ import type {
 } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { Readable, Writable } from 'node:stream'
+import { StringDecoder } from 'node:string_decoder'
 
 import type { AgentFramework, ResolvedAgentBackend } from '../agent-framework'
 import { terminateProcessTree } from '../process-tree'
@@ -62,6 +63,7 @@ type AcpAgentConnectionHooks = Readonly<{
   onProcessTreeReaped: (reaped: boolean) => void
   markProcessExitExpected: (process: ChildProcessWithoutNullStreams, epoch: number) => void
   onProcessStderr: (text: string, context: AcpProcessEventContext) => void
+  onProcessStderrEnd?: (context: AcpProcessEventContext) => void
   onProcessError: (error: unknown, context: AcpProcessEventContext) => void
   onProcessExit: (
     code: number | null,
@@ -190,12 +192,15 @@ class AcpAgentConnectionAdapter {
       if (!process) throw new Error('ACP agent process did not spawn.')
       const spawnedProcess = process
       hooks.onBackendPublished(backendAttempt.publish())
+      const stderrDecoder = new StringDecoder('utf8')
+      const stderrContext = { process: spawnedProcess, framework, epoch: input.epoch }
       spawnedProcess.stderr.on('data', (data: Buffer) => {
-        hooks.onProcessStderr(data.toString('utf8').trim(), {
-          process: spawnedProcess,
-          framework,
-          epoch: input.epoch
-        })
+        hooks.onProcessStderr(stderrDecoder.write(data), stderrContext)
+      })
+      spawnedProcess.stderr.once('end', () => {
+        const tail = stderrDecoder.end()
+        if (tail) hooks.onProcessStderr(tail, stderrContext)
+        hooks.onProcessStderrEnd?.(stderrContext)
       })
       spawnedProcess.on('error', (error) => {
         hooks.onProcessError(error, {

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -23765,7 +23765,91 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     }
   )
 
-  it('caps explicitly enabled raw stderr samples by UTF-8 bytes', async () => {
+  it.each(PERMISSION_PROJECTION_FRAMEWORKS)(
+    'redacts raw %s stderr credentials across chunk and sampling boundaries',
+    async (_name, framework, modelRoute, backendId) => {
+      const actualLog = await vi.importActual<typeof import('../logger')>('../logger')
+      const dir = await mkdtemp(join(tmpdir(), 'os-stderr-redaction-'))
+      const previousRaw = process.env.OPEN_SCIENCE_AGENT_STDERR
+      process.env.OPEN_SCIENCE_AGENT_STDERR = 'raw'
+      const child = new FakeAgentProcess()
+      startFakeAgent(
+        child,
+        ['raw-session'],
+        framework.id === 'codex'
+          ? { modes: createModes(['read-only', 'agent', 'agent-full-access'], 'agent') }
+          : {}
+      )
+      const events: AcpRuntimeEvent[] = []
+      const runtime = new AcpRuntime({
+        appVersion: '0.1.0',
+        defaultCwd: '/workspace',
+        resolveBackend: () => ({
+          framework: { ...framework, spawn: () => asAgentProcess(child) },
+          backendId,
+          modelRoute,
+          executablePath: '/bin/agent',
+          env: {},
+          ...(modelRoute === 'codex-bridge'
+            ? { responsesBridgeLease: createBackendLeaseHarness().lease }
+            : {})
+        }),
+        callbacks: { onEvent: (event) => events.push(event) }
+      })
+      const mirror = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
+      try {
+        await runtime.createSession({ cwd: '/workspace' })
+        actualLog.initLogger({ logDir: dir, mirrorToConsole: true })
+        warnLogSpy.mockImplementation(actualLog.createLogger('acp').warn)
+        vi.useFakeTimers()
+        const secret = 'fictional-credential-7319'
+        child.stderr.emit('data', Buffer.from('api'))
+        child.stderr.emit('data', Buffer.from(`Key=${secret}\n`))
+        await vi.advanceTimersByTimeAsync(1000)
+        child.stderr.emit('data', Buffer.from('Authorization: Bear'))
+        await vi.advanceTimersByTimeAsync(1000)
+        child.stderr.emit('data', Buffer.from(`er ${secret}\n`))
+        await vi.advanceTimersByTimeAsync(1000)
+        for (const line of [
+          `apiKey=${secret}\n`,
+          `Authorization: Bearer ${secret}\n`,
+          `--api-key ${secret}\n`,
+          `https://user:${secret}@example.test/path\n`
+        ]) {
+          for (let boundary = 1; boundary < line.length; boundary++) {
+            child.stderr.emit('data', Buffer.from(line.slice(0, boundary)))
+            await vi.advanceTimersByTimeAsync(1000)
+            child.stderr.emit('data', Buffer.from(line.slice(boundary)))
+            await vi.advanceTimersByTimeAsync(1000)
+          }
+        }
+        for (const byte of Buffer.from('正常诊断\n')) {
+          child.stderr.emit('data', Buffer.from([byte]))
+        }
+        // An actual stream end, unlike a reporting timer or process exit, closes a bounded tail.
+        child.stderr.emit('data', Buffer.from(`apiKey=${secret}`))
+        child.stderr.emit('end')
+        await vi.advanceTimersByTimeAsync(1000)
+        await actualLog.flushLogs()
+        expect(await readFile(join(dir, 'main.log'), 'utf8')).not.toContain(secret)
+        expect(JSON.stringify(events)).not.toContain(secret)
+        expect(JSON.stringify(mirror.mock.calls)).not.toContain(secret)
+        expect(await readFile(join(dir, 'main.log'), 'utf8')).toContain('正常诊断')
+        expect(await readFile(join(dir, 'main.log'), 'utf8')).toContain('[redacted]')
+      } finally {
+        vi.useRealTimers()
+        warnLogSpy.mockReset()
+        mirror.mockRestore()
+        if (previousRaw === undefined) delete process.env.OPEN_SCIENCE_AGENT_STDERR
+        else process.env.OPEN_SCIENCE_AGENT_STDERR = previousRaw
+        await runtime.disconnect()
+        await actualLog.flushLogs()
+        await rm(dir, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it('omits oversized raw stderr lines until their boundary', async () => {
     warnLogSpy.mockClear()
     const previousRawStderr = process.env.OPEN_SCIENCE_AGENT_STDERR
     process.env.OPEN_SCIENCE_AGENT_STDERR = 'raw'
@@ -23798,9 +23882,15 @@ describe('ACP runtime — agent process lifecycle logging', () => {
       expect(data.byteCount).toBe(9000)
       expect(data.rawSampleTruncated).toBe(true)
       expect(Buffer.byteLength(data.rawSample, 'utf8')).toBeLessThanOrEqual(4096)
-      expect(data.rawSample).toMatch(/^测+$/)
+      expect(data.rawSample).toBe('')
       expect(events).toHaveLength(1)
       expect(events[0]?.text).toContain('…[truncated]')
+      agentProcess.stderr.emit('data', Buffer.from('fictional-tail-secret\nhealthy stderr\n'))
+      await vi.advanceTimersByTimeAsync(1000)
+      expect(JSON.stringify({ logs: warnLogSpy.mock.calls, events })).not.toContain(
+        'fictional-tail-secret'
+      )
+      expect(JSON.stringify({ logs: warnLogSpy.mock.calls, events })).toContain('healthy stderr')
     } finally {
       vi.useRealTimers()
       if (previousRawStderr === undefined) delete process.env.OPEN_SCIENCE_AGENT_STDERR

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -23849,6 +23849,45 @@ describe('ACP runtime — agent process lifecycle logging', () => {
     }
   )
 
+  it('reports a raw stderr tail once with its original accounting when EOF follows the timer', async () => {
+    const previousRaw = process.env.OPEN_SCIENCE_AGENT_STDERR
+    process.env.OPEN_SCIENCE_AGENT_STDERR = 'raw'
+    const child = new FakeAgentProcess()
+    startFakeAgent(child, ['tail-session'])
+    const events: AcpRuntimeEvent[] = []
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(child),
+      callbacks: { onEvent: (event) => events.push(event) }
+    })
+    try {
+      await runtime.createSession({ cwd: '/workspace' })
+      warnLogSpy.mockClear()
+      events.length = 0
+      vi.useFakeTimers()
+      const text = 'complete line\napiKey=fictional-tail-credential'
+      child.stderr.emit('data', Buffer.from(text))
+      await vi.advanceTimersByTimeAsync(1000)
+      child.stderr.emit('end')
+      await vi.advanceTimersByTimeAsync(1000)
+      const summaries = warnLogSpy.mock.calls.filter(
+        ([message]) => message === 'agent stderr summary'
+      )
+      expect(summaries).toHaveLength(1)
+      expect(summaries[0][1]).toMatchObject({ chunkCount: 1, byteCount: Buffer.byteLength(text) })
+      expect(summaries[0][1]).toMatchObject({ rawSample: 'complete line\napiKey=[redacted]' })
+      expect(
+        events.filter((event) => event.kind === 'system' && event.title === 'agent')
+      ).toHaveLength(1)
+    } finally {
+      vi.useRealTimers()
+      if (previousRaw === undefined) delete process.env.OPEN_SCIENCE_AGENT_STDERR
+      else process.env.OPEN_SCIENCE_AGENT_STDERR = previousRaw
+      await runtime.disconnect()
+    }
+  })
+
   it('omits oversized raw stderr lines until their boundary', async () => {
     warnLogSpy.mockClear()
     const previousRawStderr = process.env.OPEN_SCIENCE_AGENT_STDERR

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -586,7 +586,7 @@ type AgentStderrWindow = {
   codexTransportSignalSample: string
   codexWebSocketFallbackObserved: boolean
   eventEligible: boolean
-  timer: ReturnType<typeof setTimeout>
+  timer?: ReturnType<typeof setTimeout>
 }
 
 type PlanDeliveryClaimRetry = {
@@ -1410,7 +1410,9 @@ class AcpRuntime {
       onProcessStderr: (text, context) => this.handleAgentProcessStderr(text, context),
       onProcessStderrEnd: (context) => {
         const tail = this.agentStderrTails.get(context.process)
-        if (tail?.text || tail?.discarding) this.handleAgentProcessStderr('', context, true)
+        if (tail?.text || (tail?.discarding && this.agentStderrWindows.has(context.process))) {
+          this.handleAgentProcessStderr('', context, true)
+        }
         this.agentStderrTails.delete(context.process)
         this.flushAgentProcessStderr(context.process)
       },
@@ -2849,6 +2851,13 @@ class AcpRuntime {
       }
       this.appendAgentStderrSample(existing, text, ended)
       this.observeCodexTransportSignal(existing, text)
+      if (!existing.timer) {
+        existing.timer = setTimeout(
+          () => this.flushAgentProcessStderr(context.process),
+          AGENT_STDERR_REPORT_WINDOW_MS
+        )
+        existing.timer.unref?.()
+      }
       return
     }
 
@@ -2965,8 +2974,13 @@ class AcpRuntime {
   private flushAgentProcessStderr(process: ChildProcessWithoutNullStreams): void {
     const window = this.agentStderrWindows.get(process)
     if (!window) return
-    this.agentStderrWindows.delete(process)
     clearTimeout(window.timer)
+    window.timer = undefined
+    // Keep the original counters and attribution until a bounded raw line is complete.
+    // With no more data there is no repeating timer; stream end/close finalizes the window.
+    const tail = this.agentStderrTails.get(process)
+    if (this.includeRawAgentStderr() && tail?.text && !tail.discarding) return
+    this.agentStderrWindows.delete(process)
 
     const windowMs = Math.max(1, Date.now() - window.startedAt)
     const includeRaw = this.includeRawAgentStderr() && window.rawSample.length > 0

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -59,6 +59,7 @@ import {
   type ResolvedAgentBackend
 } from '../agent-framework'
 import { createLogger, diagnosticErrorFields, errorLogFields } from '../logger'
+import { redactSensitiveText } from '../diagnostic-redaction'
 import type { AcpRuntimeSnapshotOwner } from './runtime-snapshot-owner'
 import { buildLiteratureReferencePrompt } from './literature-reference-prompt'
 import { buildSessionReferencePrompt } from './session-reference-prompt'
@@ -568,24 +569,6 @@ const hasCodexWebSocketFallback = (text: string): boolean =>
     text
   )
 
-const utf8PrefixWithinBytes = (value: string, maxBytes: number): string => {
-  if (maxBytes <= 0) return ''
-  if (Buffer.byteLength(value, 'utf8') <= maxBytes) return value
-
-  let low = 0
-  let high = Math.min(value.length, maxBytes)
-  while (low < high) {
-    const middle = Math.ceil((low + high) / 2)
-    if (Buffer.byteLength(value.slice(0, middle), 'utf8') <= maxBytes) low = middle
-    else high = middle - 1
-  }
-  // Do not retain half of a UTF-16 surrogate pair at the byte boundary.
-  if (low > 0 && value.charCodeAt(low - 1) >= 0xd800 && value.charCodeAt(low - 1) <= 0xdbff) {
-    low -= 1
-  }
-  return value.slice(0, low)
-}
-
 type AgentStderrWindow = {
   process: ChildProcessWithoutNullStreams
   framework: AgentFrameworkId
@@ -657,6 +640,15 @@ class AcpRuntime {
   private durablePlanDeliveries?: Map<string, { projectId: string; commandId: string }>
   private readonly planDeliveryClaimRetries = new Map<string, PlanDeliveryClaimRetry>()
   private readonly planDeliveryPreparations = new Set<string>()
+  // Incomplete lines belong to the process stream, not the one-second reporting window.
+  private readonly agentStderrTails = new WeakMap<
+    ChildProcessWithoutNullStreams,
+    {
+      text: string
+      discarding: boolean
+      window: AgentStderrWindow
+    }
+  >()
   private readonly agentStderrWindows = new Map<ChildProcessWithoutNullStreams, AgentStderrWindow>()
   private restoredContinuationContextResetSessionIds?: Set<string>
   // Ephemeral Reviewer identity, isolation, permission, and resource state lives behind one owner.
@@ -1416,6 +1408,12 @@ class AcpRuntime {
       },
       markProcessExitExpected: (process) => this.connectionClose.markExpected(process),
       onProcessStderr: (text, context) => this.handleAgentProcessStderr(text, context),
+      onProcessStderrEnd: (context) => {
+        const tail = this.agentStderrTails.get(context.process)
+        if (tail?.text || tail?.discarding) this.handleAgentProcessStderr('', context, true)
+        this.agentStderrTails.delete(context.process)
+        this.flushAgentProcessStderr(context.process)
+      },
       onProcessError: (error, context) => this.handleAgentProcessError(error, context),
       onProcessExit: (code, signal, context) => this.handleAgentProcessExit(code, signal, context),
       onConnectionClosed: () => this.connectionClose.handleUnexpectedClose(),
@@ -2823,9 +2821,10 @@ class AcpRuntime {
   // Projects adapter-bound process diagnostics while retaining epoch classification and event state.
   private handleAgentProcessStderr(
     text: string,
-    context: Parameters<AcpAgentConnectionHooks['onProcessStderr']>[1]
+    context: Parameters<AcpAgentConnectionHooks['onProcessStderr']>[1],
+    ended = false
   ): void {
-    if (!text) return
+    if (!text && !ended) return
 
     const disposition = this.processEventDisposition(context.process, context.epoch)
     const inFlight = disposition === 'current' ? this.getInFlightSessionIds() : []
@@ -2835,7 +2834,7 @@ class AcpRuntime {
       : undefined
     const existing = this.agentStderrWindows.get(context.process)
     if (existing) {
-      existing.chunkCount += 1
+      existing.chunkCount += ended ? 0 : 1
       existing.byteCount += Buffer.byteLength(text, 'utf8')
       existing.eventEligible &&= disposition === 'current'
       existing.nonActionableCodexOnly &&=
@@ -2848,7 +2847,7 @@ class AcpRuntime {
         existing.interactionSequence = undefined
         existing.sessionAttributionConsistent = false
       }
-      this.appendAgentStderrSample(existing, text)
+      this.appendAgentStderrSample(existing, text, ended)
       this.observeCodexTransportSignal(existing, text)
       return
     }
@@ -2863,7 +2862,7 @@ class AcpRuntime {
       framework: context.framework,
       epoch: context.epoch,
       startedAt: Date.now(),
-      chunkCount: 1,
+      chunkCount: ended ? 0 : 1,
       byteCount: Buffer.byteLength(text, 'utf8'),
       rawSample: '',
       rawSampleBytes: 0,
@@ -2877,7 +2876,7 @@ class AcpRuntime {
       eventEligible: disposition === 'current',
       timer
     }
-    this.appendAgentStderrSample(window, text)
+    this.appendAgentStderrSample(window, text, ended)
     this.observeCodexTransportSignal(window, text)
     this.agentStderrWindows.set(context.process, window)
   }
@@ -2911,22 +2910,56 @@ class AcpRuntime {
     return process.env[RAW_AGENT_STDERR_ENV]?.trim().toLowerCase() === 'raw'
   }
 
-  private appendAgentStderrSample(window: AgentStderrWindow, text: string): void {
-    if (!this.includeRawAgentStderr()) return
-    let available = MAX_RAW_AGENT_STDERR_SAMPLE_BYTES - window.rawSampleBytes
-    if (available <= 0) {
-      window.rawSampleTruncated = true
+  private appendAgentStderrSample(window: AgentStderrWindow, text: string, ended: boolean): void {
+    if (!this.includeRawAgentStderr()) {
+      this.agentStderrTails.delete(window.process)
       return
     }
-    if (window.rawSample) {
-      window.rawSample += '\n'
-      window.rawSampleBytes += 1
-      available -= 1
+    const tail = this.agentStderrTails.get(window.process) ?? {
+      text: '',
+      discarding: false,
+      window
     }
-    const prefix = utf8PrefixWithinBytes(text, available)
-    window.rawSample += prefix
-    window.rawSampleBytes += Buffer.byteLength(prefix, 'utf8')
-    if (prefix.length < text.length) window.rawSampleTruncated = true
+    if (tail.window !== window && (tail.text || tail.discarding)) {
+      // A line crossing reporting windows must not acquire a later prompt's attribution.
+      window.sessionAttributionConsistent = false
+    }
+    tail.window = window
+    let offset = 0
+    do {
+      const newline = text.indexOf('\n', offset)
+      const end = newline < 0 ? text.length : newline + 1
+      const part = text.slice(offset, end)
+      if (!tail.discarding) {
+        if (
+          Buffer.byteLength(tail.text, 'utf8') + Buffer.byteLength(part, 'utf8') >
+          MAX_RAW_AGENT_STDERR_SAMPLE_BYTES
+        ) {
+          tail.text = ''
+          tail.discarding = true
+        } else {
+          tail.text += part
+        }
+      }
+      if (tail.discarding) window.rawSampleTruncated = true
+      if (newline >= 0 || ended) {
+        if (!tail.discarding) {
+          const safe = redactSensitiveText(tail.text)
+          const bytes = Buffer.byteLength(safe, 'utf8')
+          if (window.rawSampleBytes + bytes <= MAX_RAW_AGENT_STDERR_SAMPLE_BYTES) {
+            window.rawSample += safe
+            window.rawSampleBytes += bytes
+          } else {
+            window.rawSampleTruncated = true
+          }
+        }
+        tail.text = ''
+        tail.discarding = false
+      }
+      offset = end
+      if (newline < 0) break
+    } while (offset < text.length)
+    this.agentStderrTails.set(window.process, tail)
   }
 
   private flushAgentProcessStderr(process: ChildProcessWithoutNullStreams): void {
@@ -2949,7 +2982,7 @@ class AcpRuntime {
       byteCount: window.byteCount,
       windowMs,
       chunksPerSecond: Number(((window.chunkCount * 1000) / windowMs).toFixed(1)),
-      ...(includeRaw
+      ...(this.includeRawAgentStderr()
         ? { rawSample: window.rawSample, rawSampleTruncated: window.rawSampleTruncated }
         : {})
     })
@@ -2978,7 +3011,7 @@ class AcpRuntime {
       level: 'warning',
       sessionId,
       title: 'agent',
-      text: includeRaw ? `${summary}\n${window.rawSample}${rawSuffix}` : summary
+      text: includeRaw ? `${summary}\n${window.rawSample}${rawSuffix}` : `${summary}${rawSuffix}`
     })
   }
 

--- a/src/main/app-lifecycle.ts
+++ b/src/main/app-lifecycle.ts
@@ -7,7 +7,7 @@ import {
   type RendererSessionPersistenceFlushOutcome
 } from './session-persistence/renderer-flush'
 import type { ShutdownStepOutcome } from './lifecycle-shutdown'
-import { flushDiagnosticsWithTimeout } from './diagnostics/flush'
+import { flushDiagnosticsWithTimeout, type DiagnosticFlush } from './diagnostics/flush'
 import { diagnosticErrorFields, type Logger } from './logger'
 import { startDiagnosticOperation } from './diagnostics/operation'
 import {
@@ -71,7 +71,7 @@ export type AppLifecycleDeps = {
   // Local structured diagnostics remain optional for the dependency-injected lifecycle tests.
   log?: Logger
   // Drains the logger's serialized write queue after the shutdown terminal record.
-  flushLogs?: () => Promise<void>
+  flushLogs?: DiagnosticFlush
   logFlushTimeoutMs?: number
   // Shared timeout budget for the preflight and post-drain renderer persistence attempts.
   rendererFlushTimeoutMs?: number

--- a/src/main/diagnostics/flush.ts
+++ b/src/main/diagnostics/flush.ts
@@ -1,7 +1,11 @@
+import type { LogFlushResult } from '../logger'
+
+export type DiagnosticFlush = () => Promise<LogFlushResult | void>
+
 export type DiagnosticFlushOutcome = 'flushed' | 'failed' | 'timeout'
 
 export const flushDiagnosticsWithTimeout = async (
-  flush: () => Promise<void>,
+  flush: DiagnosticFlush,
   timeoutMs: number
 ): Promise<DiagnosticFlushOutcome> => {
   let timer: ReturnType<typeof setTimeout> | undefined
@@ -13,7 +17,7 @@ export const flushDiagnosticsWithTimeout = async (
     Promise.resolve()
       .then(flush)
       .then(
-        () => 'flushed' as const,
+        (result) => (result?.failed ? ('failed' as const) : ('flushed' as const)),
         () => 'failed' as const
       ),
     timeout

--- a/src/main/diagnostics/startup.ts
+++ b/src/main/diagnostics/startup.ts
@@ -1,5 +1,9 @@
 import { createLogger, flushLogs, initLogger, type Logger } from '../logger'
-import { flushDiagnosticsWithTimeout, type DiagnosticFlushOutcome } from './flush'
+import {
+  flushDiagnosticsWithTimeout,
+  type DiagnosticFlush,
+  type DiagnosticFlushOutcome
+} from './flush'
 import { startDiagnosticOperation, type DiagnosticOperation } from './operation'
 
 type ApplicationDiagnosticMetadata = {
@@ -18,7 +22,7 @@ type ApplicationDiagnosticMetadata = {
 export type ApplicationDiagnostics = {
   log: Logger
   operation: DiagnosticOperation
-  flush: () => Promise<void>
+  flush: DiagnosticFlush
 }
 
 export const initializeApplicationDiagnostics = (
@@ -54,7 +58,7 @@ export const initializeApplicationDiagnostics = (
 export const reportApplicationStartupFailure = async (input: {
   operation?: DiagnosticOperation
   error: unknown
-  flush: () => Promise<void>
+  flush: DiagnosticFlush
   timeoutMs?: number
 }): Promise<DiagnosticFlushOutcome> => {
   input.operation?.fail(input.error)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,7 +38,7 @@ const shouldRunSkillRuntimeMcpServer = process.argv.includes(SKILL_RUNTIME_MCP_S
 const shouldRunPlanMcpServer = process.argv.includes(PLAN_MCP_SERVER_ARG)
 const bootstrapLog = createLogger('bootstrap')
 let startupDiagnostics: DiagnosticOperation | undefined
-let startupFlush = flushLogs
+let startupFlush: import('./diagnostics/flush').DiagnosticFlush = flushLogs
 
 if (shouldRunArtifactMcpServer) {
   // Reuse the packaged entry point as a Node stdio MCP server; import it only in this mode.

--- a/src/main/logger.test.ts
+++ b/src/main/logger.test.ts
@@ -5,12 +5,18 @@ import { join, resolve } from 'node:path'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const renameFile = vi.hoisted(() => vi.fn())
+const { renameFile, appendLogFile, openLogFile } = vi.hoisted(() => ({
+  renameFile: vi.fn(),
+  appendLogFile: vi.fn(),
+  openLogFile: vi.fn()
+}))
 
 vi.mock('node:fs/promises', async (importOriginal) => {
   const original = await importOriginal<typeof import('node:fs/promises')>()
   renameFile.mockImplementation(original.rename)
-  return { ...original, rename: renameFile }
+  appendLogFile.mockImplementation(original.appendFile)
+  openLogFile.mockImplementation(original.open)
+  return { ...original, rename: renameFile, appendFile: appendLogFile, open: openLogFile }
 })
 
 import {
@@ -24,6 +30,7 @@ import {
   runWithDiagnosticCorrelation,
   writeFatalLogSync
 } from './logger'
+import { flushDiagnosticsWithTimeout } from './diagnostics/flush'
 import {
   ApplicationModuleDisposalTimeoutError,
   shutdownApplicationSurfaces
@@ -33,6 +40,9 @@ let logDir: string | undefined
 
 afterEach(async () => {
   vi.restoreAllMocks()
+  const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+  appendLogFile.mockImplementation(fs.appendFile)
+  openLogFile.mockImplementation(fs.open)
   if (logDir) {
     await rm(logDir, { recursive: true, force: true })
     logDir = undefined
@@ -222,6 +232,8 @@ describe('logger: main-process boundary', () => {
             .soft(await getLogFileStatus())
             .toMatchObject({ lastWriteSucceeded: false, lastFailureCategory: 'rotation' })
           renameFile.mockImplementation(original.rename)
+          appendLogFile.mockImplementation(original.appendFile)
+          await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('failed')
           createLogger('diagnostics').error('rotation recovered', { detail: 'x'.repeat(150) })
           await flushLogs()
         }
@@ -234,6 +246,7 @@ describe('logger: main-process boundary', () => {
         })
       } finally {
         renameFile.mockImplementation(original.rename)
+        appendLogFile.mockImplementation(original.appendFile)
       }
     }
   )
@@ -1679,4 +1692,219 @@ describe('logger: rotation (auto-cleanup)', () => {
       lastFailureCategory: 'rotation'
     })
   })
+})
+
+describe('logger: stalled and interrupted writes', () => {
+  it('bounds pending records while reserving capacity for errors and reports discarded logs', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-queue-'))
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let release!: () => void
+    appendLogFile.mockClear()
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    appendLogFile.mockImplementationOnce(async (...args: Parameters<typeof fs.appendFile>) => {
+      await blocked
+      await fs.appendFile(...args)
+    })
+    initLogger({ logDir, mirrorToConsole: false, maxPendingBytes: 4096, maxPendingRecords: 8 })
+    const log = createLogger('queue')
+    log.info('first')
+    await vi.waitFor(() => expect(appendLogFile).toHaveBeenCalled())
+    for (let index = 0; index < 100; index++) log.info('burst', { index })
+    log.error('important error')
+    // Logging remains synchronous even while the disk cannot make progress.
+    release()
+    await flushLogs()
+    const records = (await readFile(join(logDir, 'main.log'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(records.filter((record) => record.msg === 'burst').length).toBeLessThan(8)
+    expect(records.some((record) => record.msg === 'important error')).toBe(true)
+    expect(
+      records.find((record) => record.msg === 'log records dropped')?.data.droppedRecords
+    ).toBeGreaterThan(0)
+    await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('failed')
+    log.info('after recovery')
+    await flushLogs()
+    expect(await readFile(join(logDir, 'main.log'), 'utf8')).toContain('after recovery')
+  })
+
+  it('does not report a lossless flush after a failed write followed by a successful write', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-flush-'))
+    initLogger({ logDir, mirrorToConsole: false })
+    appendLogFile.mockRejectedValueOnce(Object.assign(new Error('disk full'), { code: 'ENOSPC' }))
+    const log = createLogger('flush')
+    log.error('lost record')
+    await flushLogs()
+    log.info('recovery record')
+    await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('failed')
+    await expect(getLogFileStatus()).resolves.toMatchObject({ lastWriteSucceeded: true })
+  })
+
+  it.each(['zero bytes', 'partial JSON', 'missing newline', 'split UTF-8'])(
+    'keeps the next successful JSONL record readable after an append fails at %s',
+    async (boundary) => {
+      logDir = await mkdtemp(join(tmpdir(), 'os-logger-tail-'))
+      const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      initLogger({ logDir, mirrorToConsole: false })
+      const log = createLogger('tail')
+      log.info('preserved')
+      await flushLogs()
+      appendLogFile.mockImplementationOnce(async (path, line) => {
+        const bytes = Buffer.from(line)
+        const length =
+          boundary === 'zero bytes'
+            ? 0
+            : boundary === 'partial JSON'
+              ? 25
+              : boundary === 'missing newline'
+                ? bytes.length - 1
+                : bytes.indexOf(Buffer.from('测')) + 1
+        await fs.appendFile(path, bytes.subarray(0, length))
+        throw Object.assign(new Error('partial append'), { code: 'ENOSPC' })
+      })
+      log.error('interrupted 测')
+      await flushLogs()
+      log.info('recovered')
+      await flushLogs()
+      const records = (await readFile(join(logDir, 'main.log'), 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      expect(records.map((record) => record.msg)).toEqual(
+        expect.arrayContaining(['preserved', 'recovered'])
+      )
+    }
+  )
+
+  it('repairs a pre-existing incomplete tail without deleting complete historical lines', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-existing-tail-'))
+    await writeFile(join(logDir, 'main.log'), '{"msg":"historical"}\n{"msg":"incomplete')
+    initLogger({ logDir, mirrorToConsole: false })
+    createLogger('tail').info('new run')
+    await flushLogs()
+    const records = (await readFile(join(logDir, 'main.log'), 'utf8'))
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(records.map((record) => record.msg)).toEqual(
+      expect.arrayContaining(['historical', 'new run'])
+    )
+  })
+})
+
+describe('logger: loss and recovery contracts', () => {
+  it('bounds pending UTF-8 bytes even when the record count remains below its limit', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-byte-budget-'))
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    let release!: () => void
+    const blocked = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    appendLogFile.mockClear()
+    appendLogFile.mockImplementationOnce(async (...args: Parameters<typeof fs.appendFile>) => {
+      await blocked
+      await fs.appendFile(...args)
+    })
+    initLogger({ logDir, mirrorToConsole: false, maxPendingBytes: 4096, maxPendingRecords: 1000 })
+    const log = createLogger('bytes')
+    log.info('first')
+    await vi.waitFor(() => expect(appendLogFile).toHaveBeenCalledOnce())
+    for (let index = 0; index < 30; index++) log.info('payload', { text: '测'.repeat(200) })
+    for (let index = 0; index < 30; index++) log.error('error payload', { text: '测'.repeat(200) })
+    // Fatal logging stays synchronous and bypasses the bounded ordinary queue.
+    writeFatalLogSync('bytes', 'fatal marker')
+    expect(await readFile(join(logDir, 'main.log'), 'utf8')).toContain('fatal marker')
+    release()
+    await flushLogs()
+    const lines = (await readFile(join(logDir, 'main.log'), 'utf8')).trim().split('\n')
+    const records = lines.map((line) => JSON.parse(line))
+    const admittedBytes = lines
+      .filter((line) => !line.includes('log records dropped') && !line.includes('fatal marker'))
+      .reduce((sum, line) => sum + Buffer.byteLength(line) + 1, 0)
+    expect(admittedBytes).toBeLessThanOrEqual(4096)
+    expect(records.filter((record) => record.msg === 'error payload')).not.toHaveLength(0)
+    expect(
+      records.find((record) => record.msg === 'log records dropped')?.data.droppedRecords
+    ).toBeGreaterThan(0)
+  })
+
+  it('reports directory and inspection failures without rejecting ordinary log calls', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-io-failures-'))
+    const blocker = join(logDir, 'blocker')
+    await writeFile(blocker, 'not a directory')
+    initLogger({ logDir: join(blocker, 'logs'), mirrorToConsole: false })
+    expect(() => createLogger('io').error('cannot create directory')).not.toThrow()
+    await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('failed')
+    await expect(getLogFileStatus()).resolves.toMatchObject({ lastWriteSucceeded: false })
+    const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+    await fs.mkdir(join(logDir, 'as-directory'))
+    initLogger({ logDir, fileName: 'as-directory', mirrorToConsole: false })
+    createLogger('io').error('cannot inspect directory as log')
+    await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('failed')
+    await expect(getLogFileStatus()).resolves.toMatchObject({ lastFailureCategory: 'inspect' })
+  })
+
+  it('keeps overlapping flushes loss-aware and resets loss only with a new sink initialization', async () => {
+    logDir = await mkdtemp(join(tmpdir(), 'os-logger-overlapping-flush-'))
+    initLogger({ logDir, mirrorToConsole: false })
+    appendLogFile.mockRejectedValueOnce(new Error('disk unavailable'))
+    createLogger('io').info('lost')
+    const first = flushDiagnosticsWithTimeout(flushLogs, 1000)
+    const second = flushDiagnosticsWithTimeout(flushLogs, 1000)
+    await expect(Promise.all([first, second])).resolves.toEqual(['failed', 'failed'])
+    initLogger({ logDir, mirrorToConsole: false })
+    createLogger('io').info('new initialization')
+    await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('flushed')
+  })
+})
+
+describe('logger: interrupted tail repair', () => {
+  it.each(['read', 'truncate'] as const)(
+    'does not append when tail %s fails, and retries after recovery',
+    async (operation) => {
+      logDir = await mkdtemp(join(tmpdir(), 'os-logger-tail-retry-'))
+      const path = join(logDir, 'main.log')
+      const original = '{"msg":"preserved"}\n{"partial":'
+      await writeFile(path, original)
+      const fs = await vi.importActual<typeof import('node:fs/promises')>('node:fs/promises')
+      openLogFile.mockImplementationOnce(async (...args: Parameters<typeof fs.open>) => {
+        const handle = await fs.open(...args)
+        return {
+          stat: handle.stat.bind(handle),
+          read:
+            operation === 'read'
+              ? async () => {
+                  throw new Error('read unavailable')
+                }
+              : handle.read.bind(handle),
+          truncate:
+            operation === 'truncate'
+              ? async () => {
+                  throw new Error('truncate unavailable')
+                }
+              : handle.truncate.bind(handle),
+          close: handle.close.bind(handle)
+        }
+      })
+      initLogger({ logDir, mirrorToConsole: false })
+      createLogger('tail').info('blocked write')
+      await expect(flushDiagnosticsWithTimeout(flushLogs, 1000)).resolves.toBe('failed')
+      expect(await readFile(path, 'utf8')).toBe(original)
+      createLogger('tail').info('recovered write')
+      await flushLogs()
+      const records = (await readFile(path, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line))
+      expect(records.map((record) => record.msg)).toEqual(
+        expect.arrayContaining(['preserved', 'recovered write'])
+      )
+      expect(
+        records.find((record) => record.msg === 'log records dropped')?.data.repairedTailBytes
+      ).toBe(11)
+    }
+  )
 })

--- a/src/main/logger.ts
+++ b/src/main/logger.ts
@@ -1,4 +1,4 @@
-import { appendFile, mkdir, rename, rm, stat } from 'node:fs/promises'
+import { appendFile, mkdir, open, rename, rm, stat } from 'node:fs/promises'
 import { appendFileSync, mkdirSync } from 'node:fs'
 import { randomUUID } from 'node:crypto'
 import { AsyncLocalStorage } from 'node:async_hooks'
@@ -36,6 +36,9 @@ export type LoggerConfig = {
   maxBytes: number
   // Total files kept (the live file plus rotated backups). Older ones are deleted automatically.
   maxFiles: number
+  // Includes the in-flight record. One quarter is reserved for errors.
+  maxPendingBytes: number
+  maxPendingRecords: number
 }
 
 const DEFAULT_MAX_BYTES = 5 * 1024 * 1024 // 5 MB per file
@@ -45,10 +48,29 @@ const DEFAULT_MIRROR_TO_CONSOLE = process.env.NODE_ENV !== 'test'
 let config: LoggerConfig | undefined
 // Serializes appends (and rotation) so concurrent log calls cannot interleave partial lines.
 let writeChain: Promise<void> = Promise.resolve()
-// Running size of the live file; undefined until seeded from disk on the first write after init.
-let currentBytes: number | undefined
-let lastWriteSucceeded: boolean | null = null
-let lastFailureCategory: LogWriteFailureCategory | null = null
+// Each initialization owns its accounting even if an older sink is still draining.
+type LogSinkState = {
+  currentBytes: number | undefined
+  lastWriteSucceeded: boolean | null
+  lastFailureCategory: LogWriteFailureCategory | null
+  pendingBytes: number
+  pendingRecords: number
+  droppedRecords: number
+  repairedTailBytes: number
+  lostRecords: boolean
+}
+const createSinkState = (): LogSinkState => ({
+  currentBytes: undefined,
+  lastWriteSucceeded: null,
+  lastFailureCategory: null,
+  pendingBytes: 0,
+  pendingRecords: 0,
+  droppedRecords: 0,
+  repairedTailBytes: 0,
+  lostRecords: false
+})
+let sinkState = createSinkState()
+export type LogFlushResult = { failed: boolean }
 const diagnosticCorrelation = new AsyncLocalStorage<string>()
 
 const runWithDiagnosticCorrelation = <Result>(operation: () => Result): Result => {
@@ -685,67 +707,130 @@ const rotate = async (logDir: string, fileName: string, maxFiles: number): Promi
   )
 }
 
-const appendLine = (line: string): void => {
-  if (!config) return
-
-  const { logDir, fileName, maxBytes, maxFiles } = config
-
-  writeChain = writeChain.then(
-    async () => {
-      let failureCategory: LogWriteFailureCategory = 'directory'
-      try {
-        await mkdir(logDir, { recursive: true })
-
-        const filePath = join(logDir, fileName)
-
-        if (currentBytes === undefined) {
-          failureCategory = 'inspect'
-          currentBytes = await fileSize(filePath)
-        }
-
-        const lineBytes = Buffer.byteLength(line, 'utf8') + 1 // include the newline
-
-        // Even an empty file must not accept a record larger than its configured cap.
-        if (lineBytes > maxBytes) {
-          lastWriteSucceeded = false
-          lastFailureCategory = 'append'
-          return
-        }
-
-        // Rotate before writing when the next line would exceed the cap (but never rotate an empty file).
-        if (currentBytes > 0 && currentBytes + lineBytes > maxBytes) {
-          failureCategory = 'rotation'
-          const rotated = await rotate(logDir, fileName, maxFiles)
-          if (rotated) {
-            currentBytes = 0
-          } else {
-            // The live file may still have changed despite the failed operation (for example, another
-            // process removed it). Re-read the real size, and drop this line if it remains over cap.
-            currentBytes = await fileSize(filePath)
-            if (currentBytes > 0 && currentBytes + lineBytes > maxBytes) {
-              lastWriteSucceeded = false
-              lastFailureCategory = 'rotation'
-              return
-            }
-          }
-        }
-
-        failureCategory = 'append'
-        await appendFile(filePath, `${line}\n`, 'utf8')
-        currentBytes += lineBytes
-        lastWriteSucceeded = true
-        lastFailureCategory = null
-      } catch {
-        // An append can fail after a partial filesystem write. Re-seed from disk before the next
-        // attempt so the bounded-size decision never relies on a possibly stale byte count.
-        currentBytes = undefined
-        lastWriteSucceeded = false
-        lastFailureCategory = failureCategory
-        // Logging must never throw or reject into the app; a failed write is silently dropped.
+// A failed append (or an earlier process crash) may leave a non-JSON tail. Scan backwards
+// with bounded memory and discard only bytes after the last complete line, never a backup.
+const repairLogTail = async (path: string): Promise<{ size: number; discarded: number }> => {
+  let file: Awaited<ReturnType<typeof open>>
+  try {
+    file = await open(path, 'r+')
+  } catch (error) {
+    if (isMissingFileError(error)) return { size: 0, discarded: 0 }
+    throw error
+  }
+  try {
+    const { size } = await file.stat()
+    const buffer = Buffer.alloc(Math.min(size, 64 * 1024))
+    let end = size
+    let boundary = 0
+    while (end > 0) {
+      const start = Math.max(0, end - buffer.length)
+      const length = end - start
+      const { bytesRead } = await file.read(buffer, 0, length, start)
+      if (bytesRead !== length) throw new Error('Log tail changed during inspection')
+      const newline = buffer.subarray(0, bytesRead).lastIndexOf(10)
+      if (newline >= 0) {
+        boundary = start + newline + 1
+        break
       }
-    },
-    () => undefined
-  )
+      end = start
+    }
+    if (boundary !== size) await file.truncate(boundary)
+    return { size: boundary, discarded: size - boundary }
+  } finally {
+    await file.close()
+  }
+}
+
+const writeLine = async (
+  line: string,
+  activeConfig: LoggerConfig,
+  state: LogSinkState
+): Promise<boolean> => {
+  const { logDir, fileName, maxBytes, maxFiles } = activeConfig
+  let failureCategory: LogWriteFailureCategory = 'directory'
+  try {
+    await mkdir(logDir, { recursive: true })
+    const filePath = join(logDir, fileName)
+    if (state.currentBytes === undefined) {
+      failureCategory = 'inspect'
+      const repaired = await repairLogTail(filePath)
+      state.currentBytes = repaired.size
+      state.repairedTailBytes += repaired.discarded
+      if (repaired.discarded) state.lostRecords = true
+    }
+    const lineBytes = Buffer.byteLength(line, 'utf8') + 1
+    failureCategory = 'append'
+    if (lineBytes > maxBytes) throw new Error('Log record exceeds file budget')
+    if (state.currentBytes > 0 && state.currentBytes + lineBytes > maxBytes) {
+      failureCategory = 'rotation'
+      if (await rotate(logDir, fileName, maxFiles)) {
+        state.currentBytes = 0
+      } else {
+        state.currentBytes = await fileSize(filePath)
+        if (state.currentBytes > 0 && state.currentBytes + lineBytes > maxBytes) {
+          throw new Error('Log rotation failed')
+        }
+      }
+    }
+    failureCategory = 'append'
+    await appendFile(filePath, `${line}\n`, 'utf8')
+    state.currentBytes += lineBytes
+    state.lastWriteSucceeded = true
+    state.lastFailureCategory = null
+    return true
+  } catch {
+    state.currentBytes = undefined
+    state.lastWriteSucceeded = false
+    state.lastFailureCategory = failureCategory
+    state.lostRecords = true
+    return false
+  }
+}
+
+const appendLine = (line: string, level: LogLevel): void => {
+  if (!config) return
+  const activeConfig = config
+  const state = sinkState
+  const bytes = Buffer.byteLength(line, 'utf8') + 1
+  const fraction = level === 'error' ? 1 : 0.75
+  if (
+    state.pendingBytes + bytes > activeConfig.maxPendingBytes * fraction ||
+    state.pendingRecords + 1 > Math.floor(activeConfig.maxPendingRecords * fraction)
+  ) {
+    state.droppedRecords = Math.min(Number.MAX_SAFE_INTEGER, state.droppedRecords + 1)
+    state.lostRecords = true
+    return
+  }
+  state.pendingBytes += bytes
+  state.pendingRecords += 1
+  writeChain = writeChain.then(async () => {
+    try {
+      const succeeded = await writeLine(line, activeConfig, state)
+      // One aggregate recovery record, never one queued closure per rejected message. Do not
+      // recursively log a failure to the failed sink. A later successful write can retry it.
+      if (succeeded && (state.droppedRecords || state.repairedTailBytes)) {
+        const droppedRecords = state.droppedRecords
+        const repairedTailBytes = state.repairedTailBytes
+        const summary = formatLine(
+          'warn',
+          'logger',
+          'log records dropped',
+          {
+            droppedRecords,
+            repairedTailBytes
+          },
+          activeConfig.runId
+        )
+        if (await writeLine(summary, activeConfig, state)) {
+          state.droppedRecords -= droppedRecords
+          state.repairedTailBytes -= repairedTailBytes
+        }
+      }
+    } finally {
+      state.pendingBytes -= bytes
+      state.pendingRecords -= 1
+    }
+  })
 }
 
 // Initializes the sink. Safe to call once at startup; later calls replace the config and re-seed size.
@@ -757,11 +842,11 @@ const initLogger = (options: { logDir: string } & Partial<Omit<LoggerConfig, 'lo
     mirrorToConsole: DEFAULT_MIRROR_TO_CONSOLE,
     maxBytes: DEFAULT_MAX_BYTES,
     maxFiles: DEFAULT_MAX_FILES,
+    maxPendingBytes: 4 * 1024 * 1024,
+    maxPendingRecords: 1024,
     ...options
   }
-  currentBytes = undefined
-  lastWriteSucceeded = null
-  lastFailureCategory = null
+  sinkState = createSinkState()
 }
 
 // Absolute path of the configured log file, or undefined before init.
@@ -770,13 +855,14 @@ const getLogFilePath = (): string | undefined =>
 
 const getLogFileStatus = async (): Promise<LogFileStatus> => {
   const activeConfig = config
+  const state = sinkState
   if (!activeConfig) {
     return {
       configured: false,
       path: null,
       existing: false,
-      lastWriteSucceeded,
-      lastFailureCategory
+      lastWriteSucceeded: state.lastWriteSucceeded,
+      lastFailureCategory: state.lastFailureCategory
     }
   }
 
@@ -789,22 +875,26 @@ const getLogFileStatus = async (): Promise<LogFileStatus> => {
       configured: true,
       path,
       existing: true,
-      lastWriteSucceeded,
-      lastFailureCategory
+      lastWriteSucceeded: state.lastWriteSucceeded,
+      lastFailureCategory: state.lastFailureCategory
     }
   } catch (error) {
     return {
       configured: true,
       path,
       existing: false,
-      lastWriteSucceeded,
-      lastFailureCategory: isMissingFileError(error) ? lastFailureCategory : 'inspect'
+      lastWriteSucceeded: state.lastWriteSucceeded,
+      lastFailureCategory: isMissingFileError(error) ? state.lastFailureCategory : 'inspect'
     }
   }
 }
 
-// Resolves once all queued writes have flushed. Useful for tests and orderly shutdown.
-const flushLogs = (): Promise<void> => writeChain
+// Drain the current queue barrier, not fsync. Loss is sticky for this sink initialization;
+// later successful appends and overlapping flushes must not erase earlier missing diagnostics.
+const flushLogs = (): Promise<LogFlushResult> => {
+  const state = sinkState
+  return writeChain.then(() => ({ failed: state.lostRecords }))
+}
 
 // Fatal process failures cannot await the ordinary Promise-backed write queue: Node terminates as soon
 // as the uncaughtExceptionMonitor listeners return. Append the final bounded, redacted record
@@ -855,7 +945,7 @@ const emit = (level: LogLevel, scope: string, message: string, data?: unknown): 
 
   if (config && LEVEL_ORDER[level] < LEVEL_ORDER[config.minLevel]) return
 
-  appendLine(line)
+  appendLine(line, level)
 }
 
 export type Logger = {

--- a/src/main/renderer-diagnostics.test.ts
+++ b/src/main/renderer-diagnostics.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest'
 
+import { projectRendererFailure } from '../renderer/src/renderer-diagnostics'
+
 import type { RendererFailureReport } from '../shared/diagnostics'
 import {
   createRendererFailureReporter,
@@ -311,5 +313,43 @@ describe('createRendererFailureReporter', () => {
       dispose = registerRendererDiagnosticsIpc(target, { report: vi.fn() })
     }).not.toThrow()
     expect(() => dispose?.()).not.toThrow()
+  })
+})
+
+describe('renderer source-location deduplication', () => {
+  it.each([
+    [
+      'development',
+      'http://localhost:5173/src/pages/first.tsx:10:5',
+      'http://localhost:5173/src/pages/second.tsx:90:7'
+    ],
+    [
+      'packaged',
+      'file:///app/out/renderer/assets/index.js:13:510',
+      'file:///app/out/renderer/assets/index.js:13:902'
+    ],
+    [
+      'Windows',
+      'file:///C:/Program%20Files/OpenScience/out/renderer/assets/index.js:13:510',
+      'file:///C:/Program%20Files/OpenScience/out/renderer/assets/index.js:14:510'
+    ],
+    [
+      'async',
+      'async render (http://localhost:5173/src/page.tsx:10:5)',
+      'async render (http://localhost:5173/src/page.tsx:11:5)'
+    ]
+  ])('records distinct %s locations and suppresses a repeat', (_mode, first, second) => {
+    const report = (location: string): RendererFailureReport => {
+      const error = new TypeError('private error message')
+      error.stack = `TypeError: private error message\n    at ${location}`
+      return projectRendererFailure('window-error', error, 'workspace')
+    }
+    const error = vi.fn()
+    const reporter = createRendererFailureReporter({ log: { error, warn: vi.fn() }, now: () => 0 })
+    expect(reporter.report('renderer', report(first))).toBe('recorded')
+    expect(reporter.report('renderer', report(second))).toBe('recorded')
+    expect(reporter.report('renderer', report(first))).toBe('suppressed')
+    expect(error).toHaveBeenCalledTimes(2)
+    expect(JSON.stringify(error.mock.calls)).not.toMatch(/private|localhost|Program|page|index.js/)
   })
 })

--- a/src/main/renderer-diagnostics.test.ts
+++ b/src/main/renderer-diagnostics.test.ts
@@ -337,7 +337,9 @@ describe('renderer source-location deduplication', () => {
       'async',
       'async render (http://localhost:5173/src/page.tsx:10:5)',
       'async render (http://localhost:5173/src/page.tsx:11:5)'
-    ]
+    ],
+    ['native', 'renderStudy (native)', 'updateWorkspace (native)'],
+    ['webpack', 'webpack:///src/first.tsx:10:2', 'webpack:///src/second.tsx:10:2']
   ])('records distinct %s locations and suppresses a repeat', (_mode, first, second) => {
     const report = (location: string): RendererFailureReport => {
       const error = new TypeError('private error message')

--- a/src/renderer/src/renderer-diagnostics.test.ts
+++ b/src/renderer/src/renderer-diagnostics.test.ts
@@ -144,3 +144,34 @@ describe('projectRendererFailure', () => {
     expect(reportCount).toBe(1)
   })
 })
+
+describe('renderer fingerprint privacy and stability', () => {
+  it('ignores host, installation root, URL query and error message changes at the same location', () => {
+    const fingerprint = (url: string, message: string): string | undefined => {
+      const error = new TypeError(message)
+      error.stack = `TypeError: ${message}\n at ${url}:10:5`
+      return projectRendererFailure('window-error', error, 'workspace').fingerprint
+    }
+    expect(fingerprint('http://localhost:5173/src/page.tsx?token=private-a', 'first')).toBe(
+      fingerprint('http://localhost:3000/src/page.tsx?token=private-b', 'second')
+    )
+    expect(fingerprint('file:///Applications/One/out/renderer/assets/index.js', 'first')).toBe(
+      fingerprint('file:///C:/Users/Private/out/renderer/assets/index.js', 'second')
+    )
+  })
+
+  it('retains a bounded fallback when the stack is absent or unreadable', () => {
+    const error = new TypeError('private')
+    error.stack = undefined
+    const report = projectRendererFailure('window-error', error, 'workspace')
+    expect(report.fingerprint).toMatch(/^[a-f0-9]{8}$/)
+    Object.defineProperty(error, 'stack', {
+      get() {
+        throw new Error('unavailable')
+      }
+    })
+    expect(projectRendererFailure('window-error', error, 'workspace').fingerprint).toMatch(
+      /^[a-f0-9]{8}$/
+    )
+  })
+})

--- a/src/renderer/src/renderer-diagnostics.ts
+++ b/src/renderer/src/renderer-diagnostics.ts
@@ -32,13 +32,25 @@ const normalizedStackSignature = (value: unknown): string => {
       .split(/\r?\n/)
       .slice(1, 5)
       .map((frame) => {
-        const location = /((?:https?|file):\/\/[^\s)]+):(\d+):(\d+)\)?$/.exec(frame.trim())
-        if (!location) return 'unknown'
-        const url = new URL(location[1])
-        // App-relative resources distinguish bundled columns and development modules without
-        // carrying installation roots, host names, URL credentials, queries or error messages.
-        const resource = /\/(src\/[^?#]+|assets\/[^?#]+)$/.exec(url.pathname)?.[1]
-        return resource ? `${resource.slice(0, 512)}:${location[2]}:${location[3]}` : 'unknown'
+        const fallback = frame
+          .slice(0, 1024)
+          .replace(/[a-z][a-z0-9+.-]*:\/\/\S+/gi, '[url]')
+          .replace(/[A-Za-z]:\\[^\s)]+/g, '[path]')
+          .replace(/\/(?:[^\s/]+\/)+[^\s)]+/g, '[path]')
+          .replace(/\d+/g, '#')
+          .slice(0, 512)
+        const location = /([a-z][a-z0-9+.-]*:\/\/[^\s)]+):(\d+):(\d+)\)?$/i.exec(frame.trim())
+        if (!location) return fallback
+        try {
+          const url = new URL(location[1])
+          // App-relative resources distinguish bundled columns and development modules without
+          // carrying installation roots, host names, URL credentials, queries or error messages.
+          const resource = /\/(src\/[^?#]+|assets\/[^?#]+)$/.exec(url.pathname)?.[1]
+          return resource ? `${resource.slice(0, 512)}:${location[2]}:${location[3]}` : fallback
+        } catch {
+          // A malformed frame must not erase usable identities from the rest of the stack.
+          return fallback
+        }
       })
       .join('\n')
   } catch {

--- a/src/renderer/src/renderer-diagnostics.ts
+++ b/src/renderer/src/renderer-diagnostics.ts
@@ -28,14 +28,19 @@ const normalizedStackSignature = (value: unknown): string => {
       return errorCategoryFor(value)
     }
     return value.stack
+      .slice(0, 8192)
       .split(/\r?\n/)
       .slice(1, 5)
+      .map((frame) => {
+        const location = /((?:https?|file):\/\/[^\s)]+):(\d+):(\d+)\)?$/.exec(frame.trim())
+        if (!location) return 'unknown'
+        const url = new URL(location[1])
+        // App-relative resources distinguish bundled columns and development modules without
+        // carrying installation roots, host names, URL credentials, queries or error messages.
+        const resource = /\/(src\/[^?#]+|assets\/[^?#]+)$/.exec(url.pathname)?.[1]
+        return resource ? `${resource.slice(0, 512)}:${location[2]}:${location[3]}` : 'unknown'
+      })
       .join('\n')
-      .replace(/https?:\/\/\S+/gi, '[url]')
-      .replace(/[A-Za-z]:\\[^\s)]+/g, '[path]')
-      .replace(/\/(?:[^\s/]+\/)+[^\s)]+/g, '[path]')
-      .replace(/\d+/g, '#')
-      .slice(0, 512)
   } catch {
     return 'unknown'
   }


### PR DESCRIPTION
## Problem

A stalled disk retains an unbounded log backlog, failed appends still appear flushed, and a partial JSONL write corrupts the next record. Renderer normalization also suppresses failures at different source locations. Explicit raw agent stderr can bypass credential redaction when a field is split across chunks.

## Proposed change

- Bound pending logs to 4 MiB / 1024 records, reserving one quarter for errors. Aggregate rejected records after a successful write; preserve synchronous fatal logging.
- Return loss-aware flush results without making ordinary logging throw or extending shutdown timeouts. Loss stays sticky until logger reinitialization; this is queue drainage, not fsync.
- Repair only the active log's incomplete tail before appending. Preserve complete historical lines and rotated backups; stop if inspection or truncation fails.
- Decode stderr as a UTF-8 stream, retain the original bounded window and counters while a raw line is unfinished, and redact before logging or publishing runtime events. Omit oversized lines until a real boundary; a true stream end can finalize a bounded tail.
- Hash application-relative source locations and line/column while excluding messages, installation roots and URL queries. Keep bounded sanitized fallback identities for other stack formats, per-frame URL parse isolation, existing renderer validation and rate limits.

## Scope and non-goals

No database migration, business-state enum, UI layout/control change, telemetry service or automatic upload. The existing stderr summary now counts stream separators; the fixture reports 23 bytes including its newline instead of 22 after trimming. Existing log JSONL may gain numeric `droppedRecords` / `repairedTailBytes` summary fields. The internal flush result adds a `failed` flag and reuses existing outcome vocabulary. Approved historical handling truncates only an incomplete active-log suffix; old complete records and fingerprints are not rewritten. Raw samples may now omit an oversized line instead of emitting a potentially unsafe prefix.

## Acceptance criteria and validation

Final regression tests were run twice against unchanged baseline production code: both runs produced 20 expected failures and one passing zero-byte-write control. Restoring the repairs produced **987 passing tests across 27 files**. Independent review then identified premature EOF window emission and over-collapsed fallback frames. Three regressions failed twice on the first PR commit and pass after the corrections. The final 27-file collection, Node/Web/sandbox typechecks and lint pass after the last production logic edit.

Behavior-to-check mapping:

| Behavior | Project-owned checks | Result |
| --- | --- | --- |
| Queue byte/count bounds, error reservation, sticky loss, partial/historical writes, repair failure/retry | logger and diagnostics tests | Pass |
| Flush consumers and file-status contracts | startup, app lifecycle, logs IPC, database/Notebook logging and GeneralPanel tests | Pass |
| Distinct locations, repeat suppression, safe fields and fallbacks | main and renderer diagnostics tests | Pass |
| Split credentials at every character boundary, UTF-8, sampling windows, EOF, oversize omission | adapter and full ACP runtime tests, covering Claude Code, OpenCode, Codex Responses and Codex Bridge | Pass |
| Epoch ownership and event consumers | connection resource/close and runtime publication/snapshot tests | Pass |

Reproduce the local test set:

```sh
node node_modules/vitest/vitest.mjs run \
  src/main/logger.test.ts \
  src/main/logs-ipc.test.ts \
  src/main/index-fatal-errors.test.ts \
  src/main/renderer-diagnostics.test.ts \
  src/main/diagnostics/flush.test.ts \
  src/main/diagnostics/ipc-rejection.test.ts \
  src/main/diagnostics/operation.test.ts \
  src/main/diagnostics/privacy-canary.test.ts \
  src/main/diagnostics/startup-delay.test.ts \
  src/main/diagnostics/startup-storage-probe.test.ts \
  src/main/diagnostics/startup.test.ts \
  src/main/database/database-startup-logging.test.ts \
  src/main/database/startup-diagnostics.test.ts \
  src/main/notebook/runtime-diagnostics.test.ts \
  src/main/notebook/runtime-service-logging.integration.test.ts \
  src/main/session-persistence/projection-diagnostics.test.ts \
  src/renderer/src/renderer-diagnostics.test.ts \
  src/renderer/src/pages/settings/GeneralPanel.render.test.tsx \
  src/main/app-lifecycle.test.ts \
  src/main/index-startup-order.test.ts \
  src/main/ipc-handler-registry.test.ts \
  src/main/acp/runtime.test.ts \
  src/main/acp/agent-connection-adapter.test.ts \
  src/main/acp/connection-resource-owner.test.ts \
  src/main/acp/connection-close-workflow.test.ts \
  src/main/acp/runtime-publication-owner.test.ts \
  src/main/acp/runtime-snapshot-owner.test.ts \
  --maxWorkers=4
```

The Electron build passes. The previously failing status-bearing layout journey passed locally twice, including once after removing a temporary screenshot hook: `node node_modules/@playwright/test/cli.js test e2e/message-tool-layout-stability.spec.ts --grep "rendering with agent status$" --workers=1`. Windows CI logs proved the old expectation was 22 bytes while the actual stream correctly reports 23 including its newline; the E2E assertion is updated.

Also run `npm run typecheck` and `npm run lint`. The initial sandbox-only ACP run hit loopback `listen EPERM`; the complete affected set passed with local listening permitted.

The impact explain command falls back to full because the adapter test lacks a declared module owner. Per maintainer instruction, no full local suite was run and no impact-manifest routing was changed. Exact-head PR CI is authoritative for full and platform verification. Fault injection does not certify real disk exhaustion, OOM, native crashes or real provider execution. CodeGraph's index belongs to the main checkout; final worktree imports and consumer boundaries were checked directly.

## Review focus

Check loss accounting and queue admission, fail-closed tail repair, and stderr EOF/session attribution. Confirm that existing process subscriptions, rate limits and ordinary logging contracts remain intact. The initial independent review findings were reproduced and corrected with regression tests. Re-review and required CI for the final head remain pending.
