### PR TITLE
fix(provenance): place reproducibility before review

### DIFF
--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx
@@ -532,7 +532,14 @@ afterEach(() => {
 describe('ArtifactProvenancePanel', () => {
   it('moves provenance tab focus with ArrowRight', async () => {
     const tabs = Array.from(container.querySelectorAll<HTMLButtonElement>('[role="tab"]'))
-    expect(tabs.length).toBeGreaterThan(1)
+    expect(tabs.map((tab) => tab.textContent)).toEqual([
+      'Code',
+      'Execution Log',
+      'Messages',
+      'Environment',
+      'Reproducibility',
+      'Review'
+    ])
     act(() => tabs[0].focus())
     await act(async () => {
       tabs[0].dispatchEvent(new KeyboardEvent('keydown', { key: 'ArrowRight', bubbles: true }))

--- a/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
+++ b/src/renderer/src/pages/workspace/ArtifactProvenancePanel.tsx
@@ -124,10 +124,10 @@ type ArtifactProvenancePanelProps = {
 
 const tabs: Array<{ id: ProvenanceTab; label: string }> = [
   { id: 'code', label: 'Code' },
-  { id: 'reproducibility', label: 'Reproducibility' },
   { id: 'execution', label: 'Execution Log' },
   { id: 'messages', label: 'Messages' },
   { id: 'environment', label: 'Environment' },
+  { id: 'reproducibility', label: 'Reproducibility' },
   { id: 'review', label: 'Review' }
 ]
 const sourcesTab = { id: 'sources', label: 'Literature' } as const


### PR DESCRIPTION
## Summary

Move Reproducibility immediately before Review in the shared provenance tab list:
Code → Execution Log → Messages → Environment → Reproducibility → Review.
Literature keeps its existing position after Code when present.

Extend the existing keyboard-navigation test to assert the rendered tab order.

## Validation

Checks ran after the last material edit; independent review found no issues and confirmed the impact mapping.

- Tab order, selection and lazy loading → `npx vitest run src/renderer/src/pages/workspace/ArtifactProvenancePanel.render.test.tsx src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx` → 227 passed; one unrelated transient Copy path/“Copied” assertion failed under heavy local load.
- Failed consumer check → `npx vitest run src/renderer/src/pages/workspace/PreviewFileSurface.test.tsx -t 'shares Copy path execution and transient presentation with the header menu'` → passed on isolated rerun.
- Renderer types → `npm run typecheck:web` → passed.
- Source lint → `npm run lint` → passed.
- Formatting → targeted `prettier --check` and `git diff --check` → passed.
- Browser → rendered the worktree's real component with local fixture data, confirmed the new order, switched between Review and Reproducibility, and captured a screenshot.

Only the renderer's private tab ordering changes. PreviewFileSurface is the direct consumer covered above. Main/preload, IPC, platform-specific behavior, persistent data and enum/state definitions are unchanged. No historical-data compatibility work is needed. Full local suite omitted per maintainer request; exact-head PR CI remains authoritative. The screenshot uses fixture data, not a live reproducibility run.
