### PR TITLE
fix(install): restore stale shadcn patches during npm install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,12 +33,17 @@ npm install
 `npm install` runs a `postinstall` step that generates the Prisma client and
 installs native Electron app dependencies.
 
-If installation reports a `patch-package` failure after pulling changes, run
-`npm ci` from the repository root. An existing `node_modules` directory can retain
-an older patch even when the dependency version has not changed; `npm install`
-does not necessarily replace that package. `npm ci` recreates `node_modules`
-from `package-lock.json` and applies the current patches without updating the
-lockfile. Any manual edits inside `node_modules` will be removed.
+An existing `node_modules` directory can retain an older patch even when the
+dependency version has not changed. Before applying patches, `npm install`
+automatically restores known historical `@shadcn/react@0.3.0` scroller files to
+their original content so the current patch can apply. Recovery is limited to
+the exact version and checksums of previously committed patches; it does not
+overwrite unknown manual edits or download dependencies from a lifecycle script.
+
+If installation still reports a `patch-package` failure, review any manual edits
+inside `node_modules`, then run `npm ci` from the repository root. It recreates
+`node_modules` from `package-lock.json` and applies the current patches without
+updating the lockfile. Any manual edits inside `node_modules` will be removed.
 
 Patch failures stop installation before Prisma generation and native dependency
 setup. Do not bypass them with `--ignore-scripts` or regenerate a patch from a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,18 @@ npm install
 `npm install` runs a `postinstall` step that generates the Prisma client and
 installs native Electron app dependencies.
 
+If installation reports a `patch-package` failure after pulling changes, run
+`npm ci` from the repository root. An existing `node_modules` directory can retain
+an older patch even when the dependency version has not changed; `npm install`
+does not necessarily replace that package. `npm ci` recreates `node_modules`
+from `package-lock.json` and applies the current patches without updating the
+lockfile. Any manual edits inside `node_modules` will be removed.
+
+Patch failures stop installation before Prisma generation and native dependency
+setup. Do not bypass them with `--ignore-scripts` or regenerate a patch from a
+partially patched installation. See the upstream
+[patch-package guidance](https://github.com/ds300/patch-package#applying-patches).
+
 ### Run in development
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dev:headless": "node scripts/dev-app-branding.cjs && node scripts/dev-web.cjs --headless",
     "cli": "node cli/index.mjs",
     "build": "npm run typecheck && electron-vite build && npm run build:web",
-    "postinstall": "patch-package --error-on-fail && node scripts/check-claude-acp-patch.mjs && prisma generate && electron-builder install-app-deps && node scripts/fix-electron-path.cjs",
+    "postinstall": "node scripts/prepare-shadcn-patch.mjs && patch-package --error-on-fail && node scripts/check-claude-acp-patch.mjs && prisma generate && electron-builder install-app-deps && node scripts/fix-electron-path.cjs",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:mac": "npm run build:web && electron-vite build && electron-builder --mac",
     "build:linux": "npm run build:web && electron-vite build && electron-builder --linux",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "dev:headless": "node scripts/dev-app-branding.cjs && node scripts/dev-web.cjs --headless",
     "cli": "node cli/index.mjs",
     "build": "npm run typecheck && electron-vite build && npm run build:web",
-    "postinstall": "patch-package && node scripts/check-claude-acp-patch.mjs && prisma generate && electron-builder install-app-deps && node scripts/fix-electron-path.cjs",
+    "postinstall": "patch-package --error-on-fail && node scripts/check-claude-acp-patch.mjs && prisma generate && electron-builder install-app-deps && node scripts/fix-electron-path.cjs",
     "build:unpack": "npm run build && electron-builder --dir",
     "build:mac": "npm run build:web && electron-vite build && electron-builder --mac",
     "build:linux": "npm run build:web && electron-vite build && electron-builder --linux",

--- a/scripts/dependency-patches.test.ts
+++ b/scripts/dependency-patches.test.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { tmpdir } from 'node:os'
@@ -6,13 +7,28 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
+import history from '../test/fixtures/shadcn-patch-history.json'
+
 const require = createRequire(import.meta.url)
 const patchCli = require.resolve('patch-package/index.js')
 const patchName = '@shadcn+react+0.3.0.patch'
 const patchPath = join(process.cwd(), 'patches', patchName)
-const patchLines = readFileSync(patchPath, 'utf8').split('\n')
+const patchSource = readFileSync(patchPath, 'utf8').replaceAll('\r\n', '\n')
+const patchLines = patchSource.split('\n')
 const original = '"use client";\n' + patchLines.find((line) => line.startsWith('-import'))!.slice(1)
 const patched = '"use client";\n' + patchLines.find((line) => line.startsWith('+import'))!.slice(1)
+// Compact, byte-exact snapshots from the original Git patches; no Git history is needed in CI.
+let historicalSource = original
+const historicalVersions = history.map(({ commit, sha256, edits }) => {
+  for (const [offset, length, replacement] of [...edits].reverse() as [number, number, string][]) {
+    historicalSource =
+      historicalSource.slice(0, offset) + replacement + historicalSource.slice(offset + length)
+  }
+  if (createHash('sha256').update(historicalSource).digest('hex') !== sha256) {
+    throw new Error(`Corrupt historical patch fixture: ${commit}`)
+  }
+  return { name: commit, source: historicalSource, status: 0 }
+})
 let fixture: string | undefined
 
 afterEach(() => {
@@ -22,14 +38,36 @@ afterEach(() => {
 
 describe('dependency patch installation', () => {
   it.each([
-    ['pristine', original, 0],
-    ['already patched', patched, 0],
-    ['stale patch', patched.replace('Math.min(o,n.scrollHeight)', 'o'), 1]
-  ] as const)('handles a %s installation', (_name, source, expectedStatus) => {
+    { name: 'pristine', source: original, status: 0 },
+    { name: 'already patched', source: patched, status: 0 },
+    ...historicalVersions,
+    {
+      name: 'unknown partial patch',
+      source: patched.replace('Math.min(o,n.scrollHeight)', 'o'),
+      status: 1
+    },
+    { name: 'manual edits', source: patched.replace('var xe=8', 'var xe=9'), status: 1 },
+    {
+      name: 'different package version',
+      source: historicalVersions[1].source,
+      status: 1,
+      version: '0.3.1'
+    },
+    { name: 'CRLF patch checkout', source: historicalVersions[1].source, status: 0, crlf: true },
+    { name: 'old Windows patch output', source: historicalVersions[1].source + '\r', status: 0 },
+    {
+      name: 'unexpected patch baseline',
+      source: historicalVersions[1].source,
+      status: 1,
+      corrupt: true
+    }
+  ])('handles $name', (scenario) => {
     const { scripts } = JSON.parse(readFileSync('package.json', 'utf8')) as {
       scripts: { postinstall: string }
     }
-    const [command, ...args] = scripts.postinstall.split(' && ')[0].split(' ')
+    const [prepareCommand, patchCommand] = scripts.postinstall.split(' && ')
+    expect(prepareCommand).toBe('node scripts/prepare-shadcn-patch.mjs')
+    const [command, ...args] = patchCommand.split(' ')
     expect(command).toBe('patch-package')
     expect(args).toContain('--error-on-fail')
 
@@ -38,19 +76,50 @@ describe('dependency patch installation', () => {
     const entry = join(packageDir, 'dist', 'message-scroller', 'index.js')
     mkdirSync(join(packageDir, 'dist', 'message-scroller'), { recursive: true })
     mkdirSync(join(fixture, 'patches'))
+    mkdirSync(join(fixture, 'scripts'))
+    copyFileSync(
+      'scripts/prepare-shadcn-patch.mjs',
+      join(fixture, 'scripts', 'prepare-shadcn-patch.mjs')
+    )
     writeFileSync(join(fixture, 'package.json'), '{}')
-    writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ version: '0.3.0' }))
-    writeFileSync(entry, source)
-    copyFileSync(patchPath, join(fixture, 'patches', patchName))
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ version: scenario.version ?? '0.3.0' })
+    )
+    writeFileSync(entry, scenario.source)
+    writeFileSync(
+      join(fixture, 'patches', patchName),
+      scenario.corrupt
+        ? patchSource.replace('"use client";', '"unexpected baseline";')
+        : scenario.crlf
+          ? patchSource.replaceAll('\n', '\r\n')
+          : patchSource
+    )
 
-    // Explicitly exercise local installs: CI already enables failure exits by default.
-    const result = spawnSync(process.execPath, [patchCli, ...args], {
-      cwd: fixture,
-      env: { ...process.env, CI: '' },
-      encoding: 'utf8'
-    })
-
-    expect(result.status, result.stdout + result.stderr).toBe(expectedStatus)
-    expect(readFileSync(entry, 'utf8')).toBe(expectedStatus === 0 ? patched : source)
+    // Execute the real lifecycle stages in order. CI already enables failure exits by default.
+    for (let install = 0; install < 2; install++) {
+      let status: number | null = null
+      let output = ''
+      for (const stage of [['scripts/prepare-shadcn-patch.mjs'], [patchCli, ...args]]) {
+        const result = spawnSync(process.execPath, stage, {
+          cwd: fixture,
+          env: { ...process.env, CI: '' },
+          encoding: 'utf8'
+        })
+        status = result.status
+        output += result.stdout + result.stderr
+        if (status !== 0) break
+      }
+      expect(status, output).toBe(scenario.status)
+      const installed = readFileSync(entry, 'utf8')
+      if (scenario.status === 0) {
+        expect(installed.replaceAll('\r\n', '\n').replace(/\r$/, '') === patched).toBe(true)
+      } else {
+        expect(installed === scenario.source).toBe(true)
+      }
+      if (install === 1 || scenario.source === patched) {
+        expect(output).not.toContain('Restored the original')
+      }
+    }
   })
 })

--- a/scripts/dependency-patches.test.ts
+++ b/scripts/dependency-patches.test.ts
@@ -1,0 +1,56 @@
+import { spawnSync } from 'node:child_process'
+import { copyFileSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const patchCli = require.resolve('patch-package/index.js')
+const patchName = '@shadcn+react+0.3.0.patch'
+const patchPath = join(process.cwd(), 'patches', patchName)
+const patchLines = readFileSync(patchPath, 'utf8').split('\n')
+const original = '"use client";\n' + patchLines.find((line) => line.startsWith('-import'))!.slice(1)
+const patched = '"use client";\n' + patchLines.find((line) => line.startsWith('+import'))!.slice(1)
+let fixture: string | undefined
+
+afterEach(() => {
+  if (fixture) rmSync(fixture, { recursive: true, force: true })
+  fixture = undefined
+})
+
+describe('dependency patch installation', () => {
+  it.each([
+    ['pristine', original, 0],
+    ['already patched', patched, 0],
+    ['stale patch', patched.replace('Math.min(o,n.scrollHeight)', 'o'), 1]
+  ] as const)('handles a %s installation', (_name, source, expectedStatus) => {
+    const { scripts } = JSON.parse(readFileSync('package.json', 'utf8')) as {
+      scripts: { postinstall: string }
+    }
+    const [command, ...args] = scripts.postinstall.split(' && ')[0].split(' ')
+    expect(command).toBe('patch-package')
+    expect(args).toContain('--error-on-fail')
+
+    fixture = mkdtempSync(join(tmpdir(), 'open-science-patches-'))
+    const packageDir = join(fixture, 'node_modules', '@shadcn', 'react')
+    const entry = join(packageDir, 'dist', 'message-scroller', 'index.js')
+    mkdirSync(join(packageDir, 'dist', 'message-scroller'), { recursive: true })
+    mkdirSync(join(fixture, 'patches'))
+    writeFileSync(join(fixture, 'package.json'), '{}')
+    writeFileSync(join(packageDir, 'package.json'), JSON.stringify({ version: '0.3.0' }))
+    writeFileSync(entry, source)
+    copyFileSync(patchPath, join(fixture, 'patches', patchName))
+
+    // Explicitly exercise local installs: CI already enables failure exits by default.
+    const result = spawnSync(process.execPath, [patchCli, ...args], {
+      cwd: fixture,
+      env: { ...process.env, CI: '' },
+      encoding: 'utf8'
+    })
+
+    expect(result.status, result.stdout + result.stderr).toBe(expectedStatus)
+    expect(readFileSync(entry, 'utf8')).toBe(expectedStatus === 0 ? patched : source)
+  })
+})

--- a/scripts/prepare-shadcn-patch.mjs
+++ b/scripts/prepare-shadcn-patch.mjs
@@ -1,0 +1,47 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+
+const packageDir = join('node_modules', '@shadcn', 'react')
+const packageJson = join(packageDir, 'package.json')
+if (!existsSync(packageJson)) process.exit(0)
+if (JSON.parse(readFileSync(packageJson, 'utf8')).version !== '0.3.0') process.exit(0)
+
+const entry = join(packageDir, 'dist', 'message-scroller', 'index.js')
+// patch-package can retain CR characters from a Windows patch checkout, including at EOF.
+const installed = readFileSync(entry, 'utf8').replaceAll('\r\n', '\n').replace(/\r$/, '')
+const digest = (source) => createHash('sha256').update(source).digest('hex')
+// Released cumulative patches, in Git history order. Never overwrite unknown local edits.
+const knownPatchedHashes = new Set([
+  '6306bf6bd406eb6ecb55ea050c0f1954008fe4e8b77d01c684f33d5dd3d37063', // 81d2bb78
+  '6cef30c198329500dd3dc0ff24762cf2335a5f363ab00de33e8e5af4231be756', // cc73bb73
+  '4c620c8214a19ea267e9b465e61382699dbb5273ea8d4470fb1be40153db3a97', // 3c6b201e
+  '2bf6d13e12fb7f161bd74ddd0c7848a5224ef84dbe3c04acf430bb7d0fb669fc' // 2d0f34d1
+])
+if (!knownPatchedHashes.has(digest(installed))) process.exit(0)
+
+// This patch contains the complete two-line file. Reuse its original instead of vendoring a copy.
+// The checksum fails closed if its format or upstream baseline ever changes.
+const lines = readFileSync(join('patches', '@shadcn+react+0.3.0.patch'), 'utf8')
+  .replaceAll('\r\n', '\n')
+  .split('\n')
+const side = (prefix) =>
+  lines
+    .filter(
+      (line) =>
+        line.startsWith(' ') || (line.startsWith(prefix) && !line.startsWith(prefix.repeat(3)))
+    )
+    .map((line) => line.slice(1))
+    .join('\n')
+if (installed === side('+')) process.exit(0)
+const original = side('-')
+if (digest(original) !== '75458e9313c0c712b2bcff80b9f4a7cfdc881a30e834fc85fe114b0993c82e41') {
+  throw new Error(
+    'Unexpected @shadcn/react patch baseline; refusing to replace the installed file.'
+  )
+}
+
+writeFileSync(entry, original)
+console.log('Restored the original @shadcn/react@0.3.0 scroller before applying the current patch.')

--- a/test/fixtures/shadcn-patch-history.json
+++ b/test/fixtures/shadcn-patch-history.json
@@ -1,0 +1,46 @@
+[
+  {
+    "commit": "81d2bb78",
+    "sha256": "6306bf6bd406eb6ecb55ea050c0f1954008fe4e8b77d01c684f33d5dd3d37063",
+    "edits": [
+      [11735, 0, "(()=>{for(let $ of a)$&&$.dataset.scrollAnchor===\"true\"&&z.current.add($)})(),"]
+    ]
+  },
+  {
+    "commit": "cc73bb73",
+    "sha256": "6cef30c198329500dd3dc0ff24762cf2335a5f363ab00de33e8e5af4231be756",
+    "edits": [
+      [
+        12046,
+        0,
+        "followBottomOnResize=g.useCallback(()=>u.current!==\"following-bottom\"||!l.current?false:(Ee(),true),[Ee]),"
+      ],
+      [13316, 0, "followBottomOnResize,"],
+      [13624, 0, "e,followBottomOnResiz"],
+      [15637, 0, "followBottomOnResize:T,"],
+      [16051, 0, "if(T())return;"],
+      [16195, 0, ",T"],
+      [16424, 0, "followBottomOnResize:T,"],
+      [16880, 0, "if(T())return;"],
+      [17023, 0, "T,"]
+    ]
+  },
+  {
+    "commit": "3c6b201e",
+    "sha256": "4c620c8214a19ea267e9b465e61382699dbb5273ea8d4470fb1be40153db3a97",
+    "edits": [
+      [465, 0, "Math.min("],
+      [466, 0, ",n.scrollHeight)"]
+    ]
+  },
+  {
+    "commit": "2d0f34d1",
+    "sha256": "2bf6d13e12fb7f161bd74ddd0c7848a5224ef84dbe3c04acf430bb7d0fb669fc",
+    "edits": [
+      [11398, 1, "G"],
+      [11403, 1, "z.current"],
+      [11745, 0, "me()||"],
+      [11864, 0, ",me"]
+    ]
+  }
+]


### PR DESCRIPTION
## Problem

After pulling an updated cumulative patch, developers running `npm install` can retain an older patched copy of the same dependency version. The reported `@shadcn/react@0.3.0` scroller exactly matches the historical patch from cc73bb73, so the current patch cannot apply to its single minified line. Locally, patch-package also defaults to a successful exit after failure.

## Proposed change

Before patch-package runs, recognize the previously committed scroller versions by package version and SHA-256, restore the original file from the existing patch, and let patch-package apply the current patch normally. Developers with known old patches can run `npm install` directly without removing node_modules or running npm ci first.

The preparation step normalizes Windows patch line endings for identification, verifies the immutable upstream baseline before writing, and leaves the current version and unknown local changes untouched. It uses only Node built-ins, performs no downloads, and adds no migration state. Retain `--error-on-fail` so an unrecognized conflict stops installation. Document automatic recovery and the manual fallback for unknown edits.

## Acceptance criteria and validation

Checks ran after the last material edit:

- Reported existing installation → restore the exact cc73bb73 scroller in the isolated worktree, then `npm install --prefer-offline --no-audit --no-fund` → passed; automatic restoration ran, all six patches applied, ACP integrity and Prisma generation succeeded, and Electron native dependencies rebuilt. The resulting scroller is byte-identical to the current patch target.
- Clean installation → `npm ci --prefer-offline --no-audit --no-fund` → passed with all six patches and the complete postinstall lifecycle; package-lock.json remained unchanged.
- Historical versions, repeat installs, Windows line endings, unknown edits, version mismatch, and invalid baseline → `npm test -- scripts/dependency-patches.test.ts src/renderer/src/components/ui/message-scroller.test.tsx` → 19 tests passed. Each installation case runs twice. Compact fixtures reconstruct the four real historical patch outputs and verify their independent SHA-256 values without requiring Git history in CI.
- Runtime types → `npm run typecheck:node` and `npm run typecheck:web` → passed, including the sandbox package.
- Repository lint → `npm run lint` → passed.
- Syntax and formatting → `node --check scripts/prepare-shadcn-patch.mjs`, Prettier on changed files, and `git diff --check` → passed.

Package metadata selects the full PR Gate plan. Per the maintainer's request, local verification uses focused checks; the complete suite and Windows/Linux/macOS platform lanes run in PR CI. The existing message-scroller consumer test is included because recovery must preserve the current runtime patch behavior.

## Scope and review focus

Compatibility is limited to developer node_modules containing known historical scroller patches. No application data migration, persisted-format changes, new states/enums, or UI changes. Unknown hand-edited files are not overwritten by recovery. A clean npm ci remains the fallback for unrecognized conflicts.

No dependency version or resolution changes, so package-lock.json is unchanged. The local npm install only reordered one key and removed unrelated libc metadata; those incidental changes are excluded. Existing React peer warnings and npm audit findings are explicitly out of scope.

Review the checksum allowlist, restoration baseline guard, lifecycle ordering, and cross-platform repeat-install behavior.
