### PR TITLE
perf(runtime): bound queued work and retained history

### DIFF
--- a/e2e/session-residency-capacity.spec.ts
+++ b/e2e/session-residency-capacity.spec.ts
@@ -1,0 +1,90 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures/electron-app'
+import { openProjectSession } from './certification/helpers'
+
+// Capacity measurement, not a claim that a particular RSS value is acceptable on every machine.
+test('profiles same-process visits to forty persisted session bodies', async ({
+  app
+}, testInfo) => {
+  test.setTimeout(180_000)
+  let page = await app.completeOnboarding()
+  const cwd = await app.createTestDirectory('session-residency')
+  const projectId = await page.evaluate(async (cwd) => {
+    const project = await window.api.projects.create({
+      name: 'Residency capacity',
+      description: ''
+    })
+    const now = Date.now()
+    for (let i = 0; i < 40; i++) {
+      await window.api.sessions.saveSession({
+        id: `residency-${i}`,
+        projectId: project.id,
+        title: `Residency ${String(i).padStart(2, '0')}`,
+        cwd,
+        status: 'idle',
+        createdAt: now + i,
+        updatedAt: now + i,
+        messages: [
+          {
+            id: `body-${i}`,
+            role: 'user',
+            status: 'complete',
+            eventIds: [],
+            content: `BODY${i}\n\n${'Historical text. '.repeat(4096)}`,
+            createdAt: now,
+            updatedAt: now
+          }
+        ]
+      })
+    }
+    return project.id
+  }, cwd)
+  // The existing profiler restarts once to activate its isolated data directory.
+  await app.beginResourceProfile({ sampleIntervalMs: 1000 })
+  page = app.page
+  try {
+    await openProjectSession(page, 'Residency capacity', '^Session status:.* Residency 00$')
+    await app.markResourceProfilePhase('first-session')
+    for (let i = 0; i < 40; i++) {
+      await page
+        .getByRole('navigation', { name: 'Sessions' })
+        .getByRole('button', {
+          name: new RegExp(`^Session status:.* Residency ${String(i).padStart(2, '0')}$`)
+        })
+        .click()
+      await expect(page.locator(`[data-message-id="body-${i}"]`)).toBeVisible()
+      if ((i + 1) % 10 === 0) await app.markResourceProfilePhase(`visited-${i + 1}`)
+    }
+    await app.markResourceProfilePhase('idle-after-visits')
+    await page.waitForTimeout(3000)
+    await app.sampleResourceProfileNow()
+    await page
+      .getByRole('navigation', { name: 'Sessions' })
+      .getByRole('button', { name: /^Session status:.* Residency 00$/ })
+      .click()
+    await expect(page.locator('[data-message-id="body-0"]')).toBeVisible()
+    await app.markResourceProfilePhase('revisited-first')
+  } finally {
+    const result = await app.finishResourceProfile()
+    await testInfo.attach('session-residency-profile', {
+      path: result.summaryMarkdownPath,
+      contentType: 'text/markdown'
+    })
+    await testInfo.attach('session-residency-data', {
+      body: JSON.stringify(result.summary),
+      contentType: 'application/json'
+    })
+  }
+  // Read back the durable API after profiling: browsing/reclamation must not rewrite bodies.
+  const changedBodies = await page.evaluate(async (projectId) => {
+    const changed: number[] = []
+    for (let i = 0; i < 40; i++) {
+      const session = await window.api.sessions.loadOne({ projectId, sessionId: `residency-${i}` })
+      if (session?.messages[0]?.content !== `BODY${i}\n\n${'Historical text. '.repeat(4096)}`) {
+        changed.push(i)
+      }
+    }
+    return changed
+  }, projectId)
+  expect(changedBodies).toEqual([])
+})

--- a/e2e/transcript-capacity.spec.ts
+++ b/e2e/transcript-capacity.spec.ts
@@ -1,0 +1,79 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures/electron-app'
+import { openProjectSession } from './certification/helpers'
+
+test.use({ windowMode: 'normal' })
+
+test('PERF-03 bounds history scrolling and preserves native find across the transcript', async ({
+  app
+}, testInfo) => {
+  test.setTimeout(180_000)
+  let page = await app.completeOnboarding()
+  const cwd = await app.createTestDirectory('transcript-capacity')
+  await page.evaluate(async (cwd) => {
+    const project = await window.api.projects.create({
+      name: 'Transcript capacity',
+      description: ''
+    })
+    const now = Date.now() - 400_000
+    await window.api.sessions.saveSession({
+      id: 'capacity-history',
+      projectId: project.id,
+      title: 'Capacity history',
+      cwd,
+      status: 'idle',
+      createdAt: now,
+      updatedAt: now + 400,
+      messages: Array.from({ length: 400 }, (_, index) => ({
+        id: `capacity-${index}`,
+        role: 'user' as const,
+        content: `CAPACITYTOKEN${String(index).padStart(4, '0')}\n\n${'Historical paragraph for scrolling. '.repeat(5)}`,
+        status: 'complete' as const,
+        eventIds: [],
+        createdAt: now + index,
+        updatedAt: now + index
+      }))
+    })
+  }, cwd)
+  page = await app.restart()
+  await openProjectSession(page, 'Transcript capacity', 'Capacity history')
+  const viewport = page.locator('[data-slot="message-scroller-viewport"]')
+  const rows = viewport.locator('[data-message-id^="capacity-"]')
+  await expect(rows).toHaveCount(80)
+  const counts: number[] = [80]
+  await viewport.hover()
+  for (let i = 0; i < 4; i++) {
+    const first = await rows.first().getAttribute('data-message-id')
+    await page.mouse.wheel(0, -100_000)
+    await expect.poll(() => rows.first().getAttribute('data-message-id')).not.toBe(first)
+    counts.push(await rows.count())
+    expect(counts.at(-1)).toBeLessThanOrEqual(160)
+  }
+  await expect(rows.first()).toHaveAttribute('data-message-id', 'capacity-0')
+  const modifiers = process.platform === 'darwin' ? (['meta'] as const) : (['control'] as const)
+  await app.pressMainWindowShortcut('F', [...modifiers])
+  await expect.poll(() => app.findOverlayIsVisible()).toBe(true)
+  await expect
+    .poll(() =>
+      page
+        .context()
+        .pages()
+        .some((p) => p.url().includes('/find-overlay/'))
+    )
+    .toBe(true)
+  const overlay = page
+    .context()
+    .pages()
+    .find((p) => p.url().includes('/find-overlay/'))!
+  for (const index of [0, 200, 399]) {
+    await overlay.getByRole('textbox').fill(`CAPACITYTOKEN${String(index).padStart(4, '0')}`)
+    await expect(viewport.locator(`[data-message-id="capacity-${index}"]`)).toBeInViewport()
+  }
+  await overlay.getByRole('button', { name: 'Close find' }).click()
+  await expect.poll(() => app.findOverlayIsVisible()).toBe(false)
+  await expect.poll(() => rows.count()).toBeLessThanOrEqual(160)
+  await testInfo.attach('mounted-row-counts', {
+    body: JSON.stringify(counts),
+    contentType: 'application/json'
+  })
+})

--- a/scripts/performance/runtime-resource-profiler.test.ts
+++ b/scripts/performance/runtime-resource-profiler.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { ElectronApplication } from 'playwright'
@@ -17,6 +17,8 @@ import {
   type ElectronProcessMetric,
   type RuntimeResourceSample
 } from './runtime-resource-profiler'
+
+vi.mock('node:fs/promises', { spy: true })
 
 const processEntry = (overrides: Partial<ProcessSnapshotEntry> = {}): ProcessSnapshotEntry => ({
   pid: 10,
@@ -46,6 +48,27 @@ const electronMetric = (overrides: Partial<ElectronProcessMetric> = {}): Electro
 })
 
 describe('runtime resource profiler', () => {
+  it.each(['ENOENT', 'EACCES'])('handles a storage stat %s during sampling', async (code) => {
+    const root = await mkdtemp(join(tmpdir(), 'resource-stat-race-'))
+    try {
+      await mkdir(join(root, 'sessions'))
+      await writeFile(join(root, 'sessions', 'session.json.tmp'), 'pending write')
+      // A file listed by readdir may be renamed away before stat; model the filesystem result
+      // at that existing I/O boundary without adding a production test hook.
+      const error = Object.assign(new Error(code), { code })
+      vi.mocked(stat).mockRejectedValueOnce(error)
+      const snapshot = readRuntimeStorageSnapshot(root)
+      if (code === 'ENOENT') {
+        await expect(snapshot).resolves.toMatchObject({ temporaryFileCount: 0, temporaryBytes: 0 })
+      } else {
+        await expect(snapshot).rejects.toBe(error)
+      }
+    } finally {
+      vi.mocked(stat).mockRestore()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
   it('calculates external-process CPU deltas and resets identity after PID reuse', () => {
     const tracker = new ProcessCpuTracker()
     expect(tracker.observe(processEntry({ kind: 'agent' }), 1_000)).toEqual({ identity: '10:1' })

--- a/scripts/performance/runtime-resource-profiler.ts
+++ b/scripts/performance/runtime-resource-profiler.ts
@@ -202,7 +202,12 @@ const scanStorageFiles = async (
       if (!entry.isFile()) return
       const kind = classify(entry.name)
       if (!kind) return
-      const bytes = (await stat(path)).size
+      const info = await stat(path).catch((error: NodeJS.ErrnoException) => {
+        if (error.code === 'ENOENT') return undefined
+        throw error
+      })
+      if (!info) return // A concurrent atomic write may have already moved this temporary file.
+      const bytes = info.size
       if (kind === 'session') {
         totals.sessionFileCount += 1
         totals.sessionBytes += bytes

--- a/src/main/compute/concurrency-manager.test.ts
+++ b/src/main/compute/concurrency-manager.test.ts
@@ -21,7 +21,7 @@ const createMockJobRepo = (): ComputeJobRepository =>
     findNonTerminalByProvider: vi.fn(),
     findTerminalUnharvested: vi.fn(),
     hasActiveJobsForProvider: vi.fn(),
-    findBySession: vi.fn(),
+    findSessionConcurrencyJobs: vi.fn(),
     findPendingNotifications: vi.fn(),
     markNotificationsConsumed: vi.fn()
   }) as unknown as ComputeJobRepository
@@ -253,7 +253,7 @@ describe('ConcurrencyManager', () => {
       }
     )
     vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
-    vi.mocked(jobRepo.findBySession).mockResolvedValue([])
+    vi.mocked(jobRepo.findSessionConcurrencyJobs).mockResolvedValue([])
     await expect(durableManager.startQueueReconciliation()).rejects.toThrow('could not be restored')
     expect(await durableManager.getStatus('unrelated-session')).toMatchObject({
       active_count: 0,
@@ -773,7 +773,7 @@ describe('ConcurrencyManager', () => {
     it('returns accurate session status', async () => {
       await manager.setSessionLimit('session-1', 5)
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(3)
-      vi.mocked(jobRepo.findBySession).mockResolvedValue([
+      vi.mocked(jobRepo.findSessionConcurrencyJobs).mockResolvedValue([
         { provider_id: 'ssh:cluster-a', status: 'queued' } as ComputeJob,
         { provider_id: 'ssh:cluster-b', status: 'queued' } as ComputeJob
       ])
@@ -794,7 +794,7 @@ describe('ConcurrencyManager', () => {
 
     it('returns null session_limit when not set', async () => {
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(0)
-      vi.mocked(jobRepo.findBySession).mockResolvedValue([])
+      vi.mocked(jobRepo.findSessionConcurrencyJobs).mockResolvedValue([])
 
       const status = await manager.getStatus('session-1')
 
@@ -805,7 +805,7 @@ describe('ConcurrencyManager', () => {
 
     it('uses default ceiling of 10 when host.concurrencyLimit is undefined', async () => {
       vi.mocked(jobRepo.countActiveBySession).mockResolvedValue(1)
-      vi.mocked(jobRepo.findBySession).mockResolvedValue([
+      vi.mocked(jobRepo.findSessionConcurrencyJobs).mockResolvedValue([
         { provider_id: 'ssh:cluster-a', status: 'running' } as ComputeJob
       ])
       vi.mocked(hostRepo.get).mockResolvedValue({

--- a/src/main/compute/concurrency-manager.ts
+++ b/src/main/compute/concurrency-manager.ts
@@ -315,8 +315,8 @@ export class ConcurrencyManager {
     const sessionLimit = this.sessionLimits.get(sessionId) ?? null
     const activeCount = await this.jobRepository.countActiveBySession(sessionId)
 
-    // Find all jobs for this session to compute queued count and provider ceilings
-    const allJobs = await this.jobRepository.findBySession(sessionId)
+    // Read only status/provider metadata, including historical and needs-attention jobs.
+    const allJobs = await this.jobRepository.findSessionConcurrencyJobs(sessionId)
     const queuedJobs = allJobs.filter((job) => job.status === 'queued')
     const queuedCount = queuedJobs.length
 

--- a/src/main/compute/job-repository.test.ts
+++ b/src/main/compute/job-repository.test.ts
@@ -1,8 +1,9 @@
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ConcurrencyManager } from './concurrency-manager'
 import { ComputeJobRepository } from './job-repository'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { ComputeConnectionError, type ComputeConnectionBrokerAcquirer } from './connection-broker'
@@ -47,6 +48,43 @@ afterEach(async () => {
 })
 
 describe('ComputeJob repository (SQLite integration)', () => {
+  it('PERF-04 returns status without decrypting historical payloads', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'concurrency-projection-'))
+    const client = createProjectDbClient(storageRoot)
+    disconnect = () => client.$disconnect()
+    await migrateApplicationDatabase(client)
+    const cipher = testCipher()
+    const repo = new ComputeJobRepository(async () => client, protectedFields(cipher))
+    const hosts = new ComputeHostRepository(async () => client)
+    for (let i = 0; i < 40; i++) {
+      await repo.create({
+        id: `history-${i}`,
+        providerId: 'ssh:deleted-host',
+        shape: 'direct_ssh',
+        sessionId: 's',
+        projectId: 'p',
+        intent: 'history',
+        command: 'true',
+        commandHash: `hash-${i}`,
+        initialStatus: 'submitted'
+      })
+      await repo.update(`history-${i}`, {
+        status: 'success',
+        stdoutTail: 'x'.repeat(32768),
+        stderrTail: 'y'.repeat(32768)
+      })
+    }
+    const decrypt = vi.spyOn(cipher, 'decryptString')
+    const manager = new ConcurrencyManager(repo, hosts, async () => {})
+    expect(await manager.getStatus('s')).toEqual({
+      active_count: 0,
+      queued_count: 0,
+      session_limit: null,
+      provider_ceilings: { 'ssh:deleted-host': 10 }
+    })
+    expect(decrypt).not.toHaveBeenCalled()
+  })
+
   it('lists project overview jobs using active and recent-terminal visibility rules newest-first', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-project-job-overview-'))
 

--- a/src/main/compute/job-repository.ts
+++ b/src/main/compute/job-repository.ts
@@ -457,7 +457,7 @@ export class ComputeJobRepository {
     })
   }
 
-  // Observational projection for renderer lists and concurrency status. Unlike lifecycle scans,
+  // Observational projection for renderer lists. Unlike lifecycle scans,
   // this retains quarantined/needs-attention rows so users can inspect durable state safely.
   async findBySession(sessionId: string, statuses?: string[]): Promise<ComputeJob[]> {
     const client = await this.getClient()
@@ -470,6 +470,18 @@ export class ComputeJobRepository {
       orderBy: { createdAt: 'desc' }
     })
     return rows.map(this.toJob)
+  }
+
+  // Status reads never need sensitive job bodies or cancellation operation payloads.
+  async findSessionConcurrencyJobs(
+    sessionId: string
+  ): Promise<Pick<ComputeJob, 'status' | 'provider_id'>[]> {
+    const client = await this.getClient()
+    const rows = await client.computeJob.findMany({
+      where: { sessionId },
+      select: { status: true, providerId: true }
+    })
+    return rows.map((row) => ({ status: asStatus(row.status), provider_id: row.providerId }))
   }
 
   async findProjectOverview(projectId: string, since: Date): Promise<ComputeJob[]> {

--- a/src/main/notebook/environment-management.test.ts
+++ b/src/main/notebook/environment-management.test.ts
@@ -145,6 +145,22 @@ describe('NotebookEnvironmentManagementOwner', () => {
     expect(options.ensureRecovered).not.toHaveBeenCalled()
   })
 
+  it('does not publish a list cancelled while awaiting the manager', async () => {
+    const controller = new AbortController()
+    let finish!: (environments: []) => void
+    const pending = new Promise<[]>((resolve) => {
+      finish = resolve
+    })
+    const configured = manager()
+    vi.mocked(configured.listEnvironments).mockReturnValue(pending)
+    const { owner } = harness({ manager: configured })
+    const result = owner.manage({ action: 'list' }, controller.signal)
+    controller.abort(new Error('list cancelled'))
+    finish([])
+    await expect(result).rejects.toThrow('list cancelled')
+    expect(configured.listEnvironments).toHaveBeenCalledWith(controller.signal)
+  })
+
   it('keeps manager configuration inside the owner', async () => {
     const configuredHarness = harness()
     const owner = new NotebookEnvironmentManagementOwner({

--- a/src/main/notebook/environment-management.ts
+++ b/src/main/notebook/environment-management.ts
@@ -18,7 +18,7 @@ type NotebookEnvironmentManager = {
     request?: Extract<ManageEnvironmentsRequest, { action: 'create' }>,
     signal?: AbortSignal
   ) => Promise<EnvironmentInfo>
-  listEnvironments: () => EnvironmentInfo[]
+  listEnvironments: (signal?: AbortSignal) => EnvironmentInfo[] | Promise<EnvironmentInfo[]>
   removeEnvironment: (name: string) => void
 }
 
@@ -104,8 +104,11 @@ class NotebookEnvironmentManagementOwner {
           signal
         )
       }
-      case 'list':
-        return { environments: manager.listEnvironments() }
+      case 'list': {
+        const environments = await manager.listEnvironments(signal)
+        signal?.throwIfAborted()
+        return { environments }
+      }
       case 'remove': {
         const name = assertSafeEnvName(request.name)
         if (this.isLive(name)) {

--- a/src/main/notebook/host-model-service.test.ts
+++ b/src/main/notebook/host-model-service.test.ts
@@ -440,6 +440,67 @@ describe('HostModelService', () => {
     expect(maxActive).toBe(expected)
   })
 
+  it.each(['single', 'batch', 'mixed'] as const)(
+    'PERF-02 bounds %s requests before dispatch and releases admission on cancellation',
+    async (mode) => {
+      let blocked = true
+      const { service, runner, captureTarget } = makeService(async ({ prompt, signal }) => {
+        if (blocked)
+          await new Promise<void>((_resolve, reject) => {
+            if (signal?.aborted) reject(new RestrictedInferenceError('cancelled', 'Cancelled.'))
+            else
+              signal?.addEventListener(
+                'abort',
+                () => {
+                  reject(new RestrictedInferenceError('cancelled', 'Cancelled.'))
+                },
+                { once: true }
+              )
+          })
+        return inferenceResult(prompt)
+      })
+      const controller = new AbortController()
+      const inputs =
+        mode === 'single'
+          ? Array.from({ length: 32 }, () => ({ request: 'x'.repeat(MAX_PROMPT_BYTES) }))
+          : mode === 'batch'
+            ? [
+                {
+                  requests: Array.from({ length: 32 }, () => 'batch'),
+                  options: { max_concurrency: 4 }
+                }
+              ]
+            : [
+                ...Array.from({ length: 16 }, () => ({ request: 'single' })),
+                { requests: Array.from({ length: 16 }, () => 'batch') }
+              ]
+      const calls = inputs.map((input) =>
+        service.call(input, controller.signal).catch((error) => error)
+      )
+      let overload: unknown
+      try {
+        await vi.waitFor(() => expect(runner.run).toHaveBeenCalledTimes(4))
+        const captured = captureTarget.mock.calls.length
+        const extra = service.call({ request: 'excess' }, controller.signal).catch((error) => {
+          overload = error
+        })
+        calls.push(extra)
+        await vi.waitFor(() => expect(overload).toBeInstanceOf(Error), { timeout: 300 })
+        expect((overload as Error).message).toContain('HOST_LLM_BUSY')
+        expect(captureTarget).toHaveBeenCalledTimes(captured)
+        expect(runner.run).toHaveBeenCalledTimes(4)
+      } finally {
+        controller.abort()
+        await Promise.all(calls)
+        blocked = false
+      }
+      await expect(
+        service.call({ requests: Array.from({ length: 32 }, () => 'again') })
+      ).resolves.toHaveLength(32)
+      await service.shutdown()
+    }
+  )
+
   it('caps runner concurrency across overlapping public calls', async () => {
     let active = 0
     let maxActive = 0

--- a/src/main/notebook/host-model-service.ts
+++ b/src/main/notebook/host-model-service.ts
@@ -24,6 +24,8 @@ const MAX_BATCH_ITEMS = 32
 const MAX_BATCH_BYTES = 512 * 1024
 const DEFAULT_MAX_CONCURRENCY = 2
 const MAX_CONCURRENCY = 4
+// Includes running requests and every item retained by a batch (at most 2 MiB of prompts).
+const MAX_PENDING_REQUESTS = 32
 
 const HOST_LLM_SYSTEM_PROMPT = [
   'You are a temporary, tool-less model call inside Open Science.',
@@ -172,6 +174,7 @@ class HostModelService {
   private readonly callDrainWaiters = new Set<() => void>()
   private readonly runSlotWaiters: Array<() => void> = []
   private activeRuns = 0
+  private pendingRequests = 0
   private shuttingDown = false
 
   constructor(private readonly options: HostModelServiceOptions) {}
@@ -318,10 +321,17 @@ class HostModelService {
     return target
   }
 
-  private callScope(callerSignal: AbortSignal | undefined): {
+  private callScope(
+    callerSignal: AbortSignal | undefined,
+    requestCount = 1
+  ): {
     controller: AbortController
     close: () => void
   } {
+    if (this.pendingRequests + requestCount > MAX_PENDING_REQUESTS) {
+      throw new Error('HOST_LLM_BUSY: host.llm is busy. Retry after pending calls finish.')
+    }
+    this.pendingRequests += requestCount
     const controller = new AbortController()
     const forwardAbort = (): void => controller.abort(callerSignal?.reason)
     callerSignal?.addEventListener('abort', forwardAbort, { once: true })
@@ -332,6 +342,7 @@ class HostModelService {
       close: () => {
         callerSignal?.removeEventListener('abort', forwardAbort)
         this.activeCalls.delete(controller)
+        this.pendingRequests -= requestCount
         if (this.activeCalls.size === 0) {
           for (const resolve of this.callDrainWaiters) resolve()
           this.callDrainWaiters.clear()
@@ -478,7 +489,7 @@ class HostModelService {
     callerSignal?: AbortSignal,
     context?: HostLlmCallContext
   ): Promise<readonly HostLlmBatchItem[]> {
-    const scope = this.callScope(callerSignal)
+    const scope = this.callScope(callerSignal, parsed.length)
     try {
       const target = await this.captureTarget(scope.controller.signal)
       const results = new Array<HostLlmBatchItem>(parsed.length)

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1,4 +1,12 @@
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
 import { createHash } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join } from 'node:path'
@@ -1920,13 +1928,60 @@ describe('DefaultRuntimeProvisioner journals every prefix write', () => {
 })
 
 describe('DefaultRuntimeProvisioner.listEnvironments', () => {
-  it('returns [] when the envs dir does not exist', () => {
+  it('PERF-01 yields to the event loop while counting a large environment', async () => {
     const root = makeRoot()
-    const provisioner = new DefaultRuntimeProvisioner(makeDeps(root))
-    expect(provisioner.listEnvironments()).toEqual([])
+    const prefix = envPrefix(root, 'large-env')
+    mkdirSync(dirname(pythonBin(prefix)), { recursive: true })
+    writeFileSync(pythonBin(prefix), 'x')
+    for (let i = 0; i < 1000; i++) writeFileSync(join(prefix, `file-${i}`), 'x')
+    let heartbeat = false
+    const tick = new Promise<void>((resolve) =>
+      setImmediate(() => {
+        heartbeat = true
+        resolve()
+      })
+    )
+    try {
+      const environments = await new DefaultRuntimeProvisioner(makeDeps(root)).listEnvironments()
+      expect(environments).toEqual([
+        { name: 'large-env', language: 'python', ready: true, isDefault: false, sizeBytes: 1001 }
+      ])
+      expect(heartbeat).toBe(true)
+    } finally {
+      await tick
+      rmSync(root, { recursive: true, force: true })
+    }
   })
 
-  it('classifies python/r/default/ready and skips dirs with neither interpreter', () => {
+  it('cancels a scan without publishing partial results', async () => {
+    const root = makeRoot()
+    const prefix = envPrefix(root, 'cancel-env')
+    mkdirSync(dirname(pythonBin(prefix)), { recursive: true })
+    writeFileSync(pythonBin(prefix), 'x')
+    const controller = new AbortController()
+    const tick = new Promise<void>((resolve) =>
+      setImmediate(() => {
+        controller.abort(new Error('scan cancelled'))
+        resolve()
+      })
+    )
+    try {
+      await expect(
+        new DefaultRuntimeProvisioner(makeDeps(root)).listEnvironments(controller.signal)
+      ).rejects.toThrow('scan cancelled')
+    } finally {
+      await tick
+      rmSync(root, { recursive: true, force: true })
+    }
+  })
+
+  it('returns [] when the envs dir does not exist', async () => {
+    const root = makeRoot()
+    const provisioner = new DefaultRuntimeProvisioner(makeDeps(root))
+    expect(await provisioner.listEnvironments()).toEqual([])
+  })
+
+  it('classifies python/r/default/ready and skips dirs with neither interpreter', async () => {
     const root = makeRoot()
     // default-python: has a python bin -> python, isDefault.
     const pyDefaultPrefix = envPrefix(root, DEFAULT_PY_ENV)
@@ -1944,7 +1999,7 @@ describe('DefaultRuntimeProvisioner.listEnvironments', () => {
     mkdirSync(envPrefix(root, 'half-baked'), { recursive: true })
 
     const provisioner = new DefaultRuntimeProvisioner(makeDeps(root))
-    const infos = provisioner.listEnvironments()
+    const infos = await provisioner.listEnvironments()
 
     expect(infos.map((i) => i.name).sort()).toEqual(['default-python', 'my-analysis', 'r-stats'])
     const byName = Object.fromEntries(infos.map((i) => [i.name, i]))
@@ -1961,7 +2016,7 @@ describe('DefaultRuntimeProvisioner.listEnvironments', () => {
     expect(byName['r-stats']).toMatchObject({ language: 'r', ready: true, isDefault: false })
   })
 
-  it('maps short Windows default directories to logical names and ignores legacy duplicates', () => {
+  it('maps short Windows default directories to logical names and ignores legacy duplicates', async () => {
     const root = makeRoot()
     const shortPrefix = join(root, 'envs', '.p')
     mkdirSync(join(pythonBin(shortPrefix, 'win32'), '..'), { recursive: true })
@@ -1970,7 +2025,7 @@ describe('DefaultRuntimeProvisioner.listEnvironments', () => {
     mkdirSync(join(pythonBin(legacyPrefix, 'win32'), '..'), { recursive: true })
     writeFileSync(pythonBin(legacyPrefix, 'win32'), 'legacy')
 
-    const infos = new DefaultRuntimeProvisioner(
+    const infos = await new DefaultRuntimeProvisioner(
       makeDeps(root, { platform: 'win32' })
     ).listEnvironments()
 
@@ -1991,14 +2046,14 @@ describe('DefaultRuntimeProvisioner.removeEnvironment', () => {
     expect(() => provisioner.removeEnvironment(DEFAULT_R_ENV)).toThrow(/Refusing to remove/)
   })
 
-  it('removes a named env without rediscovering the remaining environments', () => {
+  it('removes a named env without rediscovering the remaining environments', async () => {
     const root = makeRoot()
     const namedPrefix = envPrefix(root, 'my-analysis')
     mkdirSync(join(pythonBin(namedPrefix), '..'), { recursive: true })
     writeFileSync(pythonBin(namedPrefix), 'x')
 
     const provisioner = new DefaultRuntimeProvisioner(makeDeps(root))
-    expect(provisioner.listEnvironments()).toHaveLength(1)
+    expect(await provisioner.listEnvironments()).toHaveLength(1)
 
     const listEnvironments = vi.spyOn(provisioner, 'listEnvironments')
     const result = provisioner.removeEnvironment('my-analysis')

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -1,4 +1,5 @@
-import { type Dirent, existsSync, readFileSync, readdirSync, rmSync, statSync } from 'node:fs'
+import { type Dirent, existsSync, readFileSync, readdirSync, rmSync } from 'node:fs'
+import { readdir, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { basename, dirname, join } from 'node:path'
 
@@ -1380,16 +1381,18 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
 
   // Scans the physical env directory and maps reserved Windows default directories back to their
   // logical names. Dirs with neither interpreter are skipped. Tolerant of a missing envs dir.
-  listEnvironments(): EnvironmentInfo[] {
+  async listEnvironments(signal?: AbortSignal): Promise<EnvironmentInfo[]> {
+    signal?.throwIfAborted()
     const envsDir = join(this.deps.root, 'envs')
     let entries: Dirent[]
     try {
-      entries = readdirSync(envsDir, { withFileTypes: true })
+      entries = await readdir(envsDir, { withFileTypes: true })
     } catch {
       return []
     }
     const infos: EnvironmentInfo[] = []
     for (const entry of entries) {
+      signal?.throwIfAborted()
       if (!entry.isDirectory()) continue
       const platform = this.platform
       const name = logicalEnvNameFromDirectory(entry.name)
@@ -1398,12 +1401,20 @@ export class DefaultRuntimeProvisioner implements RuntimeProvisioner {
       const isPython = existsSync(pythonBin(prefix, platform))
       const isR = !isPython && existsSync(rBin(prefix, platform))
       if (!isPython && !isR) continue
+      const before = await stat(prefix).catch(() => undefined)
+      if (!before) continue
+      const sizeBytes = await dirSizeBytes(prefix, signal)
+      const after = await stat(prefix).catch(() => undefined)
+      signal?.throwIfAborted()
+      // Discard scans of environments removed or replaced while filesystem I/O yielded.
+      if (!after || before.dev !== after.dev || before.ino !== after.ino) continue
+      if (!existsSync(isPython ? pythonBin(prefix, platform) : rBin(prefix, platform))) continue
       infos.push({
         name,
         language: isPython ? 'python' : 'r',
         ready: true,
         isDefault: name === DEFAULT_PY_ENV || name === DEFAULT_R_ENV,
-        sizeBytes: dirSizeBytes(prefix)
+        sizeBytes
       })
     }
     return infos
@@ -1796,19 +1807,22 @@ class MaxPathRetryError extends Error {
 
 // Best-effort recursive directory size (OQ5: surface disk usage in `list`). Tolerates any error
 // (permission, race with a concurrent remove, etc.) by returning undefined rather than throwing.
-const dirSizeBytes = (path: string): number | undefined => {
+const dirSizeBytes = async (path: string, signal?: AbortSignal): Promise<number | undefined> => {
   try {
     let total = 0
-    const walk = (dir: string): void => {
-      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const walk = async (dir: string): Promise<void> => {
+      signal?.throwIfAborted()
+      for (const entry of await readdir(dir, { withFileTypes: true })) {
+        signal?.throwIfAborted()
         const full = join(dir, entry.name)
-        if (entry.isDirectory()) walk(full)
-        else if (entry.isFile()) total += statSync(full).size
+        if (entry.isDirectory()) await walk(full)
+        else if (entry.isFile()) total += (await stat(full)).size
       }
     }
-    walk(path)
+    await walk(path)
     return total
   } catch {
+    signal?.throwIfAborted()
     return undefined
   }
 }

--- a/src/main/session-persistence/ipc.test.ts
+++ b/src/main/session-persistence/ipc.test.ts
@@ -461,7 +461,7 @@ describe('session persistence IPC handlers', () => {
         {
           findQueuedJobs: async () => (job.status === 'queued' ? [job] : []),
           countActiveBySession: async () => activeCount,
-          findBySession: async () => [job],
+          findSessionConcurrencyJobs: async () => [job],
           countActiveByProvider: async () => 0,
           updateIfStatus: async () => {
             job.status = 'submitted'

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -149,6 +149,151 @@ describe('session persistence startup', () => {
     )
   }
 
+  it.each(['read-only', 'failed-save', 'pending-save', 'running'] as const)(
+    'bounds untouched historical bodies without discarding %s state',
+    async (mode) => {
+      const persisted = Array.from({ length: 40 }, (_, index) =>
+        createPersistedSession({
+          id: `history-${index}`,
+          number: index + 1,
+          messages: [
+            {
+              id: `message-${index}`,
+              role: 'user',
+              status: 'complete',
+              eventIds: [],
+              content: `History ${index}: ${'x'.repeat(64 * 1024)}`,
+              createdAt: 1,
+              updatedAt: 1
+            }
+          ]
+        })
+      )
+      let finishSave: (() => void) | undefined
+      const loadOne = vi.fn(async ({ sessionId }: { sessionId: string }) =>
+        structuredClone(persisted.find((session) => session.id === sessionId))
+      )
+      window.api.sessions.list = vi.fn().mockResolvedValue({
+        sessions: persisted.map((session): SessionSummary => ({
+          number: session.number!,
+          id: session.id,
+          projectId: session.projectId,
+          title: session.title,
+          status: session.status,
+          presentedStatus: session.status,
+          pinned: false,
+          revision: 0,
+          activeMessageCount: 1,
+          artifactCount: 0,
+          filesRevision: 0,
+          createdAt: 1,
+          updatedAt: 1,
+          needsStartupRecovery: false
+        })),
+        manifest: { version: SESSION_MANIFEST_VERSION },
+        diagnostics: emptyLoadResult().diagnostics
+      })
+      window.api.sessions.loadOne = loadOne
+      await act(async () => root.render(<Probe />))
+      for (let index = 0; index < persisted.length; index++) {
+        await act(async () => {
+          useSessionStore.getState().selectSession(persisted[index].id)
+          await Promise.resolve()
+        })
+        expect(
+          useSessionStore.getState().sessions.find((session) => session.id === persisted[index].id)
+            ?.messages[0]?.content
+        ).toBe(persisted[index].messages[0].content)
+        if (index === 0 && mode === 'running') {
+          await act(async () => {
+            useSessionStore.getState().appendUserMessage({
+              sessionId: persisted[0].id,
+              messageId: persisted[0].messages[0].id,
+              content: persisted[0].messages[0].content,
+              rearmExisting: true
+            })
+          })
+          expect(
+            useSessionStore.getState().sessions.find((session) => session.id === persisted[0].id)
+              ?.status
+          ).toBe('running')
+        }
+        if (index === 0 && mode === 'pending-save') {
+          saveSession.mockImplementation(
+            (session) =>
+              new Promise((resolve) => {
+                finishSave = () => resolve(session)
+              })
+          )
+          await act(async () => {
+            useSessionStore.getState().renameSession(persisted[0].id, 'Pending title')
+            await Promise.resolve()
+          })
+        }
+        if (index === 0 && mode === 'failed-save') {
+          saveSession.mockRejectedValue(new Error('disk unavailable'))
+          await act(async () => {
+            useSessionStore.getState().renameSession(persisted[0].id, 'Unsaved title')
+            await flushSessionPersistence().catch(() => undefined)
+          })
+        }
+      }
+      await act(async () => {
+        const flushed = flushSessionPersistence().catch(() => undefined)
+        // A write awaiting its durable acknowledgement must keep the source body alive.
+        await Promise.resolve()
+        if (mode === 'pending-save') {
+          expect(
+            useSessionStore.getState().sessions.find((session) => session.id === persisted[0].id)
+              ?.messages[0]?.content
+          ).toBe(persisted[0].messages[0].content)
+          expect(finishSave).toBeTypeOf('function')
+          finishSave?.()
+        }
+        await flushed
+      })
+      const state = useSessionStore.getState()
+      expect(
+        state.sessions.filter((session) => session.contentLoaded !== false).length
+      ).toBeLessThanOrEqual(mode === 'read-only' ? 16 : 17)
+      const first = state.sessions.find((session) => session.id === persisted[0].id)!
+      if (mode === 'read-only') {
+        expect(first.contentLoaded).toBe(false)
+        expect(first.messages).toEqual([])
+        expect(saveSession).not.toHaveBeenCalled()
+      } else {
+        expect(first.contentLoaded).not.toBe(false)
+        expect(first.messages[0].content).toBe(persisted[0].messages[0].content)
+        if (mode === 'failed-save') expect(first.title).toBe('Unsaved title')
+      }
+      // Navigating back loads the original body; unloading must neither save empty content nor
+      // trigger an immediate reload of every evicted summary through the saver subscription.
+      expect(loadOne).toHaveBeenCalledTimes(40)
+      await act(async () => {
+        useSessionStore.getState().selectSession(persisted[0].id)
+        await Promise.resolve()
+      })
+      expect(
+        useSessionStore.getState().sessions.find((session) => session.id === persisted[0].id)
+          ?.messages[0]?.content
+      ).toBe(persisted[0].messages[0].content)
+      expect(loadOne).toHaveBeenCalledTimes(mode === 'read-only' ? 41 : 40)
+      expect(saveSession.mock.calls.every(([session]) => session.messages.length === 1)).toBe(true)
+      if (mode === 'read-only') {
+        await act(async () => {
+          useSessionStore.getState().renameSession(persisted[0].id, 'Renamed after reload')
+          await flushSessionPersistence()
+        })
+        expect(saveSession).toHaveBeenCalledOnce()
+        expect(saveSession.mock.calls[0][0]).toMatchObject({
+          id: persisted[0].id,
+          title: 'Renamed after reload',
+          messages: persisted[0].messages
+        })
+      }
+    }
+  )
+
   it('does not reload persisted sessions when the locale changes', async () => {
     loadAll.mockReset().mockResolvedValue(emptyLoadResult())
     await act(async () => root.render(<Probe />))

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -2185,6 +2185,38 @@ describe('renderer session persistence bridge', () => {
     }
   })
 
+  it('releases acknowledged bodies only after writes settle and retains the revision watermark', async () => {
+    const session = createPersistedSession({ revision: 4 })
+    const writing = createDeferred<PersistedChatSession>()
+    const saveSession = vi
+      .fn<SessionPersistenceApi['saveSession']>()
+      .mockImplementationOnce(() => writing.promise)
+      .mockImplementation(async (submitted) => ({ ...submitted, revision: 6 }))
+    const persistence = createOrderedSessionPersistence(createApi({ saveSession }))
+    persistence.seedAcknowledgedSessions([session])
+    const pending = persistence.saveSession(session)
+    expect(persistence.releaseAcknowledgedSessionBody(session.id)).toBe(false)
+    writing.resolve({ ...session, revision: 5 })
+    await pending
+    expect(persistence.releaseAcknowledgedSessionBody(session.id)).toBe(true)
+    expect(persistence.getAcknowledgedSession(session.id)).toBeUndefined()
+    await persistence.saveSession({ ...session, revision: 0 })
+    expect(saveSession.mock.calls[1][0].revision).toBe(5)
+  })
+
+  it('retains the acknowledged body while a failed write remains unresolved', async () => {
+    const session = createPersistedSession({ revision: 4 })
+    const persistence = createOrderedSessionPersistence(
+      createApi({
+        saveSession: vi.fn().mockRejectedValue(new Error('disk unavailable'))
+      })
+    )
+    persistence.seedAcknowledgedSessions([session])
+    await expect(persistence.saveSession(session)).rejects.toThrow('disk unavailable')
+    expect(persistence.releaseAcknowledgedSessionBody(session.id)).toBe(false)
+    expect(persistence.getAcknowledgedSession(session.id)).toMatchObject({ revision: 4 })
+  })
+
   it('invalidates a delayed save when a new hydration generation starts', async () => {
     const session = createPersistedSession({ revision: 1, title: 'Old local title' })
     const authority = createPersistedSession({ revision: 2, title: 'Hydrated title' })

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -129,6 +129,7 @@ type OrderedSessionPersistence = Pick<SessionPersistenceApi, 'saveSession' | 'sa
   ) => Promise<PersistedChatSession>
   seedAcknowledgedSessions: (sessions: readonly PersistedChatSession[]) => void
   getAcknowledgedSession: (sessionId: string) => PersistedChatSession | undefined
+  releaseAcknowledgedSessionBody: (sessionId: string) => boolean
   clearWriteFailure: (target: string) => void
   clearWriteFailures: () => void
   flush: () => Promise<void>
@@ -647,6 +648,7 @@ const createOrderedSessionPersistence = (
   api: Pick<SessionPersistenceApi, 'saveSession' | 'saveManifest'>
 ): OrderedSessionPersistence => {
   let queue: Promise<unknown> = Promise.resolve()
+  let pendingWriteCount = 0
   const acknowledgedRevisions = new Map<string, number>()
   const acknowledgedSessions = new Map<string, PersistedChatSession>()
   const pendingLatestByTarget = new Map<string, PendingLatestSessionSave>()
@@ -727,10 +729,15 @@ const createOrderedSessionPersistence = (
   const enqueue = <Result>(target: string, task: () => Promise<Result>): Promise<Result> => {
     releasePendingLatestCadence()
     pendingLatestByTarget.clear()
-    const run = queue.then(
-      () => trackWrite(target, task),
-      () => trackWrite(target, task)
-    )
+    pendingWriteCount += 1
+    const run = queue
+      .then(
+        () => trackWrite(target, task),
+        () => trackWrite(target, task)
+      )
+      .finally(() => {
+        pendingWriteCount -= 1
+      })
     queue = run.then(
       () => undefined,
       () => undefined
@@ -792,10 +799,15 @@ const createOrderedSessionPersistence = (
       acknowledgeSession(durable)
       return durable
     }
-    const run = queue.then(
-      () => trackWrite(target, runTask),
-      () => trackWrite(target, runTask)
-    )
+    pendingWriteCount += 1
+    const run = queue
+      .then(
+        () => trackWrite(target, runTask),
+        () => trackWrite(target, runTask)
+      )
+      .finally(() => {
+        pendingWriteCount -= 1
+      })
     entry.promise = run
     pendingLatestByTarget.set(target, entry)
     queue = run.then(
@@ -825,6 +837,12 @@ const createOrderedSessionPersistence = (
     getAcknowledgedSession: (sessionId) => {
       const session = acknowledgedSessions.get(sessionId)
       return session ? structuredClone(session) : undefined
+    },
+    releaseAcknowledgedSessionBody: (sessionId) => {
+      if (pendingWriteCount > 0 || failedWritesByTarget.has(`session:${sessionId}`)) return false
+      acknowledgedSessions.delete(sessionId)
+      // Keep the small revision watermark: later explicit writes must not regress their revision.
+      return true
     },
     clearWriteFailure: (target) => failedWritesByTarget.delete(target),
     clearWriteFailures: () => failedWritesByTarget.clear(),
@@ -1237,7 +1255,10 @@ type StoreSaverObserver = {
   onSuccess?: (target: string) => void
 }
 
-type StoreSaver = (state: SessionStoreSnapshot, options?: StoreSaverOptions) => Promise<unknown>
+type StoreSaver = {
+  (state: SessionStoreSnapshot, options?: StoreSaverOptions): Promise<unknown>
+  releaseReadOnlySession: (source: ChatSession, summary: ChatSession) => boolean
+}
 
 const pruneRemovedSessionWriteTargets = (
   targets: Set<string>,
@@ -1440,7 +1461,7 @@ const createStoreSaver = (
     )
   }
 
-  return (state, options) => {
+  const save: StoreSaver = (state, options) => {
     const nextSessions = state.sessions
     const previousById = indexById(previousSessions)
     const nextById = indexById(nextSessions)
@@ -1727,6 +1748,23 @@ const createStoreSaver = (
 
     return Promise.all(scheduledTasks).then(() => undefined)
   }
+  save.releaseReadOnlySession = (source, summary) => {
+    const current = useSessionStore.getState()
+    if (
+      current.selectedSessionId === source.id ||
+      current.sessions.find((session) => session.id === source.id) !== source ||
+      previousSessions.find((session) => session.id === source.id) !== source ||
+      !persistence.releaseAcknowledgedSessionBody(source.id)
+    )
+      return false
+    acknowledgedSessions.delete(source.id)
+    // Change the diff baseline before publishing the summary. Unloading is not a metadata edit
+    // and must not enqueue a save which loads the same body straight back into the store.
+    previousSessions = current.sessions.map((session) => (session === source ? summary : session))
+    useSessionStore.setState({ sessions: previousSessions })
+    return true
+  }
+  return save
 }
 
 // Starts session persistence and returns health/recovery state so App can gate input and surface failures.
@@ -2038,6 +2076,30 @@ const useSessionPersistence = (): SessionPersistenceState => {
       activeSaver = save
       saverRef.current = save
       const loadingSessionContent = new Set<string>()
+      // ponytail: only unchanged, passively loaded history is reclaimable. Edited/runtime-owned
+      // sessions stay resident; extend this policy only with a proven save-acknowledgement contract.
+      const readOnlyHistory = new Map<string, { loaded: ChatSession; summary: ChatSession }>()
+      const trimReadOnlyHistory = (): void => {
+        if (!isMounted || readOnlyHistory.size === 0) return
+        const state = useSessionStore.getState()
+        const byId = indexById(state.sessions)
+        for (const [id, entry] of readOnlyHistory) {
+          if (byId.get(id) !== entry.loaded) {
+            readOnlyHistory.delete(id)
+          }
+        }
+        const selected = state.selectedSessionId && readOnlyHistory.get(state.selectedSessionId)
+        if (selected) {
+          readOnlyHistory.delete(selected.loaded.id)
+          readOnlyHistory.set(selected.loaded.id, selected)
+        }
+        for (const [id, entry] of readOnlyHistory) {
+          if (readOnlyHistory.size <= 16) break
+          if (id === state.selectedSessionId) continue
+          if (!save.releaseReadOnlySession(entry.loaded, entry.summary)) continue
+          readOnlyHistory.delete(id)
+        }
+      }
 
       unsubscribe = useSessionStore.subscribe((state) => {
         const failedTargetCount = failedWriteTargets.current.size
@@ -2067,7 +2129,41 @@ const useSessionPersistence = (): SessionPersistenceState => {
           void loadPersistedSession({ projectId: selected.projectId, sessionId: selected.id })
             .then((session) => {
               if (!session) throw new Error('Selected Session JSON is missing.')
-              if (isMounted) hydratePersistedSessionIfPresent(session)
+              if (!isMounted) return
+              const unchangedSummary =
+                useSessionStore
+                  .getState()
+                  .sessions.find((candidate) => candidate.id === selected.id) === selected
+              const loaded = hydratePersistedSessionIfPresent(session)
+              if (
+                unchangedSummary &&
+                loaded &&
+                loaded.status === 'idle' &&
+                !loaded.activeRun &&
+                !loaded.unsavedTitle &&
+                !loaded.isPending &&
+                !loaded.runtimeContext?.sideChat &&
+                !loaded.runtimeContext?.delegatedWork &&
+                !hasStagedUploads(loaded) &&
+                pendingArtifactRequests(loaded, true).length === 0
+              ) {
+                readOnlyHistory.set(loaded.id, {
+                  loaded,
+                  summary: {
+                    ...selected,
+                    title: loaded.title,
+                    status: loaded.status,
+                    pinned: loaded.pinned,
+                    archivedAt: loaded.archivedAt,
+                    revision: loaded.revision,
+                    filesRevision: loaded.filesRevision,
+                    updatedAt: loaded.updatedAt,
+                    activeMessageCount: loaded.messages.length,
+                    artifactCount: loaded.artifacts?.length ?? 0
+                  }
+                })
+                trimReadOnlyHistory()
+              }
             })
             .catch((error) => {
               reportPersistenceError(error, 'session-load')
@@ -2075,7 +2171,7 @@ const useSessionPersistence = (): SessionPersistenceState => {
             })
             .finally(() => loadingSessionContent.delete(selected.id))
         }
-        void save(state).catch(reportPersistenceError)
+        void save(state).then(trimReadOnlyHistory).catch(reportPersistenceError)
       })
 
       // Hydration intentionally uses the user's live selection instead of the older disk manifest

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/lib/utils'
 import { flushSync } from 'react-dom'
 /* Hallmark · pre-emit critique: P5 H5 E5 S5 R5 V4 */
 import {
@@ -1398,7 +1399,11 @@ const WorkspaceMessageScrollerImpl = ({
             {/* No wrapper div: message-scroller only measures/anchors Content's direct children. */}
             <MessageScrollerContent
               ref={messageScrollerContentRef}
-              className="mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]"
+              className={cn(
+                'mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]',
+                // Native find must scroll against final row heights, not deferred containment sizes.
+                windowFindOpen && '[&>[data-message-id]]:[content-visibility:visible]'
+              )}
             >
               {reviewLoadError ? (
                 <MessageScrollerItem

--- a/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
+++ b/src/renderer/src/pages/workspace/use-transcript-window.test.tsx
@@ -19,6 +19,96 @@ const items = Array.from(
 )
 
 describe('useTranscriptWindow', () => {
+  it.each(['none', 'selection', 'focus'] as const)(
+    'PERF-03 bounds reading after releasing %s without moving the reading anchor',
+    (pin) => {
+      const viewport = document.createElement('div')
+      document.body.appendChild(viewport)
+      const root = createRoot(viewport)
+      const rows = Array.from({ length: 1000 }, (_, index) => ({
+        id: `row-${index}`,
+        type: 'message',
+        message: { id: `row-${index}` }
+      })) as WorkspaceConversationTimelineItem[]
+      Object.defineProperties(viewport, {
+        clientHeight: { value: 400 },
+        scrollHeight: { get: () => viewport.childElementCount * 20 }
+      })
+      viewport.getBoundingClientRect = () => ({ top: 100, bottom: 500 }) as DOMRect
+      viewport.scrollTo = (options) => {
+        viewport.scrollTop = (options as ScrollToOptions).top ?? 0
+      }
+      let current!: ReturnType<typeof useTranscriptWindow>
+      const Harness = (): React.JSX.Element => {
+        current = useTranscriptWindow('large', rows, -1, { current: viewport })
+        return (
+          <>
+            {current.entries.map(({ item }) => (
+              <div
+                key={item.id}
+                data-message-id={item.id}
+                ref={(node) => {
+                  if (node)
+                    node.getBoundingClientRect = () => {
+                      const top =
+                        100 + Array.from(viewport.children).indexOf(node) * 20 - viewport.scrollTop
+                      return { top, bottom: top + 20 } as DOMRect
+                    }
+                }}
+              >
+                {item.id}
+              </div>
+            ))}
+          </>
+        )
+      }
+      const expand = (direction: 'up' | 'down', bounded = true): void => {
+        viewport.scrollTop = direction === 'up' ? 0 : viewport.scrollHeight - 400
+        const anchor = Array.from(viewport.children).find(
+          (node) => node.getBoundingClientRect().bottom > 100
+        )!
+        const id = (anchor as HTMLElement).dataset.messageId
+        const top = anchor.getBoundingClientRect().top
+        act(() => current.expandAtScrollEdge(direction === 'up' ? 100 : 0))
+        if (bounded) expect(viewport.childElementCount).toBeLessThanOrEqual(160)
+        const retained = viewport.querySelector<HTMLElement>(`[data-message-id="${id}"]`)
+        expect(retained).not.toBeNull()
+        expect(retained!.getBoundingClientRect().top).toBe(top)
+      }
+      try {
+        act(() => root.render(<Harness />))
+        expect(viewport.childElementCount).toBe(80)
+        if (pin !== 'none') {
+          const pinned = viewport.lastElementChild as HTMLElement
+          if (pin === 'selection') {
+            const range = document.createRange()
+            range.selectNodeContents(pinned)
+            document.getSelection()!.addRange(range)
+          } else {
+            pinned.tabIndex = 0
+            pinned.focus()
+          }
+          for (let i = 0; i < 3; i++) expand('up', false)
+          expect(pinned.isConnected).toBe(true)
+          if (pin === 'selection') {
+            expect(document.getSelection()!.toString()).toBe('row-999')
+            document.getSelection()!.removeAllRanges()
+          } else {
+            expect(document.activeElement).toBe(pinned)
+            pinned.blur()
+          }
+        }
+        for (let i = 0; i < 12; i++) expand('up')
+        expect(current.entries[0].item.id).toBe('row-0')
+        for (let i = 0; i < 12; i++) expand('down')
+        expect(current.entries.at(-1)?.item.id).toBe('row-999')
+      } finally {
+        act(() => root.unmount())
+        viewport.remove()
+      }
+    }
+  )
+
   it('keeps the full transcript mounted when revealing a run during whole-window find', () => {
     const container = document.createElement('div')
     const root = createRoot(container)

--- a/src/renderer/src/pages/workspace/use-transcript-window.ts
+++ b/src/renderer/src/pages/workspace/use-transcript-window.ts
@@ -296,6 +296,27 @@ const useTranscriptWindow = (
     }
     const readingId = readingAnchorRef.current?.messageId
     const readingIndex = readingId ? items.findIndex((item) => item.id === readingId) : -1
+    const selection = viewport.ownerDocument.getSelection()
+    const selectionInside =
+      selection &&
+      !selection.isCollapsed &&
+      ((selection.anchorNode && viewport.contains(selection.anchorNode)) ||
+        (selection.focusNode && viewport.contains(selection.focusNode)))
+    const focusedRow = viewport.ownerDocument.activeElement?.closest('[data-message-id]')
+    // Keep a page of overscan in each direction. A live selection or focused control pins its
+    // mounted rows until the reader releases it; whole-window find is handled above.
+    if (!selectionInside && !(focusedRow && viewport.contains(focusedRow))) {
+      const limit = TRANSCRIPT_WINDOW_SIZE * 2
+      if (nextEnd - nextStart > limit) {
+        if (viewport.scrollTop < previousScrollTop) nextEnd = nextStart + limit
+        else nextStart = nextEnd - limit
+        // Trimming after a selection ends must also retain a reader in the middle of the window.
+        if (readingIndex >= 0 && (readingIndex < nextStart || readingIndex >= nextEnd)) {
+          nextStart = Math.max(0, readingIndex - TRANSCRIPT_WINDOW_SIZE)
+          nextEnd = Math.min(items.length, nextStart + limit)
+        }
+      }
+    }
     const anchorIndex =
       readingIndex >= nextStart && readingIndex < nextEnd ? readingIndex : nextStart
     const anchorId = items[anchorIndex]?.id

--- a/src/renderer/src/pages/workspace/workspace-components.test.tsx
+++ b/src/renderer/src/pages/workspace/workspace-components.test.tsx
@@ -410,7 +410,7 @@ describe('conversation message scroller integration', () => {
       "'relative w-full max-w-[56rem] text-sm leading-relaxed text-text-000 md:text-[15px]'"
     )
     expect(workspaceMessageScrollerSource).toContain(
-      'className="mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]"'
+      "'mx-auto w-full max-w-4xl gap-0 px-4 pb-[56px]'"
     )
     // Rows must stay direct children of MessageScrollerContent; no transcript wrapper div.
     expect(workspaceMessageScrollerSource).not.toContain('conversationContentClassName')


### PR DESCRIPTION
## Problem

Repeated work can retain substantially more resources than the existing per-call limits suggest: environment listing blocks the main event loop, Host LLM requests accumulate behind four execution slots, transcript windows grow as readers scroll, concurrency status decrypts historical job bodies, and visited session bodies remain resident.

## Proposed change

- **PERF-01:** traverse managed environment sizes asynchronously and sequentially, honor cancellation, and discard results when the environment directory is removed or replaced.
- **PERF-02:** admit at most 32 unfinished requests across single and batch Host LLM calls. Reserve a batch atomically, release on completion/cancellation, and return `HOST_LLM_BUSY` when full. Execution concurrency remains four.
- **PERF-03:** retain at most 160 timeline items during ordinary scrolling, preserving the reading anchor. Selection/focused controls defer trimming; native find temporarily expands the transcript and uses final row layout so matches remain visible.
- **PERF-04:** query only status/provider metadata for concurrency status, preserving historical/needs-attention visibility and provider ceilings without decrypting job bodies.
- **PERF-05:** retain up to 16 eligible, unchanged, passively loaded history bodies in recent-access order. Eviction restores the existing summary and releases persistence baselines without enqueueing an empty-body write or immediate reload. Preserve revision watermarks; defer eviction while writes remain unsettled.
- Fix a resource-profiler race reproduced during the Electron journey: tolerate a listed file disappearing before `stat`, while retaining other I/O errors.

## Scope and non-goals

No database schema, migration, session-file format, dependency, or durable queue changes. Persistence **memory ownership** changes; durable save/conflict protocols remain intact.

The history budget is deliberately conservative, not a global memory ceiling. Current, modified, running, side-chat/delegated, staged-upload, and native-version-artifact-dependent sessions remain resident. Modified sessions are not reclassified after save. Native find and active selections remain transcript-capacity exceptions. No search-index redesign or general cache framework is introduced.

The 40-session Electron fixture did **not** demonstrate a clear RSS improvement (renderer idle approximately 466 MiB before versus 470 MiB after in individual runs). The deterministic result is bounded eligible-body retention, not a claimed percentage of memory savings.

## Acceptance criteria and validation

Regression tests were exercised against unmodified implementations before fixing them, with matching failures: blocked scan heartbeat, missing overload rejection, 240 mounted rows exceeding 160, 160 unnecessary decryptions, and 40 retained bodies exceeding the history budget. The final four history regressions failed on the old implementation twice and passed on the new implementation. No production-only test hooks were added.

Behavior → project-owned checks → local result:

| Behavior / consumers | Command | Result |
|---|---|---|
| Compute status and repository contract | `npx vitest run src/main/compute/job-repository.test.ts src/main/compute/concurrency-manager.test.ts` | 81 passed |
| Environment cancellation and Host LLM admission | `npx vitest run src/main/notebook/provisioner.test.ts src/main/notebook/environment-management.test.ts src/main/notebook/host-model-service.test.ts` | 165 passed |
| RPC consumer and session IPC fixture | Host model + local RPC suite; `npx vitest run src/main/session-persistence/ipc.test.ts` | 33 passed; 34 passed |
| Scrolling, anchors, selection/focus and layout | `npx vitest run src/renderer/src/pages/workspace/use-transcript-window.test.tsx src/renderer/src/pages/workspace/WorkspaceMessageScroller.interaction.test.tsx src/renderer/src/pages/workspace/workspace-components.test.tsx` | 119 passed |
| Save acknowledgement, failed/in-flight writes, reload and store behavior | `npx vitest run src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/stores/session-store.test.ts` | 338 passed; final live-running guard refinement rerun: render suite 28 passed |
| Ownership guard and profiler race | `npx vitest run src/renderer/src/stores/session-store.architecture.test.ts scripts/performance/runtime-resource-profiler.test.ts` | 23 passed |
| Actual Electron history/find and same-process session visits | `npm run build:e2e`; `npx playwright test e2e/transcript-capacity.spec.ts e2e/session-residency-capacity.spec.ts` | Passed; final residency journey additionally read back all 40 durable bodies unchanged |
| Repository lint | `npm run lint` | Running; changed-file ESLint already passed |
| Main, sandbox and renderer types | `npm run typecheck` | Passed |

Each focused suite was rerun after the final material edit in its area. The full portable suite was also run: `npm test -- --maxWorkers=2` → **28,698 passed, 9 failed, 285 skipped** (1,545 files passed, 2 failed, 20 skipped). Eight Office parser/preview failures were reproduced on the unmodified baseline. One literature capacity test encountered Prisma `P2028` transaction-start timeout; an isolated rerun passed. Full-suite execution preceded the final profiler/guard-test refinements, which were checked separately as listed above. This is **not** a claim of an entirely green local full suite.

Additional existing Electron anchor tests showed two failures also reproduced on the unmodified baseline; native find, reopen anchoring, and stream-scroll release checks otherwise passed. Windows/Linux native behavior, very large full-transcript find, modified-session reclamation and long-duration RSS attribution remain uncovered. Exact-head CI and independent review remain required.

## Review focus

- Admission accounting across batch cancellation and shutdown.
- Async environment result validity and preservation of unknown-size semantics.
- Transcript anchor/selection/find interaction under clipping.
- Eviction ordering relative to save baselines, queued writes, revision watermarks and cold-summary hydration.
