### PR TITLE
fix(acp): register Claude skill loader for conversation grants

### DIFF
--- a/src/main/acp/permission-broker-registry.test.ts
+++ b/src/main/acp/permission-broker-registry.test.ts
@@ -14,6 +14,12 @@ import { seedDefaultPermissionGrants } from '../permission-grants/defaults'
 import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
 import { AcpPermissionBroker, projectRegistrySessionGrants } from './permission-broker'
 import { withTrustedMcpToolIdentity } from './permission-policy'
+import { claudeCodeFramework } from '../agent-framework'
+import { AcpPermissionContext, HUMAN_PERMISSION_ACTION_ORIGIN } from './permission-context'
+import {
+  AcpSessionCapabilityOwner,
+  CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY
+} from './session-capability-owner'
 
 let storageRoot: string | undefined
 let client: PrismaClient | undefined
@@ -23,6 +29,145 @@ afterEach(async () => {
   client = undefined
   if (storageRoot) await rm(storageRoot, { recursive: true, force: true })
   storageRoot = undefined
+})
+
+it('offers conversation approval for the Claude Code configured Skill loader', async () => {
+  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-skill-permission-'))
+  client = createProjectDbClient(storageRoot)
+  await migrateApplicationDatabase(client)
+  await client.project.create({ data: { id: 'project-skill', name: 'Skill project' } })
+  const registry = await createPermissionGrantRegistry({ getClient: async () => client! })
+  const owner = new AcpSessionCapabilityOwner({})
+  const provision = await owner.provision({
+    stableAppSessionId: 'session-skill',
+    framework: claudeCodeFramework,
+    nativeMcpEnabled: true,
+    bridgeMcpAliasesEnabled: false,
+    policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+    sessionCwd: storageRoot,
+    projectId: 'project-skill'
+  })
+  const setup = claudeCodeFramework.buildSessionSetup({
+    systemPromptAppends: [],
+    skillRuntimeScope: 'all',
+    sessionOptions: {
+      openScienceSkillRuntime: {
+        command: process.execPath,
+        entryPath: join(storageRoot, 'main.js'),
+        root: storageRoot
+      }
+    }
+  })
+  provision.includeFrameworkMcpServers(setup.mcpServers ?? [])
+  provision.commit('session-skill')
+  const emit = vi.fn()
+  const context = new AcpPermissionContext({
+    emitPermissionRequest: emit,
+    permissionGrantRegistry: registry,
+    routing: {
+      resolveAppSessionId: (id) => id,
+      sessionSnapshot: () => ({
+        cwd: storageRoot!,
+        frameworkId: 'claude-code',
+        permissionProfile: { selectedProfile: 'ask' }
+      }),
+      hasActivePrimarySession: () => true,
+      capturePrompt: () => undefined,
+      currentInteractionSequence: () => undefined,
+      mcpServerNamesFor: (id) => owner.mcpServerNamesFor(id),
+      reviewerContextFor: () => undefined,
+      resolveReviewerPermission: () => undefined,
+      currentFramework: () => claudeCodeFramework,
+      resolveProjectId: () => 'project-skill'
+    }
+  })
+  // claude-agent-acp 0.70.0 tools.js emits MCP title/kind without provider metadata.
+  const toolCall = {
+    toolCallId: 'load-1',
+    title: 'mcp__skills__load_skill',
+    kind: 'other' as const,
+    rawInput: { skill: 'literature-review' }
+  }
+  const requestLoad = (toolCallId: string, sessionId = 'session-skill'): Promise<unknown> => {
+    const call = { ...toolCall, toolCallId }
+    context.observeToolCall(
+      {
+        sessionId,
+        update: { sessionUpdate: 'tool_call', status: 'pending', ...call }
+      },
+      {
+        sessionId,
+        framework: 'claude-code',
+        mcpServerNames: owner.mcpServerNamesFor(sessionId)
+      }
+    )
+    return context.handleProviderRequest({
+      sessionId,
+      toolCall: call,
+      options: [
+        { optionId: 'reject', name: 'Deny', kind: 'reject_once' },
+        { optionId: 'allow', name: 'Allow Once', kind: 'allow_once' },
+        { optionId: 'allow_always', name: 'Always Allow', kind: 'allow_always' }
+      ]
+    })
+  }
+  const pending = requestLoad('load-1')
+  await vi.waitFor(() => expect(emit).toHaveBeenCalledOnce())
+  const request = emit.mock.calls[0][0]
+  try {
+    const sessionOption = request.options.find(
+      (option: { scope?: string }) => option.scope === 'session'
+    )
+    expect(sessionOption).toBeDefined()
+    await context.respondToPermission(
+      { requestId: request.requestId, optionId: sessionOption.optionId },
+      HUMAN_PERMISSION_ACTION_ORIGIN
+    )
+    await expect(pending).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'allow' } })
+    await expect(requestLoad('load-2')).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'allow' }
+    })
+    expect(emit).toHaveBeenCalledOnce()
+    const [grant] = await registry.list()
+    expect(grant).toMatchObject({
+      capability: { kind: 'mcp_tool', key: 'mcp:skills/load_skill' },
+      scope: { kind: 'session', projectId: 'project-skill', sessionId: 'session-skill' }
+    })
+    const secondProvision = await owner.provision({
+      stableAppSessionId: 'session-other',
+      framework: claudeCodeFramework,
+      nativeMcpEnabled: true,
+      bridgeMcpAliasesEnabled: false,
+      policy: CURRENT_PRIMARY_SESSION_CAPABILITY_POLICY,
+      sessionCwd: storageRoot,
+      projectId: 'project-skill'
+    })
+    secondProvision.includeFrameworkMcpServers(setup.mcpServers ?? [])
+    secondProvision.commit('session-other')
+    const otherSession = requestLoad('load-other', 'session-other')
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(2))
+    await context.respondToPermission(
+      { requestId: emit.mock.calls[1][0].requestId, optionId: 'reject' },
+      HUMAN_PERMISSION_ACTION_ORIGIN
+    )
+    await expect(otherSession).resolves.toEqual({
+      outcome: { outcome: 'selected', optionId: 'reject' }
+    })
+    await registry.revoke({ grants: [{ id: grant.id, revision: grant.revision }] })
+    const revoked = requestLoad('load-3')
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(3))
+    await context.respondToPermission(
+      { requestId: emit.mock.calls[2][0].requestId, optionId: 'reject' },
+      HUMAN_PERMISSION_ACTION_ORIGIN
+    )
+    await expect(revoked).resolves.toEqual({ outcome: { outcome: 'selected', optionId: 'reject' } })
+    expect(await registry.list()).toEqual([])
+  } finally {
+    context.cancelAllPending()
+    await pending
+    owner.revokeSession('session-skill')
+    owner.revokeSession('session-other')
+  }
 })
 
 const shellRequest = (sessionId: string): RequestPermissionRequest => ({

--- a/src/main/agent-framework/claude-code.test.ts
+++ b/src/main/agent-framework/claude-code.test.ts
@@ -188,6 +188,17 @@ describe('claudeCodeFramework', () => {
         [SKILL_RUNTIME_ROOT_ENV]: '/runtime/revision'
       }
     })
+    expect(setup.mcpServers).toEqual([
+      {
+        name: SKILL_RUNTIME_MCP_SERVER_NAME,
+        command: '/app/electron',
+        args: ['/app/main.js', '--open-science-skill-runtime-mcp'],
+        env: [
+          { name: 'ELECTRON_RUN_AS_NODE', value: '1' },
+          { name: SKILL_RUNTIME_ROOT_ENV, value: '/runtime/revision' }
+        ]
+      }
+    ])
     expect(hooks.PreToolUse[0]).toMatchObject({
       matcher: 'Bash',
       hooks: [existingPreToolUseHook]
@@ -235,6 +246,14 @@ describe('claudeCodeFramework', () => {
     expect(servers[SKILL_RUNTIME_MCP_SERVER_NAME].env[SKILL_RUNTIME_ALLOWED_NAMES_ENV]).toBe(
       '["literature-review"]'
     )
+    expect(setup.mcpServers).toEqual([
+      expect.objectContaining({
+        name: SKILL_RUNTIME_MCP_SERVER_NAME,
+        env: expect.arrayContaining([
+          { name: SKILL_RUNTIME_ALLOWED_NAMES_ENV, value: '["literature-review"]' }
+        ])
+      })
+    ])
   })
 
   it('keeps the backend Skill runtime disabled without explicit primary-session authority', () => {
@@ -258,6 +277,7 @@ describe('claudeCodeFramework', () => {
       expect(options).not.toHaveProperty('toolAliases')
       expect(options).not.toHaveProperty('mcpServers')
       expect(options).not.toHaveProperty('allowedTools')
+      expect(setup.mcpServers).toBeUndefined()
     }
   })
 

--- a/src/main/agent-framework/claude-code.ts
+++ b/src/main/agent-framework/claude-code.ts
@@ -22,6 +22,7 @@ import {
   LOAD_SKILL_TOOL_CALLABLE_NAME,
   OPEN_SCIENCE_SKILL_RUNTIME_SESSION_OPTION,
   SKILL_RUNTIME_MCP_SERVER_NAME,
+  createSkillRuntimeAcpServerConfig,
   createSkillRuntimeMcpServerConfig
 } from '../skills/runtime-mcp-server'
 
@@ -109,15 +110,18 @@ export const claudeCodeFramework: AgentFramework = {
       typeof skillRuntime.root === 'string' &&
       typeof skillRuntime.command === 'string' &&
       typeof skillRuntime.entryPath === 'string'
-    const mcpServers = skillRuntimeEnabled
+    const skillRuntimeConfig = skillRuntimeEnabled
+      ? {
+          command: skillRuntime.command as string,
+          entryPath: skillRuntime.entryPath as string,
+          root: skillRuntime.root as string,
+          ...(ctx.skillRuntimeScope !== 'all' ? { allowedNames: ctx.skillRuntimeScope } : {})
+        }
+      : undefined
+    const mcpServers = skillRuntimeConfig
       ? {
           ...recordValue(sessionOptions.mcpServers),
-          [SKILL_RUNTIME_MCP_SERVER_NAME]: createSkillRuntimeMcpServerConfig({
-            command: skillRuntime.command as string,
-            entryPath: skillRuntime.entryPath as string,
-            root: skillRuntime.root as string,
-            ...(ctx.skillRuntimeScope !== 'all' ? { allowedNames: ctx.skillRuntimeScope } : {})
-          })
+          [SKILL_RUNTIME_MCP_SERVER_NAME]: createSkillRuntimeMcpServerConfig(skillRuntimeConfig)
         }
       : sessionOptions.mcpServers
     const toolAliases = skillRuntimeEnabled
@@ -224,6 +228,10 @@ export const claudeCodeFramework: AgentFramework = {
 
     return {
       meta,
+      // Register SDK-installed tooling with the app's Session capability owner as well.
+      ...(skillRuntimeConfig
+        ? { mcpServers: [createSkillRuntimeAcpServerConfig(skillRuntimeConfig)] }
+        : {}),
       ...(persistentSystemPrompt ? { persistentSystemPrompt } : {}),
       ...(promptPrefix ? { promptPrefix } : {})
     }


### PR DESCRIPTION
## Problem

Claude Code installs `skills/load_skill` in SDK metadata but omits it from the app's Session MCP inventory. When a Skill load reaches ACP approval, the broker cannot establish its configured identity and offers only Once, so subsequent loads prompt again.

Reproduced before changing production code through real framework setup, Session capability ownership, permission context and a temporary database-backed registry. The regression failed twice with `expected [ undefined, 'once' ] to include 'session'`. Registering the identical server through the existing public interface made the control pass. The fixture follows installed claude-agent-acp 0.70.0: `session/update` tool_call followed by `session/request_permission`, title `mcp__skills__load_skill`, kind `other`, `{skill: ...}`, no provider metadata, reject_once/allow_once/allow_always options. It is an adapter-source fixture, not captured live model traffic.

## Proposed change

Expose the enabled loader through existing `SessionSetup.mcpServers`, sharing the same root and Specialist allowlist with its SDK configuration. Existing Session capability registration and correlation then provide remembered scopes; the renderer defaults to This conversation. The SDK merges configurations by server name, producing one `skills` server. Native provider responses remain one-shot; the app retains ownership of remembered grants and revocation.

## Scope and non-goals

- Only the Claude framework implementation changes. No new fields, enums, schema, store, dependency or architecture layer.
- Explicit remembered approval writes an ordinary existing `mcp:skills/load_skill` grant at the selected session/project/global scope. Loader approval does not approve tools subsequently requested by a Skill.
- No historical migration: do not upgrade past Once decisions or merge native `skill:invoke` grants into this MCP grant.
- No new UI/copy. Verified production approval controls using a request emitted by the regression; the default button selected the app session option. A local screenshot was delivered to the maintainer. The isolated browser fixture used sample Skill document content and was removed.
- OpenCode native Skill uses its allow policy plus correlated legacy request_permission fallback. Codex Responses/Bridge use native Skill descriptors/selection rather than this SDK-only MCP registration path. CodeBuddy app-preloaded Skill behavior was also checked. No equivalent defect reproduced; no speculative framework rewrites.

## Acceptance criteria and validation

Checks below ran after the last material edit, on macOS. The regression covers initial conversation approval, repeated loads without another prompt, provider-native one-shot responses, a second registered Session still prompting, denial, and revocation restoring the prompt. Framework tests cover disabled/empty scope and exact Specialist allowlist preservation.

| Behavior / path | Check | Result |
| --- | --- | --- |
| Claude config; ACP broker, grants, correlation/cancellation; create/resume/adopt; delegated consumer; renderer controls | A below | 501 passed / 12 files |
| Skill loader, config presentation and pinned ACP readiness success/failure | B below | 147 passed / 4 files (overlaps A) |
| Claude/OpenCode/Codex configuration; Responses selector; native Codex mapper; CodeBuddy turn loading | C below | 56 passed / 6 files |
| OpenCode native Skill, missing/contradictory identity; Codex Skill switching | D below | 4 passed |
| Main process typing / repository lint | `tsc --noEmit -p tsconfig.node.json --composite false`; `npm run lint` | Passed |
| Actual renderer default action | Browser production component with regression-emitted request; click default approval | Session option selected; screenshot checked |

```sh
# A
npx vitest run src/main/acp/permission-broker-registry.test.ts src/main/acp/permission-context.test.ts src/main/acp/permission-broker.test.ts src/main/acp/permission-policy.test.ts src/main/acp/provider-session-creator.test.ts src/main/acp/provider-session-resumer.test.ts src/main/acp/provider-session-adopter.test.ts src/main/acp/session-capability-owner.test.ts src/main/agent-framework/claude-code.test.ts src/main/delegation/production-framework-runtime.test.ts src/renderer/src/pages/workspace/PermissionApprovalControls.interaction.test.tsx src/renderer/src/pages/workspace/PermissionApprovalControls.render.test.tsx --maxWorkers=1
# B
npx vitest run src/main/acp/permission-broker-registry.test.ts src/main/skills/runtime-mcp-server.test.ts src/main/acp/session-presentation-policy.test.ts src/main/acp/claude-agent-acp-patch.test.ts --maxWorkers=1
# C
npx vitest run src/main/agent-framework/claude-code.test.ts src/main/agent-framework/opencode.test.ts src/main/agent-framework/codex.test.ts src/main/acp/turn-skill-owner.test.ts src/main/settings/managed-codex.test.ts src/main/settings/responses-bridge.test.ts -t '[Ss]kill' --maxWorkers=1
# D
npx vitest run src/main/acp/runtime.test.ts -t 'OpenCode native skill|OpenCode permission title|OpenCode Skill fallback|Codex native Skill selection' --maxWorkers=1
npx tsc --noEmit -p tsconfig.node.json --composite false
npm run lint
```

The local invocations used the existing shared worktree binaries instead of downloading via npx. An earlier parallel A run had six 15-second timeouts under extreme host load; the final run passed all 501 without changing timeout thresholds or assertions. No complete local npm test was run per maintainer request. Impact classification reports the framework file as unknown ownership/full fallback; required exact-head PR CI remains authoritative, without changing classifier metadata to narrow it.

## Review focus

Independent Standards and Spec reviews found no remaining findings and confirmed the final compatibility mapping. No subscription implementation changes; existing grant lifecycle and permission cleanup suites are included. Message/history branching is unchanged; Session create/resume/adopt consumers are covered.

Uncovered: real provider/model calls and Windows/Linux execution locally. The new registration includes skills in the existing provider MCP readiness wait, so actual process-start timing remains a live-provider risk; deterministic readiness success/failure and loader tests pass. No model Cartesian matrix is needed for this pre-model configuration change. PR CI owns selected portable/platform validation.
