### PR TITLE
fix(session-persistence): compare optional fields by JSON semantics

### DIFF
--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -4607,12 +4607,20 @@ describe('notebook runtime service', () => {
         runtimeSegmentId: 'runtime-child',
         promptMessageId: 'message-child'
       }
+      // A previously initialized child Frame can reach shell admission before a cold root Frame.
+      await service.state({
+        sessionId: 'session-1',
+        workspaceCwd: root,
+        provenanceContext: childContext
+      })
+
       const first = service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
         command: 'first',
         provenanceContext: rootContext
       })
+      await firstStarted.promise
       const queued = service.executeShell({
         sessionId: 'session-1',
         workspaceCwd: root,
@@ -4620,7 +4628,7 @@ describe('notebook runtime service', () => {
         provenanceContext: childContext
       })
 
-      await firstStarted.promise
+      const settledRuns = Promise.allSettled([first, queued])
       expect(entered).toEqual(['first'])
       const shutdown = service.shutdownSession('session-1')
       await shutdown
@@ -4631,7 +4639,7 @@ describe('notebook runtime service', () => {
         await vi.waitFor(() => expect(entered).toHaveLength(2))
         releases.get('must-not-start')?.()
       }
-      await Promise.allSettled([first, queued])
+      await settledRuns
 
       expect(activeWasCancelled).toBe(true)
       expect(entered).toEqual(['first'])

--- a/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
+++ b/src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx
@@ -674,6 +674,29 @@ describe('session persistence startup', () => {
     expect(saveSession.mock.calls.at(-1)?.[0].id).toBe('session-1')
   })
 
+  it('replaces unsaved local changes with durable content when retrying a conflict', async () => {
+    const restored = createPersistedSession({ revision: 1 })
+    const latest = createPersistedSession({ revision: 2, title: 'Durable title' })
+    loadAll.mockReset().mockResolvedValue({ ...emptyLoadResult(), sessions: [latest] })
+    loadAll.mockResolvedValueOnce({ ...emptyLoadResult(), sessions: [restored] })
+    saveSession.mockRejectedValue(
+      Object.assign(new Error('Session revision conflict: expected 1, actual 2.'), {
+        code: 'session-revision-conflict'
+      })
+    )
+    await act(async () => root.render(<Probe />))
+    await act(async () =>
+      useSessionStore.getState().renameSession('session-1', 'Unsaved local title')
+    )
+    expect(useSessionStore.getState().sessions[0].title).toBe('Unsaved local title')
+    await act(async () => {
+      container.querySelector<HTMLButtonElement>('[data-testid="retry-writes"]')!.click()
+    })
+    expect(useSessionStore.getState().sessions[0].title).toBe('Durable title')
+    expect(saveSession).toHaveBeenCalledOnce()
+    await expect(flushSessionPersistence()).resolves.toBeUndefined()
+  })
+
   it('reloads after a Session revision conflict instead of resending stale JSON', async () => {
     const restored = createPersistedSession({ revision: 1 })
     loadAll.mockReset().mockResolvedValue({

--- a/src/renderer/src/lib/session-persistence/session-persistence.test.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.test.ts
@@ -3300,6 +3300,122 @@ describe('renderer session persistence bridge', () => {
     })
   })
 
+  it('saves a generated file event already attached by Main after JSON readback', async () => {
+    const prompt = {
+      id: 'prompt-1',
+      role: 'user' as const,
+      content: 'Create a chart',
+      status: 'complete' as const,
+      eventIds: [] as string[],
+      createdAt: 1,
+      updatedAt: 1
+    }
+    const partial = {
+      id: 'agent-message-1',
+      role: 'agent' as const,
+      content: 'Partial',
+      status: 'streaming' as const,
+      streamId: 'run-1',
+      responseToMessageId: prompt.id,
+      eventIds: ['event-1'],
+      createdAt: 2,
+      updatedAt: 2
+    }
+    const base = materializeSessionConversationGraph(
+      createPersistedSession({
+        projectId: 'project-a',
+        revision: 8,
+        messages: [prompt, partial]
+      })
+    )
+    const authoritative = materializeSessionConversationGraph({
+      ...base,
+      revision: 9,
+      messages: [prompt, { ...partial, artifactIds: ['artifact-version-1'], updatedAt: 3 }],
+      artifacts: [
+        {
+          id: 'artifact-version-1',
+          kind: 'managed-file',
+          path: '/data/artifacts/chart.png',
+          fileUrl: 'file:///data/artifacts/chart.png',
+          size: 3,
+          name: 'chart.png',
+          createdAt: 3,
+          mtimeMs: 3
+        }
+      ],
+      updatedAt: base.updatedAt + 1
+    })
+    let durable: PersistedChatSession = JSON.parse(JSON.stringify(authoritative))
+    const main = new SessionPersistenceStateOwner({
+      repository: {
+        loadSessionWithDiagnostics: async () => ({ status: 'found', session: durable }),
+        saveSession: async (candidate) => {
+          durable = JSON.parse(
+            JSON.stringify({ ...candidate, revision: (durable.revision ?? 0) + 1 })
+          )
+          return durable
+        }
+      },
+      fileIndex: { syncSession: async () => [] },
+      assertMutable: () => undefined,
+      notifyFilesChanged: () => undefined,
+      notifyRuntimeContextSessionUpdated: () => undefined,
+      log: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+    })
+    const saveSession = vi.fn<SessionPersistenceApi['saveSession']>((session, options) =>
+      main.saveSession(session, options)
+    )
+    const api = createApi({
+      loadOne: vi.fn(async () => JSON.parse(JSON.stringify(durable))),
+      saveSession
+    })
+
+    useSessionStore.getState().hydrateSessions([base])
+    const save = createStoreSaver(api, useSessionStore.getState())
+    useSessionStore.getState().attachRunArtifacts({
+      sessionId: base.id,
+      runId: 'run-1',
+      eventId: 'artifact-event-1',
+      promptMessageId: prompt.id,
+      artifacts: [
+        {
+          id: 'artifact-version-1',
+          projectId: 'project-a',
+          sessionId: base.id,
+          messageId: partial.id,
+          name: 'chart.png',
+          path: '/data/artifacts/chart.png',
+          fileUrl: 'file:///data/artifacts/chart.png',
+          size: 3,
+          createdAt: new Date(3).toISOString(),
+          mtimeMs: 3
+        }
+      ]
+    })
+
+    // Both owners describe the same file on disk; only absent versus undefined properties differ.
+    expect(
+      JSON.parse(
+        JSON.stringify(toPersistedSession(useSessionStore.getState().sessions[0]).artifacts)
+      )
+    ).toEqual(JSON.parse(JSON.stringify(authoritative.artifacts)))
+    await expect(save(useSessionStore.getState())).resolves.toBeUndefined()
+
+    expect(saveSession.mock.calls[1][0]).toMatchObject({
+      artifacts: [expect.objectContaining(authoritative.artifacts![0])],
+      messages: [
+        expect.objectContaining({ id: prompt.id }),
+        expect.objectContaining({
+          id: partial.id,
+          content: 'Partial',
+          eventIds: ['event-1', 'artifact-event-1'],
+          artifactIds: ['artifact-version-1']
+        })
+      ]
+    })
+  })
+
   it('does not merge competing edits that select different Branch identities', async () => {
     const target = {
       id: 'prompt-1',

--- a/src/renderer/src/lib/session-persistence/session-persistence.ts
+++ b/src/renderer/src/lib/session-persistence/session-persistence.ts
@@ -190,8 +190,10 @@ const jsonValuesEqual = (left: unknown, right: unknown): boolean => {
   if (!left || !right || typeof left !== 'object' || typeof right !== 'object') return false
   const leftRecord = left as Record<string, unknown>
   const rightRecord = right as Record<string, unknown>
-  const leftKeys = Object.keys(leftRecord)
-  const rightKeys = Object.keys(rightRecord)
+  // Disk JSON omits undefined object properties; renderer projections may retain them.
+  // Compare the persisted values so a missing optional field cannot create a false conflict.
+  const leftKeys = Object.keys(leftRecord).filter((key) => leftRecord[key] !== undefined)
+  const rightKeys = Object.keys(rightRecord).filter((key) => rightRecord[key] !== undefined)
   return (
     leftKeys.length === rightKeys.length &&
     leftKeys.every(


### PR DESCRIPTION
## Problem

A renderer save can reject a recoverable revision conflict after Main has attached the same generated file. Renderer projections retain optional object properties set to `undefined`, whereas persisted JSON omits them. The recursive comparison treats these equivalent payloads as different and reports a terminal session-save conflict.

## Proposed change

Ignore undefined object properties in the existing JSON comparison. Keep actual value differences, array order, and revision checks intact. Add a regression through the real SessionPersistenceStateOwner save facade and public renderer store operations, with JSON round-trip storage. Also characterize the existing conflict Retry behavior: it reloads durable content and replaces unsaved local edits.

The branch is rebased onto `1b152084`. Stabilize the existing Notebook shutdown test by waiting for its first shell to enter before submitting child-Frame work, and attach settlement handlers before shutdown rejects queued work. A warm child Frame reproduces the old ordering deadlock with the same timeout seen in CI; this changes test synchronization only. Latest main also supplies delegation E2E fixture synchronization fixes.

## Scope and non-goals

No schema, persisted fields, enums, migrations, historical rewrites, dependencies, or UI changes. This reproduces a product defect consistent with the reported generated-file/storage warning, but the supplied log does not identify the original conflicting fields and cannot establish the incident's unique cause. Warning dismissal/reappearance and reload interaction changes remain separate work.

## Acceptance criteria and validation

The final regression fails on unmodified production code with SessionRevisionConflictError (expected 8, actual 9), despite both Artifact arrays serializing to identical JSON, and passes after this change. No new test seam was introduced.

The following checks ran after the last material edit in their affected component:

- Save recovery, genuine conflicts, session-store consumers, IPC, shared persistence, and unsaved quit protection → `npm test -- src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/lib/session-persistence/session-persistence.render.test.tsx src/renderer/src/stores/session-store.test.ts src/main/session-persistence/revision-conflict.test.ts src/main/session-persistence/renderer-flush.test.ts src/main/session-persistence/ipc.test.ts src/shared/session-persistence.test.ts` → 607 passed.
- Main, sandbox, and renderer types → `npm run typecheck` → passed.
- Notebook execution and shutdown → `npm test -- src/main/notebook/runtime-service.test.ts` → 385 passed, with no unhandled errors.
- Delegation E2E → `npx playwright test e2e/subagent-model-release-gate.spec.ts e2e/subagent-release-gate.spec.ts --workers=1` → 13 passed, 1 failed. Both formerly failing CI cases passed; the fairness scenario instead failed with a renderer conversation-graph reachability error. Its isolated rerun passed (1/1); this does not establish that the intermittent failure is fixed. Full CI remains authoritative.
- Repository lint → `npm run lint` → passed.
- Patch formatting → `git diff --check` → passed.

Affected-test explain selects full because the persistence files have no declared module owner. Per maintainer direction, full portable/platform checks are delegated to PR CI. No provider protocol, subscription timing, path handling, or migration changed. Live provider runs, packaged cross-platform behavior, and the original user's exact cold-start trigger are not locally verified. Latest-head independent review reports no actionable findings. CI run 34479864934 passed all Ubuntu portable shards, module coverage, macOS E2E lanes (including delegation), Windows core, and Windows E2E shards 1/2. Windows shard 3 failed on a flaky startup: database migrations advanced through 0026 while the storage probe reported slow I/O and the 90-second readiness limit expired; the built-in retry passed. Only this failed job and its dependents are being rerun, without relaxing timeouts or flaky-test enforcement. Final PR Gate remains pending.

## Review focus

Confirm that absent and undefined optional object properties are equivalent under persisted JSON semantics while null, changed values, and competing message/branch edits remain distinct. No screenshot is applicable because the patch does not change UI or interaction.
