### PR TITLE
fix(ci): restore nightly runtime certification prerequisites

### DIFF
--- a/.github/workflows/runtime-certification.yml
+++ b/.github/workflows/runtime-certification.yml
@@ -64,9 +64,12 @@ jobs:
           r_prefix="$RUNNER_TEMP/runtime-r"
 
           "$MICROMAMBA_BIN" create --yes --root-prefix "$root" --prefix "$python_prefix" \
-            --channel conda-forge python=3.12 matplotlib-base numpy pandas nomkl
+            --channel conda-forge python=3.12 matplotlib-base numpy pandas nomkl openpyxl pycirclize
           "$MICROMAMBA_BIN" create --yes --root-prefix "$root" --prefix "$r_prefix" \
-            --channel conda-forge r-base=4.4 r-jsonlite r-ggplot2 r-renv r-mass
+            --channel conda-forge r-base=4.4 r-jsonlite r-ggplot2 r-renv r-mass \
+            r-circlize r-dplyr r-ggrepel r-ggvenndiagram r-magrittr r-openxlsx \
+            r-patchwork r-ragg r-rcolorbrewer r-readxl r-scales r-showtext \
+            r-sysfonts r-systemfonts r-tidyr r-venndiagram
 
           echo "OPEN_SCIENCE_TEST_PY_ENV=$python_prefix/bin/python" >> "$GITHUB_ENV"
           echo "OPEN_SCIENCE_TEST_PYTHON=$python_prefix/bin/python" >> "$GITHUB_ENV"
@@ -104,9 +107,9 @@ jobs:
         run: |
           set -euo pipefail
           "$OPEN_SCIENCE_TEST_PY_ENV" -c \
-            'import matplotlib, numpy, pandas; print("python=" + __import__("sys").version.split()[0] + " matplotlib=" + matplotlib.__version__ + " numpy=" + numpy.__version__ + " pandas=" + pandas.__version__)'
+            'import matplotlib, numpy, pandas, openpyxl, pycirclize; print("python=" + __import__("sys").version.split()[0] + " matplotlib=" + matplotlib.__version__ + " numpy=" + numpy.__version__ + " pandas=" + pandas.__version__)'
           "$OPEN_SCIENCE_TEST_R_ENV/bin/Rscript" -e \
-            'library(jsonlite); library(ggplot2); cat("r=", as.character(getRversion()), " jsonlite=", as.character(packageVersion("jsonlite")), " ggplot2=", as.character(packageVersion("ggplot2")), "\n", sep="")'
+            'packages <- c("jsonlite", "ggplot2", "renv", "MASS", "circlize", "dplyr", "ggrepel", "ggVennDiagram", "magrittr", "openxlsx", "patchwork", "ragg", "RColorBrewer", "readxl", "scales", "showtext", "sysfonts", "systemfonts", "tidyr", "VennDiagram"); for (package in packages) { loadNamespace(package); cat(package, "=", as.character(packageVersion(package)), "\n", sep="") }'
 
       - name: Test real source runtime chain
         env:

--- a/.github/workflows/runtime-certification.yml
+++ b/.github/workflows/runtime-certification.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   source:
     name: Source runtime chain (Linux)
-    continue-on-error: ${{ inputs.allow_failure }}
+    continue-on-error: ${{ inputs.allow_failure == true }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:

--- a/.github/workflows/runtime-certification.yml
+++ b/.github/workflows/runtime-certification.yml
@@ -69,7 +69,7 @@ jobs:
             --channel conda-forge r-base=4.4 r-jsonlite r-ggplot2 r-renv r-mass \
             r-circlize r-dplyr r-ggrepel r-ggvenndiagram r-magrittr r-openxlsx \
             r-patchwork r-ragg r-rcolorbrewer r-readxl r-scales r-showtext \
-            r-sysfonts r-systemfonts r-tidyr r-venndiagram
+            r-sysfonts r-systemfonts r-tidyr r-venn r-venndiagram
 
           echo "OPEN_SCIENCE_TEST_PY_ENV=$python_prefix/bin/python" >> "$GITHUB_ENV"
           echo "OPEN_SCIENCE_TEST_PYTHON=$python_prefix/bin/python" >> "$GITHUB_ENV"
@@ -109,7 +109,7 @@ jobs:
           "$OPEN_SCIENCE_TEST_PY_ENV" -c \
             'import matplotlib, numpy, pandas, openpyxl, pycirclize; print("python=" + __import__("sys").version.split()[0] + " matplotlib=" + matplotlib.__version__ + " numpy=" + numpy.__version__ + " pandas=" + pandas.__version__)'
           "$OPEN_SCIENCE_TEST_R_ENV/bin/Rscript" -e \
-            'packages <- c("jsonlite", "ggplot2", "renv", "MASS", "circlize", "dplyr", "ggrepel", "ggVennDiagram", "magrittr", "openxlsx", "patchwork", "ragg", "RColorBrewer", "readxl", "scales", "showtext", "sysfonts", "systemfonts", "tidyr", "VennDiagram"); for (package in packages) { loadNamespace(package); cat(package, "=", as.character(packageVersion(package)), "\n", sep="") }'
+            'packages <- c("jsonlite", "ggplot2", "renv", "MASS", "circlize", "dplyr", "ggrepel", "ggVennDiagram", "magrittr", "openxlsx", "patchwork", "ragg", "RColorBrewer", "readxl", "scales", "showtext", "sysfonts", "systemfonts", "tidyr", "venn", "VennDiagram"); for (package in packages) { loadNamespace(package); cat(package, "=", as.character(packageVersion(package)), "\n", sep="") }'
 
       - name: Test real source runtime chain
         env:

--- a/packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts
+++ b/packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts
@@ -203,7 +203,7 @@ describe.runIf(platformSupported)('Notebook network sandbox enforcement', () => 
       })
       const allowed = await run(allowedProcess, cwd)
       await allowedProcess.cleanup('exit', { processesTerminated: true })
-      expect(allowed).toMatchObject({ code: 0, stdout: 'sandbox-ok' })
+      expect(allowed, allowed.stderr).toMatchObject({ code: 0, stdout: 'sandbox-ok' })
 
       sandbox.updatePolicy({ allowedDomains: [], deniedDomains: [] })
       const deniedProcess = await sandbox.wrap({

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -105,9 +105,10 @@ describe('runtime certification workflow', () => {
       'sysfonts',
       'systemfonts',
       'tidyr',
+      'venn',
       'VennDiagram'
     ]) {
-      expect(create.run).toContain(`r-${name.toLowerCase()}`)
+      expect(create.run?.split(/\s+/)).toContain(`r-${name.toLowerCase()}`)
       expect(verify.run).toContain(`"${name}"`)
     }
     expect(verify.run).toContain('loadNamespace(package)')

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -79,8 +79,37 @@ describe('runtime certification workflow', () => {
     expect(step(source, 'Prepare local restoration archives').run).toContain(
       'OPEN_SCIENCE_TEST_CONDA_ARCHIVES='
     )
-    expect(verify.run).toContain('library(jsonlite)')
-    expect(verify.run).toContain('library(ggplot2)')
+    for (const name of ['matplotlib', 'numpy', 'pandas', 'openpyxl', 'pycirclize']) {
+      expect(create.run).toContain(name === 'matplotlib' ? 'matplotlib-base' : name)
+      expect(verify.run).toContain(name)
+    }
+    // The real replay fixtures need workbook, plotting, and data-transformation packages too.
+    for (const name of [
+      'jsonlite',
+      'ggplot2',
+      'renv',
+      'MASS',
+      'circlize',
+      'dplyr',
+      'ggrepel',
+      'ggVennDiagram',
+      'magrittr',
+      'openxlsx',
+      'patchwork',
+      'ragg',
+      'RColorBrewer',
+      'readxl',
+      'scales',
+      'showtext',
+      'sysfonts',
+      'systemfonts',
+      'tidyr',
+      'VennDiagram'
+    ]) {
+      expect(create.run).toContain(`r-${name.toLowerCase()}`)
+      expect(verify.run).toContain(`"${name}"`)
+    }
+    expect(verify.run).toContain('loadNamespace(package)')
   })
 
   it('activates the explicit real runtime suites without package or publication side effects', () => {

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -52,7 +52,8 @@ describe('runtime certification workflow', () => {
       'cancel-in-progress': true
     })
     expect(source).toMatchObject({
-      'continue-on-error': '${{ inputs.allow_failure }}',
+      // workflow_dispatch has no allow_failure input; an explicit comparison must yield false.
+      'continue-on-error': '${{ inputs.allow_failure == true }}',
       'runs-on': 'ubuntu-latest',
       'timeout-minutes': 20
     })

--- a/src/main/notebook/host-compute.integration.test.ts
+++ b/src/main/notebook/host-compute.integration.test.ts
@@ -258,9 +258,15 @@ gate('repl kernel host.compute', () => {
 
     expect(result.status).toBe('completed')
     expect(result.stdout).toContain('"job_id":"job-1"')
-    expect(result.stdout).toMatch(
-      /"nextAction":"Save the exact job_id\..*attachJob\(job_id\)\.result\(\) once for a non-blocking peek\..*Only result_final:true is final; otherwise continue other work without polling or scanning history\..*later Turn\."/
-    )
+    const receipt = JSON.parse(result.stdout)
+    expect(receipt.nextAction).toContain('Save the exact job_id.')
+    expect(receipt.nextAction).toContain('attachJob(job_id).status() or .result()')
+    expect(receipt.nextAction).toContain('non-blocking snapshot and never scans Job history')
+    expect(receipt.nextAction).toContain('Only result_final:true is final')
+    expect(receipt.nextAction).toContain('follow_up_delivery:"suppressed"')
+    expect(receipt.nextAction).toContain('"committed"')
+    expect(receipt.nextAction).toContain('A .status() snapshot does not consume the full result.')
+    expect(receipt.nextAction).toContain('An unread final result is delivered in a later Turn.')
     expect(stub.received().map((request) => request.params)).toEqual([
       { op: 'list_compute', session_id: 'session-7' },
       {

--- a/src/main/notebook/python-loop.integration.test.ts
+++ b/src/main/notebook/python-loop.integration.test.ts
@@ -383,7 +383,7 @@ w.save(sys.argv[1])`,
       label: 'set Counter regions',
       cells: [
         vennCounterCells[0],
-        'import pandas as pd\ndf=pd.read_excel("inputs/set-membership-111111111111.xlsx",sheet_name="5组")\n' +
+        'import pandas as pd\ndf=pd.read_excel("inputs/set-membership-111111111111.xlsx",sheet_name="5 groups")\n' +
           vennCounterCells[1] +
           '\nimport json\nprint("REGIONS:"+json.dumps(dict(reg),sort_keys=True))'
       ],
@@ -403,7 +403,7 @@ w.save(sys.argv[1])`,
             pyBin!,
             [
               '-c',
-              'import pandas as pd\npd.DataFrame({"A":[" a ",None,"b"],"B":["b","c",None],"C":["a","d",None],"D":["d"," e ",None],"E":["e","f","g"]}).to_excel("inputs/set-membership-111111111111.xlsx",sheet_name="5组",index=False)'
+              'import pandas as pd\npd.DataFrame({"A":[" a ",None,"b"],"B":["b","c",None],"C":["a","d",None],"D":["d"," e ",None],"E":["e","f","g"]}).to_excel("inputs/set-membership-111111111111.xlsx",sheet_name="5 groups",index=False)'
             ],
             { cwd: dataRoot, timeout: 20000 }
           )
@@ -1230,7 +1230,7 @@ w.save(sys.argv[1])`,
     const { child, send, inspect } = startLoop(pyBin as string, {})
     try {
       await send(
-        "x = 41; label = '活跃变量'; _private = 'hidden'; sys = 1; json = 'user json'; " +
+        "x = 41; label = 'active value'; _private = 'hidden'; sys = 1; json = 'user json'; " +
           "items = list(range(10000)); blob = b'x' * 2000000; " +
           "Explosive = type('Explosive', (), {'__repr__': lambda self: (_ for _ in ()).throw(RuntimeError('no repr'))}); explosive = Explosive(); mixed = [explosive]; globals()[0] = 'non-string key'"
       )
@@ -1286,7 +1286,7 @@ w.save(sys.argv[1])`,
     const { child, send, inspect } = startLoop(pyBin as string, {})
     try {
       await send(
-        "globals()['x' * 2_000_000] = 1; globals().update({f'变量{i}': '汉' * 1000 for i in range(500)})"
+        "globals()['x' * 2_000_000] = 1; globals().update({f'value_€{i}': '€' * 1000 for i in range(500)})"
       )
       const response = await inspect()
 

--- a/src/main/notebook/python-loop.integration.test.ts
+++ b/src/main/notebook/python-loop.integration.test.ts
@@ -1286,7 +1286,7 @@ w.save(sys.argv[1])`,
     const { child, send, inspect } = startLoop(pyBin as string, {})
     try {
       await send(
-        "globals()['x' * 2_000_000] = 1; globals().update({f'value_€{i}': '€' * 1000 for i in range(500)})"
+        "globals()['x' * 2_000_000] = 1; globals().update({f'€€{i}': '€' * 1000 for i in range(500)})"
       )
       const response = await inspect()
 

--- a/src/main/notebook/r-loop.integration.test.ts
+++ b/src/main/notebook/r-loop.integration.test.ts
@@ -2690,7 +2690,8 @@ out |> write.csv(file="out.csv", row.names=FALSE)`
           'indirect_lazy <- 9L; indirect_eager <- 100L'
       )
       const refreshed = await inspect(true)
-      expect(refreshed.namespace?.variables.map(({ name }) => name)).toEqual([
+      // R sorts with the host's LC_COLLATE; compare membership in a fixed JS order.
+      expect(refreshed.namespace?.variables.map(({ name }) => name).sort()).toEqual([
         '.Random.seed',
         '.private',
         'active_value',

--- a/src/main/notebook/r-loop.integration.test.ts
+++ b/src/main/notebook/r-loop.integration.test.ts
@@ -599,7 +599,7 @@ gate('r_loop.R', () => {
             expect(evidence.confirmedReadPaths).toEqual([
               'data/inputs/differential-results-333333333333.xlsx'
             ])
-            pngs.push(readFileSync(join(dataRoot, '对角线火山图.png')))
+            pngs.push(readFileSync(join(dataRoot, 'Synthetic volcano plot.png')))
           } finally {
             child.kill()
           }
@@ -904,8 +904,8 @@ with open("inputs/expression-matrix-444444444444.csv","w") as f:
             reasonCodes: []
           })
           expect(pythonEvidence.confirmedReadPaths?.slice().sort()).toEqual([
-            'data/inputs/expression-matrix-444444444444.csv',
-            'data/inputs/differential-results-333333333333.xlsx'
+            'data/inputs/differential-results-333333333333.xlsx',
+            'data/inputs/expression-matrix-444444444444.csv'
           ])
           expect(pythonEvidence.workingFiles.map((f) => f.relativePath)).toEqual([
             'data/processed/diff_results.csv'
@@ -2629,8 +2629,8 @@ out |> write.csv(file="out.csv", row.names=FALSE)`
     const { child, send, inspect } = startLoop(rscriptBin(), {})
     try {
       await send(
-        "forced <- FALSE; x <- 41L; label <- '活跃变量'; .private <- 'hidden'; 1L -> run; 'user con' ->> con; " +
-          'items <- seq_len(100000L); blob <- raw(2000000L); huge_label <- strrep("活", 1000000L); ' +
+        "forced <- FALSE; x <- 41L; label <- 'active value'; .private <- 'hidden'; 1L -> run; 'user con' ->> con; " +
+          'items <- seq_len(100000L); blob <- raw(2000000L); huge_label <- strrep("€", 1000000L); ' +
           'makeActiveBinding("active_value", function() stop("must not evaluate"), .GlobalEnv); ' +
           'delayedAssign("lazy_value", stop("must not force"), assign.env = .GlobalEnv); ' +
           'create_lazy <- base::delayedAssign; ' +


### PR DESCRIPTION
## Problem

[Nightly run 34545411751](https://github.com/aipoch/open-science/actions/runs/34545411751) failed source runtime certification because its Python/R environments omitted packages used by the real workbook and plotting fixtures. The lane also exposed an obsolete Job receipt assertion and an R namespace assertion that depended on host collation. The macOS native lane reported a curl connection failure without showing stderr.

## Proposed change

- Make `continue-on-error` explicitly boolean so direct manual certification starts as a blocking dry-run when `allow_failure` is absent.
- Provision and preflight the workbook, plotting, and transformation packages exercised by the existing real-runtime fixtures using the existing conda-forge environments.
- Assert the current saved-ID snapshot and fallback-delivery guidance in the real REPL integration test.
- Align workbook sheet names, generated PNG names, and sorted input-path expectations with the existing English fixtures; keep multibyte namespace coverage without Chinese test text.
- Compare R namespace membership in a fixed JavaScript sort order, preserving runtime collation behavior.
- Include curl stderr in the macOS allowlist assertion to make any recurring connection failure diagnosable. This failure did not reproduce locally, including the parallel native sandbox combination; no sandbox behavior is changed.

## Scope and non-goals

CI provisioning and test assertions only. No production code, UI/interaction, persisted format, historical-data compatibility, or state/enum changes. Provisioning changes affect disposable CI environments only; packaged runtime dependencies are unchanged.

## Acceptance criteria and validation

The owner/contract checks below ran on the final implementation. After the last single-line non-ASCII fixture adjustment, both affected Python namespace checks and file lint/format checks were rerun; the other checks cover unchanged behavior:

- Real REPL receipt/wire contract, macOS filesystem/network isolation and sandbox consumers -> `RUN_KERNEL=1 npx vitest run src/main/notebook/host-compute.integration.test.ts packages/notebook-network-sandbox/src/network-enforcement.integration.test.ts packages/notebook-network-sandbox/src/filesystem-enforcement.integration.test.ts src/main/notebook/package-cache-sandbox.integration.test.ts src/main/acp/prompt-attachment-notebook-sandbox.integration.test.ts scripts/ci/runtime-certification-workflow.test.ts` -> 28 passed, 6 platform-specific skips.
- CI provisioning/callers and compute guidance -> `npx vitest run scripts/ci/runtime-certification-workflow.test.ts scripts/windows-release-workflows.test.ts src/main/compute/remote-compute-skill.test.ts` -> 23 passed.
- R binding metadata -> `RUN_KERNEL=1 OPEN_SCIENCE_TEST_R_ENV=<local-R-prefix> npx vitest run src/main/notebook/r-loop.integration.test.ts -t 'returns bounded binding metadata'` -> passed separately with `LC_ALL=C` and `LC_ALL=en_US.UTF-8`.
- Python variable metadata and multibyte response bounds -> `RUN_KERNEL=1 OPEN_SCIENCE_TEST_PY_ENV=/usr/bin/python3 npx vitest run src/main/notebook/python-loop.integration.test.ts -t 'returns fresh bounded|keeps the final JSON response'` -> 2 passed after the final fixture edit (local Python 3.9; full runtime CI uses Python 3.12).
- Affected process types -> `npm run typecheck:node` (including sandbox) -> passed.
- Lint -> `npm run lint` -> passed.
- Changed-file formatting and whitespace -> Prettier check and `git diff --check` -> passed.

The impact explain command selects the full CI plan because a CI contract test is a global gate input. Per maintainer direction, no complete local `npm test` was run; the PR Gate remains authoritative for full portable/platform coverage. Renderer checks are not needed locally because no renderer behavior or interface changed.

Final source-runtime evidence: [Runtime Certification, attempt 2](https://github.com/aipoch/open-science/actions/runs/34551857749) passed **655 tests across 19 files** on head `0c846be77e0c2fe2e32a1ae28e2f0617e43560ba`, with Python 3.12 and R 4.4. The first attempt stopped during Electron download with `ECONNRESET`; retrying the same immutable commit passed. The PR macOS-native step also passed on this head. The original macOS connection failure has not reproduced; stderr is retained for any recurrence. Remaining PR Gate checks are still running.

Release-flow impact: `release.yml` does not call Runtime Certification. Scheduled Nightly retains advisory certification and excludes it from publication preparation dependencies. Nightly Publish still waits for the overall Nightly workflow to complete, so a slow certification can delay publication under the existing workflow topology; this PR adds no publication gate.

## Review focus

Completeness of the real-runtime fixture prerequisites, retained Job result contract, and unchanged sandbox enforcement. Independent review of the final head returned **mergeable**, with no actionable findings. Remaining PR Gate checks are pending.
