### PR TITLE
fix(reproducibility): reseal recipes after helper trimming

### DIFF
--- a/src/main/artifacts/provenance-execution-evidence.ts
+++ b/src/main/artifacts/provenance-execution-evidence.ts
@@ -424,10 +424,9 @@ const buildBoundedExecutionSnapshot = (
   }
   if (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {
     while (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES && helperModules.length > 0) {
-      const evidenceWasIncomplete = helperEvidenceReasons.size > 0
       helperModules = helperModules.slice(0, -1)
       helperEvidenceReasons.add('payload-limit')
-      if (!evidenceWasIncomplete) invalidateRecipe()
+      invalidateRecipe()
     }
   }
   if (snapshotBytes() > MAX_EXECUTION_SNAPSHOT_BYTES) {

--- a/src/main/artifacts/provenance-helper-evidence.test.ts
+++ b/src/main/artifacts/provenance-helper-evidence.test.ts
@@ -9,6 +9,7 @@ import {
   parseArtifactExecutionSnapshot
 } from './provenance-execution-evidence'
 import { projectPublicArtifactExecutionSnapshot } from './provenance-read-model'
+import { artifactReproducibilityRecipeMatchesSnapshot } from './artifact-reproducibility-recipe'
 
 const digest = (source: string): string => createHash('sha256').update(source).digest('hex')
 
@@ -50,7 +51,10 @@ const run = (
   workingFiles: []
 })
 
-const snapshot = (runs: NotebookRunRecord[]): PersistedArtifactExecutionSnapshot =>
+const snapshot = (
+  runs: NotebookRunRecord[],
+  provenanceGraph?: PersistedArtifactExecutionSnapshot['provenanceGraph']
+): PersistedArtifactExecutionSnapshot =>
   buildBoundedExecutionSnapshot(
     {
       schemaVersion: 2,
@@ -60,12 +64,110 @@ const snapshot = (runs: NotebookRunRecord[]): PersistedArtifactExecutionSnapshot
       terminalPromptMessageId: 'prompt-1',
       producerRunId: runs.at(-1)!.runId,
       producerRunIndex: runs.length - 1,
-      createdAt: '2026-08-26T00:00:00.000Z'
+      createdAt: '2026-08-26T00:00:00.000Z',
+      ...(provenanceGraph ? { provenanceGraph } : {})
     },
     runs.map((value, runIndex) => ({ run: value, runIndex }))
   )
 
 describe('Artifact helper execution evidence', () => {
+  it.each([false, true])(
+    'reseals the recipe after successive helper trims (already incomplete: %s)',
+    (incomplete) => {
+      // The budget removes z, then the producer's b; a remains within the 4 MiB limit.
+      const source = `# ${'x'.repeat(2300 * 1024)}`
+      const earlier = run('earlier', 'pass', [
+        helper('helper-a', source),
+        helper('helper-z', source)
+      ])
+      if (incomplete)
+        earlier.helperEvidenceStatus = { state: 'incomplete', reasons: ['source-missing'] }
+      const producer = run('producer', 'helper_b()', [helper('helper-b', source)])
+      // Publication preserves a file checkpoint after the producer, whose helper barriers
+      // must reflect the final helper set rather than the first incomplete snapshot.
+      const graph: NonNullable<PersistedArtifactExecutionSnapshot['provenanceGraph']> = {
+        schemaVersion: 1,
+        targetEntityId: 'artifact-version:version-1',
+        completeness: 'complete',
+        reasonCodes: [],
+        activities: [
+          {
+            activityId: 'producer',
+            kind: 'notebook-run',
+            sequence: 1,
+            runIndex: 1,
+            inclusion: 'target-closure',
+            evidenceState: 'available'
+          },
+          {
+            activityId: 'publication',
+            kind: 'artifact-publication',
+            sequence: 2,
+            parentActivityId: 'producer',
+            inclusion: 'target-closure',
+            evidenceState: 'available'
+          }
+        ],
+        entities: [
+          {
+            entityId: 'file-generation:result',
+            kind: 'file-generation',
+            generationId: 'result',
+            relativePath: 'result.csv',
+            pathPortability: 'relative',
+            checksum: 'a'.repeat(64),
+            sizeBytes: 10,
+            contentStorageKey: `execution-file-evidence/blobs/sha256-${'a'.repeat(64)}`
+          },
+          {
+            entityId: 'artifact-version:version-1',
+            kind: 'artifact-version',
+            versionId: 'version-1',
+            filename: 'result.csv',
+            checksum: 'a'.repeat(64),
+            sizeBytes: 10
+          }
+        ],
+        edges: [
+          {
+            kind: 'generated',
+            activityId: 'producer',
+            entityId: 'file-generation:result',
+            authority: 'authoritative',
+            evidenceSource: 'runtime-observation'
+          },
+          {
+            kind: 'used',
+            activityId: 'publication',
+            entityId: 'file-generation:result',
+            authority: 'authoritative',
+            evidenceSource: 'artifact-publication'
+          },
+          {
+            kind: 'generated',
+            activityId: 'publication',
+            entityId: 'artifact-version:version-1',
+            authority: 'authoritative',
+            evidenceSource: 'artifact-publication'
+          }
+        ]
+      }
+      const value = snapshot([earlier, producer], graph)
+      expect(value.runs.map(({ runId }) => runId)).toEqual(['producer'])
+      expect(value.helperModules?.map(({ helperId }) => helperId)).toEqual(['helper-a'])
+      expect(Buffer.byteLength(JSON.stringify(value))).toBeLessThanOrEqual(4 * 1024 * 1024)
+      expect(value.helperEvidenceStatus?.state).toBe('incomplete')
+      expect(value.reproducibilityRecipe).toBeDefined()
+      expect(
+        artifactReproducibilityRecipeMatchesSnapshot(value.reproducibilityRecipe!, {
+          ...value,
+          provenanceGraph: graph
+        })
+      ).toBe(true)
+      expect(() => parseArtifactExecutionSnapshot(JSON.stringify(value))).not.toThrow()
+    }
+  )
+
   it.each(['r', 'python'] as const)(
     'preserves bounded per-run %s random state in immutable snapshot round trips',
     (language) => {


### PR DESCRIPTION
When execution evidence exceeds the 4 MiB snapshot limit, successive helper removals can leave a cached reproducibility recipe describing an earlier helper set. The persisted snapshot can then fail recipe consistency validation, including when helper evidence was already incomplete before trimming.

Invalidate the cached recipe after every helper removal. Add regression coverage for initially complete and already incomplete evidence, checking multiple removals, the final size bound, recipe consistency, and snapshot decoding with a published-file checkpoint.

Addresses the deferred P2 from [the review of #2438](https://github.com/aipoch/open-science/pull/2438#issuecomment-5627127189). No schema, persistence format, or UI changes.

Validation:
- Both new regression cases fail before the fix and pass after it.
- Four artifact suites: 120 tests passed, 1 skipped across the initial run and isolated rerun of two timeout failures.
- Node and sandbox type checks, ESLint for both changed files, Prettier, and git diff checks passed. The additional local renderer type check was stopped after more than 12 minutes without diagnostics; the PR's static-check job covers the full check.
