### PR TITLE
fix(release): preserve publication integrity and update lifecycle

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -480,6 +480,21 @@ jobs:
             npx electron-builder ${{ matrix.eb_args }} "${eb_ver[@]}" "${unsigned_args[@]}" --publish never
           fi
 
+      # Keep each native feed unique even when notarization is skipped. The installed app still
+      # polls latest-mac.yml; only the publication job combines the two architecture artifacts.
+      - name: Preserve architecture-specific mac update feed
+        if: ${{ matrix.platform == 'mac' }}
+        shell: bash
+        env:
+          ARCH: ${{ matrix.bin_arch }}
+        run: |
+          if [ -f dist/latest-mac.yml ]; then
+            mv dist/latest-mac.yml "dist/$ARCH-mac.yml"
+          elif [ "${{ inputs.nightly }}" != "true" ]; then
+            echo "Missing macOS update feed" >&2
+            exit 1
+          fi
+
       - name: Clean up macOS signing keychain
         if: ${{ always() && steps.mac_signing.outputs.keychain != '' }}
         shell: bash

--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -136,6 +136,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.ref.outputs.tag }}
           METADATA_ONLY: ${{ inputs.dry_run }}
+          MODE: ${{ inputs.mode }}
         run: |
           if [ ! -d "$NOTES_DIR" ]; then
             NOTES="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body)"
@@ -144,7 +145,11 @@ jobs:
           fi
           RELEASE_DATE="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json publishedAt --jq .publishedAt)"
           export RELEASE_DATE
-          validation_args=(--require-complete)
+          case "$MODE" in
+            promote) validation_args=(--require-complete) ;;
+            backfill) validation_args=(--backfill) ;;
+            *) echo "Invalid mirror mode" >&2; exit 1 ;;
+          esac
           if [ "$METADATA_ONLY" = "true" ]; then validation_args+=(--metadata-only); fi
           node scripts/generate-version-manifest.mjs dist-assets version.json "${validation_args[@]}"
 

--- a/.github/workflows/mirror-to-website.yml
+++ b/.github/workflows/mirror-to-website.yml
@@ -1,8 +1,7 @@
 # Manually mirror a published GitHub Release to the website's S3-compatible storage + CDN after its
 # repository-owned in-app release notes are ready. This workflow sends
 # installers to a fast, in-country endpoint and writes version.json (website + in-app update prompt).
-# Cache correctness is handled purely via Cache-Control headers at upload time (immutable installers,
-# no-cache manifest) — no CDN purge API is needed.
+# Versioned objects never change bytes. Channel metadata advances under a shared publisher lock.
 name: Mirror to website
 
 on:
@@ -60,7 +59,7 @@ jobs:
 
       # A dry-run exercises the real manifest/feed transforms without downloading every installer.
       # SHA256SUMS and updater feeds are small; sparse files reproduce each installer's published name
-      # and size from GitHub's read-only asset metadata, which is all the manifest generator consumes.
+      # and size from GitHub's read-only asset metadata. This explicitly skips byte verification.
       - name: Stage release metadata for dry run
         if: ${{ inputs.dry_run }}
         env:
@@ -75,7 +74,7 @@ jobs:
             --jq '.assets[] | [.name, (.size | tostring)] | @tsv' |
           while IFS=$'\t' read -r name size; do
             case "$name" in
-              *-mac-arm64.dmg|*-mac-x64.dmg|*-win-x64-setup.exe|*-linux-x64.AppImage|*_amd64.deb)
+              *-mac-arm64.dmg|*-mac-x64.dmg|*-win-x64-setup.exe|*-linux-x64.AppImage|*-linux-x86_64.AppImage|*_amd64.deb|*-mac-arm64.zip|*-mac-x64.zip)
                 [ "$name" = "$(basename "$name")" ] || { echo "Unsafe asset name: $name" >&2; exit 1; }
                 truncate -s "$size" "dist-assets/$name"
                 ;;
@@ -123,8 +122,7 @@ jobs:
       - name: Install manifest dependencies
         run: npm ci --ignore-scripts --omit=dev --omit=optional --no-audit --no-fund
 
-      # Build version.json from the downloaded files. Missing platforms warn (not fail) inside the
-      # script, so a partial release still yields a usable manifest. In-app notes come from the
+      # Validate a complete stable release before any upload. In-app notes come from the
       # checked-out repository revision; the publication date still comes from the Release so a
       # manual workflow_dispatch backfill gets the authoritative timestamp.
       - name: Generate version.json
@@ -137,6 +135,7 @@ jobs:
           NOTES_DIR: release-notes/${{ steps.ref.outputs.version }}
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.ref.outputs.tag }}
+          METADATA_ONLY: ${{ inputs.dry_run }}
         run: |
           if [ ! -d "$NOTES_DIR" ]; then
             NOTES="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json body --jq .body)"
@@ -145,13 +144,15 @@ jobs:
           fi
           RELEASE_DATE="$(gh release view "$TAG" --repo "$GITHUB_REPOSITORY" --json publishedAt --jq .publishedAt)"
           export RELEASE_DATE
-          node scripts/generate-version-manifest.mjs
+          validation_args=(--require-complete)
+          if [ "$METADATA_ONLY" = "true" ]; then validation_args+=(--metadata-only); fi
+          node scripts/generate-version-manifest.mjs dist-assets version.json "${validation_args[@]}"
 
       # electron-updater feed files (win latest.yml, linux latest-linux.yml, and the per-arch mac
       # feeds arm64-mac.yml / x64-mac.yml) must live at the channel root (a stable url the updater
       # always polls), but the installers + blockmaps they reference live under releases/<version>/.
       # Rewrite each feed's bare `path:`/`url:` filenames to that versioned subpath so the updater
-      # resolves them against the channel root. Missing feeds (e.g. a mac-only backfill) are skipped.
+      # resolves them against the channel root. The complete feed set was validated above.
       - name: Rewrite update feed paths
         env:
           VERSION: ${{ steps.ref.outputs.version }}
@@ -223,12 +224,7 @@ jobs:
           S3_PREFIX: ${{ vars.S3_PREFIX }}
         run: |
           [ -d historical-blockmaps ] || exit 0
-          while IFS= read -r -d '' blockmap; do
-            version="$(basename "$(dirname "$blockmap")")"
-            aws s3 cp "$blockmap" \
-              "s3://$S3_BUCKET/$S3_PREFIX/releases/$version/$(basename "$blockmap")" \
-              --cache-control "public, max-age=31536000, immutable" --only-show-errors
-          done < <(find historical-blockmaps -type f -name '*-win-x64-setup.exe.blockmap' -print0)
+          node scripts/publish-release-assets.mjs blockmaps historical-blockmaps
 
       # This command owns versioned uploads and optional monotonic channel promotion together.
       # Its preflight runs before any mutable channel writes; rerun the same version to recover a

--- a/.github/workflows/notarize-mac.yml
+++ b/.github/workflows/notarize-mac.yml
@@ -7,17 +7,10 @@ name: Notarize macOS
 # stapled artifacts. Splitting it out of the build means a slow notarization never ties up the build
 # matrix, and it can be re-run on its own without a rebuild.
 #
-# Two entry points, selected by the `from_run` input (NOT github.event_name — see below):
-#   - workflow_call (from_run: true) — used by release.yml and notarize-dryrun.yml right after build.
-#     Operates on the run's signed mac artifacts and re-uploads the stapled versions (overwrite) so a
-#     downstream job attaches them.
-#   - workflow_dispatch{ tag } (from_run unset -> false) — standalone repair/backfill. Notarizes +
-#     staples the mac assets already attached to an existing Release, clobbers them back, and
-#     refreshes SHA256SUMS.txt.
-#
-# The mode MUST key off `from_run`, not github.event_name: a workflow_call triggered by a
-# workflow_dispatch run (the notarization dry-run) still reports event_name == 'workflow_dispatch',
-# which would wrongly select the Release path and submit an unrelated published build.
+# Only unpublished run artifacts may change bytes. Re-run the normal release pipeline under a new
+# version to replace an already published installer; its certification and CDN URL are immutable.
+# workflow_dispatch remains as a clear failure for operators using the former backfill entry point.
+# from_run distinguishes reusable calls from dispatch, including the manual notarization dry run.
 #
 # Time cap is enforced two ways: each dmg is submitted, then waited on for at most 15m
 # (`notarytool wait --timeout 15m`), and the job as a whole is bounded by `timeout-minutes: 30`.
@@ -50,12 +43,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: 'Existing release tag whose mac assets to notarize + staple (e.g. v0.1.0)'
+        description: 'Retired backfill entry point; publish a new version through the release workflow'
         required: true
 
-# gh release upload/download in the dispatch path needs write access to release assets.
+# Notarization updates run artifacts, never published GitHub Release assets.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   notarize:
@@ -75,6 +68,15 @@ jobs:
           - arch: x64
             os: macos-15-intel
     steps:
+      - name: Require unpublished build artifacts
+        env:
+          FROM_RUN: ${{ inputs.from_run }}
+        run: |
+          if [ "$FROM_RUN" != "true" ]; then
+            echo "Published installers are immutable. Publish a new version through the release workflow." >&2
+            exit 1
+          fi
+
       # Notarization is optional: if the API key secret isn't configured, no-op so a tagged release
       # still succeeds with the ad-hoc mac build (today's behavior) instead of failing here. Every
       # real step below is gated on this.
@@ -123,18 +125,6 @@ jobs:
         with:
           name: certification-macos-${{ matrix.arch }}
           path: mac
-
-      # Standalone path: pull the arch's signed assets straight off the existing Release.
-      - name: Download signed mac assets (from the release)
-        if: steps.gate.outputs.enabled == 'true' && !inputs.from_run
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          mkdir -p mac
-          gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" \
-            --pattern "*-mac-${{ matrix.arch }}.dmg" \
-            --pattern "*-mac-${{ matrix.arch }}.zip" \
-            --dir mac
 
       # App Store Connect API key (.p8), stored base64-encoded so it survives as a single secret.
       - name: Write App Store Connect API key
@@ -228,7 +218,7 @@ jobs:
       # and regenerate a per-arch intermediate `${arch}-mac.yml` from the stapled zip (recompute sha512
       # base64 + size, minimal zip-only feed, no blockmap -> full-zip mac updates for v1). The publish
       # job merges the two arch intermediates into the single `latest-mac.yml` the updater polls.
-      # Derived purely from the stapled zip, so it is correct on both the call and standalone paths.
+      # Derived purely from the final stapled zip in this unpublished run.
       - name: Regenerate mac update feed
         if: steps.gate.outputs.enabled == 'true'
         env:
@@ -320,61 +310,3 @@ jobs:
             mac/*-mac-*.zip
             mac/*-mac.yml
           if-no-files-found: error
-
-      # Standalone path: push the stapled dmg/zip + regenerated feed back onto the Release, replacing
-      # the signed-only ones. (Re-mirror the tag afterward to publish the feed to the CDN.)
-      - name: Clobber stapled assets onto the release
-        if: steps.gate.outputs.enabled == 'true' && !inputs.from_run
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release upload "${{ inputs.tag }}" mac/*-mac-*.dmg mac/*-mac-*.zip mac/*-mac.yml \
-            --repo "$GITHUB_REPOSITORY" --clobber
-
-  # Standalone path only: after both archs are stapled + clobbered, rebuild SHA256SUMS.txt so it
-  # matches the re-stapled bytes, and merge the per-arch mac feeds into latest-mac.yml (the two
-  # notarize jobs clobbered arm64/x64-mac.yml independently; the combined feed the app polls has to be
-  # rebuilt where both are visible). (In the release.yml path, the publish job does both over the
-  # already-stapled artifacts, so no refresh is needed there.)
-  refresh-checksums:
-    if: ${{ !inputs.from_run }}
-    needs: notarize
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout (for the mac-feed merge script)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
-
-      - name: Recompute + upload SHA256SUMS.txt
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          dir=$(mktemp -d)
-          gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --dir "$dir" \
-            --pattern '*.dmg' --pattern '*.zip' --pattern '*.exe' \
-            --pattern '*.AppImage' --pattern '*.deb'
-          (
-            cd "$dir"
-            shopt -s nullglob
-            files=(*.dmg *.zip *.exe *.AppImage *.deb)
-            [ ${#files[@]} -gt 0 ] && sha256sum "${files[@]}" > SHA256SUMS.txt
-            cat SHA256SUMS.txt
-          )
-          gh release upload "${{ inputs.tag }}" "$dir/SHA256SUMS.txt" \
-            --repo "$GITHUB_REPOSITORY" --clobber
-
-      # Rebuild the combined latest-mac.yml from the re-stapled per-arch feeds and clobber it onto the
-      # release. No-ops (script exits 0) if the per-arch mac feeds aren't present (non-mac backfill).
-      - name: Merge + upload latest-mac.yml
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          dir=$(mktemp -d)
-          gh release download "${{ inputs.tag }}" --repo "$GITHUB_REPOSITORY" --dir "$dir" \
-            --pattern 'arm64-mac.yml' --pattern 'x64-mac.yml' || true
-          node scripts/merge-mac-feed.mjs "$dir"
-          if [ -f "$dir/latest-mac.yml" ]; then
-            gh release upload "${{ inputs.tag }}" "$dir/latest-mac.yml" \
-              --repo "$GITHUB_REPOSITORY" --clobber
-          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,9 @@ jobs:
       - name: Checkout (for the mac-feed merge script)
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
+      - name: Install release transform dependencies
+        run: npm ci --ignore-scripts --omit=dev --omit=optional --no-audit --no-fund
+
       - name: Download all build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
@@ -118,8 +121,7 @@ jobs:
           --output artifacts/RELEASE-CERTIFICATION.json
           --expected-sha "$GITHUB_SHA"
 
-      # Merge the two per-arch mac feeds (from notarize-mac) into the single latest-mac.yml the
-      # installed app polls (default `latest` channel). No-ops if the mac feeds are absent.
+      # Merge build or post-notarization feeds; partial mac artifacts fail before publication.
       - name: Merge mac update feed
         run: node scripts/merge-mac-feed.mjs artifacts
 

--- a/.github/workflows/stage-runtime-bundle.yml
+++ b/.github/workflows/stage-runtime-bundle.yml
@@ -139,8 +139,8 @@ jobs:
           aws configure set default.region "$S3_REGION"
 
       # The operator explicitly chooses the version, which must match DEFAULT_ENV_VERSION on this ref.
-      # Publishing the same version again replaces its objects; matrix jobs remain serialized across
-      # workflow runs so two publishes cannot race the same manifest.
+      # Same-version retries must have identical bytes. A changed pack requires a new env version;
+      # the workflow lock keeps separate runs from racing the same manifest.
       # Publishes EACH curated pack file (`<language>-<version>.tar.zst`) + the shared manifest.json as
       # discrete objects, so a consumer fetches only the pack(s) it needs. Pack files are uploaded before
       # the manifest so consumers never observe a manifest that points to a missing object.
@@ -152,21 +152,4 @@ jobs:
           S3_PREFIX: ${{ vars.S3_PREFIX }}
           VERSION: ${{ steps.ver.outputs.version }}
         run: |
-          # Channel-agnostic namespace = first segment of S3_PREFIX (e.g. "open-science/app/stable" ->
-          # "open-science"), so the env-version-keyed bundle is a sibling of the app release channel,
-          # not nested under it. Must stay in sync with the download path in build.yml.
-          ns="${S3_PREFIX%%/*}"
-          base="s3://$S3_BUCKET${ns:+/$ns}/runtime-bundle/$VERSION/${{ matrix.subdir }}"
-          key_prefix="${ns:+$ns/}runtime-bundle/$VERSION/${{ matrix.subdir }}"
-          if aws s3api head-object --bucket "$S3_BUCKET" --key "$key_prefix/manifest.json" >/dev/null 2>&1; then
-            echo "::warning::overwriting runtime bundle version $VERSION at $key_prefix"
-          fi
-          shopt -s nullglob
-          archives=(resources/default-envs/*.tar.zst)
-          for archive in "${archives[@]}"; do
-            aws s3 cp "$archive" "$base/$(basename "$archive")" \
-              --cache-control "public, max-age=31536000, immutable" --only-show-errors
-          done
-          aws s3 cp resources/default-envs/manifest.json "$base/manifest.json" \
-            --cache-control "public, max-age=31536000, immutable" --only-show-errors
-          echo "published manifest.json + ${#archives[@]} pack archives to ${ns:+$ns/}runtime-bundle/$VERSION/${{ matrix.subdir }}/"
+          node scripts/publish-release-assets.mjs runtime resources/default-envs "${{ matrix.subdir }}"

--- a/.github/workflows/windows-full-test.yml
+++ b/.github/workflows/windows-full-test.yml
@@ -143,6 +143,7 @@ jobs:
         run: cargo test --locked --manifest-path packages/notebook-network-sandbox/vendor/windows-src/Cargo.toml
 
       - name: Build Windows sandbox native host
+        id: build_native
         run: node packages/notebook-network-sandbox/vendor/windows/build.mjs x64
 
       - name: Test AppContainer ownership and removal lifecycle
@@ -151,3 +152,10 @@ jobs:
           packages/notebook-network-sandbox/vendor/windows-src/ci/smoke.ps1
           -Exe packages/notebook-network-sandbox/vendor/windows/x64/notebook-appcontainer-host.exe
           -Mode Full
+
+      - name: Test smoke fixture with a UDP-occupied gateway port
+        if: ${{ always() && steps.build_native.outcome == 'success' }}
+        shell: powershell
+        run: >-
+          packages/notebook-network-sandbox/vendor/windows-src/ci/smoke-port-regression.ps1
+          -Exe packages/notebook-network-sandbox/vendor/windows/x64/notebook-appcontainer-host.exe

--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -112,13 +112,24 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           New-Item -ItemType Directory -Force previous | Out-Null
-          $releases = gh release list --exclude-drafts --exclude-pre-releases --limit 20 --json tagName
+          $stableTag = '^v(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$'
+          if ($env:CURRENT_TAG -notmatch $stableTag) { throw "Current tag must be stable SemVer." }
+          $current = [version]$env:CURRENT_TAG.Substring(1)
+          $pages = gh api --paginate --slurp "repos/$env:GITHUB_REPOSITORY/releases?per_page=100"
           if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
-          $tag = ($releases | ConvertFrom-Json | Where-Object { $_.tagName -like 'v*' -and $_.tagName -ne $env:CURRENT_TAG } | Select-Object -First 1).tagName
+          $releases = @($pages | ConvertFrom-Json | ForEach-Object { $_ })
+          $eligible = @($releases | Where-Object {
+            if ($_.draft -or $_.prerelease -or $_.tag_name -notmatch $stableTag) { return $false }
+            $version = [version]$_.tag_name.Substring(1)
+            $installer = "aipoch-open-science-$version-win-x64-setup.exe"
+            $version -lt $current -and $_.assets.name -contains $installer -and
+              $_.assets.name -contains "$installer.blockmap"
+          })
+          $tag = ($eligible | Sort-Object { [version]$_.tag_name.Substring(1) } -Descending | Select-Object -First 1).tag_name
           if ([string]::IsNullOrWhiteSpace($tag)) {
             "available=false" >> $env:GITHUB_OUTPUT
             "reason=no-previous-stable-release" >> $env:GITHUB_OUTPUT
-            Write-Host "No previous stable release is available; fresh-install smoke already passed."
+            Write-Host "No eligible previous stable Windows installer is available; fresh-install smoke already passed."
             exit 0
           }
           gh release download $tag --pattern '*-win-x64-setup.exe' --pattern '*-win-x64-setup.exe.blockmap' --dir previous

--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -13,6 +13,11 @@ on:
         type: string
         required: true
 
+      dry_run:
+        description: Run isolated baseline-selection tests without downloading or installing releases
+        type: boolean
+        default: false
+
 permissions:
   contents: read
 
@@ -22,6 +27,7 @@ concurrency:
 
 jobs:
   windows-upgrade-smoke:
+    if: ${{ !inputs.dry_run }}
     runs-on: windows-latest
     timeout-minutes: 40
     env:
@@ -199,3 +205,19 @@ jobs:
           always() && steps.previous.outputs.available == 'true' &&
           (steps.updater.outcome != 'success' || steps.installer.outcome != 'success')
         run: exit 1
+
+  baseline-dry-run:
+    if: ${{ inputs.dry_run }}
+    runs-on: windows-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout selection harness
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+      - name: Install test dependencies
+        run: npm ci --ignore-scripts --no-audit --no-fund
+      - name: Test actual Windows baseline selection
+        run: npx vitest run scripts/windows-upgrade-baseline.test.ts

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -15,6 +15,7 @@ files:
   # the app to multiple GB AND leaking local agent state into the shipped bundle.
   - '!.claude{,/**/*}'
   - '!.codex{,/**/*}'
+  - '!**/{.worktree,.worktrees,.codegraph,.agents}{,/**/*}'
   - '!src/*'
   - '!electron.vite.config.{js,ts,mjs,cjs}'
   - '!{.eslintcache,eslint.config.mjs,.prettierignore,.prettierrc.yaml,dev-app-update.yml,CHANGELOG.md,README.md}'
@@ -184,13 +185,9 @@ deb:
     - bubblewrap
 npmRebuild: false
 # electron-updater feed. Win/Linux/macOS auto-update reads app-update.yml (generated from this block)
-# and fetches its feed from <url>. Win/Linux use the default `latest` channel (latest.yml /
-# latest-linux.yml). macOS builds override the channel to the arch at build time (see build.yml), so
-# each arch polls its own `${arch}-mac.yml` — arm64 and x64 build on separate runners and would
-# otherwise collide on one latest-mac.yml. Mac in-place update needs a Developer ID signature (now
-# configured) and the feed is regenerated post-staple in notarize-mac.yml. The GitHub Release remains
-# the human-facing download source, populated by release.yml — electron-builder runs with --publish
-# never, so this block only shapes app-update.yml + the feed files, it does not upload anything.
+# and fetches its feed from <url>. Each installed app uses the default latest channel. macOS
+# builds preserve uniquely named per-arch feed artifacts; release.yml merges them into latest-mac.yml
+# after optional notarization. --publish never means this configuration does not upload anything.
 publish:
   provider: generic
   url: https://statics.aipoch.com/open-science/app/stable

--- a/packages/notebook-network-sandbox/vendor/windows-src/ci/smoke-port-regression.ps1
+++ b/packages/notebook-network-sandbox/vendor/windows-src/ci/smoke-port-regression.ps1
@@ -1,0 +1,28 @@
+<# Run only on an elevated, ephemeral Windows test host. #>
+param([Parameter(Mandatory = $true)][string]$Exe)
+$ErrorActionPreference = 'Stop'
+$reservation = @{ listener = $null }
+$failures = 0
+try {
+  foreach ($attempt in 1..2) {
+    try {
+      & "$PSScriptRoot/smoke.ps1" -Exe $Exe -AfterSetup {
+        param([int]$Port)
+        $reservation.listener = [Net.Sockets.UdpClient]::new()
+        $reservation.listener.ExclusiveAddressUse = $true
+        $reservation.listener.Client.Bind([Net.IPEndPoint]::new([Net.IPAddress]::Any, $Port))
+        Write-Host "[regression] exclusively bound UDP port $Port; TCP gateway remains available"
+      }
+    } catch {
+      $failures++
+      Write-Host "[regression] failure: $($_.Exception.ToString())"
+      Write-Host $_.ScriptStackTrace
+      & netsh.exe interface ipv4 show excludedportrange protocol=udp
+    } finally {
+      if ($reservation.listener) { $reservation.listener.Dispose(); $reservation.listener = $null }
+    }
+  }
+  if ($failures) { throw "Smoke test failed $failures times with a TCP-only gateway port" }
+} finally {
+  if ($reservation.listener) { $reservation.listener.Dispose() }
+}

--- a/packages/notebook-network-sandbox/vendor/windows-src/ci/smoke.ps1
+++ b/packages/notebook-network-sandbox/vendor/windows-src/ci/smoke.ps1
@@ -3,7 +3,9 @@ param(
   [Parameter(Mandatory = $true)]
   [string]$Exe,
   [ValidateSet('Basic', 'Full')]
-  [string]$Mode = 'Basic'
+  [string]$Mode = 'Basic',
+  # Tests can establish host port restrictions after the native allocator chooses its port.
+  [scriptblock]$AfterSetup
 )
 
 $ErrorActionPreference = 'Stop'
@@ -115,6 +117,23 @@ try {
     throw 'Notebook AppContainer setup did not produce owned ready resources.'
   }
   $gatewayPort = [int]$status.gatewayPort
+  if ($AfterSetup) { & $AfterSetup $gatewayPort }
+  # The product gateway only needs TCP. This fixture also probes UDP at the same port, which
+  # another host process may own independently. Reserve that listener before running assertions.
+  for ($attempt = 0; $attempt -lt 5; $attempt++) {
+    try {
+      $gatewayUdpListener = [Net.Sockets.UdpClient]::new([Net.IPEndPoint]::new([Net.IPAddress]::Loopback, $gatewayPort))
+      break
+    } catch [Net.Sockets.SocketException] {
+      if ($_.Exception.SocketErrorCode -notin @('AccessDenied', 'AddressAlreadyInUse') -or $attempt -eq 4) { throw }
+      Write-Host "[windows-smoke] UDP fixture port $gatewayPort unavailable; recreate the test installation"
+      Remove-SandboxResources $installationId $ownershipRoot
+      Install-SandboxResources $installationId $ownershipRoot
+      $status = (& $hostExe status $installationId $ownershipRoot | ConvertFrom-Json)
+      $gatewayPort = [int]$status.gatewayPort
+    }
+  }
+
   $ownedReceipt = Get-Content -LiteralPath $receipt -Raw | ConvertFrom-Json
   if ($ownedReceipt.schemaVersion -ne 4 -or [string]::IsNullOrWhiteSpace($ownedReceipt.wfpSublayerKey) -or $ownedReceipt.wfpFilterKeys.Count -ne 3) {
     throw 'Notebook AppContainer receipt does not identify the owned WFP fence.'
@@ -367,7 +386,6 @@ try {
     # port must never reach a host listener.
     $outsideUdpListener = [Net.Sockets.UdpClient]::new([Net.IPEndPoint]::new([Net.IPAddress]::Loopback, 0))
     $outsideUdpPort = $outsideUdpListener.Client.LocalEndPoint.Port
-    $gatewayUdpListener = [Net.Sockets.UdpClient]::new([Net.IPEndPoint]::new([Net.IPAddress]::Loopback, $gatewayPort))
     $udpSpec = {
       param($port)
       $command = "try { `$client = [Net.Sockets.UdpClient]::new(); `$bytes = [Text.Encoding]::UTF8.GetBytes('probe'); [void]`$client.Send(`$bytes, `$bytes.Length, '127.0.0.1', $port); `$client.Dispose(); exit 0 } catch { exit 33 }"

--- a/playwright.browser.config.ts
+++ b/playwright.browser.config.ts
@@ -1,7 +1,8 @@
 import { defineConfig } from '@playwright/test'
 import base from './playwright.config'
 
-export default defineConfig(base, {
+export default defineConfig({
+  ...base,
   testDir: './e2e/browser',
   testIgnore: [],
   outputDir: 'test-results/browser',

--- a/playwright.config.test.ts
+++ b/playwright.config.test.ts
@@ -103,3 +103,18 @@ it('partitions the selected Electron suites across three shards without losing o
     expect(actual.sort()).toEqual(expected.sort())
   }
 }, 90_000)
+
+it.each(['win32', 'darwin', 'linux'] as const)(
+  'runs browser tests in exactly one Chromium project on %s',
+  async (platform) => {
+    const original = process.platform
+    Object.defineProperty(process, 'platform', { value: platform })
+    try {
+      vi.resetModules()
+      const config = (await import('./playwright.browser.config')).default
+      expect(config.projects).toEqual([{ name: 'chromium', use: { browserName: 'chromium' } }])
+    } finally {
+      Object.defineProperty(process, 'platform', { value: original })
+    }
+  }
+)

--- a/scripts/ci/mirror-channel-publication.test.ts
+++ b/scripts/ci/mirror-channel-publication.test.ts
@@ -39,7 +39,13 @@ function fixture(): {
 const fs = require('node:fs');
 const path = require('node:path');
 const [service, operation, source, destination] = process.argv.slice(2);
-if (service !== 's3' || !['cp', 'sync'].includes(operation)) throw new Error('Unexpected AWS command');
+if (service === 's3api' && operation === 'head-object') {
+ const args = process.argv.slice(2);
+ const file = path.join(process.env.FIXTURE_STORAGE, args[args.indexOf('--bucket') + 1], args[args.indexOf('--key') + 1]);
+ if (!fs.existsSync(file)) { process.stderr.write('An error occurred (404): Not Found'); process.exit(1); }
+ process.exit(0);
+}
+if (service !== 's3'  || !['cp', 'sync'].includes(operation)) throw new Error('Unexpected AWS command');
 const local = value => value.startsWith('s3://') ? path.join(process.env.FIXTURE_STORAGE, value.slice(5)) : value;
 if (process.env.FAIL_KEY && destination === 's3://fixture-bucket/stable/' + process.env.FAIL_KEY) {
   process.stderr.write('Injected upload failure'); process.exit(1);
@@ -49,6 +55,7 @@ else {
  const target = local(destination);
  fs.mkdirSync(path.dirname(target), {recursive:true});
  fs.cpSync(local(source), target, {recursive: operation === 'sync'});
+ if (process.env.FAIL_KEY === 'corrupt:' + destination) fs.appendFileSync(target, 'corrupted readback');
 }
 `,
     { mode: 0o755 }
@@ -123,6 +130,16 @@ describe.skipIf(process.platform === 'win32')('website channel publication', () 
     )
     expect(f.snapshot()).toEqual(before)
   })
+  it('rejects changed bytes before overwriting a published version', () => {
+    const f = fixture()
+    f.stage('2.1.0')
+    f.run('2.1.0')
+    writeFileSync(join(f.root, 'dist-assets', 'installer.deb'), 'replacement installer')
+    expect(() => f.run('2.1.0')).toThrow()
+    expect(readFileSync(join(f.channel, 'releases', '2.1.0', 'installer.deb'), 'utf8')).toBe(
+      'fixture installer'
+    )
+  })
   it('only promotes on explicit intent and makes same-version retries idempotent', () => {
     const f = fixture(),
       before = f.snapshot()
@@ -145,6 +162,13 @@ describe.skipIf(process.platform === 'win32')('website channel publication', () 
     f.stage('2.1.0')
     f.run('2.1.0', 'promote')
     expect(f.snapshot()).toEqual(before)
+  })
+  it('rejects successful uploads whose channel readback differs', () => {
+    const f = fixture()
+    f.stage('2.1.0')
+    expect(() =>
+      f.run('2.1.0', 'promote', 'corrupt:s3://fixture-bucket/stable/latest.yml')
+    ).toThrow(/Publication readback failed/)
   })
   it('rejects a promotion with a missing platform before channel writes', () => {
     const f = fixture(),

--- a/scripts/ci/mirror-channel-publication.test.ts
+++ b/scripts/ci/mirror-channel-publication.test.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process'
 import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { delimiter, dirname, join } from 'node:path'
 import { load } from 'js-yaml'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
@@ -90,6 +90,7 @@ else {
         cwd: root,
         // Do not inherit host AWS environment or credentials. PATH begins with the only AWS used.
         env: {
+          HOME: root,
           PATH: [bin, '/usr/bin', '/bin'].join(delimiter),
           FIXTURE_STORAGE: storage,
           S3_BUCKET: 'fixture-bucket',
@@ -98,7 +99,8 @@ else {
           MODE: mode,
           FAIL_KEY: failKey
         },
-        stdio: 'pipe'
+        // macOS Bash treats a piped stdin as a remote shell and can source .bashrc.
+        stdio: ['ignore', 'pipe', 'pipe']
       })
     }
   }
@@ -115,6 +117,25 @@ describe.skipIf(process.platform === 'win32')('website channel publication', () 
     }
     vi.stubEnv('PATH', `${wrappers}${delimiter}${process.env.PATH}`)
     const f = fixture()
+    f.stage('2.1.0')
+    f.run('2.1.0', 'promote')
+    expect(JSON.parse(f.snapshot()['version.json']).version).toBe('2.1.0')
+  })
+
+  it('keeps publication isolated from shell startup files that replace PATH', () => {
+    const f = fixture()
+    const hostBin = join(f.root, 'host-bin')
+    mkdirSync(hostBin)
+    writeFileSync(
+      join(hostBin, 'aws'),
+      '#!/bin/sh\necho "Unable to locate credentials: host AWS escaped fixture" >&2\nexit 1\n',
+      { mode: 0o755 }
+    )
+    const quote = (value: string): string => "'" + value.replaceAll("'", "'\\''") + "'"
+    writeFileSync(
+      join(f.root, '.bashrc'),
+      `export PATH=${quote([hostBin, dirname(process.execPath), '/usr/bin', '/bin'].join(delimiter))}\n`
+    )
     f.stage('2.1.0')
     f.run('2.1.0', 'promote')
     expect(JSON.parse(f.snapshot()['version.json']).version).toBe('2.1.0')

--- a/scripts/generate-version-manifest.mjs
+++ b/scripts/generate-version-manifest.mjs
@@ -19,6 +19,12 @@
 import { readFileSync, readdirSync, statSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
+import { load } from 'js-yaml'
+import {
+  artifactHash,
+  validateArtifactName,
+  validateUpdateFeed
+} from './release-artifact-validation.mjs'
 
 // Filename -> downloads key. Explicit regex table so an unexpected artifact name fails loudly (as a
 // warning) rather than being silently misfiled. deb uses the dpkg convention (underscores + amd64).
@@ -26,7 +32,7 @@ const KEY_RULES = [
   { key: 'mac-arm64', pattern: /-mac-arm64\.dmg$/ },
   { key: 'mac-x64', pattern: /-mac-x64\.dmg$/ },
   { key: 'win-x64', pattern: /-win-x64-setup\.exe$/ },
-  { key: 'linux-x64-appimage', pattern: /-linux-x64\.AppImage$/ },
+  { key: 'linux-x64-appimage', pattern: /-linux-(?:x64|x86_64)\.AppImage$/ },
   { key: 'linux-x64-deb', pattern: /_amd64\.deb$/ }
 ]
 
@@ -67,7 +73,10 @@ export function parseSha256Sums(content) {
   const map = {}
   for (const line of content.split('\n')) {
     const match = line.trim().match(/^([0-9a-fA-F]{64})\s+\*?(.+)$/)
-    if (match) map[match[2]] = match[1].toLowerCase()
+    if (match) {
+      if (Object.hasOwn(map, match[2])) throw new Error(`Duplicate SHA256 entry: ${match[2]}`)
+      map[match[2]] = match[1].toLowerCase()
+    }
   }
   return map
 }
@@ -79,7 +88,7 @@ function keyForFile(filename) {
 
 // Build the version.json manifest object from a directory of installers + SHA256SUMS.txt.
 // Pure: reads the filesystem but performs no network I/O. Only keys whose installer actually exists
-// (and has a checksum) are emitted; unrecognized files and files missing from SHA256SUMS warn.
+// are emitted; each present installer must have a matching version, size and real checksum.
 export function buildManifest({
   dir,
   version,
@@ -87,31 +96,64 @@ export function buildManifest({
   localizedNotes,
   releaseDate,
   cdnBase,
-  prefix
+  prefix,
+  metadataOnly = false,
+  requireComplete = false
 }) {
+  if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
+    throw new Error(`Invalid stable release version: ${version}`)
+  }
   const sums = parseSha256Sums(readFileSync(join(dir, 'SHA256SUMS.txt'), 'utf8'))
   const base = `${cdnBase}/${prefix}/releases/${version}`
 
   const downloads = {}
   for (const filename of readdirSync(dir)) {
     const key = keyForFile(filename)
-    if (!key) {
+    if (!key && !filename.endsWith('.zip')) {
       // Warn only for genuinely unexpected files, not known non-manifest artifacts (zips, sums, ...).
       if (!IGNORED.some((pattern) => pattern.test(filename))) {
         console.warn(`[version-manifest] unrecognized file, ignoring: ${filename}`)
       }
       continue
     }
+    validateArtifactName(filename, version)
     const sha256 = sums[filename]
-    if (!sha256) {
-      // No verifiable hash -> useless to the in-app integrity check, so drop it rather than emit it.
-      console.warn(`[version-manifest] no sha256 in SHA256SUMS.txt, skipping: ${filename}`)
-      continue
+    if (!sha256) throw new Error(`[version-manifest] no sha256 in SHA256SUMS.txt: ${filename}`)
+    const stat = statSync(join(dir, filename))
+    if (!stat.isFile() || stat.size <= 0) throw new Error(`Empty or invalid installer: ${filename}`)
+    if (!metadataOnly && artifactHash(join(dir, filename), 'sha256') !== sha256) {
+      throw new Error(`Installer SHA256 mismatch: ${filename}`)
     }
-    downloads[key] = {
-      url: `${base}/${filename}`,
-      size: statSync(join(dir, filename)).size,
-      sha256
+    if (!key) continue // mac ZIPs are update artifacts, not website download keys.
+    if (downloads[key]) throw new Error(`Duplicate installer for ${key}`)
+    downloads[key] = { url: `${base}/${filename}`, size: stat.size, sha256 }
+  }
+  for (const filename of readdirSync(dir).filter((name) =>
+    /^(latest(?:-linux)?|.*-mac)\.yml$/.test(name)
+  )) {
+    validateUpdateFeed(load(readFileSync(join(dir, filename), 'utf8')), dir, version, metadataOnly)
+  }
+  if (requireComplete) {
+    for (const { key } of KEY_RULES) {
+      if (!downloads[key]) throw new Error(`Missing stable release installer: ${key}`)
+    }
+    for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml']) {
+      const feed = validateUpdateFeed(
+        load(readFileSync(join(dir, name), 'utf8')),
+        dir,
+        version,
+        metadataOnly
+      )
+      const required =
+        name === 'latest-mac.yml'
+          ? ['-mac-arm64.zip', '-mac-x64.zip']
+          : name === 'latest.yml'
+            ? ['-win-x64-setup.exe']
+            : ['.AppImage', '.deb']
+      for (const suffix of required) {
+        if (!feed.files.some((file) => file.url.endsWith(suffix)))
+          throw new Error(`Missing ${suffix} in ${name}`)
+      }
     }
   }
 
@@ -196,7 +238,9 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     ...releaseNotes,
     releaseDate: process.env.RELEASE_DATE ?? '',
     cdnBase,
-    prefix
+    prefix,
+    metadataOnly: process.argv.includes('--metadata-only'),
+    requireComplete: process.argv.includes('--require-complete')
   })
 
   writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`)

--- a/scripts/generate-version-manifest.mjs
+++ b/scripts/generate-version-manifest.mjs
@@ -98,7 +98,8 @@ export function buildManifest({
   cdnBase,
   prefix,
   metadataOnly = false,
-  requireComplete = false
+  requireComplete = false,
+  allowLegacyNames = false
 }) {
   if (!/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
     throw new Error(`Invalid stable release version: ${version}`)
@@ -116,7 +117,7 @@ export function buildManifest({
       }
       continue
     }
-    validateArtifactName(filename, version)
+    validateArtifactName(filename, version, allowLegacyNames)
     const sha256 = sums[filename]
     if (!sha256) throw new Error(`[version-manifest] no sha256 in SHA256SUMS.txt: ${filename}`)
     const stat = statSync(join(dir, filename))
@@ -131,7 +132,13 @@ export function buildManifest({
   for (const filename of readdirSync(dir).filter((name) =>
     /^(latest(?:-linux)?|.*-mac)\.yml$/.test(name)
   )) {
-    validateUpdateFeed(load(readFileSync(join(dir, filename), 'utf8')), dir, version, metadataOnly)
+    validateUpdateFeed(
+      load(readFileSync(join(dir, filename), 'utf8')),
+      dir,
+      version,
+      metadataOnly,
+      allowLegacyNames
+    )
   }
   if (requireComplete) {
     for (const { key } of KEY_RULES) {
@@ -240,7 +247,8 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
     cdnBase,
     prefix,
     metadataOnly: process.argv.includes('--metadata-only'),
-    requireComplete: process.argv.includes('--require-complete')
+    requireComplete: process.argv.includes('--require-complete'),
+    allowLegacyNames: process.argv.includes('--backfill')
   })
 
   writeFileSync(outputPath, `${JSON.stringify(manifest, null, 2)}\n`)

--- a/scripts/generate-version-manifest.test.ts
+++ b/scripts/generate-version-manifest.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto'
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -44,7 +45,8 @@ function makeReleaseDir(files: FileSpec[]): string {
 // A canonical entry: 64-hex sha keyed off the platform so each file gets a distinct, checkable hash.
 const HEX = (n: string): string => n.repeat(64)
 function entry(key: keyof typeof INSTALLERS, extra = 0): FileSpec {
-  return { name: INSTALLERS[key], content: 'x'.repeat(10 + extra), sha: HEX(String(extra % 10)) }
+  const content = 'x'.repeat(10 + extra)
+  return { name: INSTALLERS[key], content, sha: createHash('sha256').update(content).digest('hex') }
 }
 
 describe('parseSha256Sums', () => {
@@ -227,30 +229,22 @@ describe('buildManifest', () => {
     expect(manifest.downloads['linux-x64-deb']).toBeUndefined()
   })
 
-  it('warns and skips an installer missing from SHA256SUMS', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+  it('rejects an installer missing from SHA256SUMS', () => {
     dir = makeReleaseDir([entry('mac-arm64', 1), { ...entry('mac-x64', 2), sha: null }])
-
-    const manifest = buildManifest({
-      dir,
-      version: VERSION,
-      notes: '',
-      releaseDate: '',
-      cdnBase: CDN,
-      prefix: PREFIX
-    })
-
-    expect(manifest.downloads['mac-arm64']).toBeDefined()
-    expect(manifest.downloads['mac-x64']).toBeUndefined()
-    expect(warn).toHaveBeenCalledWith(expect.stringContaining('no sha256'))
-    warn.mockRestore()
+    expect(() => buildManifest({ dir, version: VERSION, cdnBase: CDN, prefix: PREFIX })).toThrow(
+      /no sha256/
+    )
   })
 
   it('warns on an unrecognized file but stays silent for zips and checksums', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
     dir = makeReleaseDir([
       entry('mac-arm64', 1),
-      { name: 'aipoch-open-science-0.1.2-mac-arm64.zip', content: 'zip', sha: HEX('9') },
+      {
+        name: 'aipoch-open-science-0.1.2-mac-arm64.zip',
+        content: 'zip',
+        sha: createHash('sha256').update('zip').digest('hex')
+      },
       { name: 'mystery-artifact.bin', content: 'bin', sha: HEX('8') }
     ])
 

--- a/scripts/merge-mac-feed.mjs
+++ b/scripts/merge-mac-feed.mjs
@@ -8,57 +8,45 @@
 // left field apps polling a filename the pipeline never published.
 //
 // Usage: node scripts/merge-mac-feed.mjs [dir]   (dir defaults to cwd)
-// No-ops (exit 0) unless BOTH per-arch feeds are present, so a partial/non-mac run is harmless.
-import { readFileSync, writeFileSync, existsSync } from 'node:fs'
+// An entirely non-mac directory may be skipped. Any partial mac publication fails closed.
+import { readFileSync, writeFileSync, existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { dump, load } from 'js-yaml'
+import { validateUpdateFeed } from './release-artifact-validation.mjs'
 
 const dir = process.argv[2] ?? '.'
-const archFeeds = ['arm64-mac.yml', 'x64-mac.yml'].map((name) => join(dir, name))
-
-if (!archFeeds.every(existsSync)) {
-  console.log('merge-mac-feed: both per-arch feeds not present, skipping')
+const names = ['arm64-mac.yml', 'x64-mac.yml']
+if (!names.every((name) => existsSync(join(dir, name)))) {
+  if (readdirSync(dir).some((name) => /-mac(?:-|\.)/.test(name))) {
+    throw new Error('Both macOS architecture feeds are required')
+  }
+  console.log('merge-mac-feed: no macOS artifacts, skipping')
   process.exit(0)
 }
-
-// The per-arch feeds are machine-generated with a fixed shape (see notarize-mac.yml), so a targeted
-// parse is enough and avoids a YAML dependency. Each feed lists exactly one file, so after `files:`
-// the first sha512/size belong to that entry.
-const parse = (file) => {
-  const text = readFileSync(file, 'utf8')
-  const version = text.match(/^version:\s*(.+)$/m)?.[1].trim()
-  const filesBlock = text.slice(text.indexOf('files:'))
-  const url = filesBlock.match(/-\s*url:\s*(.+)/)?.[1].trim()
-  const sha512 = filesBlock.match(/sha512:\s*(.+)/)?.[1].trim()
-  const size = filesBlock.match(/size:\s*(\d+)/)?.[1]
-  const releaseDate = text.match(/^releaseDate:\s*(.+)$/m)?.[1].trim()
-  if (!version || !url || !sha512 || !size) {
-    console.error(`::error::could not parse mac feed ${file}`)
-    process.exit(1)
-  }
-  return { version, url, sha512, size, releaseDate }
-}
-
-const entries = archFeeds.map(parse)
-const version = entries[0].version
-// Newest of the two timestamps, so the combined feed's date reflects the last-stapled arch.
-const releaseDate = entries
-  .map((e) => e.releaseDate?.replace(/^["']|["']$/g, ''))
+const feeds = names.map((name) => load(readFileSync(join(dir, name), 'utf8')))
+const version = feeds[0].version
+const files = feeds.map((feed, index) => {
+  validateUpdateFeed(feed, dir, version, process.argv.includes('--metadata-only'))
+  const suffix = index === 0 ? '-mac-arm64.zip' : '-mac-x64.zip'
+  const entries = feed.files.filter((file) => file.url.endsWith(suffix))
+  if (entries.length !== 1) throw new Error(`Expected one ${suffix} update artifact`)
+  return entries[0]
+})
+const releaseDate = feeds
+  .map((feed) => feed.releaseDate)
   .filter(Boolean)
+  .map(String)
   .sort()
   .pop()
-
-const filesYaml = entries
-  .map((e) => `  - url: ${e.url}\n    sha512: ${e.sha512}\n    size: ${e.size}`)
-  .join('\n')
-
-// Top-level path/sha512 are legacy single-file fields; MacUpdater downloads from files[] after arch
-// filtering, so point them at the first entry for backward-compat.
-const yml =
-  `version: ${version}\n` +
-  `files:\n${filesYaml}\n` +
-  `path: ${entries[0].url}\n` +
-  `sha512: ${entries[0].sha512}\n` +
-  `releaseDate: ${JSON.stringify(releaseDate ?? new Date().toISOString())}\n`
-
+const yml = dump(
+  {
+    version,
+    files,
+    path: files[0].url,
+    sha512: files[0].sha512,
+    releaseDate: releaseDate ?? new Date().toISOString()
+  },
+  { lineWidth: -1 }
+)
 writeFileSync(join(dir, 'latest-mac.yml'), yml)
 process.stdout.write(yml)

--- a/scripts/merge-mac-feed.mjs
+++ b/scripts/merge-mac-feed.mjs
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/explicit-function-return-type */
 // Merge the two per-arch macOS update feeds (arm64-mac.yml + x64-mac.yml) into a single
 // latest-mac.yml that lists both arch zips. This is the feed the installed app actually polls: its
 // app-update.yml ships the default `latest` channel, so on macOS electron-updater fetches

--- a/scripts/publish-release-assets.mjs
+++ b/scripts/publish-release-assets.mjs
@@ -2,10 +2,9 @@
 // Called only after local validation, under the owning workflow's publication lock. Existing
 // versioned objects are compared by bytes, including objects predating this publisher.
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { mkdtempSync, readdirSync, rmSync, statSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
-import { load } from 'js-yaml'
 import { artifactHash } from './release-artifact-validation.mjs'
 
 const bucket = process.env.S3_BUCKET
@@ -66,57 +65,10 @@ function stableVersion(version) {
   }
   return version.split('.').map(BigInt)
 }
-function isNewer(a, b) {
-  const left = stableVersion(a),
-    right = stableVersion(b)
-  for (let i = 0; i < 3; i++) {
-    if (left[i] !== right[i]) return left[i] > right[i]
-  }
-  return false
-}
-function publishChannel(manifestFile, dir) {
-  const manifest = JSON.parse(readFileSync(manifestFile, 'utf8'))
-  stableVersion(manifest.version)
-  const feeds = readdirSync(dir).filter((name) => /^(latest(?:-linux)?|.*-mac)\.yml$/.test(name))
-  for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml']) {
-    if (!feeds.includes(name)) throw new Error(`Missing channel feed: ${name}`)
-  }
-  for (const name of feeds) {
-    if (load(readFileSync(join(dir, name), 'utf8'))?.version !== manifest.version) {
-      throw new Error(`Channel feed version mismatch: ${name}`)
-    }
-  }
-  const entries = [
-    ...feeds.map((name) => [join(dir, name), `${prefix}/${name}`]),
-    [manifestFile, `${prefix}/version.json`]
-  ]
-  // A newer feed may remain after a failed promotion whose final manifest was never written.
-  // Never let an older queued run roll that feed back either; rerun the newer release to recover.
-  for (const [, key] of entries) {
-    const existing = readObject(key)
-    if (!existing) continue
-    const text = readFileSync(existing, 'utf8')
-    const version = (key.endsWith('.json') ? JSON.parse(text) : load(text))?.version
-    if (isNewer(version, manifest.version)) {
-      console.log(`Backfill only: channel already contains newer release ${version}`)
-      return
-    }
-  }
-  // This is ordered, not atomic across keys. The version manifest is the final completion marker;
-  // a failed upload is recovered by rerunning the same version, without replacing installer bytes.
-  for (const [file, key] of entries) copy(file, key, false)
-  for (const [file, key] of entries) {
-    const actual = readObject(key)
-    if (!actual || artifactHash(actual, 'sha256') !== artifactHash(file, 'sha256')) {
-      throw new Error(`Publication readback failed: ${basename(file)}`)
-    }
-  }
-}
 
 try {
   const [mode, dir, argument] = process.argv.slice(2)
-  if (mode === 'channel') publishChannel(dir, argument)
-  else if (mode === 'runtime') {
+  if (mode === 'runtime') {
     if (
       !/^[1-9]\d*$/.test(process.env.VERSION ?? '') ||
       !/^(osx-arm64|osx-64|linux-64|win-64)$/.test(argument)
@@ -136,6 +88,7 @@ try {
       readdirSync(dir)
         .filter((name) => name !== 'version.json')
         .map((name) => [join(dir, name), `${base}/${name}`])
+        .concat(argument ? [[argument, `${base}/version.json`]] : [])
     )
   } else if (mode === 'blockmaps') {
     const entries = []

--- a/scripts/publish-release-assets.mjs
+++ b/scripts/publish-release-assets.mjs
@@ -1,0 +1,154 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+// Called only after local validation, under the owning workflow's publication lock. Existing
+// versioned objects are compared by bytes, including objects predating this publisher.
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readdirSync, readFileSync, rmSync, statSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join } from 'node:path'
+import { load } from 'js-yaml'
+import { artifactHash } from './release-artifact-validation.mjs'
+
+const bucket = process.env.S3_BUCKET
+const prefix = process.env.S3_PREFIX
+if (!bucket || !prefix) throw new Error('S3_BUCKET and S3_PREFIX are required')
+const temp = mkdtempSync(join(tmpdir(), 'release-publish-'))
+const aws = (args) => spawnSync('aws', args, { encoding: 'utf8', timeout: 600_000 })
+const checked = (args) => {
+  const result = aws(args)
+  if (result.status !== 0)
+    throw new Error(result.error?.message ?? result.stderr ?? 'AWS operation failed')
+  return result.stdout
+}
+const remote = (key) => `s3://${bucket}/${key}`
+let sequence = 0
+function readObject(key) {
+  const head = aws(['s3api', 'head-object', '--bucket', bucket, '--key', key])
+  if (head.status !== 0) {
+    if (!head.error && /\((?:404|NoSuchKey|NotFound)\)/.test(head.stderr)) return undefined
+    throw new Error(`Cannot inspect publication object: ${head.error?.message ?? head.stderr}`)
+  }
+  const file = join(temp, String(sequence++))
+  checked(['s3', 'cp', remote(key), file, '--only-show-errors'])
+  return file
+}
+function copy(file, key, immutable) {
+  checked([
+    's3',
+    'cp',
+    file,
+    remote(key),
+    '--cache-control',
+    immutable ? 'public, max-age=31536000, immutable' : 'no-cache',
+    '--only-show-errors'
+  ])
+}
+function publishImmutable(entries) {
+  const pending = []
+  // Check the complete batch before writing, so a changed final manifest cannot authorize any
+  // different pack/installer bytes. An interrupted first upload can resume its missing objects.
+  for (const [file, key] of entries) {
+    if (!statSync(file).isFile() || statSync(file).size <= 0)
+      throw new Error(`Invalid publication file: ${file}`)
+    const existing = readObject(key)
+    if (!existing) pending.push([file, key])
+    else {
+      const equal = artifactHash(file, 'sha256') === artifactHash(existing, 'sha256')
+      rmSync(existing)
+      if (!equal)
+        throw new Error(`Published bytes are immutable; use a new version: ${basename(file)}`)
+    }
+  }
+  for (const [file, key] of pending) copy(file, key, true)
+}
+function stableVersion(version) {
+  if (typeof version !== 'string' || !/^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/.test(version)) {
+    throw new Error(`Invalid stable version: ${version}`)
+  }
+  return version.split('.').map(BigInt)
+}
+function isNewer(a, b) {
+  const left = stableVersion(a),
+    right = stableVersion(b)
+  for (let i = 0; i < 3; i++) {
+    if (left[i] !== right[i]) return left[i] > right[i]
+  }
+  return false
+}
+function publishChannel(manifestFile, dir) {
+  const manifest = JSON.parse(readFileSync(manifestFile, 'utf8'))
+  stableVersion(manifest.version)
+  const feeds = readdirSync(dir).filter((name) => /^(latest(?:-linux)?|.*-mac)\.yml$/.test(name))
+  for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml']) {
+    if (!feeds.includes(name)) throw new Error(`Missing channel feed: ${name}`)
+  }
+  for (const name of feeds) {
+    if (load(readFileSync(join(dir, name), 'utf8'))?.version !== manifest.version) {
+      throw new Error(`Channel feed version mismatch: ${name}`)
+    }
+  }
+  const entries = [
+    ...feeds.map((name) => [join(dir, name), `${prefix}/${name}`]),
+    [manifestFile, `${prefix}/version.json`]
+  ]
+  // A newer feed may remain after a failed promotion whose final manifest was never written.
+  // Never let an older queued run roll that feed back either; rerun the newer release to recover.
+  for (const [, key] of entries) {
+    const existing = readObject(key)
+    if (!existing) continue
+    const text = readFileSync(existing, 'utf8')
+    const version = (key.endsWith('.json') ? JSON.parse(text) : load(text))?.version
+    if (isNewer(version, manifest.version)) {
+      console.log(`Backfill only: channel already contains newer release ${version}`)
+      return
+    }
+  }
+  // This is ordered, not atomic across keys. The version manifest is the final completion marker;
+  // a failed upload is recovered by rerunning the same version, without replacing installer bytes.
+  for (const [file, key] of entries) copy(file, key, false)
+  for (const [file, key] of entries) {
+    const actual = readObject(key)
+    if (!actual || artifactHash(actual, 'sha256') !== artifactHash(file, 'sha256')) {
+      throw new Error(`Publication readback failed: ${basename(file)}`)
+    }
+  }
+}
+
+try {
+  const [mode, dir, argument] = process.argv.slice(2)
+  if (mode === 'channel') publishChannel(dir, argument)
+  else if (mode === 'runtime') {
+    if (
+      !/^[1-9]\d*$/.test(process.env.VERSION ?? '') ||
+      !/^(osx-arm64|osx-64|linux-64|win-64)$/.test(argument)
+    ) {
+      throw new Error('Invalid runtime version or subdir')
+    }
+    const base = `${prefix.split('/')[0]}/runtime-bundle/${process.env.VERSION}/${argument}`
+    const files = readdirSync(dir).filter((name) => name.endsWith('.tar.zst'))
+    if (files.length === 0) throw new Error('No runtime archives')
+    publishImmutable(
+      [...files, 'manifest.json'].map((name) => [join(dir, name), `${base}/${name}`])
+    )
+  } else if (mode === 'release') {
+    stableVersion(process.env.VERSION)
+    const base = `${prefix}/releases/${process.env.VERSION}`
+    publishImmutable(
+      readdirSync(dir)
+        .filter((name) => name !== 'version.json')
+        .map((name) => [join(dir, name), `${base}/${name}`])
+    )
+  } else if (mode === 'blockmaps') {
+    const entries = []
+    for (const version of readdirSync(dir)) {
+      stableVersion(version)
+      for (const name of readdirSync(join(dir, version))) {
+        if (!name.endsWith('-win-x64-setup.exe.blockmap'))
+          throw new Error('Unexpected blockmap file')
+        entries.push([join(dir, version, name), `${prefix}/releases/${version}/${name}`])
+      }
+    }
+    publishImmutable(entries)
+  } else throw new Error(`Unknown publication mode: ${mode}`)
+} finally {
+  rmSync(temp, { recursive: true, force: true })
+}

--- a/scripts/publish-update-channel.mjs
+++ b/scripts/publish-update-channel.mjs
@@ -5,6 +5,7 @@
 import { execFileSync } from 'node:child_process'
 import { readFileSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { createHash } from 'node:crypto'
 import { load } from 'js-yaml'
 
 const {
@@ -73,18 +74,12 @@ if (promote) {
   }
 }
 
-aws(
-  's3',
-  'sync',
-  'dist-assets/',
-  `${root}/releases/${version}/`,
-  '--exclude',
-  'version.json',
-  '--cache-control',
-  'public, max-age=31536000, immutable',
-  '--only-show-errors'
+// The immutable uploader preflights the entire version, including its manifest, before any writes.
+execFileSync(
+  process.execPath,
+  ['scripts/publish-release-assets.mjs', 'release', 'dist-assets', 'version.json'],
+  { stdio: 'pipe' }
 )
-upload('version.json', `releases/${version}/version.json`, true, 'application/json')
 if (!promote) {
   console.log(`Backfilled ${version}; channel entries unchanged.`)
 } else {
@@ -92,5 +87,15 @@ if (!promote) {
   // retry repairs a partial write, and the preflight prevents an older run overwriting any newer feed.
   for (const name of feeds) upload(join('dist-assets', name), name, false, 'text/yaml')
   upload('version.json', 'version.json', false, 'application/json')
+  // Metadata is small; compare actual readback bytes before reporting a completed promotion.
+  for (const [file, name] of [
+    ...feeds.map((name) => [join('dist-assets', name), name]),
+    ['version.json', 'version.json']
+  ]) {
+    const digest = (bytes) => createHash('sha256').update(bytes).digest('hex')
+    if (digest(readRemote(name)) !== digest(readFileSync(file))) {
+      throw new Error(`Publication readback failed: ${name}`)
+    }
+  }
   console.log(`Promoted stable channel to ${version}.`)
 }

--- a/scripts/release-artifact-validation.mjs
+++ b/scripts/release-artifact-validation.mjs
@@ -20,26 +20,35 @@ export function artifactHash(file, algorithm, encoding = 'hex') {
   }
 }
 
-export function validateArtifactName(name, version) {
+export function validateArtifactName(name, version, allowLegacyNames = false) {
   if (
     typeof name !== 'string' ||
     /[/\\\r\n]/.test(name) ||
     !(
       name.startsWith(`aipoch-open-science-${version}-`) ||
-      name.startsWith(`aipoch-open-science_${version}_`)
+      name.startsWith(`aipoch-open-science_${version}_`) ||
+      (allowLegacyNames &&
+        (name.startsWith(`open-science-${version}-`) ||
+          name.startsWith(`open-science_${version}_`)))
     )
   ) {
     throw new Error(`Artifact name does not match release ${version}: ${name}`)
   }
 }
 
-export function validateUpdateFeed(feed, dir, version, metadataOnly = false) {
+export function validateUpdateFeed(
+  feed,
+  dir,
+  version,
+  metadataOnly = false,
+  allowLegacyNames = false
+) {
   if (feed?.version !== version || !Array.isArray(feed.files) || feed.files.length === 0) {
     throw new Error(`Invalid update feed for release ${version}`)
   }
   const seen = new Set()
   for (const file of feed.files) {
-    validateArtifactName(file.url, version)
+    validateArtifactName(file.url, version, allowLegacyNames)
     if (seen.has(file.url)) throw new Error(`Duplicate feed artifact: ${file.url}`)
     seen.add(file.url)
     const stat = statSync(join(dir, file.url))

--- a/scripts/release-artifact-validation.mjs
+++ b/scripts/release-artifact-validation.mjs
@@ -1,0 +1,67 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { createHash } from 'node:crypto'
+import { closeSync, openSync, readSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+// Release installers can exceed a gigabyte. Keep hashing bounded without changing the synchronous
+// manifest API used by the CLI and its consumers.
+export function artifactHash(file, algorithm, encoding = 'hex') {
+  const fd = openSync(file, 'r')
+  try {
+    const hash = createHash(algorithm)
+    const buffer = Buffer.alloc(1024 * 1024)
+    let length
+    while ((length = readSync(fd, buffer, 0, buffer.length, null)) > 0) {
+      hash.update(buffer.subarray(0, length))
+    }
+    return hash.digest(encoding)
+  } finally {
+    closeSync(fd)
+  }
+}
+
+export function validateArtifactName(name, version) {
+  if (
+    typeof name !== 'string' ||
+    /[/\\\r\n]/.test(name) ||
+    !(
+      name.startsWith(`aipoch-open-science-${version}-`) ||
+      name.startsWith(`aipoch-open-science_${version}_`)
+    )
+  ) {
+    throw new Error(`Artifact name does not match release ${version}: ${name}`)
+  }
+}
+
+export function validateUpdateFeed(feed, dir, version, metadataOnly = false) {
+  if (feed?.version !== version || !Array.isArray(feed.files) || feed.files.length === 0) {
+    throw new Error(`Invalid update feed for release ${version}`)
+  }
+  const seen = new Set()
+  for (const file of feed.files) {
+    validateArtifactName(file.url, version)
+    if (seen.has(file.url)) throw new Error(`Duplicate feed artifact: ${file.url}`)
+    seen.add(file.url)
+    const stat = statSync(join(dir, file.url))
+    if (
+      !stat.isFile() ||
+      !Number.isSafeInteger(file.size) ||
+      file.size <= 0 ||
+      file.size !== stat.size
+    ) {
+      throw new Error(`Feed artifact size mismatch: ${file.url}`)
+    }
+    if (typeof file.sha512 !== 'string' || !/^[A-Za-z0-9+/]{86}==$/.test(file.sha512)) {
+      throw new Error(`Invalid feed SHA512: ${file.url}`)
+    }
+    if (!metadataOnly && artifactHash(join(dir, file.url), 'sha512', 'base64') !== file.sha512) {
+      throw new Error(`Feed artifact SHA512 mismatch: ${file.url}`)
+    }
+  }
+  if (feed.path !== undefined || feed.sha512 !== undefined) {
+    const legacy = feed.files.find((file) => file.url === feed.path)
+    if (!legacy || legacy.sha512 !== feed.sha512)
+      throw new Error('Legacy feed fields disagree with files')
+  }
+  return feed
+}

--- a/scripts/release-publication-regressions.test.ts
+++ b/scripts/release-publication-regressions.test.ts
@@ -1,0 +1,506 @@
+import { createHash } from 'node:crypto'
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { load } from 'js-yaml'
+import { afterEach, expect, it } from 'vitest'
+
+import { buildManifest } from './generate-version-manifest.mjs'
+
+const repo = process.cwd()
+const require = createRequire(join(repo, 'package.json'))
+const directories: string[] = []
+const temporaryDirectory = (): string => {
+  const dir = mkdtempSync(join(tmpdir(), 'release-publication-'))
+  directories.push(dir)
+  return dir
+}
+afterEach(() =>
+  directories.splice(0).forEach((dir) => rmSync(dir, { recursive: true, force: true }))
+)
+const sha256 = (bytes: string): string => createHash('sha256').update(bytes).digest('hex')
+const config = load(readFileSync(join(repo, 'electron-builder.yml'), 'utf8')) as {
+  appImage: { artifactName: string }
+}
+const manifest = (dir: string): ReturnType<typeof buildManifest> =>
+  buildManifest({ dir, version: '0.27.0', cdnBase: 'https://cdn.example', prefix: 'open-science' })
+const installer = (name: string, digest?: string): string => {
+  const dir = temporaryDirectory()
+  writeFileSync(join(dir, name), 'synthetic installer')
+  writeFileSync(
+    join(dir, 'SHA256SUMS.txt'),
+    `${digest ?? sha256('synthetic installer')}  ${name}\n`
+  )
+  return dir
+}
+
+it('excludes local worktrees and tool state through the real packaging filter', () => {
+  const { getMainFileMatchers } = require('app-builder-lib/out/fileMatcher')
+  const filter = getMainFileMatchers(
+    repo,
+    join(temporaryDirectory(), 'out'),
+    (x: string) => x,
+    {},
+    {
+      info: {
+        projectDir: repo,
+        buildResourcesDir: 'build',
+        config,
+        isPrepackedAppAsar: false,
+        debugLogger: { isEnabled: false }
+      }
+    },
+    join(repo, 'dist'),
+    false
+  )[0].createFilter()
+  expect(filter(join(repo, 'out/main/index.js'), { isDirectory: () => false })).toBe(true)
+  for (const filename of [
+    '.worktree/example/.env',
+    '.worktrees/example/src/app.ts',
+    '.codegraph/codegraph.db',
+    '.agents/local.json'
+  ]) {
+    expect(filter(join(repo, filename), { isDirectory: () => false }), filename).toBe(false)
+  }
+})
+
+it('includes the AppImage filename produced by the installed builder', () => {
+  const { Arch, getArtifactArchName } = require('builder-util')
+  const { expandMacro } = require('app-builder-lib/out/util/macroExpander')
+  const name = expandMacro(
+    config.appImage.artifactName,
+    getArtifactArchName(Arch.x64, 'AppImage'),
+    { name: 'open-science', version: '0.27.0' },
+    { ext: 'AppImage', os: 'linux' }
+  )
+  expect(manifest(installer(name)).downloads['linux-x64-appimage']).toMatchObject({
+    size: Buffer.byteLength('synthetic installer'),
+    sha256: sha256('synthetic installer')
+  })
+})
+
+it('rejects an installer from a different release version', () => {
+  const dir = installer('aipoch-open-science-0.26.0-win-x64-setup.exe')
+  expect(() => manifest(dir)).toThrow()
+})
+
+it('rejects a checksum that does not match the installer bytes', () => {
+  const dir = installer('aipoch-open-science-0.27.0-win-x64-setup.exe', '0'.repeat(64))
+  expect(() => manifest(dir)).toThrow()
+})
+
+const writeFeed = (dir: string, arch: string, version: string): void => {
+  const name = `aipoch-open-science-${version}-mac-${arch}.zip`
+  const bytes = `synthetic ${arch} zip`
+  writeFileSync(join(dir, name), bytes)
+  writeFileSync(
+    join(dir, `${arch}-mac.yml`),
+    `version: ${version}\nfiles:\n  - url: ${name}\n    sha512: ${createHash('sha512').update(bytes).digest('base64')}\n    size: ${Buffer.byteLength(bytes)}\n`
+  )
+}
+const merge = (dir: string): ReturnType<typeof spawnSync> =>
+  spawnSync(process.execPath, [join(repo, 'scripts/merge-mac-feed.mjs'), dir], { encoding: 'utf8' })
+
+it('rejects macOS feeds from different release versions', () => {
+  const dir = temporaryDirectory()
+  writeFeed(dir, 'arm64', '0.27.0')
+  writeFeed(dir, 'x64', '0.26.0')
+  expect(merge(dir).status).not.toBe(0)
+})
+
+it('does not successfully publish a macOS feed with only one architecture', () => {
+  const dir = temporaryDirectory()
+  writeFeed(dir, 'arm64', '0.27.0')
+  writeFileSync(join(dir, 'latest-mac.yml'), readFileSync(join(dir, 'arm64-mac.yml')))
+  // This is the artifact directory left by a skipped notarization plus flattening collision.
+  rmSync(join(dir, 'arm64-mac.yml'))
+  expect(merge(dir).status).not.toBe(0)
+})
+
+type Workflow = { jobs: Record<string, { steps: Array<{ name: string; run?: string }> }> }
+const workflowStep = (filename: string, job: string, name: string): string => {
+  const workflow = load(readFileSync(join(repo, '.github/workflows', filename), 'utf8')) as Workflow
+  const script = workflow.jobs[job].steps.find((step) => step.name === name)?.run
+  if (!script) throw new Error(`Missing workflow step: ${name}`)
+  return script
+}
+
+// The real workflow shell runs against an isolated filesystem object store. No credentials,
+// network, installer execution or production source seam is involved.
+const objectStore = (): { cwd: string; env: NodeJS.ProcessEnv; remote: string } => {
+  const cwd = temporaryDirectory()
+  const bin = join(cwd, 'bin')
+  const remote = join(cwd, 'remote')
+  mkdirSync(bin)
+  mkdirSync(remote)
+  symlinkSync(join(repo, 'scripts'), join(cwd, 'scripts'), 'dir')
+  writeFileSync(
+    join(bin, 'aws'),
+    `#!/usr/bin/env node
+const fs = require('node:fs'), path = require('node:path');
+const args = process.argv.slice(2), root = process.env.TEST_OBJECT_STORE;
+fs.appendFileSync(path.join(root, 'operations.jsonl'), JSON.stringify(args) + '\\n');
+const local = p => p.startsWith('s3://') ? path.join(root, p.slice(5)) : p;
+if (args[0] === 's3api' && args[1] === 'head-object') {
+  if (process.env.TEST_FAIL_INSPECT === 'true') { console.error('An error occurred (403): Forbidden'); process.exit(1); }
+  const file = path.join(root, args[args.indexOf('--bucket') + 1], args[args.indexOf('--key') + 1]);
+  if (!fs.existsSync(file)) { console.error('An error occurred (404) when calling HeadObject: Not Found'); process.exit(1); }
+  process.exit(0);
+}
+if (args[0] !== 's3' || args[1] !== 'cp') throw Error('Unsupported AWS test operation');
+if (args[3].startsWith('s3://') && args[3].endsWith(process.env.TEST_FAIL_UPLOAD || '\\0')) {console.error('Upload interrupted'); process.exit(1);}
+const source = local(args[2]), target = local(args[3]);
+fs.mkdirSync(path.dirname(target), {recursive:true}); fs.copyFileSync(source, target);
+`,
+    { mode: 0o755 }
+  )
+  return {
+    cwd,
+    remote,
+    env: {
+      ...process.env,
+      PATH: `${bin}:${process.env.PATH}`,
+      TEST_OBJECT_STORE: remote,
+      S3_BUCKET: 'test-bucket',
+      S3_PREFIX: 'open-science/app/stable',
+      VERSION: '1'
+    }
+  }
+}
+
+it.skipIf(process.platform === 'win32')(
+  'keeps the newer stable pointer when an older release is mirrored',
+  () => {
+    const { cwd, remote, env } = objectStore()
+    const script = workflowStep('mirror-to-website.yml', 'mirror', 'Upload version.json')
+    mkdirSync(join(cwd, 'dist-assets'))
+    for (const version of ['0.27.0', '0.26.0']) {
+      for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml'])
+        writeFileSync(join(cwd, 'dist-assets', name), `version: ${version}\n`)
+      writeFileSync(join(cwd, 'version.json'), JSON.stringify({ version }))
+      const result = spawnSync('bash', ['-eu', '-c', script], { cwd, env, encoding: 'utf8' })
+      expect(result.status, result.stderr).toBe(0)
+    }
+    expect(
+      JSON.parse(
+        readFileSync(join(remote, 'test-bucket/open-science/app/stable/version.json'), 'utf8')
+      ).version
+    ).toBe('0.27.0')
+  }
+)
+
+it.skipIf(process.platform === 'win32')(
+  'preserves published runtime bytes when the same version is restaged',
+  () => {
+    const { cwd, remote, env } = objectStore()
+    const workflow = load(
+      readFileSync(join(repo, '.github/workflows/stage-runtime-bundle.yml'), 'utf8')
+    ) as Workflow
+    const job = Object.keys(workflow.jobs).find((key) =>
+      workflow.jobs[key].steps?.some((step) => step.name === 'Upload bundle to CDN')
+    )!
+    const script = workflowStep('stage-runtime-bundle.yml', job, 'Upload bundle to CDN').replaceAll(
+      '${{ matrix.subdir }}',
+      'linux-64'
+    )
+    const local = join(cwd, 'resources/default-envs')
+    mkdirSync(local, { recursive: true })
+    for (const bytes of ['original archive', 'changed archive']) {
+      writeFileSync(join(local, 'python-3.12.tar.zst'), bytes)
+      writeFileSync(join(local, 'manifest.json'), JSON.stringify({ sha256: sha256(bytes) }))
+      const result = spawnSync('bash', ['-eu', '-c', script], { cwd, env, encoding: 'utf8' })
+      if (bytes === 'original archive') expect(result.status, result.stderr).toBe(0)
+    }
+    expect(
+      readFileSync(
+        join(remote, 'test-bucket/open-science/runtime-bundle/1/linux-64/python-3.12.tar.zst'),
+        'utf8'
+      )
+    ).toBe('original archive')
+  }
+)
+
+it.skipIf(process.platform === 'win32')(
+  'does not replace certified public installers during standalone notarization',
+  () => {
+    const { cwd, remote, env } = objectStore()
+    const name = 'aipoch-open-science-0.27.0-mac-arm64.dmg'
+    mkdirSync(join(cwd, 'mac'))
+    writeFileSync(join(remote, name), 'certified original')
+    writeFileSync(
+      join(remote, 'RELEASE-CERTIFICATION.json'),
+      JSON.stringify({ sha256: sha256('certified original') })
+    )
+    writeFileSync(join(cwd, 'mac', name), 'stapled replacement')
+    writeFileSync(
+      join(cwd, 'bin', 'gh'),
+      `#!/usr/bin/env node
+const fs = require('node:fs'), path = require('node:path');
+const args = process.argv.slice(2);
+if (args[0] !== 'release' || args[1] !== 'upload') throw Error('Unexpected GitHub operation');
+for (const file of args.slice(3, args.indexOf('--repo'))) {
+  if (fs.existsSync(file)) fs.copyFileSync(file, path.join(process.env.TEST_OBJECT_STORE, path.basename(file)));
+}
+`,
+      { mode: 0o755 }
+    )
+    const workflow = load(
+      readFileSync(join(repo, '.github/workflows/notarize-mac.yml'), 'utf8')
+    ) as Workflow
+    // Exercise the existing public-release write boundary using final stapled bytes as input.
+    // Real Apple signing is outside this test; GitHub's filesystem effect is the only substitute.
+    const upload = workflow.jobs.notarize.steps.find(
+      (step) => step.name === 'Clobber stapled assets onto the release'
+    )
+    if (upload?.run) {
+      const result = spawnSync(
+        'bash',
+        ['-eu', '-c', upload.run.replaceAll('${{ inputs.tag }}', 'v0.27.0')],
+        {
+          cwd,
+          env: { ...env, GITHUB_REPOSITORY: 'example/test' },
+          encoding: 'utf8'
+        }
+      )
+      expect(result.status, result.stderr).toBe(0)
+    }
+    const certification = JSON.parse(
+      readFileSync(join(remote, 'RELEASE-CERTIFICATION.json'), 'utf8')
+    )
+    expect(sha256(readFileSync(join(remote, name), 'utf8'))).toBe(certification.sha256)
+  }
+)
+
+it('packages required runtime files without local tool directories in a harmless ASAR sample', async () => {
+  const { cpSync, existsSync } = await import('node:fs')
+  const { createPackage, listPackage } = require('@electron/asar')
+  const source = temporaryDirectory(),
+    staged = temporaryDirectory(),
+    dest = join(temporaryDirectory(), 'app.asar')
+  const keep = ['out/main/index.js', 'resources/start.py', 'resources/native/addon.node']
+  const reject = [
+    '.worktree/copy/.env',
+    'nested/.worktree/copy/main.js',
+    '.codegraph/index.db',
+    'nested/.agents/state.json',
+    '.worktrees/old/main.js'
+  ]
+  for (const name of [...keep, ...reject]) {
+    mkdirSync(join(source, name, '..'), { recursive: true })
+    writeFileSync(join(source, name), 'harmless test fixture')
+  }
+  const { getMainFileMatchers } = require('app-builder-lib/out/fileMatcher')
+  const filter = getMainFileMatchers(
+    source,
+    staged,
+    (value: string) => value,
+    {},
+    {
+      info: {
+        projectDir: source,
+        buildResourcesDir: 'build',
+        config,
+        isPrepackedAppAsar: false,
+        debugLogger: { isEnabled: false }
+      }
+    },
+    join(source, 'dist'),
+    false
+  )[0].createFilter()
+  cpSync(source, staged, {
+    recursive: true,
+    filter: (file) => file === source || filter(file, require('node:fs').statSync(file))
+  })
+  for (const name of reject) expect(existsSync(join(staged, name)), name).toBe(false)
+  await createPackage(staged, dest)
+  const contents = listPackage(dest).map((name: string) => name.replaceAll('\\', '/'))
+  for (const name of keep) expect(contents).toContain(`/${name}`)
+  expect(contents.some((name: string) => /\.(worktrees?|codegraph|agents)(\/|$)/.test(name))).toBe(
+    false
+  )
+})
+
+it('rejects duplicate AppImage spellings instead of selecting an arbitrary download', () => {
+  const dir = installer('aipoch-open-science-0.27.0-linux-x64.AppImage')
+  const other = 'aipoch-open-science-0.27.0-linux-x86_64.AppImage'
+  writeFileSync(join(dir, other), 'synthetic installer')
+  writeFileSync(
+    join(dir, 'SHA256SUMS.txt'),
+    `${sha256('synthetic installer')}  aipoch-open-science-0.27.0-linux-x64.AppImage\n${sha256('synthetic installer')}  ${other}\n`
+  )
+  expect(() => manifest(dir)).toThrow(/Duplicate installer/)
+})
+
+it('rejects duplicate checksums and zero-byte installers', () => {
+  const name = 'aipoch-open-science-0.27.0-win-x64-setup.exe'
+  const dir = installer(name)
+  const sums = readFileSync(join(dir, 'SHA256SUMS.txt'), 'utf8')
+  writeFileSync(join(dir, 'SHA256SUMS.txt'), sums + sums)
+  expect(() => manifest(dir)).toThrow(/Duplicate SHA256/)
+  writeFileSync(join(dir, name), '')
+  writeFileSync(join(dir, 'SHA256SUMS.txt'), `${sha256('')}  ${name}\n`)
+  expect(() => manifest(dir)).toThrow(/Empty/)
+})
+
+it('merges matching native macOS ZIPs and refuses tampered feed bytes', () => {
+  const dir = temporaryDirectory()
+  writeFeed(dir, 'arm64', '0.27.0')
+  writeFeed(dir, 'x64', '0.27.0')
+  const result = merge(dir)
+  expect(result.status, String(result.stderr)).toBe(0)
+  const feed = load(readFileSync(join(dir, 'latest-mac.yml'), 'utf8')) as { files: unknown[] }
+  expect(feed.files).toHaveLength(2)
+  writeFileSync(join(dir, 'aipoch-open-science-0.27.0-mac-x64.zip'), 'tampered bytes')
+  const tampered = merge(dir)
+  expect(tampered.status).not.toBe(0)
+  expect(String(tampered.stderr)).toMatch(/mismatch/)
+})
+
+it('allows a non-mac local merge directory without manufacturing a feed', () => {
+  expect(merge(temporaryDirectory()).status).toBe(0)
+})
+
+it('keeps sparse dry-run validation explicit while checking feed versions and sizes', () => {
+  const name = 'aipoch-open-science-0.27.0-win-x64-setup.exe'
+  const dir = installer(name, '0'.repeat(64))
+  const options = {
+    dir,
+    version: '0.27.0',
+    cdnBase: 'https://cdn.example',
+    prefix: 'open-science',
+    metadataOnly: true
+  }
+  expect(buildManifest(options).downloads['win-x64']).toBeDefined()
+  expect(() => buildManifest({ ...options, metadataOnly: false })).toThrow(/SHA256 mismatch/)
+  writeFileSync(join(dir, 'latest.yml'), `version: 0.26.0\nfiles: []\n`)
+  expect(() => buildManifest(options)).toThrow(/Invalid update feed/)
+})
+
+it.skipIf(process.platform === 'win32')(
+  'rejects the retired notarization dispatch before credential or asset operations',
+  () => {
+    const script = workflowStep(
+      'notarize-mac.yml',
+      'notarize',
+      'Require unpublished build artifacts'
+    )
+    expect(
+      spawnSync('bash', ['-eu', '-c', script], {
+        env: { ...process.env, FROM_RUN: 'false' },
+        encoding: 'utf8'
+      })
+    ).toMatchObject({ status: 1 })
+    expect(
+      spawnSync('bash', ['-eu', '-c', script], {
+        env: { ...process.env, FROM_RUN: 'true' },
+        encoding: 'utf8'
+      })
+    ).toMatchObject({ status: 0 })
+    const raw = readFileSync(join(repo, '.github/workflows/notarize-mac.yml'), 'utf8')
+    expect(raw).not.toContain('gh release upload')
+    expect(raw).not.toContain('contents: write')
+  }
+)
+
+const stageRuntime = (fixture: ReturnType<typeof objectStore>): ReturnType<typeof spawnSync> => {
+  const script = workflowStep(
+    'stage-runtime-bundle.yml',
+    'stage',
+    'Upload bundle to CDN'
+  ).replaceAll('${{ matrix.subdir }}', 'linux-64')
+  return spawnSync('bash', ['-eu', '-c', script], { ...fixture, encoding: 'utf8' })
+}
+const runtimeFixture = (): ReturnType<typeof objectStore> => {
+  const fixture = objectStore()
+  mkdirSync(join(fixture.cwd, 'resources/default-envs'), { recursive: true })
+  writeFileSync(join(fixture.cwd, 'resources/default-envs/python-3.12.tar.zst'), 'archive')
+  writeFileSync(
+    join(fixture.cwd, 'resources/default-envs/manifest.json'),
+    JSON.stringify({ sha256: sha256('archive') })
+  )
+  return fixture
+}
+
+it.skipIf(process.platform === 'win32')(
+  'resumes an interrupted runtime upload and makes an identical retry a no-op',
+  () => {
+    const fixture = runtimeFixture()
+    fixture.env.TEST_FAIL_UPLOAD = '/manifest.json'
+    expect(stageRuntime(fixture).status).not.toBe(0)
+    delete fixture.env.TEST_FAIL_UPLOAD
+    expect(stageRuntime(fixture).status).toBe(0)
+    writeFileSync(join(fixture.remote, 'operations.jsonl'), '')
+    expect(stageRuntime(fixture).status).toBe(0)
+    const operations = readFileSync(join(fixture.remote, 'operations.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(operations.some((args) => args[0] === 's3' && args[3].startsWith('s3://'))).toBe(false)
+  }
+)
+
+it.skipIf(process.platform === 'win32')(
+  'does not treat an inaccessible runtime object as absent',
+  () => {
+    const fixture = runtimeFixture()
+    fixture.env.TEST_FAIL_INSPECT = 'true'
+    const result = stageRuntime(fixture)
+    expect(result.status).not.toBe(0)
+    expect(String(result.stderr)).toMatch(/Cannot inspect/)
+    const operations = readFileSync(join(fixture.remote, 'operations.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(operations.some((args) => args[0] === 's3')).toBe(false)
+  }
+)
+
+it.skipIf(process.platform === 'win32')(
+  'refuses a changed runtime manifest before uploading any extra pack',
+  () => {
+    const fixture = runtimeFixture()
+    expect(stageRuntime(fixture).status).toBe(0)
+    writeFileSync(join(fixture.cwd, 'resources/default-envs/r-4.4.tar.zst'), 'new archive')
+    writeFileSync(join(fixture.cwd, 'resources/default-envs/manifest.json'), '{"changed":true}')
+    writeFileSync(join(fixture.remote, 'operations.jsonl'), '')
+    const result = stageRuntime(fixture)
+    expect(result.status).not.toBe(0)
+    expect(String(result.stderr)).toMatch(/immutable/)
+    const operations = readFileSync(join(fixture.remote, 'operations.jsonl'), 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line))
+    expect(operations.some((args) => args[0] === 's3' && args[3].startsWith('s3://'))).toBe(false)
+  }
+)
+
+it.skipIf(process.platform === 'win32')(
+  'recovers a partially promoted channel without allowing an older queued run to roll its feeds back',
+  () => {
+    const fixture = objectStore()
+    const { cwd, remote, env } = fixture
+    const script = workflowStep('mirror-to-website.yml', 'mirror', 'Upload version.json')
+    mkdirSync(join(cwd, 'dist-assets'))
+    const promote = (version: string): ReturnType<typeof spawnSync> => {
+      writeFileSync(join(cwd, 'version.json'), JSON.stringify({ version }))
+      for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml'])
+        writeFileSync(join(cwd, 'dist-assets', name), `version: ${version}\n`)
+      return spawnSync('bash', ['-eu', '-c', script], { cwd, env, encoding: 'utf8' })
+    }
+    expect(promote('0.26.0').status).toBe(0)
+    env.TEST_FAIL_UPLOAD = '/version.json'
+    expect(promote('0.27.0').status).not.toBe(0)
+    delete env.TEST_FAIL_UPLOAD
+    expect(promote('0.26.0').status).toBe(0)
+    const channel = join(remote, 'test-bucket/open-science/app/stable')
+    expect(
+      (load(readFileSync(join(channel, 'latest.yml'), 'utf8')) as { version: string }).version
+    ).toBe('0.27.0')
+    expect(promote('0.27.0').status).toBe(0)
+    expect(JSON.parse(readFileSync(join(channel, 'version.json'), 'utf8')).version).toBe('0.27.0')
+  },
+  30000
+)

--- a/scripts/release-publication-regressions.test.ts
+++ b/scripts/release-publication-regressions.test.ts
@@ -1,6 +1,14 @@
 import { createHash } from 'node:crypto'
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSync } from 'node:fs'
+import {
+  copyFileSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -170,27 +178,6 @@ fs.mkdirSync(path.dirname(target), {recursive:true}); fs.copyFileSync(source, ta
     }
   }
 }
-
-it.skipIf(process.platform === 'win32')(
-  'keeps the newer stable pointer when an older release is mirrored',
-  () => {
-    const { cwd, remote, env } = objectStore()
-    const script = workflowStep('mirror-to-website.yml', 'mirror', 'Upload version.json')
-    mkdirSync(join(cwd, 'dist-assets'))
-    for (const version of ['0.27.0', '0.26.0']) {
-      for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml'])
-        writeFileSync(join(cwd, 'dist-assets', name), `version: ${version}\n`)
-      writeFileSync(join(cwd, 'version.json'), JSON.stringify({ version }))
-      const result = spawnSync('bash', ['-eu', '-c', script], { cwd, env, encoding: 'utf8' })
-      expect(result.status, result.stderr).toBe(0)
-    }
-    expect(
-      JSON.parse(
-        readFileSync(join(remote, 'test-bucket/open-science/app/stable/version.json'), 'utf8')
-      ).version
-    ).toBe('0.27.0')
-  }
-)
 
 it.skipIf(process.platform === 'win32')(
   'preserves published runtime bytes when the same version is restaged',
@@ -477,30 +464,77 @@ it.skipIf(process.platform === 'win32')(
   }
 )
 
+it('validates legacy installer bytes for version-directory backfill without updater feeds', () => {
+  const dir = installer('open-science-0.1.2-linux-x86_64.AppImage')
+  const args = {
+    dir,
+    version: '0.1.2',
+    cdnBase: 'https://cdn.example',
+    prefix: 'open-science',
+    allowLegacyNames: true
+  }
+  expect(buildManifest(args).downloads['linux-x64-appimage']).toMatchObject({
+    sha256: sha256('synthetic installer')
+  })
+  writeFileSync(join(dir, 'open-science-0.1.2-linux-x86_64.AppImage'), 'corrupted installer')
+  expect(() => buildManifest(args)).toThrow(/SHA256 mismatch/)
+})
+
 it.skipIf(process.platform === 'win32')(
-  'recovers a partially promoted channel without allowing an older queued run to roll its feeds back',
+  'backfills a legacy release through the real mirror steps without changing stable',
   () => {
-    const fixture = objectStore()
-    const { cwd, remote, env } = fixture
-    const script = workflowStep('mirror-to-website.yml', 'mirror', 'Upload version.json')
-    mkdirSync(join(cwd, 'dist-assets'))
-    const promote = (version: string): ReturnType<typeof spawnSync> => {
-      writeFileSync(join(cwd, 'version.json'), JSON.stringify({ version }))
-      for (const name of ['latest.yml', 'latest-linux.yml', 'latest-mac.yml'])
-        writeFileSync(join(cwd, 'dist-assets', name), `version: ${version}\n`)
-      return spawnSync('bash', ['-eu', '-c', script], { cwd, env, encoding: 'utf8' })
+    const { cwd, remote, env } = objectStore()
+    rmSync(join(cwd, 'scripts'))
+    mkdirSync(join(cwd, 'scripts'))
+    for (const name of [
+      'generate-version-manifest.mjs',
+      'release-artifact-validation.mjs',
+      'publish-update-channel.mjs',
+      'publish-release-assets.mjs'
+    ]) {
+      copyFileSync(join(repo, 'scripts', name), join(cwd, 'scripts', name))
     }
-    expect(promote('0.26.0').status).toBe(0)
-    env.TEST_FAIL_UPLOAD = '/version.json'
-    expect(promote('0.27.0').status).not.toBe(0)
-    delete env.TEST_FAIL_UPLOAD
-    expect(promote('0.26.0').status).toBe(0)
+    symlinkSync(join(repo, 'node_modules'), join(cwd, 'node_modules'), 'dir')
+    const dir = join(cwd, 'dist-assets')
+    mkdirSync(dir)
+    const name = 'open-science-0.1.2-linux-x86_64.AppImage'
+    writeFileSync(join(dir, name), 'synthetic installer')
+    writeFileSync(join(dir, 'SHA256SUMS.txt'), `${sha256('synthetic installer')}  ${name}\n`)
+    const notes = join(cwd, 'notes')
+    mkdirSync(notes)
+    writeFileSync(join(notes, 'en.md'), 'Historical release')
+    writeFileSync(
+      join(cwd, 'bin', 'gh'),
+      '#!/usr/bin/env node\nconsole.log("2026-01-01T00:00:00Z")\n',
+      { mode: 0o755 }
+    )
     const channel = join(remote, 'test-bucket/open-science/app/stable')
-    expect(
-      (load(readFileSync(join(channel, 'latest.yml'), 'utf8')) as { version: string }).version
-    ).toBe('0.27.0')
-    expect(promote('0.27.0').status).toBe(0)
-    expect(JSON.parse(readFileSync(join(channel, 'version.json'), 'utf8')).version).toBe('0.27.0')
-  },
-  30000
+    mkdirSync(channel, { recursive: true })
+    const current = JSON.stringify({ version: '0.27.0' })
+    writeFileSync(join(channel, 'version.json'), current)
+    const run = (step: string, mode: string): ReturnType<typeof spawnSync> =>
+      spawnSync('bash', ['-eu', '-c', workflowStep('mirror-to-website.yml', 'mirror', step)], {
+        cwd,
+        encoding: 'utf8',
+        env: {
+          ...env,
+          VERSION: '0.1.2',
+          MODE: mode,
+          METADATA_ONLY: 'false',
+          NOTES_DIR: notes,
+          CDN_BASE_URL: 'https://cdn.example',
+          TAG: 'v0.1.2',
+          GITHUB_REPOSITORY: 'fixture/repo'
+        }
+      })
+    const generated = run('Generate version.json', 'backfill')
+    expect(generated.status, generated.stderr).toBe(0)
+    const published = run('Sync installers to versioned path', 'backfill')
+    expect(published.status, published.stderr).toBe(0)
+    expect(readFileSync(join(channel, 'releases/0.1.2', name), 'utf8')).toBe('synthetic installer')
+    expect(readFileSync(join(channel, 'version.json'), 'utf8')).toBe(current)
+    expect(run('Generate version.json', 'promote').status).not.toBe(0)
+    expect(run('Sync installers to versioned path', 'promote').status).not.toBe(0)
+    expect(readFileSync(join(channel, 'version.json'), 'utf8')).toBe(current)
+  }
 )

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -713,7 +713,9 @@ if ($artifactReservationBase -eq $artifactReservationCommit) {
     expect(historical.run).toContain('historical-blockmaps/$version/$name')
     expect(historical.run).toContain('gzip -t "$target"')
     const backfill = findStep(mirror, 'Backfill historical Windows blockmaps')
-    expect(backfill.run).toContain('releases/$version/$(basename "$blockmap")')
+    expect(backfill.run).toContain(
+      'scripts/publish-release-assets.mjs blockmaps historical-blockmaps'
+    )
     for (const sideEffectStep of [
       'Configure AWS credentials',
       'Collect historical Windows blockmaps',

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -552,8 +552,8 @@ if ($artifactReservationBase -eq $artifactReservationCommit) {
     expect(previous.run).toContain('gh release download')
     expect(previous.run).toContain('*-win-x64-setup.exe.blockmap')
     expect(previous.run).not.toContain('Get-AuthenticodeSignature')
-    expect(previous.run).toContain("$_.tagName -like 'v*'")
-    expect(previous.run).toContain('$_.tagName -ne $env:CURRENT_TAG')
+    expect(previous.run).toContain('gh api --paginate --slurp')
+    expect(previous.run).toContain('$version -lt $current')
     expect(findStep(upgrade, 'Certify Windows electron-updater differential update')).toMatchObject(
       {
         id: 'updater',

--- a/scripts/windows-upgrade-baseline.test.ts
+++ b/scripts/windows-upgrade-baseline.test.ts
@@ -1,35 +1,82 @@
 import { spawnSync } from 'node:child_process'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { load } from 'js-yaml'
 import { expect, it } from 'vitest'
 
-// Run the workflow's actual PowerShell selection boundary. The gh function is deliberately local:
-// it supplies API pages and records downloads, never reaches GitHub or executes an installer.
-it.skipIf(process.platform !== 'win32')(
-  'selects an older stable installer when replaying a historical release',
-  () => {
-    const dir = mkdtempSync(join(tmpdir(), 'windows-upgrade-baseline-'))
-    try {
-      const workflow = load(
-        readFileSync('.github/workflows/windows-upgrade-smoke.yml', 'utf8')
-      ) as {
-        jobs: Record<string, { steps: { name: string; run?: string }[] }>
-      }
-      const step = workflow.jobs['windows-upgrade-smoke'].steps.find(
-        (item) => item.name === 'Download previous stable Windows installer'
-      )!
-      expect(step.run).toBeTruthy()
-      const script = join(dir, 'selection.ps1')
-      writeFileSync(
-        script,
-        `
+const release = (tag: string, blockmap = true, draft = false): object => ({
+  tag_name: tag,
+  draft,
+  prerelease: false,
+  assets: (blockmap ? ['.exe', '.exe.blockmap'] : ['.exe']).map((ext) => ({
+    name: `aipoch-open-science-${tag.slice(1)}-win-x64-setup${ext}`
+  }))
+})
+
+// Run the workflow's actual PowerShell selection boundary. The gh function supplies API pages and
+// records downloads locally; no GitHub traffic or real installer execution is possible.
+it.skipIf(process.platform !== 'win32').each([
+  {
+    name: 'historical release',
+    current: 'v0.27.0',
+    pages: [[release('v0.28.0'), release('v0.27.0'), release('v0.26.0')]],
+    expected: 'v0.26.0'
+  },
+  {
+    name: 'out-of-order publication',
+    current: 'v0.27.0',
+    pages: [[release('v0.9.0'), release('v0.26.0'), release('v0.25.0')]],
+    expected: 'v0.26.0'
+  },
+  {
+    name: 'older installer on a later API page',
+    current: 'v0.27.0',
+    pages: [Array.from({ length: 20 }, (_, i) => release(`v0.28.${i}`)), [release('v0.26.0')]],
+    expected: 'v0.26.0'
+  },
+  {
+    name: 'missing blockmap and draft release',
+    current: 'v0.27.0',
+    pages: [[release('v0.26.0', false), release('v0.25.0', true, true), release('v0.24.0')]],
+    expected: 'v0.24.0'
+  },
+  {
+    name: 'first stable release',
+    current: 'v0.1.0',
+    pages: [[release('v0.1.0')]],
+    expected: undefined
+  },
+  {
+    name: 'failed release lookup',
+    current: 'v0.27.0',
+    pages: [],
+    expected: undefined,
+    failed: true
+  }
+])('selects an eligible older Windows installer: $name', ({ current, pages, expected, failed }) => {
+  const dir = mkdtempSync(join(tmpdir(), 'windows-upgrade-baseline-'))
+  try {
+    const workflow = load(readFileSync('.github/workflows/windows-upgrade-smoke.yml', 'utf8')) as {
+      jobs: Record<string, { steps: { name: string; run?: string }[] }>
+    }
+    const step = workflow.jobs['windows-upgrade-smoke'].steps.find(
+      (item) => item.name === 'Download previous stable Windows installer'
+    )!
+    expect(step.run).toBeTruthy()
+    writeFileSync(join(dir, 'releases.json'), JSON.stringify(pages))
+    const script = join(dir, 'selection.ps1')
+    writeFileSync(
+      script,
+      `
 function gh {
   $global:LASTEXITCODE = 0
+  if ($env:TEST_API_FAIL -eq 'true') { $global:LASTEXITCODE = 7; return }
   if ($args[0] -eq 'release' -and $args[1] -eq 'list') {
-    return '[{"tagName":"v0.28.0"},{"tagName":"v0.27.0"},{"tagName":"v0.26.0"}]'
+    $releases = @(Get-Content -Raw $env:TEST_RELEASES | ConvertFrom-Json | ForEach-Object { $_ })
+    return ConvertTo-Json -InputObject @($releases | ForEach-Object { @{tagName=$_.tag_name} })
   }
+  if ($args[0] -eq 'api') { return Get-Content -Raw $env:TEST_RELEASES }
   if ($args[0] -eq 'release' -and $args[1] -eq 'download') {
     $args[2] | Out-File -FilePath $env:TEST_SELECTED_TAG -Encoding utf8
     return
@@ -38,21 +85,28 @@ function gh {
 }
 ${step.run}
 `
+    )
+    const result = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-File', script], {
+      cwd: dir,
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        CURRENT_TAG: current,
+        TEST_RELEASES: join(dir, 'releases.json'),
+        GITHUB_REPOSITORY: 'example/test',
+        GITHUB_OUTPUT: join(dir, 'output.txt'),
+        TEST_SELECTED_TAG: join(dir, 'selected.txt'),
+        TEST_API_FAIL: failed ? 'true' : 'false'
+      }
+    })
+    expect(result.status, result.stderr).toBe(failed ? 7 : 0)
+    if (expected) expect(readFileSync(join(dir, 'selected.txt'), 'utf8').trim()).toBe(expected)
+    else expect(existsSync(join(dir, 'selected.txt'))).toBe(false)
+    if (!failed)
+      expect(readFileSync(join(dir, 'output.txt'), 'utf8')).toContain(
+        `available=${expected ? 'true' : 'false'}`
       )
-      const result = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-File', script], {
-        cwd: dir,
-        encoding: 'utf8',
-        env: {
-          ...process.env,
-          CURRENT_TAG: 'v0.27.0',
-          GITHUB_OUTPUT: join(dir, 'output.txt'),
-          TEST_SELECTED_TAG: join(dir, 'selected.txt')
-        }
-      })
-      expect(result.status, result.stderr).toBe(0)
-      expect(readFileSync(join(dir, 'selected.txt'), 'utf8').trim()).toBe('v0.26.0')
-    } finally {
-      rmSync(dir, { recursive: true, force: true })
-    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
   }
-)
+})

--- a/scripts/windows-upgrade-baseline.test.ts
+++ b/scripts/windows-upgrade-baseline.test.ts
@@ -1,0 +1,58 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { load } from 'js-yaml'
+import { expect, it } from 'vitest'
+
+// Run the workflow's actual PowerShell selection boundary. The gh function is deliberately local:
+// it supplies API pages and records downloads, never reaches GitHub or executes an installer.
+it.skipIf(process.platform !== 'win32')(
+  'selects an older stable installer when replaying a historical release',
+  () => {
+    const dir = mkdtempSync(join(tmpdir(), 'windows-upgrade-baseline-'))
+    try {
+      const workflow = load(
+        readFileSync('.github/workflows/windows-upgrade-smoke.yml', 'utf8')
+      ) as {
+        jobs: Record<string, { steps: { name: string; run?: string }[] }>
+      }
+      const step = workflow.jobs['windows-upgrade-smoke'].steps.find(
+        (item) => item.name === 'Download previous stable Windows installer'
+      )!
+      expect(step.run).toBeTruthy()
+      const script = join(dir, 'selection.ps1')
+      writeFileSync(
+        script,
+        `
+function gh {
+  $global:LASTEXITCODE = 0
+  if ($args[0] -eq 'release' -and $args[1] -eq 'list') {
+    return '[{"tagName":"v0.28.0"},{"tagName":"v0.27.0"},{"tagName":"v0.26.0"}]'
+  }
+  if ($args[0] -eq 'release' -and $args[1] -eq 'download') {
+    $args[2] | Out-File -FilePath $env:TEST_SELECTED_TAG -Encoding utf8
+    return
+  }
+  throw "Unexpected gh operation: $args"
+}
+${step.run}
+`
+      )
+      const result = spawnSync('pwsh', ['-NoProfile', '-NonInteractive', '-File', script], {
+        cwd: dir,
+        encoding: 'utf8',
+        env: {
+          ...process.env,
+          CURRENT_TAG: 'v0.27.0',
+          GITHUB_OUTPUT: join(dir, 'output.txt'),
+          TEST_SELECTED_TAG: join(dir, 'selected.txt')
+        }
+      })
+      expect(result.status, result.stderr).toBe(0)
+      expect(readFileSync(join(dir, 'selected.txt'), 'utf8').trim()).toBe('v0.26.0')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  }
+)

--- a/src/main/compute/compute-job-operation-repository.ts
+++ b/src/main/compute/compute-job-operation-repository.ts
@@ -4,6 +4,13 @@ import type { Prisma, PrismaClient } from '@prisma/client'
 
 import type { ComputeJobStatus } from '../../shared/compute'
 
+// Match upload publication's admission budget on the shared single-connection SQLite client.
+// Execution deadlines and rollback behavior remain Prisma defaults.
+const runOperationTransaction = <Result>(
+  client: Pick<PrismaClient, '$transaction'>,
+  operation: (transaction: Prisma.TransactionClient) => Promise<Result>
+): Promise<Result> => client.$transaction(operation, { maxWait: 10_000 })
+
 type OperationClient = Pick<PrismaClient, '$transaction' | 'computeJobOperation'>
 type OperationClientProvider = () => Promise<OperationClient>
 
@@ -117,7 +124,7 @@ class ComputeJobOperationRepository {
     | { found: true; jobStatus: ComputeJobStatus; record: ComputeJobOperationRecord }
   > {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
+    return runOperationTransaction(client, async (transaction) => {
       const job = await transaction.computeJob.findFirst({
         where: {
           id: jobId,
@@ -183,7 +190,7 @@ class ComputeJobOperationRepository {
     claimToken: string
   ): Promise<ClaimedComputeJobOperation | null> {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
+    return runOperationTransaction(client, async (transaction) => {
       switch (kind) {
         case 'cancel': {
           const terminal = await transaction.computeJobOperation.findFirst({
@@ -256,7 +263,7 @@ class ComputeJobOperationRepository {
     remoteWorkdirAbsent = false
   ): Promise<boolean> {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
+    return runOperationTransaction(client, async (transaction) => {
       switch (claim.operation.kind) {
         case 'cancel': {
           const terminalized = await transaction.computeJob.updateMany({
@@ -316,7 +323,7 @@ class ComputeJobOperationRepository {
     now: Date
   ): Promise<boolean> {
     const client = await this.getClient()
-    return client.$transaction(async (transaction) => {
+    return runOperationTransaction(client, async (transaction) => {
       const job = await transaction.computeJob.findFirst({
         where: {
           id: jobId,

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -5912,11 +5912,12 @@ describe('notebook runtime service', () => {
           }
         }
       )
+      const repository = new NotebookRunRepository(root)
       const service = new NotebookRuntimeService({
         configRoot: root,
         dataRoot: root,
         projectId: 'default-project',
-        repository: new NotebookRunRepository(root),
+        repository,
         executorFactory: () => ({ execute, shutdown: async () => ({ reaped: true }) })
       })
       const request = { sessionId: 'session-1', workspaceCwd: root, cellId: 'cell-b' }
@@ -5941,11 +5942,29 @@ describe('notebook runtime service', () => {
             })
           )
           await blockerStarted.promise
+          // Real durable admission may exceed vi.waitFor's one-second default under CI load.
+          const appendRun = repository.appendOrGetRun.bind(repository)
+          vi.spyOn(repository, 'appendOrGetRun').mockImplementationOnce(async (input) => {
+            await new Promise((resolve) => setTimeout(resolve, 1250))
+            return appendRun(input)
+          })
           // Data runs have no public queued-state projection. Observe the existing queue entry
           // without replacing its behavior so rewriting happens strictly after admission.
+          const admitted = createDeferred<void>()
+          const enqueueExecution = NotebookSessionAggregate.prototype.enqueueExecution
           enqueue = vi.spyOn(NotebookSessionAggregate.prototype, 'enqueueExecution')
-          pending.push(service.runCell(request))
-          await vi.waitFor(() => expect(enqueue).toHaveBeenCalledTimes(1))
+          enqueue.mockImplementation(function (
+            this: NotebookSessionAggregate,
+            ...args: Parameters<typeof enqueueExecution>
+          ) {
+            const result = enqueueExecution.apply(this, args)
+            admitted.resolve()
+            return result
+          })
+          const queuedRun = service.runCell(request)
+          pending.push(queuedRun)
+          await Promise.race([admitted.promise, queuedRun])
+          expect(enqueue).toHaveBeenCalledTimes(1)
           enqueue.mockRestore()
           await expect(
             service.beginCodeCell({ ...request, language: requestedLanguage })

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -25,6 +25,7 @@ import { ProjectRepository } from '../projects/repository'
 import { buildSessionProjection, SessionProjectionRepository } from './projection'
 import { SessionAuxiliaryTurnUsageRecorder } from './auxiliary-turn-usage'
 import { SessionRepository } from './repository'
+import { ComputeJobOperationRepository } from '../compute/compute-job-operation-repository'
 import type { SessionLoadDiagnostic } from './repository'
 
 const createDeferred = <Value>(): {
@@ -326,6 +327,65 @@ describe('Session projection', () => {
 
     expect(buildSessionProjection(pending).summary.needsStartupRecovery).toBe(true)
   })
+
+  it('lets a session save and cancellation recovery wait for an active database transaction', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'session-transaction-admission-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const operations = new ComputeJobOperationRepository(async () => client!)
+    const entered = createDeferred<void>()
+    const release = createDeferred<void>()
+    const active = client.$transaction(async (tx) => {
+      await tx.$queryRawUnsafe('SELECT 1')
+      entered.resolve()
+      await release.promise
+    })
+    await entered.promise
+    // This is shorter than Prisma's existing five-second transaction execution budget, but
+    // exceeds its implicit two-second admission budget on this single-connection database.
+    const timer = setTimeout(() => release.resolve(), 2_500)
+    try {
+      const results = await Promise.allSettled([
+        repository.saveSession(session('waiting-session')),
+        operations.claimNext('cancel', new Date(), 30_000, 'waiting-cancellation')
+      ])
+      const failures = results.flatMap((result) =>
+        result.status === 'rejected'
+          ? [{ code: result.reason?.code, message: String(result.reason) }]
+          : []
+      )
+      expect(failures, JSON.stringify(failures)).toEqual([])
+      expect(await client.session.findUnique({ where: { id: 'waiting-session' } })).toMatchObject({
+        title: 'Session waiting-session'
+      })
+      expect(results[1]).toEqual({ status: 'fulfilled', value: null })
+    } finally {
+      clearTimeout(timer)
+      release.resolve()
+      await active
+    }
+  }, 15_000)
+
+  it('saves sessions while cancellation recovery polls the shared database', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'session-recovery-contention-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    const operations = new ComputeJobOperationRepository(async () => client!)
+    const results = await Promise.allSettled(
+      Array.from({ length: 40 }, async (_, index) => {
+        if (index % 2) return operations.claimNext('cancel', new Date(), 30_000, `claim-${index}`)
+        return repository.saveSession(session(`concurrent-${index}`))
+      })
+    )
+    expect(results.filter((result) => result.status === 'rejected')).toEqual([])
+    expect(await client.session.count()).toBe(20)
+  }, 30_000)
 
   it('allocates a global number and serves summaries and usage without Session JSON', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-session-projection-'))

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -14,6 +14,13 @@ import {
   type SessionUsageProjection
 } from '../../shared/session-persistence'
 
+// Match upload publication's admission budget on the shared single-connection SQLite client.
+// Execution deadlines and rollback behavior remain Prisma defaults.
+const runProjectionTransaction = <Result>(
+  client: Pick<PrismaClient, '$transaction'>,
+  operation: (transaction: Prisma.TransactionClient) => Promise<Result>
+): Promise<Result> => client.$transaction(operation, { maxWait: 10_000 })
+
 const PROJECTION_STATE_ID = 'session-projection'
 const PROJECTION_VERSION = 4
 const SESSION_NUMBER_SEQUENCE_ID = 'global'
@@ -595,7 +602,7 @@ export class SessionProjectionRepository {
     const client = await this.client()
     const projection = buildSessionProjection(session)
     assertProjectionStorageShape(projection)
-    const number = await client.$transaction(async (tx) => {
+    const number = await runProjectionTransaction(client, async (tx) => {
       const project = await tx.project.findFirst({
         where: { id: session.projectId, deletedAt: null },
         select: { id: true }
@@ -651,7 +658,7 @@ export class SessionProjectionRepository {
     const projection = buildSessionProjection(session)
     assertProjectionStorageShape(projection)
     const client = await this.client()
-    await client.$transaction(async (tx) => {
+    await runProjectionTransaction(client, async (tx) => {
       const project = await tx.project.findFirst({
         where: { id: session.projectId, deletedAt: null },
         select: { id: true }
@@ -680,7 +687,7 @@ export class SessionProjectionRepository {
     const projection = buildSessionProjection(session)
     assertProjectionStorageShape(projection)
     const client = await this.client()
-    await client.$transaction(async (tx) => {
+    await runProjectionTransaction(client, async (tx) => {
       const existing = await tx.session.findUnique({ where: { id: session.id } })
       if (!existing) throw new Error('Pending Session projection identity is missing.')
       if (existing.deletedAtMs !== null) {
@@ -702,7 +709,7 @@ export class SessionProjectionRepository {
     operation: 'save' | 'delete' = 'save'
   ): Promise<void> {
     const client = await this.client()
-    await client.$transaction(async (tx) => {
+    await runProjectionTransaction(client, async (tx) => {
       if (operation === 'delete') {
         const existing = await tx.session.findUnique({
           where: { id: sessionId },
@@ -722,7 +729,7 @@ export class SessionProjectionRepository {
 
   async commitDelete(projectId: string, sessionId: string): Promise<void> {
     const client = await this.client()
-    await client.$transaction(async (tx) => {
+    await runProjectionTransaction(client, async (tx) => {
       const existing = await tx.session.findUnique({
         where: { id: sessionId },
         select: { projectId: true }

--- a/src/main/update/create-strategy.test.ts
+++ b/src/main/update/create-strategy.test.ts
@@ -27,6 +27,8 @@ vi.mock('electron', () => ({
   shell: { openExternal: vi.fn(async () => {}), openPath: vi.fn(async () => '') }
 }))
 vi.mock('electron-updater', () => ({
+  AppImageUpdater: class {},
+  DebUpdater: class {},
   CancellationToken: class {
     cancelled = false
     cancel(): void {

--- a/src/main/update/electron-updater-provider-regressions.test.ts
+++ b/src/main/update/electron-updater-provider-regressions.test.ts
@@ -4,7 +4,11 @@ import { join } from 'node:path'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { expect, it, vi } from 'vitest'
-import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+import {
+  ElectronUpdaterStrategy,
+  type MinimalAutoUpdater,
+  type MinimalCancellationToken
+} from './electron-updater-strategy'
 vi.mock('electron', () => ({
   app: { getVersion: () => '0.26.0' },
   BrowserWindow: { getAllWindows: () => [] },
@@ -16,7 +20,7 @@ vi.mock('electron-updater', async () => ({
   autoUpdater: {},
   CancellationToken: class {
     cancelled = false
-    cancel() {
+    cancel(): void {
       this.cancelled = true
     }
   }
@@ -26,7 +30,7 @@ const { AppUpdater } = requireRepo('electron-updater/out/AppUpdater')
 const { DebUpdater } = requireRepo('electron-updater/out/DebUpdater')
 const { CancellationToken } = requireRepo('builder-util-runtime')
 const log = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
-const offline = async () => {
+const offline = async (): Promise<never> => {
   throw new Error('No network in audit')
 }
 
@@ -41,7 +45,11 @@ it.each([true, false])(
     const validation = new Promise<void>((r) => {
       release = r
     })
-    const updater = new EventEmitter() as any
+    const updater = new EventEmitter() as EventEmitter &
+      MinimalAutoUpdater & {
+        _logger: typeof log
+        getOrCreateDownloadHelper: () => Promise<unknown>
+      }
     updater.autoDownload = true
     updater.autoInstallOnAppQuit = true
     updater._logger = log
@@ -60,8 +68,9 @@ it.each([true, false])(
       },
       setDownloadedFile: async () => {}
     })
-    let token: any
-    updater.downloadUpdate = (t: any) => {
+    let token: MinimalCancellationToken | undefined
+    updater.downloadUpdate = (t?: MinimalCancellationToken): Promise<unknown> => {
+      if (!t) throw new Error('Expected cancellation token')
       token = t
       return AppUpdater.prototype.executeDownload.call(updater, {
         fileExtension: 'exe',
@@ -77,7 +86,7 @@ it.each([true, false])(
         task: async () => {
           throw new Error('Network task must not run for cache')
         },
-        done: async (e: any) => updater.emit('update-downloaded', e)
+        done: async (e: unknown) => updater.emit('update-downloaded', e)
       })
     }
     const s = new ElectronUpdaterStrategy({
@@ -94,7 +103,7 @@ it.each([true, false])(
       const downloading = s.download()
       await enteredPromise
       if (cancelled) expect((await s.cancel()).state).toBe('available')
-      expect(token.cancelled).toBe(cancelled)
+      expect(token?.cancelled).toBe(cancelled)
       release()
       await downloading
       expect(s.getStatus().state).toBe(cancelled ? 'available' : 'ready')
@@ -111,7 +120,7 @@ it('does not claim an AppImage size for an unknown Linux provider that may downl
     { url: 'aipoch-open-science-0.27.0-linux-x64.AppImage', size: 900 },
     { url: 'aipoch-open-science_0.27.0_amd64.deb', size: 600 }
   ]
-  const updater = new EventEmitter() as any
+  const updater = new EventEmitter() as EventEmitter & MinimalAutoUpdater
   updater.checkForUpdates = async () =>
     updater.emit('update-available', { version: '0.27.0', files })
   updater.downloadUpdate = vi.fn()
@@ -125,21 +134,21 @@ it('does not claim an AppImage size for an unknown Linux provider that may downl
     broadcast: () => {}
   })
   await strategy.check()
-  let selected: any
+  let selected: { info: { size: number } } | undefined
   const provider = {
     resolveFiles: () =>
       files.map((info) => ({ url: new URL(info.url, 'https://cdn.example/'), info }))
   }
   DebUpdater.prototype.doDownloadUpdate.call(
     {
-      executeDownload: (o: any) => {
+      executeDownload: (o: { fileInfo: { info: { size: number } } }) => {
         selected = o.fileInfo
         return Promise.resolve([])
       }
     },
     { updateInfoAndProvider: { provider, info: { version: '0.27.0', files } } }
   )
-  expect(selected.info.size).toBe(600)
+  expect(selected?.info.size).toBe(600)
   expect(strategy.getStatus().totalBytes).toBeUndefined()
 })
 

--- a/src/main/update/electron-updater-provider-regressions.test.ts
+++ b/src/main/update/electron-updater-provider-regressions.test.ts
@@ -1,0 +1,233 @@
+import { EventEmitter } from 'node:events'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { expect, it, vi } from 'vitest'
+import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+vi.mock('electron', () => ({
+  app: { getVersion: () => '0.26.0' },
+  BrowserWindow: { getAllWindows: () => [] },
+  net: {}
+}))
+vi.mock('electron-updater', async () => ({
+  AppImageUpdater: (await import('electron-updater/out/AppImageUpdater')).AppImageUpdater,
+  DebUpdater: (await import('electron-updater/out/DebUpdater')).DebUpdater,
+  autoUpdater: {},
+  CancellationToken: class {
+    cancelled = false
+    cancel() {
+      this.cancelled = true
+    }
+  }
+}))
+const requireRepo = createRequire(join(process.cwd(), 'package.json'))
+const { AppUpdater } = requireRepo('electron-updater/out/AppUpdater')
+const { DebUpdater } = requireRepo('electron-updater/out/DebUpdater')
+const { CancellationToken } = requireRepo('builder-util-runtime')
+const log = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+const offline = async () => {
+  throw new Error('No network in audit')
+}
+
+it.each([true, false])(
+  'handles real updater cache completion with cancellation=%s',
+  async (cancelled) => {
+    const temp = await mkdtemp(join(tmpdir(), 'release-update-cache-'))
+    let entered!: () => void, release!: () => void
+    const enteredPromise = new Promise<void>((r) => {
+      entered = r
+    })
+    const validation = new Promise<void>((r) => {
+      release = r
+    })
+    const updater = new EventEmitter() as any
+    updater.autoDownload = true
+    updater.autoInstallOnAppQuit = true
+    updater._logger = log
+    updater.checkForUpdates = async () => {
+      updater.emit('checking-for-update')
+      updater.emit('update-available', { version: '0.27.0' })
+    }
+    updater.quitAndInstall = vi.fn()
+    updater.getOrCreateDownloadHelper = async () => ({
+      cacheDirForPendingUpdate: temp,
+      cacheDir: temp,
+      validateDownloadedPath: async (p: string) => {
+        entered()
+        await validation
+        return p
+      },
+      setDownloadedFile: async () => {}
+    })
+    let token: any
+    updater.downloadUpdate = (t: any) => {
+      token = t
+      return AppUpdater.prototype.executeDownload.call(updater, {
+        fileExtension: 'exe',
+        fileInfo: {
+          url: new URL('https://cdn.example/app.exe'),
+          info: { url: 'app.exe', sha512: Buffer.alloc(64).toString('base64') }
+        },
+        downloadUpdateOptions: {
+          cancellationToken: t,
+          requestHeaders: {},
+          updateInfoAndProvider: { info: { version: '0.27.0' } }
+        },
+        task: async () => {
+          throw new Error('Network task must not run for cache')
+        },
+        done: async (e: any) => updater.emit('update-downloaded', e)
+      })
+    }
+    const s = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.26.0',
+      platform: 'win32',
+      arch: 'x64',
+      fetchImpl: offline,
+      broadcast: () => {},
+      createCancellationToken: () => new CancellationToken()
+    })
+    try {
+      await s.check()
+      const downloading = s.download()
+      await enteredPromise
+      if (cancelled) expect((await s.cancel()).state).toBe('available')
+      expect(token.cancelled).toBe(cancelled)
+      release()
+      await downloading
+      expect(s.getStatus().state).toBe(cancelled ? 'available' : 'ready')
+      expect(updater.quitAndInstall).not.toHaveBeenCalled()
+    } finally {
+      release()
+      await rm(temp, { recursive: true, force: true })
+    }
+  }
+)
+
+it('does not claim an AppImage size for an unknown Linux provider that may download deb', async () => {
+  const files = [
+    { url: 'aipoch-open-science-0.27.0-linux-x64.AppImage', size: 900 },
+    { url: 'aipoch-open-science_0.27.0_amd64.deb', size: 600 }
+  ]
+  const updater = new EventEmitter() as any
+  updater.checkForUpdates = async () =>
+    updater.emit('update-available', { version: '0.27.0', files })
+  updater.downloadUpdate = vi.fn()
+  updater.quitAndInstall = vi.fn()
+  const strategy = new ElectronUpdaterStrategy({
+    updater,
+    currentVersion: '0.26.0',
+    platform: 'linux',
+    arch: 'x64',
+    fetchImpl: offline,
+    broadcast: () => {}
+  })
+  await strategy.check()
+  let selected: any
+  const provider = {
+    resolveFiles: () =>
+      files.map((info) => ({ url: new URL(info.url, 'https://cdn.example/'), info }))
+  }
+  DebUpdater.prototype.doDownloadUpdate.call(
+    {
+      executeDownload: (o: any) => {
+        selected = o.fileInfo
+        return Promise.resolve([])
+      }
+    },
+    { updateInfoAndProvider: { provider, info: { version: '0.27.0', files } } }
+  )
+  expect(selected.info.size).toBe(600)
+  expect(strategy.getStatus().totalBytes).toBeUndefined()
+})
+
+it.each(['download-progress', 'update-downloaded', 'error'])(
+  'ignores cancelled provider %s while an immediate retry waits for cleanup',
+  async (event) => {
+    let finish!: () => void
+    const draining = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    const updater = Object.assign(new EventEmitter(), {
+      autoDownload: false,
+      autoInstallOnAppQuit: false,
+      checkForUpdates: async () => {
+        updater.emit('update-available', { version: '0.27.0' })
+      },
+      downloadUpdate: vi.fn(async () => {
+        await draining
+      }),
+      quitAndInstall: vi.fn()
+    })
+    const broadcasts = vi.fn()
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      currentVersion: '0.26.0',
+      platform: 'win32',
+      broadcast: broadcasts,
+      fetchImpl: offline
+    })
+    await strategy.check()
+    const first = strategy.download()
+    await strategy.cancel()
+    const second = strategy.download()
+    const waiting = strategy.getStatus()
+    broadcasts.mockClear()
+    updater.emit(
+      event,
+      event === 'error' ? new Error('cancelled transfer') : { percent: 100, total: 900 }
+    )
+    expect(strategy.getStatus()).toBe(waiting)
+    expect(broadcasts).not.toHaveBeenCalled()
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(1)
+    updater.downloadUpdate.mockImplementationOnce(async () => {
+      updater.emit('update-downloaded', { version: '0.27.0' })
+    })
+    finish()
+    await Promise.all([first, second])
+    expect(updater.downloadUpdate).toHaveBeenCalledTimes(2)
+    expect(strategy.getStatus().state).toBe('ready')
+  }
+)
+
+it.each(['deb', 'AppImage'])(
+  'uses the actual %s provider format for the Linux estimate',
+  async (format) => {
+    const { AppImageUpdater } = requireRepo('electron-updater/out/AppImageUpdater')
+    const Provider = format === 'deb' ? DebUpdater : AppImageUpdater
+    const updater = new Provider(undefined, {
+      version: '0.26.0',
+      name: 'test',
+      isPackaged: true,
+      appUpdateConfigPath: '',
+      userDataPath: '',
+      baseCachePath: '',
+      whenReady: async () => {},
+      relaunch: () => {},
+      quit: () => {},
+      onQuit: () => {}
+    })
+    const files = [
+      { url: 'aipoch-open-science-0.27.0-linux-x86_64.AppImage', size: 900 },
+      { url: 'aipoch-open-science_0.27.0_amd64.deb', size: 600 }
+    ]
+    updater.checkForUpdates = async () =>
+      updater.emit('update-available', { version: '0.27.0', files })
+    const strategy = new ElectronUpdaterStrategy({
+      updater,
+      platform: 'linux',
+      arch: 'x64',
+      broadcast: () => {},
+      fetchImpl: offline
+    })
+    await strategy.check()
+    expect(strategy.getStatus().totalBytes).toBe(format === 'deb' ? 600 : 900)
+    updater.emit('update-available', {
+      version: '0.27.0',
+      files: files.filter((file) => !file.url.endsWith(`.${format}`))
+    })
+    expect(strategy.getStatus().totalBytes).toBeUndefined()
+  }
+)

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -3,7 +3,7 @@ import { EventEmitter } from 'node:events'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import type { Logger } from '../logger'
-import { ElectronUpdaterStrategy } from './electron-updater-strategy'
+import { ElectronUpdaterStrategy, type ElectronUpdaterDeps } from './electron-updater-strategy'
 import { createActiveResearchSafeInstallGate, createDurableInstallGate } from './strategy'
 import {
   clearApplicationShutdownTrigger,
@@ -16,6 +16,8 @@ afterEach(() => clearApplicationShutdownTrigger())
 // so importing the strategy doesn't pull a real Electron runtime into the test process. A stub
 // CancellationToken stands in for the real class so the default token factory works in download().
 vi.mock('electron-updater', () => ({
+  AppImageUpdater: class {},
+  DebUpdater: class {},
   autoUpdater: {},
   CancellationToken: class {
     cancelled = false
@@ -101,6 +103,10 @@ const diagnosticRecords = (log: Logger): Record<string, unknown>[] =>
     vi.mocked(log[level]).mock.calls.map(([, data]) => data as Record<string, unknown>)
   )
 
+// Generic fixtures use a macOS ZIP feed; keep their platform deterministic on Linux/Windows CI.
+const createStrategy = (deps: ElectronUpdaterDeps): ElectronUpdaterStrategy =>
+  new ElectronUpdaterStrategy({ platform: 'darwin', arch: 'arm64', ...deps })
+
 describe('ElectronUpdaterStrategy', () => {
   it.each(['up-to-date', 'error'])(
     'releases a waiting download after a provider check returns %s',
@@ -116,7 +122,7 @@ describe('ElectronUpdaterStrategy', () => {
         if (outcome === 'error') throw new Error('offline')
         updater.emit('update-not-available', { version: '0.2.0' })
       })
-      const strategy = new ElectronUpdaterStrategy({
+      const strategy = createStrategy({
         updater,
         currentVersion: '0.2.0',
         broadcast: vi.fn(),
@@ -146,7 +152,7 @@ describe('ElectronUpdaterStrategy', () => {
       await gate
       updater.emit('update-available', { version: '0.3.0' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -174,7 +180,7 @@ describe('ElectronUpdaterStrategy', () => {
       await checkGate
       updater.emit('update-available', { version: '0.3.0' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -195,7 +201,7 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('disables auto download/install on construction', () => {
     const updater = new FakeUpdater()
-    new ElectronUpdaterStrategy({ updater, currentVersion: '0.2.0', broadcast: vi.fn() })
+    createStrategy({ updater, currentVersion: '0.2.0', broadcast: vi.fn() })
     expect(updater.autoDownload).toBe(false)
     expect(updater.autoInstallOnAppQuit).toBe(false)
   })
@@ -203,7 +209,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('maps check → available with restart applyKind', async () => {
     const broadcast = vi.fn()
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast,
@@ -222,7 +228,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('records a completed in-place check without release notes or feed URLs', async () => {
     const updater = new FakeUpdater()
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -252,7 +258,7 @@ describe('ElectronUpdaterStrategy', () => {
     const broadcast = vi.fn()
     const updater = new FakeUpdater()
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast,
@@ -311,7 +317,7 @@ describe('ElectronUpdaterStrategy', () => {
       await downloadGate
       updater.emit('update-downloaded', { version: '0.3.0' })
     }
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -377,7 +383,7 @@ describe('ElectronUpdaterStrategy', () => {
       await checkGate
       updater.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -405,7 +411,7 @@ describe('ElectronUpdaterStrategy', () => {
       await checkGate
       updater.emit('update-available', { version: '0.3.0', releaseNotes: 'notes' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -442,7 +448,7 @@ describe('ElectronUpdaterStrategy', () => {
         { status: 200 }
       )
     }) as unknown as typeof fetch
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -550,7 +556,7 @@ describe('ElectronUpdaterStrategy', () => {
       if (token?.cancelled) throw new Error('cancelled')
     }
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -596,7 +602,7 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('cancel is a no-op when nothing is downloading', async () => {
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -616,7 +622,7 @@ describe('ElectronUpdaterStrategy', () => {
       await new Promise<void>((resolve) => (release = resolve))
       updater.emit('update-downloaded', { version: '0.3.0' })
     }
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -636,7 +642,7 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('does not download an installer again after the lifecycle is ready', async () => {
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -669,7 +675,7 @@ describe('ElectronUpdaterStrategy', () => {
         updater.emit('update-downloaded', { version: '0.3.0' })
       }
     }
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -697,7 +703,7 @@ describe('ElectronUpdaterStrategy', () => {
     updater.checkForUpdates = vi.fn(async () => {
       updater.emit('update-not-available', { version: '0.2.0' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn()
@@ -712,7 +718,7 @@ describe('ElectronUpdaterStrategy', () => {
       updater.emit('error', new Error('raw provider diagnostic detail'))
     })
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -751,7 +757,7 @@ describe('ElectronUpdaterStrategy', () => {
     const broadcast = vi.fn()
     const installGate = vi.fn(async () => ({ completed: true, reaped: true }))
     const markUpdateShutdown = vi.fn(() => vi.fn())
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast,
@@ -787,7 +793,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('apply installs silently and relaunches (quitAndInstall(true, true))', async () => {
     const updater = new FakeUpdater()
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -811,7 +817,7 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('can install silently without relaunching for a headless caller', async () => {
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn()
@@ -829,7 +835,7 @@ describe('ElectronUpdaterStrategy', () => {
     updater.quitAndInstall.mockImplementation(() => {
       throw new Error('installer unavailable')
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -850,7 +856,7 @@ describe('ElectronUpdaterStrategy', () => {
     const updater = new FakeUpdater()
     const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
     const confirmRendererDurability = vi.fn(async () => true)
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -872,7 +878,7 @@ describe('ElectronUpdaterStrategy', () => {
     const updater = new FakeUpdater()
     const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
     const confirmRendererDurability = vi.fn(async () => false)
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -897,7 +903,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('blocks restart before backend teardown when delegated work is running', async () => {
     const updater = new FakeUpdater()
     const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -919,7 +925,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('blocks restart while an Agent Runtime installation is active', async () => {
     const updater = new FakeUpdater()
     const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -945,7 +951,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('blocks restart for root-agent, notebook, and reviewer work without tearing them down', async () => {
     const updater = new FakeUpdater()
     const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -977,7 +983,7 @@ describe('ElectronUpdaterStrategy', () => {
           finishGate = () => resolve({ completed: true, reaped: true })
         })
     )
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast,
@@ -1012,7 +1018,7 @@ describe('ElectronUpdaterStrategy', () => {
     const gate = vi.fn(async () => ({ completed: false, reaped: false }))
     const releaseInstallHandoff = vi.fn()
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1044,7 +1050,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('records a thrown install-gate failure without its error message', async () => {
     const updater = new FakeUpdater()
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1074,7 +1080,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('ignores stale updater errors during preparation', async () => {
     const updater = new FakeUpdater()
     let finishGate: (() => void) | undefined
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1099,7 +1105,7 @@ describe('ElectronUpdaterStrategy', () => {
     const updater = new FakeUpdater()
     const releaseInstallHandoff = vi.fn()
     const log = createLogSpy()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1134,7 +1140,7 @@ describe('ElectronUpdaterStrategy', () => {
     updater.quitAndInstall.mockImplementationOnce(() => {
       throw new Error('installer launch failed')
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn()
@@ -1149,7 +1155,7 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('restores an actionable error when the install gate throws', async () => {
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1170,7 +1176,7 @@ describe('ElectronUpdaterStrategy', () => {
   it('apply refuses to install when the teardown completed but a tree was not cleanly reaped', async () => {
     const updater = new FakeUpdater()
     const gate = vi.fn(async () => ({ completed: true, reaped: false }))
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1186,7 +1192,7 @@ describe('ElectronUpdaterStrategy', () => {
 
   it('hydrates notes from the CDN manifest when the version matches', async () => {
     const updater = new FakeUpdater()
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1204,7 +1210,7 @@ describe('ElectronUpdaterStrategy', () => {
     updater.checkForUpdates = vi.fn(async () => {
       updater.emit('update-available', { version: '0.3.0' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1219,7 +1225,7 @@ describe('ElectronUpdaterStrategy', () => {
     updater.checkForUpdates = vi.fn(async () => {
       updater.emit('update-available', { version: '0.3.0' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1240,7 +1246,7 @@ describe('ElectronUpdaterStrategy', () => {
         ]
       })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       platform: 'darwin',
@@ -1265,7 +1271,7 @@ describe('ElectronUpdaterStrategy', () => {
         ]
       })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       platform: 'darwin',
@@ -1290,7 +1296,7 @@ describe('ElectronUpdaterStrategy', () => {
         ]
       })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       platform: 'darwin',
@@ -1316,7 +1322,7 @@ describe('ElectronUpdaterStrategy', () => {
         ]
       })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       platform: 'darwin',
@@ -1341,7 +1347,7 @@ describe('ElectronUpdaterStrategy', () => {
         ]
       })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       platform: 'darwin',
@@ -1368,7 +1374,7 @@ describe('ElectronUpdaterStrategy', () => {
         ]
       })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       platform: 'darwin',
@@ -1416,7 +1422,7 @@ describe('ElectronUpdaterStrategy', () => {
     updater.checkForUpdates = vi.fn(async () => {
       updater.emit('update-available', { version: '0.3.0' })
     })
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),
@@ -1441,7 +1447,7 @@ describe('ElectronUpdaterStrategy', () => {
         updater.emit('update-downloaded', { version: '0.3.0' })
       }
     }
-    const strategy = new ElectronUpdaterStrategy({
+    const strategy = createStrategy({
       updater,
       currentVersion: '0.2.0',
       broadcast: vi.fn(),

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron'
 import { spawnSync } from 'node:child_process'
-import { autoUpdater, CancellationToken } from 'electron-updater'
+import { autoUpdater, CancellationToken, AppImageUpdater, DebUpdater } from 'electron-updater'
 
 import { APP } from '../../shared/app-config'
 import { isCurrentInFlight } from '../../shared/in-flight-promise'
@@ -144,11 +144,18 @@ const PLATFORM_ARCH_TOKENS: Record<string, string[]> = {
 const extractArtifactSize = (
   files: UpdateFeedFile[] | undefined,
   platform: NodeJS.Platform,
-  arch: string
+  arch: string,
+  updater: MinimalAutoUpdater
 ): number | undefined => {
   if (!files || files.length === 0) return undefined
-  const targetExt = PLATFORM_ARTIFACT_EXT[platform]
+  const targetExt = platform === 'linux'
+    ? updater instanceof DebUpdater ? '.deb' : updater instanceof AppImageUpdater ? '.AppImage' : undefined
+    : PLATFORM_ARTIFACT_EXT[platform]
   if (!targetExt) return undefined
+  if (platform === 'linux') {
+    const matches = files.filter((file) => file.url?.endsWith(targetExt) && file.size != null)
+    return matches.length === 1 ? matches[0].size : undefined
+  }
   const archToken = PLATFORM_ARCH_TOKENS[platform]?.find((token) => arch.includes(token))
   if (archToken) {
     // Match both extension and arch token — the exact artifact electron-updater will download.
@@ -259,7 +266,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       ) {
         return
       }
-      const totalBytes = extractArtifactSize(i.files, this.platform, this.arch)
+      const totalBytes = extractArtifactSize(i.files, this.platform, this.arch, this.updater)
       this.setStatus({
         state: 'available',
         latest: i.version,
@@ -410,6 +417,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
     }
     if (this.checkLifecycle) return this.checkLifecycle
 
+    this.transferToken = undefined
     const readyStatus = this.status.state === 'ready' ? this.status : undefined
     const operation = startDiagnosticOperation(this.log, {
       operation: 'update-check',

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -148,9 +148,14 @@ const extractArtifactSize = (
   updater: MinimalAutoUpdater
 ): number | undefined => {
   if (!files || files.length === 0) return undefined
-  const targetExt = platform === 'linux'
-    ? updater instanceof DebUpdater ? '.deb' : updater instanceof AppImageUpdater ? '.AppImage' : undefined
-    : PLATFORM_ARTIFACT_EXT[platform]
+  const targetExt =
+    platform === 'linux'
+      ? updater instanceof DebUpdater
+        ? '.deb'
+        : updater instanceof AppImageUpdater
+          ? '.AppImage'
+          : undefined
+      : PLATFORM_ARTIFACT_EXT[platform]
   if (!targetExt) return undefined
   if (platform === 'linux') {
     const matches = files.filter((file) => file.url?.endsWith(targetExt) && file.size != null)

--- a/src/main/update/update-integrity-regressions.test.ts
+++ b/src/main/update/update-integrity-regressions.test.ts
@@ -15,6 +15,8 @@ vi.mock('electron', () => ({
   shell: {}
 }))
 vi.mock('electron-updater', () => ({
+  DebUpdater: class {},
+  AppImageUpdater: class {},
   autoUpdater: {},
   CancellationToken: class {
     cancelled = false


### PR DESCRIPTION
## Problem

Release transforms could omit the real Linux AppImage, accept inconsistent installer/feed data, and move stable backwards during historical backfill. Local packages could include worktrees and tool state. Cancelled cached downloads could become ready again, and Linux estimates could describe a different package format.

## Proposed change

Exclude local tooling from packages; validate installer hashes, versions, sizes and feed relationships; preserve macOS architecture feeds before optional notarization. Serialize mirror publication, keep versioned objects immutable, advance channel metadata monotonically and verify readback. Retire mutation of already-published installers during standalone notarization. Preserve cancellation while an old provider operation drains and derive Linux estimates from the actual updater type.

Browser-only Playwright configuration now replaces inherited Electron projects on Windows, avoiding duplicate browser cases. Session projection and compute-operation transactions use the existing upload-publication admission budget of ten seconds; a valid transaction occupying the single connection for 2.5 seconds previously caused both operations to fail under Prisma’s implicit two-second admission limit.

The Windows native smoke fixture reserves its UDP listener during setup and recreates only its test-owned installation when that numeric TCP gateway port is unavailable to UDP. All network isolation assertions remain active; bounded fixture preparation prevents unrelated host UDP ownership from aborting the smoke test.

## Scope and non-goals

No database schema, client manifest or IPC schema changes, public state enums, or user-data migrations. Historical AppImage spelling remains accepted; duplicate variants fail. Historical mirrors accept the old open-science prefix and missing feeds only for version-directory backfill, without rolling stable back. Changed runtime bytes require a new environment version. Publication of multiple channel files remains ordered rather than atomic; rerunning the same version repairs an interrupted promotion.

Windows baseline selection now uses paginated stable releases strictly below the current version and requires both installer and blockmap. The real Windows runner reproduced the original higher-version selection; the same isolated workflow passed all six fixed-behavior and edge-case tests. The eight additional policy/UX suggestions in the source assessment are outside this repair.

Persistence impact: session and compute-operation transactions may wait up to ten seconds for admission under contention. Execution deadlines, rollback, connection count and persisted formats are unchanged. No retries or global queue are introduced. The exact transaction holding the connection in the failed Windows CI run is still unidentified; the regression reproduces the matching admission failure mechanism.

## Acceptance criteria and validation

- Actual builder filter/name, manifest and mac-feed CLI, workflow shell with isolated object-store effects: deterministic red assertions on unchanged implementations, then passing regressions.
- Real electron-updater cache completion, cancelled retries, actual Linux updater types, existing update owner/store/dialog consumers: passing focused tests.
- Local affected set: 335 passing tests, with six Windows-only tests skipped locally and passed on Windows; Node and sandbox typechecks passed. Complete local npm test intentionally omitted per maintainer instruction. The impact classifier selects full CI because packaging configuration is a global input and release scripts lack selective ownership.
- Windows baseline dry-run exercises the workflow's actual selection step with a local gh substitute; it performs no release download, installation, signing or publication.
- No real installer, Apple notarization or production CDN operation was performed locally. Lint passed with local-only planning fixtures excluded. Real UpdateDialog screenshots were inspected using status snapshots from the actual strategy regressions (including a synthetic 600-byte deb fixture). Behavior tests ran after the last material edit; the final test-only mock change also passed ESLint. Node/sandbox typechecks and full shipped-source lint passed before that mock-only edit. The approved historical-format compatibility fix accepts legacy filenames only in backfill validation, retains actual checksum checks, and never promotes these releases. The workflow retains main’s explicit backfill/promote modes and single channel publisher.
- Browser configuration → `npx vitest run playwright.config.test.ts` → seven passing tests. The Windows configuration regression failed twice before repair. Real light/dark CSV browser cases passed locally with retries disabled; the previously failing browser and workspace-restart shards passed in CI on 6867b856.
- Transaction admission, persisted session rows and cancellation polling → focused session-persistence and compute owner/consumer Vitest suites → 325 passing tests. The real-client held-transaction regression failed twice with P2028 on unchanged runtime code and passed after repair. Node/sandbox typechecks and targeted ESLint passed; the final assertion-only enhancement was rerun green. No global persistence setting or schema changed.
- Windows native smoke → `windows-full-test.yml` with `mode=notebook-sandbox` → 14 native tests, full ownership/removal lifecycle and two controlled UDP-contention regressions passed on the final sandbox/workflow files. The same regression failed twice before repair with the reported access-permissions error: [red](https://github.com/aipoch/open-science/actions/runs/34429410745), [green](https://github.com/aipoch/open-science/actions/runs/34429730623). Local workflow tests passed 24 tests; YAML formatting and diff checks passed. The original CI port holder was not identified. No production native code, WFP policy or persisted-format changes were needed.
- Independent review of 3ba6ef4e returned mergeable; its Windows upload/session-save shard passed. The Windows core job passed on an unchanged rerun. A different workspace shard still failed its first attempt during database startup (migrating rather than ready); no startup change is included. Independent review of 7ad84e21 returned [mergeable with no actionable findings](https://github.com/aipoch/open-science/pull/2412#issuecomment-5611840774). Its Windows core job passed, including the actual native smoke. Other CI lanes are still running: https://github.com/aipoch/open-science/actions/runs/34430048733 . The PR is not yet fully green and remains unmerged.

Local commands (from the worktree):

```sh
npx vitest run scripts/release-publication-regressions.test.ts scripts/ci/mirror-channel-publication.test.ts scripts/windows-release-workflows.test.ts scripts/windows-upgrade-baseline.test.ts scripts/ci/release-workflows.test.ts scripts/ci/runtime-certification-workflow.test.ts scripts/ci/release-certification-evidence.test.ts scripts/generate-version-manifest.test.ts scripts/electron-builder-config.test.ts src/main/update src/shared/update.test.ts src/renderer/src/stores/update-store.test.ts src/renderer/src/components/UpdateDialog.render.test.tsx src/renderer/src/components/UpdateDialog.lifecycle.test.tsx --maxWorkers=2
npm run typecheck:node
npm run lint -- --ignore-pattern 'docs/internal/**'
```

Windows red evidence: https://github.com/aipoch/open-science/actions/runs/34373975547 — assertion received `v0.28.0`, expected `v0.26.0`, for current `v0.27.0`. The same unchanged commit failed identically on two attempts. All production release/installation steps were skipped in this dry-run.

Windows green evidence: https://github.com/aipoch/open-science/actions/runs/34374883854 — all six baseline tests passed, with production release/installation steps skipped.

## Review focus

Cancellation ownership during drain/retry; complete stable feed validation versus metadata-only dry-run; immutable-object preflight and interrupted publication recovery; fail-closed access errors; retained historical naming compatibility; Windows browser project replacement; bounded session and compute transaction admission and unchanged rollback behavior.
