### PR TITLE
fix(export): ignore runtime timestamps in conversation checks

### DIFF
--- a/src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx
+++ b/src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx
@@ -5,8 +5,9 @@ import { waitFor } from '@testing-library/react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import type { ChatSession } from '@/stores/session-store'
+import { useSessionStore, type ChatSession } from '@/stores/session-store'
 import { ConversationExportDialog } from './ConversationExportDialog'
+import { createConversationExportDocument } from '../../../../shared/conversation-export'
 import {
   saveSessionInOrder,
   resetSessionPersistenceWriteFailuresForTests
@@ -93,6 +94,106 @@ describe('ConversationExportDialog', () => {
     vi.restoreAllMocks()
     vi.unstubAllGlobals()
     resetSessionPersistenceWriteFailuresForTests()
+  })
+
+  it('exports a settled conversation after a delayed stop and durable refresh', async () => {
+    const durable = createSession()
+    const initialState = useSessionStore.getState()
+    useSessionStore.getState().hydrateSessions([durable])
+    vi.spyOn(Date, 'now').mockReturnValue(10)
+    // The durable completion can arrive before its runtime stop event reaches the renderer.
+    useSessionStore.getState().finishRun(durable.id)
+    useSessionStore.getState().applyDurableSessionProjection({
+      source: useSessionStore.getState().sessions[0]!,
+      session: durable,
+      mode: 'runtime-context-authority'
+    })
+    const snapshot = useSessionStore.getState().sessions[0]!
+    const writeFile = vi.fn().mockResolvedValue(undefined)
+    const onClose = vi.fn()
+    const service = createConversationExportService({
+      loadSession: async () => durable,
+      isSessionActive: () => false,
+      showSaveDialog: async () => ({ canceled: false, filePath: '/in-memory/export.md' }),
+      getDownloadsPath: () => '/in-memory',
+      writeFile,
+      publishUserFile: async (path, write) => {
+        await write(path)
+      }
+    })
+    try {
+      expect(snapshot.status).toBe('idle')
+      const preview = createConversationExportDocument(snapshot, 0)
+      const saved = createConversationExportDocument(durable, 0)
+      expect(preview.updatedAt).not.toBe(saved.updatedAt)
+      expect({ ...preview, updatedAt: saved.updatedAt }).toEqual(saved)
+      expect(snapshot.messages.map(({ content }) => content)).toEqual(
+        durable.messages.map(({ content }) => content)
+      )
+      const render = (session: ChatSession | undefined): void => {
+        root.render(
+          <ConversationExportDialog
+            session={session}
+            currentSession={snapshot}
+            onClose={onClose}
+            onExport={service.exportConversation}
+          />
+        )
+      }
+      act(() => render(snapshot))
+      act(() => render(undefined))
+      act(() => render(snapshot))
+      act(() => findControl('radio', 'Markdown')?.click())
+      await act(async () => {
+        document.body
+          .querySelector<HTMLButtonElement>('[data-testid="conversation-export-confirm"]')
+          ?.click()
+      })
+      await waitFor(() =>
+        expect(
+          document.body.querySelector<HTMLButtonElement>(
+            '[data-testid="conversation-export-confirm"]'
+          )?.disabled
+        ).toBe(false)
+      )
+      expect(document.body.querySelector('[role="alert"]')?.textContent ?? '').toBe('')
+      expect(writeFile).toHaveBeenCalledWith(
+        '/in-memory/export.md',
+        expect.stringContaining('The selected limitations')
+      )
+      expect(writeFile.mock.calls[0]?.[1]).toContain(
+        `updated: ${JSON.stringify(new Date(durable.updatedAt).toISOString())}`
+      )
+      expect(onClose).toHaveBeenCalledOnce()
+    } finally {
+      useSessionStore.setState(initialState, true)
+    }
+  })
+
+  it('keeps export available when only the current Session update time changes', async () => {
+    const session = createSession()
+    const onExport = vi.fn().mockResolvedValue({ saved: true })
+    const onClose = vi.fn()
+    act(() =>
+      root.render(
+        <ConversationExportDialog
+          session={session}
+          currentSession={{ ...session, updatedAt: session.updatedAt + 1 }}
+          onClose={onClose}
+          onExport={onExport}
+        />
+      )
+    )
+    const confirm = document.body.querySelector<HTMLButtonElement>(
+      '[data-testid="conversation-export-confirm"]'
+    )!
+    expect(confirm.disabled).toBe(false)
+    expect(document.body.textContent).not.toContain('The conversation changed.')
+    await act(async () => {
+      confirm.click()
+    })
+    await waitFor(() => expect(onClose).toHaveBeenCalledOnce())
+    expect(onExport).toHaveBeenCalledOnce()
   })
 
   it('defaults to the whole PDF export and omits a selection field', async () => {

--- a/src/renderer/src/pages/workspace/ConversationExportDialog.tsx
+++ b/src/renderer/src/pages/workspace/ConversationExportDialog.tsx
@@ -17,7 +17,7 @@ import { flushSessionPersistence } from '@/lib/session-persistence/session-persi
 import { cn } from '@/lib/utils'
 import type { ChatSession } from '@/stores/session-store'
 import {
-  createConversationExportDocument,
+  serializeConversationExportContent,
   hashConversationExportContent,
   createConversationExportTurns,
   type ConversationExportFormat,
@@ -67,9 +67,10 @@ const ConversationExportDialogContent = ({
   const turns = useMemo(() => createConversationExportTurns(session.messages), [session.messages])
   const conversationChanged = useMemo(() => {
     if (!currentSession) return true
-    const snapshot = createConversationExportDocument(session, 0)
-    const current = createConversationExportDocument(currentSession, 0)
-    return JSON.stringify(snapshot) !== JSON.stringify(current)
+    return (
+      serializeConversationExportContent(session) !==
+      serializeConversationExportContent(currentSession)
+    )
   }, [currentSession, session])
   const validSelectedPromptIds = turns.flatMap((turn) =>
     selectedPromptIds.has(turn.promptMessageId) ? [turn.promptMessageId] : []

--- a/src/shared/conversation-export.test.ts
+++ b/src/shared/conversation-export.test.ts
@@ -6,7 +6,8 @@ import {
   renderConversationHtml,
   renderConversationMarkdown,
   sanitizeExportFilename,
-  sanitizeExportMarkdown
+  sanitizeExportMarkdown,
+  serializeConversationExportContent
 } from './conversation-export'
 import type { PersistedChatSession } from './session-persistence'
 
@@ -65,6 +66,69 @@ const createSession = (): PersistedChatSession => ({
 })
 
 describe('conversation export projection', () => {
+  it('ignores only the Session update time when comparing reviewed export content', () => {
+    const session = createSession()
+    const updated = { ...session, updatedAt: session.updatedAt + 1 }
+    expect(serializeConversationExportContent(updated)).toBe(
+      serializeConversationExportContent(session)
+    )
+    expect(createConversationExportDocument(updated, 0).updatedAt).toBe(updated.updatedAt)
+  })
+
+  it.each([
+    [
+      'title',
+      (session: PersistedChatSession) => {
+        session.title = 'Changed title'
+      }
+    ],
+    [
+      'creation time',
+      (session: PersistedChatSession) => {
+        session.createdAt += 1
+      }
+    ],
+    [
+      'message text',
+      (session: PersistedChatSession) => {
+        session.messages[1].content = 'Changed answer'
+      }
+    ],
+    [
+      'message time',
+      (session: PersistedChatSession) => {
+        session.messages[1].createdAt += 1
+      }
+    ],
+    [
+      'message order',
+      (session: PersistedChatSession) => {
+        session.messages.reverse()
+      }
+    ],
+    [
+      'attachment',
+      (session: PersistedChatSession) => {
+        session.artifacts![0].name = 'changed.pdf'
+      }
+    ],
+    [
+      'image',
+      (session: PersistedChatSession) => {
+        session.messages[0].images = [
+          { id: 'image-1', mimeType: 'image/png', data: 'AAAA', byteLength: 3 }
+        ]
+      }
+    ]
+  ] as const)('still detects changes to %s in reviewed content', (_field, mutate) => {
+    const original = createSession()
+    const changed = createSession()
+    mutate(changed)
+    expect(serializeConversationExportContent(changed)).not.toBe(
+      serializeConversationExportContent(original)
+    )
+  })
+
   it('removes complete provider think blocks while preserving ordinary Markdown', () => {
     expect(
       sanitizeExportMarkdown(

--- a/src/shared/conversation-export.ts
+++ b/src/shared/conversation-export.ts
@@ -268,13 +268,16 @@ export const sanitizeExportMarkdown = (content: string): string => {
   return parts.map((part) => part.raw).join('')
 }
 
+// Session updatedAt also tracks runtime/metadata changes. It is not part of the reviewed
+// content, but remains in the exported document. Use the same comparison in both processes.
+export const serializeConversationExportContent = (session: PersistedChatSession): string =>
+  JSON.stringify({ ...createConversationExportDocument(session, 0), updatedAt: 0 })
+
 // A precondition only: Main still renders its own durable Session, never renderer-supplied data.
 export const hashConversationExportContent = async (
   session: PersistedChatSession
 ): Promise<string> => {
-  const bytes = new TextEncoder().encode(
-    JSON.stringify(createConversationExportDocument(session, 0))
-  )
+  const bytes = new TextEncoder().encode(serializeConversationExportContent(session))
   const digest = await globalThis.crypto.subtle.digest('SHA-256', bytes)
   return Array.from(new Uint8Array(digest), (byte) => byte.toString(16).padStart(2, '0')).join('')
 }


### PR DESCRIPTION
## Problem

A settled conversation can remain impossible to export as Markdown after reopening the dialog: Main rejects it with “The conversation changed. Close and reopen export to review it.” The two reported failures name the same Session export command; a separate `.ipynb` defect has not been established.

A deterministic reproduction hydrates a completed Session, processes a delayed runtime stop, applies durable runtime authority, then closes/reopens the real export dialog and submits. The renderer retains a later Session `updatedAt`; all other export document fields match. The timestamp alone invalidated the content hash. This reproduces the reported symptom, without claiming the unavailable original Session followed this exact event order.

## Proposed change

Use one shared serialized content comparison for the renderer's stale-dialog check and Main's expected-content hash. Normalize only Session `updatedAt` for comparison. Exported Markdown/PDF still use Main's durable content and real timestamps. Title, message content/order/times, attachments, and images remain checked.

## Scope and non-goals

- No new persisted fields, enum values, data model, migration, historical compatibility path, dependency, or UI layout.
- No ACP adapter, model request, subscription, or Notebook export changes. No snapshot cache or persistence refactor.
- The visible behavior change is that timestamp-only differences no longer block export.

## Acceptance criteria and validation

Checks ran after the final material edit:

- Reported symptom → `npm test -- src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx -t 'delayed stop'` → repeated failure with the exact reported error before the fix; passes after the fix. Uses the existing production store/dialog/main-service boundary and existing save ports; no new production test seam.
- Shared comparison, Main Markdown/PDF export, dialog save failures/content changes, and workspace export entry → `npm test -- src/shared/conversation-export.test.ts src/main/session-persistence/conversation-export.test.ts src/renderer/src/pages/workspace/ConversationExportDialog.interaction.test.tsx src/renderer/src/pages/workspace/workspace-session-controller.test.ts` → 116 passed.
- Static validation → `npm run typecheck` and `npm run lint` → passed.
- Browser component verification → actual production component/CSS with synthetic Session data and substituted native save boundary; Markdown result produced, dialog closes, screenshot captured. Temporary fixture removed.

Local validation is on macOS. Reported Windows/Electron and live Codex + MiniMax were not exercised; shared comparison contains no platform-dependent path handling or provider branching. Electron native save is covered through existing service ports, not a live native dialog. The module explain command (`npm run test:affected:explain -- --base origin/main --head HEAD`) falls back to full because the export interaction test has no registered module owner. The explicit local impact set above follows the shared comparison → Main export / renderer dialog → workspace entry chain. Per maintainer request, no full local suite; exact-head PR CI is the final portable/platform authority.

Final CI evidence for head `3226c83ac5e35ff6588100c36274f4f0241cbd27`: PR Gate passed, with 30 checks passing and one planned skip. The initial Windows core run hit its 15-minute job budget; Windows E2E shard 2/3 reported an Electron graceful-close timeout that passed on its internal retry but failed the repository's fail-on-flaky policy. Only failed jobs were rerun once; both Windows checks passed on the second workflow attempt. No CI configuration or unrelated application code was changed. Independent Codex review on this head: mergeable, no actionable findings (static inspection).

## Review focus

Confirm that only the non-content Session update timestamp is excluded, exported timestamps remain intact, and real content changes continue to fail closed. Check the reproduction/evidence mapping against the final diff.
