### PR TITLE
fix(lifecycle): recover from startup and renderer failures

### DIFF
--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -280,8 +280,9 @@ describe('production application command wiring', () => {
       )
     )
     expect(occurrences(indexSource, 'RemoteAccessService.create()')).toBe(1)
+    // Ownership bookkeeping may sit between acquisition and binding; preserve their order.
     expect(startup).toMatch(
-      /const remoteAccess = await RemoteAccessService\.create\(\) bindRemoteAccess\(remoteAccess\) const webController = createWebServiceController\(\{[^}]*externalAccess: remoteAccess\.webAccess/
+      /const remoteAccess = await RemoteAccessService\.create\(\).*?bindRemoteAccess\(remoteAccess\) const webController = createWebServiceController\(\{[^}]*externalAccess: remoteAccess\.webAccess/
     )
     expect(startup).toContain('remoteAccess.attachWebController(webController)')
     expect(startup).toContain('registerRemoteAccessIpcHandlers(remoteAccess)')

--- a/src/main/index-startup-failure.test.ts
+++ b/src/main/index-startup-failure.test.ts
@@ -1,0 +1,253 @@
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => {
+  const log = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  return {
+    log,
+    startupFailure: vi.fn(),
+    disposeRuntime: vi.fn(async () => {}),
+    disposeWeb: vi.fn(async () => {}),
+    shutdownRemote: vi.fn(async () => {}),
+    failAt: 'web' as 'icon' | 'remote' | 'web',
+    failure: Object.assign(new Error('listen EADDRINUSE'), { code: 'EADDRINUSE' }),
+    electron: {
+      app: {
+        isPackaged: true,
+        setName: vi.fn(),
+        getPath: () => '/isolated-test',
+        getVersion: () => '0.0.0',
+        on: vi.fn(),
+        whenReady: async () => {},
+        getPreferredSystemLanguages: () => ['en'],
+        quit: vi.fn(),
+        exit: vi.fn(),
+        setBadgeCount: vi.fn(),
+        isUnityRunning: () => false
+      },
+      BrowserWindow: { getAllWindows: () => [] },
+      protocol: { registerSchemesAsPrivileged: vi.fn() },
+      nativeImage: {},
+      nativeTheme: {},
+      ipcMain: {},
+      powerMonitor: {},
+      crashReporter: {}
+    }
+  }
+})
+vi.mock('node:module', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:module')>()
+  return {
+    ...actual,
+    createRequire: (url: string) => {
+      const require = actual.createRequire(url)
+      return (id: string) => (id === 'electron' ? fixture.electron : require(id))
+    }
+  }
+})
+vi.mock('./logger', () => ({
+  createLogger: () => fixture.log,
+  diagnosticErrorFields: (e: unknown) => e,
+  flushLogs: vi.fn(),
+  writeFatalLogSync: vi.fn()
+}))
+vi.mock('./diagnostics/startup', () => ({
+  initializeApplicationDiagnostics: () => ({
+    log: fixture.log,
+    operation: { phase: vi.fn(), fail: vi.fn(), complete: vi.fn() },
+    flush: vi.fn()
+  }),
+  reportApplicationStartupFailure: fixture.startupFailure
+}))
+vi.mock('./settings/credential-store-mode', () => ({ configureCredentialStore: vi.fn() }))
+vi.mock('./crash-diagnostics', () => ({
+  installChildProcessGoneLogging: vi.fn(),
+  startLocalCrashReporting: () => ({ enabled: false })
+}))
+vi.mock('./managed-preview-resources', () => ({ MANAGED_PREVIEW_SCHEME: {} }))
+vi.mock('./office-preview/office-preview-runtime-protocol', () => ({
+  OFFICE_PREVIEW_RUNTIME_SCHEME_CONFIG: {}
+}))
+vi.mock('./renderer-diagnostics', () => ({
+  createRendererFailureReporter: vi.fn(),
+  registerRendererDiagnosticsIpc: vi.fn()
+}))
+vi.mock('./single-instance', () => ({ acquireSingleInstanceLock: () => true }))
+vi.mock('./web-service/options', () => ({
+  parseWebModeOptions: () => ({ headless: true, enabled: true, port: 44100 })
+}))
+vi.mock('./system-lifecycle-adapters', () => ({
+  installSystemLifecycleAdapters: () => ({
+    bindWindow: vi.fn(),
+    installPowerMonitorListeners: vi.fn()
+  })
+}))
+vi.mock('./diagnostics/startup-storage-probe', () => ({ timedStartupStorageProbe: vi.fn() }))
+vi.mock('@electron-toolkit/utils', () => ({ electronApp: { setAppUserModelId: vi.fn() } }))
+vi.mock('./managed-preview-protocol', () => ({
+  createManagedPreviewProtocolBridge: () => ({ registrar: {}, dispose: vi.fn() })
+}))
+vi.mock('./windows', () => ({ configureMainWindow: vi.fn(), createMainWindow: vi.fn() }))
+vi.mock('./locale/owner', () => ({
+  LocalePreferenceOwner: class {
+    t = (key: string): string => key
+    subscribe = (): ReturnType<typeof vi.fn> => vi.fn()
+  }
+}))
+vi.mock('./locale/ipc', () => ({ registerLocalePreferenceIpc: () => vi.fn() }))
+vi.mock('./window-shortcuts', () => ({ installWindowShortcuts: vi.fn() }))
+vi.mock('./network-ipc', () => ({ registerNetworkIpcHandlers: vi.fn() }))
+vi.mock('./database/database-startup-logging', () => ({
+  createDatabaseStartupLogging: () => ({ migrationOptions: vi.fn(), reportBlocked: vi.fn() })
+}))
+vi.mock('./database/database-startup-ipc', () => ({
+  registerDatabaseStartupIpc: () => vi.fn(),
+  installDatabaseStartupQuitGuard: () => ({ dispose: vi.fn(), release: vi.fn() })
+}))
+vi.mock('./database/startup-diagnostics', () => ({ buildStartupDiagnostics: vi.fn() }))
+vi.mock('./projects/prisma-client', () => ({ getProjectDbClient: async () => ({}) }))
+vi.mock('./storage-root', () => ({ resolveConfigRoot: () => '/isolated-test' }))
+vi.mock('./settings/document-store', () => ({ SettingsDocumentStore: class {} }))
+vi.mock('./settings/repository', () => ({
+  SettingsRepository: class {
+    getSettings = async (): Promise<Record<string, never>> => ({})
+  }
+}))
+vi.mock('./ipc', () => ({
+  registerIpcHandlers: async () => ({
+    dispose: fixture.disposeRuntime,
+    notificationInbox: { configureDesktop: vi.fn() },
+    settingsService: {
+      getAppIconVariant: async () => {
+        if (fixture.failAt === 'icon') throw fixture.failure
+        return 'light'
+      }
+    },
+    bindRemoteAccess: vi.fn()
+  })
+}))
+vi.mock('./storage/migration-state', () => ({
+  installMigrationQuitGuard: vi.fn(),
+  isMigrationInProgress: () => false
+}))
+vi.mock('./tray', () => ({
+  createAppTray: vi.fn(),
+  refreshAppTrayLocale: vi.fn(),
+  setTrayIconVariant: vi.fn()
+}))
+vi.mock('./app-lifecycle', () => ({ installAppLifecycle: vi.fn() }))
+vi.mock('./ipc-handler-registry', () => ({ disposeIpcHandlerRegistry: vi.fn() }))
+vi.mock('./web-service', () => ({
+  createWebServiceController: () => ({
+    ensureStarted: async () => {
+      throw fixture.failure
+    },
+    dispose: fixture.disposeWeb
+  }),
+  buildAuthenticatedWebUrl: vi.fn()
+}))
+vi.mock('./second-instance-router', () => ({ routeSecondInstance: vi.fn() }))
+vi.mock('./window-close-confirm', () => ({ createElectronCloseConfirm: vi.fn() }))
+vi.mock('./session-persistence/renderer-flush', () => ({
+  createElectronSessionPersistenceFlush: vi.fn(),
+  notifyRendererSessionPersistenceFlushAborted: vi.fn(),
+  rendererSessionPersistenceFlushBlocksShutdown: vi.fn()
+}))
+vi.mock('./app-icon', () => ({
+  createAppIconController: () => ({}),
+  buildAppIconPreviews: vi.fn()
+}))
+vi.mock('./remote-access', () => ({
+  RemoteAccessService: {
+    create: async () => {
+      if (fixture.failAt === 'remote') throw fixture.failure
+      return {
+        webAccess: {},
+        attachWebController: vi.fn(),
+        shutdown: fixture.shutdownRemote,
+        restore: vi.fn()
+      }
+    }
+  },
+  registerRemoteAccessIpcHandlers: vi.fn()
+}))
+vi.mock('./notifications/desktop-attention', () => ({
+  createDesktopAttentionController: vi.fn(),
+  wireDesktopAttention: vi.fn()
+}))
+vi.mock('./notifications/desktop-badge', () => ({
+  createDesktopBadgeAdapter: vi.fn(),
+  createWindowsBadgeBitmap: vi.fn()
+}))
+vi.mock('./notifications/notification-inbox-controller', () => ({
+  wireNotificationInboxController: vi.fn()
+}))
+vi.mock('./notifications/unread-task-ipc', () => ({
+  registerUnreadTaskIpc: () => ({ confirmSessionVisible: async () => false })
+}))
+
+const monitorListeners = process.listeners('uncaughtExceptionMonitor')
+beforeEach(() => {
+  vi.resetModules()
+  vi.clearAllMocks()
+  fixture.failAt = 'web'
+  fixture.disposeWeb.mockReset().mockResolvedValue()
+  fixture.disposeRuntime.mockReset().mockResolvedValue()
+})
+afterEach(() => {
+  for (const listener of process.listeners('uncaughtExceptionMonitor')) {
+    if (!monitorListeners.includes(listener))
+      process.removeListener('uncaughtExceptionMonitor', listener)
+  }
+})
+
+it('disposes acquired application surfaces when explicit web startup fails before context handoff', async () => {
+  // Exercise the real process entry, startup orchestration and database owner; replace only
+  // environmental services so the existing web-start boundary deterministically rejects.
+  await import('./index')
+  await vi.waitFor(() => expect(fixture.electron.app.exit).toHaveBeenCalledWith(1))
+  expect(fixture.startupFailure).toHaveBeenCalledWith(
+    expect.objectContaining({ error: fixture.failure })
+  )
+  expect.soft(fixture.disposeRuntime).toHaveBeenCalledOnce()
+  expect.soft(fixture.disposeWeb).toHaveBeenCalledOnce()
+  expect.soft(fixture.shutdownRemote).toHaveBeenCalledOnce()
+})
+
+it.each(['icon', 'remote'] as const)(
+  'cleans the runtime when %s preparation fails without disposing uncreated services',
+  async (stage) => {
+    fixture.failAt = stage
+    await import('./index')
+    await vi.waitFor(() => expect(fixture.electron.app.exit).toHaveBeenCalledWith(1))
+    expect(fixture.startupFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ error: fixture.failure })
+    )
+    expect(fixture.disposeRuntime).toHaveBeenCalledOnce()
+    expect(fixture.disposeWeb).not.toHaveBeenCalled()
+    expect(fixture.shutdownRemote).not.toHaveBeenCalled()
+  }
+)
+
+it.each(['reject', 'hang'] as const)(
+  'preserves the startup error and continues cleanup when Web disposal will %s',
+  async (failure) => {
+    if (failure === 'reject') fixture.disposeWeb.mockRejectedValue(new Error('cleanup failed'))
+    else fixture.disposeWeb.mockImplementation(() => new Promise(() => {}))
+    await import('./index')
+    await vi.waitFor(() => expect(fixture.electron.app.exit).toHaveBeenCalledWith(1), {
+      timeout: 4000
+    })
+    expect(fixture.startupFailure).toHaveBeenCalledWith(
+      expect.objectContaining({ error: fixture.failure })
+    )
+    expect(fixture.disposeWeb).toHaveBeenCalledOnce()
+    expect(fixture.disposeRuntime).toHaveBeenCalledOnce()
+    expect(fixture.shutdownRemote).toHaveBeenCalledOnce()
+    expect(fixture.disposeWeb.mock.invocationCallOrder[0]).toBeLessThan(
+      fixture.disposeRuntime.mock.invocationCallOrder[0]
+    )
+    expect(fixture.disposeRuntime.mock.invocationCallOrder[0]).toBeLessThan(
+      fixture.shutdownRemote.mock.invocationCallOrder[0]
+    )
+  }
+)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -489,6 +489,13 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
           ]
         ) => {
           startupDiagnostics?.phase('compose-runtime')
+          // Retain ownership before the complete context can be handed to the lifecycle.
+          let disposePartialRuntime:
+            Awaited<ReturnType<typeof registerIpcHandlers>>['dispose'] | undefined
+          let partialRemoteAccess:
+            Awaited<ReturnType<typeof RemoteAccessService.create>> | undefined
+          let partialWebController: ReturnType<typeof createWebServiceController> | undefined
+          let disposeTrayLocaleSubscription: (() => void) | undefined
 
           try {
             startupDiagnostics?.phase('register-application-ipc')
@@ -503,7 +510,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             // the app icon variant — the tray only exists once the lifecycle is installed (assigned in the
             // createTray callback). Mirrors the trayBox late-binding pattern in app-lifecycle.ts.
             const appTrayBox: { current: ReturnType<typeof createAppTray> } = { current: undefined }
-            const disposeTrayLocaleSubscription = localeOwner.subscribe(() =>
+            disposeTrayLocaleSubscription = localeOwner.subscribe(() =>
               refreshAppTrayLocale(appTrayBox.current)
             )
             // Unread state restores before the main-window lifecycle is installed. Late-bind its getter so
@@ -561,6 +568,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               },
               listAppIconPreviews: () => buildAppIconPreviews(nativeImage, iconVariantPaths)
             })
+            disposePartialRuntime = disposeApplicationRuntime
             startupDiagnostics?.phase('compose-desktop-surfaces')
 
             // The controller must exist before its IPC responder, while the responder calls back into the
@@ -610,6 +618,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             })
             startupDiagnostics?.phase('compose-remote-access')
             const remoteAccess = await RemoteAccessService.create()
+            partialRemoteAccess = remoteAccess
             bindRemoteAccess(remoteAccess)
             const webController = createWebServiceController({
               applicationCommands,
@@ -622,6 +631,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
               computePreferences,
               detectActiveSessions
             })
+            partialWebController = webController
             remoteAccess.attachWebController(webController)
             registerRemoteAccessIpcHandlers(remoteAccess)
             // A launch that itself requested serving (a dedicated headless daemon, or an explicit --serve) is
@@ -633,7 +643,7 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             void remoteAccess.restore()
 
             const disposeApplicationIpcHandlers = (): void => {
-              disposeTrayLocaleSubscription()
+              disposeTrayLocaleSubscription?.()
               disposeLocalePreferenceIpc()
               managedPreviewProtocolBridge.dispose()
               disposeDatabaseStartupIpc()
@@ -710,8 +720,23 @@ async function startElectronApp(mainEntryPath: string): Promise<void> {
             // Invalidate caller leases immediately if composition fails after registering IPC. The
             // outer shell rollback destroys the window and quits, but renderer calls can still arrive
             // while that shutdown is in flight.
-            disposeIpcHandlerRegistry()
-            managedPreviewProtocolBridge.dispose()
+            for (const invalidate of [
+              disposeIpcHandlerRegistry,
+              () => managedPreviewProtocolBridge.dispose()
+            ]) {
+              try {
+                invalidate()
+              } catch {
+                // Preserve the startup error and still stop all acquired services.
+              }
+            }
+            await createApplicationLifecycleShutdown({
+              disposeApplicationRuntime: () => disposePartialRuntime?.(),
+              remoteAccess: { shutdown: () => partialRemoteAccess?.shutdown() },
+              webController: { dispose: () => partialWebController?.dispose() },
+              disposeIpcHandlers: () => disposeTrayLocaleSubscription?.(),
+              log
+            })()
             throw error
           }
         },

--- a/src/main/window-close-confirm.test.ts
+++ b/src/main/window-close-confirm.test.ts
@@ -111,6 +111,36 @@ const flushPreferenceRead = async (): Promise<void> => {
 }
 
 describe('createCloseConfirm', () => {
+  it.each([
+    { name: 'agent', sessions: [session], unlisted: false },
+    { name: 'Reviewer or installer', sessions: [], unlisted: true },
+    {
+      name: 'delegated work',
+      sessions: [{ ...session, kind: 'delegated' as const }],
+      unlisted: false
+    }
+  ])(
+    'does not authorize quitting $name when the native confirmation fails',
+    async ({ sessions, unlisted }) => {
+      const nativeFallback = vi.fn().mockRejectedValue(new Error('Native dialog unavailable'))
+      const h = makeHarness({ isRendererAvailable: () => false, nativeFallback })
+      const result = await h.confirm('quit', sessions, unlisted)
+      expect(nativeFallback).toHaveBeenCalledOnce()
+      expect(result).toBe('cancel')
+    }
+  )
+
+  it('cancels a failed native fallback after missing ACK and permits a subsequent confirmation', async () => {
+    const nativeFallback = vi
+      .fn<CloseConfirmDeps['nativeFallback']>()
+      .mockRejectedValueOnce(new Error('dialog unavailable'))
+      .mockResolvedValueOnce({ choice: 'quit' })
+    const h = makeHarness({ nativeFallback })
+    await expect(h.confirm('quit', [session])).resolves.toBe('cancel')
+    await expect(h.confirm('quit', [session])).resolves.toBe('quit')
+    expect(nativeFallback).toHaveBeenCalledTimes(2)
+  })
+
   it('resolves quit immediately for the quit variant with no running work (no IPC)', async () => {
     const h = makeHarness()
     await expect(h.confirm('quit', [])).resolves.toBe('quit')
@@ -240,12 +270,12 @@ describe('createCloseConfirm', () => {
 
   it('still settles when the native fallback rejects (never strands the confirm)', async () => {
     // A stranded promise would pin the caller's in-flight guard forever and block quit. If the native
-    // dialog rejects (e.g. the window was destroyed), quit proceeds and close-to-tray stays resident.
+    // dialog rejects (e.g. the window was destroyed), cancel quit and keep close-to-tray resident.
     const rejecting = vi.fn(async (): Promise<NativeCloseConfirmResult> => {
       throw new Error('dialog failed')
     })
     const quitHarness = makeHarness({ isRendererAvailable: () => false, nativeFallback: rejecting })
-    await expect(quitHarness.confirm('quit', [session])).resolves.toBe('quit')
+    await expect(quitHarness.confirm('quit', [session])).resolves.toBe('cancel')
 
     const trayHarness = makeHarness({ isRendererAvailable: () => false, nativeFallback: rejecting })
     await expect(trayHarness.confirm('close-to-tray', [session])).resolves.toBe('minimize')

--- a/src/main/window-close-confirm.ts
+++ b/src/main/window-close-confirm.ts
@@ -72,7 +72,7 @@ const DEFAULT_HANG_GRACE_MS = 10_000
 
 // Coordinates a close/quit confirmation. Main computes `sessions` plus activity without a Session row,
 // so the quit variant resolves without IPC only when both are idle; otherwise the renderer renders the
-// modal and replies with the choice, with a native/proceed fallback if it can't.
+// modal and replies with the choice, with a native confirmation fallback if it can't.
 export const createCloseConfirm = (
   deps: CloseConfirmDeps
 ): ((
@@ -105,7 +105,7 @@ export const createCloseConfirm = (
 
     // Never let a fallback rejection leave the confirm unsettled: a stranded promise would pin the
     // caller's in-flight guard forever and permanently block quit. On failure, keep the app resident
-    // for close-to-tray and proceed for quit.
+    // for close-to-tray and cancel an unconfirmed quit.
     const safeFallback = async (): Promise<CloseConfirmChoice> => {
       try {
         const result = await deps.nativeFallback(variant, sessions)
@@ -113,9 +113,7 @@ export const createCloseConfirm = (
         await persistPreference(choice, result.remember)
         return choice
       } catch {
-        return enforceDelegatedBlock(
-          variant === 'quit' ? 'quit' : variant === 'close-to-tray' ? 'minimize' : 'cancel'
-        )
+        return enforceDelegatedBlock(variant === 'close-to-tray' ? 'minimize' : 'cancel')
       }
     }
 

--- a/src/renderer/src/components/application-error-boundary.test.tsx
+++ b/src/renderer/src/components/application-error-boundary.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ApplicationErrorBoundary } from './application-error-boundary'
+import { NotificationErrorBoundary } from './NotificationErrorBoundary'
+
+const BrokenView = (): never => {
+  throw new TypeError('private research content and secret-token')
+}
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+it('reports only a projected failure and keeps private error content out of the recovery page', () => {
+  const reportRendererFailure = vi.fn()
+  const quit = vi.fn()
+  window.api = {
+    diagnostics: { reportRendererFailure },
+    databaseStartup: { quit }
+  } as unknown as Window['api']
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  render(
+    <ApplicationErrorBoundary>
+      <BrokenView />
+    </ApplicationErrorBoundary>
+  )
+  expect(screen.getByRole('alert')).toBeTruthy()
+  expect(screen.getByRole('button', { name: 'Reload page' })).toBeTruthy()
+  expect(document.body.textContent).not.toContain('secret-token')
+  expect(reportRendererFailure).toHaveBeenCalledOnce()
+  expect(reportRendererFailure).toHaveBeenCalledWith({
+    source: 'handled-error',
+    surface: 'unknown',
+    errorCategory: 'type',
+    fingerprint: expect.stringMatching(/^[a-f0-9]{8}$/)
+  })
+  expect(quit).not.toHaveBeenCalled()
+})
+
+it('keeps recovery visible when reporting the failure throws', () => {
+  window.api = {
+    diagnostics: {
+      reportRendererFailure: () => {
+        throw new Error('bridge unavailable')
+      }
+    }
+  } as unknown as Window['api']
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  expect(() =>
+    render(
+      <ApplicationErrorBoundary>
+        <BrokenView />
+      </ApplicationErrorBoundary>
+    )
+  ).not.toThrow()
+  expect(screen.getByRole('button', { name: 'Reload page' })).toBeTruthy()
+})
+
+it('leaves a locally contained notification failure within its existing boundary', () => {
+  window.api = {} as Window['api']
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  render(
+    <ApplicationErrorBoundary>
+      <div>Application content</div>
+      <NotificationErrorBoundary>
+        <BrokenView />
+      </NotificationErrorBoundary>
+    </ApplicationErrorBoundary>
+  )
+  expect(screen.getByText('Application content')).toBeTruthy()
+  expect(screen.queryByRole('button', { name: 'Reload page' })).toBeNull()
+})

--- a/src/renderer/src/components/application-error-boundary.tsx
+++ b/src/renderer/src/components/application-error-boundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import { RefreshCw } from 'lucide-react'
+
+import { ErrorNotice } from '@/components/error-notice'
+import { projectRendererFailure } from '../renderer-diagnostics'
+
+const ApplicationErrorFallback = (): React.JSX.Element => {
+  const { t } = useTranslation()
+  return (
+    <main className="flex min-h-svh items-center justify-center bg-background px-6 text-foreground">
+      <div className="w-full max-w-lg">
+        <ErrorNotice
+          role="alert"
+          icon={RefreshCw}
+          tone="amber"
+          title={t("Open Science couldn't display this page")}
+          description={t(
+            'Background work may still be running. Reloading may lose unsaved changes on this page.'
+          )}
+          primaryButton={{ label: t('Reload page'), onClick: () => window.location.reload() }}
+        />
+      </div>
+    </main>
+  )
+}
+
+// Keep recovery outside the business stores and startup gate: either can fail while rendering.
+// Recovery is user-initiated page navigation; this boundary never stops or resubmits backend work.
+class ApplicationErrorBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false }
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true }
+  }
+
+  componentDidCatch(error: Error): void {
+    try {
+      window.api?.diagnostics?.reportRendererFailure(
+        projectRendererFailure('handled-error', error, 'unknown')
+      )
+    } catch {
+      // An unavailable diagnostics bridge must not break the recovery surface.
+    }
+  }
+
+  render(): ReactNode {
+    return this.state.failed ? <ApplicationErrorFallback /> : this.props.children
+  }
+}
+
+export { ApplicationErrorBoundary }

--- a/src/renderer/src/components/database-startup-gate.test.tsx
+++ b/src/renderer/src/components/database-startup-gate.test.tsx
@@ -1,5 +1,7 @@
 // @vitest-environment jsdom
 
+import { StrictMode } from 'react'
+
 import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
@@ -35,6 +37,192 @@ describe('DatabaseStartupGate', () => {
         }
       }
     } as unknown as Window['api']
+  })
+
+  it('keeps the ready application mounted after a delayed retry snapshot', async () => {
+    let resolveRetry!: (state: DatabaseStartupState) => void
+    retry.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve
+        })
+    )
+    await act(async () => {
+      render(
+        <DatabaseStartupGate>
+          <div>Business application</div>
+        </DatabaseStartupGate>
+      )
+    })
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    act(() => publish({ phase: 'ready' }))
+    const application = screen.getByText('Business application')
+    await act(async () => resolveRetry({ phase: 'starting' }))
+    expect(screen.queryByText('Business application')).toBe(application)
+    expect(screen.queryByText('Starting Open Science…')).toBeNull()
+  })
+
+  it.each(['ready', 'blocked'] as const)(
+    'keeps a newer %s event when retry rejects',
+    async (phase) => {
+      let rejectRetry!: (error: Error) => void
+      retry.mockImplementation(
+        () =>
+          new Promise((_resolve, reject) => {
+            rejectRetry = reject
+          })
+      )
+      await act(async () => {
+        render(
+          <DatabaseStartupGate>
+            <div>Business application</div>
+          </DatabaseStartupGate>
+        )
+      })
+      const blocked: DatabaseStartupState = {
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      }
+      act(() => publish(blocked))
+      fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+      act(() => publish(phase === 'ready' ? { phase } : blocked))
+      await act(async () => rejectRetry(new Error('late failure')))
+      expect(screen.queryByText('Open Science could not finish checking its database.')).toBeNull()
+      expect(
+        screen.getByText(phase === 'ready' ? 'Business application' : blocked.error.message)
+      ).toBeTruthy()
+    }
+  )
+
+  it('keeps a newer blocked event when a retry returns an older starting state', async () => {
+    let resolveRetry!: (state: DatabaseStartupState) => void
+    retry.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve
+        })
+    )
+    await act(async () => {
+      render(
+        <DatabaseStartupGate>
+          <div>Business application</div>
+        </DatabaseStartupGate>
+      )
+    })
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_newer_than_app',
+          message: 'A newer app is required.',
+          retryable: false
+        }
+      })
+    )
+    await act(async () => resolveRetry({ phase: 'starting' }))
+    expect(screen.getByText('A newer app is required.')).toBeTruthy()
+    expect(screen.queryByRole('button', { name: 'Retry' })).toBeNull()
+  })
+
+  it('accepts a retry snapshot before ready and ignores events after unmount', async () => {
+    let resolveRetry!: (state: DatabaseStartupState) => void
+    retry.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve
+        })
+    )
+    const view = render(
+      <DatabaseStartupGate>
+        <div>Business application</div>
+      </DatabaseStartupGate>
+    )
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    await act(async () => resolveRetry({ phase: 'starting' }))
+    expect(screen.getByText('Starting Open Science…')).toBeTruthy()
+    act(() => publish({ phase: 'ready' }))
+    expect(screen.getByText('Business application')).toBeTruthy()
+    view.unmount()
+    act(() => publish({ phase: 'starting' }))
+    expect(screen.queryByText('Starting Open Science…')).toBeNull()
+  })
+
+  it('ignores a retry from an unmounted StrictMode gate after a new gate is ready', async () => {
+    let resolveRetry!: (state: DatabaseStartupState) => void
+    retry.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveRetry = resolve
+        })
+    )
+    const view = render(
+      <StrictMode>
+        <DatabaseStartupGate>
+          <div>Old application</div>
+        </DatabaseStartupGate>
+      </StrictMode>
+    )
+    act(() =>
+      publish({
+        phase: 'blocked',
+        error: {
+          code: 'database_open_failed',
+          message: 'Open Science could not open its database.',
+          retryable: true
+        }
+      })
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+    view.unmount()
+    getState.mockResolvedValue({ phase: 'ready' })
+    await act(async () => {
+      render(
+        <StrictMode>
+          <DatabaseStartupGate>
+            <div>New application</div>
+          </DatabaseStartupGate>
+        </StrictMode>
+      )
+    })
+    const application = screen.getByText('New application')
+    await act(async () => resolveRetry({ phase: 'starting' }))
+    expect(screen.getByText('New application')).toBe(application)
+    expect(screen.queryByText('Starting Open Science…')).toBeNull()
   })
 
   it('reuses the branded startup loader while checking and migrating the database', () => {

--- a/src/renderer/src/components/database-startup-gate.tsx
+++ b/src/renderer/src/components/database-startup-gate.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useRef, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import {
   CircleArrowUp,
@@ -100,25 +100,27 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
   )
   const [retrying, setRetrying] = useState(false)
   const [issueDraftOpen, setIssueDraftOpen] = useState(false)
+  const subscription = useRef<{ events: number } | null>(null)
 
   useEffect(() => {
     if (!databaseStartup) return
-    let disposed = false
-    let receivedEvent = false
+    const owner = { events: 0 }
+    subscription.current = owner
     const unsubscribe = databaseStartup.onStateChanged((next) => {
-      receivedEvent = true
-      if (!disposed) setState(next)
+      owner.events += 1
+      if (subscription.current === owner) setState(next)
     })
     void databaseStartup
       .getState()
       .then((current) => {
-        if (!disposed && !receivedEvent) setState(current)
+        if (subscription.current === owner && owner.events === 0) setState(current)
       })
       .catch(() => {
-        if (!disposed && !receivedEvent) setState(applyUnavailableStartupFallback)
+        if (subscription.current === owner && owner.events === 0)
+          setState(applyUnavailableStartupFallback)
       })
     return () => {
-      disposed = true
+      if (subscription.current === owner) subscription.current = null
       unsubscribe()
     }
   }, [databaseStartup])
@@ -126,15 +128,26 @@ const DatabaseStartupGate = ({ children }: DatabaseStartupGateProps): React.JSX.
   if (state.phase === 'ready') return <>{children}</>
 
   const retry = (): void => {
-    if (!databaseStartup) return
+    const owner = subscription.current
+    if (!databaseStartup || !owner) return
+    const events = owner.events
     setRetrying(true)
     void databaseStartup
       .retry()
-      .then(setState)
-      .catch(() => {
-        setState(restoreUnavailableUnlessReady)
+      .then((next) => {
+        if (subscription.current === owner && owner.events === events) setState(next)
       })
-      .finally(() => setRetrying(false))
+      .catch(() => {
+        if (subscription.current !== owner) return
+        // A retry may publish checking before failing. Recover that pending attempt, but keep
+        // newer starting/blocked/ready events authoritative over an obsolete rejection.
+        setState(
+          owner.events === events ? restoreUnavailableUnlessReady : applyUnavailableStartupFallback
+        )
+      })
+      .finally(() => {
+        if (subscription.current === owner) setRetrying(false)
+      })
   }
 
   const openIssueDraft = (): void => {

--- a/src/renderer/src/main.render.test.tsx
+++ b/src/renderer/src/main.render.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+
+const root = vi.hoisted(() => ({ render: vi.fn() }))
+vi.mock('react-dom/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('react-dom/client')>()
+  return {
+    ...actual,
+    createRoot: (container: Element, options: Parameters<typeof actual.createRoot>[1]) =>
+      container.id === 'root' ? root : actual.createRoot(container, options)
+  }
+})
+vi.mock('./App', () => ({
+  default: () => {
+    throw new Error('Main view render failed')
+  }
+}))
+vi.mock('@/components/streamdown/install-streamdown', () => ({ installStreamdown: vi.fn() }))
+vi.mock('@/lib/locale-preference', () => ({
+  applyHtmlLang: vi.fn(),
+  resolveInitialLocale: () => 'en'
+}))
+vi.mock('@/lib/theme', () => ({ applyTheme: vi.fn(), resolveInitialTheme: () => 'light' }))
+vi.mock('@/stores/network-store', () => ({ startNetworkMonitor: vi.fn() }))
+vi.mock('./renderer-diagnostics', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('./renderer-diagnostics')>()),
+  installRendererFailureDiagnostics: vi.fn()
+}))
+vi.mock('@/stores/navigation-store', () => ({
+  useNavigationStore: { getState: () => ({ view: 'workspace' }) }
+}))
+vi.mock('@/stores/settings-store', () => ({ useSettingsStore: { getState: () => ({}) } }))
+vi.mock('@/stores/locale-store', () => ({ startLocalePreferenceSync: vi.fn() }))
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+it('contains a main-view render failure in the real root composition and offers recovery', async () => {
+  document.body.innerHTML = '<div id="root"></div>'
+  window.api = {} as Window['api']
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  await import('./main')
+  expect(root.render).toHaveBeenCalledOnce()
+  const tree = root.render.mock.calls[0][0] as ReactNode
+  // Mount exactly the tree supplied by the production entry point. Only the failing view and
+  // unrelated bootstrap side effects are doubled; no boundary is added by this test.
+  expect(() => render(tree)).not.toThrow()
+  expect(screen.queryAllByRole('button').length).toBeGreaterThan(0)
+})

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -3,6 +3,7 @@ import './assets/main.css'
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
+import { ApplicationErrorBoundary } from '@/components/application-error-boundary'
 import { DatabaseStartupGate } from '@/components/database-startup-gate'
 import { installStreamdown } from '@/components/streamdown/install-streamdown'
 import { initI18n } from '@/i18n'
@@ -53,8 +54,10 @@ window.addEventListener('drop', (event) => event.preventDefault())
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <DatabaseStartupGate>
-      <App />
-    </DatabaseStartupGate>
+    <ApplicationErrorBoundary>
+      <DatabaseStartupGate>
+        <App />
+      </DatabaseStartupGate>
+    </ApplicationErrorBoundary>
   </StrictMode>
 )

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5031,6 +5031,9 @@
     "Recheck saved conversations": "Gespeicherte Konversationen erneut prüfen",
     "Some changes have not been saved.": "Einige Änderungen wurden nicht gespeichert.",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Einmal erlauben gilt für die nächste Ausführung in dieser Laufzeitumgebung, auch wenn sich der Code ändert. Während dieser Ausführung sind mehrere Verbindungen zu dieser Domain erlaubt.",
-    "Next execution in this runtime": "Nächste Ausführung in dieser Laufzeitumgebung"
+    "Next execution in this runtime": "Nächste Ausführung in dieser Laufzeitumgebung",
+    "Open Science couldn't display this page": "Open Science konnte diese Seite nicht anzeigen",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "Hintergrundaufgaben werden möglicherweise noch ausgeführt. Beim Neuladen können ungespeicherte Änderungen auf dieser Seite verloren gehen.",
+    "Reload page": "Seite neu laden"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5193,6 +5193,9 @@
     "Recheck saved conversations": "Volver a comprobar las conversaciones guardadas",
     "Some changes have not been saved.": "Algunos cambios no se han guardado.",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Permitir una vez se aplica a la siguiente ejecución en este entorno, aunque cambie el código. Permite varias conexiones a este dominio durante esa ejecución.",
-    "Next execution in this runtime": "Siguiente ejecución en este entorno"
+    "Next execution in this runtime": "Siguiente ejecución en este entorno",
+    "Open Science couldn't display this page": "Open Science no pudo mostrar esta página",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "Es posible que las tareas en segundo plano sigan en ejecución. Al volver a cargar, pueden perderse los cambios sin guardar de esta página.",
+    "Reload page": "Volver a cargar la página"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5193,6 +5193,9 @@
     "Recheck saved conversations": "Revérifier les conversations enregistrées",
     "Some changes have not been saved.": "Certaines modifications n’ont pas été enregistrées.",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Autoriser une fois s’applique à la prochaine exécution dans cet environnement, même si le code change. Plusieurs connexions à ce domaine sont autorisées pendant cette exécution.",
-    "Next execution in this runtime": "Prochaine exécution dans cet environnement"
+    "Next execution in this runtime": "Prochaine exécution dans cet environnement",
+    "Open Science couldn't display this page": "Open Science n’a pas pu afficher cette page",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "Des tâches peuvent encore être en cours en arrière-plan. Le rechargement peut entraîner la perte des modifications non enregistrées sur cette page.",
+    "Reload page": "Recharger la page"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4877,6 +4877,9 @@
     "Recheck saved conversations": "保存済みの会話を再確認",
     "Some changes have not been saved.": "一部の変更が保存されていません。",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "1回のみ許可は、コードが変更されても、このランタイムでの次の実行に適用されます。その実行中は、このドメインへの複数の接続が許可されます。",
-    "Next execution in this runtime": "このランタイムでの次の実行"
+    "Next execution in this runtime": "このランタイムでの次の実行",
+    "Open Science couldn't display this page": "Open Science でこのページを表示できませんでした",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "バックグラウンドの処理は引き続き実行されている可能性があります。再読み込みすると、このページの未保存の変更が失われる可能性があります。",
+    "Reload page": "ページを再読み込み"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4875,6 +4875,9 @@
     "Recheck saved conversations": "저장된 대화 다시 확인",
     "Some changes have not been saved.": "일부 변경 사항이 저장되지 않았습니다.",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "한 번 허용은 코드가 변경되어도 이 런타임의 다음 실행에 적용됩니다. 해당 실행 중에는 이 도메인에 여러 번 연결할 수 있습니다.",
-    "Next execution in this runtime": "이 런타임의 다음 실행"
+    "Next execution in this runtime": "이 런타임의 다음 실행",
+    "Open Science couldn't display this page": "Open Science에서 이 페이지를 표시할 수 없습니다",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "백그라운드 작업이 아직 실행 중일 수 있습니다. 새로고침하면 이 페이지의 저장되지 않은 변경 사항이 손실될 수 있습니다.",
+    "Reload page": "페이지 새로고침"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5326,6 +5326,9 @@
     "Recheck saved conversations": "Повторно проверить сохранённые диалоги",
     "Some changes have not been saved.": "Некоторые изменения не сохранены.",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "Однократное разрешение действует для следующего выполнения в этой среде, даже если код изменится. Во время этого выполнения разрешено несколько подключений к этому домену.",
-    "Next execution in this runtime": "Следующее выполнение в этой среде"
+    "Next execution in this runtime": "Следующее выполнение в этой среде",
+    "Open Science couldn't display this page": "Open Science не удалось отобразить эту страницу",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "Фоновые задачи могут всё ещё выполняться. При перезагрузке несохранённые изменения на этой странице могут быть потеряны.",
+    "Reload page": "Перезагрузить страницу"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4877,6 +4877,9 @@
     "Recheck saved conversations": "重新检查已保存的对话",
     "Some changes have not been saved.": "部分更改尚未保存。",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "允许一次适用于此运行时的下一次执行，即使代码发生变化也仍然适用。该次执行期间可多次连接此域名。",
-    "Next execution in this runtime": "此运行时的下一次执行"
+    "Next execution in this runtime": "此运行时的下一次执行",
+    "Open Science couldn't display this page": "Open Science 无法显示此页面",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "后台工作可能仍在运行。重新加载可能会丢失此页面上未保存的更改。",
+    "Reload page": "重新加载页面"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4877,6 +4877,9 @@
     "Recheck saved conversations": "重新檢查已儲存的對話",
     "Some changes have not been saved.": "部分變更尚未儲存。",
     "Allow once applies to the next execution in this runtime, even if the code changes. It allows multiple connections to this domain during that execution.": "允許一次適用於此執行環境的下一次執行，即使程式碼有所變更也仍然適用。該次執行期間可多次連線至此網域。",
-    "Next execution in this runtime": "此執行環境的下一次執行"
+    "Next execution in this runtime": "此執行環境的下一次執行",
+    "Open Science couldn't display this page": "Open Science 無法顯示此頁面",
+    "Background work may still be running. Reloading may lose unsaved changes on this page.": "背景工作可能仍在執行。重新載入可能會遺失此頁面上未儲存的變更。",
+    "Reload page": "重新載入頁面"
   }
 }


### PR DESCRIPTION
## Problem

A failure after runtime registration but before startup Context handoff skips acquired service cleanup. Separately, a late Retry snapshot can replace a newer ready event and unmount the application, and native confirmation failure currently authorizes quitting active work. An uncaught root React render error also leaves no page recovery control.

## Proposed change

- Retain acquired Runtime, RemoteAccess and Web handles during startup and use the existing bounded shutdown coordinator on composition failure, preserving the original error.
- Ignore obsolete Retry responses by tracking the current subscription lifetime and event count. Preserve recovery from a retry that publishes checking and then rejects.
- Cancel an unconfirmed ordinary quit when native confirmation fails. Preserve idle quit, close-to-tray, explicit decisions and nonordinary shutdown routing.
- Add a root Error Boundary using ErrorNotice, projected diagnostics and manual page reload. Translate its three strings into all eight locales and warn about background work and unsaved page changes.

## Scope and non-goals

No database/schema change, migration, persisted field, shared enum, dependency, historical process cleanup, automatic reload/task resubmission, or slow-start timeout UI. New bookkeeping is memory-only. Existing shutdown can still flush its existing state. The provider, history and active-branch contracts are unchanged.

## Acceptance criteria and validation

Expected-correct tests exercised the unchanged base before repair: 13 behavioral failures / 65 passing controls. The repaired regression set passes all 81 tests. Tests exercise the real startup entry, Gate, confirmation coordinator and renderer root with controlled environmental dependencies; no production test seam was added.

Checks ran after the final material edits:

| Behavior | Root command / selected checks | Result |
| --- | --- | --- |
| Startup ownership, bounded cleanup, quit policy, event order, root recovery and translations | `npm test -- <13 owner files>`: app-startup, application-runtime, app-lifecycle, window-close-confirm, index-startup-failure, index-startup-order, database-startup-owner, database-startup-ipc, main.render, application-error-boundary, database-startup-gate, renderer diagnostics, i18n resources | 1042 passed |
| Caller cleanup, durability, shutdown, diagnostics, Web bootstrap and local containment | `npm test -- <6 consumer files>`: caller-lifecycle, session-persistence/renderer-flush, lifecycle-shutdown, main renderer-diagnostics, web/bootstrap, NotificationErrorBoundary | 124 passed |
| Expanded regressions after baseline replay | `npm test --` index-startup-failure, window-close-confirm, database-startup-gate, main.render, application-error-boundary | 81 passed |
| Runtime types | `npm run typecheck:node` (includes sandbox), `npm run typecheck:web` | passed |
| Source quality | `npm run lint`, changed-file Prettier, `git diff --check` | passed |
| Recovery UI | Actual components + production CSS and zh-Hans in Chromium; click Reload page, verify a fresh recovered page and no private error content | passed; screenshot captured |

The final `test:affected:explain -- --base e4b8546e3ab6d0f278abdfa98aa1f8f24a67ec25 --head HEAD` requests full fallback because the new process-entry test has no registered module owner. Per maintainer instruction, local validation uses the explicit owner/consumer set above; PR CI supplies the full and platform suites. No ownership manifest was expanded just to narrow CI.

## Review focus

Check partial ownership before handoff, preservation of the initial startup failure despite cleanup rejection/timeout, stale event ordering, and the intentional native-confirmation failure policy. Independent review and exact-head CI remain required.

Local tests do not certify real OS port-conflict/process-tree cleanup, packaged Electron crashes, system shutdown or live provider survival across page reload. Bootstrap/preload failures remain outside React error-boundary coverage.

After GitHub reported real merge conflicts, main was merged and both sets of locale additions were retained. The post-merge nine-file owner/i18n run passes 1010 tests, and node/sandbox/web typechecks plus lint pass. The process-entry tests now await the existing app.exit signal rather than a one-second polling deadline; the five cleanup expectations fail twice on original production code and pass on the repaired code.

CI follow-up: the existing application-command-wiring test assumed creation and binding statements were adjacent. Its exact failure was reproduced locally, then the assertion was adjusted to allow ownership bookkeeping while preserving order, unique creation and narrow capability checks. The wiring, startup-entry and runtime suites pass together (36 tests). A prior Windows workspace run also had one startup `migrating` timeout that passed its built-in retry; no timeout or migration behavior was relaxed. The updated head must pass fresh CI, including that Windows lane.
