### PR TITLE
fix(web): guard Electron-only handoff lifecycle APIs in web mode

### DIFF
--- a/src/renderer/src/pages/workspace/handoff-lifecycle-source.test.ts
+++ b/src/renderer/src/pages/workspace/handoff-lifecycle-source.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { HandoffLifecycleEvent } from '../../../../shared/handoff-lifecycle'
 import type { CompletionHandoffLifecycleEvent } from '../../../../shared/specialist'
+import { installWebRendererContracts } from '../../../web/api-installer'
 
 import { IpcHandoffLifecycleClient } from './handoff-lifecycle-source'
 
@@ -25,6 +26,42 @@ const event = (
 })
 
 describe('IPC handoff lifecycle client', () => {
+  it('handles the web-installed specialist API without Electron-only lifecycle methods', async () => {
+    const api: Record<string, unknown> = {}
+    const invoke = vi.fn()
+    const subscribe = vi.fn()
+    installWebRendererContracts(api, {
+      availableRpcChannels: new Set(['specialist:list']),
+      restrictedRpcChannels: new Set(),
+      invoke,
+      subscribe,
+      nativeAdapters: {}
+    })
+
+    expect(api.specialist).toMatchObject({ list: expect.any(Function) })
+    for (const method of ['getHandoffEvents', 'onHandoffLifecycleEvent', 'retryHandoff']) {
+      expect(api.specialist).not.toHaveProperty(method)
+    }
+    // The shared API type describes Electron; the web installer intentionally omits these methods.
+    const client = new IpcHandoffLifecycleClient(
+      () => api.specialist as typeof window.api.specialist
+    )
+    const listener = vi.fn()
+    const snapshot = client.getEvents('session-1')
+    expect(snapshot).toEqual([])
+    const unsubscribe = client.subscribe(listener)
+
+    await expect(client.load('session-1')).resolves.toBeUndefined()
+    expect(client.getEvents('session-1')).toBe(snapshot)
+    expect(unsubscribe).not.toThrow()
+    await expect(
+      client.retry({ sessionId: 'session-1', originatingTurnId: 'turn-1' })
+    ).rejects.toThrow('Handoff lifecycle API is unavailable')
+    expect(listener).not.toHaveBeenCalled()
+    expect(invoke).not.toHaveBeenCalled()
+    expect(subscribe).not.toHaveBeenCalled()
+  })
+
   it('keeps the empty event snapshot stable before a session has handoff events', () => {
     const api = {
       getHandoffEvents: vi.fn(async () => []),

--- a/src/renderer/src/pages/workspace/handoff-lifecycle-source.ts
+++ b/src/renderer/src/pages/workspace/handoff-lifecycle-source.ts
@@ -98,7 +98,7 @@ class IpcHandoffLifecycleClient implements HandoffLifecycleEventSource {
 
   async load(sessionId: string): Promise<void> {
     const api = this.getApi()
-    if (!api) return
+    if (!api || typeof api.getHandoffEvents !== 'function') return
 
     const retained = await api.getHandoffEvents(sessionId)
     this.merge(sessionId, retained.map(toHandoffEvent))
@@ -106,7 +106,8 @@ class IpcHandoffLifecycleClient implements HandoffLifecycleEventSource {
 
   async retry(request: HandoffRetryRequest): Promise<void> {
     const api = this.getApi()
-    if (!api) throw new Error('Handoff lifecycle API is unavailable')
+    if (!api || typeof api.retryHandoff !== 'function')
+      throw new Error('Handoff lifecycle API is unavailable')
     const event = [...this.getEvents(request.sessionId)]
       .reverse()
       .find((candidate) => candidate.provenance.originatingTurnId === request.originatingTurnId)
@@ -117,7 +118,7 @@ class IpcHandoffLifecycleClient implements HandoffLifecycleEventSource {
   private ensureChangedListener(): void {
     if (this.stopChangedListener) return
     const api = this.getApi()
-    if (!api) return
+    if (!api || typeof api.onHandoffLifecycleEvent !== 'function') return
     this.stopChangedListener = api.onHandoffLifecycleEvent((event) => {
       if (event.removed) {
         this.remove(event.sessionId, event.id)


### PR DESCRIPTION
## Summary

Adds `typeof` function guards to `IpcHandoffLifecycleClient` methods (`load`, `retry`, `ensureChangedListener`) so they gracefully no-op when the underlying Electron-only APIs (`onHandoffLifecycleEvent`, `getHandoffEvents`, `retryHandoff`) are not available in the web Remote Access UI.

## Problem

v0.27.0 introduced `IpcHandoffLifecycleClient` which calls `api.onHandoffLifecycleEvent()`, `api.getHandoffEvents()`, and `api.retryHandoff()` without checking whether these methods exist. In the Electron desktop app these methods are registered via the preload script, but in the web version the contract catalog marks them as `ELECTRON` profile and the web API installer skips them.

This causes a white screen crash (`TypeError: t.onHandoffLifecycleEvent is not a function`) when accessing Open Science via web browser.

## Fix

```typescript
// Before
if (!api) return
this.stopChangedListener = api.onHandoffLifecycleEvent(...)

// After
if (!api || typeof api.onHandoffLifecycleEvent !== "function") return
this.stopChangedListener = api.onHandoffLifecycleEvent(...)
```

This matches the existing guard pattern in `WorkspacePage.tsx` (lines 2303, 2309).

## Testing

- Verified: web Remote Access no longer crashes on load
- Verified: Electron desktop app continues to work (methods are present, typeof check passes)
- Verified: `retry()` now throws a clear error message instead of `TypeError` when called on web

Fixes #2423