### PR TITLE
test(ci): cover delayed delegation branch switching

### DIFF
--- a/e2e/subagent-release-gate.spec.ts
+++ b/e2e/subagent-release-gate.spec.ts
@@ -1,5 +1,6 @@
 import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
 import { expect } from '@playwright/test'
 import type { Page } from 'playwright'
 
@@ -705,6 +706,11 @@ test('parks an upward message on branch switch and resumes it after restart and 
     })
     .toBe('queued')
   expect(sessionId).toEqual(expect.any(String))
+
+  // Reproduce a slow CI branch switch: the old fixture released Main after two seconds,
+  // allowing the queued message to be accepted before its branch became inactive.
+  // The release-file barrier must keep it parked regardless of this scheduling delay.
+  await delay(5_000)
 
   await Promise.all([
     page.waitForEvent('domcontentloaded'),


### PR DESCRIPTION
## Problem

Follow-up to #2252. Its macOS delegation run observed an `accepted` receipt where the branch-park journey expected `queued`: the old fake provider completed Main after two seconds, allowing delivery before a slow branch switch. The retry passed, but the fail-on-flaky gate correctly rejected the run.

The merged default branch already contains a release-file barrier for this fixture. This PR makes the existing journey reproduce the slow-switch condition so a return to the old timer cannot silently pass.

## Proposed change

Delay branch switching by five seconds after observing the queued receipt. Retain the existing production Electron/IPC assertions for branch parking, restart, restoration, and eventual delivery. The delay deliberately perturbs scheduling; it does not replace synchronization or increase assertion timeouts.

## Scope and non-goals

One test file, six added lines. No production behavior, architecture, fields, enum values, data model, persistence format, historical compatibility, dependencies, or UI changes.

The other #2252 failure, CI Integrity rejecting `scripts/ci/change-impact.json`, was reproduced as the documented protected-control-plane rule. Preserve that guard rather than weaken it.

## Acceptance criteria and validation

- Old fixture timing -> same Electron journey with `--retries=0 --repeat-each=2` -> both runs failed at the reported `{ sessionStatus: 'idle', receiptStatus: 'queued' }` assertion with `receiptStatus: 'accepted'`.
- Existing release-file barrier restored -> `npx playwright test e2e/subagent-release-gate.spec.ts --grep 'parks an upward message' --retries=0 --repeat-each=2` -> both passed (19.4s, 20.2s).
- CI integrity/classification -> `npx vitest run scripts/ci/check-ci-integrity.test.ts scripts/ci/classify-pr-changes.test.ts` -> 109 passed.
- Build -> `npm run build:e2e` -> passed.
- Final diff -> `npm run lint`, targeted ESLint, `git diff --check` -> passed.

Final behavior checks ran after the test edit and restoration of the checked-in fixture; the temporary old implementation is not included. The build preceded the test-only edit. No application process types or consumer contracts changed, so no additional application module/typecheck scope was selected. No full local `npm test` was run, as requested by the maintainer. Windows and full-suite evidence remain the responsibility of exact-head PR CI.

Local setup required building the newly merged process-tree-native module with cached headers and `CXXFLAGS=-std=c++17`; initial missing-dependency failures were excluded from regression evidence. No build configuration or dependency changes are included.

## Review focus

Confirm the five-second perturbation remains before branch switching and the existing receipt/restart/restoration assertions remain intact. CI must retain its fail-on-flaky behavior.

Original failure: https://github.com/aipoch/open-science/actions/runs/34473883621/job/102860763127
