### PR TITLE
fix(csv-preview): keep sticky row numbers opaque while scrolling

### DIFF
--- a/e2e/browser/csv-preview.spec.ts
+++ b/e2e/browser/csv-preview.spec.ts
@@ -1,0 +1,36 @@
+import { expect, test } from '@playwright/test'
+
+for (const theme of ['light', 'dark']) {
+  test(`CSV row numbers cover scrolled data in ${theme} mode`, async ({ page }, testInfo) => {
+    await page.goto('/csv-preview.html')
+    await page.evaluate(
+      (theme) => document.documentElement.classList.toggle('dark', theme === 'dark'),
+      theme
+    )
+    const table = page.getByRole('table')
+    await expect(table).toBeVisible()
+    await table.evaluate((table) => {
+      const scroller = table.parentElement!
+      scroller.scrollLeft = 200
+      scroller.scrollTop = scroller.scrollHeight
+    })
+    const rows = table.locator('tbody tr')
+    for (const index of [98, 99]) {
+      const cell = rows.nth(index).locator('td').first()
+      const geometry = await cell.evaluate((cell) => {
+        const style = getComputedStyle(cell)
+        const rowStyle = getComputedStyle(cell.parentElement!)
+        return {
+          background: style.backgroundColor,
+          rowBackground: rowStyle.backgroundColor,
+          left: cell.getBoundingClientRect().left,
+          scrollLeft: cell.closest('table')!.parentElement!.getBoundingClientRect().left
+        }
+      })
+      expect(geometry.background).not.toBe('rgba(0, 0, 0, 0)')
+      expect(geometry.background).toBe(geometry.rowBackground)
+      expect(geometry.left).toBeCloseTo(geometry.scrollLeft, 0)
+    }
+    await page.screenshot({ path: testInfo.outputPath(`csv-${theme}.png`) })
+  })
+}

--- a/e2e/browser/fixture/csv-preview.html
+++ b/e2e/browser/fixture/csv-preview.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>CSV preview scroll test</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/csv-preview.tsx"></script>
+  </body>
+</html>

--- a/e2e/browser/fixture/csv-preview.tsx
+++ b/e2e/browser/fixture/csv-preview.tsx
@@ -1,0 +1,37 @@
+import '@/assets/main.css'
+import { createRoot } from 'react-dom/client'
+import { initI18n } from '@/i18n'
+import { CsvPreviewRenderer } from '@/pages/workspace/previews/renderers/CsvPreview'
+import { createManagedPreviewTestTransport } from '@/pages/workspace/previews/managed-preview-test-support'
+
+const content = [
+  Array.from({ length: 13 }, (_, i) => `group${i + 1}`).join(','),
+  ...Array.from({ length: 100 }, (_, row) =>
+    Array.from({ length: 13 }, (_, col) => `${row + col}.123456789`).join(',')
+  )
+].join('\n')
+const transport = createManagedPreviewTestTransport({
+  read: async () => ({ content, encoding: 'utf8', size: content.length, truncated: false })
+})
+window.api = { previewResources: transport } as unknown as typeof window.api
+window.fetch = transport.fetch
+initI18n('en')
+createRoot(document.getElementById('root')!).render(
+  <div style={{ width: 640, height: 540, margin: 24 }}>
+    <CsvPreviewRenderer
+      item={{
+        id: 'csv-scroll',
+        type: 'file',
+        title: 'data.csv',
+        name: 'data.csv',
+        path: 'artifact://data.csv',
+        format: 'csv',
+        source: 'artifact',
+        projectId: 'project-1',
+        sessionId: 'session-1',
+        managedFileId: 'csv-scroll',
+        selectedVersionId: 'version-1'
+      }}
+    />
+  </div>
+)

--- a/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
+++ b/src/renderer/src/pages/workspace/previews/renderers/CsvPreview.tsx
@@ -175,7 +175,7 @@ export const CsvPreviewRenderer = ({ item }: PreviewFileRendererProps): React.JS
           </thead>
           <tbody className="bg-bg-000 text-text-100">
             {dataRows.map((row, rowIndex) => (
-              <tr key={rowIndex} className="odd:bg-bg-10">
+              <tr key={rowIndex} className="bg-bg-000 odd:bg-bg-10">
                 <td className="sticky left-0 z-[1] w-12 border-b border-r border-border-300 bg-inherit px-3 py-1.5 text-right font-mono text-text-300">
                   {rowIndex + 1}
                 </td>


### PR DESCRIPTION
## Problem

Horizontal scrolling lets data show through the sticky CSV row numbers on even rows. Those cells inherit their row's transparent background; the opaque background on `tbody` cannot cover the scrolled cells.

## Proposed change

Give every data row the existing opaque base surface while retaining the odd-row stripe. Add a real-browser regression fixture and assertions for odd/even row opacity and sticky positioning after horizontal and vertical scrolling in light and dark themes.

## Scope and non-goals

CSV/TSV renderer presentation only. No parsing, API, state/enum, persistence, historical-data compatibility, or translation changes. This fixes data showing beneath row numbers; it does not redesign native scrollbars.

## Acceptance criteria and validation

All local checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| CSV parsing/counts and preview consumer boundaries | `npx vitest run src/renderer/src/pages/workspace/previews/renderers/CsvPreview.test.tsx src/renderer/src/pages/workspace/previews/PreviewToolContent.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx` | 190 passed |
| Sticky row opacity, stripe consistency and positioning after two-axis scrolling | `npx playwright test --config playwright.csv-local.config.ts e2e/browser/csv-preview.spec.ts` | 2 passed; both failed on transparent even-row backgrounds before the fix |
| Renderer types | `npm run typecheck:web` | Passed |
| Source style | `npm run lint` | Passed |

The browser run used an uncommitted equivalent of `playwright.browser.config.ts` on port 4187 with installed Chrome because port 4178 was occupied and the bundled Playwright browser was unavailable. The checked-in test can run with `npx playwright test --config playwright.browser.config.ts e2e/browser/csv-preview.spec.ts` in the standard environment. Screenshots were captured and shown in the task.

The renderer owns this CSS change; representative preview consumers were checked, and no interface changed. Main/preload, ACP, filesystem and migration lanes were excluded locally because those behaviors are unchanged. Full local tests were omitted as requested; PR CI is authoritative. Native Electron/OS scrollbar rendering was not separately tested. Independent review should confirm this evidence covers the final diff.

## Review focus

Confirm that inherited backgrounds are opaque for both stripe parities and continue to match the theme; keep the change limited to row presentation.
