### PR TITLE
fix(privacy)!: require explicit media loads and secure model input

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -61,6 +61,63 @@ practices govern how it processes that content.
 Treat project content, model output, downloaded files, Skills, Specialist packages,
 custom Connectors, MCP servers, and remote compute hosts as untrusted until reviewed.
 
+### Data recipients
+
+Local storage and local processes do not imply offline operation. The selected provider endpoint
+receives the message, relevant history, and attachments prepared for the task. Scenario models may
+use another provider: a fixed title model receives the first message text; a vision model receives
+an image and returns evidence that can then be sent to the main model. Review both the provider name
+and endpoint in Settings when choosing these models.
+
+Read-only Connectors still send query terms, identifiers, filters, or other tool arguments to their
+sources. Literature lookup may query several services with DOI/PMID identifiers; a metadata lookup
+is not an automatic upload of the local PDF. Remote jobs transfer the scripts and selected inputs
+needed for the job. In the Web UI, uploaded files first go to the machine running Open Science,
+which can be different from the machine running the browser.
+
+Custom remote model endpoints require HTTPS. HTTP is supported for `localhost`, IPv4 loopback, and
+IPv6 loopback; private-network addresses alone do not establish an encrypted connection. Existing
+remote HTTP configurations remain editable but cannot supply a running model until corrected.
+
+Messages and Markdown previews defer external media until the user activates it. The control shows
+the destination hosts and exposes the full URLs on hover. This permission is local to the displayed
+media and its URL set, not a permanent domain grant. After activation, media uses the browser's
+network stack and normal redirect behavior; it is not routed through the Notebook domain policy.
+Mermaid image nodes are blocked before diagram rendering; use a separate Markdown image to load
+them explicitly. Ordinary diagrams remain available. Managed artifact previews retain their existing
+authorization. Import previews that disable media continue to suppress it entirely.
+
+Image understanding uses metadata-minimized derivatives. Original attachments remain intact for
+scientific provenance and explicit file/metadata analysis. Small still images are losslessly encoded
+from their decoded, oriented pixels when they fit the payload budget; larger derivatives retain the
+existing resizing/compression limits. Removing metadata does not remove identifying information
+visible in the picture or prevent an explicitly authorized file tool from reading the original.
+
+### Cancellation, deletion, and retention
+
+Stopping a request can stop subsequent work or stop waiting for a response. It cannot retract bytes
+already received by a service. Pausing a batch may wait for the current item to settle. Deleting a
+local session, attachment, temporary profile, or vision cache removes that local resource; it does
+not instruct the model provider to erase its copies. Remote job file cleanup and provider-side
+deletion are separate operations and must be confirmed by the owning service.
+
+Retention, training use, and deletion guarantees depend on the selected service and account policy.
+Open Science does not infer a zero-retention guarantee from HTTPS, local models, or cancellation.
+
+### Runtime network verification
+
+The app proxy settings affect Electron sessions and the environment of subsequently started
+processes. They do not change the OS proxy, reconfigure already running agent processes, or control
+a remote browser's network stack. Third-party runtime telemetry cannot be established from this
+repository's environment flags alone.
+
+Before making a runtime-specific privacy claim, test the exact runtime version in an isolated
+profile with synthetic data: startup, login, idle, send, cancel, exit, and proxy changes with both
+existing and newly started processes. Record destination origins, request categories, which process
+initiated them, and whether synthetic content was transmitted. Repeat for desktop and remote Web.
+This is an acceptance checklist, not a claim that those third-party traffic measurements have been
+completed or that all runtimes are offline.
+
 ## Local data and credentials
 
 Open Science keeps configuration and research data in local storage by default:

--- a/e2e/browser/fixture/media-privacy.html
+++ b/e2e/browser/fixture/media-privacy.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Media privacy regression</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/media-privacy.tsx"></script>
+  </body>
+</html>

--- a/e2e/browser/fixture/media-privacy.tsx
+++ b/e2e/browser/fixture/media-privacy.tsx
@@ -1,0 +1,26 @@
+import '@/assets/main.css'
+import { createRoot } from 'react-dom/client'
+import { initI18n } from '@/i18n'
+import { PresentedAgentMarkdown } from '@/components/streamdown/AgentMarkdown'
+import { SessionMessageMarkdown } from '@/pages/workspace/SessionMessageMarkdown'
+
+initI18n('en')
+const mermaidCase = new URLSearchParams(location.search).get('mermaid')
+const imageChart =
+  '```mermaid\nflowchart TD\n A@{ img: "https://privacy-canary.invalid/image.png", label: "Image", h: 60 }\n```'
+const chart =
+  mermaidCase === 'ordinary'
+    ? '```mermaid\nflowchart TD\n A@{ shape: rect, label: "Start" } --> B["Finish"]\n```'
+    : imageChart
+createRoot(document.getElementById('root')!).render(
+  mermaidCase ? (
+    <PresentedAgentMarkdown content={chart} allowMedia={mermaidCase !== 'disabled'} />
+  ) : (
+    <SessionMessageMarkdown
+      content={'![Figure](https://privacy-canary.invalid/image.png)'}
+      artifacts={[]}
+      onPreviewArtifact={() => {}}
+      onPreviewArtifactModal={() => {}}
+    />
+  )
+)

--- a/e2e/browser/media-privacy.spec.ts
+++ b/e2e/browser/media-privacy.spec.ts
@@ -1,5 +1,10 @@
 import { expect, test } from '@playwright/test'
 
+const imageBytes = Buffer.from(
+  'iVBORw0KGgoAAAANSUhEUgAAAQAAAACgCAIAAABseyVrAAAACXBIWXMAAAPoAAAD6AG1e1JrAAADPklEQVR4nO3b0QkAIQwE0ZQ+pVuF5CMPLOAYRk7N7kxZCMxZDfa/wEIgG4AECOQPQAIEcgQiAQK5A5AAgVyCSYBAXoFIgECeQUmAQOYAJEAggzASIJBJMAkQSBSCBAgkC0QCBBKGIwECSYOSAIHEoUmAQPoAJEAghRgSIJBGGAkQSCWSBAikE0yCFLKV4knQ7W2w/wUWAtkAJEAgfwASIJAjEAkQyB2ABAjkEkwCBPIKRAIE8gxKAgQyByABAhmEkQCBTIJJgECiECRAIFkgEiCQMBwJEEgalAQIJA5NAgTSByABAinEkACBNMJIgEAqkSRAIJ1gEqSQrRRPgm5vg/0vsBDIBiABAvkDkACBHIFIgEDuACRAIJdgEiCQVyASIJBnUBIgkDkACRDIIIwECGQSTAIEEoUgAQLJApEAgYThSIBA0qAkQCBxaBIgkD4ACRBIIYYECKQRRgIEUokkAQLpBJMghWyleBJ0exvsf4GFQDYACRDIH4AECOQIRAIEcgcgAQK5BJMAgbwCkQCBPIOSAIHMAUiAQAZhJEAgk2ASIJAoBAkQSBaIBAgkDEcCBJIGJQECiUOTAIH0AUiAQAoxJEBAI4wECIxKJAkQGJ1gEoxDkVI8Ceb4Ntj/AguBbAASIJA/AAkQyBGIBAjkDkACBHIJJgECeQUiAQJ5BiUBApkDkACBDMJIgEAmwSRAIFEIEiCQLBAJEEgYjgQIJA1KAgQShyYBAukDkACBFGJIgEAaYSRAIJVIEiCQTjAJUshWiidBt7fB/hdYCGQDkACB/AFIgECOQCRAIHcAEiCQSzAJEMgrEAkQyDMoCRDIHIAECGQQRgIEMgkmAQKJQpAAgWSBSIBAwnAkQCBpUBIgkDg0CRBIH4AECKQQQwIE0ggjAQKpRJIAgXSCSZBCtlI8Cbq9Dfa/wEIgG4AECOQPQAIEcgQiAQK5A5AAgVyCSYBAXoFIgECeQUmAQOYAJEAggzASIJBJMAkQSBSCBAgkC0QCBBKGIwECSYOSAIHEoUmAQPoAJEAghRgSIJBGGAkQSCWSBAikE0yCFLKV4knQ7W2w/wUWAtkAJEAgfwASIJAjEAkQyB2ABAj0fRs8ThEJYWBXp48AAAAASUVORK5CYII=',
+  'base64'
+)
+
 test('message image requests wait for activation, including after reopening history', async ({
   page
 }) => {
@@ -8,10 +13,7 @@ test('message image requests wait for activation, including after reopening hist
     requests.push(route.request().url())
     await route.fulfill({
       contentType: 'image/png',
-      body: Buffer.from(
-        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jS1sAAAAASUVORK5CYII=',
-        'base64'
-      )
+      body: imageBytes
     })
   })
   await page.goto('/media-privacy.html')
@@ -58,4 +60,19 @@ test('ordinary Mermaid charts retain shape metadata and render without image req
   await page.goto('/media-privacy.html?mermaid=ordinary')
   await expect(page.locator('svg[data-mermaid-render-id]')).toBeVisible()
   await expect(page.getByText('Images in Mermaid diagrams are blocked')).toHaveCount(0)
+})
+
+test('approved images retain the native download action', async ({ page }) => {
+  await page.route('https://privacy-canary.invalid/**', (route) =>
+    route.fulfill({ contentType: 'image/png', body: imageBytes })
+  )
+  await page.goto('/media-privacy.html')
+  await page.getByRole('button', { name: /privacy-canary.invalid/ }).click()
+  const wrapper = page.locator('[data-streamdown="image-wrapper"]')
+  await expect(wrapper.locator('img')).toHaveJSProperty('naturalWidth', 256)
+  await wrapper.hover()
+  await page.screenshot({ path: test.info().outputPath('approved-image-download.png') })
+  const download = page.waitForEvent('download')
+  await wrapper.getByRole('button', { name: 'Download image' }).click()
+  expect((await download).suggestedFilename()).toBe('image.png')
 })

--- a/e2e/browser/media-privacy.spec.ts
+++ b/e2e/browser/media-privacy.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from '@playwright/test'
+
+test('message image requests wait for activation, including after reopening history', async ({
+  page
+}) => {
+  const requests: string[] = []
+  await page.route('https://privacy-canary.invalid/**', async (route) => {
+    requests.push(route.request().url())
+    await route.fulfill({
+      contentType: 'image/png',
+      body: Buffer.from(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+jS1sAAAAASUVORK5CYII=',
+        'base64'
+      )
+    })
+  })
+  await page.goto('/media-privacy.html')
+  await expect(page.locator('.agent-markdown')).toBeVisible()
+  // Give layout, image decoding and lazy loading time to issue any automatic request.
+  await page.waitForTimeout(300)
+  expect(requests).toEqual([])
+  await page.getByRole('button', { name: /privacy-canary.invalid/ }).click()
+  await expect.poll(() => requests.length).toBe(1)
+  await expect(page.locator('img')).toHaveAttribute(
+    'src',
+    'https://privacy-canary.invalid/image.png'
+  )
+  await page.reload()
+  await expect(page.getByRole('button', { name: /privacy-canary.invalid/ })).toBeVisible()
+  await page.waitForTimeout(300)
+  expect(requests).toHaveLength(1)
+})
+
+for (const mode of ['enabled', 'disabled']) {
+  test(`Mermaid image nodes cannot issue hidden requests with media ${mode}`, async ({ page }) => {
+    const requests: string[] = []
+    await page.route('https://privacy-canary.invalid/**', async (route) => {
+      requests.push(route.request().url())
+      await route.abort()
+    })
+    await page.goto(`/media-privacy.html?mermaid=${mode}`)
+    await expect(page.locator('.agent-markdown')).toBeVisible()
+    await expect
+      .poll(
+        async () =>
+          requests.length > 0 ||
+          (await page.getByText('Images in Mermaid diagrams are blocked').isVisible())
+      )
+      .toBe(true)
+    expect(requests).toEqual([])
+    await expect(page.getByText('Images in Mermaid diagrams are blocked')).toBeVisible()
+  })
+}
+
+test('ordinary Mermaid charts retain shape metadata and render without image requests', async ({
+  page
+}) => {
+  await page.goto('/media-privacy.html?mermaid=ordinary')
+  await expect(page.locator('svg[data-mermaid-render-id]')).toBeVisible()
+  await expect(page.getByText('Images in Mermaid diagrams are blocked')).toHaveCount(0)
+})

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,6 +18,8 @@ export default defineConfig(
       // Local package caches and generated scratch trees are not repository source.
       '**/.pnpm-store/**',
       '**/tmp/**',
+      // Frozen investigation evidence is not maintained source, matching the Vitest boundary.
+      'docs/internal/**',
       // Packaged e2e build output (electron-builder --dir into dist-e2e-*); bundled JS, not source.
       '**/dist-e2e-*',
       // Git worktrees hold full source copies; don't lint duplicate source from either supported root.

--- a/src/main/acp/prompt-content-owner.test.ts
+++ b/src/main/acp/prompt-content-owner.test.ts
@@ -1,3 +1,5 @@
+import sharp from 'sharp'
+import * as attachmentMedia from '../uploads/attachment-media'
 import type { ContentBlock } from '@agentclientprotocol/sdk'
 import { access, mkdtemp, readFile, rm, stat, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
@@ -44,6 +46,15 @@ vi.mock('../uploads/attachment-media', async (importOriginal) => {
   return { ...actual, extractPdfText: vi.fn(actual.extractPdfText) }
 })
 
+// Valid, deterministic model images: production now decodes small inputs to remove metadata.
+const imageBytes = await sharp({ create: { width: 2, height: 2, channels: 3, background: 'red' } })
+  .png()
+  .toBuffer()
+const historyImageBytes = await sharp({
+  create: { width: 2, height: 2, channels: 3, background: 'blue' }
+})
+  .png()
+  .toBuffer()
 const roots: string[] = []
 
 describe('PDF preparation routing', () => {
@@ -108,6 +119,7 @@ const createTrustedLease = (bytes: Buffer): TrustedLeaseFixture => {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -554,7 +566,7 @@ describe('AcpPromptContentOwner', () => {
     const root = await createRoot()
     const replacedPath = join(root, 'replaced.png')
     await writeFile(replacedPath, 'wrong image bytes')
-    const trustedBytes = Buffer.from('trusted image bytes')
+    const trustedBytes = imageBytes
     const trustedLease = createTrustedLease(trustedBytes)
     const owner = new AcpPromptContentOwner({
       fileReferenceResolver: new FileReferenceResolver([
@@ -851,8 +863,8 @@ describe('AcpPromptContentOwner', () => {
       historyImages: [
         {
           mimeType: 'image/png',
-          data: Buffer.from('history-image').toString('base64'),
-          byteLength: Buffer.byteLength('history-image')
+          data: historyImageBytes.toString('base64'),
+          byteLength: historyImageBytes.length
         }
       ],
       historyUploads: [immutableHistoryUpload],
@@ -1187,8 +1199,8 @@ describe('AcpPromptContentOwner', () => {
     const owner = new AcpPromptContentOwner({
       fileReferenceResolver: createManagedFileReferenceResolver({})
     })
-    const historyData = Buffer.from('history-image').toString('base64')
-    const currentData = Buffer.from('current-image').toString('base64')
+    const historyData = historyImageBytes.toString('base64')
+    const currentData = imageBytes.toString('base64')
 
     const result = await owner.prepare({
       appSessionId: 'session-1',
@@ -1198,14 +1210,14 @@ describe('AcpPromptContentOwner', () => {
         {
           mimeType: 'image/png',
           data: historyData,
-          byteLength: Buffer.byteLength('history-image')
+          byteLength: historyImageBytes.length
         }
       ],
       currentImages: [
         {
           mimeType: 'image/png',
           data: currentData,
-          byteLength: Buffer.byteLength('current-image')
+          byteLength: imageBytes.length
         }
       ],
       historyUploads: [],
@@ -1484,7 +1496,7 @@ describe('AcpPromptContentOwner', () => {
     const owner = new AcpPromptContentOwner({
       uploadRepository: uploads,
       fileReferenceResolver: createManagedFileReferenceResolver({ uploads }),
-      inlineImageBudgetBytes: 15
+      inlineImageBudgetBytes: imageBytes.toString('base64').length + 1
     })
     const stageImage = async (name: string): Promise<UploadedAttachment> => {
       const [image] = await stageUploadFixtures(uploads, {
@@ -1492,7 +1504,7 @@ describe('AcpPromptContentOwner', () => {
           {
             name,
             mimeType: 'image/png',
-            content: Buffer.from('png-bytes').toString('base64')
+            content: imageBytes.toString('base64')
           }
         ]
       })
@@ -1602,7 +1614,7 @@ describe('AcpPromptContentOwner', () => {
     const owner = new AcpPromptContentOwner({
       uploadRepository: uploads,
       fileReferenceResolver: createManagedFileReferenceResolver({ uploads }),
-      inlineImageBudgetBytes: 15
+      inlineImageBudgetBytes: imageBytes.toString('base64').length + 1
     })
     const stageImage = async (name: string): Promise<UploadedAttachment> => {
       const [image] = await stageUploadFixtures(uploads, {
@@ -1610,7 +1622,7 @@ describe('AcpPromptContentOwner', () => {
           {
             name,
             mimeType: 'image/png',
-            content: Buffer.from('png-bytes').toString('base64')
+            content: imageBytes.toString('base64')
           }
         ]
       })
@@ -1662,7 +1674,7 @@ describe('AcpPromptContentOwner', () => {
 it.each(['current failure', 'historical failure', 'image budget', 'evidence budget'])(
   'preserves mixed image identity through %s',
   async (scenario) => {
-    const bytes = Buffer.from('historical image')
+    const bytes = historyImageBytes
     const lease = createTrustedLease(bytes)
     const attachment: UploadedAttachment = {
       id: 'upload-1',
@@ -1698,7 +1710,7 @@ it.each(['current failure', 'historical failure', 'image budget', 'evidence budg
       } as never,
       fileReferenceResolver: new FileReferenceResolver([])
     })
-    const currentData = Buffer.from('current image').toString('base64')
+    const currentData = imageBytes.toString('base64')
     for (const historyUploads of [
       [],
       Array.from({ length: scenario.includes('budget') ? 9 : 1 }, () => attachment)
@@ -1707,7 +1719,9 @@ it.each(['current failure', 'historical failure', 'image budget', 'evidence budg
         appSessionId: 'session-1',
         projectId: 'project-1',
         text: 'Analyze the new image',
-        currentImages: [{ mimeType: 'image/png', data: currentData, byteLength: 13 }],
+        currentImages: [
+          { mimeType: 'image/png', data: currentData, byteLength: imageBytes.length }
+        ],
         historyImages: [],
         historyUploads,
         currentUploads: [],
@@ -1783,6 +1797,16 @@ it.each(['current failure', 'historical failure', 'image budget', 'evidence budg
 it.each(['current', 'historical'] as const)(
   'retains current inline images before native %s upload overflow',
   async (origin) => {
+    vi.spyOn(attachmentMedia, 'prepareModelImageData').mockImplementation(async (bytes) => ({
+      data: bytes.toString('base64'),
+      mimeType: 'image/png'
+    }))
+    vi.spyOn(attachmentMedia, 'buildImageContentData').mockImplementation(
+      async (path, _mimeType, _size, readBytes) => ({
+        data: Buffer.from(readBytes ? await readBytes() : await readFile(path)).toString('base64'),
+        mimeType: 'image/png'
+      })
+    )
     const root = await createRoot()
     const uploads = new UploadRepository(root)
     const pendingUploads = await stageUploadFixtures(uploads, {

--- a/src/main/acp/prompt-content-owner.ts
+++ b/src/main/acp/prompt-content-owner.ts
@@ -29,6 +29,7 @@ import {
 import { createLogger, errorLogFields } from '../logger'
 import {
   buildImageContentData,
+  prepareModelImageData,
   canInlineImageInSession,
   consumeInlineImageBudget,
   extractPdfText,
@@ -234,7 +235,7 @@ class AcpPromptContentOwner {
       )
     }
     let currentImageBytes = 0
-    const currentImages = (input.currentImages ?? []).map((candidate, index) => {
+    const validatedCurrentImages = (input.currentImages ?? []).map((candidate, index) => {
       const image = sanitizeAcpMessageImage(candidate)
       if (!image) throw new Error(`Invalid current image at index ${index}.`)
       currentImageBytes += image.byteLength
@@ -245,6 +246,10 @@ class AcpPromptContentOwner {
       }
       return image
     })
+    const currentImages = [] as Array<{ data: string; mimeType: string }>
+    for (const image of validatedCurrentImages) {
+      currentImages.push(await prepareModelImageData(Buffer.from(image.data, 'base64')))
+    }
     let promptUploads: UploadedAttachment[] = []
     const resolvedReferences: FileReference[] = []
     let historyImageCount = 0
@@ -316,7 +321,7 @@ class AcpPromptContentOwner {
             : undefined
         if (
           appendBlock(
-            { type: 'image', data: image.data, mimeType: image.mimeType },
+            { type: 'image', ...(await prepareModelImageData(Buffer.from(image.data, 'base64'))) },
             undefined,
             source
           )

--- a/src/main/acp/prompt-image-privacy.test.ts
+++ b/src/main/acp/prompt-image-privacy.test.ts
@@ -1,0 +1,94 @@
+import { mkdtemp, writeFile, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import sharp from 'sharp'
+import { afterEach, expect, it, vi } from 'vitest'
+
+let root: string | undefined
+afterEach(async () => {
+  if (root) await rm(root, { recursive: true, force: true })
+})
+it.each(['reference', 'current', 'history'] as const)(
+  'omits private EXIF from outgoing %s images and preserves the source',
+  async (kind) => {
+    const { AcpPromptContentOwner } = await import('./prompt-content-owner')
+    const { FileReferenceResolver } = await import('./file-reference-resolver')
+    const bytes = await sharp({ create: { width: 4, height: 4, channels: 3, background: 'red' } })
+      .jpeg()
+      .withExif({ IFD0: { Artist: 'AUDIT_PERSON_CANARY' } })
+      .toBuffer()
+    root = await mkdtemp(join(tmpdir(), 'privacy-prompt-'))
+    const path = join(root, 'private.jpg')
+    await writeFile(path, bytes)
+    const trustedLease = {
+      size: bytes.length,
+      read: vi.fn(async (buffer: Uint8Array, offset: number, length: number, position: number) => {
+        const chunk = bytes.subarray(position, position + length)
+        buffer.set(chunk, offset)
+        return { bytesRead: chunk.length }
+      }),
+      readRange: vi.fn(async (begin: number, end: number) => bytes.subarray(begin, end)),
+      copyTo: vi.fn(async (destination: string) => writeFile(destination, bytes, { flag: 'wx' })),
+      verifyUnchanged: vi.fn(async () => {}),
+      close: vi.fn(async () => {})
+    }
+    const owner = new AcpPromptContentOwner({
+      fileReferenceResolver: new FileReferenceResolver([
+        {
+          source: 'artifact',
+          resolve: async () =>
+            ({
+              absolutePath: path,
+              name: 'private.jpg',
+              mimeType: 'image/jpeg',
+              allowSkillImportReference: false,
+              trustedLease
+            }) as never
+        }
+      ])
+    })
+    const prepared = await owner.prepare({
+      appSessionId: 'audit-session',
+      projectId: 'audit-project',
+      text: 'Describe this image',
+      historyImages:
+        kind === 'history'
+          ? [{ mimeType: 'image/jpeg', data: bytes.toString('base64'), byteLength: bytes.length }]
+          : [],
+      currentImages:
+        kind === 'current'
+          ? [{ mimeType: 'image/jpeg', data: bytes.toString('base64'), byteLength: bytes.length }]
+          : [],
+      historyUploads: [],
+      currentUploads: [],
+      references:
+        kind === 'reference'
+          ? [
+              {
+                id: 'audit-file',
+                name: 'private.jpg',
+                path: 'artifact-version:audit',
+                source: 'artifact',
+                mimeType: 'image/jpeg'
+              }
+            ]
+          : [],
+      codexSkillInputs: [],
+      skillImportEnabled: false
+    })
+    try {
+      const block = (typeof prepared.content === 'string' ? [] : prepared.content).find(
+        (x) => x.type === 'image'
+      )
+      expect(block).toBeTruthy()
+      expect(
+        (await sharp(Buffer.from(block!.data, 'base64')).metadata()).exif?.includes(
+          Buffer.from('AUDIT_PERSON_CANARY')
+        ) ?? false
+      ).toBe(false)
+    } finally {
+      prepared.close()
+      expect(await readFile(path)).toEqual(bytes)
+    }
+  }
+)

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1,3 +1,5 @@
+import sharp from 'sharp'
+import * as attachmentMedia from '../uploads/attachment-media'
 import * as acp from '@agentclientprotocol/sdk'
 import type {
   ContentBlock,
@@ -58,7 +60,9 @@ import { ArtifactRunRegistry } from '../artifacts/run-registry'
 import { validateDurableMessageOwnership } from '../artifacts/provenance-message-finalization'
 import type { ArtifactVersionFile } from '../../shared/artifact-provenance'
 import type { ArtifactRunClaim } from '../artifacts/run-registry'
-import { createPngBytes, createPngInlineSource } from '../artifacts/artifact-test-fixtures'
+const imageBytes = await sharp({ create: { width: 2, height: 2, channels: 3, background: 'red' } })
+  .png()
+  .toBuffer()
 import { writeArtifactFileForCurrentRun } from '../artifacts/mcp-server'
 import { createArtifactVersionLocator } from '../../shared/artifact-provenance'
 import { BEGIN_ACTIVITY_GROUP_TOOL_NAME } from '../../shared/activity-groups'
@@ -1165,6 +1169,7 @@ const auditedIsMcp = (toolCallId: string): boolean | undefined => {
 }
 
 afterEach(async () => {
+  vi.restoreAllMocks()
   await Promise.allSettled(temporaryDisconnections.splice(0).map((disconnect) => disconnect()))
   if (temporaryRoot) {
     await rm(temporaryRoot, { recursive: true, force: true })
@@ -1783,7 +1788,7 @@ describe('ACP runtime provider prompt acceptance', () => {
       })
 
       const session = await runtime.createSession({ cwd: '/workspace' })
-      const imageData = Buffer.from(`visual-${modelRoute}`).toString('base64')
+      const imageData = imageBytes.toString('base64')
       await runtime.sendPrompt({
         sessionId: session.sessionId,
         text: 'Research this.',
@@ -1791,7 +1796,7 @@ describe('ACP runtime provider prompt acceptance', () => {
           {
             mimeType: 'image/png',
             data: imageData,
-            byteLength: Buffer.byteLength(`visual-${modelRoute}`)
+            byteLength: imageBytes.length
           }
         ]
       })
@@ -3173,8 +3178,8 @@ describe('ACP runtime restored permission continuation', () => {
               {
                 id: 'permission-replay-image',
                 mimeType: 'image/png',
-                data: createPngBytes('permission-replay').toString('base64'),
-                byteLength: createPngBytes('permission-replay').byteLength
+                data: imageBytes.toString('base64'),
+                byteLength: imageBytes.byteLength
               }
             ],
             eventIds: [],
@@ -7259,8 +7264,8 @@ describe('ACP runtime session management', () => {
             {
               id: 'choice-replay-image',
               mimeType: 'image/png',
-              data: createPngBytes('choice-replay').toString('base64'),
-              byteLength: createPngBytes('choice-replay').byteLength
+              data: imageBytes.toString('base64'),
+              byteLength: imageBytes.byteLength
             }
           ],
           eventIds: [],
@@ -7523,7 +7528,7 @@ describe('ACP runtime session management', () => {
         {
           name: 'paste.png',
           mimeType: 'image/png',
-          content: Buffer.from('png-bytes').toString('base64')
+          content: imageBytes.toString('base64')
         },
         {
           name: 'notes.txt',
@@ -7563,7 +7568,7 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts[0][1]).toMatchObject({
       type: 'image',
       mimeType: 'image/png',
-      data: Buffer.from('png-bytes').toString('base64'),
+      data: imageBytes.toString('base64'),
       uri: expect.stringContaining('/uploads/default-project/remote-session-1/paste.png')
     })
     expect(receivedPrompts[0][2]).toMatchObject({
@@ -7648,7 +7653,7 @@ describe('ACP runtime session management', () => {
         managedFileVersions: { openLatest } as never
       }
     })
-    const historyImageData = Buffer.from('history-image').toString('base64')
+    const historyImageData = imageBytes.toString('base64')
 
     const session = await runtime.createSession({ cwd: '/workspace' })
     await runtime.sendPrompt({
@@ -7658,7 +7663,7 @@ describe('ACP runtime session management', () => {
         {
           mimeType: 'image/png',
           data: historyImageData,
-          byteLength: Buffer.byteLength('history-image')
+          byteLength: imageBytes.length
         }
       ],
       historyAttachments: [historyUpload],
@@ -7829,12 +7834,12 @@ describe('ACP runtime session management', () => {
         {
           name: 'no-mime.png',
           mimeType: undefined,
-          content: Buffer.from('png-a').toString('base64')
+          content: imageBytes.toString('base64')
         },
         {
           name: 'generic.png',
           mimeType: 'application/octet-stream',
-          content: Buffer.from('png-b').toString('base64')
+          content: imageBytes.toString('base64')
         }
       ]
     })
@@ -7865,16 +7870,21 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts[0][1]).toMatchObject({
       type: 'image',
       mimeType: 'image/png',
-      data: Buffer.from('png-a').toString('base64')
+      data: imageBytes.toString('base64')
     })
     expect(receivedPrompts[0][2]).toMatchObject({
       type: 'image',
       mimeType: 'image/png',
-      data: Buffer.from('png-b').toString('base64')
+      data: imageBytes.toString('base64')
     })
   })
 
   it('degrades an image attachment to a resource link when replay images consume the inline budget', async () => {
+    // Isolate byte-budget admission from image compression; real decoding has its own regressions.
+    vi.spyOn(attachmentMedia, 'prepareModelImageData').mockImplementation(async (bytes) => ({
+      data: bytes.toString('base64'),
+      mimeType: 'image/png'
+    }))
     const root = await createTemporaryRoot()
     const uploadRepository = new UploadRepository(root)
     const [attachment] = await stageUploadFixtures(uploadRepository, {
@@ -7882,7 +7892,7 @@ describe('ACP runtime session management', () => {
         {
           name: 'overflow.png',
           mimeType: 'image/png',
-          content: Buffer.from('small-image').toString('base64')
+          content: imageBytes.toString('base64')
         }
       ]
     })
@@ -7940,16 +7950,14 @@ describe('ACP runtime session management', () => {
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
       uploads: { repository: uploadRepository },
-      inlineImageBudgetBytes: 15
+      inlineImageBudgetBytes: imageBytes.toString('base64').length + 1
     })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
 
     const stageImage = (name: string): Promise<UploadedAttachment[]> =>
       stageUploadFixtures(uploadRepository, {
-        files: [
-          { name, mimeType: 'image/png', content: Buffer.from('png-bytes').toString('base64') }
-        ]
+        files: [{ name, mimeType: 'image/png', content: imageBytes.toString('base64') }]
       })
 
     await runtime.sendPrompt({
@@ -7968,7 +7976,7 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts[0][1]).toMatchObject({
       type: 'image',
       mimeType: 'image/png',
-      data: Buffer.from('png-bytes').toString('base64')
+      data: imageBytes.toString('base64')
     })
     // Second turn: the accumulated total would overflow, so the image degrades to a file reference
     // instead of base64 — keeping the request under the ceiling so compaction stays viable.
@@ -7980,9 +7988,7 @@ describe('ACP runtime session management', () => {
       uri: expect.stringContaining('second.png')
     })
     // The raw image bytes must not be inlined anywhere in the degraded turn.
-    expect(JSON.stringify(receivedPrompts[1])).not.toContain(
-      Buffer.from('png-bytes').toString('base64')
-    )
+    expect(JSON.stringify(receivedPrompts[1])).not.toContain(imageBytes.toString('base64'))
   })
 
   it('keeps image bytes charged when later prompt content preparation fails', async () => {
@@ -8000,13 +8006,11 @@ describe('ACP runtime session management', () => {
       defaultCwd: '/workspace',
       spawnAgent: () => asAgentProcess(process),
       uploads: { repository: uploadRepository },
-      inlineImageBudgetBytes: 15
+      inlineImageBudgetBytes: imageBytes.toString('base64').length + 1
     })
     const stageImage = (name: string): Promise<UploadedAttachment[]> =>
       stageUploadFixtures(uploadRepository, {
-        files: [
-          { name, mimeType: 'image/png', content: Buffer.from('png-bytes').toString('base64') }
-        ]
+        files: [{ name, mimeType: 'image/png', content: imageBytes.toString('base64') }]
       })
 
     const session = await runtime.createSession({ cwd: '/workspace' })
@@ -8042,9 +8046,7 @@ describe('ACP runtime session management', () => {
       mimeType: 'image/png',
       uri: expect.stringContaining('second.png')
     })
-    expect(JSON.stringify(receivedPrompts[0])).not.toContain(
-      Buffer.from('png-bytes').toString('base64')
-    )
+    expect(JSON.stringify(receivedPrompts[0])).not.toContain(imageBytes.toString('base64'))
   })
 
   it('registers every finalized prompt Upload Version with the trusted Notebook bridge', async () => {
@@ -9572,7 +9574,7 @@ describe('ACP runtime session management', () => {
       runId: 'run-1',
       filename: 'chart.png',
       mimeType: 'image/png',
-      source: createPngInlineSource('runtime referenced image')
+      source: { kind: 'inline', content: imageBytes.toString('base64'), encoding: 'base64' }
     })
 
     // A referenced binary output has no rich representation, so it falls through to a resource link.
@@ -9750,7 +9752,7 @@ describe('ACP runtime session management', () => {
     expect(receivedPrompts[0][2]).toMatchObject({
       type: 'image',
       mimeType: 'image/png',
-      data: createPngBytes('runtime referenced image').toString('base64'),
+      data: imageBytes.toString('base64'),
       uri: expect.stringMatching(/^file:.*\.png$/u)
     })
     // Referenced binary artifact -> provider-neutral local file descriptor.
@@ -10189,7 +10191,7 @@ describe('ACP runtime session management', () => {
     // The kernel's real cwd for this session, keyed by the FINAL id (not the notebook alias).
     const notebookDataDir = join(root, 'notebooks', 'default-project', finalSessionId, 'data')
     await mkdir(notebookDataDir, { recursive: true })
-    const sourcePng = createPngBytes('runtime notebook image')
+    const sourcePng = imageBytes
     await writeFile(join(notebookDataDir, 'sine.png'), sourcePng)
 
     let writtenPath: string | undefined

--- a/src/main/settings/openai-provider-bridge.test.ts
+++ b/src/main/settings/openai-provider-bridge.test.ts
@@ -411,3 +411,33 @@ describe('OpenAiProviderBridge', () => {
     })
   })
 })
+
+it('refuses a persisted remote HTTP target before forwarding a prompt or credential', async () => {
+  const upstream = vi.fn<typeof fetch>(async () => new Response('{}'))
+  const bridge = new OpenAiProviderBridge(
+    [
+      {
+        id: 'legacy',
+        wire: 'chat-completions',
+        endpoint: 'http://remote-gateway.invalid/v1/chat/completions',
+        key: 'PRIVATE_KEY_CANARY',
+        model: 'test-model'
+      }
+    ],
+    'legacy',
+    upstream
+  )
+  const connection = await bridge.start()
+  try {
+    const response = await fetch(`${connection.baseUrl}/v1/chat/completions`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${connection.token}`, 'content-type': 'application/json' },
+      body: JSON.stringify({ messages: [{ role: 'user', content: 'PRIVATE_RESEARCH_CANARY' }] })
+    })
+    expect(upstream).not.toHaveBeenCalled()
+    expect(response.ok).toBe(false)
+    expect(await response.text()).toContain('HTTPS')
+  } finally {
+    await bridge.close()
+  }
+})

--- a/src/main/settings/provider-fetch.ts
+++ b/src/main/settings/provider-fetch.ts
@@ -1,7 +1,14 @@
-// Provider requests carry credentials in headers or bodies. Keep redirects manual so fetch never
-// forwards those credentials to an endpoint that was not selected by the provider configuration.
-export const fetchProviderRequest = (
+import { isSecureProviderUrl, PROVIDER_TRANSPORT_ERROR } from '../../shared/provider-base-url'
+
+// Enforce this at the sending boundary as well as the form: persisted configurations and every
+// provider adapter must obey the same policy before credentials or content reach the network.
+export const fetchProviderRequest = async (
   fetchImpl: typeof fetch,
   input: string | URL | Request,
   init?: RequestInit
-): Promise<Response> => fetchImpl(input, { ...init, redirect: 'manual' })
+): Promise<Response> => {
+  const url = new URL(typeof input === 'string' || input instanceof URL ? input : input.url)
+  if (!isSecureProviderUrl(url)) throw new Error(PROVIDER_TRANSPORT_ERROR)
+  // Provider requests carry credentials; never follow redirects to another selected or unselected URL.
+  return fetchImpl(input, { ...init, redirect: 'manual' })
+}

--- a/src/main/settings/provider-privacy.test.ts
+++ b/src/main/settings/provider-privacy.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { getCustomProviderBaseUrlError } from '../../shared/provider-base-url'
+import { fetchProviderRequest } from './provider-fetch'
+import { resolveProviderDraft } from './provider-draft-projection'
+import { listProviderModels } from './list-models'
+import { validateProvider } from './validate'
+
+describe('provider transport privacy', () => {
+  it.each([
+    'http://remote-gateway.invalid',
+    'http://192.168.1.8:8000',
+    'http://[::ffff:127.0.0.1]',
+    'http://localhost.example.com',
+    'http://127.0.0.1.example.com'
+  ])('rejects remote HTTP before validation or catalog credentials leave: %s', async (baseUrl) => {
+    const fetchImpl = vi.fn<typeof fetch>(
+      async () => new Response(JSON.stringify({ data: [{ id: 'test-model' }] }), { status: 200 })
+    )
+    const target = resolveProviderDraft({
+      type: 'custom',
+      baseUrl,
+      key: 'PRIVACY_KEY_CANARY',
+      model: 'test-model',
+      apiEndpoints: ['openai']
+    })
+    const validation = await validateProvider(target, { fetchImpl })
+    const catalog = await listProviderModels(
+      { url: `${baseUrl}/v1/models`, key: target.key },
+      { fetchImpl }
+    )
+    expect(fetchImpl).not.toHaveBeenCalled()
+    expect(validation.ok).toBe(false)
+    expect(catalog.ok).toBe(false)
+    expect(getCustomProviderBaseUrlError(baseUrl)).toBeDefined()
+  })
+
+  it.each([
+    'https://gateway.invalid:8443',
+    'http://localhost:8000',
+    'http://127.0.0.2:8000',
+    'http://[::1]:8000',
+    'http://2130706433:8000'
+  ])('preserves HTTPS and loopback model validation: %s', async (baseUrl) => {
+    const fetchImpl = vi.fn<typeof fetch>(async () => new Response('{}'))
+    const target = resolveProviderDraft({
+      type: 'custom',
+      baseUrl,
+      key: 'LOCAL_CANARY',
+      model: 'test-model',
+      apiEndpoints: ['openai']
+    })
+    expect(getCustomProviderBaseUrlError(baseUrl)).toBeUndefined()
+    await validateProvider(target, { fetchImpl })
+    expect(fetchImpl).toHaveBeenCalledOnce()
+    expect(fetchImpl.mock.calls[0][1]?.redirect).toBe('manual')
+  })
+
+  it.each(['string', 'URL', 'Request'])(
+    'guards the actual request boundary for %s inputs from old configurations',
+    async (kind) => {
+      const url = 'http://remote-gateway.invalid/v1/chat/completions'
+      const input = kind === 'URL' ? new URL(url) : kind === 'Request' ? new Request(url) : url
+      const fetchImpl = vi.fn<typeof fetch>(async () => new Response('{}'))
+      await expect(async () =>
+        fetchProviderRequest(fetchImpl, input, {
+          method: 'POST',
+          headers: { authorization: 'Bearer PRIVACY_KEY_CANARY' },
+          body: 'PRIVATE_RESEARCH_CANARY'
+        })
+      ).rejects.toThrow()
+      expect(fetchImpl).not.toHaveBeenCalled()
+    }
+  )
+})

--- a/src/main/settings/provider-runtime-projection.test.ts
+++ b/src/main/settings/provider-runtime-projection.test.ts
@@ -351,3 +351,17 @@ describe('ProviderRuntimeProjectionOwner', () => {
     )
   })
 })
+
+it('rejects a persisted remote HTTP provider before projecting credentials into an agent process', () => {
+  const owner = new ProviderRuntimeProjectionOwner()
+  const provider: StoredProvider = {
+    id: 'legacy',
+    name: 'Legacy',
+    type: 'custom',
+    baseUrl: 'http://remote-gateway.invalid',
+    model: 'model',
+    keyRef: encryptKey('PRIVACY_CANARY')
+  }
+  expect(() => owner.resolveProvider(provider)).toThrow(/HTTPS/)
+  expect(owner.toProviderView(provider).baseUrl).toBe(provider.baseUrl)
+})

--- a/src/main/settings/provider-runtime-projection.ts
+++ b/src/main/settings/provider-runtime-projection.ts
@@ -1,3 +1,4 @@
+import { getCustomProviderBaseUrlError } from '../../shared/provider-base-url'
 import type { ChatApiEndpoint, ProviderView } from '../../shared/settings'
 import {
   isClaudeSubscriptionProvider,
@@ -204,6 +205,10 @@ class ProviderRuntimeProjectionOwner {
   }
 
   resolveProvider(provider: StoredProvider, modelOverride?: string): ResolvedProvider {
+    if (provider.type === 'custom' && provider.baseUrl) {
+      const error = getCustomProviderBaseUrlError(provider.baseUrl)
+      if (error) throw new Error(error)
+    }
     const key =
       provider.type === 'xai-subscription'
         ? undefined

--- a/src/main/uploads/attachment-media.sharp.test.ts
+++ b/src/main/uploads/attachment-media.sharp.test.ts
@@ -148,3 +148,57 @@ describe('sharp image-processing adapter', () => {
     )
   })
 })
+
+it.each(['jpeg', 'png', 'webp'] as const)(
+  'removes EXIF from small %s without changing oriented pixels or original bytes',
+  async (format) => {
+    root = await mkdtemp(join(tmpdir(), 'model-image-privacy-'))
+    const path = join(root, `image.${format}`)
+    const original = await sharp({
+      create: {
+        width: 3,
+        height: 2,
+        channels: 4,
+        background: { r: 20, g: 100, b: 200, alpha: 0.5 }
+      }
+    })
+      .toFormat(format)
+      .withExif({ IFD0: { Artist: 'PRIVATE_AUTHOR_CANARY' } })
+      .withMetadata({ orientation: 6 })
+      .toBuffer()
+    await writeFile(path, original)
+    expect((await sharp(original).metadata()).exif).toBeDefined()
+    const result = await buildImageContentData(path, `image/${format}`, original.length)
+    const output = Buffer.from(result.data, 'base64')
+    expect((await sharp(output).metadata()).exif).toBeUndefined()
+    expect((await sharp(output).metadata()).icc).toBeUndefined()
+    expect(await sharp(output).ensureAlpha().raw().toBuffer()).toEqual(
+      await sharp(original).autoOrient().ensureAlpha().raw().toBuffer()
+    )
+    expect(await readFile(path)).toEqual(original)
+  }
+)
+
+it.each(['gif', 'webp'] as const)(
+  'preserves small %s animation while removing metadata',
+  async (format) => {
+    root = await mkdtemp(join(tmpdir(), 'model-animation-privacy-'))
+    const path = join(root, `image.${format}`)
+    const original = await sharp(Buffer.from([255, 0, 0, 0, 0, 255]), {
+      raw: { width: 1, height: 2, channels: 3, pageHeight: 1 }
+    })
+      .toFormat(format, { loop: 2, delay: [100, 200] })
+      .toBuffer()
+    await writeFile(path, original)
+    const result = await buildImageContentData(path, `image/${format}`, original.length)
+    const output = Buffer.from(result.data, 'base64')
+    expect(await sharp(output, { animated: true }).metadata()).toMatchObject({
+      pages: 2,
+      loop: 2,
+      delay: [100, 200]
+    })
+    expect(await sharp(output, { animated: true }).ensureAlpha().raw().toBuffer()).toEqual(
+      await sharp(original, { animated: true }).ensureAlpha().raw().toBuffer()
+    )
+  }
+)

--- a/src/main/uploads/attachment-media.test.ts
+++ b/src/main/uploads/attachment-media.test.ts
@@ -496,15 +496,18 @@ describe('buildImageContentData', () => {
     expect(sharpFactory).not.toHaveBeenCalled()
   })
 
-  it('passes small images through untouched as raw base64', async () => {
+  it('processes small images without returning original metadata bytes', async () => {
     const filePath = join(root, 'small.png')
     const bytes = Buffer.from('tiny-image-bytes')
     await writeFile(filePath, bytes)
 
     const result = await buildImageContentData(filePath, 'image/png', bytes.byteLength)
 
-    expect(result).toEqual({ data: bytes.toString('base64'), mimeType: 'image/png' })
-    expect(sharpFactory).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      data: Buffer.from('png-bytes').toString('base64'),
+      mimeType: 'image/png'
+    })
+    expect(sharpFactory).toHaveBeenCalledWith(bytes)
   })
 
   it('reads small managed images from the trusted byte source instead of the path', async () => {
@@ -518,7 +521,10 @@ describe('buildImageContentData', () => {
       readBytes
     )
 
-    expect(result).toEqual({ data: bytes.toString('base64'), mimeType: 'image/png' })
+    expect(result).toEqual({
+      data: Buffer.from('png-bytes').toString('base64'),
+      mimeType: 'image/png'
+    })
     expect(readBytes).toHaveBeenCalledOnce()
   })
 

--- a/src/main/uploads/attachment-media.ts
+++ b/src/main/uploads/attachment-media.ts
@@ -489,17 +489,13 @@ export const prepareImageContentData = async (
   }
 }
 
-// Builds the base64 payload for an image content block, downscaling oversized images first.
-// Small images pass through unchanged. Oversized images must be decoded and reduced below the hard
-// payload limit; returning their original bytes would allow a 50MB upload to escape this boundary.
-export const buildImageContentData = async (
-  filePath: string,
-  mimeType: string | undefined,
-  size: number,
-  readBytes?: () => Promise<Uint8Array>
+// Model input is a derivative; never alter scientific source files. Small still images use PNG
+// to preserve decoded pixels/alpha while stripping ancillary metadata. Keep GIF/WebP animation.
+export const prepareModelImageData = async (
+  bytes: Buffer,
+  sourceSize = bytes.byteLength
 ): Promise<ImageContentData> => {
-  const fallbackMimeType = mimeType ?? 'application/octet-stream'
-
+  const size = Math.max(sourceSize, bytes.byteLength)
   if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
     throw new ImageContentError(
       'IMAGE_SOURCE_TOO_LARGE',
@@ -507,21 +503,44 @@ export const buildImageContentData = async (
       { sourceBytes: size, limitBytes: MAX_AUTO_PROCESS_IMAGE_BYTES }
     )
   }
-
-  if (size <= MAX_INLINE_IMAGE_BYTES) {
-    const source = readBytes ? Buffer.from(await readBytes()) : await readFile(filePath)
-    return { data: source.toString('base64'), mimeType: fallbackMimeType }
-  }
-
   try {
-    // Managed versions supply integrity-checked bytes; legacy callers still read the resolved path.
-    const bytes = readBytes ? Buffer.from(await readBytes()) : await readFile(filePath)
-    if (bytes.byteLength > MAX_AUTO_PROCESS_IMAGE_BYTES) {
-      throw new ImageContentError(
-        'IMAGE_SOURCE_TOO_LARGE',
-        `Image source is ${bytes.byteLength} bytes, exceeding the automatic processing limit.`,
-        { sourceBytes: bytes.byteLength, limitBytes: MAX_AUTO_PROCESS_IMAGE_BYTES }
-      )
+    if (size <= MAX_INLINE_IMAGE_BYTES) {
+      const { default: sharp } = await import('sharp')
+      const image = sharp(bytes, {
+        animated: true,
+        failOn: 'error',
+        limitInputPixels: MAX_DECODED_IMAGE_PIXELS
+      })
+      const metadata = await image.metadata()
+      const animated = (metadata.pages ?? 1) > 1
+      const format =
+        animated && metadata.format === 'gif'
+          ? 'gif'
+          : animated && metadata.format === 'webp'
+            ? 'webp'
+            : 'png'
+      const oriented = image.autoOrient()
+      const output = await (
+        format === 'gif'
+          ? oriented.gif()
+          : format === 'webp'
+            ? oriented.webp({ lossless: true })
+            : oriented.png()
+      ).toBuffer()
+      if (output.byteLength <= MAX_IMAGE_PAYLOAD_BYTES) {
+        return { data: output.toString('base64'), mimeType: `image/${format}` }
+      }
+      // Do not silently discard animation when metadata removal makes a small image too large.
+      if (animated)
+        throw new ImageContentError(
+          'IMAGE_PAYLOAD_TOO_LARGE',
+          'Processed animation exceeds the inline image limit.',
+          {
+            sourceBytes: size,
+            payloadBytes: output.byteLength,
+            limitBytes: MAX_IMAGE_PAYLOAD_BYTES
+          }
+        )
     }
     const processed = await processImageBytes(bytes, 'sharp-raster')
     return { data: processed.data, mimeType: processed.mimeType }
@@ -536,13 +555,29 @@ export const buildImageContentData = async (
         cause: error.cause
       })
     }
-
     throw new ImageContentError(
       'IMAGE_PROCESSING_FAILED',
-      `Failed to safely process oversized ${size}-byte image.`,
+      `Failed to safely process ${size}-byte image.`,
       { sourceBytes: size, limitBytes: MAX_IMAGE_PAYLOAD_BYTES, cause: error }
     )
   }
+}
+
+export const buildImageContentData = async (
+  filePath: string,
+  _mimeType: string | undefined,
+  size: number,
+  readBytes?: () => Promise<Uint8Array>
+): Promise<ImageContentData> => {
+  if (size > MAX_AUTO_PROCESS_IMAGE_BYTES) {
+    throw new ImageContentError(
+      'IMAGE_SOURCE_TOO_LARGE',
+      `Image source is ${size} bytes, exceeding the automatic processing limit.`,
+      { sourceBytes: size, limitBytes: MAX_AUTO_PROCESS_IMAGE_BYTES }
+    )
+  }
+  const bytes = readBytes ? Buffer.from(await readBytes()) : await readFile(filePath)
+  return prepareModelImageData(bytes, size)
 }
 
 // Resolves the on-disk pdfjs asset directories so CID/CJK fonts map to Unicode during extraction.

--- a/src/renderer/src/components/streamdown/AgentMarkdown.media.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.media.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, expect, it, vi } from 'vitest'
+import { SessionMessageMarkdown } from '@/pages/workspace/SessionMessageMarkdown'
+import { PresentedAgentMarkdown } from './AgentMarkdown'
+
+afterEach(cleanup)
+const url = 'https://unapproved.invalid/pixel.png?research=CANARY'
+it('keeps a message image off the network until activation and resets consent when the URL changes', () => {
+  const props = { artifacts: [], onPreviewArtifact: vi.fn(), onPreviewArtifactModal: vi.fn() }
+  const view = render(<SessionMessageMarkdown {...props} content={`![Figure](${url})`} />)
+  expect(view.container.querySelector('img[src]')).toBeNull()
+  fireEvent.click(view.getByRole('button', { name: /unapproved.invalid/ }))
+  expect(view.container.querySelector('img')?.getAttribute('src')).toBe(url)
+  view.rerender(<SessionMessageMarkdown {...props} content={`![Figure](${url}&changed=1)`} />)
+  expect(view.container.querySelector('img[src]')).toBeNull()
+})
+it.each([false, true])(
+  'gates HTML image, video poster and nested sources in streaming=%s',
+  (isAnimating) => {
+    const content = `<img src="${url}" alt="Figure" />\n\n<video controls poster="https://poster.invalid/poster.png"><source src="https://video.invalid/movie.mp4" type="video/mp4" /><track src="https://captions.invalid/captions.vtt" /></video>`
+    const view = render(<PresentedAgentMarkdown content={content} isAnimating={isAnimating} />)
+    expect(view.container.querySelector('img[src],video[poster],source[src],track[src]')).toBeNull()
+    const videoButton = view.getByRole('button', { name: /poster.invalid/ })
+    expect(videoButton.textContent).toContain('video.invalid')
+    expect(videoButton.textContent).toContain('captions.invalid')
+    fireEvent.click(videoButton)
+    expect(view.container.querySelector('video')?.getAttribute('poster')).toContain(
+      'poster.invalid'
+    )
+    expect(view.container.querySelector('source')?.getAttribute('src')).toContain('video.invalid')
+    expect(view.container.querySelector('img[src]')).toBeNull()
+  }
+)
+it('preserves local SVG references and disabled-media previews', () => {
+  const content = '<svg><use href="#chart" /></svg>\n\n![Figure](https://remote.invalid/a.png)'
+  const view = render(<PresentedAgentMarkdown content={content} />)
+  expect(view.container.querySelector('use')?.getAttribute('href')).toBe('#chart')
+  view.rerender(<PresentedAgentMarkdown content={content} allowMedia={false} />)
+  expect(view.container.querySelector('img')).toBeNull()
+})
+it('does not load SVG references or orphan sources from remote sites', () => {
+  const view = render(
+    <PresentedAgentMarkdown
+      content={
+        '<svg><use href="https://remote.invalid/a.svg#x" /></svg>\n\n<source src="https://remote.invalid/a.mp4" />'
+      }
+    />
+  )
+  expect(view.container.querySelector('[href^="https:"],[src^="https:"]')).toBeNull()
+})

--- a/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.test.tsx
@@ -261,7 +261,7 @@ describe('AgentMarkdown renderer recovery', () => {
     await act(async () => {
       root.render(<AgentMarkdown content="Plain shared markdown" />)
     })
-    expect(streamdownHarness.components).toBeUndefined()
+    expect(streamdownHarness.components?.a).toBeUndefined()
 
     await act(async () => {
       root.render(<AgentMarkdown content="Session markdown" sessionLinks />)

--- a/src/renderer/src/components/streamdown/AgentMarkdown.tsx
+++ b/src/renderer/src/components/streamdown/AgentMarkdown.tsx
@@ -23,6 +23,14 @@ import 'katex/dist/katex.min.css'
 
 import { createMarkdownPluginNeedsScanner } from './code-fence'
 import { AGENT_ALLOWED_TAGS, AGENT_CONTROLS } from './streamdown-config'
+import {
+  DeferredImage,
+  DeferredVideo,
+  DeferredAudio,
+  ApprovedSource,
+  ApprovedTrack,
+  LocalSvgUse
+} from './DeferredMedia'
 import { LinkSafetyModal } from './LinkSafetyModal'
 import { SessionMessageLink } from './SessionMessageLink'
 import { createStreamingBlockquote } from './streaming-blockquote'
@@ -51,6 +59,15 @@ type AgentMarkdownProps = {
 type RichAgentMarkdownProps = AgentMarkdownProps & {
   incrementalBlocks?: boolean
 }
+
+const deferredMediaComponents = {
+  img: DeferredImage,
+  video: DeferredVideo,
+  audio: DeferredAudio,
+  source: ApprovedSource,
+  track: ApprovedTrack,
+  use: LocalSvgUse
+} satisfies Components
 
 const sessionLinkComponents = { a: SessionMessageLink } satisfies Components
 
@@ -88,21 +105,30 @@ type MermaidErrorPanelProps = {
 
 const MermaidErrorPanel = ({ chart, error, retry }: MermaidErrorPanelProps): React.JSX.Element => {
   const { t } = useTranslation()
+  const mediaBlocked = error.includes('MERMAID_IMAGE_BLOCKED')
   return (
     <div className="my-2 rounded-lg border border-amber-200 bg-amber-50 px-3 py-2.5 text-[13px] leading-5 text-amber-950 dark:border-amber-800/50 dark:bg-amber-950/20 dark:text-amber-100">
-      <p className="font-medium">{t('Mermaid syntax could not be rendered')}</p>
-      <p className="mt-1 text-[12px] text-amber-900/90 dark:text-amber-200/90">{error}</p>
-      <p className="mt-2 text-[12px] text-amber-800/80 dark:text-amber-300/80">
-        <Trans
-          t={t}
-          i18nKey="Common causes: an xychart is missing the <kw1>title</kw1> keyword, axis labels are not quoted, or <kw2>y-axis</kw2> or <kw3>bar/line</kw3> data rows are missing."
-          components={{
-            kw1: <code className="rounded bg-amber-100/80 px-1 dark:bg-amber-900/50" />,
-            kw2: <code className="rounded bg-amber-100/80 px-1 dark:bg-amber-900/50" />,
-            kw3: <code className="rounded bg-amber-100/80 px-1 dark:bg-amber-900/50" />
-          }}
-        />
+      <p className="font-medium">
+        {mediaBlocked
+          ? t('Images in Mermaid diagrams are blocked')
+          : t('Mermaid syntax could not be rendered')}
       </p>
+      <p className="mt-1 text-[12px] text-amber-900/90 dark:text-amber-200/90">
+        {mediaBlocked ? t('Use a separate Markdown image to load it explicitly.') : error}
+      </p>
+      {!mediaBlocked && (
+        <p className="mt-2 text-[12px] text-amber-800/80 dark:text-amber-300/80">
+          <Trans
+            t={t}
+            i18nKey="Common causes: an xychart is missing the <kw1>title</kw1> keyword, axis labels are not quoted, or <kw2>y-axis</kw2> or <kw3>bar/line</kw3> data rows are missing."
+            components={{
+              kw1: <code className="rounded bg-amber-100/80 px-1 dark:bg-amber-900/50" />,
+              kw2: <code className="rounded bg-amber-100/80 px-1 dark:bg-amber-900/50" />,
+              kw3: <code className="rounded bg-amber-100/80 px-1 dark:bg-amber-900/50" />
+            }}
+          />
+        </p>
+      )}
       <details className="mt-2">
         <summary className="cursor-pointer text-[12px] text-amber-900/90 dark:text-amber-200/90">
           {t('View source')}
@@ -111,13 +137,15 @@ const MermaidErrorPanel = ({ chart, error, retry }: MermaidErrorPanelProps): Rea
           {chart}
         </pre>
       </details>
-      <button
-        type="button"
-        className="mt-2 rounded-md border border-amber-300 bg-white px-2.5 py-1 text-[12px] text-amber-950 hover:bg-amber-100/80 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:bg-amber-900/40"
-        onClick={retry}
-      >
-        {t('Retry')}
-      </button>
+      {!mediaBlocked && (
+        <button
+          type="button"
+          className="mt-2 rounded-md border border-amber-300 bg-white px-2.5 py-1 text-[12px] text-amber-950 hover:bg-amber-100/80 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-100 dark:hover:bg-amber-900/40"
+          onClick={retry}
+        >
+          {t('Retry')}
+        </button>
+      )}
     </div>
   )
 }
@@ -231,14 +259,12 @@ const RichAgentMarkdown = memo(
     )
     const plugins = useMarkdownPlugins(renderedContent)
     const renderedComponents = useMemo(() => {
-      const merged =
-        !sessionLinks && !components && !extension
-          ? undefined
-          : {
-              ...(sessionLinks ? sessionLinkComponents : {}),
-              ...components,
-              ...extension?.components
-            }
+      const merged = {
+        ...(sessionLinks ? sessionLinkComponents : {}),
+        ...components,
+        ...extension?.components,
+        ...deferredMediaComponents
+      }
       // While streaming, hide quotes with no non-empty paragraph render-side instead of the old
       // `blockquote:not(:has(p:not(:empty)))` rule, a style-recalc hotspot on each DOM commit.
       if (!isAnimating) return merged
@@ -270,7 +296,9 @@ const RichAgentMarkdown = memo(
           normalizeHtmlIndentation={!isAnimating}
           allowedTags={allowedTags}
           literalTagContent={extension?.literalTagContent}
-          disallowedElements={allowMedia ? undefined : NETWORK_FETCHING_MEDIA_ELEMENTS}
+          disallowedElements={
+            allowMedia ? ['iframe', 'object', 'embed'] : NETWORK_FETCHING_MEDIA_ELEMENTS
+          }
           shikiTheme={plugins.code ? shikiThemes : undefined}
           mermaid={plugins.mermaid ? mermaidOptions : undefined}
         >

--- a/src/renderer/src/components/streamdown/DeferredMedia.tsx
+++ b/src/renderer/src/components/streamdown/DeferredMedia.tsx
@@ -1,10 +1,13 @@
 import { createContext, useContext, useState, type ComponentProps, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
-import type { ExtraProps } from 'streamdown'
+import { Streamdown, type ExtraProps } from 'streamdown'
+import type { Root } from 'hast'
 
 // Approval is local to this rendered media element, and bound to the complete URL set. A streaming
 // replacement or added poster/source must never inherit consent for a different request.
 const MediaUrls = createContext<readonly string[]>([])
+// The rehype transform replaces this seed with exactly one image; it is never displayed.
+const imageSeed = '![]()'
 type MediaNode = NonNullable<ExtraProps['node']>
 const remoteUrls = (node?: MediaNode): string[] => {
   if (!node) return []
@@ -66,16 +69,34 @@ const DeferredImage = ({
   title
 }: ComponentProps<'img'> & ExtraProps): ReactNode => (
   <MediaGate node={node} alt={alt}>
-    <img
-      src={src}
-      alt={alt ?? ''}
-      width={width}
-      height={height}
-      title={title}
-      referrerPolicy="no-referrer"
-      className="max-w-full rounded-lg"
-      data-streamdown="image"
-    />
+    {/* The public renderer retains Streamdown's image wrapper, controls and download behavior.
+        Supply only one image node, so alt/URL text cannot introduce more Markdown or requests. */}
+    <Streamdown
+      mode="static"
+      className="contents"
+      rehypePlugins={[
+        () => (): Root => ({
+          type: 'root',
+          children: [
+            {
+              type: 'element',
+              tagName: 'img',
+              properties: {
+                src,
+                alt: alt ?? '',
+                width,
+                height,
+                title,
+                referrerPolicy: 'no-referrer'
+              },
+              children: []
+            }
+          ]
+        })
+      ]}
+    >
+      {imageSeed}
+    </Streamdown>
   </MediaGate>
 )
 const DeferredVideo = ({

--- a/src/renderer/src/components/streamdown/DeferredMedia.tsx
+++ b/src/renderer/src/components/streamdown/DeferredMedia.tsx
@@ -1,0 +1,145 @@
+import { createContext, useContext, useState, type ComponentProps, type ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import type { ExtraProps } from 'streamdown'
+
+// Approval is local to this rendered media element, and bound to the complete URL set. A streaming
+// replacement or added poster/source must never inherit consent for a different request.
+const MediaUrls = createContext<readonly string[]>([])
+type MediaNode = NonNullable<ExtraProps['node']>
+const remoteUrls = (node?: MediaNode): string[] => {
+  if (!node) return []
+  const urls: string[] = []
+  for (const key of ['src', 'poster']) {
+    const value = node.properties[key]
+    if (typeof value !== 'string' || !value) continue
+    if (/^(blob:|data:(?:image|audio|video)\/)/i.test(value)) continue
+    try {
+      const url = new URL(value, window.location.href)
+      if (url.protocol === 'http:' || url.protocol === 'https:') urls.push(url.href)
+    } catch {
+      /* Streamdown already filters unusable URLs. */
+    }
+  }
+  for (const child of node.children) {
+    if (child.type === 'element') urls.push(...remoteUrls(child))
+  }
+  return [...new Set(urls)]
+}
+
+const MediaGate = ({
+  node,
+  alt,
+  children
+}: ExtraProps & { alt?: string; children: ReactNode }): ReactNode => {
+  const { t } = useTranslation()
+  const urls = remoteUrls(node)
+  const identity = JSON.stringify(urls)
+  const [approved, setApproved] = useState<string>()
+  if (urls.length && approved !== identity) {
+    const domains = [...new Set(urls.map((url) => new URL(url).host))].join(', ')
+    return (
+      <button
+        type="button"
+        data-deferred-media=""
+        className="my-1 inline-flex max-w-full flex-col items-start rounded-md border px-3 py-2 text-left text-sm"
+        title={urls.join('\n')}
+        onClick={(event) => {
+          event.preventDefault()
+          event.stopPropagation()
+          setApproved(identity)
+        }}
+      >
+        {alt && <span>{alt}</span>}
+        <span>{t('Load media from {{domains}}', { domains })}</span>
+      </button>
+    )
+  }
+  return <MediaUrls.Provider value={urls}>{children}</MediaUrls.Provider>
+}
+
+const DeferredImage = ({
+  node,
+  src,
+  alt,
+  width,
+  height,
+  title
+}: ComponentProps<'img'> & ExtraProps): ReactNode => (
+  <MediaGate node={node} alt={alt}>
+    <img
+      src={src}
+      alt={alt ?? ''}
+      width={width}
+      height={height}
+      title={title}
+      referrerPolicy="no-referrer"
+      className="max-w-full rounded-lg"
+      data-streamdown="image"
+    />
+  </MediaGate>
+)
+const DeferredVideo = ({
+  node,
+  src,
+  poster,
+  width,
+  height,
+  children
+}: ComponentProps<'video'> & ExtraProps): ReactNode => (
+  <MediaGate node={node}>
+    <video
+      src={src}
+      poster={poster}
+      width={width}
+      height={height}
+      controls
+      preload="none"
+      playsInline
+      className="max-w-full"
+    >
+      {children}
+    </video>
+  </MediaGate>
+)
+const DeferredAudio = ({
+  node,
+  src,
+  children
+}: ComponentProps<'audio'> & ExtraProps): ReactNode => (
+  <MediaGate node={node}>
+    <audio src={src} controls preload="none">
+      {children}
+    </audio>
+  </MediaGate>
+)
+const ApprovedSource = ({ node, src, type }: ComponentProps<'source'> & ExtraProps): ReactNode => {
+  const approved = useContext(MediaUrls)
+  return remoteUrls(node).every((url) => approved.includes(url)) ? (
+    <source src={src} type={type} />
+  ) : null
+}
+const ApprovedTrack = ({
+  node,
+  src,
+  kind,
+  srcLang,
+  label,
+  default: isDefault
+}: ComponentProps<'track'> & ExtraProps): ReactNode => {
+  const approved = useContext(MediaUrls)
+  return remoteUrls(node).every((url) => approved.includes(url)) ? (
+    <track src={src} kind={kind} srcLang={srcLang} label={label} default={isDefault} />
+  ) : null
+}
+
+// Keep SVG chart references local. Do not turn an SVG subtree into an embedded remote document.
+const LocalSvgUse = ({
+  href,
+  x,
+  y,
+  width,
+  height
+}: ComponentProps<'use'> & ExtraProps): ReactNode =>
+  href?.startsWith('#') ? <use href={href} x={x} y={y} width={width} height={height} /> : null
+
+export { DeferredImage, DeferredVideo, DeferredAudio, ApprovedSource, ApprovedTrack, LocalSvgUse }

--- a/src/renderer/src/components/streamdown/install-streamdown.download.test.ts
+++ b/src/renderer/src/components/streamdown/install-streamdown.download.test.ts
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { createElement } from 'react'
 
 import { installStreamdown } from './install-streamdown'
+import { PresentedAgentMarkdown } from './AgentMarkdown'
 
 let uninstall: (() => void) | undefined
 let saveBlobFile: ReturnType<typeof vi.fn>
@@ -90,6 +93,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  cleanup()
   uninstall?.()
   uninstall = undefined
   document.body.innerHTML = ''
@@ -98,6 +102,27 @@ afterEach(() => {
 })
 
 describe('Streamdown blob download bridge', () => {
+  it('downloads an approved Markdown image through the existing save bridge', async () => {
+    const fetchImage = vi.spyOn(globalThis, 'fetch').mockResolvedValue({
+      blob: async () => new Blob(['image bytes'], { type: 'image/png' })
+    } as Response)
+    const view = render(
+      createElement(PresentedAgentMarkdown, {
+        content: '![Figure](https://image.invalid/figure.png)'
+      })
+    )
+    expect(fetchImage).not.toHaveBeenCalled()
+    fireEvent.click(view.getByRole('button', { name: /image.invalid/ }))
+    fireEvent.load(view.container.querySelector('img')!)
+    fireEvent.click(view.getByRole('button', { name: 'Download image' }))
+    await vi.waitFor(() => expect(saveBlobFile).toHaveBeenCalledOnce())
+    expect(fetchImage).toHaveBeenCalledWith('https://image.invalid/figure.png')
+    expect(saveBlobFile.mock.calls[0]?.[0]).toMatchObject({
+      suggestedName: 'figure.png',
+      mimeType: 'image/png'
+    })
+  })
+
   it('saves a blob created synchronously by the current Streamdown button action', async () => {
     const root = document.createElement('div')
     root.className = 'agent-markdown-root'

--- a/src/renderer/src/components/streamdown/mermaid-runtime.ts
+++ b/src/renderer/src/components/streamdown/mermaid-runtime.ts
@@ -11,6 +11,16 @@ const wrapInstance = (instance: MermaidInstance): MermaidInstance => ({
   render: async (renderId, source) => {
     // Remembered even when rendering fails: the error panel can fall back to the same source.
     rememberMermaidSource(renderId, source)
+    // Mermaid image shapes fetch through new Image() before an SVG exists. Parse shape metadata
+    // before rendering, including quoted/escaped YAML keys; a post-render sanitizer is too late.
+    if (/@\s*\{/.test(source)) {
+      const { default: renderer } = await import('mermaid')
+      const diagram = await renderer.mermaidAPI.getDiagramFromText(source)
+      const db = diagram.db as { getVertices?: () => Map<string, { img?: string }> }
+      if (db.getVertices && [...db.getVertices().values()].some((vertex) => vertex.img)) {
+        throw new Error('MERMAID_IMAGE_BLOCKED')
+      }
+    }
     const result = await instance.render(renderId, source)
     return { ...result, svg: annotateSvg(result.svg, renderId) }
   }

--- a/src/renderer/src/pages/settings/validation-message.ts
+++ b/src/renderer/src/pages/settings/validation-message.ts
@@ -31,6 +31,10 @@ const localizeProviderResourceMessage = (message: string, t: TFunction): string 
   switch (message) {
     case 'The provider changed while loading models. Try again.':
       return t('The provider changed while loading models. Try again.')
+    case 'Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.':
+      return t(
+        'Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.'
+      )
     case 'Base URL must be a valid HTTP or HTTPS URL.':
       return t('Base URL must be a valid HTTP or HTTPS URL.')
     case 'Base URL must not include query parameters or fragments.':

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5038,6 +5038,10 @@
     "Verifying installer…": "Installationsprogramm wird überprüft…",
     "Open Science couldn't display this page": "Open Science konnte diese Seite nicht anzeigen",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "Hintergrundaufgaben werden möglicherweise noch ausgeführt. Beim Neuladen können ungespeicherte Änderungen auf dieser Seite verloren gehen.",
-    "Reload page": "Seite neu laden"
+    "Reload page": "Seite neu laden",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "URLs für entfernte Modelle müssen HTTPS verwenden. HTTP ist nur für localhost oder Loopback-Adressen erlaubt.",
+    "Load media from {{domains}}": "Medien von {{domains}} laden",
+    "Images in Mermaid diagrams are blocked": "Bilder in Mermaid-Diagrammen sind blockiert",
+    "Use a separate Markdown image to load it explicitly.": "Verwenden Sie ein separates Markdown-Bild, um es ausdrücklich zu laden."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5200,6 +5200,10 @@
     "Verifying installer…": "Verificando el instalador…",
     "Open Science couldn't display this page": "Open Science no pudo mostrar esta página",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "Es posible que las tareas en segundo plano sigan en ejecución. Al volver a cargar, pueden perderse los cambios sin guardar de esta página.",
-    "Reload page": "Volver a cargar la página"
+    "Reload page": "Volver a cargar la página",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "Las URL de modelos remotos deben usar HTTPS. HTTP solo se permite para localhost o direcciones de bucle invertido.",
+    "Load media from {{domains}}": "Cargar contenido multimedia de {{domains}}",
+    "Images in Mermaid diagrams are blocked": "Las imágenes en diagramas Mermaid están bloqueadas",
+    "Use a separate Markdown image to load it explicitly.": "Utilice una imagen Markdown independiente para cargarla de forma explícita."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5200,6 +5200,10 @@
     "Verifying installer…": "Vérification du programme d’installation…",
     "Open Science couldn't display this page": "Open Science n’a pas pu afficher cette page",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "Des tâches peuvent encore être en cours en arrière-plan. Le rechargement peut entraîner la perte des modifications non enregistrées sur cette page.",
-    "Reload page": "Recharger la page"
+    "Reload page": "Recharger la page",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "Les URL des modèles distants doivent utiliser HTTPS. HTTP est autorisé uniquement pour localhost ou les adresses de bouclage.",
+    "Load media from {{domains}}": "Charger le média depuis {{domains}}",
+    "Images in Mermaid diagrams are blocked": "Les images dans les diagrammes Mermaid sont bloquées",
+    "Use a separate Markdown image to load it explicitly.": "Utilisez une image Markdown séparée pour la charger explicitement."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4884,6 +4884,10 @@
     "Verifying installer…": "インストーラーを検証中…",
     "Open Science couldn't display this page": "Open Science でこのページを表示できませんでした",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "バックグラウンドの処理は引き続き実行されている可能性があります。再読み込みすると、このページの未保存の変更が失われる可能性があります。",
-    "Reload page": "ページを再読み込み"
+    "Reload page": "ページを再読み込み",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "リモートモデルの URL には HTTPS が必要です。HTTP は localhost またはループバックアドレスでのみ使用できます。",
+    "Load media from {{domains}}": "{{domains}} からメディアを読み込む",
+    "Images in Mermaid diagrams are blocked": "Mermaid 図内の画像はブロックされています",
+    "Use a separate Markdown image to load it explicitly.": "個別の Markdown 画像を使って明示的に読み込んでください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4882,6 +4882,10 @@
     "Verifying installer…": "설치 프로그램 확인 중…",
     "Open Science couldn't display this page": "Open Science에서 이 페이지를 표시할 수 없습니다",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "백그라운드 작업이 아직 실행 중일 수 있습니다. 새로고침하면 이 페이지의 저장되지 않은 변경 사항이 손실될 수 있습니다.",
-    "Reload page": "페이지 새로고침"
+    "Reload page": "페이지 새로고침",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "원격 모델 URL은 HTTPS를 사용해야 합니다. HTTP는 localhost 또는 루프백 주소에만 허용됩니다.",
+    "Load media from {{domains}}": "{{domains}}에서 미디어 불러오기",
+    "Images in Mermaid diagrams are blocked": "Mermaid 다이어그램의 이미지가 차단되었습니다",
+    "Use a separate Markdown image to load it explicitly.": "별도의 Markdown 이미지를 사용하여 직접 불러오세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5333,6 +5333,10 @@
     "Verifying installer…": "Проверка установщика…",
     "Open Science couldn't display this page": "Open Science не удалось отобразить эту страницу",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "Фоновые задачи могут всё ещё выполняться. При перезагрузке несохранённые изменения на этой странице могут быть потеряны.",
-    "Reload page": "Перезагрузить страницу"
+    "Reload page": "Перезагрузить страницу",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "URL удалённых моделей должны использовать HTTPS. HTTP разрешён только для localhost или адресов обратной петли.",
+    "Load media from {{domains}}": "Загрузить медиа с {{domains}}",
+    "Images in Mermaid diagrams are blocked": "Изображения в диаграммах Mermaid заблокированы",
+    "Use a separate Markdown image to load it explicitly.": "Используйте отдельное изображение Markdown, чтобы загрузить его явно."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4884,6 +4884,10 @@
     "Verifying installer…": "正在校验安装程序…",
     "Open Science couldn't display this page": "Open Science 无法显示此页面",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "后台工作可能仍在运行。重新加载可能会丢失此页面上未保存的更改。",
-    "Reload page": "重新加载页面"
+    "Reload page": "重新加载页面",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "远程模型 URL 必须使用 HTTPS。HTTP 仅允许用于 localhost 或回环地址。",
+    "Load media from {{domains}}": "加载来自 {{domains}} 的媒体",
+    "Images in Mermaid diagrams are blocked": "已阻止 Mermaid 图表中的图片",
+    "Use a separate Markdown image to load it explicitly.": "请使用单独的 Markdown 图片，以便手动加载。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4884,6 +4884,10 @@
     "Verifying installer…": "正在驗證安裝程式…",
     "Open Science couldn't display this page": "Open Science 無法顯示此頁面",
     "Background work may still be running. Reloading may lose unsaved changes on this page.": "背景工作可能仍在執行。重新載入可能會遺失此頁面上未儲存的變更。",
-    "Reload page": "重新載入頁面"
+    "Reload page": "重新載入頁面",
+    "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "遠端模型 URL 必須使用 HTTPS。HTTP 僅允許用於 localhost 或迴路位址。",
+    "Load media from {{domains}}": "載入來自 {{domains}} 的媒體",
+    "Images in Mermaid diagrams are blocked": "已封鎖 Mermaid 圖表中的圖片",
+    "Use a separate Markdown image to load it explicitly.": "請使用獨立的 Markdown 圖片，以便手動載入。"
   }
 }

--- a/src/shared/provider-base-url.ts
+++ b/src/shared/provider-base-url.ts
@@ -1,6 +1,18 @@
 import { isSensitiveUrlQueryKey } from './diagnostic-redaction'
 
+export const PROVIDER_TRANSPORT_ERROR =
+  'Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.'
+
+// URL parsing canonicalizes IPv4 shorthand/decimal forms before checking the loopback range.
+export const isSecureProviderUrl = (url: URL): boolean =>
+  url.protocol === 'https:' ||
+  (url.protocol === 'http:' &&
+    (url.hostname === 'localhost' ||
+      url.hostname === '[::1]' ||
+      /^127\.\d+\.\d+\.\d+$/.test(url.hostname)))
+
 export type CustomProviderBaseUrlError =
+  | typeof PROVIDER_TRANSPORT_ERROR
   | 'Base URL must be a valid HTTP or HTTPS URL.'
   | 'Base URL must not include query parameters or fragments.'
   | 'Remove credentials from the Base URL and use the API key field.'
@@ -18,6 +30,7 @@ export const getCustomProviderBaseUrlError = (
   if ((url.protocol !== 'http:' && url.protocol !== 'https:') || !url.hostname) {
     return 'Base URL must be a valid HTTP or HTTPS URL.'
   }
+  if (!isSecureProviderUrl(url)) return PROVIDER_TRANSPORT_ERROR
   if (url.username || url.password || [...url.searchParams.keys()].some(isSensitiveUrlQueryKey)) {
     return 'Remove credentials from the Base URL and use the API key field.'
   }


### PR DESCRIPTION
## Problem

Viewing model-generated Markdown can start remote media requests without activation, small model images can include private metadata, and custom remote HTTP endpoints can receive credentials and content in plaintext.

## Proposed change

- Defer remote image/audio/video sources and posters until the user activates a control showing the destination hosts. Approval is scoped to the rendered element and its complete URL set. Block Mermaid image nodes before Mermaid can issue requests; preserve ordinary diagrams. After activation, reuse Streamdown’s native image renderer to preserve downloads and the existing Electron save bridge.
- Normalize images at prompt assembly for attachments, references, current messages, and history. Strip ancillary metadata from model-input derivatives, preserve original files, and retain existing image budgets and animation handling.
- Require HTTPS for remote model URLs at validation, request sending, and runtime configuration projection. Preserve localhost and IPv4/IPv6 loopback HTTP.
- Document data recipients, cancellation/deletion limits, and the remaining third-party traffic verification work. Exclude frozen `docs/internal/` evidence from lint, matching the existing Vitest boundary.

## Scope and non-goals

**Historical compatibility:** existing remote HTTP configurations remain stored and editable but cannot run until changed to HTTPS. Previously saved messages use the new media activation and image-derivative rules when viewed or replayed. Because vision-cache keys include the emitted image bytes, normalization can cause a one-time cache miss and recomputation for old images. No attachment, cache, or database migration is performed.

**State:** add only per-element in-memory media approval and transport/render error branches; no new persisted state enum.

**Persistence:** no schema, database fields, persisted-format changes, or original-file rewrites. No new durable external resource.

This does not provide an offline mode, a final-origin media allowlist after activation, third-party telemetry guarantees, or provider-side deletion. Subscription lifecycle and active-branch selection remain owned by their existing runtime/persistence boundaries.

## Acceptance criteria and validation

The image-download review regression was reproduced against the first PR commit (missing download button), then covered by the real save bridge and a Chromium download test.

Original failures were reproduced before the production changes: premature browser requests, EXIF canaries in outgoing image blocks, and credential-bearing HTTP requests reaching the injected transport. Regression tests now assert the safe behavior alongside legitimate controls.

Checks ran in the dedicated worktree after the final material edits:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Renderer, prompt/image preparation, provider resolution, uploads, and translations | Deduplicated `createModuleTestPlan`/`executeModuleTestPlan` plans plus new/direct regression files | 128 files: 127 passed, 1 skipped; 5,297 tests passed, 4 skipped |
| Media activation, reopened history, Mermaid rejection and ordinary diagrams | `playwright test ... e2e/browser/media-privacy.spec.ts` | 5 passed |
| Main, sandbox and renderer types | `npm run typecheck` | Passed |
| Maintained source and configuration | `npm run lint` | Passed |

Module plans: `session_renderer`, `workspace_runtime`, `image_input_compatibility`, `settings_backend_resolution`, `settings_provider_accounts`, `settings_service_facade`, `upload_repository`, `i18n_catalog`, and `i18n_renderer_adapter`. Their curated checks are reproducible with `npm run test:module -- <module-id>`; new regressions are checked in beside their public boundaries. Runtime consumer coverage includes Claude Code, OpenCode, Codex Responses, and Codex Bridge. Existing branch replay and lifecycle tests remain included through the runtime modules.

Real Chromium and isolated Electron renderer fixtures exercise the browser network boundary; no real provider credentials were sent. The exact-commit impact explain command selects the full CI plan because the new browser fixtures and lint configuration are not owned by its manifest. Local validation uses the explicit module set above at the maintainer’s request; Windows/Linux execution and complete validation are delegated to PR CI. Third-party runtime login/idle/telemetry and remote-Web traffic measurements remain unverified.

## Review focus

Check metadata minimization without modifying scientific originals, preserved prompt budgets/history selection, transport enforcement for saved configurations and subprocess projections, and media approval invalidation when URLs change. The deliberate compatibility change for remote HTTP also applies to private-network endpoints.


The latest automated review's Mermaid metadata concern was checked against the locked and installed Mermaid **11.17.2**. Its `FlowVertex` type declares `img?: string`, and `FlowDb.addVertex` assigns `vertex.img = doc?.img`. Running `mermaidAPI.getDiagramFromText` with both `img:` and `"img":` produced `{ img: "https://privacy-canary.invalid/image.png", props: {} }`; `vertex.props?.img` was undefined. The checked-in real-browser tests also reject those image nodes before any request with media both enabled and disabled. This finding was not reproduced, so the production guard was not changed to the incorrect property. The earlier download finding is covered by the subsequent fix and regression tests.
