### PR TITLE
ci(build): parallelize verification and fix release regressions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -205,6 +205,8 @@ jobs:
       - name: Test macOS native behavior and release regressions
         run: >-
           npx vitest run
+          src/main/windows.test.ts
+          packages/notebook-network-sandbox/src/filesystem-policy.test.ts
           packages/notebook-network-sandbox/src/filesystem-enforcement.integration.test.ts
           packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts
           src/main/net/network-info.test.ts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,10 @@ on:
           notarization in isolation; release/nightly leave it false so builds stay gated on tests.
         type: boolean
         default: false
+      verify_only:
+        description: Run verification without packaging, signing, or publication.
+        type: boolean
+        default: false
       platform_name:
         description: >-
           If set, emit only this matrix name (macos-arm64, macos-x64, linux-x64, or windows-x64).
@@ -38,14 +42,14 @@ on:
         type: string
         default: ''
 jobs:
-  # Run the quality suite once on Apple Silicon beside the native package matrix. The reusable
+  # Run static checks beside sharded portable tests and the native package matrix. The reusable
   # workflow still fails when this job fails, so every caller's publish boundary remains fail closed
   # without putting the full verification duration on the matrix's critical path.
   verify:
-    name: Verify (lint + typecheck + test + package)
+    name: Verify static checks and CLI package
     # Skipped by the notarization dry-run (skip_verify), which only needs a signed mac build.
     if: ${{ !inputs.skip_verify }}
-    runs-on: macos-14
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -70,16 +74,156 @@ jobs:
           NODE_OPTIONS: --max-old-space-size=4096
         run: npm run typecheck
 
-      - name: Test (with coverage)
-        run: npm run test:coverage
+      - name: Check translation catalogs
+        run: npx vitest run src/renderer/src/i18n/resources.test.ts
 
       - name: Check CLI package
         run: npm run check:cli-package
+
+  verify_tests:
+    name: Full portable tests (Ubuntu, shard ${{ matrix.shard }}/3)
+    if: ${{ !inputs.skip_verify }}
+    runs-on: ubuntu-latest
+    env:
+      VITEST_DEFER_COVERAGE_THRESHOLDS: '1'
+      VITEST_PORTABLE_CI: '1'
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: node scripts/ci/npm-ci.mjs
+      - name: Test complete suite shard
+        id: verify_shard
+        continue-on-error: true
+        # The static lane owns i18n; the native lane retains the original macOS sandbox checks.
+        # PR Gate separately verifies real Linux isolation with its required system dependencies.
+        run: >-
+          npx vitest run
+          --coverage
+          --coverage.reporter=text-summary
+          --testTimeout=30000
+          --shard=${{ matrix.shard }}/3
+          --reporter=blob
+          --outputFile=vitest-reports/blob-${{ matrix.shard }}.json
+      - name: Upload full-suite blob report
+        if: ${{ always() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-test-blob-${{ matrix.shard }}
+          path: vitest-reports/
+          overwrite: true
+          retention-days: 7
+          if-no-files-found: error
+      - name: Enforce full-suite shard
+        if: ${{ always() }}
+        shell: bash
+        env:
+          VERIFY_SHARD_OUTCOME: ${{ steps.verify_shard.outcome }}
+        run: |
+          set -euo pipefail
+          failed=0
+          if [[ "$VERIFY_SHARD_OUTCOME" != "success" ]]; then
+            echo "verify_shard ended with $VERIFY_SHARD_OUTCOME" >&2
+            failed=1
+          fi
+          exit "$failed"
+
+  verify_coverage:
+    name: Verify merged coverage
+    needs: verify_tests
+    if: ${{ !cancelled() && !inputs.skip_verify }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: node scripts/ci/npm-ci.mjs
+      - name: Download all test shards
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          pattern: build-test-blob-*
+          path: vitest-reports
+          merge-multiple: true
+      - name: Require complete successful shards
+        env:
+          SHARDS_RESULT: ${{ needs.verify_tests.result }}
+        run: |
+          test "$SHARDS_RESULT" = success
+          for shard in 1 2 3; do
+            test -s "vitest-reports/blob-$shard.json"
+          done
+      - name: Merge test reports and enforce coverage
+        run: npx vitest run --merge-reports=vitest-reports --coverage --passWithNoTests
+      - name: Upload coverage report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: build-coverage-report
+          path: coverage/
+          overwrite: true
+          retention-days: 7
+          if-no-files-found: error
+
+  verify_macos:
+    name: Verify macOS native behavior
+    if: ${{ !inputs.skip_verify }}
+    runs-on: macos-14
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: node scripts/ci/npm-ci.mjs
+      # Keep platform-gated cases that Ubuntu skips, plus regressions from the macOS release run.
+      - name: Test macOS native behavior and release regressions
+        run: >-
+          npx vitest run
+          packages/notebook-network-sandbox/src/filesystem-enforcement.integration.test.ts
+          packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts
+          src/main/net/network-info.test.ts
+          src/main/notebook/managed-runtime-guard.test.ts
+          src/main/notebook/package-cache-sandbox.integration.test.ts
+          src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts
+          src/main/compute/compute-remote-operation-owner.test.ts
+          scripts/ci/mirror-channel-publication.test.ts
+          src/main/literature/catalog-capacity.test.ts
+      - name: Test production macOS kernel sandbox
+        run: >-
+          npx vitest run src/main/notebook/kernel-executor.test.ts
+          -t 'executes the repl loop through the production network sandbox'
 
   # Resolve the platform matrix. mac_only trims it to the two mac archs — used by the notarization
   # dry-run (notarize-dryrun.yml), which only needs a signed mac build. With mac_only false (the
   # release.yml / nightly.yml callers) the full matrix is emitted, so their behavior is unchanged.
   setup:
+    if: ${{ !inputs.verify_only }}
     name: Resolve platform matrix
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,11 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      verify_only:
+        description: Verify tests and coverage without building or publishing packages.
+        type: boolean
+        default: false
 
 # Required to create a Release and upload assets.
 permissions:
@@ -49,11 +54,14 @@ jobs:
   build:
     needs: release-preflight
     uses: ./.github/workflows/build.yml
+    with:
+      verify_only: ${{ github.event_name == 'workflow_dispatch' && inputs.verify_only }}
     secrets: inherit
 
   # Exercise the exact uploaded packages in separate native jobs. A failed matrix leg can be retried
   # against the immutable build artifact without repeating installation, packaging, or signing.
   package-smoke:
+    if: ${{ !inputs.verify_only }}
     needs: build
     uses: ./.github/workflows/package-smoke.yml
 

--- a/scripts/ci/mirror-channel-publication.test.ts
+++ b/scripts/ci/mirror-channel-publication.test.ts
@@ -3,11 +3,12 @@ import { mkdtempSync, mkdirSync, readFileSync, rmSync, symlinkSync, writeFileSyn
 import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { load } from 'js-yaml'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 const feeds = ['latest.yml', 'latest-linux.yml', 'latest-mac.yml', 'arm64-mac.yml', 'x64-mac.yml']
 const roots: string[] = []
 afterEach(() => {
+  vi.unstubAllEnvs()
   for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true })
 })
 
@@ -28,6 +29,8 @@ function fixture(): {
   const channel = join(storage, 'fixture-bucket', 'stable')
   symlinkSync(join(process.cwd(), 'scripts'), join(root, 'scripts'), 'dir')
   mkdirSync(bin)
+  // Pin Node and Bash so runner-installed wrappers cannot replace the fixture PATH.
+  symlinkSync(process.execPath, join(bin, 'node'))
   mkdirSync(channel, { recursive: true })
   mkdirSync(join(root, 'dist-assets'))
   writeFileSync(
@@ -76,11 +79,11 @@ else {
     expect(start).toBeGreaterThanOrEqual(0)
     for (const step of steps.slice(start)) {
       if (!step.run) continue
-      execFileSync('bash', ['-e', '-o', 'pipefail', '-c', step.run], {
+      execFileSync('/bin/bash', ['--noprofile', '--norc', '-e', '-o', 'pipefail', '-c', step.run], {
         cwd: root,
         // Do not inherit host AWS environment or credentials. PATH begins with the only AWS used.
         env: {
-          PATH: `${bin}${delimiter}${process.env.PATH}`,
+          PATH: [bin, '/usr/bin', '/bin'].join(delimiter),
           FIXTURE_STORAGE: storage,
           S3_BUCKET: 'fixture-bucket',
           S3_PREFIX: 'stable',
@@ -97,6 +100,19 @@ else {
 }
 
 describe.skipIf(process.platform === 'win32')('website channel publication', () => {
+  it('ignores runner shell wrappers and uses only the fixture AWS executable', () => {
+    const wrappers = mkdtempSync(join(tmpdir(), 'mirror-runner-wrappers-'))
+    roots.push(wrappers)
+    for (const command of ['bash', 'node', 'aws']) {
+      writeFileSync(join(wrappers, command), '#!/bin/sh\nexit 97\n', { mode: 0o755 })
+    }
+    vi.stubEnv('PATH', `${wrappers}${delimiter}${process.env.PATH}`)
+    const f = fixture()
+    f.stage('2.1.0')
+    f.run('2.1.0', 'promote')
+    expect(JSON.parse(f.snapshot()['version.json']).version).toBe('2.1.0')
+  })
+
   it('preserves newer channel entry bytes when mirroring an older release', () => {
     const f = fixture(),
       before = f.snapshot()

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -449,6 +449,8 @@ describe('build verification throughput', () => {
     expect(macos['runs-on']).toBe('macos-14')
     const native = step(macos, 'Test macOS native behavior and release regressions').run
     for (const path of [
+      'src/main/windows.test.ts',
+      'packages/notebook-network-sandbox/src/filesystem-policy.test.ts',
       'packages/notebook-network-sandbox/src/filesystem-enforcement.integration.test.ts',
       'packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts',
       'src/main/net/network-info.test.ts',

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -424,3 +424,83 @@ describe('website mirror publication intent', () => {
     expect(publication.run).toBe('node scripts/publish-update-channel.mjs')
   })
 })
+
+describe('build verification throughput', () => {
+  it('runs Ubuntu static checks independently from three complete portable shards', () => {
+    const { verify, verify_tests: tests, verify_macos: macos } = workflow('build.yml').jobs
+    expect(verify['runs-on']).toBe('ubuntu-latest')
+    expect(verify.needs).toBeUndefined()
+    expect(tests.needs).toBeUndefined()
+    expect(tests['runs-on']).toBe('ubuntu-latest')
+    expect(tests.strategy?.matrix?.shard).toEqual([1, 2, 3])
+    expect(tests.env).toEqual({
+      VITEST_DEFER_COVERAGE_THRESHOLDS: '1',
+      VITEST_PORTABLE_CI: '1'
+    })
+    expect(step(tests, 'Test complete suite shard').run).toContain('--shard=${{ matrix.shard }}/3')
+    expect(step(tests, 'Test complete suite shard').run).toContain('--coverage')
+    expect(step(tests, 'Enforce full-suite shard').if).toBe('${{ always() }}')
+    expect(step(verify, 'Check translation catalogs').run).toBe(
+      'npx vitest run src/renderer/src/i18n/resources.test.ts'
+    )
+    for (const job of [verify, tests, macos]) {
+      expect(job.if).toBe('${{ !inputs.skip_verify }}')
+    }
+    expect(macos['runs-on']).toBe('macos-14')
+    const native = step(macos, 'Test macOS native behavior and release regressions').run
+    for (const path of [
+      'packages/notebook-network-sandbox/src/filesystem-enforcement.integration.test.ts',
+      'packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts',
+      'src/main/net/network-info.test.ts',
+      'src/main/notebook/managed-runtime-guard.test.ts',
+      'src/main/notebook/package-cache-sandbox.integration.test.ts',
+      'src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts',
+      'src/main/compute/compute-remote-operation-owner.test.ts',
+      'scripts/ci/mirror-channel-publication.test.ts',
+      'src/main/literature/catalog-capacity.test.ts'
+    ])
+      expect(native).toContain(path)
+    expect(step(macos, 'Test production macOS kernel sandbox').run).toContain(
+      'executes the repl loop through the production network sandbox'
+    )
+  })
+
+  it('requires successful shards and all blobs before enforcing aggregate coverage', () => {
+    const job = workflow('build.yml').jobs.verify_coverage
+    expect(job.needs).toBe('verify_tests')
+    expect(job.if).toBe('${{ !cancelled() && !inputs.skip_verify }}')
+    expect(job.env).toBeUndefined()
+    const guard = step(job, 'Require complete successful shards')
+    expect(guard.env).toEqual({ SHARDS_RESULT: '${{ needs.verify_tests.result }}' })
+    expect(guard.run).toContain('test "$SHARDS_RESULT" = success')
+    expect(guard.run).toContain('for shard in 1 2 3')
+    expect(guard.run).toContain('test -s "vitest-reports/blob-$shard.json"')
+    expect(step(job, 'Merge test reports and enforce coverage').run).toBe(
+      'npx vitest run --merge-reports=vitest-reports --coverage --passWithNoTests'
+    )
+    expect(step(job, 'Upload coverage report').with).toMatchObject({
+      overwrite: true,
+      'if-no-files-found': 'error'
+    })
+  })
+
+  it('reuses real verification for a manual release dry-run without packaging or publication', () => {
+    const release = workflow('release.yml')
+    const build = workflow('build.yml')
+    expect(release.on?.workflow_dispatch).toMatchObject({
+      inputs: { verify_only: { type: 'boolean', default: false } }
+    })
+    expect(release.jobs.build.with?.verify_only).toBe(
+      "${{ github.event_name == 'workflow_dispatch' && inputs.verify_only }}"
+    )
+    expect(build.jobs.setup.if).toBe('${{ !inputs.verify_only }}')
+    expect(build.jobs.build.needs).toBe('setup')
+    expect(build.jobs.build.if).toBe("${{ needs.setup.result == 'success' }}")
+    expect(release.jobs['package-smoke'].if).toBe('${{ !inputs.verify_only }}')
+    for (const name of ['publish', 'notarize-mac']) {
+      expect(release.jobs[name].if).toBe(
+        "github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')"
+      )
+    }
+  })
+})

--- a/src/main/literature/catalog-capacity.test.ts
+++ b/src/main/literature/catalog-capacity.test.ts
@@ -71,3 +71,47 @@ it('allows a small catalog write while a large library search is running', async
     await rm(root, { recursive: true, force: true })
   }
 }, 120000)
+
+it.each([false, true])(
+  'waits for a valid read transaction before writing (notifications: %s)',
+  async (notify) => {
+    const root = await mkdtemp(join(tmpdir(), 'literature-transaction-wait-'))
+    const client = createProjectDbClient(root)
+    try {
+      await migrateApplicationDatabase(client)
+      const events: unknown[] = []
+      const catalog = new LiteratureCatalog(
+        async () => client,
+        undefined,
+        undefined,
+        undefined,
+        notify ? (event) => events.push(event) : undefined
+      )
+      let ready!: () => void
+      const started = new Promise<void>((resolve) => {
+        ready = resolve
+      })
+      // Match the single-connection search: a valid read may outlast Prisma's 2s acquire default.
+      const read = client.$transaction(
+        async (transaction) => {
+          await transaction.$queryRaw`SELECT 1`
+          ready()
+          await new Promise((resolve) => setTimeout(resolve, 2500))
+        },
+        { timeout: 30_000 }
+      )
+      await started
+      const write = catalog.transact({
+        kind: 'create-item',
+        item: literatureItemInputSchema.parse({ itemType: 'book', title: 'Queued reference' })
+      })
+      const results = await Promise.allSettled([read, write])
+      expect(results.map(({ status }) => status)).toEqual(['fulfilled', 'fulfilled'])
+      expect(await client.literatureItem.count()).toBe(1)
+      expect(events).toHaveLength(notify ? 1 : 0)
+    } finally {
+      await client.$disconnect()
+      await rm(root, { recursive: true, force: true })
+    }
+  }
+)

--- a/src/main/literature/catalog.ts
+++ b/src/main/literature/catalog.ts
@@ -829,7 +829,10 @@ class LiteratureCatalog {
       | ((result: T) => Omit<LiteratureChangedEvent, 'revision'>),
     options?: { timeout: number }
   ): Promise<T> {
-    if (!this.onChanged) return client.$transaction(operation, options)
+    // A library search may hold the single SQLite connection for up to 30 seconds.
+    // Acquisition must not fail at Prisma's 2s default while that valid read is still running.
+    const transactionOptions = { maxWait: 30_000, ...options }
+    if (!this.onChanged) return client.$transaction(operation, transactionOptions)
     const committed = await client.$transaction(async (transaction) => {
       const count = async (): Promise<bigint> =>
         (
@@ -838,7 +841,7 @@ class LiteratureCatalog {
       const before = await count()
       const result = await operation(transaction)
       return { result, changed: (await count()) !== before }
-    }, options)
+    }, transactionOptions)
     if (committed.changed) {
       duplicateGroups.delete(client)
       this.publishChanged(typeof changes === 'function' ? changes(committed.result) : changes)

--- a/src/main/settings/backend-route-planner.architecture.test.ts
+++ b/src/main/settings/backend-route-planner.architecture.test.ts
@@ -41,6 +41,8 @@ const portablePath = (path: string): string => relative(projectRoot, path).repla
 const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsPlanner = (path: string): boolean => {
+  // The AST predicate below requires this literal module name; skip unrelated files before parsing.
+  if (!readSource(path).includes('backend-route-planner')) return false
   let imports = false
   const sourceFile = sourceFileFor(path)
   const visit = (node: Node): void => {

--- a/src/main/settings/backend-selection-owner.architecture.test.ts
+++ b/src/main/settings/backend-selection-owner.architecture.test.ts
@@ -41,6 +41,8 @@ const portablePath = (path: string): string => relative(projectRoot, path).repla
 const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
+  // The AST predicate below requires this literal module name; skip unrelated files before parsing.
+  if (!readSource(path).includes('backend-selection-owner')) return false
   let imports = false
   const sourceFile = sourceFileFor(path)
   const visit = (node: Node): void => {

--- a/src/main/settings/provider-auth-lifecycle.architecture.test.ts
+++ b/src/main/settings/provider-auth-lifecycle.architecture.test.ts
@@ -41,6 +41,8 @@ const portablePath = (path: string): string => relative(projectRoot, path).repla
 const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
+  // The AST predicate below requires this literal module name; skip unrelated files before parsing.
+  if (!readSource(path).includes('provider-auth-lifecycle')) return false
   let imports = false
   const sourceFile = sourceFileFor(path)
   const visit = (node: Node): void => {

--- a/src/main/settings/provider-runtime-projection.architecture.test.ts
+++ b/src/main/settings/provider-runtime-projection.architecture.test.ts
@@ -41,6 +41,8 @@ const portablePath = (path: string): string => relative(projectRoot, path).repla
 const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
+  // The AST predicate below requires this literal module name; skip unrelated files before parsing.
+  if (!readSource(path).includes('provider-runtime-projection')) return false
   let imports = false
   const sourceFile = sourceFileFor(path)
   const visit = (node: Node): void => {

--- a/src/main/settings/provider-transport-owner.architecture.test.ts
+++ b/src/main/settings/provider-transport-owner.architecture.test.ts
@@ -40,6 +40,8 @@ const sourceFileFor = (path: string): SourceFile =>
 const productionSources = (): readonly string[] => listProductionSources(projectRoot)
 
 const importsOwner = (path: string): boolean => {
+  // The AST predicate below requires this literal module name; skip unrelated files before parsing.
+  if (!readSource(path).includes('provider-transport-owner')) return false
   let imports = false
   const sourceFile = sourceFileFor(path)
   const visit = (node: Node): void => {

--- a/src/main/storage-root-routing.architecture.test.ts
+++ b/src/main/storage-root-routing.architecture.test.ts
@@ -17,9 +17,12 @@ const projectRoot = resolve(__dirname, '../..')
 const source = (path: string): string => readFileSync(resolve(projectRoot, path), 'utf8')
 
 const referencesIdentifier = (path: string, name: string): boolean => {
+  const contents = readFileSync(path, 'utf8')
+  // Escaped identifiers still require parsing even when the literal name is absent.
+  if (!contents.includes(name) && !contents.includes('\\')) return false
   const file = createSourceFile(
     path,
-    readFileSync(path, 'utf8'),
+    contents,
     ScriptTarget.Latest,
     true,
     path.endsWith('.tsx') ? ScriptKind.TSX : ScriptKind.TS


### PR DESCRIPTION
## Problem

Release dispatch [34433164916](https://github.com/aipoch/open-science/actions/runs/34433164916) finished all four native builds but failed verification after 47 minutes. Its predecessor spent 39m21s in one macOS coverage step. The failed run exposed a host-dependent publication fixture, valid-read/write acquisition contention, and repeated whole-tree AST parsing timeouts.

## Proposed change

- Run complete portable coverage in three Ubuntu shards alongside Ubuntu schema/lint/type/CLI checks. Run i18n guards without coverage instrumentation. Merge blobs and enforce the existing aggregate coverage thresholds only after all three shards succeed and their reports exist.
- Retain focused macOS native sandbox, network, kernel and platform-gated tests, plus the publication/capacity regressions. Linux sandbox certification remains in PR Gate. Keep packaging concurrent and publication dependent on the entire reusable Build result.
- Add `Release > verify_only` for a focused dispatch of these exact jobs without packaging, signing, notarization or publication. Normal release and existing signing dry-run defaults are unchanged.
- Pin fixture Bash/Node and constrain its PATH so runner wrappers cannot bypass fake AWS. Prefilter impossible architecture matches before the original AST predicates. Give literature writes a 30s connection-acquisition budget matching the valid search transaction budget; keep transaction execution timeouts and commit/notification behavior.

The approach follows [Vitest's CI](https://github.com/vitest-dev/vitest/blob/main/.github/workflows/ci.yml): Linux main verification with separately scoped platform checks and parallel heavy suites.

## Scope and non-goals

No schema, persisted-format, historical-data migration, application enum/state or UI changes. The only runtime change is bounded literature write acquisition waiting; no retry or new queue. CI stores short-lived blob/coverage artifacts and adds a boolean manual input. No package publication is requested by the verification dry-run. No test assertions, coverage thresholds, or platform packaging checks are removed.

## Acceptance criteria and validation

Local checks below ran after the relevant final material edits; the maintainer explicitly requested no complete local npm test. The final dependency-aware explain selects full CI because scripts/ci is a global input.

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Workflow routing, shard gates, fixture isolation, Vitest config, architecture guards, literature owner/consumer paths | Targeted Vitest run: release-workflows, mirror-channel-publication, check-ci-integrity, vitest.config, architecture-source-index, six changed architecture suites, catalog-capacity, library-tool-contracts, batch-jobs, pdf-attachment-reliability | 15 files / 192 tests passed |
| Catalog writes, acquire waiting and notification paths | `npm test -- src/main/literature/catalog-capacity.test.ts src/main/literature/catalog.test.ts` | 126 tests passed; both new acquire-wait cases failed before the fix |
| Translation guards | `npm test -- src/renderer/src/i18n/resources.test.ts` | 804 passed |
| Types and lint | `npm run typecheck:node`; `npm run lint` | Passed |
| CI integrity | `node scripts/ci/check-ci-integrity.mjs --base d1b3a184e5220872d0917065ab7741226d3f86b1 --head <head>` | Passed, no violations |
| Real blob generation/merge | Three explicit shared-test files sharded 1/3–3/3 and merged with V8 coverage | 55 tests, three blobs and merged coverage summary; sample thresholds deferred, full thresholds remain CI-authoritative |

Negative probe: all six architecture guards reject injected forbidden consumers; probe removed before final tests. The six-suite coverage benchmark fell from 45.68s to 13.20s wall time (test execution 36.03s to 3.77s), with identical 17 assertions. This is a local scan benchmark, not a claimed whole-workflow speedup.

The publication fixture fix was additionally applied to an isolated checkout of the original failed release SHA 7ad84e21: all 10 publication tests passed, including the new wrapper regression that failed before fixing isolation. This PR does not import that separate release branch's other changes.

## Review focus

Check platform test selection, missing/failed shard handling, `skip_verify`/`verify_only` behavior and publication dependencies. Review the bounded runtime acquisition wait separately from CI-only changes. The focused Release verification run and independent review passed on 9110f9e. Final-head PR Gate and independent review passed after adding two native test selections; total compute cost has not been measured. No Windows/macOS lane is claimed locally verified beyond the explicit checks above.


### Remote verification and final platform coverage

[Focused Release run 34437395619](https://github.com/aipoch/open-science/actions/runs/34437395619) passed on 9110f9e: static checks 6m04s, macOS native 2m34s, Ubuntu shards 10m49s / 12m33s / 14m39s, coverage merge 1m55s. Total verification wall time was **16m38s**, versus **47m02s** in successful baseline 34359554641 (about 65% lower). Coverage thresholds passed; packaging/publication were skipped. This measures verification, not total release duration or runner-minute savings.

Final commit 3ffd025 only adds `src/main/windows.test.ts` and `packages/notebook-network-sandbox/src/filesystem-policy.test.ts` to the macOS step and its contract, preserving native Cmd shortcut and zsh checks as well as explicit Darwin-gated tests. Final affected check: `npm test -- scripts/ci/release-workflows.test.ts src/main/windows.test.ts packages/notebook-network-sandbox/src/filesystem-policy.test.ts` — 103 passed on macOS; formatting, diff checks and CI integrity passed. One restricted local attempt could not bind the fixture Unix socket; the scoped host run passed without code changes. Prior runtime/scan evidence applies unchanged; the performance run predates only these two additional native selections. Final-head PR Gate passed and remains the authoritative complete-suite result.


### Final gate and independent review

Final head: `3ffd0254c266cb5c7e14e3792d420f26430251b8`. [PR Gate run 34438620980](https://github.com/aipoch/open-science/actions/runs/34438620980) passed its required gate, all portable shards and merged coverage, both macOS E2E groups, all three Windows E2E shards, Windows core, Linux isolation, static checks and policy. [Independent Codex review](https://github.com/aipoch/open-science/actions/runs/34438619535) reports **mergeable, no actionable findings** on this exact head. The evidence mapping covers the final runtime change and the final four-line platform-test selection refinement; no complete local suite or full publishing release was run.
