### PR TITLE
fix(windows-installer): preserve elevation before update preflight

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -183,6 +183,18 @@ FunctionEnd
   StrCpy $perUserDataBackup ""
   StrCpy $dataProtectionFailed "0"
   StrCpy $dataRestoreFailed "0"
+  # The assisted install section elevates silent per-machine upgrades AFTER .onInit.
+  # Match that existing decision before any write probe or data move: the outer process
+  # must reach UAC, and only its elevated child may protect/replace the old installation.
+  ${if} ${Silent}
+  ${andIf} $hasPerMachineInstallation == "1"
+    ${ifNot} ${UAC_IsAdmin}
+      Goto openScienceCustomInit_done
+    ${endif}
+    # With both HKCU and HKLM registrations, initMultiUser initially chooses CurrentUser,
+    # but the silent install section later selects all-users. Preflight that final target.
+    !insertmacro setInstallModePerAllUsers
+  ${endif}
   ReadRegStr $perMachineInstallDirCache HKEY_LOCAL_MACHINE "${INSTALL_REGISTRY_KEY}" InstallLocation
   ReadRegStr $perUserInstallDirCache HKEY_CURRENT_USER "${INSTALL_REGISTRY_KEY}" InstallLocation
   Push $perMachineInstallDirCache
@@ -235,6 +247,7 @@ FunctionEnd
     Call ensureExistingUninstallerIsWritable
     !insertmacro protectMachineDataRootForSelectedMode
   ${endif}
+  openScienceCustomInit_done:
 !macroend
 
 # These callbacks cover cancellation or an installer failure before the post-uninstall hooks run.

--- a/scripts/fixtures/windows-update-notice/NoticeRegression.cs
+++ b/scripts/fixtures/windows-update-notice/NoticeRegression.cs
@@ -1,5 +1,6 @@
 // An opt-in native installer test, not an application helper. Observes real Win32 dialogs
-// belonging only to the child installer. No UI or updater behavior is mocked.
+// belonging only to the child installer. The elevation variant substitutes only the
+// external UAC request; it observes the actual NSIS cancellation path without granting rights.
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -67,29 +68,52 @@ class NoticeRegression {
   }
 
   static int Main(string[] args) {
-    string install = null, uninstaller = null, originalAcl = null;
+    string install = null, uninstaller = null, protectedFile = null, originalAcl = null, machineDirectory = null;
+    const string MachineHive = "Software\\" + Guid + "-machine-hive";
+    bool createdMachineHive = false;
     FileStream held = null;
     Process updater = null;
     try {
       var fixture = Path.GetFullPath(args[0]);
       var scenario = args[1];
+      bool elevation = scenario.Contains("elevation");
+      bool currentUser = scenario == "denied-currentuser";
+      bool elevatedTarget = scenario == "denied-elevated-target";
+      bool writable = scenario == "writable";
+      var elevationMarker = Path.Combine(Path.GetTempPath(), "elevation-requested");
+      Require(!File.Exists(elevationMarker), "Previous elevation marker exists; inspect it before running.");
       foreach (var hive in new[] { Registry.CurrentUser, Registry.LocalMachine }) {
         using (var key = hive.OpenSubKey("Software\\" + Guid)) Require(key == null, "Previous test registration exists; inspect it before running.");
       }
+      using (var key = Registry.CurrentUser.OpenSubKey(MachineHive))
+        Require(key == null, "Previous simulated machine hive exists; inspect it before running.");
       install = Path.Combine(fixture, "installed");
       Require(!Directory.Exists(install) || Directory.GetFileSystemEntries(install).Length == 0, "Test install directory must be empty.");
       Directory.CreateDirectory(install);
       var previous = Path.Combine(fixture, "0.25.1", "dist", "notice-fixture-installer.exe");
-      var current = Path.Combine(fixture, "0.26.0", "dist", "notice-fixture-installer.exe");
+      var current = Path.Combine(fixture, elevatedTarget ? "elevated-preflight" : elevation || currentUser ? "elevation" : "0.26.0", "dist", "notice-fixture-installer.exe");
       Require(Run(previous, "/S /D=" + install) == 0, "Fixture install failed.");
       var executable = Path.Combine(install, Name + ".exe");
       uninstaller = Path.Combine(install, "Uninstall " + Name + ".exe");
+      protectedFile = uninstaller;
+      if (elevatedTarget) {
+        var candidateDirectory = Path.Combine(fixture, "machine-installed");
+        Require(!Directory.Exists(candidateDirectory), "Simulated machine install already exists.");
+        Directory.CreateDirectory(candidateDirectory);
+        machineDirectory = candidateDirectory;
+        protectedFile = Path.Combine(machineDirectory, Path.GetFileName(uninstaller));
+        File.Copy(uninstaller, protectedFile);
+        using (var key = Registry.CurrentUser.CreateSubKey(MachineHive + "\\Software\\" + Guid)) {
+          createdMachineHive = true;
+          key.SetValue("InstallLocation", machineDirectory);
+        }
+      }
       Require(Run(executable, "") == 25, "Previous version was not launchable.");
       bool denied = scenario.StartsWith("denied");
       bool silent = scenario.EndsWith("silent");
       bool retry = scenario == "locked-retry";
       if (denied) {
-        var original = File.GetAccessControl(uninstaller);
+        var original = File.GetAccessControl(protectedFile);
         foreach (FileSystemAccessRule rule in original.GetAccessRules(true, false, typeof(SecurityIdentifier)))
           Require(rule.IsInherited, "Fixture must have an inherited DACL for safe restoration.");
         Require(!original.AreAccessRulesProtected, "Fixture DACL must not be protected.");
@@ -99,22 +123,48 @@ class NoticeRegression {
         foreach (var sid in new[] { "S-1-5-18", "S-1-5-32-544" })
           acl.AddAccessRule(new FileSystemAccessRule(new SecurityIdentifier(sid), FileSystemRights.FullControl, AccessControlType.Allow));
         acl.AddAccessRule(new FileSystemAccessRule(new SecurityIdentifier("S-1-5-32-545"), FileSystemRights.ReadAndExecute, AccessControlType.Allow));
-        File.SetAccessControl(uninstaller, acl);
+        File.SetAccessControl(protectedFile, acl);
         bool refused = false;
-        try { using (File.Open(uninstaller, FileMode.Open, FileAccess.Write, FileShare.Read)) {} }
+        try { using (File.Open(protectedFile, FileMode.Open, FileAccess.Write, FileShare.Read)) {} }
         catch (UnauthorizedAccessException) { refused = true; }
         Require(refused, "Permission fixture needs a non-elevated process; write probe unexpectedly succeeded.");
-      } else {
+      } else if (!writable) {
         held = File.Open(uninstaller, FileMode.Open, FileAccess.Read, FileShare.Read);
       }
-      updater = Start(current, "/S --updated " + (silent ? "" : "--force-run ") + "/D=" + install);
-      if (silent) {
+      var nestedData = Path.Combine(install, "OpenScience", "sentinel.txt");
+      if (scenario.EndsWith("-data")) {
+        Directory.CreateDirectory(Path.GetDirectoryName(nestedData));
+        File.WriteAllText(nestedData, "keep original data");
+      }
+      updater = Start(current, "/S --updated " + (elevation ? "/allusers " : currentUser ? "/currentuser " : "") + (silent || writable ? "" : "--force-run ") + (elevatedTarget ? "" : "/D=" + install));
+      if (elevation) {
+        string notice = "";
+        var timer = Stopwatch.StartNew();
+        while (!updater.HasExited && timer.ElapsedMilliseconds < 10000) {
+          var dialog = Dialog(updater);
+          if (dialog != IntPtr.Zero) { notice = Text(dialog); Click(dialog, 2); break; }
+          Thread.Sleep(30);
+        }
+        int exit = Finish(updater);
+        Require(File.Exists(elevationMarker), "Installer rejected the protected file before requesting UAC; exit=" + exit + "\n" + notice);
+        if (scenario.EndsWith("-data"))
+          Require(File.ReadAllText(elevationMarker).Contains("data-in-place"), "Outer installer moved user data before UAC approval.");
+        File.Delete(elevationMarker);
+        Require(exit == 1223, "Installer did not preserve UAC cancellation exit status.");
+        if (scenario.EndsWith("-data")) {
+          Require(File.ReadAllText(nestedData) == "keep original data", "Cancellation changed nested user data.");
+          File.Delete(nestedData);
+          Directory.Delete(Path.GetDirectoryName(nestedData));
+        }
+      } else if (writable) {
+        Require(Finish(updater) == 0, "Writable current-user upgrade failed.");
+      } else if (silent) {
         Require(Finish(updater) == 2, "Unattended update must fail silently with exit 2.");
       } else {
         var dialog = WaitForNotice(updater);
         var text = Text(dialog);
         Console.WriteLine(text);
-        Require(text.Contains(uninstaller), "Notice omitted the affected file.");
+        Require(text.Contains(protectedFile), "Notice did not identify the final installation target.");
         Require(text.Contains(denied ? "Windows error: 5" : "Windows error: 32"), "Notice omitted the actual Windows error.");
         Require(text.Contains(denied ? "administrator" : "Retry"), "Notice did not explain recovery.");
         // Local screenshot mode leaves the real dialog available for Computer Use.
@@ -127,7 +177,8 @@ class NoticeRegression {
         } else Click(dialog, 2); // Windows gives a single OK button IDCANCEL, as well as Cancel.
         Require(Finish(updater) == (retry ? 0 : 2), "Unexpected installer result after notice action.");
       }
-      Require(Run(executable, "") == (retry ? 26 : 25), "Notice action left the wrong app version.");
+      Require(!File.Exists(elevationMarker), "Current-user update unexpectedly requested elevation.");
+      Require(Run(executable, "") == (retry || writable ? 26 : 25), "Notice action left the wrong app version.");
       Console.WriteLine("PASS: " + scenario);
       return 0;
     } catch (Exception error) {
@@ -137,8 +188,13 @@ class NoticeRegression {
       if (updater != null) { if (!updater.HasExited) { updater.Kill(); updater.WaitForExit(); } updater.Dispose(); }
       if (held != null) held.Dispose();
       if (originalAcl != null) {
-        Require(Run("icacls.exe", "\"" + uninstaller + "\" /reset") == 0, "Could not restore fixture DACL.");
-        Require(File.GetAccessControl(uninstaller).GetSecurityDescriptorSddlForm(AccessControlSections.Access) == originalAcl, "Fixture DACL was not restored exactly.");
+        Require(Run("icacls.exe", "\"" + protectedFile + "\" /reset") == 0, "Could not restore fixture DACL.");
+        Require(File.GetAccessControl(protectedFile).GetSecurityDescriptorSddlForm(AccessControlSections.Access) == originalAcl, "Fixture DACL was not restored exactly.");
+      }
+      if (createdMachineHive) Registry.CurrentUser.DeleteSubKeyTree(MachineHive);
+      if (machineDirectory != null && Directory.Exists(machineDirectory)) {
+        File.Delete(Path.Combine(machineDirectory, "Uninstall " + Name + ".exe"));
+        Directory.Delete(machineDirectory);
       }
       if (uninstaller != null && File.Exists(uninstaller)) {
         Require(Run(uninstaller, "/S /currentuser _?=" + install) == 0, "Fixture uninstall failed.");

--- a/scripts/fixtures/windows-update-notice/README.md
+++ b/scripts/fixtures/windows-update-notice/README.md
@@ -44,10 +44,45 @@ remove any real Open Science installation or change its permissions.
 | Access denied, unattended update   | No blocking notice; exit 2, previous app launchable                                  |
 | File occupied, unattended update   | No blocking notice; exit 2, previous app launchable                                  |
 
-With the unmodified hook, the three interactive cases fail because the installer
+Before the failure-notice change, the three interactive cases fail because the installer
 exits 2 without displaying a notice, leaving the old app launchable. The unattended
 cases already pass. This reproduces a sufficient cause of the reported silent
 failure, not proof of a specific reporter's ACL or antivirus state.
 
 This fixture covers the installer boundary, not Electron relaunch, all NSIS error
 codes, full package contents, antivirus products, or elevated/manual recovery.
+
+## Legacy per-machine elevation ordering
+
+The additional `elevation` installer embeds the current hook and replaces only
+`UAC_RunElevated` with `elevation-probe.nsh`. Real secure-desktop consent cannot be
+driven unattended by this test. The replacement records the request and returns
+Win32 cancellation (1223); the real NSIS initialization and cancellation handling
+still run. No administrative rights are granted and no production seam is added.
+
+The `denied-elevation` cases select all-users mode through the public `/allusers`
+argument, with an actual protected fixture uninstaller. They require reaching UAC
+before rejecting the file, preserving cancellation status, and keeping the old
+executable launchable. The nested-data case also requires the original data to
+remain in place at the moment of the request and after cancellation.
+`denied-currentuser` verifies that `/currentuser` retains the access-denied notice
+without requesting UAC. `writable` verifies a normal current-user upgrade succeeds.
+
+On the pre-fix hook, `denied-elevation` fails with the actual error-5 notice and
+installer exit 2 before any elevation request. After the fix it reaches the request
+and preserves the simulated cancellation. This covers the same upstream decision
+used for a registered legacy per-machine install; it does not create an HKLM
+registration or certify real UAC approval, different-account credentials, or a
+complete elevated upgrade. The `0.26.0` fixture directory is a version marker;
+its hook always comes from the current working tree.
+
+`denied-elevated-target` exercises the elevated preflight with both user and
+machine registrations pointing to different directories. The fixture reports an
+admin token to NSIS but keeps real OS write denial in place. Its `preInit` uses
+Win32 `RegOverridePredefKey` to redirect HKLM only within the fixture process to
+a dedicated HKCU test hive; it never writes the real machine registration. The
+test requires the machine-target error notice and the original user executable
+to remain launchable, proving target selection happens before either uninstall.
+The temporary hive and machine-target file are removed in `finally`.
+This covers branch behavior, not the security properties of an actual elevated
+token. Both test prefixes are excluded from uninstaller generation/execution.

--- a/scripts/fixtures/windows-update-notice/build.mjs
+++ b/scripts/fixtures/windows-update-notice/build.mjs
@@ -10,15 +10,27 @@ const compiler = process.env.OPEN_SCIENCE_MAKENSIS
 if (!compiler) throw new Error('Set OPEN_SCIENCE_MAKENSIS to the cached makensis.exe.')
 const name = 'open-science-update-notice-test'
 const guid = '11f7eae6-e7e3-4c1c-931f-2a9b1df095ea'
-for (const [version, code, hook] of [
+const currentHook = await readFile('build/installer.nsh', 'utf8')
+const elevationProbe = await readFile(
+  'scripts/fixtures/windows-update-notice/elevation-probe.nsh',
+  'utf8'
+)
+const elevatedPreflightProbe = await readFile(
+  'scripts/fixtures/windows-update-notice/elevated-preflight-probe.nsh',
+  'utf8'
+)
+for (const [directory, version, code, hook] of [
   [
+    '0.25.1',
     '0.25.1',
     25,
     execFileSync('git', ['show', 'v0.25.1:build/installer.nsh'], { encoding: 'utf8' })
   ],
-  ['0.26.0', 26, await readFile('build/installer.nsh', 'utf8')]
+  ['0.26.0', '0.26.0', 26, currentHook],
+  ['elevation', '0.26.0', 26, elevationProbe + currentHook],
+  ['elevated-preflight', '0.26.0', 26, elevatedPreflightProbe + currentHook]
 ]) {
-  const projectDir = join(root, version)
+  const projectDir = join(root, directory)
   const packed = join(projectDir, 'packed')
   await mkdir(join(packed, 'resources'), { recursive: true })
   await writeFile(

--- a/scripts/fixtures/windows-update-notice/elevated-preflight-probe.nsh
+++ b/scripts/fixtures/windows-update-notice/elevated-preflight-probe.nsh
@@ -1,0 +1,22 @@
+# Exercise elevated target selection without granting OS privileges. Redirect only
+# this fixture process's HKLM reads to its dedicated HKCU test hive before initMultiUser.
+!ifndef BUILD_UNINSTALLER
+!include "UAC.nsh"
+!undef UAC_IsAdmin
+!define UAC_IsAdmin `1 == 1`
+!macro preInit
+  System::Call 'advapi32::RegOpenKeyExW(p 0x80000001, w "Software\11f7eae6-e7e3-4c1c-931f-2a9b1df095ea-machine-hive", i 0, i 0x20119, *p .R8) i .R0'
+  ${if} $R0 != 0
+    IntOp $R0 $R0 + 1000
+    SetErrorLevel $R0
+    Quit
+  ${endif}
+  System::Call 'advapi32::RegOverridePredefKey(p 0x80000002, p R8) i .R0'
+  System::Call 'advapi32::RegCloseKey(p R8)'
+  ${if} $R0 != 0
+    IntOp $R0 $R0 + 2000
+    SetErrorLevel $R0
+    Quit
+  ${endif}
+!macroend
+!endif

--- a/scripts/fixtures/windows-update-notice/elevation-probe.nsh
+++ b/scripts/fixtures/windows-update-notice/elevation-probe.nsh
@@ -1,0 +1,16 @@
+# Test-only replacement for the external secure-desktop request. Keep NSIS's actual
+# mode selection, initialization and cancellation handling; do not grant privileges.
+!ifndef BUILD_UNINSTALLER
+!include "UAC.nsh"
+!macroundef UAC_RunElevated
+!macro UAC_RunElevated
+  FileOpen $R9 "$TEMP\elevation-requested" w
+  FileWrite $R9 "requested"
+  ${if} ${FileExists} "$INSTDIR\OpenScience\sentinel.txt"
+    FileWrite $R9 " data-in-place"
+  ${endif}
+  FileClose $R9
+  StrCpy $0 1223
+  SetErrorLevel 1223
+!macroend
+!endif

--- a/scripts/windows-update-notice.test.ts
+++ b/scripts/windows-update-notice.test.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process'
-import { mkdirSync, readFileSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync, rmdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { join, resolve } from 'node:path'
 
 import { beforeAll, describe, expect, it } from 'vitest'
@@ -16,6 +16,14 @@ describe.skipIf(process.platform !== 'win32' || !fixture)('Windows update failur
       readFileSync(join(root, '0.26.0/installer.nsh'), 'utf8'),
       'Rebuild the native fixture after changing build/installer.nsh.'
     ).toBe(readFileSync('build/installer.nsh', 'utf8'))
+    expect(readFileSync(join(root, 'elevation/installer.nsh'), 'utf8')).toBe(
+      readFileSync('scripts/fixtures/windows-update-notice/elevation-probe.nsh', 'utf8') +
+        readFileSync('build/installer.nsh', 'utf8')
+    )
+    expect(readFileSync(join(root, 'elevated-preflight/installer.nsh'), 'utf8')).toBe(
+      readFileSync('scripts/fixtures/windows-update-notice/elevated-preflight-probe.nsh', 'utf8') +
+        readFileSync('build/installer.nsh', 'utf8')
+    )
     for (const [key, directory] of Object.entries({
       TEMP: 'temp',
       TMP: 'temp',
@@ -42,7 +50,18 @@ describe.skipIf(process.platform !== 'win32' || !fixture)('Windows update failur
     expect(result.error).toBeUndefined()
     expect(result.status, result.stdout + result.stderr).toBe(0)
   })
-  it.each(['denied', 'locked', 'locked-retry', 'denied-silent', 'locked-silent'])(
+  it.each([
+    'denied',
+    'locked',
+    'locked-retry',
+    'denied-silent',
+    'locked-silent',
+    'denied-elevation',
+    'denied-elevation-data',
+    'denied-currentuser',
+    'denied-elevated-target',
+    'writable'
+  ])(
     '%s: explains interactive failure and preserves safe installer behavior',
     (scenario) => {
       const result = spawnSync(runner, [root, scenario], {
@@ -57,4 +76,25 @@ describe.skipIf(process.platform !== 'win32' || !fixture)('Windows update failur
     },
     95000
   )
+  it('preserves a pre-existing machine fixture when setup refuses it', () => {
+    const directory = join(root, 'machine-installed')
+    const sentinel = join(directory, 'Uninstall open-science-update-notice-test.exe')
+    mkdirSync(directory)
+    try {
+      writeFileSync(sentinel, 'pre-existing fixture')
+      const result = spawnSync(runner, [root, 'denied-elevated-target'], {
+        env,
+        encoding: 'utf8',
+        windowsHide: true,
+        timeout: 90000
+      })
+      expect(result.error).toBeUndefined()
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('Simulated machine install already exists.')
+      expect(readFileSync(sentinel, 'utf8')).toBe('pre-existing fixture')
+    } finally {
+      if (existsSync(sentinel)) unlinkSync(sentinel)
+      if (existsSync(directory)) rmdirSync(directory)
+    }
+  }, 95000)
 })


### PR DESCRIPTION
## Problem

The early uninstaller write check introduced in #2155 runs during NSIS initialization, before electron-builder's existing silent per-machine elevation in the install section. An unelevated update to a protected legacy installation exits with Windows error 5 before it can request UAC. The notice added in #2359 exposes that earlier failure; repeated update attempts retain the old version.

## Proposed change

Defer custom initialization side effects to the elevated child for silent upgrades that electron-builder already elevates. Keep write checks and nested-data protection before either old uninstall. Align elevated preflight with the upstream final all-users target when user and machine registrations coexist.

## Scope and non-goals

- Production change is 13 lines in the existing NSIS hook. No new updater service, database field/model, enum, registry field, or persistence format.
- Restores legacy per-machine update behavior. No broad escalation for all access-denied errors, ACL rewriting, installation relocation, or expansion of the current-user installation UI.
- HKCU-only installations at unwritable paths retain the existing manual-recovery notice. The reporter's registration scope is not available in their app log.
- Existing installation registration and temporary data protection retain their owners and formats; their timing moves after the existing elevation request.

## Acceptance criteria and validation

The new installer-boundary regression was run twice on the unfixed production hook. Both runs failed with the real error-5 notice and exit 2 before UAC was requested. The fixed hook passes that regression.

Final checks ran after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Native initialization, UAC request/cancellation, unchanged old app/data, current-user denial/success, locks/retry, mixed-registration preflight, fixture cleanup | `npm test -- scripts/windows-update-notice.test.ts --maxWorkers=1` with built native fixtures and `OPEN_SCIENCE_UPDATE_NOTICE_FIXTURE` | 11 passed |
| Installer and updater contracts/consumers | `npm test -- scripts/windows-installer-smoke.test.ts scripts/windows-updater-certification.test.ts scripts/electron-builder-config.test.ts src/main/update/electron-updater-strategy.test.ts` | 113 passed |
| Changed script standards | `npm run lint`; targeted Prettier check; `git diff --check` | Passed |
| Native fixture compilation | `node scripts/fixtures/windows-update-notice/build.mjs .scratch/notice-fixture` with cached NSIS tools | Passed |

Independent Standards and Spec reviews have no open code findings. No application TypeScript implementation/interface changed, so unrelated runtime typechecks and renderer E2E were not selected. The full portable suite was not run locally at the maintainer's request; exact-head CI remains authoritative.

Exact-head CI for `fb54f4f2eb22c98a2e9c17658e696844ab277ed0` passed: [PR Gate run 34466282019](https://github.com/aipoch/open-science/actions/runs/34466282019), including all three portable-suite shards, coverage, Windows core and all Windows E2E shards, Linux Notebook isolation, all macOS build/E2E lanes, and static checks. CI Integrity and CodeQL also passed. Automated PR review reported "mergeable" with no actionable findings. The unselected legacy-coverage compatibility lane was skipped; native UAC certification remains outside these results.

Additional real Windows validation on September 10: installed the isolated previous fixture under Program Files with its real HKLM registration. The medium-token driver proved write access to the existing uninstaller was denied, then launched the current fixture using exactly `/S --updated --force-run`, without `/allusers`, `/D`, `runas`, or either test prefix. With manual UAC consent, the installer exited 0 and the launchable payload changed from 25 to 26; machine scope, the original Windows account, and nested data were preserved. A subsequent real UAC rejection exited 1223 and preserved the installed executable hash, uninstaller DACL, registration, and nested data. Programs and Features showed the updated isolated package at 0.26.0 (the fixture's version marker, embedding this PR's hook). Its installation-record screenshot was captured locally; the secure-desktop UAC itself was not capturable by the window tool.

The isolated machine installation was subsequently uninstalled with manual consent. Its owned directory and fixture installation/uninstall registrations in both registry views were verified absent; no real Open Science installation was altered.

## Review focus

- The unelevated outer process must reach existing UAC before any write probe or data move. Its elevated child must still preflight the correct final target before destructive replacement.
- Tests substitute secure-desktop consent with cancellation. A second fixture simulates the admin predicate and redirects HKLM only inside its process to a dedicated HKCU test hive. These verify control flow without granting privileges or writing real machine registration.
- Same-account real UAC approval/rejection and a complete isolated-fixture upgrade are now verified. Different-account credentials, the full released application package, and the reporter's unknown registration scope remain outside this evidence. Portable CI skips the opt-in native tests; those skips are not certification. No renderer page, custom dialog layout, or copy changed.


Current merge status: the newer required PR Gate run failed, including after one failed-job rerun. The PR has not been merged. See the public [PR Gate results](https://github.com/aipoch/open-science/actions/runs/34475384079).
