### PR TITLE
fix(composer): open pasted file references before session creation

### DIFF
--- a/e2e/browser/fixture/message-clipboard.tsx
+++ b/e2e/browser/fixture/message-clipboard.tsx
@@ -22,12 +22,68 @@ import {
   type ComposerDraft
 } from '@/pages/workspace/workspace-composer-upload-controller'
 import { useSettingsStore } from '@/stores/settings-store'
+import { PreviewFileSurface } from '@/pages/workspace/PreviewFileSurface'
+import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
+import { useNavigationStore } from '@/stores/navigation-store'
+import { createManagedPreviewTestTransport } from '@/pages/workspace/previews/managed-preview-test-support'
 import type { ChatMessage } from '@/stores/session-store'
 import type { Annotation } from '../../../src/shared/annotations'
 import type { SessionPdfContextSource } from '../../../src/shared/session-persistence'
 
 initI18n('en')
 useSettingsStore.setState({ skillsLoaded: true })
+useNavigationStore.setState({
+  activeProjectId: new URLSearchParams(location.search).get('project') ?? 'project'
+})
+const transport = createManagedPreviewTestTransport({
+  read: async () => {
+    if (new URLSearchParams(location.search).has('unavailable')) throw new Error('File unavailable')
+    const content = 'gene,log2FoldChange,pValue\nTP53,2.4,0.001\nBRCA1,-1.8,0.008\nEGFR,1.5,0.02'
+    return { content, encoding: 'utf8', size: content.length, truncated: false }
+  }
+})
+const browserFetch = window.fetch.bind(window)
+window.fetch = (input, init) =>
+  String(input).startsWith('open-science-preview:')
+    ? transport.fetch(input, init)
+    : browserFetch(input, init)
+Object.defineProperty(window, 'api', {
+  value: {
+    previewResources: { acquire: transport.acquire, release: transport.release },
+    managedFileVersions: {
+      inspect: async () => ({
+        ok: true,
+        value: {
+          source: 'upload',
+          projectId: 'project',
+          fileId: 'csv-file',
+          sessionId: 'source',
+          displayName: 'volcano-plot.csv',
+          headVersionId: 'csv-version',
+          selectedVersionId: 'csv-version',
+          versions: [
+            {
+              id: 'csv-version',
+              source: 'upload',
+              fileId: 'csv-file',
+              versionNumber: 1,
+              displayName: 'volcano-plot.csv',
+              originKind: 'user_upload',
+              basedOnVersionId: null,
+              contentType: 'text/csv',
+              sizeBytes: 80,
+              checksum: 'fixture',
+              createdAt: '2026-09-09T00:00:00.000Z'
+            }
+          ],
+          canEdit: false,
+          canDiff: false
+        }
+      })
+    },
+    projectFiles: { resolveFile: async () => null }
+  }
+})
 const noop = (): void => undefined
 // Only external effects are stubbed. Copy, paste, rendering and draft undo are production code.
 const unavailable = async (): Promise<never> => {
@@ -49,7 +105,7 @@ const parts: NonNullable<ChatMessage['parts']> = [
     versionId: 'csv-version',
     source: 'upload',
     name: 'volcano-plot.csv',
-    path: 'uploads/plot.csv',
+    path: 'upload-version:project/source/csv-version',
     mimeType: 'text/csv'
   },
   { type: 'text', text: ' ' },
@@ -60,7 +116,7 @@ const parts: NonNullable<ChatMessage['parts']> = [
     versionId: 'xlsx-version',
     source: 'upload',
     name: 'volcano-plot-differential-analysis.xlsx',
-    path: 'uploads/analysis.xlsx'
+    path: 'upload-version:project/source/xlsx-version'
   },
   { type: 'text', text: '\nCreate a volcano plot in R' }
 ]
@@ -84,6 +140,9 @@ const initialDraft: ComposerDraft = {
 
 export function ClipboardFixture(): React.JSX.Element {
   const [doc, setDoc] = useState(emptyDoc)
+  const preview = usePreviewWorkbenchStore((state) =>
+    state.items.find((item) => item.id === state.activeItemId)
+  )
   const [caretRequest, setCaretRequest] = useState<{
     key: number
     position: ComposerCaretPosition
@@ -152,12 +211,30 @@ export function ClipboardFixture(): React.JSX.Element {
             onUndo={controller.actions.undo}
             onRedo={controller.actions.redo}
             caretRequest={caretRequest}
-            mentionPreviewContext={{
-              projectId: new URLSearchParams(location.search).get('project') ?? 'project',
-              sessionId: 'target'
-            }}
+            mentionPreviewContext={
+              new URLSearchParams(location.search).has('new')
+                ? undefined
+                : {
+                    projectId: new URLSearchParams(location.search).get('project') ?? 'project',
+                    sessionId: 'target'
+                  }
+            }
           />
         </section>
+        {preview?.type === 'file' && (
+          <section
+            className="h-96 overflow-hidden rounded-xl border border-border"
+            data-testid="preview"
+          >
+            <PreviewFileSurface
+              item={preview}
+              onClose={() => usePreviewWorkbenchStore.getState().removeItem(preview.id)}
+            />
+          </section>
+        )}
+        <output hidden data-testid="preview-item">
+          {JSON.stringify(preview)}
+        </output>
         <output hidden data-testid="draft">
           {JSON.stringify(doc)}
         </output>

--- a/e2e/browser/message-clipboard.spec.ts
+++ b/e2e/browser/message-clipboard.spec.ts
@@ -1,5 +1,32 @@
 import { expect, test } from '@playwright/test'
 
+for (const unavailable of [false, true]) {
+  test(`opens pasted references before a Session exists (${unavailable ? 'unavailable' : 'readable'})`, async ({
+    page,
+    context
+  }, testInfo) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+    await page.goto(`/message-clipboard.html?new${unavailable ? '&unavailable' : ''}`)
+    await page.getByRole('button', { name: 'Copy message', exact: true }).click()
+    await expect(page.getByRole('button', { name: 'Copied', exact: true })).toBeVisible()
+    const editor = page.getByRole('textbox', { name: 'Ask anything' })
+    await editor.click()
+    await editor.press('ControlOrMeta+V')
+    await expect(editor.locator('[data-mention-type="artifact"]')).toHaveCount(2)
+    await editor.locator('[data-mention-type="artifact"]').first().click()
+    await expect(page.getByTestId('preview')).toBeVisible()
+    await expect(page.getByTestId('preview-item')).toContainText('"managedFileId":"csv-file"')
+    if (unavailable)
+      await expect(
+        page
+          .getByTestId('preview-file-content-surface')
+          .getByRole('button', { name: 'Retry', exact: true })
+      ).toBeVisible()
+    else await expect(page.getByTestId('preview')).toContainText('TP53')
+    await page.screenshot({ path: testInfo.outputPath('pasted-file-preview.png'), fullPage: true })
+  })
+}
+
 // The operating-system clipboard is shared across browser contexts.
 test.describe.configure({ mode: 'serial' })
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.actions.test.tsx
@@ -81,6 +81,9 @@ const renderItem = async (
       messageId: string,
       target: EditAnnotationTarget | undefined
     ) => void
+    onPreviewMentionArtifact?: React.ComponentProps<
+      typeof WorkspaceMessageItem
+    >['onPreviewMentionArtifact']
     canBranchInNewSession?: boolean
     onBranchInNewSession?: (messageId: string) => void
     subsequentTurns?: number
@@ -103,7 +106,7 @@ const renderItem = async (
         onPreviewArtifact={noop}
         onPreviewUploadAttachment={noop}
         onOpenSkillMention={noop}
-        onPreviewMentionArtifact={noop}
+        onPreviewMentionArtifact={options.onPreviewMentionArtifact ?? noop}
         canEditMessage={options.canEditMessage ?? false}
         showUserActions={options.showUserActions}
         onSendEditedMessage={options.onSendEditedMessage}
@@ -1077,6 +1080,27 @@ describe('WorkspaceMessageItem user message actions', () => {
     expect(editor?.textContent).toBe('Run /forecast now')
     // The structured skill segment comes back as a chip, not flattened text.
     expect(editor?.querySelector('[data-mention-type="skill"]')).not.toBeNull()
+  })
+
+  it('uses the message owner preview action for a file chip in the inline editor', async () => {
+    const part = {
+      type: 'artifact' as const,
+      source: 'upload' as const,
+      id: 'mention-1',
+      sourceFileId: 'file-1',
+      versionId: 'version-1',
+      name: 'volcano.csv',
+      path: 'uploads/volcano.csv'
+    }
+    const preview = vi.fn()
+    await renderItem(createMessage({ content: '@volcano.csv', parts: [part] }), {
+      canEditMessage: true,
+      onPreviewMentionArtifact: preview
+    })
+    await click(getButton('Edit message'))
+    const chip = getEditor()!.querySelector<HTMLElement>('[data-mention-type="artifact"]')!
+    await click(chip)
+    expect(preview).toHaveBeenCalledWith(expect.objectContaining(part))
   })
 
   it('separates read-only uploaded files from the message editor', async () => {

--- a/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageItem.tsx
@@ -1716,6 +1716,7 @@ const WorkspaceMessageItemImpl = ({
                     }}
                     onSubmit={handleConfirmEdit}
                     onPaste={ignoreEditPaste}
+                    onPreviewMentionArtifact={onPreviewMentionArtifact}
                     placeholder={t('Edit your message')}
                     ariaLabel={t('Edit message')}
                     focusRequest={editFocusRequest}

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.interaction.test.tsx
@@ -254,6 +254,7 @@ type Overrides = Partial<{
   historyStatus: string
   onNavigateHistory: (direction: 'previous' | 'next') => boolean
   mentionPreviewContext: { sessionId: string; projectId?: string }
+  onPreviewMentionArtifact: React.ComponentProps<typeof ComposerEditor>['onPreviewMentionArtifact']
   focusRequest: string | number
   restoreFocusRequest: number
   caretRequest: { key: number; position: { nodeIndex: number; offset: number } }
@@ -278,6 +279,7 @@ const renderEditor = (overrides: Overrides = {}): void => {
         historyStatus={overrides.historyStatus}
         onNavigateHistory={overrides.onNavigateHistory}
         mentionPreviewContext={overrides.mentionPreviewContext}
+        onPreviewMentionArtifact={overrides.onPreviewMentionArtifact}
         focusRequest={overrides.focusRequest}
         restoreFocusRequest={overrides.restoreFocusRequest}
         caretRequest={overrides.caretRequest}
@@ -1508,7 +1510,54 @@ describe('ComposerEditor', () => {
     expect(usePreviewWorkbenchStore.getState().items).toEqual([])
   })
 
-  it('opens an upload mention chip in the preview workbench on click after a successful probe', async () => {
+  it.each(pickerProjectFiles)(
+    'opens a pasted $source reference before a target Session exists',
+    async (file) => {
+      renderEditor()
+      editor().focus()
+      setCaret(editor(), 0)
+      const part = {
+        type: 'artifact',
+        id: file.id,
+        sourceFileId: file.sourceFileId,
+        versionId: file.sourceVersionId,
+        source: file.source,
+        name: file.name,
+        path: file.path,
+        mimeType: file.mimeType
+      }
+      const carrier = document.createElement('span')
+      carrier.setAttribute(
+        'data-open-science-message',
+        JSON.stringify({
+          version: 1,
+          origin: location.origin,
+          projectId: 'default',
+          parts: [part]
+        })
+      )
+      const paste = new Event('paste', { bubbles: true, cancelable: true })
+      Object.defineProperty(paste, 'clipboardData', {
+        value: {
+          getData: (type: string) => (type === 'text/html' ? carrier.outerHTML : `@${file.name}`)
+        }
+      })
+      act(() => editor().dispatchEvent(paste))
+      const chip = editor().querySelector<HTMLElement>('[data-mention-type="artifact"]')
+      expect(chip).not.toBeNull()
+      await act(async () => chip!.click())
+      expect(usePreviewWorkbenchStore.getState().panelState).toBe('open')
+      expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
+        projectId: 'default',
+        sessionId: 'session-1',
+        managedFileId: file.sourceFileId,
+        path: file.path,
+        name: file.name
+      })
+    }
+  )
+
+  it('opens an upload mention chip in the preview workbench on click through the shared preview surface', async () => {
     renderEditor({
       mentionPreviewContext: { sessionId: 'session-1', projectId: 'default' },
       doc: {
@@ -1534,7 +1583,7 @@ describe('ComposerEditor', () => {
     expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('up-1')
   })
 
-  it('keeps an upload mention chip inert when the probe fails', async () => {
+  it('opens the preview surface to handle unreadable files without a silent probe', async () => {
     ;(
       window as unknown as { api: { uploads: { readPreview: ReturnType<typeof vi.fn> } } }
     ).api.uploads.readPreview.mockRejectedValueOnce(new Error('gone'))
@@ -1560,11 +1609,14 @@ describe('ComposerEditor', () => {
       await Promise.resolve()
     })
 
-    expect(usePreviewWorkbenchStore.getState().items).toEqual([])
+    expect(window.api.uploads.readPreview).not.toHaveBeenCalled()
+    expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('up-1')
   })
 
   it('opens a Literature PDF mention without probing Upload or Artifact storage', () => {
+    const ownerPreview = vi.fn()
     renderEditor({
+      onPreviewMentionArtifact: ownerPreview,
       mentionPreviewContext: { sessionId: 'session-1', projectId: 'default' },
       doc: {
         nodes: [
@@ -1586,6 +1638,7 @@ describe('ComposerEditor', () => {
 
     expect(window.api.uploads.readPreview).not.toHaveBeenCalled()
     expect(window.api.artifacts.readPreview).not.toHaveBeenCalled()
+    expect(ownerPreview).not.toHaveBeenCalled()
     expect(usePreviewWorkbenchStore.getState().activeItemId).toBe('literature-item-1')
     expect(usePreviewWorkbenchStore.getState().items[0]).toMatchObject({
       sessionId: '__literature__',

--- a/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
+++ b/src/renderer/src/pages/workspace/composer/ComposerEditor.tsx
@@ -12,7 +12,6 @@ import { usePreviewWorkbenchStore } from '@/stores/preview-workbench-store'
 
 import { createPreviewFileItemFromLocal, LOCAL_PREVIEW_SESSION_ID } from '../preview-file-item'
 import { createPreviewFileItemFromMention } from '../preview-file-item'
-import { createPreviewRequestScope } from '../previews/preview-file-reader'
 
 import {
   ArtifactMentionPopup,
@@ -74,9 +73,9 @@ type ComposerEditorProps = {
   isHistoryBrowsing?: boolean
   historyStatus?: string
   onNavigateHistory?: (direction: 'previous' | 'next') => boolean
-  // Scope for previewing clicked `@` mention chips (uploads/artifacts); without it those chips
-  // stay inert on click (linked-folder chips resolve through the granted-roots store instead).
+  // Legacy paths need their owner context; version locators already carry their source Session.
   mentionPreviewContext?: { sessionId: string; projectId?: string }
+  onPreviewMentionArtifact?: (part: Parameters<typeof createPreviewFileItemFromMention>[0]) => void
   focusRequest?: string | number
   restoreFocusRequest?: number
   caretRequest?: { key: number; position: ComposerCaretPosition }
@@ -452,6 +451,7 @@ export const ComposerEditor = ({
   historyStatus = '',
   onNavigateHistory,
   mentionPreviewContext,
+  onPreviewMentionArtifact,
   focusRequest,
   restoreFocusRequest,
   caretRequest
@@ -567,9 +567,8 @@ export const ComposerEditor = ({
   }, [emitDocFromDom])
 
   // Clicking an `@` mention chip opens the file in the preview workbench, like the sent-message
-  // pills do. Linked-folder chips resolve rootId + relativePath through the granted-roots store
-  // (inert once the root is revoked); upload/artifact chips probe first so a stale chip stays
-  // inert, then open through the mention preview item.
+  // pills do. The preview surface owns loading, errors and retry; do not gate it on a separate
+  // read probe. Linked-folder chips still require a currently granted root.
   const handleClick = (event: React.MouseEvent<HTMLDivElement>): void => {
     const root = editorRef.current
     const pastedTextMarker = (event.target as HTMLElement).closest?.(
@@ -627,10 +626,7 @@ export const ComposerEditor = ({
       return
     }
 
-    if (
-      (source !== 'upload' && source !== 'artifact' && source !== 'literature') ||
-      !mentionPreviewContext
-    ) {
+    if (source !== 'upload' && source !== 'artifact' && source !== 'literature') {
       return
     }
     const path = chip.getAttribute('data-mention-path')
@@ -639,36 +635,25 @@ export const ComposerEditor = ({
     const part: Parameters<typeof createPreviewFileItemFromMention>[0] = {
       type: 'artifact',
       id: chip.getAttribute('data-mention-id') ?? path,
+      sourceFileId: chip.getAttribute('data-mention-source-file-id') ?? undefined,
       name: chip.getAttribute('data-mention-filename') ?? path,
       path,
       source,
       mimeType: chip.getAttribute('data-mention-mime-type') ?? undefined,
       versionId: chip.getAttribute('data-mention-version-id') ?? undefined
     }
-    const { sessionId, projectId } = mentionPreviewContext
-    if (source === 'literature') {
-      usePreviewWorkbenchStore
-        .getState()
-        .upsertAndActivateItem(createPreviewFileItemFromMention(part, '__literature__', projectId))
+    if (onPreviewMentionArtifact && source !== 'literature') {
+      onPreviewMentionArtifact(part)
       return
     }
-    void (async () => {
-      const read =
-        source === 'upload' ? window.api.uploads.readPreview : window.api.artifacts.readPreview
-      try {
-        await read({
-          ...createPreviewRequestScope({ projectId, sessionId, source, path }),
-          path,
-          maxBytes: 1,
-          encoding: 'utf8'
-        })
-      } catch {
-        return
-      }
-      usePreviewWorkbenchStore
-        .getState()
-        .upsertAndActivateItem(createPreviewFileItemFromMention(part, sessionId, projectId))
-    })()
+    const item = createPreviewFileItemFromMention(
+      part,
+      source === 'literature' ? '__literature__' : (mentionPreviewContext?.sessionId ?? ''),
+      mentionPreviewContext?.projectId ?? activeProjectId
+    )
+    // An unscoped legacy path cannot identify its source Session. Do not guess from the filename.
+    if (!item.sessionId) return
+    usePreviewWorkbenchStore.getState().upsertAndActivateItem(item)
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {


### PR DESCRIPTION
## Problem

Pasting a copied message into a new conversation restores green file-reference chips, but clicking them does nothing because the editor requires a target Session that does not exist yet. The click handler also drops the existing `sourceFileId`, and a failed preliminary file read silently prevents the preview from opening. Inline message editing does not connect its file chips to the message owner's preview action.

## Proposed change

- Resolve versioned references through the existing preview-item constructor, using the source Project/Session encoded in the reference before a target Session exists.
- Preserve `sourceFileId` when opening the preview. Let the existing preview surface own content loading, failure and retry instead of gating it on a separate read probe.
- Connect inline editing to the message owner's preview action. Keep Literature attachments on their existing dedicated preview path.

## Scope and non-goals

Renderer-only fix; no new dependencies, persisted fields, state enums, database migrations, clipboard formats, or architectural changes. Preview tabs retain the existing persistence mechanism. Plain-text draft-to-draft clipboard expansion is excluded.

Historical compatibility is deliberately unchanged: an old physical path without source Session context cannot be resolved in a new conversation and is not guessed from its filename. Existing owner-context paths remain supported; no historical data is rewritten.

## Acceptance criteria and validation

All checks below ran after the last material edit. Independent standards and spec reviews completed with no remaining findings.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Pasted Upload/Artifact references before Session creation, logical identity, Literature routing | `ComposerEditor.interaction.test.tsx` | Passed |
| Clipboard validation and inline-edit consumer | `message-clipboard.test.ts`, `WorkspaceMessageItem.actions.test.tsx`, `WorkspaceMessageItem.mentions.test.tsx` | Passed |
| Preview identity, surface loading/error behavior and fallbacks | `preview-file-item.test.ts`, `PreviewFileSurface.test.tsx`, `previews/PreviewFileContent.test.tsx`, `previews/PreviewFallback.test.tsx` | Passed |
| Workspace draft preservation | `WorkspacePage.draft-preservation.test.tsx` | Passed |
| Real system clipboard: open readable/unavailable preview before Session creation, undo/redo, cross-Project plain-text fallback | `e2e/browser/message-clipboard.spec.ts` | 4 passed using installed Chrome |
| Renderer types and lint | `npm run typecheck:web`, `npm run lint`, `git diff --check` | Passed |

The nine targeted Vitest files contain 417 tests. The combined run passed 416 and timed out one existing large-source preview test at 15 seconds; rerunning the complete `PreviewFileContent.test.tsx` file with `--maxWorkers=1` passed all 45 tests in 3.48 seconds. No test timeout or product behavior was weakened.

Portable browser command: `npm run test:e2e:browser -- e2e/browser/message-clipboard.spec.ts`. Locally the pinned Playwright Chromium was unavailable, so a temporary, uncommitted config selected the already-installed Chrome and reused the fixture server. Both successful preview and unavailable/retry screenshots were captured and visually checked. The fixture uses production rendering/copy/paste code with mocked file transport; it does not certify backend permissions or real storage reads.

Consumers were included because the editor gains an optional owner callback and changes preview activation. Node/ACP/provider, database, and native platform lanes were excluded locally because no runtime protocol, persistence, or OS-path implementation changes. Full portable and platform CI remain authoritative; no local full `npm test` run was performed, as requested.

## Review focus

Source identity survives copy/paste and click; new conversations do not create a Session merely to preview a file; unavailable content reaches the existing error/retry surface; inline-edit Literature references avoid the Upload/Artifact probe.
