### PR TITLE
fix(e2e): expect the migration cleanup flag in certification

### DIFF
--- a/e2e/certification/storage-migration.spec.ts
+++ b/e2e/certification/storage-migration.spec.ts
@@ -28,7 +28,7 @@ test('stages a verified data-root move and recovers on discard', async ({ app })
     return { migration, staged, discarded }
   }, parent)
 
-  expect(result.migration).toEqual({ ok: true })
+  expect(result.migration).toEqual({ ok: true, cleanupPending: false })
   expect(result.staged).toMatchObject({ kind: 'recover', recoveryStatus: 'verified' })
   expect(result.discarded.kind).toBe('move')
 


### PR DESCRIPTION
## Problem

The packaged storage-migration certification (`regression / p0`) fails on the v0.27.0 tag: the E2E asserts the migration result with strict `toEqual({ ok: true })`, but #2325 added `cleanupPending` to the session-deletion result that this flow surfaces, so the app now correctly returns `{ ok: true, cleanupPending: false }`. The PR gate does not run the packaged certification lane, so the stale assertion was not caught before the tag.

## Proposed change

Assert the explicit new shape: `toEqual({ ok: true, cleanupPending: false })` — stricter than `toMatchObject`, and documents the field the delivery ledger reports (no cleanup pending after a discarded migration).

## Scope and non-goals

Test-only, one line. No product change; the migration behavior (`ok: true`, verified recovery on discard) is unchanged.

## Validation

- The assertion matches the actual packaged-app result observed in the failing run ([job log](https://github.com/aipoch/open-science/actions/runs/34359554641/job/102555688074): received `{ ok: true, cleanupPending: false }`, retried and reproduced twice).
- PR CI re-validators lint/typecheck on the touched spec.