### PR TITLE
fix(literature): verify terminal PDF metadata identifiers

### DIFF
--- a/src/renderer/src/pages/literature/literature-pdf-extraction.test.ts
+++ b/src/renderer/src/pages/literature/literature-pdf-extraction.test.ts
@@ -1,0 +1,171 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { literatureItemInputSchema } from '../../../../shared/literature'
+import { extractLiteraturePdfDraft, completeLiteraturePdfDraft } from './literature-pdf-metadata'
+
+const pdf = vi.hoisted(() => ({ getDocument: vi.fn() }))
+vi.mock('../workspace/previews/pdfjs', () => ({ pdfjsLib: pdf }))
+const title = 'Proteins regulate replication through stabilization'
+const doi = '10.1234/article'
+const fallback = literatureItemInputSchema.parse({ itemType: 'journalArticle', title: 'paper' })
+const resolved = { ...fallback, title, containerTitle: 'Example Journal' }
+const publication = `References\n10.1234/reference\nSubmitted 5 June 2024\nAccepted 11 February 2025\nPublished 19 March 2025\n${doi}`
+const item = (str: string, height = 10): { str: string; height: number; hasEOL: boolean } => ({
+  str,
+  height,
+  hasEOL: true
+})
+
+const setup = (
+  last = publication,
+  first = [item(title, 18), item('Abstract and body')],
+  pages = 15
+  // eslint-disable-next-line @typescript-eslint/explicit-function-return-type -- Preserve each mock's inferred callable signature.
+) => {
+  const cleanup = vi.fn()
+  const destroy = vi.fn()
+  const getPage = vi.fn(async (n: number) => ({
+    getTextContent: vi.fn(async () => ({
+      items: n === 1 ? first : [item(n === pages ? last : 'Body')]
+    })),
+    cleanup
+  }))
+  pdf.getDocument.mockReturnValue({
+    promise: Promise.resolve({
+      numPages: pages,
+      getPage,
+      destroy,
+      getMetadata: async () => ({ info: { Title: 'Generic publisher title' } })
+    })
+  })
+  const lookup = vi.fn().mockResolvedValue(resolved)
+  vi.stubGlobal('window', { api: { literature: { lookupMetadata: lookup } } })
+  const file = new File(['%PDF-1.4'], 'paper.pdf')
+  return { file, lookup, getPage, cleanup, destroy }
+}
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.clearAllMocks()
+})
+
+describe('PDF terminal publication DOI fallback', () => {
+  it('checks the prominent first-page title before adopting the publication DOI and reuses its lookup', async () => {
+    const { file, lookup, getPage, destroy } = setup()
+    const draft = await extractLiteraturePdfDraft(file, fallback)
+    expect(draft.identifiers).toEqual([{ scheme: 'doi', value: doi, isPrimary: true }])
+    expect((await completeLiteraturePdfDraft(draft)).title).toBe(title)
+    expect(lookup).toHaveBeenCalledExactlyOnceWith(doi)
+    expect(getPage.mock.calls.map(([n]) => n)).toEqual([1, 2, 15])
+    expect(destroy).toHaveBeenCalledOnce()
+  })
+  it.each([
+    'References\n10.1234/reference',
+    `Published 19 March 2025\n${doi}`,
+    `Accepted 11 February 2025\nPublished 19 March 2025\n${doi}\n10.1234/other`,
+    `Accepted 11 February 2025\nPublished 19 March 2025\nReferences\n${doi}`
+  ])('does not query an ambiguous or reference-only tail: %s', async (last) => {
+    const { file, lookup } = setup(last)
+    expect((await extractLiteraturePdfDraft(file, fallback)).identifiers).toEqual([])
+    expect(lookup).not.toHaveBeenCalled()
+  })
+  it('rejects a real referenced work even when its title occurs in the body or embedded metadata', async () => {
+    const { file, lookup } = setup(publication, [
+      item('The current article has a different title', 18),
+      item(title)
+    ])
+    lookup.mockResolvedValue({ ...resolved, title })
+    expect((await extractLiteraturePdfDraft(file, fallback)).identifiers).toEqual([])
+  })
+  it('retains the local draft when lookup fails', async () => {
+    const { file, lookup, destroy } = setup()
+    lookup.mockRejectedValue(new Error('offline'))
+    expect((await extractLiteraturePdfDraft(file, fallback)).title).toBe('Generic publisher title')
+    expect(destroy).toHaveBeenCalledOnce()
+  })
+  it('cleans up a failing last page and preserves the already extracted metadata', async () => {
+    const { file, getPage, cleanup, destroy } = setup()
+    getPage.mockImplementation(async (n) => ({
+      getTextContent: vi.fn(async () => {
+        if (n === 15) throw new Error('unreadable page')
+        return { items: [item(title, 18)] }
+      }),
+      cleanup
+    }))
+    expect((await extractLiteraturePdfDraft(file, fallback)).title).toBe('Generic publisher title')
+    expect(cleanup).toHaveBeenCalledTimes(3)
+    expect(destroy).toHaveBeenCalledOnce()
+  })
+  it.each(['', 'Short'])(
+    'does not query without a substantial prominent title: %s',
+    async (text) => {
+      const { file, lookup } = setup(publication, [item(text, 18)])
+      expect((await extractLiteraturePdfDraft(file, fallback)).identifiers).toEqual([])
+      expect(lookup).not.toHaveBeenCalled()
+    }
+  )
+  it('preserves a detected PMID as a secondary identifier', async () => {
+    const { file } = setup(publication, [item(title, 18), item('PMID: 40106570')])
+    expect((await extractLiteraturePdfDraft(file, fallback)).identifiers).toEqual([
+      { scheme: 'doi', value: doi, isPrimary: true },
+      { scheme: 'pmid', value: '40106570', isPrimary: false }
+    ])
+  })
+  it('keeps an existing first-page DOI without reading the last page', async () => {
+    const { file, lookup, getPage } = setup(publication, [item(title, 18), item('10.1234/front')])
+    expect((await extractLiteraturePdfDraft(file, fallback)).identifiers[0].value).toBe(
+      '10.1234/front'
+    )
+    expect(getPage.mock.calls.map(([n]) => n)).toEqual([1, 2])
+    expect(lookup).not.toHaveBeenCalled()
+  })
+  it('does not reread a one-page PDF or read an oversized file', async () => {
+    const { file, getPage } = setup('', [item(title, 18)], 1)
+    await extractLiteraturePdfDraft(file, fallback)
+    expect(getPage.mock.calls.map(([n]) => n)).toEqual([1])
+    const oversized = new File([], 'large.pdf')
+    Object.defineProperty(oversized, 'size', { value: 51 * 1024 * 1024 })
+    expect(await extractLiteraturePdfDraft(oversized, fallback)).toBe(fallback)
+    expect(pdf.getDocument).toHaveBeenCalledOnce()
+  })
+})
+
+// Minimal real PDF: split large-font title, generic Info title, and a publication DOI on page 3.
+// Keep the publisher pattern reproducible without embedding a user's copyrighted article.
+const publicationPdf = (): Uint8Array<ArrayBuffer> => {
+  const streams = [
+    'BT /F1 18 Tf 30 700 Td (Proteins regulate replication) Tj 0 -22 Td (through stabilization) Tj /F1 10 Tf 0 -30 Td (Abstract and body) Tj ET',
+    'BT /F1 10 Tf 30 700 Td (Body) Tj ET',
+    'BT /F1 10 Tf 30 700 Td (References) Tj 0 -15 Td (10.1234/reference) Tj 0 -30 Td (Accepted 11 February 2025) Tj 0 -15 Td (Published 19 March 2025) Tj 0 -15 Td (10.1234/article) Tj ET'
+  ]
+  const objects = [
+    '<< /Type /Catalog /Pages 2 0 R >>',
+    '<< /Type /Pages /Kids [5 0 R 7 0 R 9 0 R] /Count 3 >>',
+    '<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>',
+    '<< /Title (Generic publisher title) >>',
+    ...streams.flatMap((stream, i) => [
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Resources << /Font << /F1 3 0 R >> >> /Contents ${6 + i * 2} 0 R >>`,
+      `<< /Length ${stream.length} >>\nstream\n${stream}\nendstream`
+    ])
+  ]
+  let text = '%PDF-1.4\n'
+  const offsets = objects.map((object, i) => {
+    const offset = text.length
+    text += `${i + 1} 0 obj\n${object}\nendobj\n`
+    return offset
+  })
+  const xref = text.length
+  text += `xref\n0 ${objects.length + 1}\n0000000000 65535 f \n`
+  text += offsets.map((offset) => `${String(offset).padStart(10, '0')} 00000 n \n`).join('')
+  text += `trailer\n<< /Size ${objects.length + 1} /Root 1 0 R /Info 4 0 R >>\nstartxref\n${xref}\n%%EOF\n`
+  return new TextEncoder().encode(text)
+}
+
+it('extracts and completes a real PDF using PDF.js font geometry and text joining', async () => {
+  const { lookup } = setup()
+  const realPdf = await import('pdfjs-dist/legacy/build/pdf.mjs')
+  pdf.getDocument.mockImplementation(realPdf.getDocument)
+  const file = new File([publicationPdf()], 'article.pdf', { type: 'application/pdf' })
+  const local = await extractLiteraturePdfDraft(file, fallback)
+  expect(local.identifiers).toEqual([{ scheme: 'doi', value: doi, isPrimary: true }])
+  expect((await completeLiteraturePdfDraft(local)).title).toBe(title)
+  expect(lookup).toHaveBeenCalledExactlyOnceWith(doi)
+})

--- a/src/renderer/src/pages/literature/literature-pdf-metadata.ts
+++ b/src/renderer/src/pages/literature/literature-pdf-metadata.ts
@@ -4,11 +4,32 @@ import {
   type LiteratureCreatorInput,
   type LiteratureItemInput
 } from '../../../../shared/literature'
-import { joinPdfTextItems } from '../../../../shared/pdf-text'
+import { joinPdfTextItems, type PdfTextItem } from '../../../../shared/pdf-text'
 
 const MAX_LOCAL_PDF_METADATA_BYTES = 50 * 1024 * 1024
 const DOI_PATTERN = /\b10\.\d{4,9}\/[-._;()/:A-Z0-9]+/giu
 const PMID_PATTERN = /\b(?:PMID|PubMed\s+ID)\s*:?\s*(\d{6,9})\b/iu
+
+// A terminal publication block is stronger evidence than a DOI somewhere in References.
+const PUBLICATION_DOI_PATTERN =
+  /(?:^|\n)Accepted[^\n]*\b\d{4}\s*\nPublished[^\n]*\b\d{4}\s*\n(?:https?:\/\/(?:dx\.)?doi\.org\/|doi:\s*)?(10\.\d{4,9}\/[-._;()/:A-Z0-9]+)\s*$/iu
+
+const comparableTitle = (text: string): string =>
+  text
+    .normalize('NFKC')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]/gu, '')
+
+const prominentPdfTitle = (items: readonly PdfTextItem[]): string => {
+  const height = (item: PdfTextItem): number =>
+    item.height ?? (item.transform ? Math.hypot(item.transform[2], item.transform[3]) : 0)
+  const textItems = items.filter((item) => item.str?.trim())
+  const largest = textItems.reduce((max, item) => Math.max(max, height(item)), 0)
+  if (!largest) return ''
+  return comparableTitle(
+    joinPdfTextItems(textItems.filter((item) => Math.abs(height(item) - largest) < 0.1))
+  )
+}
 
 const DOI_CACHE_SIZE = 32
 const DOI_CACHE_MS = 5 * 60_000
@@ -131,17 +152,54 @@ const extractLiteraturePdfDraft = async (
   try {
     const { info } = await document.getMetadata()
     const pageTexts: string[] = []
+    let firstPageTitle = ''
     for (let pageNumber = 1; pageNumber <= Math.min(2, document.numPages); pageNumber += 1) {
       const page = await document.getPage(pageNumber)
       const content = await page.getTextContent()
       page.cleanup()
-      pageTexts.push(joinPdfTextItems(content.items.map((item) => ('str' in item ? item : {}))))
+      const items = content.items.map((item) => ('str' in item ? item : {}))
+      if (pageNumber === 1) firstPageTitle = prominentPdfTitle(items)
+      pageTexts.push(joinPdfTextItems(items))
     }
     const extracted = parseLiteraturePdfMetadata(
       info as Record<string, unknown>,
       pageTexts.join('\n').slice(0, 30_000)
     )
-    return { ...fallback, ...extracted }
+    const draft = { ...fallback, ...extracted }
+    if (!draft.identifiers.some(({ scheme }) => scheme === 'doi') && document.numPages > 2) {
+      try {
+        const page = await document.getPage(document.numPages)
+        let text: string
+        try {
+          const content = await page.getTextContent()
+          text = joinPdfTextItems(content.items.map((item) => ('str' in item ? item : {}))).slice(
+            -4_000
+          )
+        } finally {
+          page.cleanup()
+        }
+        const doi = PUBLICATION_DOI_PATTERN.exec(text)?.[1]
+        if (doi && firstPageTitle.length >= 20) {
+          const normalized = normalizeLiteratureIdentifierValue('doi', doi)
+          const resolved = await lookupPdfDoi(normalized)
+          // A valid DOI may belong to a cited paper. Require the complete prominent title,
+          // not the embedded Title, a substring in the abstract, or a fuzzy title match.
+          if (comparableTitle(resolved.title) === firstPageTitle) {
+            return {
+              ...draft,
+              url: createLiteratureIdentifierUrl('doi', normalized) ?? '',
+              identifiers: [
+                { scheme: 'doi', value: normalized, isPrimary: true },
+                ...draft.identifiers.map((identifier) => ({ ...identifier, isPrimary: false }))
+              ]
+            }
+          }
+        }
+      } catch {
+        // Optional tail parsing or lookup must not discard the local metadata already read.
+      }
+    }
+    return draft
   } finally {
     await document.destroy()
   }


### PR DESCRIPTION
## Problem

PDF import only inspects the first two pages. A Science Advances PDF with generic embedded metadata and its article DOI after the publication dates on the final page therefore never reaches metadata lookup.

## Proposed change

When the initial draft has no DOI, inspect only the final page for a terminal Accepted/Published/DOI block. Adopt its DOI only when the existing lookup returns a title exactly matching the normalized largest-font text on the first page. Reuse the existing lookup cache. Missing, ambiguous, mismatched, unreadable, and offline cases preserve the local draft.

## Scope and non-goals

- Shared single/batch import extraction only; existing first-two-page DOI behavior is unchanged.
- No API, fields, enums, schema, migrations, dependencies, historical backfill, or new UI steps. Existing user-confirmed saves persist the resulting metadata in existing fields.
- Filename PMID lookup and generic PDF title/date inference are separate work.
- Deliberately conservative: mixed title font sizes, a larger logo/heading, or other publication-block layouts can prevent the fallback. This is not a general guarantee of correct attribution for existing front-page DOI extraction.

## Acceptance criteria and validation

Checks below ran after the last material edit; independent review confirmed this impact mapping:

| Behavior | Check | Result |
| --- | --- | --- |
| Candidate validation, title matching, cleanup, PMID preservation, real PDF.js geometry, existing parser and lookup cache | `npx vitest run src/renderer/src/pages/literature/literature-pdf-extraction.test.ts src/renderer/src/pages/literature/literature-pdf-metadata.test.ts src/renderer/src/pages/literature/literature-pdf-completion.test.ts` | 19 tests passed in final combined run |
| Single and batch import consumers | Same final invocation also included `LiteratureLibraryPage.render.test.tsx` and `LiteraturePdfBatchImportDialog.test.tsx` | Final combined run: 341 passed, 1 existing project-batch test timed out at 15s; isolated rerun passed in 2.02s. A preceding run timed out on a different existing Duplicates-row test; its isolated rerun passed in 1.95s. No timeout thresholds changed. All 342 selected tests have passing final-state evidence. |
| Renderer types | `npm run typecheck:web` | Passed |
| Repository lint | `npm run lint` | Passed |
| Web build | `npm run build:web` | Passed; existing chunk-size warnings |
| Supplied PDF through real authenticated Web import and live metadata lookup | Isolated test instance, installed Chrome, actual file | Correct title, Science Advances, 13 authors, DOI 10.1126/sciadv.adq9111; screenshots captured locally |

The original PDF and captured live response are local diagnostic inputs, not committed. The permanent synthetic PDF test is generated from minimal original text and exercises production PDF.js. No full local `npm test`, as requested by the maintainer. Backend, migration, and OS-specific local lanes are excluded because their implementations/contracts are unchanged; PR CI remains authoritative. Two local suite timeouts above are an uncovered performance/flakiness risk, not hidden as full-suite passes.

## Review focus

Check that the fallback cannot adopt an ordinary reference DOI merely because it resolves, that exact title matching fails conservatively, and that optional tail failures retain the original draft. Existing front-page identification and provider date selection are intentionally unchanged.

### Final PR CI evidence

All selected PR checks passed for head `d389c9ab17a5db3d1f6238a88e9faaad93d6b558`, including all three Ubuntu full-suite shards, module/coverage aggregation, macOS and Windows E2E, static checks, and CodeQL. Automated Codex review reported **No actionable findings**.

The initial Ubuntu shard 3 run timed out after 30 seconds in the unchanged Notebook test `cancels and drains queued shell work before Session shutdown completes` (`src/main/notebook/runtime-service.test.ts`). The exact test passed locally on this head in 414 ms. Rerunning only that CI shard and its dependent aggregation passed without code or timeout changes. The first failure is retained here as flakiness evidence.
