### PR TITLE
fix(literature): preserve PubMed dates and journal abbreviations

### DIFF
--- a/src/main/literature/citation-formatter.test.ts
+++ b/src/main/literature/citation-formatter.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest'
 
 import { LITERATURE_CITATION_STYLES, type LiteratureItemInput } from '../../shared/literature'
 import { LiteratureCitationFormatter } from './citation-formatter'
+import { toCslItem } from '../../shared/literature-csl'
 import { citationResourceDirectory, LiteratureCitationStyleLibrary } from './citation-style-library'
 
 const reference: LiteratureItemInput = {
@@ -31,6 +32,58 @@ const reference: LiteratureItemInput = {
 }
 
 describe('LiteratureCitationFormatter', () => {
+  it('renders the journal abbreviation without replacing the article title in a short-title style', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-pubmed-csl-'))
+    try {
+      const styles = new LiteratureCitationStyleLibrary(join(root, 'styles'))
+      const styleId = await styles.import(`<?xml version="1.0"?>
+<style xmlns="http://purl.org/net/xbiblio/csl" version="1.0" class="in-text">
+  <info><title>PubMed metadata regression</title><id>https://example.test/pubmed</id></info>
+  <citation><layout><choose><if variable="title-short"><text variable="title-short"/></if><else><text variable="title"/></else></choose></layout></citation>
+  <bibliography><layout><group delimiter=" | "><text variable="title"/><text variable="container-title-short"/></group></layout></bibliography>
+</style>`)
+      const formatter = new LiteratureCitationFormatter(styles)
+      const { items } = await formatter.parseReferences(
+        'PMID- 12345678\nTI  - A useful paper\nJT  - Journal of Useful Results\nTA  - J Useful Results\n'
+      )
+      const [formatted] = await formatter.formatReferences(
+        [{ id: 'paper', item: items[0]! }],
+        styleId,
+        'en-US'
+      )
+      expect(formatted?.inText).toBe('A useful paper')
+      expect(formatted?.reference).toContain('J Useful Results')
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('preserves a PubMed day through RIS export and reimport', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const { items } = await formatter.parseReferences(
+      'PMID- 12345678\nTI  - Dated paper\nDP  - 2024 Jan 15\n'
+    )
+    const ris = await formatter.exportReferences([{ id: 'dated', item: items[0]! }], 'ris')
+    const imported = await formatter.parseReferences(ris)
+    expect(imported.errors).toEqual([])
+    expect(imported.items[0]?.issuedText).toBe('2024-1-15')
+  })
+
+  it('projects PubMed publication dates and journal abbreviations into the correct citation fields', async () => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'PMID- 12345678\nTI  - A useful paper\nDP  - 2024 Jan 15\nJT  - Journal of Useful Results\nTA  - J Useful Results\n'
+    )
+    const record = parsed.items[0]!
+    expect(record.issuedText).toBe('2024 Jan 15')
+    expect(record.shortTitle).toBe('')
+    expect(toCslItem('paper', record)).toMatchObject({
+      issued: { 'date-parts': [[2024, 1, 15]] },
+      'container-title': 'Journal of Useful Results',
+      'container-title-short': 'J Useful Results'
+    })
+    expect(toCslItem('paper', record)).not.toHaveProperty('title-short')
+  })
+
   it.each([
     [
       'CN  - Research Consortium',
@@ -313,10 +366,15 @@ PMC - PMC1234567
           issuedText: '2024 Jan',
           issuedYear: 2024,
           containerTitle: 'Journal of Useful Results',
-          shortTitle: 'J Useful Results',
+          shortTitle: '',
           language: 'eng',
           url: 'https://pubmed.ncbi.nlm.nih.gov/12345678/',
-          typeFields: { volume: '12', issue: '3', pages: '44-58' },
+          typeFields: {
+            volume: '12',
+            issue: '3',
+            pages: '44-58',
+            journalAbbreviation: 'J Useful Results'
+          },
           creators: [
             {
               nameMode: 'person',

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -193,12 +193,13 @@ const parseNbib = (input: string): ParsedCitationRecords | undefined => {
       issuedText,
       issuedYear: /^\d{4}/u.test(issuedText) ? Number(issuedText.slice(0, 4)) : undefined,
       containerTitle: nbibText(record, 'JT') || nbibText(record, 'TA'),
-      shortTitle: nbibText(record, 'TA'),
+      shortTitle: '',
       language: nbibText(record, 'LA'),
       rights: '',
       url: pmid ? `https://pubmed.ncbi.nlm.nih.gov/${encodeURIComponent(pmid)}/` : '',
       extra: authors.uncertain.join('\n'),
       typeFields: {
+        ...(nbibText(record, 'TA') ? { journalAbbreviation: nbibText(record, 'TA') } : {}),
         ...(nbibText(record, 'VI') ? { volume: nbibText(record, 'VI') } : {}),
         ...(nbibText(record, 'IP') ? { issue: nbibText(record, 'IP') } : {}),
         ...(nbibText(record, 'PG') ? { pages: nbibText(record, 'PG') } : {})

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx
@@ -4551,6 +4551,29 @@ describe('LiteratureLibraryPage', () => {
     expect(headings.indexOf('Abstract')).toBeLessThan(headings.indexOf('Publication metadata'))
   })
 
+  it('uses the full journal title when only an article short title is available', async () => {
+    const entry: LiteratureItemView = {
+      ...libraryItem,
+      item: {
+        ...libraryItem.item,
+        containerTitle: 'Journal of Useful Results',
+        shortTitle: 'Article short title',
+        issuedText: '2024',
+        typeFields: {},
+        identifiers: []
+      }
+    }
+    search.mockImplementation((request: { scope: string }) =>
+      Promise.resolve(request.scope === 'library' ? { entries: [entry] } : { entries: [] })
+    )
+    render(<LiteratureLibraryPage />)
+    fireEvent.click(screen.getByRole('button', { name: 'All references' }))
+    await openReferenceDetail(await screen.findByText(entry.item.title))
+    expect(
+      within(screen.getByRole('dialog')).getByText('Journal of Useful Results. 2024')
+    ).not.toBeNull()
+  })
+
   it('orders a reference detail as publication, title, full authors, abstract, then metadata', async () => {
     const richItem: LiteratureItemView = {
       ...libraryItem,
@@ -4558,8 +4581,13 @@ describe('LiteratureLibraryPage', () => {
         ...libraryItem.item,
         itemType: 'review',
         issuedText: '2024 Jan',
-        shortTitle: 'J Retrieval',
-        typeFields: { volume: '12', issue: '3', pages: '44-58' },
+        shortTitle: 'Article short title',
+        typeFields: {
+          volume: '12',
+          issue: '3',
+          pages: '44-58',
+          journalAbbreviation: 'J Retrieval'
+        },
         creators: [
           ...libraryItem.item.creators,
           {

--- a/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
+++ b/src/renderer/src/pages/literature/LiteratureLibraryPage.tsx
@@ -1094,7 +1094,7 @@ const typeFieldText = (item: LiteratureItemInput, field: string): string => {
 }
 
 const publicationSummary = (item: LiteratureItemInput): string => {
-  const publication = item.shortTitle || item.containerTitle
+  const publication = typeFieldText(item, 'journalAbbreviation') || item.containerTitle
   const date = item.issuedText || item.issuedYear?.toString() || ''
   const volume = typeFieldText(item, 'volume')
   const issue = typeFieldText(item, 'issue')

--- a/src/shared/literature-csl.test.ts
+++ b/src/shared/literature-csl.test.ts
@@ -21,12 +21,36 @@ const item = (overrides: Partial<LiteratureItemInput> = {}): LiteratureItemInput
 })
 
 describe('toCslItem', () => {
+  it('keeps journal abbreviations separate from article short titles in both directions', () => {
+    const source = item({
+      title: 'A useful paper',
+      shortTitle: 'Useful paper',
+      containerTitle: 'Journal of Useful Results',
+      typeFields: { journalAbbreviation: 'J Useful Results' }
+    })
+    const csl = toCslItem('paper', source)
+    expect(csl).toMatchObject({
+      'title-short': 'Useful paper',
+      'container-title-short': 'J Useful Results'
+    })
+    expect(fromCslItem(csl)).toMatchObject({
+      shortTitle: 'Useful paper',
+      typeFields: { journalAbbreviation: 'J Useful Results' }
+    })
+  })
+
   it.each([
     ['2024-03-12', 2023, [2024, 3, 12]],
     ['2024-3-12', undefined, [2024, 3, 12]],
     ['2024-02', undefined, [2024, 2]],
     ['2024', undefined, [2024]],
     ['2024-02-29', undefined, [2024, 2, 29]],
+    ['2024 Jan 15', 2024, [2024, 1, 15]],
+    ['2024 Dec', 2024, [2024, 12]],
+    ['2024 Feb 29', 2024, [2024, 2, 29]],
+    ['2023 Feb 29', 2023, [2023]],
+    ['2024 Jan-Feb', 2024, [2024]],
+    ['2024 Winter', 2024, [2024]],
     ['2023-02-29', 2023, [2023]],
     ['2024-13-01', 2024, [2024]],
     ['2024-04-31', 2024, [2024]],

--- a/src/shared/literature-csl.ts
+++ b/src/shared/literature-csl.ts
@@ -69,6 +69,7 @@ type CslItem = Readonly<{
   issued?: CslDate
   accessed?: CslDate
   'container-title'?: string
+  'container-title-short'?: string
   'title-short'?: string
   abstract?: string
   language?: string
@@ -106,7 +107,30 @@ const creatorsFor = (
 }
 
 const issuedDate = (item: LiteratureItemInput): CslDate | undefined => {
-  const match = /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/u.exec(item.issuedText.trim())
+  // PubMed DP uses English month abbreviations. Normalize only unambiguous dates;
+  // seasons and ranges retain the existing year fallback, and the original text is untouched.
+  const months = [
+    'jan',
+    'feb',
+    'mar',
+    'apr',
+    'may',
+    'jun',
+    'jul',
+    'aug',
+    'sep',
+    'oct',
+    'nov',
+    'dec'
+  ]
+  const dateText = item.issuedText
+    .trim()
+    .replace(
+      /^(\d{4})\s+(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)(?:\s+(\d{1,2}))?$/iu,
+      (_match, year: string, month: string, day: string | undefined) =>
+        `${year}-${months.indexOf(month.toLowerCase()) + 1}${day === undefined ? '' : `-${day}`}`
+    )
+  const match = /^(\d{4})(?:-(\d{1,2})(?:-(\d{1,2}))?)?$/u.exec(dateText)
   if (match) {
     const year = Number(match[1])
     const month = match[2] ? Number(match[2]) : undefined
@@ -169,6 +193,7 @@ const toCslItem = (id: string, item: LiteratureItemInput): CslItem => {
   const publisher = typeField(item, 'publisher')
   const publisherPlace = typeField(item, 'publisherPlace')
   const edition = typeField(item, 'edition')
+  const journalAbbreviation = typeField(item, 'journalAbbreviation')
 
   return {
     id,
@@ -180,6 +205,7 @@ const toCslItem = (id: string, item: LiteratureItemInput): CslItem => {
     ...(issued ? { issued } : {}),
     ...(accessed ? { accessed } : {}),
     ...(item.containerTitle ? { 'container-title': item.containerTitle } : {}),
+    ...(journalAbbreviation ? { 'container-title-short': journalAbbreviation } : {}),
     ...(item.shortTitle ? { 'title-short': item.shortTitle } : {}),
     ...(item.abstract ? { abstract: item.abstract } : {}),
     ...(item.language ? { language: item.language } : {}),
@@ -275,7 +301,8 @@ const fromCslItem = (value: Record<string, unknown>): LiteratureItemInput => {
       ['pages', stringField(value, 'page')],
       ['publisher', stringField(value, 'publisher')],
       ['publisherPlace', stringField(value, 'publisher-place')],
-      ['edition', stringField(value, 'edition')]
+      ['edition', stringField(value, 'edition')],
+      ['journalAbbreviation', stringField(value, 'container-title-short')]
     ].filter((entry): entry is [string, string] => Boolean(entry[1]))
   )
 


### PR DESCRIPTION
PubMed NBIB dates such as `2024 Jan 15` previously became year-only CSL dates, and the `TA` journal abbreviation was stored as the article short title.

Preserve explicit publication months and days while retaining the original date text and the existing year fallback for ambiguous or invalid dates. Store journal abbreviations in `typeFields.journalAbbreviation`, map them to CSL `container-title-short` in both directions, and display the journal abbreviation or full journal title in reference details.

Validation on Windows:
- 70 tests passed across the CSL, citation formatter, citation fidelity, and export round-trip suites.
- 2 targeted reference-detail render tests passed.
- Main and renderer TypeScript checks passed.
- ESLint and Prettier checks passed for all changed files.

Existing records with journal abbreviations stored as article short titles are not automatically migrated, to avoid overwriting user-edited metadata. Third-party citation-engine handling of `form="short"` is unchanged.