### PR TITLE
feat(acp): offer tested managed Codex upgrades

### DIFF
--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -1,11 +1,11 @@
 import { execFileSync, type ChildProcessWithoutNullStreams } from 'node:child_process'
-import { once } from 'node:events'
+import { once, EventEmitter } from 'node:events'
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   CODEX_BRIDGE_MODEL,
@@ -19,7 +19,8 @@ import { terminateProcessTree } from '../process-tree'
 import { CODEX_VERSION } from '../settings/managed-codex'
 import { CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../shared/settings'
 
-const fakeChild = {} as ChildProcessWithoutNullStreams
+const fakeChild = new EventEmitter() as ChildProcessWithoutNullStreams
+afterEach(() => fakeChild.emit('close', 0))
 
 describe('codexFramework', () => {
   it('offers the scoped Skill loader and recovery guidance without enabling shell', () => {
@@ -470,33 +471,36 @@ describe('codexFramework', () => {
     })
   })
 
-  it('keeps Codex bundled model metadata for a trusted official OpenAI model', () => {
-    const framework = createCodexFramework()
-    const config = framework.prepareModelConfig(
-      {
-        type: 'official',
-        vendorId: 'openai',
-        apiEndpoints: ['responses'],
-        baseUrl: 'https://gateway.example/v1',
-        model: 'gpt-5.4',
-        key: 'sk-plaintext-secret'
-      },
-      {
-        storageRoot: '/data',
-        executablePath: '/runtime/codex-acp',
-        nativeVersion: CODEX_VERSION
-      }
-    )
+  it.each(['gpt-5.4', 'gpt-6-astra'])(
+    'keeps bundled metadata for trusted official model %s',
+    (model) => {
+      const framework = createCodexFramework()
+      const config = framework.prepareModelConfig(
+        {
+          type: 'official',
+          vendorId: 'openai',
+          apiEndpoints: ['responses'],
+          baseUrl: 'https://gateway.example/v1',
+          model,
+          key: 'sk-plaintext-secret'
+        },
+        {
+          storageRoot: '/data',
+          executablePath: '/runtime/codex-acp',
+          nativeVersion: CODEX_VERSION
+        }
+      )
 
-    expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).not.toHaveProperty('model_catalog_json')
-    expect(config.configFiles).toEqual([
-      {
-        path: join('/data', 'codex', 'config.toml'),
-        content: 'cli_auth_credentials_store = "ephemeral"\n',
-        mode: 0o600
-      }
-    ])
-  })
+      expect(JSON.parse(config.env?.CODEX_CONFIG ?? '')).not.toHaveProperty('model_catalog_json')
+      expect(config.configFiles).toEqual([
+        {
+          path: join('/data', 'codex', 'config.toml'),
+          content: 'cli_auth_credentials_store = "ephemeral"\n',
+          mode: 0o600
+        }
+      ])
+    }
+  )
 
   it('keeps the native catalog when an unbundled official model is only a sibling option', () => {
     const framework = createCodexFramework()
@@ -536,7 +540,7 @@ describe('codexFramework', () => {
       {
         storageRoot: '/data',
         executablePath: '/runtime/codex-acp',
-        nativeVersion: CODEX_VERSION,
+        nativeVersion: '0.144.6',
         reasoningEffort: 'max',
         reasoningEfforts: ['low', 'medium', 'high', 'xhigh', 'max']
       }

--- a/src/main/agent-framework/codex.test.ts
+++ b/src/main/agent-framework/codex.test.ts
@@ -20,7 +20,9 @@ import { CODEX_VERSION } from '../settings/managed-codex'
 import { CODEX_SUBSCRIPTION_PROVIDER_ID } from '../../shared/settings'
 
 const fakeChild = new EventEmitter() as ChildProcessWithoutNullStreams
-afterEach(() => fakeChild.emit('close', 0))
+afterEach(async () => {
+  await terminateProcessTree(fakeChild)
+})
 
 describe('codexFramework', () => {
   it('offers the scoped Skill loader and recovery guidance without enabling shell', () => {

--- a/src/main/agent-framework/codex.ts
+++ b/src/main/agent-framework/codex.ts
@@ -32,7 +32,7 @@ import { isProductionDelegatedWorkFramework } from '../delegation/production-rea
 import { CODEX_SUBSCRIPTION_PROVIDER_ID, isCodexSubscriptionProvider } from '../../shared/settings'
 import { prepareCodexRuntimeHomeAuthentication } from '../settings/codex-auth'
 import { codexStorageDir, codexSubscriptionStorageDir } from '../settings/codex-paths'
-import { CODEX_VERSION } from '../settings/managed-codex'
+import { CODEX_VERSION, spawnCodexWithInstallAdmission } from '../settings/managed-codex'
 import { clearSystemProxyEnvironment } from '../settings/system-proxy'
 import { registerOwnedPosixProcessGroup } from '../process-tree'
 import codexNativeModelInstructions from './codex-native-model-instructions.md?raw'
@@ -55,6 +55,7 @@ export const CODEX_BRIDGE_MODEL = 'gpt-5.4'
 const CODEX_EFFECTIVE_CONTEXT_WINDOW_PERCENT = 95
 const CODEX_NATIVE_MODEL_CATALOG_FILENAME_PREFIX = 'model-catalog-'
 const CODEX_BUNDLED_MODEL_IDS_BY_VERSION = {
+  // Existing installations keep their verified catalog until the user explicitly updates.
   '0.144.6': [
     'gpt-5.6-sol',
     'gpt-5.6-terra',
@@ -64,8 +65,21 @@ const CODEX_BUNDLED_MODEL_IDS_BY_VERSION = {
     'gpt-5.4-mini',
     'gpt-5.2',
     'codex-auto-review'
+  ],
+  [CODEX_VERSION]: [
+    'gpt-6-astra',
+    'gpt-daybreak-blue-latest',
+    'gpt-daybreak-red-latest',
+    'gpt-5.6-sol',
+    'gpt-5.6-terra',
+    'gpt-5.6-luna',
+    'gpt-5.5',
+    'gpt-5.4',
+    'gpt-5.4-mini',
+    'gpt-5.2',
+    'codex-auto-review'
   ]
-} satisfies Record<typeof CODEX_VERSION, readonly string[]>
+} satisfies Record<string, readonly string[]>
 const CODEX_MODE_IDS = {
   ask: 'read-only',
   auto: 'agent',
@@ -428,18 +442,22 @@ export const createCodexFramework = ({
         : input.executablePath
     const args = isJavaScript ? [input.executablePath, ...input.args] : input.args
 
-    const child = spawnProcess(command, args, {
-      env: buildSpawnEnvironment(input, sourceEnv),
-      stdio: 'pipe',
-      // Keep a terminal/dev-runner SIGINT aimed at the Electron application's foreground process
-      // group from killing Codex before the app's awaited ACP teardown can mark and reap it. Piped
-      // stdio remains referenced (we never unref the child), and the resource owner still performs
-      // explicit cross-platform tree teardown. Node's detached process-group behavior is POSIX-only;
-      // creating an independent Windows console/process group here would change packaged startup.
-      detached: platform !== 'win32',
-      windowsHide: true,
-      shell: needsShell
-    })
+    const child = spawnCodexWithInstallAdmission(
+      [input.executablePath, ...(input.env.CODEX_PATH ? [input.env.CODEX_PATH] : [])],
+      () =>
+        spawnProcess(command, args, {
+          env: buildSpawnEnvironment(input, sourceEnv),
+          stdio: 'pipe',
+          // Keep a terminal/dev-runner SIGINT aimed at the Electron application's foreground process
+          // group from killing Codex before the app's awaited ACP teardown can mark and reap it. Piped
+          // stdio remains referenced (we never unref the child), and the resource owner still performs
+          // explicit cross-platform tree teardown. Node's detached process-group behavior is POSIX-only;
+          // creating an independent Windows console/process group here would change packaged startup.
+          detached: platform !== 'win32',
+          windowsHide: true,
+          shell: needsShell
+        })
+    )
     if (platform !== 'win32') registerOwnedPosixProcessGroup(child)
     return child
   },

--- a/src/main/delegation/codex-execution.test.ts
+++ b/src/main/delegation/codex-execution.test.ts
@@ -1,5 +1,6 @@
 import type { PromptResponse } from '@agentclientprotocol/sdk'
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import * as processTree from '../process-tree'
 import { describe, expect, it, vi } from 'vitest'
 
 import type { AcpPermissionResponse } from '../../shared/acp'
@@ -52,7 +53,10 @@ type CertificationHarness = Readonly<{
   runtimeConnections: AcpDelegateRuntime[]
 }>
 
-const makeCertificationAdapter = (capacity = 4): CertificationHarness => {
+const makeCertificationAdapter = (
+  capacity = 4,
+  failure?: 'throw' | 'reuse'
+): CertificationHarness => {
   const controls = new Map<string, RuntimeControl>()
   const inputs: DelegateExecutionInput[] = []
   const scopes: PreparedCodexDelegateExecution[] = []
@@ -102,6 +106,8 @@ const makeCertificationAdapter = (capacity = 4): CertificationHarness => {
     },
     createRuntime(scope, callbacks, agentProcess): AcpDelegateRuntime {
       agentProcesses.push(agentProcess)
+      if (failure === 'throw') throw new Error('runtime construction failed')
+      if (failure === 'reuse' && runtimeConnections[0]) return runtimeConnections[0]
       const prompt = deferred<PromptResponse>()
       const prompts: string[] = []
       const responses: AcpPermissionResponse[] = []
@@ -231,6 +237,40 @@ delegatedWorkCertificationContract((options) => {
 })
 
 describe('Codex delegated-work isolation evidence', () => {
+  it.each(['throw', 'reuse'] as const)(
+    'reaps the process tree after %s construction failure',
+    async (failure) => {
+      const reap = vi.spyOn(processTree, 'terminateProcessTree').mockResolvedValue({ reaped: true })
+      try {
+        const { adapter, driver, agentProcesses } = makeCertificationAdapter(2, failure)
+        const reservation = await adapter.execution.reserve(2)
+        const run = (index: number): ReturnType<typeof adapter.execution.run> =>
+          adapter.execution.run(
+            {
+              session: { projectId: 'project', sessionId: 'session' },
+              frameId: `frame-${index}`,
+              attemptId: `attempt-${index}`,
+              runtimeSegmentId: `segment-${index}`,
+              task: 'task',
+              inputs: [],
+              continuation: false
+            },
+            reservation.slotIds[index]
+          )
+        run(0)
+        if (failure === 'reuse') {
+          await driver.waitForStart('attempt-0')
+          run(1)
+        }
+        await vi.waitFor(() => expect(reap).toHaveBeenCalledOnce())
+        expect(reap).toHaveBeenCalledWith(agentProcesses.at(-1))
+        if (failure === 'reuse') await driver.complete('attempt-0', 'done')
+      } finally {
+        reap.mockRestore()
+      }
+    }
+  )
+
   it('rejects uncertified runtimes and unavailable providers before durable admission', async () => {
     for (const candidate of [
       {

--- a/src/main/delegation/codex-execution.test.ts
+++ b/src/main/delegation/codex-execution.test.ts
@@ -193,26 +193,32 @@ const makeCertificationAdapter = (capacity = 4): CertificationHarness => {
 }
 
 describe('Codex delegated-work production adapter', () => {
-  it('audits the pinned runtime and fails closed for an unreviewed runtime pair', () => {
-    expect(
-      getCodexNativeDelegationAudit({
-        nativeVersion: CODEX_VERSION,
-        adapterVersion: CODEX_ACP_VERSION
-      })
-    ).toEqual([
-      { entryPoint: 'task', status: 'not-present' },
-      { entryPoint: 'agent', status: 'not-present' },
-      { entryPoint: 'multi-agent', status: 'disabled' }
-    ])
+  it.each([CODEX_VERSION, '0.144.6'])(
+    'audits reviewed runtime %s and fails closed for an unreviewed pair',
+    (nativeVersion) => {
+      expect(
+        getCodexNativeDelegationAudit({
+          nativeVersion,
+          adapterVersion: CODEX_ACP_VERSION
+        })
+      ).toEqual([
+        { entryPoint: 'task', status: 'not-present' },
+        { entryPoint: 'agent', status: 'not-present' },
+        { entryPoint: 'multi-agent', status: 'disabled' }
+      ])
 
-    expect(
-      getCodexNativeDelegationAudit({ nativeVersion: 'future', adapterVersion: CODEX_ACP_VERSION })
-    ).toEqual([
-      { entryPoint: 'task', status: 'unknown' },
-      { entryPoint: 'agent', status: 'unknown' },
-      { entryPoint: 'multi-agent', status: 'unknown' }
-    ])
-  })
+      expect(
+        getCodexNativeDelegationAudit({
+          nativeVersion: 'future',
+          adapterVersion: CODEX_ACP_VERSION
+        })
+      ).toEqual([
+        { entryPoint: 'task', status: 'unknown' },
+        { entryPoint: 'agent', status: 'unknown' },
+        { entryPoint: 'multi-agent', status: 'unknown' }
+      ])
+    }
+  )
 })
 
 delegatedWorkCertificationContract((options) => {

--- a/src/main/delegation/codex-execution.ts
+++ b/src/main/delegation/codex-execution.ts
@@ -1,5 +1,6 @@
 import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 
+import { terminateProcessTree } from '../process-tree'
 import { codexFramework } from '../agent-framework/codex'
 import type { AgentFramework, AgentSpawnInput } from '../agent-framework/types'
 import { CODEX_ACP_VERSION, CODEX_VERSION } from '../settings/managed-codex'
@@ -149,11 +150,11 @@ const createCodexDelegateExecution = (
       try {
         runtime = options.createRuntime(codexScope, callbacks, agentProcess)
       } catch (error) {
-        agentProcess.kill()
+        void terminateProcessTree(agentProcess)
         throw error
       }
       if (issuedRuntimes.has(runtime)) {
-        agentProcess.kill()
+        void terminateProcessTree(agentProcess)
         throw new Error('Codex delegated execution requires an independent runtime connection.')
       }
       issuedRuntimes.add(runtime)

--- a/src/main/delegation/codex-execution.ts
+++ b/src/main/delegation/codex-execution.ts
@@ -55,14 +55,16 @@ type CodexDelegateExecution = Readonly<{
 }>
 
 /**
- * Native entry-point evidence is intentionally pinned to the exact reviewed Codex/codex-acp pair.
+ * Native entry-point evidence is pinned to reviewed Codex/codex-acp pairs. Keep the previously
+ * reviewed CLI usable while the managed upgrade remains optional.
  * Upgrades fail closed until their tool inventory and feature switches are audited again.
  */
 const getCodexNativeDelegationAudit = (
   identity: CodexRuntimeIdentity
 ): readonly NativeDelegationAudit[] => {
   const reviewed =
-    identity.nativeVersion === CODEX_VERSION && identity.adapterVersion === CODEX_ACP_VERSION
+    (identity.nativeVersion === CODEX_VERSION || identity.nativeVersion === '0.144.6') &&
+    identity.adapterVersion === CODEX_ACP_VERSION
   if (!reviewed) {
     return Object.freeze(
       (['task', 'agent', 'multi-agent'] as const).map((entryPoint) =>

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -9,7 +9,8 @@ const { spawnMock } = vi.hoisted(() => ({
 
 vi.mock('node:child_process', () => ({ spawn: spawnMock }))
 
-const { registerOwnedPosixProcessGroup, terminateProcessTree } = await import('./process-tree')
+const { onProcessTreeReaped, registerOwnedPosixProcessGroup, terminateProcessTree } =
+  await import('./process-tree')
 
 // Minimal ChildProcess stand-in: an EventEmitter (so waitForExit's once('exit') resolves) exposing the
 // pid/kill/killed/exitCode surface the code under test touches. kill() flips killed like Node does.
@@ -372,5 +373,31 @@ describe('terminateProcessTree (posix)', () => {
     ps.emit('close', 0)
 
     await expect(pending).resolves.toEqual({ reaped: true })
+  })
+})
+
+describe('process tree reap notification', () => {
+  it('retains admission after close and failed teardown, and releases once after confirmed teardown', async () => {
+    setPlatform('win32')
+    const child = new FakeChild(4321)
+    child.exitCode = 0
+    const release = vi.fn()
+    onProcessTreeReaped(child as never, release)
+    child.emit('close', 0)
+    expect(release).not.toHaveBeenCalled()
+    const failedKiller = new EventEmitter()
+    spawnMock.mockReturnValueOnce(failedKiller)
+    const failed = terminateProcessTree(child as never)
+    failedKiller.emit('exit', 1, null)
+    await expect(failed).resolves.toEqual({ reaped: false })
+    expect(release).not.toHaveBeenCalled()
+    for (let attempt = 0; attempt < 2; attempt++) {
+      const killer = new EventEmitter()
+      spawnMock.mockReturnValueOnce(killer)
+      const pending = terminateProcessTree(child as never)
+      killer.emit('exit', 0, null)
+      await expect(pending).resolves.toEqual({ reaped: true })
+    }
+    expect(release).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/process-tree.test.ts
+++ b/src/main/process-tree.test.ts
@@ -161,15 +161,22 @@ describe('terminateProcessTree (win32)', () => {
     expect(log.error).toHaveBeenCalled()
   })
 
-  it('with an undefined pid does not spawn taskkill and reports the tree reaped', async () => {
-    setPlatform('win32')
-    const child = new FakeChild(undefined)
+  it.each(['win32', 'linux', 'darwin'])(
+    'with an undefined pid reports the tree reaped on %s',
+    async (platform) => {
+      setPlatform(platform)
+      const child = new FakeChild(undefined)
+      const release = vi.fn()
+      onProcessTreeReaped(child as never, release)
+      child.emit('close', -2)
 
-    // No pid means nothing spawned/already gone — nothing left to reap.
-    await expect(terminateProcessTree(child as never)).resolves.toEqual({ reaped: true })
-    expect(spawnMock).not.toHaveBeenCalled()
-    expect(child.kill).not.toHaveBeenCalled()
-  })
+      // No pid means nothing spawned/already gone — nothing left to reap.
+      await expect(terminateProcessTree(child as never)).resolves.toEqual({ reaped: true })
+      expect(spawnMock).not.toHaveBeenCalled()
+      expect(child.kill).not.toHaveBeenCalled()
+      expect(release).toHaveBeenCalledOnce()
+    }
+  )
 })
 
 describe('terminateProcessTree (posix)', () => {

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -27,6 +27,12 @@ export const registerOwnedPosixProcessGroup = (child: ChildProcess): void => {
   ownedPosixProcessGroups.set(child, { kind: 'owned-posix-process-group', id: groupId })
 }
 
+// File replacement must wait for confirmed tree teardown, not the adapter's close event.
+const processTreeReapCallbacks = new WeakMap<ChildProcess, () => void>()
+export const onProcessTreeReaped = (child: ChildProcess, callback: () => void): void => {
+  processTreeReapCallbacks.set(child, callback)
+}
+
 // Upper bound for awaiting a direct child's real exit (POSIX) or taskkill's own completion (Windows).
 // Bounded so a wedged process can never hang app teardown; the caller (before-quit) also time-bounds
 // the whole shutdown, this is a second, tighter guard scoped to a single tree.
@@ -411,10 +417,16 @@ export const terminateProcessTree = async (
   signal?: NodeJS.Signals,
   log?: ProcessTreeLogger
 ): Promise<ProcessTreeKillResult> => {
-  if (process.platform === 'win32') {
-    return terminateWindowsTree(child, signal, log)
-  }
   const ownedGroup = ownedPosixProcessGroups.get(child)
-  if (ownedGroup) return terminateOwnedPosixProcessGroup(ownedGroup, signal, log)
-  return terminatePosixTree(child, signal, log)
+  const result = await (process.platform === 'win32'
+    ? terminateWindowsTree(child, signal, log)
+    : ownedGroup
+      ? terminateOwnedPosixProcessGroup(ownedGroup, signal, log)
+      : terminatePosixTree(child, signal, log))
+  if (result.reaped) {
+    const callback = processTreeReapCallbacks.get(child)
+    processTreeReapCallbacks.delete(child)
+    callback?.()
+  }
+  return result
 }

--- a/src/main/process-tree.ts
+++ b/src/main/process-tree.ts
@@ -314,9 +314,11 @@ const terminatePosixTree = async (
   signal: NodeJS.Signals | undefined,
   log: ProcessTreeLogger | undefined
 ): Promise<ProcessTreeKillResult> => {
+  // Node leaves pid undefined when spawn fails; no process (or descendant) was created.
+  // Its error/close events may already have fired before cleanup starts.
+  if (child.pid === undefined) return { reaped: true }
   const gracefulSignal = signal ?? 'SIGTERM'
-  const snapshot =
-    child.pid === undefined ? { pids: [], complete: true } : await collectDescendantPids(child.pid)
+  const snapshot = await collectDescendantPids(child.pid)
   const descendants = snapshot.pids
 
   signalPids(descendants, gracefulSignal)

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -840,6 +840,60 @@ describe('AgentRuntimeManager', () => {
     ])
   })
 
+  it('excludes installation until detection finishes publishing its snapshot', async () => {
+    inventory.codexAdapter.set(managedAdapterPath, '1.6.2')
+    inventory.codexNative.set(managedCodexPath, '0.144.6')
+    const publishing = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    const setInfo = repository.setCodexInfo.bind(repository)
+    vi.spyOn(repository, 'setCodexInfo').mockImplementationOnce(async (info) => {
+      publishing.resolve()
+      await release.promise
+      return setInfo(info)
+    })
+    const installManagedCodexImpl = vi.fn(async ({ installId }: { installId: string }) => ({
+      result: { installId, ok: false, error: 'installer reached' }
+    }))
+    manager = createManager({ installManagedCodexImpl })
+    const detection = manager.detectCodex()
+    await publishing.promise
+    try {
+      await expect(manager.installCodex({ source: 'managed' }, vi.fn())).resolves.toMatchObject({
+        ok: false,
+        error: 'Runtime detection is in progress. Retry after it finishes.'
+      })
+      expect(installManagedCodexImpl).not.toHaveBeenCalled()
+    } finally {
+      release.resolve()
+      await detection
+    }
+    await expect(manager.installCodex({ source: 'managed' }, vi.fn())).resolves.toMatchObject({
+      error: 'installer reached'
+    })
+  })
+
+  it('rejects independent detection during installation and admits it after failure', async () => {
+    const started = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<void>()
+    manager = createManager({
+      installManagedCodexImpl: async ({ installId }) => {
+        started.resolve()
+        await release.promise
+        return { result: { installId, ok: false, error: 'stopped' } }
+      }
+    })
+    const install = manager.installCodex({ source: 'managed' }, vi.fn())
+    await started.promise
+    try {
+      await expect(manager.detectCodex()).rejects.toThrow('Runtime installation is in progress')
+      await expect(manager.detectClaude()).rejects.toThrow('Runtime installation is in progress')
+    } finally {
+      release.resolve()
+      await install
+    }
+    await expect(manager.detectCodex()).resolves.toBeUndefined()
+  })
+
   it('rejects a second managed runtime install until the active install finishes', async () => {
     const installStarted = Promise.withResolvers<void>()
     const releaseInstall = Promise.withResolvers<void>()

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -907,6 +907,10 @@ export class AgentRuntimeManager {
     return { activeBackendAffected: wasActive }
   }
 
+  isManagedCodexNativePath(path: string): boolean {
+    return path === managedCodexBinary(this.configRoot)
+  }
+
   isManagedRuntimePath(frameworkId: AgentFrameworkId, path: string): boolean {
     if (frameworkId === 'claude-code') return isManagedClaudePath(path, this.configRoot)
     if (frameworkId === 'opencode') return isManagedOpencodePath(path, this.configRoot)

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -572,6 +572,11 @@ export class AgentRuntimeManager {
     signal?: AbortSignal
   ): Promise<T> {
     this.shutdownAbort.signal.throwIfAborted()
+    // The install's own post-install detection is allowed; independent detection must not probe
+    // files being replaced or publish an older snapshot after the installer commits its result.
+    if (this.activeInstallId !== undefined && signal !== this.activeInstallAbort?.signal) {
+      throw new Error('Runtime installation is in progress. Wait before detecting agents.')
+    }
     const operationSignal = signal
       ? AbortSignal.any([signal, this.shutdownAbort.signal])
       : this.shutdownAbort.signal
@@ -826,6 +831,15 @@ export class AgentRuntimeManager {
       return { installId, ok: false, error: 'Another install is already in progress.' }
     }
 
+    // Check synchronously before claiming install admission. activeDetections includes repository
+    // writes, so replacement cannot race a probe or its delayed snapshot commit.
+    if (this.activeDetections.size > 0) {
+      return {
+        installId,
+        ok: false,
+        error: 'Runtime detection is in progress. Retry after it finishes.'
+      }
+    }
     const controller = new AbortController()
     const completion = Promise.withResolvers<Error | undefined>()
     let cleanupFailure: Error | undefined

--- a/src/main/settings/codex-auth.test.ts
+++ b/src/main/settings/codex-auth.test.ts
@@ -1,13 +1,15 @@
 import { existsSync } from 'node:fs'
 import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
+import { installManagedCodex, managedCodexAdapterEntry, managedCodexBinary } from './managed-codex'
 
 import { describe, expect, it, vi } from 'vitest'
 
 import { codexSubscriptionStorageDir } from '../agent-framework/codex'
 import {
   CodexAuthController,
+  openCodexAuthSession,
   createCodexAuthEnvironment,
   ensureCodexAuthHome,
   importCodexAuthentication,
@@ -1075,6 +1077,32 @@ describe('CodexAuthController', () => {
     } finally {
       resolveStatus({ type: 'unauthenticated' })
       vi.useRealTimers()
+    }
+  })
+})
+
+describe('Codex authentication install admission', () => {
+  it('blocks replacement while authentication owns the runtime and releases after tree teardown', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-auth-admission-'))
+    const adapterPath = managedCodexAdapterEntry(root)
+    let auth: CodexAuthSession | undefined
+    try {
+      await mkdir(dirname(adapterPath), { recursive: true })
+      await writeFile(adapterPath, 'process.stdin.resume(); setInterval(() => {}, 1000)')
+      auth = await openCodexAuthSession({
+        adapterPath,
+        nativePath: managedCodexBinary(root),
+        mode: 'isolated',
+        storageRoot: root
+      })
+      const options = { dataRoot: root, installId: 'update', onEvent: vi.fn(), registries: [] }
+      expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
+      await auth.close()
+      auth = undefined
+      expect((await installManagedCodex(options)).result.error).toBe('no registries configured')
+    } finally {
+      await auth?.close()
+      await rm(root, { recursive: true, force: true })
     }
   })
 })

--- a/src/main/settings/codex-auth.ts
+++ b/src/main/settings/codex-auth.ts
@@ -8,7 +8,8 @@ import { Readable, Writable } from 'node:stream'
 import * as acp from '@agentclientprotocol/sdk'
 
 import type { CodexSubscriptionTransport } from '../../shared/settings'
-import { terminateProcessTree } from '../process-tree'
+import { registerOwnedPosixProcessGroup, terminateProcessTree } from '../process-tree'
+import { spawnCodexWithInstallAdmission } from './managed-codex'
 import { codexSubscriptionStorageDir } from './codex-paths'
 import { augmentedPathEnv } from './shell-path'
 import { clearSystemProxyEnvironment, type SystemProxyEnvironment } from './system-proxy'
@@ -1011,12 +1012,18 @@ export const openCodexAuthSession = async ({
   if (isJavaScript) env.ELECTRON_RUN_AS_NODE = '1'
   if (nativePath) env.CODEX_PATH = nativePath
 
-  const child = spawn(command, args, {
-    env,
-    shell: needsShell,
-    stdio: 'pipe',
-    windowsHide: true
-  })
+  const child = spawnCodexWithInstallAdmission(
+    [adapterPath, ...(nativePath ? [nativePath] : [])],
+    () =>
+      spawn(command, args, {
+        env,
+        shell: needsShell,
+        stdio: 'pipe',
+        detached: process.platform !== 'win32',
+        windowsHide: true
+      })
+  )
+  if (process.platform !== 'win32') registerOwnedPosixProcessGroup(child)
   const stream = acp.ndJsonStream(
     Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
     Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>

--- a/src/main/settings/codex-detect.test.ts
+++ b/src/main/settings/codex-detect.test.ts
@@ -1,6 +1,7 @@
 import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join, win32 } from 'node:path'
+import { installManagedCodex, managedCodexBinary } from './managed-codex'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { warnLogSpy } = vi.hoisted(() => ({
@@ -372,6 +373,28 @@ describe('codex-detect: real ACP initialize smoke', () => {
     })
     // The smoke reaped the tree cleanly, so it must not emit the degraded-reap warning.
     expect(warnLogSpy).not.toHaveBeenCalled()
+  })
+
+  it('holds installation admission through an unconfirmed detection tree teardown', async () => {
+    const started = Promise.withResolvers<void>()
+    const cleanup = Promise.withResolvers<{ reaped: boolean }>()
+    terminateProcessTreeSpy.mockImplementation(() => {
+      started.resolve()
+      return cleanup.promise
+    })
+    const adapterPath = await writeFakeAdapter('admission-adapter.js', { protocolVersion: 1 })
+    const detection = runAcpInitializeSmoke(process.platform)(adapterPath, {
+      codexPath: managedCodexBinary(tempRoot)
+    })
+    await started.promise
+    const options = { dataRoot: tempRoot, installId: 'update', onEvent: vi.fn(), registries: [] }
+    try {
+      expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
+    } finally {
+      cleanup.resolve({ reaped: false })
+      await detection
+    }
+    expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
   })
 
   it('still reports the adapter as ready but warns when the process tree is only partially reaped', async () => {

--- a/src/main/settings/codex-detect.ts
+++ b/src/main/settings/codex-detect.ts
@@ -9,7 +9,8 @@ import { isSupportedCodexAcpVersion } from '../../shared/codex-runtime'
 import { createLogger } from '../logger'
 import { augmentedPathEnv } from './shell-path'
 import { stripCodexCredentialEnv } from './process-tree'
-import { terminateProcessTree } from '../process-tree'
+import { registerOwnedPosixProcessGroup, terminateProcessTree } from '../process-tree'
+import { spawnCodexWithInstallAdmission } from './managed-codex'
 
 const execFileAsync = promisify(execFile)
 
@@ -294,18 +295,24 @@ const runAcpInitializeSmoke =
       const result = await new Promise<boolean>((resolve) => {
         let settled = false
         let buffer = ''
-        const child = spawn(command, args, {
-          windowsHide: true,
-          shell: useShell,
-          stdio: ['pipe', 'pipe', 'ignore'],
-          env: {
-            ...stripCodexCredentialEnv(augmentedPathEnv(process.env)),
-            ...(isJavaScript ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
-            NO_BROWSER: '1',
-            CODEX_HOME: codexHome,
-            ...(opts.codexPath ? { CODEX_PATH: opts.codexPath } : {})
-          }
-        })
+        const child = spawnCodexWithInstallAdmission(
+          [adapterPath, ...(opts.codexPath ? [opts.codexPath] : [])],
+          () =>
+            spawn(command, args, {
+              detached: platform !== 'win32',
+              windowsHide: true,
+              shell: useShell,
+              stdio: ['pipe', 'pipe', 'ignore'],
+              env: {
+                ...stripCodexCredentialEnv(augmentedPathEnv(process.env)),
+                ...(isJavaScript ? { ELECTRON_RUN_AS_NODE: '1' } : {}),
+                NO_BROWSER: '1',
+                CODEX_HOME: codexHome,
+                ...(opts.codexPath ? { CODEX_PATH: opts.codexPath } : {})
+              }
+            })
+        )
+        if (platform !== 'win32') registerOwnedPosixProcessGroup(child)
 
         const finish = (ok: boolean): void => {
           if (settled) return

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
 import {
@@ -2222,6 +2222,31 @@ describe('sanitizeManagedCodexDiagnostic', () => {
 const actualProcessTree = await vi.importActual<typeof import('../process-tree')>('../process-tree')
 
 describe('managed Codex process admission', () => {
+  it('releases admission after a real missing executable fails to spawn', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'codex-failed-spawn-'))
+    try {
+      const child = spawnCodexWithInstallAdmission([managedCodexAdapterEntry(dataRoot)], () =>
+        spawn(join(dataRoot, 'missing-executable'), [], { stdio: 'pipe' })
+      )
+      child.on('error', () => undefined)
+      await new Promise<void>((resolve) => child.once('close', () => resolve()))
+      expect(child.pid).toBeUndefined()
+      await expect(actualProcessTree.terminateProcessTree(child)).resolves.toEqual({ reaped: true })
+      expect(
+        (
+          await installManagedCodex({
+            dataRoot,
+            installId: 'retry',
+            onEvent: vi.fn(),
+            registries: []
+          })
+        ).result.error
+      ).toBe('no registries configured')
+    } finally {
+      await rm(dataRoot, { recursive: true, force: true })
+    }
+  })
+
   it('blocks replacement after adapter close until every process tree is reaped', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'codex-admission-'))
     const adapter = managedCodexAdapterEntry(dataRoot)

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -1,3 +1,5 @@
+import { EventEmitter } from 'node:events'
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { constants } from 'node:fs'
 import {
@@ -182,6 +184,7 @@ import {
   managedCodexBinary,
   managedCodexRoot,
   installManagedCodex,
+  spawnCodexWithInstallAdmission,
   patchCodexAcpContextUsageSource,
   patchCodexAcpModelCatalogStartupSource,
   patchCodexAcpSkillInputSource,
@@ -194,7 +197,7 @@ import {
 } from './managed-codex'
 
 it('runs Windows Codex command shims through the shell during version verification', async () => {
-  const spawnVersion = vi.fn(async () => ({ status: 0, stdout: 'codex-cli 0.144.6' }))
+  const spawnVersion = vi.fn(async () => ({ status: 0, stdout: 'codex-cli 0.153.4' }))
 
   await expect(
     runManagedCodexVersion(
@@ -204,7 +207,7 @@ it('runs Windows Codex command shims through the shell during version verificati
       'win32',
       spawnVersion
     )
-  ).resolves.toBe('0.144.6')
+  ).resolves.toBe('0.153.4')
   expect(spawnVersion).toHaveBeenCalledWith(
     '"C:\\Users\\me\\AppData\\Roaming\\npm\\codex.cmd"',
     ['--version'],
@@ -282,7 +285,7 @@ describe('managed Codex paths and platform resolution', () => {
     const platform = resolveManagedCodexPlatform({ platform: 'darwin', arch: 'arm64' })
 
     expect(CODEX_ACP_VERSION).toBe('1.6.2')
-    expect(CODEX_VERSION).toBe('0.144.6')
+    expect(CODEX_VERSION).toBe('0.153.4')
     expect(CODEX_ACP_INTEGRITY).toMatch(/^sha512-/)
     expect(Object.keys(CODEX_INTEGRITIES).sort()).toEqual([
       'darwin-arm64',
@@ -538,7 +541,7 @@ describe('installManagedCodex', () => {
 
     const controller = new AbortController()
     const verifyAdapter = vi.fn().mockResolvedValue('1.6.2')
-    const verifyCodex = vi.fn().mockResolvedValue('0.144.6')
+    const verifyCodex = vi.fn().mockResolvedValue('0.153.4')
     const verifyPair = vi.fn().mockResolvedValue(undefined)
     const outcome = await installManagedCodex({
       installId: 'codex-1',
@@ -560,11 +563,11 @@ describe('installManagedCodex', () => {
       adapterPath: managedCodexAdapterEntry(root),
       adapterVersion: '1.6.2',
       codexPath: managedCodexBinary(root, platform),
-      codexVersion: '0.144.6'
+      codexVersion: '0.153.4'
     })
     expect(metadataUrls).toEqual([
       'https://reg/@agentclientprotocol%2fcodex-acp/1.6.2',
-      'https://reg/@openai%2fcodex/0.144.6-darwin-arm64'
+      'https://reg/@openai%2fcodex/0.153.4-darwin-arm64'
     ])
     expect(await readFile(managedCodexAdapterEntry(root), 'utf8')).toContain('codex-acp')
     expect(await readFile(managedCodexBinary(root, platform), 'utf8')).toBe('native-codex')
@@ -632,7 +635,7 @@ describe('installManagedCodex', () => {
       fetchJson,
       fetchTarball,
       verifyAdapter: () => Promise.resolve('1.6.2'),
-      verifyCodex: () => Promise.resolve('0.144.6'),
+      verifyCodex: () => Promise.resolve('0.153.4'),
       verifyPair,
       integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) },
       existingCodexPath: externalCodexPath
@@ -643,7 +646,7 @@ describe('installManagedCodex', () => {
       adapterPath: managedCodexAdapterEntry(root),
       adapterVersion: '1.6.2',
       codexPath: externalCodexPath,
-      codexVersion: '0.144.6'
+      codexVersion: '0.153.4'
     })
     expect(metadataUrls).toEqual(['https://reg/@agentclientprotocol%2fcodex-acp/1.6.2'])
     expect(await readFile(managedCodexAdapterEntry(root), 'utf8')).toContain('adapter-only')
@@ -703,7 +706,7 @@ describe('installManagedCodex', () => {
       fetchJson,
       fetchTarball,
       verifyAdapter: () => Promise.resolve('1.6.2'),
-      verifyCodex: () => Promise.resolve('0.144.6'),
+      verifyCodex: () => Promise.resolve('0.153.4'),
       verifyPair,
       integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) },
       existingCodexPath: externalCodexPath
@@ -714,9 +717,9 @@ describe('installManagedCodex', () => {
       adapterPath: managedCodexAdapterEntry(root),
       adapterVersion: '1.6.2',
       codexPath: managedCodexBinary(root, platform),
-      codexVersion: '0.144.6'
+      codexVersion: '0.153.4'
     })
-    expect(metadataUrls).toContain('https://reg/@openai%2fcodex/0.144.6-darwin-arm64')
+    expect(metadataUrls).toContain('https://reg/@openai%2fcodex/0.153.4-darwin-arm64')
     expect(await readFile(externalCodexPath, 'utf8')).toBe('user-owned-incompatible-codex')
     expect(await readFile(managedCodexBinary(root, platform), 'utf8')).toBe(
       'managed-compatible-codex'
@@ -763,7 +766,7 @@ describe('installManagedCodex', () => {
       fetchJson,
       fetchTarball,
       verifyAdapter: () => Promise.resolve('1.6.2'),
-      verifyCodex: () => Promise.resolve('0.144.6'),
+      verifyCodex: () => Promise.resolve('0.153.4'),
       verifyPair,
       integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
     })
@@ -821,7 +824,7 @@ describe('installManagedCodex', () => {
       },
       verifyCodex: async () => {
         smokeChecks += 1
-        return '0.144.6'
+        return '0.153.4'
       },
       integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
     })
@@ -918,7 +921,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -969,7 +972,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -1025,7 +1028,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -1086,7 +1089,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -1150,7 +1153,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -1211,7 +1214,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -1268,7 +1271,7 @@ describe('installManagedCodex', () => {
         fetchJson: fetchJsonSpy,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -1328,7 +1331,7 @@ describe('installManagedCodex', () => {
         fetchJson,
         fetchTarball,
         verifyAdapter: () => Promise.resolve('1.6.2'),
-        verifyCodex: () => Promise.resolve('0.144.6'),
+        verifyCodex: () => Promise.resolve('0.153.4'),
         verifyPair: vi.fn().mockResolvedValue(undefined),
         integrities: { adapter: sha512(adapterTgz), codex: sha512(nativeTgz) }
       })
@@ -2213,5 +2216,65 @@ describe('sanitizeManagedCodexDiagnostic', () => {
     expect(diagnostic.text).toContain('[redacted]')
     expect(diagnostic.text.length).toBeLessThanOrEqual(4 * 1024)
     expect(diagnostic.truncated).toBe(true)
+  })
+})
+
+describe('managed Codex process admission', () => {
+  it('blocks replacement until every process closes, including idle sessions', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'codex-admission-'))
+    const adapter = managedCodexAdapterEntry(dataRoot)
+    const native = managedCodexBinary(dataRoot)
+    const first = new EventEmitter() as ChildProcessWithoutNullStreams
+    const second = new EventEmitter() as ChildProcessWithoutNullStreams
+    const options = { dataRoot, installId: 'update', onEvent: vi.fn(), registries: [] }
+    try {
+      spawnCodexWithInstallAdmission([adapter, native], () => first)
+      spawnCodexWithInstallAdmission([adapter, native], () => second)
+      expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
+      first.emit('close', 0)
+      expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
+      second.emit('close', 0)
+      expect((await installManagedCodex(options)).result.error).toBe('no registries configured')
+    } finally {
+      first.emit('close', 0)
+      second.emit('close', 0)
+      await rm(dataRoot, { recursive: true, force: true })
+    }
+  })
+
+  it('blocks a racing spawn during installation and releases after failure', async () => {
+    const dataRoot = await mkdtemp(join(tmpdir(), 'codex-admission-'))
+    const adapter = managedCodexAdapterEntry(dataRoot)
+    const spawn = vi.fn(() => new EventEmitter() as ChildProcessWithoutNullStreams)
+    try {
+      const install = installManagedCodex({
+        dataRoot,
+        installId: 'update',
+        onEvent: vi.fn(),
+        registries: []
+      })
+      expect(() => spawnCodexWithInstallAdmission([adapter], spawn)).toThrow('being updated')
+      expect(spawn).not.toHaveBeenCalled()
+      await install
+      spawnCodexWithInstallAdmission([adapter], spawn).emit('close', 0)
+      expect(spawn).toHaveBeenCalledOnce()
+      expect(() =>
+        spawnCodexWithInstallAdmission([adapter], () => {
+          throw new Error('spawn failed')
+        })
+      ).toThrow('spawn failed')
+      expect(
+        (
+          await installManagedCodex({
+            dataRoot,
+            installId: 'retry',
+            onEvent: vi.fn(),
+            registries: []
+          })
+        ).result.error
+      ).toBe('no registries configured')
+    } finally {
+      await rm(dataRoot, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -2219,8 +2219,10 @@ describe('sanitizeManagedCodexDiagnostic', () => {
   })
 })
 
+const actualProcessTree = await vi.importActual<typeof import('../process-tree')>('../process-tree')
+
 describe('managed Codex process admission', () => {
-  it('blocks replacement until every process closes, including idle sessions', async () => {
+  it('blocks replacement after adapter close until every process tree is reaped', async () => {
     const dataRoot = await mkdtemp(join(tmpdir(), 'codex-admission-'))
     const adapter = managedCodexAdapterEntry(dataRoot)
     const native = managedCodexBinary(dataRoot)
@@ -2234,6 +2236,10 @@ describe('managed Codex process admission', () => {
       first.emit('close', 0)
       expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
       second.emit('close', 0)
+      expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
+      await actualProcessTree.terminateProcessTree(first)
+      expect((await installManagedCodex(options)).result.error).toContain('Codex is in use')
+      await actualProcessTree.terminateProcessTree(second)
       expect((await installManagedCodex(options)).result.error).toBe('no registries configured')
     } finally {
       first.emit('close', 0)
@@ -2256,7 +2262,7 @@ describe('managed Codex process admission', () => {
       expect(() => spawnCodexWithInstallAdmission([adapter], spawn)).toThrow('being updated')
       expect(spawn).not.toHaveBeenCalled()
       await install
-      spawnCodexWithInstallAdmission([adapter], spawn).emit('close', 0)
+      await actualProcessTree.terminateProcessTree(spawnCodexWithInstallAdmission([adapter], spawn))
       expect(spawn).toHaveBeenCalledOnce()
       expect(() =>
         spawnCodexWithInstallAdmission([adapter], () => {

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { execFile, spawn, type ChildProcess } from 'node:child_process'
 import { createReadStream, type Dirent } from 'node:fs'
 import {
   chmod,
@@ -122,10 +122,10 @@ const codexPathKey = (path: string): string => {
   return process.platform === 'win32' ? absolute.toLowerCase() : absolute
 }
 
-export const spawnCodexWithInstallAdmission = (
+export const spawnCodexWithInstallAdmission = <T extends ChildProcess>(
   paths: readonly string[],
-  spawnProcess: () => ChildProcessWithoutNullStreams
-): ChildProcessWithoutNullStreams => {
+  spawnProcess: () => T
+): T => {
   const keys = [...new Set(paths.map(codexPathKey))]
   if (keys.some((key) => codexInstallPaths.has(key))) {
     throw new Error(

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto'
-import { execFile, spawn } from 'node:child_process'
+import { execFile, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
 import { createReadStream, type Dirent } from 'node:fs'
 import {
   chmod,
@@ -28,7 +28,7 @@ import {
   ACP_MODEL_TURN_COUNT_META_KEY,
   ACP_TURN_TOKEN_USAGE_META_KEY
 } from '../../shared/acp'
-import { MINIMUM_CODEX_ACP_VERSION } from '../../shared/codex-runtime'
+import { MANAGED_CODEX_VERSION, MINIMUM_CODEX_ACP_VERSION } from '../../shared/codex-runtime'
 import {
   DEFAULT_REGISTRIES,
   defaultFetchJson,
@@ -46,7 +46,7 @@ import { toErrorMessage } from '../error-message'
 const execFileAsync = promisify(execFile)
 
 export const CODEX_ACP_VERSION = MINIMUM_CODEX_ACP_VERSION
-export const CODEX_VERSION = '0.144.6'
+export const CODEX_VERSION = MANAGED_CODEX_VERSION
 
 const log = createLogger('managed-codex')
 const MAX_INITIALIZE_DIAGNOSTIC_CHARS = 4 * 1024
@@ -56,17 +56,17 @@ export const CODEX_ACP_INTEGRITY =
 
 export const CODEX_INTEGRITIES: Readonly<Record<string, string>> = {
   'darwin-arm64':
-    'sha512-6zgvh70MzBNSeT17HEhSOrmmGGZGAKzSC7x6JAq+edkJkdPYA9P0I1tG7aJ49GlBkBxuC+MKBH1qm6+2Cghcww==',
+    'sha512-B1qhN3fa1ay0R0wGziXqgwSkB5icpYChNKHhtBHff/0UtSTC7z+l8aTtvMlGjH3E8HEvY3+njIJelM9CAAoVWg==',
   'darwin-x64':
-    'sha512-THRyPG0zSU6M8NQAge1LHEHsJDnoH4BpKsfJHB/qe3Fm+Wf6zqAmWJFlOKzBm27m0K2Hq3za4Ac2I5p5i4yp/A==',
+    'sha512-vnSbbPzfoDZmmyzsxswsDDXQ06IVFBzkQU7/hroB3ji93Ok2utcsq8Psfk2tjF5r9mEx8RWFJhzuTGHG26/NDA==',
   'linux-arm64':
-    'sha512-PGiLXMN+2IQRkf7tOLi64dMInjU1pRLbz0Rwfj/yt2Y97SZQqAjFQoi2wmswmqtqMDnfwCPTC1DRXVQkvU6T6Q==',
+    'sha512-QKdjYLYV4hXIuUQDP3P6F4NXuWFoKo9WUoV4nAREIx55kiUyi8UsYdsVobkeXir5n/maEQgYMCKLHVma4rNPiw==',
   'linux-x64':
-    'sha512-4E7EnzCg0OnBxCyYnwJ+qnZwWHYe0YScr5ucKWbngE9u4+0XrpWELqq2Kn9jl5GZK8MDjU7PrJwFIwusHOHjuw==',
+    'sha512-x1EcwBlY3AObM1VTUHNM2AzAJQsyreGdagpF+qFiYi/Oa30VBktvvG0C6tLtCzqW6hjZNWkGZQWmeVk7MuJKWg==',
   'win32-arm64':
-    'sha512-SpMjXJLW43JzMP0K62mVcYfmFcpk0BK4AOgYmWSfyZHs3iRtHMd0UYw7605n/9lwkT2EqbwQLT2omZFeKJFzwA==',
+    'sha512-/FBh42976ltF1kxDoPQBg1Q6+hwChRU5/sm5dfeC8kFVQMvOCGoGeY5d8rRZGVJE8XojlXo74VQb0sHowcfgBw==',
   'win32-x64':
-    'sha512-dN39VnjEthKz5io1RNWwZDtErdSn07nW3pGUgvlA6DMxgm/nuGaIAZO/sG/Hgxq/x5j9HteAENfrFgVkpZ0lFg=='
+    'sha512-lMkB43kJZH0VFr+hoXc11qqR7QtQIbkr07ALgj4urKL1osNyUyuy1iXd3Vzz2iCYvBUCSw7I0l/W1cEPGx9euQ=='
 }
 
 export type ManagedCodexPlatform = {
@@ -112,6 +112,68 @@ export const managedCodexBinary = (
   platform: ManagedCodexPlatform = resolveManagedCodexPlatform()
 ): string =>
   join(managedCodexRoot(dataRoot), 'codex', 'vendor', platform.target, 'bin', platform.binName)
+
+// Main-process admission for app-launched Codex processes and replacement of their files.
+// Acquire synchronously before spawn/download: checking only UI prompt state leaves a start race.
+const codexProcessUsers = new Map<string, number>()
+const codexInstallPaths = new Set<string>()
+const codexPathKey = (path: string): string => {
+  const absolute = resolve(path)
+  return process.platform === 'win32' ? absolute.toLowerCase() : absolute
+}
+
+export const spawnCodexWithInstallAdmission = (
+  paths: readonly string[],
+  spawnProcess: () => ChildProcessWithoutNullStreams
+): ChildProcessWithoutNullStreams => {
+  const keys = [...new Set(paths.map(codexPathKey))]
+  if (keys.some((key) => codexInstallPaths.has(key))) {
+    throw new Error(
+      'Codex is being updated. Wait for the update to finish before starting a session.'
+    )
+  }
+  for (const key of keys) codexProcessUsers.set(key, (codexProcessUsers.get(key) ?? 0) + 1)
+  const release = (): void => {
+    for (const key of keys) {
+      const remaining = (codexProcessUsers.get(key) ?? 1) - 1
+      if (remaining > 0) codexProcessUsers.set(key, remaining)
+      else codexProcessUsers.delete(key)
+    }
+  }
+  try {
+    const child = spawnProcess()
+    // close follows failed spawn as well as normal exit, and waits for inherited stdio to close.
+    child.once('close', release)
+    return child
+  } catch (error) {
+    release()
+    throw error
+  }
+}
+
+export const installManagedCodex = async (
+  options: InstallManagedCodexOptions
+): Promise<ManagedCodexInstallOutcome> => {
+  const keys = [
+    managedCodexAdapterEntry(options.dataRoot),
+    managedCodexBinary(options.dataRoot, options.platform)
+  ].map(codexPathKey)
+  if (keys.some((key) => codexProcessUsers.has(key) || codexInstallPaths.has(key))) {
+    return {
+      result: {
+        installId: options.installId,
+        ok: false,
+        error: 'Codex is in use. Close Codex sessions and stop background tasks before updating.'
+      }
+    }
+  }
+  for (const key of keys) codexInstallPaths.add(key)
+  try {
+    return await installManagedCodexFiles(options)
+  } finally {
+    for (const key of keys) codexInstallPaths.delete(key)
+  }
+}
 
 const adapterEntryInRoot = (root: string): string => join(root, 'adapter', 'dist', 'index.js')
 
@@ -1384,7 +1446,7 @@ const replaceDirectory = async (staged: string, destination: string): Promise<vo
   if (hasBackup) await rm(backup, { recursive: true, force: true }).catch(() => undefined)
 }
 
-export const installManagedCodex = async (
+const installManagedCodexFiles = async (
   options: InstallManagedCodexOptions
 ): Promise<ManagedCodexInstallOutcome> => {
   const {
@@ -1517,7 +1579,7 @@ export const installManagedCodex = async (
           stream: 'system',
           chunk: `Existing Codex CLI is incompatible with the managed adapter; falling back to the managed Codex CLI.\n`
         })
-        return installManagedCodex({ ...options, existingCodexPath: undefined })
+        return installManagedCodexFiles({ ...options, existingCodexPath: undefined })
       }
 
       signal?.throwIfAborted()

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -40,7 +40,7 @@ import {
 } from './managed-claude'
 import { createLogger } from '../logger'
 import { stripCodexCredentialEnv } from './process-tree'
-import { terminateProcessTree } from '../process-tree'
+import { onProcessTreeReaped, terminateProcessTree } from '../process-tree'
 import { toErrorMessage } from '../error-message'
 
 const execFileAsync = promisify(execFile)
@@ -142,8 +142,7 @@ export const spawnCodexWithInstallAdmission = (
   }
   try {
     const child = spawnProcess()
-    // close follows failed spawn as well as normal exit, and waits for inherited stdio to close.
-    child.once('close', release)
+    onProcessTreeReaped(child, release)
     return child
   } catch (error) {
     release()

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { Readable, Writable } from 'node:stream'
+import { createInterface } from 'node:readline'
 
 import * as acp from '@agentclientprotocol/sdk'
 import { expect, it, vi } from 'vitest'
@@ -910,7 +911,11 @@ it.runIf(runLiveContract)(
               cwd: root,
               mcpServers: []
             })
-            expect(session.models?.currentModelId).toContain('gpt-6-astra')
+            expect(session.configOptions).toEqual(
+              expect.arrayContaining([
+                expect.objectContaining({ id: 'model', currentValue: 'gpt-6-astra' })
+              ])
+            )
             expect(JSON.stringify(session.configOptions)).toContain('gpt-6-astra')
             await ctx.request(acp.methods.agent.session.close, { sessionId: session.sessionId })
           }
@@ -923,4 +928,64 @@ it.runIf(runLiveContract)(
     }
   },
   30_000
+)
+
+it.runIf(runLiveContract)(
+  'bundles Astra in the native model catalog without generated metadata',
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-native-models-'))
+    const child = spawn(nativeCodexPath!, ['app-server'], {
+      env: {
+        PATH: process.env.PATH,
+        SystemRoot: process.env.SystemRoot,
+        HOME: root,
+        USERPROFILE: root,
+        CODEX_HOME: root
+      },
+      stdio: 'pipe',
+      windowsHide: true
+    })
+    const lines = createInterface({ input: child.stdout })
+    child.stderr.resume()
+    let timer: ReturnType<typeof setTimeout> | undefined
+    try {
+      const models = await new Promise<Array<{ model: string }>>((resolve, reject) => {
+        timer = setTimeout(() => reject(new Error('Native model/list timed out')), 10_000)
+        child.once('error', reject)
+        child.once('close', () => reject(new Error('Native app-server closed before model/list')))
+        lines.on('line', (line) => {
+          const response = JSON.parse(line) as {
+            id?: number
+            error?: unknown
+            result?: { data?: Array<{ model: string }> }
+          }
+          if (response.error) {
+            reject(new Error(JSON.stringify(response.error)))
+            return
+          }
+          if (response.id === 1)
+            child.stdin.write(
+              JSON.stringify({ id: 2, method: 'model/list', params: { includeHidden: true } }) +
+                '\n'
+            )
+          if (response.id === 2) resolve(response.result?.data ?? [])
+        })
+        child.stdin.write(
+          JSON.stringify({
+            id: 1,
+            method: 'initialize',
+            params: { clientInfo: { name: 'astra-model-contract', version: '1' } }
+          }) + '\n'
+        )
+      })
+      expect(models).toEqual(
+        expect.arrayContaining([expect.objectContaining({ model: 'gpt-6-astra' })])
+      )
+    } finally {
+      clearTimeout(timer)
+      lines.close()
+      await terminate(child)
+      await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    }
+  }
 )

--- a/src/main/settings/responses-bridge.integration.test.ts
+++ b/src/main/settings/responses-bridge.integration.test.ts
@@ -8,6 +8,7 @@ import * as acp from '@agentclientprotocol/sdk'
 import { expect, it, vi } from 'vitest'
 
 import { CODEX_BRIDGE_MODEL, createCodexFramework } from '../agent-framework/codex'
+import { CODEX_VERSION } from './managed-codex'
 import { terminateProcessTree } from '../process-tree'
 import { REVIEWER_BRIDGE_NAMESPACED_TOOLS } from '../reviewer/bridge-tools'
 import { ReviewerMcpServer, type SubmitFindingsHandler } from '../reviewer/mcp-server'
@@ -848,6 +849,77 @@ it.runIf(runLiveContract)(
       await bridge.close()
       await reviewerMcp.stop()
       await rm(tempRoot, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    }
+  },
+  30_000
+)
+
+it.runIf(runLiveContract)(
+  'creates an Astra session with bundled metadata from the tested native runtime',
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), 'codex-astra-catalog-'))
+    const proxy = new NativeResponsesCompatibilityProxy(
+      { baseUrl: 'https://vendor.invalid/v1', model: 'gpt-6-astra' },
+      async () => {
+        throw new Error('This metadata check must not make a model request')
+      }
+    )
+    const connection = await proxy.start()
+    const config = createCodexFramework().prepareModelConfig(
+      {
+        type: 'official',
+        vendorId: 'openai',
+        apiEndpoints: ['responses'],
+        baseUrl: 'https://api.openai.com/v1',
+        model: 'gpt-6-astra'
+      },
+      {
+        storageRoot: root,
+        executablePath: adapterPath!,
+        nativeVersion: CODEX_VERSION,
+        responsesBridge: connection
+      }
+    )
+    expect(JSON.parse(config.env!.CODEX_CONFIG)).not.toHaveProperty('model_catalog_json')
+    for (const file of config.configFiles ?? []) {
+      await mkdir(dirname(file.path), { recursive: true })
+      await writeFile(file.path, file.content)
+    }
+    const child = spawnAdapter(root, {
+      ...process.env,
+      ...config.env,
+      CODEX_PATH: nativeCodexPath!
+    })
+    const stderr: string[] = []
+    child.stderr.on('data', (chunk) => stderr.push(String(chunk)))
+    try {
+      await acp
+        .client({ name: 'astra-metadata-contract' })
+        .connectWith(
+          acp.ndJsonStream(
+            Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+            Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>
+          ),
+          async (ctx) => {
+            await ctx.request(acp.methods.agent.initialize, {
+              protocolVersion: acp.PROTOCOL_VERSION,
+              clientCapabilities: {}
+            })
+            await ctx.request(acp.methods.agent.providers.set, config.providerConfiguration!)
+            const session = await ctx.request(acp.methods.agent.session.new, {
+              cwd: root,
+              mcpServers: []
+            })
+            expect(session.models?.currentModelId).toContain('gpt-6-astra')
+            expect(JSON.stringify(session.configOptions)).toContain('gpt-6-astra')
+            await ctx.request(acp.methods.agent.session.close, { sessionId: session.sessionId })
+          }
+        )
+      expect(stderr.join('')).not.toContain('Model metadata for gpt-6-astra not found')
+    } finally {
+      await terminate(child)
+      await proxy.close()
+      await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
     }
   },
   30_000

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -2242,6 +2242,27 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(preflight.opencodeReady).toBe(false)
   })
 
+  it('projects native ownership separately from the managed adapter without persisting the projection', async () => {
+    const service = createService()
+    const { managedCodexAdapterEntry, managedCodexBinary } = await import('./managed-codex')
+    const adapter = managedCodexAdapterEntry(storageRoot)
+    for (const [nativePath, expected] of [
+      [managedCodexBinary(storageRoot), true],
+      [join(storageRoot, 'external-codex'), false]
+    ] as const) {
+      await repository.setCodexInfo({
+        resolvedPath: adapter,
+        version: '1.6.2',
+        nativePath,
+        nativeVersion: '0.144.6'
+      })
+      const snapshot = await service.getSettingsView()
+      expect(snapshot.codexManaged).toBe(true)
+      expect(snapshot.codex.nativeManaged).toBe(expected)
+      expect((await repository.getSettings()).codex).not.toHaveProperty('nativeManaged')
+    }
+  })
+
   it('detects Codex and exposes readiness for its selected adapter', async () => {
     const adapterPath = '/data/codex-managed/adapter/dist/index.js'
     const nativePath = '/data/codex-managed/codex/vendor/target/bin/codex'
@@ -2260,6 +2281,7 @@ describe('SettingsService: preflight & spawn config', () => {
     expect(snapshot.codex).toEqual({
       resolvedPath: adapterPath,
       version: '1.6.2',
+      nativeManaged: false,
       nativeVersion: '0.144.6'
     })
     expect(await service.getPreflight()).toMatchObject({ codexReady: true, agentReady: true })

--- a/src/main/settings/settings-view.ts
+++ b/src/main/settings/settings-view.ts
@@ -17,6 +17,7 @@ import { toSettingsPreferencesSnapshot } from './preferences'
 import type { StoredProvider, StoredSettings } from './types'
 
 type ManagedRuntimeProjection = {
+  isManagedCodexNativePath: (path: string) => boolean
   isManagedRuntimePath: (frameworkId: AgentFrameworkId, path: string) => boolean
 }
 
@@ -38,7 +39,10 @@ export const buildSettingsSnapshot = (
     codex: {
       resolvedPath: settings.codex?.resolvedPath,
       version: settings.codex?.version,
-      nativeVersion: settings.codex?.nativeVersion
+      nativeVersion: settings.codex?.nativeVersion,
+      ...(settings.codex?.nativePath
+        ? { nativeManaged: runtimeManager.isManagedCodexNativePath(settings.codex.nativePath) }
+        : {})
     },
     claudeManaged: settings.claude?.resolvedPath
       ? runtimeManager.isManagedRuntimePath('claude-code', settings.claude.resolvedPath)

--- a/src/renderer/src/pages/settings/AgentFrameworkCard.render.test.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkCard.render.test.tsx
@@ -385,3 +385,47 @@ describe('AgentFrameworkCard', () => {
     expect(onInstall).toHaveBeenCalledWith('managed')
   })
 })
+
+it('offers an optional update without selecting or disabling a ready runtime', () => {
+  const onInstall = vi.fn()
+  const onSelect = vi.fn()
+  renderCard({
+    ready: true,
+    name: 'Codex',
+    path: '/codex',
+    updateAvailable: true,
+    versionDetail: 'Codex CLI 0.144.6 · ACP 1.6.2',
+    onInstall,
+    onSelect
+  })
+  expect(container.querySelector('[role="radio"]')).not.toBeNull()
+  expect(container.textContent).toContain('Codex CLI 0.144.6 · ACP 1.6.2')
+  act(() => container.querySelector<HTMLButtonElement>('[aria-label="Update Codex"]')?.click())
+  expect(onInstall).toHaveBeenCalledWith('managed')
+  expect(onSelect).not.toHaveBeenCalled()
+})
+
+it('keeps update progress and errors visible on a ready runtime', () => {
+  renderCard({
+    ready: true,
+    name: 'Codex',
+    path: '/codex',
+    updateAvailable: true,
+    install: {
+      isInstalling: true,
+      installProgress: null,
+      installLogs: ['download'],
+      installError: 'Update failed'
+    }
+  })
+  expect(container.querySelector('[role="progressbar"]')).not.toBeNull()
+  expect(container.querySelector('[role="alert"]')?.textContent).toBe('Update failed')
+  expect(container.textContent).toContain('download')
+})
+
+it('disables the optional update during a prompt', () => {
+  renderCard({ ready: true, name: 'Codex', updateAvailable: true, promptInFlight: true })
+  expect(container.querySelector<HTMLButtonElement>('[aria-label="Update Codex"]')?.disabled).toBe(
+    true
+  )
+})

--- a/src/renderer/src/pages/settings/AgentFrameworkCard.tsx
+++ b/src/renderer/src/pages/settings/AgentFrameworkCard.tsx
@@ -38,6 +38,9 @@ type AgentFrameworkCardProps = {
   needsRepair: boolean
   // Detected version, rendered as a muted `vX.Y.Z` right after the name.
   version?: string
+  versionDetail?: string
+  updateAvailable?: boolean
+  updateHint?: string
   // Resolved runtime/adapter path; its presence also gates the Uninstall control.
   path?: string
   // Repository/docs link shown under the path (e.g. the ACP adapter repo for ACP-based runtimes).
@@ -87,9 +90,9 @@ type AgentFrameworkCardPreviewState =
   'default' | 'hover' | 'focus' | 'active' | 'disabled' | 'loading' | 'error' | 'success'
 
 // Unified agent-framework card for the settings Model panel. The whole card is the radio option
-// that switches the active framework (only ready runtimes are selectable); the action column on
-// the right carries exactly one action — Uninstall when ready, Repair when a detected runtime
-// fails preflight, Install when nothing was detected — and stops clicks bubbling into a selection.
+// that switches the active framework (only ready runtimes are selectable). The action column
+// offers an optional managed update alongside Uninstall, or Repair/Install for an unavailable
+// runtime, and stops action clicks from selecting the framework.
 const AgentFrameworkCard = ({
   icon,
   name,
@@ -100,6 +103,9 @@ const AgentFrameworkCard = ({
   minimumVersion,
   needsRepair,
   version,
+  versionDetail,
+  updateAvailable = false,
+  updateHint,
   path,
   sourceLabel,
   sourceUrl,
@@ -144,7 +150,7 @@ const AgentFrameworkCard = ({
   const installLogs = install.installLogs
   const installError = previewState === 'error' ? t('Update failed') : install.installError
   // Any framework's install (or any uninstall) locks this card's Install menu.
-  const installLocked = installRunning || isUninstalling
+  const installLocked = installRunning || isUninstalling || isDetecting || Boolean(promptInFlight)
 
   // Show the bar while this card's install runs; fall back to an indeterminate label before the
   // first progress tick arrives.
@@ -262,6 +268,10 @@ const AgentFrameworkCard = ({
               )}
             </div>
             <p className="mt-0.5 text-xs text-muted-foreground">{description}</p>
+            {versionDetail ? (
+              <p className="mt-1 text-xs text-muted-foreground">{versionDetail}</p>
+            ) : null}
+            {updateHint ? <p className="mt-1 text-xs text-muted-foreground">{updateHint}</p> : null}
             {updateRequired && minimumVersion ? (
               <p className="mt-1 font-mono text-[11px] text-status-warning-foreground dark:text-status-warning-dark-foreground">
                 {t('Requires Codex ACP v{{version}} or later', { version: minimumVersion })}
@@ -285,26 +295,39 @@ const AgentFrameworkCard = ({
             ) : null}
           </div>
           {/* Actions live outside the selection gesture: clicks here must not switch frameworks.
-              Exactly one action per card: Uninstall when ready, Repair when detected-but-broken,
-              Install when nothing was detected. */}
-          {!ready || showUninstall ? (
+              Ready runtimes may offer Update alongside Uninstall. */}
+          {!ready || showUninstall || updateAvailable ? (
             <div
               className="ml-auto flex shrink-0 items-center gap-2"
               onClick={(event) => event.stopPropagation()}
             >
-              {ready ? (
-                <RuntimeUninstallControl
-                  label={name}
-                  uninstallCommand={uninstallCommand}
-                  managed={managed}
-                  active={active}
-                  isUninstalling={isUninstalling}
-                  isDetecting={isDetecting}
-                  // Global by contract: an install of ANY framework locks every card's Uninstall.
-                  isInstalling={installRunning}
-                  promptInFlight={promptInFlight}
-                  onUninstall={onUninstall}
+              {ready && updateAvailable ? (
+                <AgentInstallSourceMenu
+                  name={name}
+                  intent="update"
+                  sources={installSources}
+                  installing={installing}
+                  disabled={installLocked}
+                  npmAvailable={npmAvailable}
+                  blockedInstallSources={blockedInstallSources}
+                  onInstall={onInstall}
                 />
+              ) : null}
+              {ready ? (
+                showUninstall ? (
+                  <RuntimeUninstallControl
+                    label={name}
+                    uninstallCommand={uninstallCommand}
+                    managed={managed}
+                    active={active}
+                    isUninstalling={isUninstalling}
+                    isDetecting={isDetecting}
+                    // Global by contract: an install of ANY framework locks every card's Uninstall.
+                    isInstalling={installRunning}
+                    promptInFlight={promptInFlight}
+                    onUninstall={onUninstall}
+                  />
+                ) : null
               ) : (
                 <AgentInstallSourceMenu
                   name={name}
@@ -321,9 +344,9 @@ const AgentFrameworkCard = ({
           ) : null}
         </div>
 
-        {!ready ? (
+        {!ready || installing || installError || installLogs.length > 0 ? (
           <div className="mt-2 space-y-3">
-            <p className="text-xs text-muted-foreground">{notReadyHint}</p>
+            {!ready ? <p className="text-xs text-muted-foreground">{notReadyHint}</p> : null}
 
             {progress ? (
               // Determinate bar when the installer reports bytes, indeterminate slide otherwise —
@@ -335,7 +358,9 @@ const AgentFrameworkCard = ({
                 </div>
                 <div
                   role="progressbar"
-                  aria-label={updateRequired ? t('Update progress') : t('Install progress')}
+                  aria-label={
+                    updateRequired || updateAvailable ? t('Update progress') : t('Install progress')
+                  }
                   aria-valuemin={0}
                   aria-valuemax={100}
                   aria-valuenow={percent}

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -18,6 +18,8 @@ import {
 } from '../../../../shared/settings'
 import {
   isSupportedCodexAcpVersion,
+  hasCodexNativeUpdate,
+  MANAGED_CODEX_VERSION,
   MINIMUM_CODEX_ACP_VERSION
 } from '../../../../shared/codex-runtime'
 import { AgentFrameworkCard } from './AgentFrameworkCard'
@@ -333,6 +335,9 @@ const AgentPanel = ({
     updateRequired?: boolean
     minimumVersion?: string
     version?: string
+    versionDetail?: string
+    updateAvailable?: boolean
+    updateHint?: string
     path?: string
     sourceLabel: string
     sourceUrl: string
@@ -412,7 +417,24 @@ const AgentPanel = ({
         codex.resolvedPath && codex.version && !isSupportedCodexAcpVersion(codex.version)
       ),
       minimumVersion: MINIMUM_CODEX_ACP_VERSION,
-      version: codex.version,
+      versionDetail: t('Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}', {
+        nativeVersion: codex.nativeVersion ?? t('Unknown'),
+        adapterVersion: codex.version ?? t('Unknown')
+      }),
+      updateAvailable: Boolean(
+        codexManaged && codex.nativeManaged && hasCodexNativeUpdate(codex.nativeVersion)
+      ),
+      updateHint: hasCodexNativeUpdate(codex.nativeVersion)
+        ? codexManaged && codex.nativeManaged
+          ? t(
+              'Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.',
+              { version: MANAGED_CODEX_VERSION }
+            )
+          : t(
+              'Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.',
+              { version: MANAGED_CODEX_VERSION }
+            )
+        : undefined,
       path: codex.resolvedPath,
       sourceLabel: 'agentclientprotocol/codex-acp',
       sourceUrl: 'https://github.com/agentclientprotocol/codex-acp',
@@ -603,6 +625,9 @@ const AgentPanel = ({
       minimumVersion={card.minimumVersion}
       needsRepair={cardNeedsRepair(card)}
       version={card.version}
+      versionDetail={card.versionDetail}
+      updateAvailable={card.updateAvailable}
+      updateHint={card.updateHint}
       path={card.path}
       sourceLabel={card.sourceLabel}
       sourceUrl={card.sourceUrl}

--- a/src/renderer/src/pages/settings/AgentPanel.tsx
+++ b/src/renderer/src/pages/settings/AgentPanel.tsx
@@ -417,10 +417,13 @@ const AgentPanel = ({
         codex.resolvedPath && codex.version && !isSupportedCodexAcpVersion(codex.version)
       ),
       minimumVersion: MINIMUM_CODEX_ACP_VERSION,
-      versionDetail: t('Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}', {
-        nativeVersion: codex.nativeVersion ?? t('Unknown'),
-        adapterVersion: codex.version ?? t('Unknown')
-      }),
+      versionDetail:
+        codex.resolvedPath || codex.version || codex.nativeVersion
+          ? t('Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}', {
+              nativeVersion: codex.nativeVersion ?? t('Unknown'),
+              adapterVersion: codex.version ?? t('Unknown')
+            })
+          : undefined,
       updateAvailable: Boolean(
         codexManaged && codex.nativeManaged && hasCodexNativeUpdate(codex.nativeVersion)
       ),

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -4679,6 +4679,58 @@ describe('SettingsPage Codex framework', () => {
     }
   ]
 
+  it.each([
+    [true, '0.144.6', true],
+    [false, '0.144.6', false],
+    [true, '0.153.4', false],
+    [true, '0.154.0', false],
+    [true, undefined, false]
+  ])(
+    'offers a tested native update only for an older managed CLI (%s, %s)',
+    async (nativeManaged, nativeVersion, expected) => {
+      const api = window.api.settings
+      const snapshot = {
+        claude: {},
+        opencode: {},
+        codebuddy: {},
+        codex: {
+          resolvedPath: '/data/codex-managed/adapter/dist/index.js',
+          version: '1.6.2',
+          nativeVersion,
+          nativeManaged
+        },
+        providers: [],
+        agentFrameworkId: 'codex',
+        agentFrameworks: frameworks,
+        claudeManaged: false,
+        opencodeManaged: false,
+        codexManaged: true
+      }
+      api.getSettings = vi.fn().mockResolvedValue(snapshot)
+      api.getPreflight = vi.fn().mockResolvedValue({
+        codexReady: true,
+        agentReady: true,
+        agentFrameworkId: 'codex',
+        activeProviderReady: false
+      })
+      await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+      await openAgentPanel()
+      const update = document.body.querySelector<HTMLButtonElement>('[aria-label="Update Codex"]')
+      expect(Boolean(update)).toBe(expected)
+      if (!nativeManaged)
+        expect(document.body.textContent).toContain('Update your external installation manually')
+      if (expected) {
+        const installCodex = vi
+          .fn()
+          .mockResolvedValue({ installId: 'upgrade', ok: false, error: 'Codex is in use' })
+        api.installCodex = installCodex
+        api.onInstallLog = vi.fn().mockReturnValue(() => undefined)
+        await act(async () => update?.click())
+        expect(installCodex).toHaveBeenCalledWith({ source: 'managed' })
+      }
+    }
+  )
+
   it('offers Codex as a selectable framework behind the switch confirmation', async () => {
     const api = (window as unknown as { api: { settings: Record<string, unknown> } }).api
     const snapshot = {
@@ -4720,8 +4772,8 @@ describe('SettingsPage Codex framework', () => {
 
     const codexRadio = document.body.querySelector<HTMLButtonElement>('[aria-label="Use Codex"]')
     expect(codexRadio).not.toBeNull()
-    // The adapter version shows as a muted v-tag after the name; the repo link points at the ACP adapter.
-    expect(document.body.textContent).toContain('v1.6.2')
+    // The native and adapter versions are displayed separately; the repo link points at the ACP adapter.
+    expect(document.body.textContent).toContain('Codex CLI 0.144.6 · ACP 1.6.2')
     expect(document.body.textContent).toContain('agentclientprotocol/codex-acp')
 
     await act(async () => codexRadio?.click())

--- a/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
+++ b/src/renderer/src/pages/settings/SettingsPage.render.test.tsx
@@ -4679,6 +4679,30 @@ describe('SettingsPage Codex framework', () => {
     }
   ]
 
+  it('omits the version line when Codex has never been detected', async () => {
+    window.api.settings.getSettings = vi.fn().mockResolvedValue({
+      claude: {},
+      opencode: {},
+      codebuddy: {},
+      codex: {},
+      providers: [],
+      agentFrameworkId: 'codex',
+      agentFrameworks: frameworks,
+      claudeManaged: false,
+      opencodeManaged: false,
+      codexManaged: false
+    })
+    window.api.settings.getPreflight = vi.fn().mockResolvedValue({
+      codexReady: false,
+      agentReady: false,
+      agentFrameworkId: 'codex',
+      activeProviderReady: false
+    })
+    await act(async () => root.render(<SettingsPage open onClose={vi.fn()} />))
+    await openAgentPanel()
+    expect(document.body.textContent).not.toContain('Codex CLI Unknown')
+  })
+
   it.each([
     [true, '0.144.6', true],
     [false, '0.144.6', false],

--- a/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
+++ b/src/renderer/src/pages/workspace/previews/office-behavior-regressions.test.ts
@@ -256,7 +256,9 @@ describe('Office behavior through real parsers and adapters', () => {
   })
 
   it('preserves original sheet identity and hidden flags across blank sheets', async () => {
-    await renderWorkbook(workbookBytes('xlsx', false, true), 'xlsx')
+    const outcome = await renderWorkbook(workbookBytes('xlsx', false, true), 'xlsx')
+    // The startup probe also emits sheets; wait for the actual workbook's first paint.
+    await vi.waitFor(() => expect(outcome.state).toBe('ready'))
     const context = ParserWorker.instances[0].context
     expect(context.workbook?.SheetNames).toEqual(['Visible', 'Hidden'])
     expect(context.sheets).toEqual([

--- a/src/shared/codex-runtime.ts
+++ b/src/shared/codex-runtime.ts
@@ -3,6 +3,16 @@ import { compareVersions } from './update'
 // The app installs this adapter version and treats it as the oldest ACP contract it can safely run.
 // Newer compatible adapters remain usable; older installs stay discoverable so Settings can offer an
 // explicit update instead of misreporting them as missing.
+// App-tested native CLI target; this is not a minimum for all models or external installations.
+export const MANAGED_CODEX_VERSION = '0.153.4'
+
+export const hasCodexNativeUpdate = (version: string | undefined): boolean =>
+  Boolean(
+    version &&
+    /^\d+\.\d+\.\d+$/.test(version) &&
+    compareVersions(version, MANAGED_CODEX_VERSION) < 0
+  )
+
 export const MINIMUM_CODEX_ACP_VERSION = '1.6.2'
 
 export const isSupportedCodexAcpVersion = (version: string): boolean =>

--- a/src/shared/codex-runtime.ts
+++ b/src/shared/codex-runtime.ts
@@ -1,8 +1,5 @@
 import { compareVersions } from './update'
 
-// The app installs this adapter version and treats it as the oldest ACP contract it can safely run.
-// Newer compatible adapters remain usable; older installs stay discoverable so Settings can offer an
-// explicit update instead of misreporting them as missing.
 // App-tested native CLI target; this is not a minimum for all models or external installations.
 export const MANAGED_CODEX_VERSION = '0.153.4'
 
@@ -13,6 +10,9 @@ export const hasCodexNativeUpdate = (version: string | undefined): boolean =>
     compareVersions(version, MANAGED_CODEX_VERSION) < 0
   )
 
+// The app installs this adapter version and treats it as the oldest ACP contract it can safely run.
+// Newer compatible adapters remain usable; older installs stay discoverable so Settings can offer an
+// explicit update instead of misreporting them as missing.
 export const MINIMUM_CODEX_ACP_VERSION = '1.6.2'
 
 export const isSupportedCodexAcpVersion = (version: string): boolean =>

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5042,6 +5042,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "URLs für entfernte Modelle müssen HTTPS verwenden. HTTP ist nur für localhost oder Loopback-Adressen erlaubt.",
     "Load media from {{domains}}": "Medien von {{domains}} laden",
     "Images in Mermaid diagrams are blocked": "Bilder in Mermaid-Diagrammen sind blockiert",
-    "Use a separate Markdown image to load it explicitly.": "Verwenden Sie ein separates Markdown-Bild, um es ausdrücklich zu laden."
+    "Use a separate Markdown image to load it explicitly.": "Verwenden Sie ein separates Markdown-Bild, um es ausdrücklich zu laden.",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "Auf die getestete Codex CLI v{{version}} aktualisieren. Schließen Sie vorher die Codex-Sitzungen.",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} ist verfügbar. Aktualisieren Sie Ihre externe Installation manuell und lassen Sie sie erneut erkennen."
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5204,6 +5204,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "Las URL de modelos remotos deben usar HTTPS. HTTP solo se permite para localhost o direcciones de bucle invertido.",
     "Load media from {{domains}}": "Cargar contenido multimedia de {{domains}}",
     "Images in Mermaid diagrams are blocked": "Las imágenes en diagramas Mermaid están bloqueadas",
-    "Use a separate Markdown image to load it explicitly.": "Utilice una imagen Markdown independiente para cargarla de forma explícita."
+    "Use a separate Markdown image to load it explicitly.": "Utilice una imagen Markdown independiente para cargarla de forma explícita.",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "Actualizar a la versión probada Codex CLI v{{version}}. Cierre las sesiones de Codex antes de actualizar.",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} está disponible. Actualice su instalación externa manualmente y vuelva a detectarla."
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5204,6 +5204,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "Les URL des modèles distants doivent utiliser HTTPS. HTTP est autorisé uniquement pour localhost ou les adresses de bouclage.",
     "Load media from {{domains}}": "Charger le média depuis {{domains}}",
     "Images in Mermaid diagrams are blocked": "Les images dans les diagrammes Mermaid sont bloquées",
-    "Use a separate Markdown image to load it explicitly.": "Utilisez une image Markdown séparée pour la charger explicitement."
+    "Use a separate Markdown image to load it explicitly.": "Utilisez une image Markdown séparée pour la charger explicitement.",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "Mettez à jour vers la version testée Codex CLI v{{version}}. Fermez les sessions Codex avant la mise à jour.",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} est disponible. Mettez à jour votre installation externe manuellement, puis relancez la détection."
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -4888,6 +4888,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "リモートモデルの URL には HTTPS が必要です。HTTP は localhost またはループバックアドレスでのみ使用できます。",
     "Load media from {{domains}}": "{{domains}} からメディアを読み込む",
     "Images in Mermaid diagrams are blocked": "Mermaid 図内の画像はブロックされています",
-    "Use a separate Markdown image to load it explicitly.": "個別の Markdown 画像を使って明示的に読み込んでください。"
+    "Use a separate Markdown image to load it explicitly.": "個別の Markdown 画像を使って明示的に読み込んでください。",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "検証済みの Codex CLI v{{version}} に更新できます。更新前に Codex セッションを閉じてください。",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} が利用可能です。外部のインストールを手動で更新してから、再検出してください。"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -4886,6 +4886,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "원격 모델 URL은 HTTPS를 사용해야 합니다. HTTP는 localhost 또는 루프백 주소에만 허용됩니다.",
     "Load media from {{domains}}": "{{domains}}에서 미디어 불러오기",
     "Images in Mermaid diagrams are blocked": "Mermaid 다이어그램의 이미지가 차단되었습니다",
-    "Use a separate Markdown image to load it explicitly.": "별도의 Markdown 이미지를 사용하여 직접 불러오세요."
+    "Use a separate Markdown image to load it explicitly.": "별도의 Markdown 이미지를 사용하여 직접 불러오세요.",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "검증된 Codex CLI v{{version}}로 업데이트할 수 있습니다. 업데이트 전에 Codex 세션을 닫으세요.",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} 버전을 사용할 수 있습니다. 외부 설치를 수동으로 업데이트한 후 다시 감지하세요."
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5337,6 +5337,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "URL удалённых моделей должны использовать HTTPS. HTTP разрешён только для localhost или адресов обратной петли.",
     "Load media from {{domains}}": "Загрузить медиа с {{domains}}",
     "Images in Mermaid diagrams are blocked": "Изображения в диаграммах Mermaid заблокированы",
-    "Use a separate Markdown image to load it explicitly.": "Используйте отдельное изображение Markdown, чтобы загрузить его явно."
+    "Use a separate Markdown image to load it explicitly.": "Используйте отдельное изображение Markdown, чтобы загрузить его явно.",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "Обновите до проверенной версии Codex CLI v{{version}}. Перед обновлением закройте сеансы Codex.",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Доступна Codex CLI v{{version}}. Обновите внешнюю установку вручную, затем повторите обнаружение."
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -4888,6 +4888,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "远程模型 URL 必须使用 HTTPS。HTTP 仅允许用于 localhost 或回环地址。",
     "Load media from {{domains}}": "加载来自 {{domains}} 的媒体",
     "Images in Mermaid diagrams are blocked": "已阻止 Mermaid 图表中的图片",
-    "Use a separate Markdown image to load it explicitly.": "请使用单独的 Markdown 图片，以便手动加载。"
+    "Use a separate Markdown image to load it explicitly.": "请使用单独的 Markdown 图片，以便手动加载。",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "可更新至已验证的 Codex CLI v{{version}}。更新前请关闭 Codex 会话。",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} 已可用。请手动更新外部安装，然后重新检测。"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -4888,6 +4888,9 @@
     "Remote model URLs must use HTTPS. HTTP is only allowed for localhost or loopback addresses.": "遠端模型 URL 必須使用 HTTPS。HTTP 僅允許用於 localhost 或迴路位址。",
     "Load media from {{domains}}": "載入來自 {{domains}} 的媒體",
     "Images in Mermaid diagrams are blocked": "已封鎖 Mermaid 圖表中的圖片",
-    "Use a separate Markdown image to load it explicitly.": "請使用獨立的 Markdown 圖片，以便手動載入。"
+    "Use a separate Markdown image to load it explicitly.": "請使用獨立的 Markdown 圖片，以便手動載入。",
+    "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}": "Codex CLI {{nativeVersion}} · ACP {{adapterVersion}}",
+    "Update to the tested Codex CLI v{{version}}. Close Codex sessions before updating.": "可更新至已驗證的 Codex CLI v{{version}}。更新前請關閉 Codex 工作階段。",
+    "Codex CLI v{{version}} is available. Update your external installation manually, then re-detect.": "Codex CLI v{{version}} 已可用。請手動更新外部安裝，然後重新偵測。"
   }
 }

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -252,6 +252,8 @@ export type CodexInfo = {
   resolvedPath?: string
   version?: string
   nativeVersion?: string
+  // Read-only ownership projection; never persisted in Settings.
+  nativeManaged?: boolean
 }
 
 // Result of probing the machine for a runnable claude executable.


### PR DESCRIPTION
## Problem

Open Science pins its managed Codex CLI to 0.144.6, so reinstalling cannot obtain Astra's bundled metadata. Settings primarily shows the separate ACP adapter version, leaving users without a clear native-runtime upgrade action. Fixes #2389.

## Proposed change

Pin the managed native CLI to 0.153.4 with versioned npm SHA-512 values for all six platforms, retaining ACP 1.6.2. Trust its verified bundled Astra catalog while preserving the previously supported 0.144.6 catalog and delegation certification.

Show CLI and ACP versions separately. Offer an explicit update only for an older app-owned CLI/adapter pair; external CLI installations receive manual update guidance. Reuse existing installation, progress, diagnostics and snapshot refresh. Main-process admission refuses replacement while an app-launched Codex process uses the target and prevents new starts during replacement. Admission remains held after adapter close or failed teardown and is released only after the shared process-tree owner confirms complete cleanup. Undetected Codex cards omit version details. Settings detection and installation reject overlap using existing admission state; detection includes its repository write, while an installer may run its own post-install detection. Detection smoke and authentication (login/status/logout) processes also hold per-path admission until confirmed tree cleanup. This shared Settings rule applies to all agent install/detect entry points and was approved by the maintainer.

## Scope and non-goals

No database migration, new persisted fields, state enum, automatic updates, arbitrary version selection or hot session migration. `CodexInfo.nativeManaged` is an optional read-only snapshot projection, not stored data. Installation still changes app-owned runtime files and existing path/version values. Existing external binaries remain externally owned, and the installer retains its staged verification and backup recovery. Existing sessions retain their history/branch format and current resume/replay paths.

## Acceptance criteria and validation

Checks below ran against the final relevant implementation; overlapping counts are not additive:

| Behavior | Command / check | Result |
| --- | --- | --- |
| Installation admission, replacement, runtime manager, model catalogs, Settings UI, all locales | Targeted `npm test --` for managed-codex, agent-runtime-manager, codex, SettingsPage, AgentFrameworkCard and i18n/resources | 1,389 passed |
| Four backend routes and consumers | `npm run test:module -- settings_backend_resolution` | 800 passed; opt-in live cases skipped without binary paths |
| Settings commands, snapshots, Electron/Web contracts, subscriptions | `npm run test:module -- settings_service_facade` | 1,054 passed |
| Previous/current delegation certification, shared native shell policy, install subscription cleanup | Targeted codex-execution, production-frameworks, native-shell-policy, settings-runtime-slice | 62 passed |
| Review regressions: adapter close versus confirmed tree teardown, retries, undetected UI | Targeted installer/framework/process-tree/Settings tests plus ACP lifecycle and i18n guards | 261 + 846 passed |
| Detection/replacement race, delayed snapshot publication, incomplete smoke cleanup | Targeted manager, detector and installer suites | 135 passed; backend/service modules rechecked with 800 / 1,054 passing |
| Authentication update admission | Targeted authentication/installer/process-tree suites with a real child process | 124 passed |
| Failed spawn and delegated construction cleanup | Targeted process-tree/delegation tests; authentication/session regressions; real missing-executable installer regression | 41 / 206 / 63 passed (overlapping suites) |
| Native Astra catalog | Opt-in real CLI 0.153.4 / patched ACP 1.6.2 native model/list and ACP session/new contracts | Both passed, no fallback metadata warning; no paid model request |
| Cross-process types and lint | `npm run typecheck`; `npm run lint` | Passed |
| Visual UI | Browser-rendered production component, Chinese translations, before/after simulated update | Inspected; screenshots delivered in task |

The native model/list Astra assertion fails on CLI 0.144.6 and passes on 0.153.4, independently of the app-generated catalog.

Real-binary compatibility checks also passed native Responses MCP routing, deterministic auth failure, reviewer tool routing, implicit Skill loading on Responses/Chat bridge including restart/resume, and completion handoff. Clear inherited proxy variables and use loopback NO_PROXY for these local-server tests: the host proxy otherwise returns 503.

**Known validation limits:** two explicit native Skill-input cases and the manual compaction notification case fail identically against both CLI 0.144.6 and 0.153.4 with the same patched ACP 1.6.2. They remain reported baseline failures, not claimed fixed or silently skipped. Real subscription-account login and non-macOS binary execution were not exercised locally. CI is authoritative for the full portable/platform suite. No full local `npm test` was run, as requested.

The CI-only Office regression now waits for the actual preview to become ready before checking sheet identity; a startup-probe response is insufficient. This maintainer-approved test-only scope extension preserves all existing assertions. Its 16-test suite passed normally and with coverage instrumentation.

## Review focus

Review process-use admission and release, snapshot ownership versus adapter ownership, preservation of old CLI behavior, exact model/version trust, and upgrade progress/errors on an otherwise ready card. Source reference: https://github.com/openai/codex/releases/tag/rust-v0.153.4 and the release-tagged `codex-rs/models-manager/models.json`.
