### PR TITLE
fix(accessibility): restore consistent keyboard and assistive interactions

### DIFF
--- a/e2e/browser/settings-layout.spec.ts
+++ b/e2e/browser/settings-layout.spec.ts
@@ -125,16 +125,30 @@ for (const localized of localizedSettingsCases) {
         )
         .toEqual([])
 
-      const highLabel = effort
-        .getByRole('radio', { name: 'High', exact: true })
-        .locator('[data-slot="settings-segment-label"]')
-      await expect(highLabel).not.toHaveAttribute('data-compact', 'true')
-      if (localized.locale === 'ru') {
-        await expect(
-          effort
-            .getByRole('radio', { name: localized.defaultEffort, exact: true })
-            .locator('[data-slot="settings-segment-label"]')
-        ).toHaveAttribute('data-compact', 'true')
+      const defaultText = effort
+        .getByRole('radio', { name: localized.defaultEffort, exact: true })
+        .locator('[data-slot="settings-segment-label-text"]')
+      const originalFont = await defaultText.evaluate((text) =>
+        parseFloat(getComputedStyle(text).fontSize)
+      )
+      const originalRootStyle = await page.evaluate(() => document.documentElement.style.fontSize)
+      await page.evaluate(() => {
+        document.documentElement.style.fontSize = `${parseFloat(getComputedStyle(document.documentElement).fontSize) * 2}px`
+      })
+      try {
+        await expect
+          .poll(() => defaultText.evaluate((text) => parseFloat(getComputedStyle(text).fontSize)))
+          .toBeGreaterThanOrEqual(originalFont * 2)
+        expect(
+          await defaultText.evaluate(
+            (text) =>
+              text.scrollHeight <= text.clientHeight + 1 && text.scrollWidth <= text.clientWidth + 1
+          )
+        ).toBe(true)
+      } finally {
+        await page.evaluate((value) => {
+          document.documentElement.style.fontSize = value
+        }, originalRootStyle)
       }
       const clippedPolicyLabels = async (): Promise<Array<string | undefined>> =>
         settings

--- a/e2e/workspace-conversation.spec.ts
+++ b/e2e/workspace-conversation.spec.ts
@@ -371,7 +371,10 @@ test('resolves Agent permission requests through both Allow and Deny decisions',
   const permissionActions = page.getByTestId('permission-actions')
   await expect(permissionActions).toHaveCSS('position', 'sticky')
   await expect(permissionActions).toHaveCSS('bottom', '0px')
-  const resizeHandle = page.getByRole('button', { name: 'Resize permission panel' })
+  const resizeHandle = page.getByRole('separator', { name: 'Resize permission panel' })
+  await expect
+    .poll(async () => Number(await resizeHandle.getAttribute('aria-valuenow')))
+    .toBeGreaterThan(0)
   const handleBounds = await resizeHandle.boundingBox()
   expect(handleBounds).not.toBeNull()
   const restingHandleBackground = await resizeHandle.evaluate(

--- a/src/renderer/src/pages/settings/SettingsSegmentedControl.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsSegmentedControl.render.test.tsx
@@ -78,7 +78,7 @@ describe('SettingsSegmentedControl', () => {
     )
   })
 
-  it('compacts only labels that do not fit at the normal font size', async () => {
+  it('preserves relative typography when localized labels exceed the available width', async () => {
     const resizeCallbacks: ResizeObserverCallback[] = []
     vi.stubGlobal(
       'ResizeObserver',
@@ -116,7 +116,7 @@ describe('SettingsSegmentedControl', () => {
     expect(labels).toHaveLength(2)
     expect(texts).toHaveLength(2)
 
-    let longLabelWidth = 82
+    const longLabelWidth = 82
     Object.defineProperty(labels[0], 'clientWidth', { configurable: true, value: 56 })
     Object.defineProperty(labels[1], 'clientWidth', { configurable: true, value: 56 })
     Object.defineProperty(texts[0], 'scrollWidth', {
@@ -133,24 +133,8 @@ describe('SettingsSegmentedControl', () => {
       resizeCallbacks.forEach((callback) => callback([], {} as ResizeObserver))
     })
 
-    expect(labels[0].dataset.compact).toBe('true')
-    expect(labels[0].dataset.compactSize).toBe('9')
-    expect(texts[0].style.fontSize).toBe('9px')
-    expect(labels[1].dataset.compact).toBeUndefined()
-    expect(
-      labels[1].querySelector('[data-slot="settings-segment-label-text"]')?.className
-    ).toContain('text-xs')
-
-    longLabelWidth = 46
-    act(() => {
-      resizeCallbacks.forEach((callback) => callback([], {} as ResizeObserver))
-    })
-
-    expect(labels[0].dataset.compact).toBeUndefined()
-    expect(labels[0].dataset.compactSize).toBeUndefined()
-    expect(texts[0].style.fontSize).toBe('')
-    expect(
-      labels[0].querySelector('[data-slot="settings-segment-label-text"]')?.className
-    ).toContain('text-xs')
+    expect(texts[0].style.fontSize).not.toMatch(/px$/)
+    expect(texts[0].textContent).toBe('По умолчанию')
+    expect(texts[1].textContent).toBe('High')
   })
 })

--- a/src/renderer/src/pages/settings/SettingsSegmentedControl.tsx
+++ b/src/renderer/src/pages/settings/SettingsSegmentedControl.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
+import { useState, type ReactNode } from 'react'
 import { RadioGroup, Tabs } from 'radix-ui'
 
 import { cn } from '@/lib/utils'
@@ -17,86 +17,6 @@ type SettingsSegmentedControlProps<Value extends string> = {
   columnWidth?: string
   className?: string
   segmentClassName?: string
-}
-
-const AdaptiveSegmentLabel = ({ children }: { children: string | number }): React.JSX.Element => {
-  const labelRef = useRef<HTMLSpanElement>(null)
-  const textRef = useRef<HTMLSpanElement>(null)
-  const [compactFontSize, setCompactFontSize] = useState<number>()
-  const measure = useCallback(() => {
-    const label = labelRef.current
-    const text = textRef.current
-    if (!label || !text) return
-
-    const previousStyle = {
-      fontSize: text.style.fontSize,
-      lineHeight: text.style.lineHeight,
-      maxHeight: text.style.maxHeight,
-      overflowWrap: text.style.overflowWrap,
-      whiteSpace: text.style.whiteSpace
-    }
-    text.style.fontSize = '0.75rem'
-    text.style.lineHeight = '1rem'
-    text.style.maxHeight = 'none'
-    text.style.whiteSpace = 'nowrap'
-    const normalWidth = text.scrollWidth
-
-    let nextCompactFontSize: number | undefined
-    if (normalWidth > label.clientWidth + 1) {
-      text.style.maxHeight = 'none'
-      text.style.overflowWrap = 'break-word'
-      text.style.whiteSpace = 'normal'
-      for (const candidate of [10, 9, 8]) {
-        text.style.fontSize = `${candidate}px`
-        text.style.lineHeight = `${candidate + 2}px`
-        nextCompactFontSize = candidate
-        if (text.scrollHeight <= 25) break
-      }
-    }
-    Object.assign(text.style, previousStyle)
-
-    setCompactFontSize((current) =>
-      current === nextCompactFontSize ? current : nextCompactFontSize
-    )
-  }, [])
-
-  useLayoutEffect(() => {
-    measure()
-    if (typeof ResizeObserver === 'undefined') return
-
-    const observer = new ResizeObserver(measure)
-    observer.observe(labelRef.current!)
-    observer.observe(textRef.current!)
-    return () => observer.disconnect()
-  }, [children, measure])
-
-  return (
-    <span
-      ref={labelRef}
-      data-slot="settings-segment-label"
-      data-compact={compactFontSize === undefined ? undefined : true}
-      data-compact-size={compactFontSize}
-      className="relative flex h-full w-full min-w-0 items-center justify-center overflow-hidden"
-    >
-      <span
-        ref={textRef}
-        data-slot="settings-segment-label-text"
-        className={cn(
-          'block max-w-full text-center',
-          compactFontSize === undefined
-            ? 'whitespace-nowrap text-xs leading-4'
-            : 'max-h-6 whitespace-normal break-words'
-        )}
-        style={
-          compactFontSize === undefined
-            ? undefined
-            : { fontSize: `${compactFontSize}px`, lineHeight: `${compactFontSize + 2}px` }
-        }
-      >
-        {children}
-      </span>
-    </span>
-  )
 }
 
 const SettingsSegmentedControl = <Value extends string>({
@@ -134,13 +54,20 @@ const SettingsSegmentedControl = <Value extends string>({
   )
   const segmentClasses = (selected: boolean): string =>
     cn(
-      'relative z-10 flex h-7 items-center justify-center rounded-md px-1 text-xs font-medium transition-colors motion-reduce:transition-none',
+      'relative z-10 flex min-h-7 items-center justify-center rounded-md px-1 py-1 text-xs font-medium transition-colors motion-reduce:transition-none',
       selected ? 'text-foreground' : 'text-muted-foreground hover:text-foreground',
       segmentClassName
     )
   const segmentLabel = (label: ReactNode): ReactNode =>
     typeof label === 'string' || typeof label === 'number' ? (
-      <AdaptiveSegmentLabel>{label}</AdaptiveSegmentLabel>
+      <span data-slot="settings-segment-label" className="min-w-0 w-full">
+        <span
+          data-slot="settings-segment-label-text"
+          className="block whitespace-normal break-words text-xs leading-4 text-center"
+        >
+          {label}
+        </span>
+      </span>
     ) : (
       label
     )

--- a/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.accessibility.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.accessibility.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+import type { ComponentProps } from 'react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import { SpecialistCapabilitiesSection } from '@/pages/settings/SpecialistCapabilitiesSection'
+const data = vi.hoisted(() => ({
+  skills: [{ id: 's1', name: 'Audit skill', enabled: true, available: true }],
+  connectors: [{ id: 'c1', name: 'catalog', displayName: 'Catalog connector', enabled: true }],
+  customServers: [],
+  loadConnectors: vi.fn(),
+  loadSkills: vi.fn()
+}))
+vi.mock('@/stores/settings-store', () => ({
+  useSettingsStore: (select: (state: typeof data) => unknown) => select(data)
+}))
+vi.mock('@/stores/tag-store', () => ({
+  useTagStore: (select: (state: { assignments: never[] }) => unknown) => select({ assignments: [] })
+}))
+vi.mock('@/pages/settings/ResourceTagControls', () => ({ TagFilter: () => null }))
+let props: ComponentProps<typeof SpecialistCapabilitiesSection>
+beforeEach(() => {
+  props = {
+    capabilityMode: 'selected',
+    onCapabilityModeChange: vi.fn(),
+    selectedSkillIds: [],
+    excludedSkillIds: [],
+    selectedConnectorIds: [],
+    excludedConnectorIds: [],
+    updateSkillIds: vi.fn(),
+    updateConnectorIds: vi.fn(),
+    activeTab: 'skills',
+    onActiveTabChange: vi.fn()
+  }
+})
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+it('full access prevents changes to inactive selected capabilities', () => {
+  render(
+    <SpecialistCapabilitiesSection {...props} capabilityMode="full" selectedSkillIds={['s1']} />
+  )
+  const remove = screen.getByRole('button', { name: 'Remove Audit skill' }) as HTMLButtonElement
+  fireEvent.click(remove)
+  expect(props.updateSkillIds).not.toHaveBeenCalled()
+  expect(props.onCapabilityModeChange).not.toHaveBeenCalled()
+})
+it('capability tabs move focus to the next tab with ArrowRight', async () => {
+  render(<SpecialistCapabilitiesSection {...props} />)
+  const tabs = screen.getAllByRole('tab')
+  act(() => tabs[0].focus())
+  fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+  await waitFor(() => expect(document.activeElement).toBe(tabs[1]))
+})
+it('choosing a capability restores focus to its add trigger', async () => {
+  render(<SpecialistCapabilitiesSection {...props} />)
+  const trigger = screen.getByRole('button', { name: '＋ Add a skill' })
+  fireEvent.click(trigger)
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('searchbox')))
+  const choice = screen.getByRole('button', { name: 'Audit skill' })
+  act(() => choice.focus())
+  expect(document.activeElement).toBe(choice)
+  fireEvent.click(choice)
+  expect(props.updateSkillIds).toHaveBeenCalledOnce()
+  expect(screen.queryByRole('searchbox')).toBeNull()
+  await waitFor(() => expect(document.activeElement).toBe(trigger))
+})
+it('Escape closes the capability popup before reaching its parent', async () => {
+  const parent = vi.fn()
+  render(
+    <div onKeyDown={parent}>
+      <SpecialistCapabilitiesSection {...props} />
+    </div>
+  )
+  const trigger = screen.getByRole('button', { name: '＋ Add a skill' })
+  fireEvent.click(trigger)
+  await waitFor(() => expect(document.activeElement).toBe(screen.getByRole('searchbox')))
+  fireEvent.keyDown(screen.getByRole('searchbox'), { key: 'Escape' })
+  expect(screen.queryByRole('searchbox')).toBeNull()
+  expect(parent).not.toHaveBeenCalled()
+  expect(trigger.getAttribute('aria-expanded')).toBe('false')
+})
+
+it('connector selection returns focus and preserves the selected identifiers', async () => {
+  render(<SpecialistCapabilitiesSection {...props} activeTab="connectors" />)
+  const trigger = screen.getByRole('button', { name: '＋ Add a connector' })
+  fireEvent.click(trigger)
+  const choice = screen.getByRole('button', { name: 'Catalog connector' })
+  act(() => choice.focus())
+  fireEvent.click(choice)
+  expect(props.updateConnectorIds).toHaveBeenCalledOnce()
+  await waitFor(() => expect(document.activeElement).toBe(trigger))
+})
+
+it('full access disables removal of a selected connector', () => {
+  render(
+    <SpecialistCapabilitiesSection
+      {...props}
+      activeTab="connectors"
+      capabilityMode="full"
+      selectedConnectorIds={['c1']}
+    />
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'Remove Catalog connector' }))
+  expect(props.updateConnectorIds).not.toHaveBeenCalled()
+})
+
+it('composition Escape leaves the capability search open', async () => {
+  render(<SpecialistCapabilitiesSection {...props} />)
+  fireEvent.click(screen.getByRole('button', { name: '＋ Add a skill' }))
+  const input = screen.getByRole('searchbox')
+  fireEvent.compositionStart(input)
+  fireEvent.keyDown(input, { key: 'Escape', isComposing: true, keyCode: 229 })
+  expect(screen.getByRole('searchbox')).toBe(input)
+  fireEvent.compositionEnd(input)
+  fireEvent.keyDown(input, { key: 'Escape' })
+  expect(screen.queryByRole('searchbox')).toBeNull()
+})
+
+it('closes an open capability popup when full access replaces selected mode', async () => {
+  const { rerender } = render(<SpecialistCapabilitiesSection {...props} />)
+  fireEvent.click(screen.getByRole('button', { name: '＋ Add a skill' }))
+  expect(screen.getByRole('searchbox')).toBe(document.activeElement)
+  rerender(<SpecialistCapabilitiesSection {...props} capabilityMode="full" />)
+  await waitFor(() =>
+    expect(document.activeElement).toBe(screen.getByRole('switch', { name: 'Full access' }))
+  )
+  expect(screen.queryByRole('searchbox')).toBeNull()
+  expect(props.updateSkillIds).not.toHaveBeenCalled()
+  rerender(<SpecialistCapabilitiesSection {...props} />)
+  expect(screen.queryByRole('searchbox')).toBeNull()
+})

--- a/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.tsx
+++ b/src/renderer/src/pages/settings/SpecialistCapabilitiesSection.tsx
@@ -1,5 +1,7 @@
 import { TooltipProvider } from '@/components/ui/tooltip'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { Tabs } from 'radix-ui'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
 import { useTranslation } from 'react-i18next'
 import { X } from 'lucide-react'
 import { cn } from '@/lib/utils'
@@ -133,40 +135,20 @@ const SpecialistCapabilitiesSection = ({
   const connectorSearchRef = useRef<HTMLInputElement>(null)
   const [skillPopoverOpen, setSkillPopoverOpen] = useState(false)
   const [connectorPopoverOpen, setConnectorPopoverOpen] = useState(false)
-  const skillDropdownRef = useRef<HTMLDivElement>(null)
-  const connectorDropdownRef = useRef<HTMLDivElement>(null)
-  useSettingsSearchShortcut(skillSearchRef, skillPopoverOpen)
-  useSettingsSearchShortcut(connectorSearchRef, connectorPopoverOpen)
-  const skillTriggerRef = useRef<HTMLButtonElement>(null)
-  const connectorTriggerRef = useRef<HTMLButtonElement>(null)
-
-  const closeSkillDropdown = useCallback(() => setSkillPopoverOpen(false), [])
-  const closeConnectorDropdown = useCallback(() => setConnectorPopoverOpen(false), [])
-
-  useEffect(() => {
-    if (!skillPopoverOpen) return
-    const handle = (e: MouseEvent): void => {
-      if (skillDropdownRef.current && !skillDropdownRef.current.contains(e.target as Node)) {
-        closeSkillDropdown()
-      }
+  useSettingsSearchShortcut(skillSearchRef, skillPopoverOpen && !isFullAccess)
+  useSettingsSearchShortcut(connectorSearchRef, connectorPopoverOpen && !isFullAccess)
+  const fullAccessRef = useRef<HTMLButtonElement>(null)
+  const selectionRef = useRef<HTMLDivElement>(null)
+  const composingRef = useRef(false)
+  if (isFullAccess && (skillPopoverOpen || connectorPopoverOpen)) {
+    setSkillPopoverOpen(false)
+    setConnectorPopoverOpen(false)
+  }
+  useLayoutEffect(() => {
+    if (isFullAccess && selectionRef.current?.contains(document.activeElement)) {
+      fullAccessRef.current?.focus()
     }
-    document.addEventListener('mousedown', handle)
-    return () => document.removeEventListener('mousedown', handle)
-  }, [skillPopoverOpen, closeSkillDropdown])
-
-  useEffect(() => {
-    if (!connectorPopoverOpen) return
-    const handle = (e: MouseEvent): void => {
-      if (
-        connectorDropdownRef.current &&
-        !connectorDropdownRef.current.contains(e.target as Node)
-      ) {
-        closeConnectorDropdown()
-      }
-    }
-    document.addEventListener('mousedown', handle)
-    return () => document.removeEventListener('mousedown', handle)
-  }, [connectorPopoverOpen, closeConnectorDropdown])
+  }, [isFullAccess])
 
   useEffect(() => {
     void loadConnectors()
@@ -368,6 +350,7 @@ const SpecialistCapabilitiesSection = ({
           connector; selecting it disables the Select capabilities panel below. */}
         <button
           type="button"
+          ref={fullAccessRef}
           role="switch"
           aria-checked={isFullAccess}
           aria-label={t('Full access')}
@@ -409,23 +392,26 @@ const SpecialistCapabilitiesSection = ({
         {/* Select capabilities — greyed and non-interactive while Full access is on. Clicking the
           greyed panel turns Full access off so the lists become editable. */}
         <div className="relative">
-          <div
+          <Tabs.Root
+            ref={selectionRef}
+            inert={isFullAccess}
+            value={activeTab}
+            activationMode="manual"
+            onValueChange={(value) => onActiveTabChange(value as 'skills' | 'connectors')}
             className={cn(
               'rounded-lg',
               isFullAccess && 'pointer-events-none opacity-45 select-none'
             )}
           >
             <div className="mb-3 flex items-center justify-between">
-              <div
+              <Tabs.List
                 className="inline-flex gap-0.5 rounded-lg bg-muted p-1"
-                role="tablist"
                 aria-label={t('Capability type')}
               >
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={activeTab === 'skills'}
+                <Tabs.Trigger
+                  value="skills"
                   onClick={() => onActiveTabChange('skills')}
+                  disabled={isFullAccess}
                   className={cn(
                     'rounded-md px-3 py-1 text-[12.5px] font-medium',
                     activeTab === 'skills'
@@ -435,12 +421,11 @@ const SpecialistCapabilitiesSection = ({
                 >
                   {t('Skills')}{' '}
                   <span className="ml-0.5 text-[11px] opacity-75">{selectedSkillIds.length}</span>
-                </button>
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={activeTab === 'connectors'}
+                </Tabs.Trigger>
+                <Tabs.Trigger
+                  value="connectors"
                   onClick={() => onActiveTabChange('connectors')}
+                  disabled={isFullAccess}
                   className={cn(
                     'rounded-md px-3 py-1 text-[12.5px] font-medium',
                     activeTab === 'connectors'
@@ -452,274 +437,328 @@ const SpecialistCapabilitiesSection = ({
                   <span className="ml-0.5 text-[11px] opacity-75">
                     {selectedConnectorIds.length}
                   </span>
-                </button>
-              </div>
+                </Tabs.Trigger>
+              </Tabs.List>
 
               {/* Add button + dropdown — right side of the same row */}
               {activeTab === 'skills' ? (
-                <div className="relative" ref={skillDropdownRef}>
-                  <button
-                    ref={skillTriggerRef}
-                    type="button"
-                    onClick={() => {
-                      setSkillPopoverOpen((prev) => !prev)
-                      setSkillSearchQuery('')
-                      setTimeout(() => skillSearchRef.current?.focus(), 0)
+                <Popover
+                  open={skillPopoverOpen && !isFullAccess}
+                  onOpenChange={(open) => {
+                    setSkillPopoverOpen(open)
+                    composingRef.current = false
+                    if (open) setSkillSearchQuery('')
+                  }}
+                >
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      disabled={isFullAccess}
+                      className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                    >
+                      {t('＋ Add a skill')}
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    aria-label={t('＋ Add a skill')}
+                    align="end"
+                    className="flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card p-0 text-foreground shadow-md"
+                    onCloseAutoFocus={(event) => {
+                      if (isFullAccess) {
+                        event.preventDefault()
+                        fullAccessRef.current?.focus()
+                      }
                     }}
-                    className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                    onOpenAutoFocus={(event) => {
+                      event.preventDefault()
+                      skillSearchRef.current?.focus()
+                    }}
+                    onCompositionStart={() => {
+                      composingRef.current = true
+                    }}
+                    onCompositionEnd={() => {
+                      composingRef.current = false
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Escape') event.stopPropagation()
+                    }}
+                    onEscapeKeyDown={(event) => {
+                      if (event.isComposing || composingRef.current || event.keyCode === 229)
+                        event.preventDefault()
+                    }}
                   >
-                    {t('＋ Add a skill')}
-                  </button>
-                  {skillPopoverOpen ? (
-                    <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
-                      <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
-                        <input
-                          ref={skillSearchRef}
-                          type="search"
-                          aria-label={t('Search skills to add')}
-                          aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
-                          placeholder={t('Search skills…')}
-                          value={skillSearchQuery}
-                          onChange={(e) => setSkillSearchQuery(e.target.value)}
-                          className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
-                        />
-                        <TagFilter
-                          resourceType="catalog.skill"
-                          value={skillTagFilter}
-                          onChange={setSkillTagFilter}
-                          className="mt-2 w-full"
-                        />
-                      </div>
-                      <div className="flex-1">
-                        {filteredAddableSkills.length === 0 ? (
-                          <p className="px-3 py-3 text-[12px] text-muted-foreground">
-                            {skillSearchQuery
-                              ? t('No matching skills')
-                              : t('No more skills to add')}
-                          </p>
-                        ) : (
-                          filteredAddableSkills.map((skill) => (
-                            <button
-                              key={skill.id}
-                              type="button"
-                              onClick={() => {
-                                addSkill(skill.id)
-                                setSkillPopoverOpen(false)
-                              }}
-                              className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
-                            >
-                              <span className="min-w-0 flex-1 truncate text-[12.5px]">
-                                {skill.name}
-                              </span>
-                            </button>
-                          ))
-                        )}
-                      </div>
+                    <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
+                      <input
+                        ref={skillSearchRef}
+                        type="search"
+                        aria-label={t('Search skills to add')}
+                        aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
+                        placeholder={t('Search skills…')}
+                        value={skillSearchQuery}
+                        onChange={(e) => setSkillSearchQuery(e.target.value)}
+                        className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                      />
+                      <TagFilter
+                        resourceType="catalog.skill"
+                        value={skillTagFilter}
+                        onChange={setSkillTagFilter}
+                        className="mt-2 w-full"
+                      />
                     </div>
-                  ) : null}
-                </div>
+                    <div className="flex-1">
+                      {filteredAddableSkills.length === 0 ? (
+                        <p className="px-3 py-3 text-[12px] text-muted-foreground">
+                          {skillSearchQuery ? t('No matching skills') : t('No more skills to add')}
+                        </p>
+                      ) : (
+                        filteredAddableSkills.map((skill) => (
+                          <button
+                            key={skill.id}
+                            type="button"
+                            onClick={() => {
+                              addSkill(skill.id)
+                              setSkillPopoverOpen(false)
+                            }}
+                            className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                              {skill.name}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </PopoverContent>
+                </Popover>
               ) : (
-                <div className="relative" ref={connectorDropdownRef}>
-                  <button
-                    ref={connectorTriggerRef}
-                    type="button"
-                    onClick={() => {
-                      setConnectorPopoverOpen((prev) => !prev)
-                      setConnectorSearchQuery('')
-                      setTimeout(() => connectorSearchRef.current?.focus(), 0)
+                <Popover
+                  open={connectorPopoverOpen && !isFullAccess}
+                  onOpenChange={(open) => {
+                    setConnectorPopoverOpen(open)
+                    composingRef.current = false
+                    if (open) setConnectorSearchQuery('')
+                  }}
+                >
+                  <PopoverTrigger asChild>
+                    <button
+                      type="button"
+                      disabled={isFullAccess}
+                      className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                    >
+                      {t('＋ Add a connector')}
+                    </button>
+                  </PopoverTrigger>
+                  <PopoverContent
+                    aria-label={t('＋ Add a connector')}
+                    align="end"
+                    className="flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card p-0 text-foreground shadow-md"
+                    onCloseAutoFocus={(event) => {
+                      if (isFullAccess) {
+                        event.preventDefault()
+                        fullAccessRef.current?.focus()
+                      }
                     }}
-                    className="flex h-[28px] items-center rounded-lg border border-dashed border-border bg-card px-3 text-[12px] text-muted-foreground hover:bg-muted"
+                    onOpenAutoFocus={(event) => {
+                      event.preventDefault()
+                      connectorSearchRef.current?.focus()
+                    }}
+                    onCompositionStart={() => {
+                      composingRef.current = true
+                    }}
+                    onCompositionEnd={() => {
+                      composingRef.current = false
+                    }}
+                    onKeyDown={(event) => {
+                      if (event.key === 'Escape') event.stopPropagation()
+                    }}
+                    onEscapeKeyDown={(event) => {
+                      if (event.isComposing || composingRef.current || event.keyCode === 229)
+                        event.preventDefault()
+                    }}
                   >
-                    {t('＋ Add a connector')}
-                  </button>
-                  {connectorPopoverOpen ? (
-                    <div className="absolute right-0 top-full z-50 mt-1 flex max-h-[260px] w-[240px] flex-col overflow-y-auto rounded-lg border border-border bg-card shadow-md">
-                      <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
-                        <input
-                          ref={connectorSearchRef}
-                          type="search"
-                          aria-label={t('Search connectors to add')}
-                          aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
-                          placeholder={t('Search connectors…')}
-                          value={connectorSearchQuery}
-                          onChange={(e) => setConnectorSearchQuery(e.target.value)}
-                          className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
-                        />
-                        <TagFilter
-                          resourceType="catalog.connector"
-                          value={connectorTagFilter}
-                          onChange={setConnectorTagFilter}
-                          className="mt-2 w-full"
-                        />
-                      </div>
-                      <div className="flex-1">
-                        {filteredAddableConnectors.length === 0 ? (
-                          <p className="px-3 py-3 text-[12px] text-muted-foreground">
-                            {connectorSearchQuery
-                              ? t('No matching connectors')
-                              : t('No more connectors to add')}
-                          </p>
-                        ) : (
-                          filteredAddableConnectors.map((connector) => (
-                            <button
-                              key={connector.id}
-                              type="button"
-                              onClick={() => {
-                                addConnector(connector.id)
-                                setConnectorPopoverOpen(false)
-                              }}
-                              className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
-                            >
-                              <span className="min-w-0 flex-1 truncate text-[12.5px]">
-                                {connector.name}
-                              </span>
-                            </button>
-                          ))
-                        )}
-                      </div>
+                    <div className="sticky top-0 z-10 border-b border-border bg-card p-2">
+                      <input
+                        ref={connectorSearchRef}
+                        type="search"
+                        aria-label={t('Search connectors to add')}
+                        aria-keyshortcuts={getSettingsSearchKeyShortcuts()}
+                        placeholder={t('Search connectors…')}
+                        value={connectorSearchQuery}
+                        onChange={(e) => setConnectorSearchQuery(e.target.value)}
+                        className="w-full rounded-md border border-border bg-card px-2.5 py-1.5 text-[12.5px] text-foreground placeholder:text-muted-foreground outline-none focus:border-primary"
+                      />
+                      <TagFilter
+                        resourceType="catalog.connector"
+                        value={connectorTagFilter}
+                        onChange={setConnectorTagFilter}
+                        className="mt-2 w-full"
+                      />
                     </div>
-                  ) : null}
-                </div>
+                    <div className="flex-1">
+                      {filteredAddableConnectors.length === 0 ? (
+                        <p className="px-3 py-3 text-[12px] text-muted-foreground">
+                          {connectorSearchQuery
+                            ? t('No matching connectors')
+                            : t('No more connectors to add')}
+                        </p>
+                      ) : (
+                        filteredAddableConnectors.map((connector) => (
+                          <button
+                            key={connector.id}
+                            type="button"
+                            onClick={() => {
+                              addConnector(connector.id)
+                              setConnectorPopoverOpen(false)
+                            }}
+                            className="flex h-[32px] w-full items-center gap-2 px-3 text-left hover:bg-muted"
+                          >
+                            <span className="min-w-0 flex-1 truncate text-[12.5px]">
+                              {connector.name}
+                            </span>
+                          </button>
+                        ))
+                      )}
+                    </div>
+                  </PopoverContent>
+                </Popover>
               )}
             </div>
 
-            {activeTab === 'skills' ? (
-              <div>
-                <div className="overflow-hidden rounded-lg border border-border">
-                  {selectedSkillRows.length === 0 ? (
-                    <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
-                      {t('No skills added yet.')}
-                    </p>
-                  ) : (
-                    selectedSkillRows.map((skill) => {
-                      const openSkill =
-                        !skill.missing && onOpenSkillDetail !== undefined
-                          ? () => onOpenSkillDetail(skill.id)
-                          : undefined
-                      return (
-                        <div
-                          key={skill.id}
-                          {...clickableRowProps(
-                            openSkill,
-                            t('View {{name}} details', { name: skill.name })
-                          )}
-                          className={capabilityRowClassName(openSkill !== undefined)}
-                        >
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-[12.5px]">{skill.name}</div>
-                            {!skill.missing && skill.description ? (
-                              <div className="truncate text-[11px] text-muted-foreground">
-                                {skill.description}
-                              </div>
-                            ) : null}
-                          </div>
-                          {skill.missing ? (
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {t('Missing · unavailable')}
-                            </span>
-                          ) : (
-                            <>
-                              {skill.source ? (
-                                <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
-                                  {skill.source}
-                                </span>
-                              ) : null}
-                              {!skill.mainEnabled ? (
-                                <span className="shrink-0 text-[11px] text-muted-foreground">
-                                  {t('Main disabled · available here')}
-                                </span>
-                              ) : null}
-                            </>
-                          )}
-                          <SettingsIconAction
-                            label={t('Remove {{name}}', { name: skill.name })}
-                            icon={X}
-                            onClick={stopThen(() => removeSkill(skill.id))}
-                            danger
-                          />
-                        </div>
-                      )
-                    })
-                  )}
-                </div>
-                <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
-                  <span aria-hidden="true">ⓘ</span>
-                  <span>
-                    {t(
-                      'Skills start empty and must be added. Skills not listed here are hidden from this specialist, and Skill calls to them are rejected.'
-                    )}
-                  </span>
-                </p>
-              </div>
-            ) : null}
-
-            {activeTab === 'connectors' ? (
-              <div>
-                <div className="overflow-hidden rounded-lg border border-border">
-                  {selectedConnectorRows.length === 0 ? (
-                    <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
-                      {t('No connectors added yet.')}
-                    </p>
-                  ) : (
-                    selectedConnectorRows.map((connector) => {
-                      const canonicalConnectorId = (): string =>
-                        customServers.find(
-                          (server) => server.id === connector.id || server.name === connector.id
-                        )?.id ?? connector.id
-                      const openConnector =
-                        connector.available && onOpenConnectorDetail !== undefined
-                          ? () => onOpenConnectorDetail(canonicalConnectorId())
-                          : undefined
-                      return (
-                        <div
-                          key={connector.id}
-                          {...clickableRowProps(
-                            openConnector,
-                            t('View {{name}} details', { name: connector.name })
-                          )}
-                          className={capabilityRowClassName(openConnector !== undefined)}
-                        >
-                          <div className="min-w-0 flex-1">
-                            <div className="truncate text-[12.5px]">{connector.name}</div>
-                            {connector.available && connector.description ? (
-                              <div className="truncate text-[11px] text-muted-foreground">
-                                {connector.description}
-                              </div>
-                            ) : null}
-                          </div>
-                          {!connector.available ? (
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {t('Unavailable — {{reason}}', {
-                                reason: connector.availability ?? t('not installed')
-                              })}
-                            </span>
-                          ) : !connector.mainEnabled ? (
-                            <span className="shrink-0 text-[11px] text-muted-foreground">
-                              {t('Main disabled · available here')}
-                            </span>
+            <Tabs.Content value="skills">
+              <div className="overflow-hidden rounded-lg border border-border">
+                {selectedSkillRows.length === 0 ? (
+                  <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
+                    {t('No skills added yet.')}
+                  </p>
+                ) : (
+                  selectedSkillRows.map((skill) => {
+                    const openSkill =
+                      !skill.missing && onOpenSkillDetail !== undefined
+                        ? () => onOpenSkillDetail(skill.id)
+                        : undefined
+                    return (
+                      <div
+                        key={skill.id}
+                        {...clickableRowProps(
+                          openSkill,
+                          t('View {{name}} details', { name: skill.name })
+                        )}
+                        className={capabilityRowClassName(openSkill !== undefined)}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[12.5px]">{skill.name}</div>
+                          {!skill.missing && skill.description ? (
+                            <div className="truncate text-[11px] text-muted-foreground">
+                              {skill.description}
+                            </div>
                           ) : null}
-                          <SettingsIconAction
-                            label={t('Remove {{name}}', { name: connector.name })}
-                            icon={X}
-                            onClick={stopThen(() => removeConnector(connector.id))}
-                            danger
-                          />
                         </div>
-                      )
-                    })
-                  )}
-                </div>
-                <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
-                  <span aria-hidden="true">ⓘ</span>
-                  <span>
-                    {t(
-                      "Connectors start empty and must be added. Connectors not listed here are blocked at runtime for this specialist's sessions."
-                    )}
-                  </span>
-                </p>
+                        {skill.missing ? (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {t('Missing · unavailable')}
+                          </span>
+                        ) : (
+                          <>
+                            {skill.source ? (
+                              <span className="shrink-0 rounded bg-muted px-1.5 py-0.5 text-[10px] capitalize text-muted-foreground">
+                                {skill.source}
+                              </span>
+                            ) : null}
+                            {!skill.mainEnabled ? (
+                              <span className="shrink-0 text-[11px] text-muted-foreground">
+                                {t('Main disabled · available here')}
+                              </span>
+                            ) : null}
+                          </>
+                        )}
+                        <SettingsIconAction
+                          label={t('Remove {{name}}', { name: skill.name })}
+                          icon={X}
+                          disabled={isFullAccess}
+                          onClick={stopThen(() => removeSkill(skill.id))}
+                          danger
+                        />
+                      </div>
+                    )
+                  })
+                )}
               </div>
-            ) : null}
-          </div>
+              <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
+                <span aria-hidden="true">ⓘ</span>
+                <span>
+                  {t(
+                    'Skills start empty and must be added. Skills not listed here are hidden from this specialist, and Skill calls to them are rejected.'
+                  )}
+                </span>
+              </p>
+            </Tabs.Content>
+
+            <Tabs.Content value="connectors">
+              <div className="overflow-hidden rounded-lg border border-border">
+                {selectedConnectorRows.length === 0 ? (
+                  <p className="px-3 py-3.5 text-[12px] text-muted-foreground">
+                    {t('No connectors added yet.')}
+                  </p>
+                ) : (
+                  selectedConnectorRows.map((connector) => {
+                    const canonicalConnectorId = (): string =>
+                      customServers.find(
+                        (server) => server.id === connector.id || server.name === connector.id
+                      )?.id ?? connector.id
+                    const openConnector =
+                      connector.available && onOpenConnectorDetail !== undefined
+                        ? () => onOpenConnectorDetail(canonicalConnectorId())
+                        : undefined
+                    return (
+                      <div
+                        key={connector.id}
+                        {...clickableRowProps(
+                          openConnector,
+                          t('View {{name}} details', { name: connector.name })
+                        )}
+                        className={capabilityRowClassName(openConnector !== undefined)}
+                      >
+                        <div className="min-w-0 flex-1">
+                          <div className="truncate text-[12.5px]">{connector.name}</div>
+                          {connector.available && connector.description ? (
+                            <div className="truncate text-[11px] text-muted-foreground">
+                              {connector.description}
+                            </div>
+                          ) : null}
+                        </div>
+                        {!connector.available ? (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {t('Unavailable — {{reason}}', {
+                              reason: connector.availability ?? t('not installed')
+                            })}
+                          </span>
+                        ) : !connector.mainEnabled ? (
+                          <span className="shrink-0 text-[11px] text-muted-foreground">
+                            {t('Main disabled · available here')}
+                          </span>
+                        ) : null}
+                        <SettingsIconAction
+                          label={t('Remove {{name}}', { name: connector.name })}
+                          icon={X}
+                          disabled={isFullAccess}
+                          onClick={stopThen(() => removeConnector(connector.id))}
+                          danger
+                        />
+                      </div>
+                    )
+                  })
+                )}
+              </div>
+              <p className="mt-2.5 flex gap-2 rounded-lg bg-muted p-2.5 text-[11.5px] leading-snug text-muted-foreground">
+                <span aria-hidden="true">ⓘ</span>
+                <span>
+                  {t(
+                    "Connectors start empty and must be added. Connectors not listed here are blocked at runtime for this specialist's sessions."
+                  )}
+                </span>
+              </p>
+            </Tabs.Content>
+          </Tabs.Root>
 
           {isFullAccess ? (
             <button

--- a/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
+++ b/src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
@@ -583,6 +583,8 @@ describe('SpecialistEditor', () => {
     })
     await act(async () => {
       fireEvent.click(document.body.querySelector<HTMLElement>('[aria-label="Full access"]')!)
+    })
+    await act(async () => {
       fireEvent.click(
         Array.from(document.body.querySelectorAll<HTMLButtonElement>('button')).find(
           (button) => button.textContent === '＋ Add a skill'

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -1,3 +1,4 @@
+import { waitFor } from '@testing-library/react'
 // @vitest-environment jsdom
 import { act, useState } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
@@ -493,6 +494,32 @@ afterEach(() => {
 })
 
 describe('ArtifactProvenancePanel', () => {
+  it('moves provenance tab focus with ArrowRight', async () => {
+    const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'))
+    expect(tabs.length).toBeGreaterThan(1)
+    act(() => tabs[0].focus())
+    await act(async () => {
+      tabs[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))
+    })
+    await waitFor(() => expect(document.activeElement).toBe(tabs[1]))
+    expect(tabs[0].getAttribute('aria-selected')).toBe('true')
+    expect(getVersionExecution).not.toHaveBeenCalled()
+    await act(async () => {
+      tabs[1].dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+    await waitFor(() => expect(getVersionExecution).toHaveBeenCalledOnce())
+    expect(tabs[1].getAttribute('aria-selected')).toBe('true')
+  })
+
+  it('links the selected provenance tab to its content panel', () => {
+    const tab = container.querySelector<HTMLButtonElement>('[role="tab"][aria-selected="true"]')!
+    const panelId = tab.getAttribute('aria-controls')
+    expect(panelId).toBeTruthy()
+    const panel = document.getElementById(panelId!)!
+    expect(panel.getAttribute('role')).toBe('tabpanel')
+    expect(panel.getAttribute('aria-labelledby')).toBe(tab.id)
+  })
+
   it.each([1, 2])('renders the English package count for %i installed packages', async (count) => {
     const snapshot = provenance()
     const environment = snapshot.evidence!.environment as { packages: unknown[] }

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -1,3 +1,4 @@
+import { Tabs } from 'radix-ui'
 import { useVersionHistoryPages } from './use-version-history-pages'
 import { VersionHistoryLoadButton } from './VersionHistoryLoadButton'
 import {
@@ -1277,7 +1278,13 @@ const ArtifactProvenancePanel = ({
   ) : undefined
 
   return (
-    <div className="flex size-full min-h-0 flex-col bg-bg-000" data-testid="artifact-provenance">
+    <Tabs.Root
+      value={isUserEdit && literature ? 'sources' : activeTab}
+      activationMode="manual"
+      onValueChange={(value) => setActiveTab(value as ProvenanceTab)}
+      className="flex size-full min-h-0 flex-col bg-bg-000"
+      data-testid="artifact-provenance"
+    >
       <div className="flex h-9 shrink-0 items-center gap-2 border-b border-border-300/60 px-2">
         <Button
           type="button"
@@ -1344,27 +1351,37 @@ const ArtifactProvenancePanel = ({
 
       <VersionHistoryLoadButton history={history} />
       {(!isUserEdit || literature) && !isLegacyVersion ? (
-        <div
+        <Tabs.List
           ref={tabScrollFadeRef}
-          role="tablist"
+          aria-label={t('Provenance')}
           className="scroll-fade-x flex shrink-0 gap-1 overflow-x-auto border-b border-border-300/60 px-2 py-1"
         >
           {visibleTabs.map((tab) => (
-            <button
+            <Tabs.Trigger
               key={tab.id}
-              type="button"
-              role="tab"
-              aria-selected={isUserEdit || activeTab === tab.id}
-              className={`rounded px-2 py-1 text-xs ${isUserEdit || activeTab === tab.id ? 'bg-bg-300 text-text-000' : 'text-text-200 hover:text-text-100'}`}
+              value={tab.id}
               onClick={() => setActiveTab(tab.id)}
+              className={`rounded px-2 py-1 text-xs ${isUserEdit || activeTab === tab.id ? 'bg-bg-300 text-text-000' : 'text-text-200 hover:text-text-100'}`}
             >
               {t(tab.label)}
-            </button>
+            </Tabs.Trigger>
           ))}
-        </div>
+        </Tabs.List>
       ) : null}
 
-      <div className="min-h-0 flex-1 overflow-y-auto">
+      {(!isUserEdit || literature) && !isLegacyVersion
+        ? visibleTabs
+            .filter((tab) => tab.id !== (isUserEdit && literature ? 'sources' : activeTab))
+            .map((tab) => <Tabs.Content key={tab.id} value={tab.id} />)
+        : null}
+      <Tabs.Content
+        value={isUserEdit && literature ? 'sources' : activeTab}
+        role={(!isUserEdit || literature) && !isLegacyVersion ? 'tabpanel' : 'region'}
+        {...((!isUserEdit || literature) && !isLegacyVersion
+          ? {}
+          : { 'aria-labelledby': undefined })}
+        className="min-h-0 flex-1 overflow-y-auto"
+      >
         {error ? (
           <ProvenanceLoadNotice
             key={provenanceKey + ':core'}
@@ -2016,8 +2033,8 @@ const ArtifactProvenancePanel = ({
             </section>
           )
         ) : null}
-      </div>
-    </div>
+      </Tabs.Content>
+    </Tabs.Root>
   )
 }
 

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.accessibility.test.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.accessibility.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ComposerSpecialistPicker } from '@/pages/workspace/ComposerSpecialistPicker'
+const data = vi.hoisted(() => ({
+  items: [
+    { kind: 'custom', id: 'r', name: 'Researcher', description: 'Research', enabled: true },
+    { kind: 'custom', id: 's', name: 'Statistician', description: 'Statistics', enabled: true }
+  ],
+  isLoaded: true,
+  load: vi.fn()
+}))
+vi.mock('@/stores/specialist-store', () => ({
+  useSpecialistStore: (select: (state: typeof data) => unknown) => select(data)
+}))
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+it('composing Enter preserves the specialist and keeps the picker open', async () => {
+  window.api = {} as typeof window.api
+  const onChange = vi.fn()
+  render(<ComposerSpecialistPicker selectedId="r" onChange={onChange} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Choose Specialist: Researcher' }))
+  const input = screen.getByRole('combobox')
+  fireEvent.compositionStart(input)
+  fireEvent.change(input, { target: { value: 'Stat' } })
+  await act(async () => {
+    fireEvent.keyDown(input, { key: 'Enter', isComposing: true, keyCode: 229 })
+  })
+  expect(onChange).not.toHaveBeenCalled()
+  expect(screen.getByRole('combobox')).toBe(input)
+})
+
+it('composition navigation preserves the candidate and ordinary Enter still selects afterward', () => {
+  const onChange = vi.fn()
+  render(<ComposerSpecialistPicker selectedId="r" onChange={onChange} />)
+  fireEvent.click(screen.getByRole('button', { name: 'Choose Specialist: Researcher' }))
+  const input = screen.getByRole('combobox')
+  const active = input.getAttribute('aria-activedescendant')
+  fireEvent.compositionStart(input)
+  for (const key of ['ArrowDown', 'ArrowUp', 'Home', 'End', 'Enter', 'Escape'])
+    fireEvent.keyDown(input, { key })
+  expect(onChange).not.toHaveBeenCalled()
+  expect(input.getAttribute('aria-activedescendant')).toBe(active)
+  expect(screen.getByRole('combobox')).toBe(input)
+  fireEvent.compositionEnd(input)
+  fireEvent.keyDown(input, { key: 'ArrowDown' })
+  fireEvent.keyDown(input, { key: 'Enter' })
+  expect(onChange).toHaveBeenCalledWith('s')
+})

--- a/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
+++ b/src/renderer/src/pages/workspace/ComposerSpecialistPicker.tsx
@@ -37,6 +37,7 @@ const ComposerSpecialistPicker = ({
   const [query, setQuery] = useState('')
   const [activeIndex, setActiveIndex] = useState(0)
   const inputRef = useRef<HTMLInputElement | null>(null)
+  const composingRef = useRef(false)
   const listboxId = useId()
 
   useEffect(() => {
@@ -92,6 +93,7 @@ const ComposerSpecialistPicker = ({
     <Popover
       open={open}
       onOpenChange={(nextOpen) => {
+        composingRef.current = false
         setOpen(nextOpen)
         if (nextOpen) {
           setQuery('')
@@ -126,6 +128,10 @@ const ComposerSpecialistPicker = ({
         sideOffset={8}
         collisionPadding={8}
         className="w-[min(16rem,calc(100vw-1rem))] rounded-xl border border-border-200 bg-bg-000 p-1.5 text-text-000 shadow-menu"
+        onEscapeKeyDown={(event) => {
+          if (event.isComposing || composingRef.current || event.keyCode === 229)
+            event.preventDefault()
+        }}
         onOpenAutoFocus={(event) => {
           event.preventDefault()
           inputRef.current?.focus()
@@ -149,7 +155,19 @@ const ComposerSpecialistPicker = ({
               setQuery(event.currentTarget.value)
               setActiveIndex(0)
             }}
+            onCompositionStart={() => {
+              composingRef.current = true
+            }}
+            onCompositionEnd={() => {
+              composingRef.current = false
+            }}
             onKeyDown={(event) => {
+              if (
+                event.nativeEvent.isComposing ||
+                composingRef.current ||
+                event.nativeEvent.keyCode === 229
+              )
+                return
               if (filteredOptions.length === 0) return
               if (event.key === 'ArrowDown') {
                 event.preventDefault()

--- a/src/renderer/src/pages/workspace/PanelControls.accessibility.test.tsx
+++ b/src/renderer/src/pages/workspace/PanelControls.accessibility.test.tsx
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { ResizableBottomPanel } from '@/pages/workspace/ResizableBottomPanel'
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  vi.unstubAllGlobals()
+})
+it('resizing publishes the current size through a value-bearing handle', () => {
+  render(
+    <ResizableBottomPanel ariaLabel="Resize question panel" testId="surface" scrollTestId="scroll">
+      <p>Question</p>
+    </ResizableBottomPanel>
+  )
+  const surface = screen.getByTestId('surface')
+  vi.spyOn(surface, 'getBoundingClientRect').mockImplementation(
+    () => ({ height: Number.parseFloat(surface.style.height) || 400 }) as DOMRect
+  )
+  const handle = screen.getByLabelText('Resize question panel')
+  fireEvent.keyDown(handle, { key: 'ArrowUp' })
+  expect(surface.style.height).toBe('432px')
+  expect(handle.getAttribute('aria-valuenow')).toBe('432')
+  expect(handle.getAttribute('role')).toBe('separator')
+  expect(document.getElementById(handle.getAttribute('aria-controls')!)).toBe(
+    screen.getByTestId('scroll')
+  )
+  const originalHeight = window.innerHeight
+  try {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: 500 })
+    act(() => window.dispatchEvent(new Event('resize')))
+    expect(surface.style.height).toBe('350px')
+    expect(handle.getAttribute('aria-valuenow')).toBe('350')
+    expect(handle.getAttribute('aria-valuemax')).toBe('350')
+  } finally {
+    Object.defineProperty(window, 'innerHeight', { configurable: true, value: originalHeight })
+  }
+})

--- a/src/renderer/src/pages/workspace/ResizableBottomPanel.tsx
+++ b/src/renderer/src/pages/workspace/ResizableBottomPanel.tsx
@@ -1,4 +1,13 @@
-import { useRef, useState, type KeyboardEvent, type PointerEvent, type ReactNode } from 'react'
+import {
+  useCallback,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactNode
+} from 'react'
 
 const PANEL_MIN_HEIGHT_PX = 288
 const PANEL_MAX_HEIGHT_PX = 704
@@ -32,8 +41,10 @@ const ResizableBottomPanel = ({
   const surfaceRef = useRef<HTMLDivElement>(null)
   const dragStateRef = useRef<DragState | undefined>(undefined)
   const [height, setHeight] = useState<number>()
+  const panelId = useId()
+  const [size, setSize] = useState({ now: 0, min: 0, max: 0 })
 
-  const resizeBounds = (): ResizeBounds => {
+  const resizeBounds = useCallback((): ResizeBounds => {
     const viewportMax = Math.round(
       Math.min(window.innerHeight * PANEL_MAX_VIEWPORT_RATIO, PANEL_MAX_HEIGHT_PX)
     )
@@ -68,14 +79,48 @@ const ResizableBottomPanel = ({
       min,
       max
     }
-  }
+  }, [scrollTestId, constrainGrowthToOverflow, minimumContentSelector, minimumContentIndex])
+
+  useLayoutEffect(() => {
+    const surface = surfaceRef.current
+    if (!surface) return
+    const measure = (): void => {
+      const bounds = resizeBounds()
+      const actual = Math.round(surface.getBoundingClientRect().height)
+      // Natural content may be shorter than the preferred drag minimum.
+      const next = {
+        now: actual,
+        min: Math.min(bounds.min, actual),
+        max: Math.max(bounds.max, actual)
+      }
+      setSize((current) =>
+        current.now === next.now && current.min === next.min && current.max === next.max
+          ? current
+          : next
+      )
+      if (height !== undefined && height > bounds.max) setHeight(bounds.max)
+    }
+    measure()
+    const observer = typeof ResizeObserver === 'undefined' ? undefined : new ResizeObserver(measure)
+    observer?.observe(surface)
+    const scroll = surface.querySelector<HTMLElement>(`[data-testid="${scrollTestId}"]`)
+    if (scroll) {
+      observer?.observe(scroll)
+      for (const child of scroll.children) observer?.observe(child)
+    }
+    window.addEventListener('resize', measure)
+    return () => {
+      observer?.disconnect()
+      window.removeEventListener('resize', measure)
+    }
+  }, [height, resizeBounds, scrollTestId, children])
 
   const resizeTo = (nextHeight: number): void => {
     const bounds = resizeBounds()
     setHeight(Math.min(bounds.max, Math.max(bounds.min, Math.round(nextHeight))))
   }
 
-  const handlePointerDown = (event: PointerEvent<HTMLButtonElement>): void => {
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>): void => {
     if (
       !surfaceRef.current ||
       event.isPrimary === false ||
@@ -91,13 +136,13 @@ const ResizableBottomPanel = ({
     }
   }
 
-  const handlePointerMove = (event: PointerEvent<HTMLButtonElement>): void => {
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>): void => {
     const dragState = dragStateRef.current
     if (!dragState || dragState.pointerId !== event.pointerId) return
     resizeTo(dragState.startHeight - (event.clientY - dragState.startY))
   }
 
-  const endPointerDrag = (event: PointerEvent<HTMLButtonElement>): void => {
+  const endPointerDrag = (event: PointerEvent<HTMLDivElement>): void => {
     if (dragStateRef.current?.pointerId !== event.pointerId) return
     if (event.currentTarget.hasPointerCapture?.(event.pointerId)) {
       event.currentTarget.releasePointerCapture(event.pointerId)
@@ -105,7 +150,7 @@ const ResizableBottomPanel = ({
     dragStateRef.current = undefined
   }
 
-  const handleResizeKeyDown = (event: KeyboardEvent<HTMLButtonElement>): void => {
+  const handleResizeKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
     if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown') return
     event.preventDefault()
     const currentHeight = surfaceRef.current?.getBoundingClientRect().height
@@ -126,9 +171,16 @@ const ResizableBottomPanel = ({
       data-testid={testId}
       style={height === undefined ? undefined : { height }}
     >
-      <button
-        type="button"
+      <div
+        role="separator"
+        tabIndex={0}
         aria-label={ariaLabel}
+        aria-orientation="horizontal"
+        aria-valuenow={size.now}
+        aria-valuetext={`${size.now}px`}
+        aria-valuemin={size.min}
+        aria-valuemax={size.max}
+        aria-controls={panelId}
         className={`group absolute top-0 z-20 grid cursor-ns-resize touch-none select-none place-items-center focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50 ${
           variant === 'integrated'
             ? 'left-1/2 h-8 w-24 -translate-x-1/2 -translate-y-1/2 rounded-full bg-gradient-to-b from-bg-10/0 to-bg-000/95 [@media(pointer:coarse)]:h-11 [@media(pointer:coarse)]:w-28'
@@ -145,8 +197,9 @@ const ResizableBottomPanel = ({
           aria-hidden="true"
           className="relative z-10 h-1 w-12 rounded-full bg-text-300/70 transition-colors duration-200 group-hover:bg-text-100 group-focus-visible:bg-text-100 group-active:bg-text-000"
         />
-      </button>
+      </div>
       <div
+        id={panelId}
         className={`min-h-0 flex-1 overscroll-contain rounded-2xl border border-border-200 bg-bg-000 ${
           variant === 'integrated' ? 'overflow-hidden shadow-none' : 'overflow-y-auto shadow-sm'
         }`}

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.accessibility.test.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.accessibility.test.tsx
@@ -1,0 +1,48 @@
+// @vitest-environment jsdom
+import type { ComponentProps } from 'react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SessionNotebookContent } from '@/pages/workspace/SessionNotebookDialog'
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+it('Notebook kernel tabs move focus with ArrowRight', async () => {
+  const base = {
+    cellId: 'c',
+    source: 'agent',
+    script: '1',
+    status: 'completed',
+    startedAt: 1,
+    executionCount: 1,
+    text: { stdout: '', stderr: '', traceback: '', plain: [] },
+    outputs: [],
+    artifacts: [],
+    workingFiles: [],
+    rootFrameId: 'root',
+    agentFrameId: 'root'
+  }
+  await act(async () => {
+    render(
+      <SessionNotebookContent
+        sessionId="s"
+        frameLabels={{ root: 'Main Agent' }}
+        runs={
+          [
+            { ...base, runId: 'py', kernelKind: 'python' },
+            { ...base, runId: 'r', kernelKind: 'r' }
+          ] as ComponentProps<typeof SessionNotebookContent>['runs']
+        }
+        status="ready"
+        onClose={vi.fn()}
+        onExport={vi.fn()}
+        onExportAll={vi.fn()}
+      />
+    )
+  })
+  const tabs = screen.getAllByRole('tab')
+  expect(tabs.length).toBeGreaterThan(1)
+  act(() => tabs[0].focus())
+  fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+  await waitFor(() => expect(document.activeElement).toBe(tabs[1]))
+})

--- a/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
+++ b/src/renderer/src/pages/workspace/SessionNotebookDialog.tsx
@@ -1,3 +1,4 @@
+import { Tabs } from 'radix-ui'
 import { useCallback, useEffect, useLayoutEffect, useRef, useState, type RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import { Download, LoaderCircle, X } from 'lucide-react'
@@ -347,7 +348,15 @@ const SessionNotebookContent = ({
   const exportAllCount = dataKernelsWithRuns.length
 
   return (
-    <>
+    <Tabs.Root
+      value={effectiveActiveKind}
+      activationMode="manual"
+      className="contents"
+      onValueChange={(value) => {
+        setActiveKind(value as NotebookKernelKind)
+        setExportSuccess(undefined)
+      }}
+    >
       <div className="flex shrink-0 items-center justify-between border-b border-border-300/90 px-5 py-3.5">
         <h2 className="flex min-w-0 items-center gap-3 text-lg font-semibold text-foreground">
           <span>{t('Session notebook')}</span>
@@ -477,22 +486,20 @@ const SessionNotebookContent = ({
                 </SelectContent>
               </Select>
             </div>
-            <div
-              role="tablist"
+            <Tabs.List
+              aria-label={t('Session notebook')}
               data-testid="session-kernel-switcher"
               className="flex shrink-0 items-center gap-1 border-y border-border bg-muted px-3 py-1.5"
             >
               {visibleKinds.map((kind) => (
-                <button
+                <Tabs.Trigger
                   key={kind}
-                  type="button"
-                  role="tab"
-                  aria-selected={effectiveActiveKind === kind}
-                  data-testid={`session-notebook-tab-${kind}`}
+                  value={kind}
                   onClick={() => {
                     setActiveKind(kind)
                     setExportSuccess(undefined)
                   }}
+                  data-testid={`session-notebook-tab-${kind}`}
                   className={cn(
                     'flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors focus-visible:outline-none focus-visible:ring-[3px] focus-visible:ring-ring/50',
                     effectiveActiveKind === kind
@@ -505,10 +512,16 @@ const SessionNotebookContent = ({
                     {historySummary?.kernelCounts[kind] ??
                       projectedRuns.filter((run) => resolveRunKernelKind(run) === kind).length}
                   </span>
-                </button>
+                </Tabs.Trigger>
               ))}
-            </div>
-            <div
+            </Tabs.List>
+            {visibleKinds
+              .filter((kind) => kind !== effectiveActiveKind)
+              .map((kind) => (
+                <Tabs.Content key={kind} value={kind} />
+              ))}
+            <Tabs.Content
+              value={effectiveActiveKind}
               className="divide-y divide-border-100"
               data-testid={`session-notebook-kernel-${effectiveActiveKind}`}
             >
@@ -529,7 +542,7 @@ const SessionNotebookContent = ({
                   </div>
                 ))
               )}
-            </div>
+            </Tabs.Content>
           </>
         )}
       </div>
@@ -623,7 +636,7 @@ const SessionNotebookContent = ({
           </TooltipProvider>
         </div>
       </div>
-    </>
+    </Tabs.Root>
   )
 }
 


### PR DESCRIPTION
## Problem

Several renderer controls expose inconsistent keyboard and assistive behavior: inactive specialist capabilities can still be edited, capability popups lose focus and leak Escape, tabs lack navigation and content relationships, IME confirmation can select a specialist, localized labels shrink instead of respecting text enlargement, and resize handles expose no current value.

## Proposed change

Use the existing Radix Popover and Tabs components for capability selection and view navigation. Disable the inactive selection region, restore popup focus, protect composition input, retain relative label typography with wrapping, and expose measured panel size and bounds through a focusable separator. Arrow keys move tab focus; Enter/Space activates a tab, preserving lazy provenance loading.

## Scope and non-goals

Renderer interaction fixes only. No database fields, persisted formats, business enums, migrations, historical compatibility layer, dependency changes, or execution architecture changes. Existing selected capability IDs, legacy connector identifiers, credential serialization, notebook history, artifact versions and save/revision paths remain authoritative. Resize measurements and composition refs are temporary UI state.

## Acceptance criteria and validation

- The final regression assertions were run against unchanged production baseline and failed twice for the reported behavior before being verified green on the fixes. They exercise real rendered components and existing store/API boundaries; no production test seam was introduced.
- Capability disablement, popup focus/Escape and full-mode transition -> specialist capability/editor suites -> pass.
- IME confirmation/navigation and ordinary selection -> specialist picker suites -> pass.
- Tab focus, manual activation, lazy loading, content relationships, notebook history/export -> Notebook and provenance suites -> pass.
- Relative label typography and credential/context-window consumers -> segmented control, reasoning effort, credential editor and context-window suites -> pass.
- Resize value, controlled content, keyboard/window bounds and pointer capture -> bottom panel suites and conversation consumer -> pass.
- Focused owner/consumer/i18n impact set: `npx vitest run` with the files below -> 1,136 tests pass. No full local `npm test`; exact-head PR CI supplies full and platform checks.
- `npm run typecheck`, `npm run lint`, changed-file formatting and `git diff --check` -> pass after the final material edit.
- Existing project browser suite: `npx playwright test --config playwright.browser.config.ts e2e/browser/settings-layout.spec.ts` -> all 9 locale/viewport cases pass, including text enlargement and unchanged layout checks.
- Existing Electron permission journey: `npx playwright test e2e/workspace-conversation.spec.ts -g "resolves Agent permission requests"` -> pass with separator semantics and unchanged Allow/Deny and pointer checks.
- Real Chromium fixture imports actual components/CSS/catalogs: full-mode Tab traversal, add/Escape focus return, manual tab activation, measured resize value, and all eight locale labels at doubled root font size pass. Spanish label changes from 12px to 24px; previously it stayed at 10px. Screenshots saved locally for maintainer review.

<details><summary>Exact focused test set</summary>

```text
src/renderer/src/i18n/resources.test.ts
src/renderer/src/components/ui/popover.render.test.tsx
src/renderer/src/pages/settings/ConnectorNamedCredentialEditor.render.test.tsx
src/renderer/src/pages/settings/ReasoningEffortSelect.render.test.tsx
src/renderer/src/pages/settings/SettingsSegmentedControl.render.test.tsx
src/renderer/src/pages/settings/SpecialistCapabilitiesSection.accessibility.test.tsx
src/renderer/src/pages/settings/SpecialistEditor.persistence.render.test.tsx
src/renderer/src/pages/settings/SpecialistEditor.render.test.tsx
src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
src/renderer/src/pages/workspace/ComposerSpecialistPicker.accessibility.test.tsx
src/renderer/src/pages/workspace/ComposerSpecialistPicker.interaction.test.tsx
src/renderer/src/pages/workspace/ContextWindowDialog.render.test.tsx
src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx
src/renderer/src/pages/workspace/PanelControls.accessibility.test.tsx
src/renderer/src/pages/workspace/ResizableBottomPanel.test.tsx
src/renderer/src/pages/workspace/SessionNotebookDialog.accessibility.test.tsx
src/renderer/src/pages/workspace/SessionNotebookDialog.interaction.test.tsx
src/renderer/src/pages/workspace/SessionNotebookDialog.render.test.tsx
```
</details>

Consumer scope includes ContextWindowDialog, which also uses the segmented control, plus the existing conversation, specialist editor, credential and provenance contracts. No main-process interface changed; no new persistence/platform path was introduced. Native OS IME sequences, VoiceOver/NVDA speech, and Electron/browser-menu zoom are not certified by DOM/root-font tests and remain platform checks.

## Review focus

Check popup focus when full access is selected, manual tab activation without unintended fetches, and measurement synchronization during resize. Independent local review found no blocking correctness issue; its additional state-transition and exact-size assertions are included. Avoid introducing duplicate business state or broad accessibility abstractions.
