### PR TITLE
fix(notebook): restore Windows R access and startup retry

### DIFF
--- a/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
+++ b/packages/notebook-network-sandbox/runtime/src/notebook-runtime.ts
@@ -168,7 +168,7 @@ const initialize = async (config: NetworkRuntimeConfig, ask: NetworkAskCallback)
 
 const wrap = async (
   request: NetworkWrapRequest
-): Promise<{ argv: string[]; env: NodeJS.ProcessEnv }> => {
+): Promise<{ argv: string[]; env: NodeJS.ProcessEnv; windowsJobObject?: true }> => {
   if (finishing.size > 0) await Promise.allSettled([...finishing])
   const config = runtimeConfig
   if (!config) throw new Error('Notebook process runtime is not initialized.')

--- a/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
+++ b/packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer.ts
@@ -393,7 +393,7 @@ const setWindowsRuntimeAccess = async (
 
 const windowsLaunch = (
   request: WindowsLaunchRequest
-): { argv: string[]; env: NodeJS.ProcessEnv } => {
+): { argv: string[]; env: NodeJS.ProcessEnv; windowsJobObject: true } => {
   const shell: WindowsShell =
     typeof request.shell === 'object'
       ? request.shell
@@ -439,6 +439,7 @@ const windowsLaunch = (
     delete env.OPEN_SCIENCE_MCP_RPC_SOCKET_PATH
   }
   return {
+    windowsJobObject: true,
     argv: [
       request.hostPath,
       'launch',

--- a/packages/notebook-network-sandbox/src/index.test.ts
+++ b/packages/notebook-network-sandbox/src/index.test.ts
@@ -34,6 +34,26 @@ beforeEach(() => {
 })
 
 describe('NotebookNetworkSandbox', () => {
+  it.each([undefined, true] as const)(
+    'preserves native job containment evidence (%s)',
+    async (windowsJobObject) => {
+      const sandbox = new NotebookNetworkSandbox(options())
+      vi.spyOn(sandbox, 'status').mockResolvedValue({ kind: 'ready', warnings: [] })
+      backend.wrap.mockResolvedValue({ argv: ['host'], env: {}, windowsJobObject })
+      try {
+        await sandbox.initialize()
+        const wrapped = await sandbox.wrap({
+          command: 'workload',
+          cwd: '/workspace',
+          onNetworkAccessRequest: denyNetwork
+        })
+        expect(wrapped.windowsJobObject).toBe(windowsJobObject)
+        wrapped.cleanup()
+      } finally {
+        await sandbox.dispose()
+      }
+    }
+  )
   it('reports unsupported platforms without starting a backend', async () => {
     const sandbox = new NotebookNetworkSandbox(options())
 

--- a/packages/notebook-network-sandbox/src/index.ts
+++ b/packages/notebook-network-sandbox/src/index.ts
@@ -158,6 +158,7 @@ class NotebookNetworkSandbox {
     return {
       argv: wrapped.argv,
       env: wrapped.env,
+      ...(wrapped.windowsJobObject ? { windowsJobObject: true as const } : {}),
       annotateStderr: (stderr) => this.#backend.annotateStderr(commandId, stderr),
       resetNetworkConnections: () => this.#backend.resetCommandConnections(commandId),
       cleanup: () => this.#releaseCommand(commandId, true)

--- a/packages/notebook-network-sandbox/src/types.ts
+++ b/packages/notebook-network-sandbox/src/types.ts
@@ -64,6 +64,8 @@ export type NotebookSandboxCommand = Readonly<{
 export type NotebookSandboxedProcess = Readonly<{
   argv: readonly string[]
   env: NodeJS.ProcessEnv
+  /** The native host owns a kill-on-close Job Object covering every workload descendant. */
+  windowsJobObject?: true
   annotateStderr: (stderr: string) => string
   resetNetworkConnections: () => void
   cleanup: () => void

--- a/packages/notebook-network-sandbox/src/windows-r-startup.integration.test.ts
+++ b/packages/notebook-network-sandbox/src/windows-r-startup.integration.test.ts
@@ -1,0 +1,92 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+import { expect, it } from 'vitest'
+
+import {
+  readAppContainerStatus,
+  windowsLaunch
+} from '../runtime/src/platform/windows-appcontainer.js'
+import { createRuntimeConfig } from './config.js'
+
+const rscript = process.env.OPEN_SCIENCE_TEST_RSCRIPT
+const dllDirectory = process.env.OPEN_SCIENCE_TEST_R_DLL_DIR
+
+// Opt in against an existing R and an installed protected sandbox. The native launch boundary
+// avoids competing with the desktop application's gateway port; neither probe uses the network.
+it.skipIf(process.platform !== 'win32' || !rscript).each(['r', 'powershell'] as const)(
+  'starts %s against the selected R installation under the real AppContainer',
+  async (kind) => {
+    const workspace = await mkdtemp(join(tmpdir(), 'windows-r-startup-'))
+    const config = createRuntimeConfig({
+      policy: { allowedDomains: [], deniedDomains: [] },
+      resources: { root: resolve('packages/notebook-network-sandbox/vendor') }
+    })
+    const env = {
+      ...process.env,
+      ...(dllDirectory ? { PATH: `${dllDirectory};${process.env.PATH ?? ''}` } : {})
+    }
+    const code = 'stopifnot(requireNamespace("jsonlite", quietly=TRUE)); cat("R_READY")'
+    try {
+      const host = spawnSync(rscript!, ['--vanilla', '-e', code], {
+        env,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: 15_000
+      })
+      expect(host.status, host.stderr).toBe(0)
+      expect(host.stdout).toContain('R_READY')
+      expect(
+        await readAppContainerStatus(
+          config.windowsHostPath,
+          config.installationId,
+          config.windowsOwnershipRoot
+        )
+      ).toMatchObject({ owned: true, ownershipState: 'owned', profileExists: true })
+      const shellCode = `& '${rscript!.replaceAll("'", "''")}' --version`
+      const wrapped = windowsLaunch({
+        command: '',
+        executable:
+          kind === 'r'
+            ? rscript!
+            : join(process.env.SystemRoot!, 'System32/WindowsPowerShell/v1.0/powershell.exe'),
+        args:
+          kind === 'r'
+            ? ['--vanilla', '-e', code]
+            : [
+                '-NoProfile',
+                '-NonInteractive',
+                '-EncodedCommand',
+                Buffer.from(shellCode, 'utf16le').toString('base64')
+              ],
+        cwd: workspace,
+        env,
+        gatewayPort: 61200,
+        gatewayCredentials: { username: 'unused-offline-probe', password: 'unused-offline-probe' },
+        hostPath: config.windowsHostPath,
+        installationId: config.installationId,
+        ownershipRoot: config.windowsOwnershipRoot,
+        filesystem: {
+          readOnlyRoots: [dirname(dirname(rscript!)), ...(dllDirectory ? [dllDirectory] : [])],
+          readWriteRoots: [workspace],
+          deniedReadRoots: [],
+          deniedWriteRoots: []
+        }
+      })
+      const result = spawnSync(wrapped.argv[0]!, wrapped.argv.slice(1), {
+        cwd: workspace,
+        env: wrapped.env,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: 15_000
+      })
+      expect(result.status, result.stderr).toBe(0)
+      expect(result.stdout).toContain(kind === 'r' ? 'R_READY' : 'Rscript')
+      expect(result.stderr).not.toContain('InitializeDefaultDrives')
+    } finally {
+      await rm(workspace, { recursive: true, force: true })
+    }
+  },
+  40_000
+)

--- a/resources/notebook/kernel_process_host.js
+++ b/resources/notebook/kernel_process_host.js
@@ -58,8 +58,7 @@ for (const signal of ['SIGINT', 'SIGTERM']) {
   })
 }
 
-child.once('error', () => process.exit(126))
-child.once('exit', (code, signal) => {
+const finish = (code, signal) => {
   if (signal) {
     try {
       process.kill(process.pid, signal)
@@ -69,4 +68,13 @@ child.once('exit', (code, signal) => {
     return
   }
   process.exit(code ?? 1)
-})
+}
+
+// Only the parent can create this IPC channel. It is not inherited by the workload, and stdout is
+// never used as containment evidence. A wrapper killed before native-host exit sends no receipt.
+const reportExit = (code, signal) => {
+  if (process.send) process.send('kernel-child-exited', () => finish(code, signal))
+  else finish(code, signal)
+}
+child.once('error', () => reportExit(126))
+child.once('exit', reportExit)

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -398,7 +398,7 @@ import {
 } from './storage/migration-state'
 import { isDataRootMissing } from './storage/path-presence'
 import { normalizeLegacyDataPaths } from './storage/normalize-legacy-paths'
-import { DataRootCleanupJournal } from './storage/data-root-cleanup'
+import { createDataRootSourceCleanup, DataRootCleanupJournal } from './storage/data-root-cleanup'
 import {
   markManagedProjectWorkspacesRetained,
   markManagedWorkspaceRetained,
@@ -406,7 +406,6 @@ import {
   restoreManagedProjectWorkspacesActive,
   restoreManagedWorkspaceActive
 } from './storage/managed-workspace-ownership'
-import { deleteSources } from './storage/data-migration'
 import { removeMicromambaCacheForRoot } from './notebook/micromamba-cache'
 import { removeNotebookWorkloadCache } from './notebook/notebook-workload-cache-paths'
 import { createDelegatedActivityProjection, detectActiveSessions } from './storage/detect-active'
@@ -722,11 +721,14 @@ const createApplicationModules = async (
     Boolean(storedSettings.dataRoot?.trim()) && (await isDataRootMissing(resolveDataRoot()))
   initializeDataRootWriteAvailability(configuredDataRootMissing)
   const dataRootCleanupJournal = new DataRootCleanupJournal(resolveConfigRoot())
+  const cleanupDataRootSources = createDataRootSourceCleanup((runtimeRoot) =>
+    notebookNetworkSandbox.revokeManagedRAccess(runtimeRoot)
+  )
   await runDataRootStartupRecovery(
     async () => {
       const cleanup = await dataRootCleanupJournal.recover(
         resolveDataRoot(),
-        deleteSources,
+        cleanupDataRootSources,
         (sourceRoot) => {
           const runtimeRoot = join(sourceRoot, 'runtime')
           const workloadRemoved = removeNotebookWorkloadCache(runtimeRoot)
@@ -4157,6 +4159,9 @@ const createApplicationModules = async (
     waitForRecovery,
     assertProvisionAllowed,
     onRepairStarting: (language, target) => notebookService.prepareRuntimeRepair(language, target),
+    revokeRuntimeAccess: async (language) => {
+      if (language === 'r') await notebookNetworkSandbox.revokeManagedRAccess(provisioningRoot)
+    },
     onRepairCompleted: (language) => notebookService.completeRuntimeRepair(language)
   })
   // Always register the handlers (serialized is undefined when the provisioner could not be built).
@@ -4224,7 +4229,8 @@ const createApplicationModules = async (
         }
       }
     },
-    cleanupJournal: dataRootCleanupJournal
+    cleanupJournal: dataRootCleanupJournal,
+    deleteSources: cleanupDataRootSources
   })
   declareElectronAdapter('storage', () =>
     registerStorageIpcHandlers(

--- a/src/main/notebook/environment-lifecycle-workflows.ts
+++ b/src/main/notebook/environment-lifecycle-workflows.ts
@@ -44,6 +44,7 @@ type NotebookEnvironmentLifecycleDeps = {
     target: ExplicitRuntimeRepairTarget
   ) => Promise<void> | void
   onRepairCompleted?: (language: NotebookLanguage) => Promise<void> | void
+  revokeRuntimeAccess?: (language: NotebookLanguage) => Promise<void>
 }
 
 const RUNTIME_UNAVAILABLE_MESSAGE =
@@ -148,13 +149,16 @@ const createNotebookEnvironmentLifecycle = (
           if (deps.waitForRecovery) await deps.waitForRecovery()
           await provisioner.repair(parsedLanguage, report, {
             force: true,
-            onStarting: deps.onRepairStarting
-              ? () =>
-                  deps.onRepairStarting?.(
-                    parsedLanguage,
-                    explicitRuntimeRepairTarget(parsedLanguage, runtimeIdentity)
-                  )
-              : undefined,
+            onStarting:
+              deps.onRepairStarting || deps.revokeRuntimeAccess
+                ? async () => {
+                    await deps.onRepairStarting?.(
+                      parsedLanguage,
+                      explicitRuntimeRepairTarget(parsedLanguage, runtimeIdentity)
+                    )
+                    await deps.revokeRuntimeAccess?.(parsedLanguage)
+                  }
+                : undefined,
             onVerified: () => deps.onRepairCompleted?.(parsedLanguage)
           })
         }),

--- a/src/main/notebook/kernel-executor.ts
+++ b/src/main/notebook/kernel-executor.ts
@@ -442,6 +442,9 @@ const helperInitializationError = (
 // as independent processes; the requested kind never triggers a restart of another.
 class NotebookKernelExecutor implements NotebookExecutor {
   private readonly procs = new Map<ProcessKey, ProcState>()
+  // A dead admission wrapper alone does not prove native Job Object teardown. Its private IPC
+  // acknowledgement is sent only after the sandbox host exits; workload stdio cannot forge it.
+  private readonly exitedWindowsJobs = new WeakSet<ChildProcessWithoutNullStreams>()
   // In-flight process-tree teardowns, keyed by the process key of the proc being reaped. A dropped
   // proc's tree is killed asynchronously; ensureProc awaits any pending teardown for a key before
   // spawning its replacement, so two live process trees for the SAME (kind, env) never briefly coexist.
@@ -995,7 +998,9 @@ class NotebookKernelExecutor implements NotebookExecutor {
         : {})
     }
     let child: ChildProcessWithoutNullStreams
+    const windowsJobObject = this.platform === 'win32' && sandboxed?.windowsJobObject === true
     try {
+      // The first three descriptors remain pipes even when the fourth carries a token or IPC.
       child = spawn(spawnExecutable, spawnArgs, {
         cwd: spawnCwd,
         env: effectiveSpawnEnv,
@@ -1004,19 +1009,32 @@ class NotebookKernelExecutor implements NotebookExecutor {
         // Windows descendants are contained by the sandbox host's kill-on-close Job Object and the
         // taskkill /T fallback used by terminateProcessTree.
         detached: this.platform !== 'win32',
-        ...(rpcTokenFileDescriptor ? { stdio: ['pipe', 'pipe', 'pipe', 'pipe'] } : {})
-      })
+        ...(rpcTokenFileDescriptor
+          ? { stdio: ['pipe', 'pipe', 'pipe', 'pipe'] }
+          : windowsJobObject && ownershipIntent
+            ? { stdio: ['pipe', 'pipe', 'pipe', 'ipc'] }
+            : {})
+      }) as ChildProcessWithoutNullStreams
     } catch (error) {
       if (ownershipIntent) this.processLifecycle?.abandonSpawn(ownershipIntent)
       sandboxed?.cleanup()
       throw error
     }
+    if (windowsJobObject) {
+      if (ownershipIntent) {
+        child.on('message', (message) => {
+          if (message === 'kernel-child-exited') this.exitedWindowsJobs.add(child)
+        })
+      } else {
+        // Without durable admission the child handle addresses the native sandbox host itself.
+        child.once('exit', () => this.exitedWindowsJobs.add(child))
+      }
+    }
     if (this.platform !== 'win32') registerOwnedPosixProcessGroup(child)
     let ownershipReceipt: KernelProcessReceipt | undefined
     const cleanupFailedSpawn = async (): Promise<void> => {
-      const result = await terminateProcessTree(child)
-      if (ownershipReceipt) this.processLifecycle?.complete(ownershipReceipt, result.reaped)
-      else if (ownershipIntent && result.reaped) {
+      const result = await this.killChild(child, ownershipReceipt)
+      if (!ownershipReceipt && ownershipIntent && result.reaped) {
         this.processLifecycle?.abandonSpawn(ownershipIntent)
       }
       sandboxed?.cleanup()
@@ -1494,7 +1512,12 @@ class NotebookKernelExecutor implements NotebookExecutor {
     child: ChildProcessWithoutNullStreams,
     ownershipReceipt?: KernelProcessReceipt
   ): Promise<ProcessTreeKillResult> {
-    const result = await terminateProcessTree(child)
+    const jobExited = (): boolean =>
+      this.exitedWindowsJobs.has(child) && (child.exitCode !== null || child.signalCode !== null)
+    const result = jobExited() ? { reaped: true } : await terminateProcessTree(child)
+    // Native exit can race a taskkill of the admission wrapper. Its acknowledgement remains
+    // authoritative even when taskkill reports that the wrapper's PID has already disappeared.
+    if (jobExited()) result.reaped = true
     if (ownershipReceipt) this.processLifecycle?.complete(ownershipReceipt, result.reaped)
     child.removeAllListeners('exit')
     child.removeAllListeners('close')

--- a/src/main/notebook/kernel-startup-retry.integration.test.ts
+++ b/src/main/notebook/kernel-startup-retry.integration.test.ts
@@ -1,0 +1,163 @@
+import { spawnSync } from 'node:child_process'
+import { mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { expect, it } from 'vitest'
+
+import { createRuntimeConfig } from '../../../packages/notebook-network-sandbox/src/config'
+import { windowsLaunch } from '../../../packages/notebook-network-sandbox/runtime/src/platform/windows-appcontainer'
+import { NotebookKernelExecutor } from './kernel-executor'
+import { KernelProcessLifecycleOwner } from './kernel-process-lifecycle.windows-posix'
+import type { NotebookProcessSandbox } from './process-sandbox'
+
+it.skipIf(process.platform !== 'win32').each([
+  { protectedMode: false, crashAdmission: false },
+  ...(process.env.OPEN_SCIENCE_TEST_WINDOWS_SANDBOX === '1'
+    ? [
+        { protectedMode: true, crashAdmission: false },
+        { protectedMode: true, crashAdmission: true }
+      ]
+    : [])
+])(
+  'retries only a proven reaped R lane (protected: $protectedMode, admission crash: $crashAdmission)',
+  async ({ protectedMode, crashAdmission }) => {
+    const root = await mkdtemp(join(tmpdir(), 'kernel-startup-retry-'))
+    const loop = join(root, 'loop.cjs')
+    const admissionHost = join(root, 'admission.cjs')
+    if (crashAdmission) {
+      await writeFile(
+        admissionHost,
+        `
+        const fs = require('node:fs')
+        const child = require('node:child_process').spawn(process.argv[4], process.argv.slice(5), {
+          stdio: 'inherit', windowsHide: true
+        })
+        fs.writeFileSync('native.pid', String(child.pid))
+        setInterval(() => {
+          if (fs.existsSync('loop.pid')) {
+            // A workload/stdio message must never substitute for the private host acknowledgement.
+            console.log('kernel-child-exited')
+            process.exit(1)
+          }
+        }, 10)
+      `
+      )
+    }
+    const owner = new KernelProcessLifecycleOwner({ storageRoot: root })
+    await owner.ensureReady()
+    // The desktop app owns the gateway port. Exercise the real native launch without opening a
+    // second gateway; these offline fixtures do not make network requests.
+    const config = createRuntimeConfig({
+      policy: { allowedDomains: [], deniedDomains: [] },
+      resources: { root: resolve('packages/notebook-network-sandbox/vendor') }
+    })
+    const processSandbox: NotebookProcessSandbox = {
+      async wrap(invocation) {
+        const wrapped = windowsLaunch({
+          ...invocation,
+          command: '',
+          filesystem: invocation.filesystem,
+          gatewayPort: 61200,
+          gatewayCredentials: { username: 'offline', password: 'offline' },
+          hostPath: config.windowsHostPath,
+          installationId: config.installationId,
+          ownershipRoot: config.windowsOwnershipRoot
+        })
+        return {
+          ...wrapped,
+          executable: wrapped.argv[0]!,
+          args: wrapped.argv.slice(1),
+          annotateStderr: (stderr) => stderr,
+          cleanup: () => undefined
+        }
+      }
+    }
+    const executor = new NotebookKernelExecutor({
+      rLoopPath: loop,
+      processLifecycle: owner,
+      laneKey: 'startup-retry',
+      ...(crashAdmission ? { processHostPath: admissionHost } : {}),
+      ...(protectedMode ? { processSandbox } : {})
+    })
+    const request = {
+      language: 'r' as const,
+      code: 'cat(R.version.string)',
+      cwd: root,
+      notebookSessionRoot: root,
+      dataRoot: root,
+      runtimeRoot: join(root, 'runtime'),
+      // A real child process reproduces startup exit without requiring an installed R or changing ACLs.
+      resolvedInterpreter: { command: process.execPath, args: ['--preserve-symlinks-main'] },
+      sessionId: 'startup-retry',
+      projectId: 'startup-retry',
+      timeoutMs: 5_000
+    }
+    let descendantPid: number | undefined
+    try {
+      await writeFile(
+        loop,
+        crashAdmission
+          ? `require('node:fs').writeFileSync('loop.pid', String(process.pid)); setInterval(() => {}, 1000)\n`
+          : protectedMode
+            ? `const child = require('node:child_process').spawn(process.execPath,
+              ['-e', 'setInterval(() => {}, 1000)'], { stdio: 'inherit' })
+             child.once('spawn', () => {
+               require('node:fs').writeFileSync('descendant.pid', String(child.pid))
+               process.exit(1)
+             })\n`
+            : 'process.exit(1)\n'
+      )
+      const failed = await executor.execute(request)
+      expect(failed.status).toBe('failed')
+      expect(failed.stderr).toContain('Notebook kernel process exited with exit code 1.')
+      if (protectedMode && !crashAdmission) {
+        descendantPid = Number(await readFile(join(root, 'descendant.pid'), 'utf8'))
+      }
+      const ledger = join(root, 'runtime', 'kernel-processes')
+      const entries = await readdir(ledger)
+      for (const entry of entries) {
+        const record = JSON.parse(await readFile(join(ledger, entry), 'utf8'))
+        expect(() => process.kill(record.pid, 0)).toThrow()
+      }
+      await writeFile(
+        loop,
+        `process.stdin.once('data', data => {
+          const req_id = data.toString().split(' ')[0]
+          console.log(JSON.stringify({ req_id, stdout: 'RETRY_OK', stderr: '', error: null, figures: [] }))
+        })\n`
+      )
+      const retried = await executor.execute(request)
+      if (protectedMode && !crashAdmission) {
+        expect(retried, JSON.stringify(retried)).toMatchObject({
+          status: 'completed',
+          stdout: 'RETRY_OK'
+        })
+        // Do not wait for descendant cleanup before requesting the replacement. Admission must
+        // complete the teardown itself; the crashed workload cannot survive a successful retry.
+        expect(() => process.kill(descendantPid!, 0)).toThrow()
+      } else {
+        // A dead ordinary parent does not prove that its descendants were reaped.
+        expect(retried.status).toBe('failed')
+        expect(retried.stderr).toContain('KERNEL_STARTUP_FENCE')
+        if (crashAdmission) {
+          expect(Number(await readFile(join(root, 'loop.pid'), 'utf8'))).toBeGreaterThan(0)
+        }
+      }
+    } finally {
+      if (crashAdmission) {
+        const nativePid = Number(await readFile(join(root, 'native.pid'), 'utf8'))
+        // This PID belongs to this test's native host, whose live Job Object owns the workload.
+        spawnSync('taskkill', ['/PID', String(nativePid), '/T', '/F'], { windowsHide: true })
+      }
+      if (descendantPid) {
+        try {
+          process.kill(descendantPid, 'SIGKILL')
+        } catch {
+          /* Already reaped by the native job. */
+        }
+      }
+      await executor.shutdown()
+      await rm(root, { recursive: true, force: true })
+    }
+  }
+)

--- a/src/main/notebook/network-sandbox-owner.test.ts
+++ b/src/main/notebook/network-sandbox-owner.test.ts
@@ -39,8 +39,53 @@ vi.mock('@aipoch/notebook-network-sandbox', () => ({
 }))
 
 import { NotebookNetworkSandboxOwner, commandLine } from './network-sandbox-owner'
+import { DEFAULT_R_ENV, envPrefix, legacyDefaultEnvPrefix, rScriptBin } from './runtime-paths'
 
 const fixtureDirectories: string[] = []
+
+it.each([undefined, true] as const)(
+  'preserves the native job capability in the executor adapter (%s)',
+  async (windowsJobObject) => {
+    const root = await mkdtemp(join(tmpdir(), 'os-job-capability-'))
+    fixtureDirectories.push(root)
+    const owner = new NotebookNetworkSandboxOwner({
+      resourceRoot: root,
+      getSettings: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+      persistAlwaysAllow: vi.fn(),
+      requestDecision: vi.fn()
+    })
+    backend.wrap.mockResolvedValueOnce({
+      argv: ['host'],
+      env: {},
+      windowsJobObject,
+      annotateStderr: (stderr: string) => stderr,
+      resetNetworkConnections: backend.resetNetworkConnections,
+      cleanup: backend.cleanup
+    })
+    try {
+      const wrapped = await owner.wrap({
+        executable: process.execPath,
+        args: [],
+        env: {},
+        cwd: root,
+        commandText: 'workload',
+        sessionId: 'session',
+        projectId: 'project',
+        runtime: 'r',
+        filesystem: {
+          readOnlyRoots: [],
+          readWriteRoots: [root],
+          deniedReadRoots: [],
+          deniedWriteRoots: []
+        }
+      })
+      expect(wrapped.windowsJobObject).toBe(windowsJobObject)
+      wrapped.cleanup()
+    } finally {
+      await owner.dispose()
+    }
+  }
+)
 
 const createCapturingLogger = (): { logger: Logger; records: unknown[] } => {
   const records: unknown[] = []
@@ -98,6 +143,34 @@ afterEach(async () => {
 })
 
 describe('NotebookNetworkSandboxOwner', () => {
+  it.each([false, true])(
+    'removes the managed R grant before path replacement (cancelled: %s)',
+    async (cancelled) => {
+      const owner = new NotebookNetworkSandboxOwner({
+        resourceRoot: '/resources',
+        getSettings: async () => DEFAULT_NOTEBOOK_NETWORK_SETTINGS,
+        persistAlwaysAllow: vi.fn(),
+        requestDecision: vi.fn(),
+        platform: 'win32'
+      })
+      backend.setWindowsRuntimeAccess.mockResolvedValueOnce({ cancelled })
+      const operation = owner.revokeManagedRAccess('/data/runtime')
+      if (cancelled) await expect(operation).rejects.toThrow('permission removal was cancelled')
+      else await expect(operation).resolves.toBeUndefined()
+      expect(backend.setWindowsRuntimeAccess).toHaveBeenCalledWith(
+        rScriptBin(envPrefix('/data/runtime', DEFAULT_R_ENV, 'win32'), 'win32'),
+        false
+      )
+      if (!cancelled) {
+        expect(backend.setWindowsRuntimeAccess).toHaveBeenCalledWith(
+          rScriptBin(legacyDefaultEnvPrefix('/data/runtime', DEFAULT_R_ENV), 'win32'),
+          false
+        )
+      }
+      expect(backend.wrap).not.toHaveBeenCalled()
+    }
+  )
+
   it('does not pass parent secrets or R startup overrides to the runtime verification child', async () => {
     const root = await mkdtemp(join(tmpdir(), 'os-r-verification-env-'))
     fixtureDirectories.push(root)

--- a/src/main/notebook/network-sandbox-owner.ts
+++ b/src/main/notebook/network-sandbox-owner.ts
@@ -38,7 +38,13 @@ import {
 import type { GrantedLocalRoot } from '../../shared/local-fs'
 import { kernelExecutableReadRoot } from './kernel-executor'
 import { windowsCondaPrefixForR } from './environment-discovery'
-import { condaActivatedPath } from './runtime-paths'
+import {
+  condaActivatedPath,
+  DEFAULT_R_ENV,
+  envPrefix,
+  legacyDefaultEnvPrefix,
+  rScriptBin
+} from './runtime-paths'
 
 export type NotebookNetworkDecision = 'deny' | 'allowOnce' | 'alwaysAllow' | 'unavailable'
 
@@ -280,6 +286,7 @@ class NotebookNetworkSandboxOwner implements NotebookProcessSandbox {
       executable,
       args,
       env: wrapped.env,
+      ...(wrapped.windowsJobObject ? { windowsJobObject: true as const } : {}),
       beginExecution: () => {
         if (cleaned) throw new Error('Notebook sandbox process is already closed.')
         if (executionActive) throw new Error('Notebook sandbox execution is already active.')
@@ -534,6 +541,26 @@ class NotebookNetworkSandboxOwner implements NotebookProcessSandbox {
       endExecution?.()
       invocation?.cleanup()
       await rm(cwd, { recursive: true, force: true })
+    }
+  }
+
+  // The caller has stopped the affected kernels and holds repair/migration admission. Revoke while
+  // the exact old directories still exist so the native owner can remove every recorded ACL.
+  async revokeManagedRAccess(runtimeRoot: string): Promise<void> {
+    if (!this.supportsWindowsRuntimeAccess) return
+    // A damaged legacy interpreter can make discovery fall back to the short layout. Keep the
+    // original exact path addressable; the native owner removes only its recorded permissions.
+    const prefixes = new Set([
+      envPrefix(runtimeRoot, DEFAULT_R_ENV, this.platform),
+      legacyDefaultEnvPrefix(runtimeRoot, DEFAULT_R_ENV)
+    ])
+    for (const prefix of prefixes) {
+      const result = await this.setWindowsRuntimeAccess(rScriptBin(prefix, this.platform), false)
+      if (result.cancelled) {
+        throw new Error(
+          'R permission removal was cancelled; the existing runtime must be preserved.'
+        )
+      }
     }
   }
 

--- a/src/main/notebook/process-sandbox.ts
+++ b/src/main/notebook/process-sandbox.ts
@@ -22,6 +22,8 @@ export type NotebookSandboxedSpawn = Readonly<{
   executable: string
   args: readonly string[]
   env: NodeJS.ProcessEnv
+  // Only the native protected Windows host provides kill-on-close descendant containment.
+  windowsJobObject?: true
   beginExecution?: () => () => void
   annotateStderr: (stderr: string) => string
   cleanup: () => void

--- a/src/main/notebook/runtime-repair.test.ts
+++ b/src/main/notebook/runtime-repair.test.ts
@@ -18,12 +18,55 @@ import { NotebookRuntimeRepairPolicy } from './runtime-repair-policy'
 import { createNotebookEnvironmentLifecycle } from './environment-lifecycle-workflows'
 import { serializeProvisioner } from './environment-operation-foundation'
 import { DefaultRuntimeProvisioner } from './provisioner'
-import { envPrefix, pythonBin } from './runtime-paths'
+import { DEFAULT_R_ENV, envPrefix, pythonBin, rBin } from './runtime-paths'
 import { NotebookSessionAggregate, type NotebookSessionRuntimeBinding } from './session-aggregate'
 
 type RepairOptions = ConstructorParameters<typeof NotebookRuntimeRepairOwner>[0]
 
 const roots: string[] = []
+
+it.each([false, true])(
+  'drains and revokes managed R before deleting its prefix (cancelled: %s)',
+  async (cancelled) => {
+    const root = mkdtempSync(join(tmpdir(), 'r-repair-access-'))
+    roots.push(root)
+    const interpreter = rBin(envPrefix(root, DEFAULT_R_ENV))
+    mkdirSync(dirname(interpreter), { recursive: true })
+    writeFileSync(interpreter, 'original R')
+    const order: string[] = []
+    const fetchBundle = vi.fn(async () => {
+      order.push('rebuild')
+      expect(existsSync(interpreter)).toBe(false)
+      throw new Error('rebuild reached')
+    })
+    const provisioner = new DefaultRuntimeProvisioner({
+      root,
+      mm: '/unused-mm',
+      channel: 'conda-forge',
+      fetchBundle,
+      runArgv: vi.fn(),
+      verify: vi.fn()
+    })
+    const lifecycle = createNotebookEnvironmentLifecycle({
+      provisioner,
+      root,
+      projectProgress: () => undefined,
+      onRepairStarting: async () => {
+        order.push('drain')
+      },
+      revokeRuntimeAccess: async () => {
+        order.push('revoke')
+        expect(readFileSync(interpreter, 'utf8')).toBe('original R')
+        if (cancelled) throw new Error('permission removal cancelled')
+      }
+    })
+    await expect(lifecycle.repair('r', interpreter)).rejects.toThrow(
+      cancelled ? 'permission removal cancelled' : 'rebuild reached'
+    )
+    expect(order).toEqual(cancelled ? ['drain', 'revoke'] : ['drain', 'revoke', 'rebuild'])
+    if (cancelled) expect(readFileSync(interpreter, 'utf8')).toBe('original R')
+  }
+)
 
 afterEach(() => {
   vi.restoreAllMocks()

--- a/src/main/notebook/runtime-workflows.test.ts
+++ b/src/main/notebook/runtime-workflows.test.ts
@@ -32,6 +32,11 @@ vi.mock('./environment-discovery', async (importOriginal) => ({
 }))
 
 import { createRuntimeWorkflows, type RuntimeWorkflowDeps } from './runtime-workflows'
+import {
+  beginMigrationPreparation,
+  endMigration,
+  waitForDataRootWriters
+} from '../storage/migration-state'
 
 type SettingsPort = RuntimeWorkflowDeps['settingsService']
 
@@ -98,6 +103,111 @@ beforeEach(() => {
 })
 
 describe('runtime workflows', () => {
+  it('blocks R authorization once data-root handoff preparation starts', async () => {
+    discoveryState.r = [
+      {
+        language: 'r',
+        provenance: 'app-managed',
+        envId: 'managed-r',
+        interpreterPath: '/runtime/bin/R',
+        label: 'R',
+        runnable: true
+      }
+    ]
+    const grant = vi.fn(async () => ({ cancelled: false }))
+    const workflows = createRuntimeWorkflows({
+      settingsService: fakeSettingsService(),
+      runtimeRoot: () => '/runtime',
+      setWindowsRuntimeAccess: grant
+    })
+    const migration = beginMigrationPreparation()
+    try {
+      await expect(
+        workflows.setSandboxAccess({ language: 'r', envId: 'managed-r', authorized: true })
+      ).rejects.toThrow('moving your data')
+      expect(grant).not.toHaveBeenCalled()
+    } finally {
+      migration.finish()
+      endMigration()
+    }
+  })
+
+  it('keeps data-root writers draining until an admitted R authorization finishes', async () => {
+    discoveryState.r = [
+      {
+        language: 'r',
+        provenance: 'app-managed',
+        envId: 'managed-r',
+        interpreterPath: '/runtime/bin/R',
+        label: 'R',
+        runnable: true
+      }
+    ]
+    let finish!: () => void
+    const held = new Promise<void>((resolve) => {
+      finish = resolve
+    })
+    const grant = vi.fn(async () => {
+      await held
+      return { cancelled: false }
+    })
+    const workflows = createRuntimeWorkflows({
+      settingsService: fakeSettingsService(),
+      runtimeRoot: () => '/runtime',
+      setWindowsRuntimeAccess: grant
+    })
+    const authorization = workflows.setSandboxAccess({
+      language: 'r',
+      envId: 'managed-r',
+      authorized: true
+    })
+    try {
+      await vi.waitFor(() => expect(grant).toHaveBeenCalledOnce())
+      let drained = false
+      const drain = waitForDataRootWriters().then(() => {
+        drained = true
+      })
+      await Promise.resolve()
+      expect(drained).toBe(false)
+      finish()
+      await authorization
+      await drain
+      expect(drained).toBe(true)
+    } finally {
+      finish()
+      await authorization
+    }
+  })
+
+  it('authorizes managed R and revokes its access after disabling and draining it', async () => {
+    const env: DiscoveredInterpreter = {
+      language: 'r',
+      provenance: 'app-managed',
+      envId: 'managed-r',
+      interpreterPath: 'D:\\data\\runtime\\envs\\.r\\Lib\\R\\bin\\R.exe',
+      label: 'Managed R',
+      runnable: true
+    }
+    discoveryState.r = [env]
+    const settingsService = fakeSettingsService()
+    const events: string[] = []
+    const workflows = createRuntimeWorkflows({
+      settingsService,
+      runtimeRoot: () => '/runtime',
+      setWindowsRuntimeAccess: async (_path, authorized) => {
+        events.push(authorized ? 'grant' : 'remove')
+        return { cancelled: false }
+      },
+      onRuntimeDisabled: async () => {
+        expect((await settingsService.getRuntimeEnablement('r')).enabled[env.envId]).toBe(false)
+        events.push('drain')
+      }
+    })
+    await workflows.setSandboxAccess({ language: 'r', envId: env.envId, authorized: true })
+    await workflows.setEnvironmentEnabled({ language: 'r', envId: env.envId, enabled: false })
+    expect(events).toEqual(['grant', 'drain', 'remove'])
+  })
+
   it('rejects authorization for non-runnable R while allowing its access to be removed', async () => {
     discoveryState.r = [
       {
@@ -162,7 +272,7 @@ describe('runtime workflows', () => {
     })
     await expect(
       workflows.setSandboxAccess({ language: 'r', envId: 'unknown', authorized: true })
-    ).rejects.toThrow('Select a discovered external R')
+    ).rejects.toThrow('Select a discovered managed or external R')
     expect(setWindowsRuntimeAccess).not.toHaveBeenCalled()
     await workflows.setSandboxAccess({ language: 'r', envId: env.envId, authorized: true })
     expect(setWindowsRuntimeAccess).toHaveBeenLastCalledWith(

--- a/src/main/notebook/runtime-workflows.ts
+++ b/src/main/notebook/runtime-workflows.ts
@@ -8,6 +8,7 @@ import {
 } from './environment-discovery'
 import { listEnvPackages } from './package-listing'
 import type { MicromambaRunner } from './windows-micromamba-runner'
+import { isMigrationInProgress, withDataRootWrite } from '../storage/migration-state'
 
 // Upper bound on concurrent package listings inside listPackageCounts (mirrors the bounded
 // probe concurrency in environment-discovery): enough to fill the Settings badges quickly without
@@ -94,11 +95,16 @@ const createRuntimeWorkflows = (deps: RuntimeWorkflowDeps): RuntimeWorkflows => 
     operation: () => Promise<T>
   ): Promise<T> => {
     if (language !== 'r' || !deps.setWindowsRuntimeAccess) return operation()
+    if (isMigrationInProgress()) {
+      throw new Error(
+        'Open Science is moving your data. Wait for the move to finish before running this.'
+      )
+    }
     if (runtimeAccessUpdate)
       throw new Error('An R runtime permission change is already in progress.')
     runtimeAccessUpdate = true
     try {
-      return await operation()
+      return await withDataRootWrite(operation)
     } finally {
       runtimeAccessUpdate = false
     }
@@ -146,8 +152,8 @@ const createRuntimeWorkflows = (deps: RuntimeWorkflowDeps): RuntimeWorkflows => 
         const env = (await discoverLanguageEnvs('r')).find(
           (candidate) => candidate.envId === request.envId
         )
-        if (!env || env.provenance !== 'user-own')
-          throw new Error('Select a discovered external R runtime.')
+        if (!env || env.provenance === 'agent-created')
+          throw new Error('Select a discovered managed or external R runtime.')
         if (request.authorized && !env.runnable)
           throw new Error('R must be runnable with jsonlite before verifying sandbox access.')
         if (!request.authorized) {
@@ -243,7 +249,7 @@ const createRuntimeWorkflows = (deps: RuntimeWorkflowDeps): RuntimeWorkflows => 
             const env = (await discoverLanguageEnvs('r')).find(
               (candidate) => candidate.envId === request.envId
             )
-            if (env?.provenance === 'user-own') {
+            if (env && env.provenance !== 'agent-created') {
               const result = await deps.setWindowsRuntimeAccess(
                 rscriptFor(env.interpreterPath),
                 false

--- a/src/main/storage/command-owner.ts
+++ b/src/main/storage/command-owner.ts
@@ -105,6 +105,7 @@ type StorageCommandOwnerDeps = {
   micromambaRunner?: Pick<MicromambaRunner, 'resolve'>
   exportRuntimeLocks?: typeof exportRuntimeLocks
   discardStagedCopy?: typeof discardStagedCopy
+  deleteSources?: typeof import('./data-migration').deleteSources
   runDataRootMigration?: typeof runDataRootMigration
   pauseDataRootWriters?: typeof pauseDataRootWriters
   // Windows classification probes volume capabilities; inject only when a host-independent command
@@ -840,6 +841,7 @@ const createStorageCommandOwner = (deps: StorageCommandOwnerDeps) => {
             // Prove the on-disk copy is the one this session staged (guards against a stale marker).
             expectedToken: staged.token,
             cleanupJournal,
+            deleteSources: deps.deleteSources,
             cleanupRuntimeCache: (sourceRoot) => cleanupRuntimeCache(join(sourceRoot, 'runtime')),
             logger,
             diagnosticCorrelationId: staged.correlationId

--- a/src/main/storage/data-root-cleanup.test.ts
+++ b/src/main/storage/data-root-cleanup.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { deleteSources } from './data-migration'
-import { DataRootCleanupJournal } from './data-root-cleanup'
+import { createDataRootSourceCleanup, DataRootCleanupJournal } from './data-root-cleanup'
 import { readMigrationMarker, scanInventory, writeMigrationMarker } from './migration-marker'
 
 let root: string
@@ -38,6 +38,56 @@ afterEach(async () => {
 })
 
 describe('DataRootCleanupJournal', () => {
+  it('preserves old runtime access before commit and retries cancelled removal after commit', async () => {
+    const runtime = join(source, 'runtime')
+    await mkdir(runtime)
+    await writeFile(join(runtime, 'R.exe'), 'old runtime')
+    await mkdir(join(target, 'runtime'))
+    await writeFile(join(target, 'runtime', 'R.exe'), 'new runtime')
+    const migratedDirs = [
+      join('runtime', 'pkgs'),
+      join('runtime', 'provenance', 'environment-manifests')
+    ]
+    for (const dir of migratedDirs) await mkdir(join(target, dir), { recursive: true })
+    await writeMigrationMarker(target, {
+      version: 1,
+      token: 'runtime-cleanup',
+      source,
+      target,
+      createdAt: 1,
+      status: 'verified',
+      migratedDirs,
+      inventory: await scanInventory(target, migratedDirs)
+    })
+    const revoke = vi.fn(async () => {
+      expect(await readFile(join(runtime, 'R.exe'), 'utf8')).toBe('old runtime')
+      throw new Error('permission removal cancelled')
+    })
+    const removeSources = createDataRootSourceCleanup(revoke)
+    const journal = new DataRootCleanupJournal(configRoot)
+    const stage = (): Promise<string[]> =>
+      journal.stage({ token: 'runtime-cleanup', source, target, dirs: ['runtime'], createdAt: 1 })
+    await stage()
+    // Abandoned or failed pointer commit keeps the source as current and must preserve its access.
+    await journal.recover(source, removeSources)
+    expect(revoke).not.toHaveBeenCalled()
+    expect(await readFile(join(runtime, 'R.exe'), 'utf8')).toBe('old runtime')
+    await stage()
+    await journal.markCommitted('runtime-cleanup')
+    expect(await journal.recover(target, removeSources)).toEqual({ pending: true, failureCount: 1 })
+    expect(revoke).toHaveBeenCalledWith(runtime)
+    expect(await readFile(join(runtime, 'R.exe'), 'utf8')).toBe('old runtime')
+    revoke.mockResolvedValue(undefined as never)
+    const restarted = new DataRootCleanupJournal(configRoot)
+    expect(await restarted.recover(target, removeSources)).toEqual({
+      pending: false,
+      failureCount: 0
+    })
+    await expect(readFile(join(runtime, 'R.exe'))).rejects.toMatchObject({ code: 'ENOENT' })
+    expect(await readFile(join(target, 'runtime', 'R.exe'), 'utf8')).toBe('new runtime')
+    await restarted.recover(target, removeSources)
+    expect(revoke).toHaveBeenCalledTimes(2)
+  })
   it('removes copied legacy Notebook evidence through the durable cleanup journal', async () => {
     const legacyDirectory = 'notebook-file-evidence'
     await mkdir(join(source, legacyDirectory, 'project-1'), { recursive: true })

--- a/src/main/storage/data-root-cleanup.ts
+++ b/src/main/storage/data-root-cleanup.ts
@@ -2,7 +2,7 @@ import { lstat, realpath, rm } from 'node:fs/promises'
 import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 
 import { MIGRATABLE_DATA_DIRS } from './data-directories'
-import { capturePortableMetadata, restorePortableMetadata } from './data-migration'
+import { capturePortableMetadata, deleteSources, restorePortableMetadata } from './data-migration'
 import {
   DurableJsonRecoveryBarrierError,
   readDurableJsonFile,
@@ -65,6 +65,15 @@ type DeleteSources = (
 ) => Promise<{ deleted: string[]; failed: { dir: string; error: string }[] }>
 type CleanupRuntimeCache = (source: string) => Promise<boolean> | boolean
 type CleanupRecoveryResult = Readonly<{ pending: boolean; failureCount: number }>
+
+// One deletion adapter is shared by committed migration and durable cleanup replay. Copying,
+// discarding a staged copy, and switching to an existing root never remove the source runtime.
+export const createDataRootSourceCleanup =
+  (revokeRuntimeAccess: (runtimeRoot: string) => Promise<void>): typeof deleteSources =>
+  async (source, dirs, onProgress) => {
+    if (dirs.includes('runtime')) await revokeRuntimeAccess(join(source, 'runtime'))
+    return deleteSources(source, dirs, onProgress)
+  }
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === 'object' && value !== null && !Array.isArray(value)

--- a/src/main/storage/ipc.test.ts
+++ b/src/main/storage/ipc.test.ts
@@ -1529,6 +1529,48 @@ describe('storage IPC handlers', () => {
     expect(cleanupRuntimeCache).not.toHaveBeenCalled()
   })
 
+  it.each(['commit', 'failed-pointer', 'discard', 'cancel-copy'] as const)(
+    'runs source permission cleanup only after pointer commit (%s)',
+    async (action) => {
+      initDataRoot(dataRoot)
+      const order: string[] = []
+      const { deleteSources } = await import('./data-migration')
+      const cleanup = vi.fn<typeof deleteSources>(async (...args) => {
+        expect(order).toEqual(['commit'])
+        order.push('cleanup')
+        return deleteSources(...args)
+      })
+      const deps = fakeDeps({
+        deleteSources: cleanup,
+        ...(action === 'cancel-copy'
+          ? {
+              runDataRootMigration: async () => ({
+                ok: false as const,
+                error: 'migration cancelled',
+                cancelled: true
+              })
+            }
+          : {})
+      })
+      vi.mocked(deps.settingsService.setDataRoot).mockImplementation(async () => {
+        if (action === 'failed-pointer') throw new Error('settings write failed')
+        order.push('commit')
+      })
+      registerStorageIpcHandlers(deps)
+      await invoke('storage:migrate', { parent: targetParent })
+      expect(cleanup).not.toHaveBeenCalled()
+      if (action === 'cancel-copy') return
+      if (action === 'discard') {
+        await invoke('storage:discard-migrated-copy', { parent: targetParent })
+        expect(cleanup).not.toHaveBeenCalled()
+      } else {
+        const result = await invoke('storage:commit-and-relaunch', { parent: targetParent })
+        expect(result).toMatchObject({ ok: action === 'commit' })
+        expect(order).toEqual(action === 'commit' ? ['commit', 'cleanup'] : [])
+      }
+    }
+  )
+
   it('commit-and-relaunch invokes settingsService.setDataRoot as a method, preserving its `this`', async () => {
     initDataRoot(dataRoot)
     // Regression: the real settings service is a class whose setDataRoot reads `this.repository`.

--- a/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.render.test.tsx
@@ -186,6 +186,34 @@ const click = async (el: Element | null): Promise<void> => {
 }
 
 describe('RuntimesPanel', () => {
+  it('offers the existing sandbox authorization and removal controls for managed Windows R', async () => {
+    Object.assign(window.api, { platform: 'win32' })
+    const managed = {
+      ...rEnvs[0],
+      provenance: 'app-managed',
+      condaEnv: 'default-r',
+      runnable: true,
+      detail: undefined
+    }
+    listEnvironments.mockResolvedValue({ python: pythonEnvs, r: [managed] })
+    const authorize = vi.fn(async () => ({ cancelled: false }))
+    Object.assign(window.api.runtime, { setSandboxAccess: authorize })
+    await render()
+    const button = Array.from(container.querySelectorAll('button')).find(
+      (element) => element.textContent === 'Authorize and verify'
+    )
+    expect(button).toBeDefined()
+    await click(button!)
+    expect(authorize).toHaveBeenCalledWith('r', managed.envId, true)
+    expect(container.textContent).toContain('R access verified')
+    const remove = Array.from(container.querySelectorAll('button')).find(
+      (element) => element.textContent === 'Remove R access'
+    )
+    expect(remove).toBeDefined()
+    await click(remove!)
+    expect(authorize).toHaveBeenLastCalledWith('r', managed.envId, false)
+  })
+
   it('explains that authorization can remain when R verification fails', async () => {
     Object.assign(window.api, { platform: 'win32' })
     listEnvironments.mockResolvedValue({

--- a/src/renderer/src/pages/settings/RuntimesPanel.tsx
+++ b/src/renderer/src/pages/settings/RuntimesPanel.tsx
@@ -582,7 +582,7 @@ const RuntimesPanel = ({
           </div>
         ) : null}
 
-        {external && language === 'r' && window.api.platform === 'win32' ? (
+        {(external || defaultManaged) && language === 'r' && window.api.platform === 'win32' ? (
           <div className="mt-3 border-t border-border pt-3">
             <p className="text-xs text-muted-foreground">
               {t(


### PR DESCRIPTION
## Problem

On Windows, a repaired managed R installation can run on the host but fail inside AppContainer with access denied while normalizing its library paths. The existing selected-R authorization flow was available only for user-owned R, leaving managed installations without that recovery control.

A protected kernel that exits during startup can then leave its lane blocked by KERNEL_STARTUP_FENCE: taskkill reports a missing parent even though the native Job Object has already terminated its descendants.

## Proposed change

- Expose the existing explicit authorization/removal flow for discovered managed R and reuse its translated Settings controls.
- Propagate the native Windows Job Object guarantee through the launch adapters. Release the existing process receipt only after private admission-host IPC proves the native host exited; ordinary dead parents and admission-wrapper crashes remain fenced.
- Revoke recorded managed-R access after stopping kernels and before repair deletes the old prefix. Include exact current and legacy default-R identities, even when the legacy interpreter is damaged.
- Share source cleanup between committed data-root migration and startup recovery. Revoke only at actual source deletion, preserving access on copy cancellation, staging discard and pointer-write failure. Cancellation after pointer commit leaves the old source and existing cleanup journal pending; it does not roll back the committed move.

## Scope and non-goals

No new database fields, persistent formats or state enums. The containment capability and exit acknowledgement are transient. Existing version-1 process receipts remain unchanged. This adds a managed-R entry point to the existing native selected-runtime ACL owner: explicit authorization may upgrade an existing schema-4 receipt to already-supported schema 5, recording the selected/canonical executable and exact ancestor permissions. It does not introduce drive-wide recursive access or automatic elevation during execution.

Existing exact ownership receipts govern revoke, retry and global sandbox removal/uninstall. Missing directories and unowned resources are not discovered by scanning. Repair cancellation retains the interpreter; committed migration cancellation retains source data for existing journal recovery. Historical managed installations require explicit authorization. Agent-created environments and CLIXML rendering changes are outside this scope.

## Acceptance criteria and validation

**Managed-R acceptance is complete:** real AppContainer R startup, the requested sine plot, and protected startup retry passed locally. The maintainer approved handling the separately reproduced PowerShell FileSystem initialization failure in a later independent fix. The opt-in PowerShell diagnostic remains known failing and is not counted as passing or fixed by this PR.

Regression tests were added before their production fixes: managed authorization failed with the external-only guard/missing control; protected retry failed repeatedly with the reported startup fence; permission/migration admission, real repair deletion ordering, committed source cleanup, and missing legacy-interpreter cleanup likewise failed at their public behavior boundaries before passing. Native retry tests use the real Windows helper with deterministic interpreter fixtures, including descendants and an admission-wrapper crash that cannot forge proof through stdout.

Final evidence, run after the last relevant material edit:

| Affected behavior | Command / project-owned checks | Result |
| --- | --- | --- |
| Executor, durable receipt, sandbox owner, runtime workflows and repair; storage command/journal consumers; Settings and translations | Targeted Vitest run of kernel-executor, kernel-process-lifecycle, kernel-startup-retry.integration, network-sandbox-owner, runtime-workflows, environment-lifecycle-workflows, runtime-repair, process-tree, storage/ipc, migration-state, data-root-cleanup, RuntimesPanel.render and i18n/resources with OPEN_SCIENCE_TEST_WINDOWS_SANDBOX=1 | 13 files passed; 1181 passed, 79 skipped |
| Sandbox launch adapter and public capability contracts | npm run test:module -- notebook_network_sandbox | 85 passed, 13 skipped |
| Data-root migration service consumer | node node_modules/vitest/vitest.mjs run src/main/storage/migration-service.test.ts -t '^(?!.*external relative link).*$' --maxWorkers=1 | 101 passed, 7 skipped; three relative-symlink fixtures explicitly excluded after Windows EPERM, plus four existing skips |
| Main, sandbox and renderer types | npm run typecheck | Passed |
| Repository source lint | node node_modules/eslint/bin/eslint.js --cache --ignore-pattern 'docs/internal/**' . | Passed; only unshipped local artifacts excluded |
| Changed-file formatting and whitespace | Prettier --check on all changed/new shipped files; git diff --check | Passed |
| Actual installed R and PowerShell | Opt-in windows-r-startup.integration.test.ts | Real R startup passed; PowerShell startup still fails |

No complete local npm test was run, as requested by the maintainer. Storage consumer tests are included because the deletion interface changed. Windows native retry was exercised locally; POSIX/platform lanes and the excluded symlink cases remain assigned to exact-head PR CI. The actual Settings component was visually checked through localhost with labelled fixture data; this is not a packaged authorization journey.

Independent standards and specification reviews cleared the corrected cleanup-order and coverage findings. Following successful native R verification and the maintainer-approved PowerShell scope split, independent review confirmed that the evidence covers the final managed-R and startup-retry scope.

## Review focus

- Private native-host exit evidence must never be replaced by workload output or a missing parent PID.
- Permission removal must precede destructive repair/source cleanup, while abandoned migration must preserve current-runtime access.
- Real R and the requested plot are verified. PowerShell compatibility is explicitly deferred; no additional system-drive grant or native receipt format is introduced. Parent-query behavior is corroborated by [GetLongPathName documentation](https://learn.microsoft.com/en-us/windows/win32/api/fileapi/nf-fileapi-getlongpathnamew) and [Microsoft sandbox host preparation notes](https://github.com/microsoft/mxc/blob/main/docs/host-prep.md).

CI follow-up: all exact-head checks passed on attempt 2. One Windows E2E shard required a targeted rerun after an intermittent database-startup fixture timeout. No source or assertion changes were made for the rerun.

