### PR TITLE
perf(notebook): skip installs for satisfied package requests

### DIFF
--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -53,6 +53,94 @@ const readBinding = async (
 }
 
 describe('EnvironmentStateTracker', () => {
+  it.each(['python', 'r'] as const)(
+    'fresh %s inspection bypasses cache and does not publish state',
+    async (language) => {
+      dataRoot = await mkdtemp(join(tmpdir(), 'fresh-package-inspection-'))
+      const name = language === 'python' ? 'scikit-learn' : 'R.utils'
+      const requested = language === 'python' ? 'scikit_learn' : name
+      const inspectInstalled = vi.fn().mockResolvedValue({
+        packages: [
+          {
+            name,
+            ecosystem: language,
+            version: '1.0',
+            versionStatus: 'known',
+            evidenceSources: []
+          }
+        ]
+      })
+      const captureFingerprint = vi.fn()
+      const resolveMicromamba = vi.fn()
+      const tracker = new EnvironmentStateTracker({
+        dataRoot,
+        inspectInstalled,
+        captureFingerprint,
+        resolveMicromamba
+      })
+      const capture = { ...target, language, runtimeSource: 'managed' as const }
+      expect(
+        (await tracker.inspectPackages(capture, [requested], { fresh: true })).packages[0]
+      ).toMatchObject({ status: 'installed', version: '1.0' })
+      inspectInstalled.mockResolvedValue({ packages: [] })
+      expect(
+        (await tracker.inspectPackages(capture, [requested], { fresh: true })).packages[0].status
+      ).toBe('missing')
+      expect(inspectInstalled).toHaveBeenCalledTimes(2)
+      expect(captureFingerprint).not.toHaveBeenCalled()
+      expect(resolveMicromamba).not.toHaveBeenCalled()
+      expect(await readdir(dataRoot)).toEqual([])
+    }
+  )
+
+  it('does not certify conflicting Python distribution versions', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'ambiguous-python-inspection-'))
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: async () => ({
+        packages: ['1.0', '2.0'].map((version) => ({
+          name: 'numpy',
+          version,
+          versionStatus: 'known' as const,
+          ecosystem: 'python' as const,
+          evidenceSources: []
+        }))
+      })
+    })
+    expect(
+      (await tracker.inspectPackages(target, ['numpy==2.0'], { fresh: true })).packages[0].status
+    ).toBe('unknown')
+  })
+
+  it('uses exact R names and the first library rank during fresh inspection', async () => {
+    dataRoot = await mkdtemp(join(tmpdir(), 'ranked-r-inspection-'))
+    const tracker = new EnvironmentStateTracker({
+      dataRoot,
+      inspectInstalled: async () => ({
+        packages: [2, 1].map((libraryRank) => ({
+          name: 'R.utils',
+          version: `${libraryRank}.0`,
+          libraryRank,
+          versionStatus: 'known' as const,
+          ecosystem: 'r' as const,
+          evidenceSources: []
+        }))
+      })
+    })
+    const result = await tracker.inspectPackages(
+      { ...target, language: 'r' },
+      ['R.utils', 'r.utils', 'R-utils'],
+      { fresh: true }
+    )
+    expect(result.packages[0]).toMatchObject({
+      status: 'installed',
+      version: '1.0',
+      libraryRank: 1
+    })
+    expect(result.packages[1].status).toBe('missing')
+    expect(result.packages[2].status).toBe('missing')
+  })
+
   it.each([
     { language: 'r', requested: 'org.Hs.eg.db', names: ['org.Hs.eg.db'], matched: true },
     { language: 'r', requested: 'org.hs.eg.db', names: ['org.Hs.eg.db'], matched: false },

--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -53,6 +53,40 @@ const readBinding = async (
 }
 
 describe('EnvironmentStateTracker', () => {
+  it.each(['python', 'r'] as const)(
+    'cancels a running fresh %s metadata subprocess',
+    async (language) => {
+      dataRoot = await mkdtemp(join(tmpdir(), 'cancel-package-inspection-'))
+      const ready = join(dataRoot, 'ready')
+      const tracker = new EnvironmentStateTracker({ dataRoot })
+      const controller = new AbortController()
+      const pending = tracker.inspectPackages(
+        {
+          ...target,
+          language,
+          runtimeSource: 'managed',
+          condaPrefix: dataRoot,
+          command: process.execPath,
+          args: [
+            '-e',
+            `require('node:fs').writeFileSync(${JSON.stringify(ready)}, 'ready'); setInterval(() => {}, 1000)`,
+            '--'
+          ]
+        },
+        ['numpy'],
+        { fresh: true, signal: controller.signal }
+      )
+      const rejection = expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      try {
+        await vi.waitFor(async () => expect(await readFile(ready, 'utf8')).toBe('ready'))
+      } finally {
+        controller.abort()
+      }
+      await rejection
+      expect(await readdir(dataRoot)).toEqual(['ready'])
+    }
+  )
+
   it.each(['win32', 'darwin', 'linux'] as const)(
     'isolates fresh managed Python/R metadata from host libraries on %s',
     async (platform) => {

--- a/src/main/notebook/environment-state-tracker.test.ts
+++ b/src/main/notebook/environment-state-tracker.test.ts
@@ -2,7 +2,7 @@ import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
 import { mkdir, mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import { dirname, join, win32, posix } from 'node:path'
 import { promisify } from 'node:util'
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -53,6 +53,45 @@ const readBinding = async (
 }
 
 describe('EnvironmentStateTracker', () => {
+  it.each(['win32', 'darwin', 'linux'] as const)(
+    'isolates fresh managed Python/R metadata from host libraries on %s',
+    async (platform) => {
+      const path = platform === 'win32' ? win32 : posix
+      const root = platform === 'win32' ? 'C:\\runtime-test' : '/runtime-test'
+      const condaPrefix = path.join(root, 'envs', 'analysis')
+      vi.stubEnv('PYTHONPATH', '/host-only-python')
+      vi.stubEnv('PYTHONNOUSERSITE', '0')
+      vi.stubEnv('R_LIBS', '/host-only-r')
+      vi.stubEnv('R_LIBS_USER', '/host-user-r')
+      vi.stubEnv('R_LIBS_SITE', '/host-site-r')
+      try {
+        const execute = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+        const tracker = new EnvironmentStateTracker({ dataRoot: root, platform, execFile: execute })
+        for (const language of ['python', 'r'] as const) {
+          await tracker.inspectPackages(
+            { ...target, language, runtimeSource: 'managed', condaPrefix },
+            ['numpy'],
+            { fresh: true }
+          )
+          const [, args, options] = execute.mock.calls.at(-1)!
+          expect(options.env.HOME).toBe(path.join(join(root, 'runtime'), 'home'))
+          if (language === 'python') {
+            expect(options.env.PYTHONPATH).toBeUndefined()
+            expect(options.env.PYTHONNOUSERSITE).toBe('1')
+            expect(args).toContain('-I')
+          } else {
+            expect(options.env.R_LIBS).toBeUndefined()
+            expect(options.env.R_LIBS_SITE).toBeUndefined()
+            expect(options.env.R_LIBS_USER).toBe(
+              join(condaPrefix, platform === 'win32' ? 'Lib' : 'lib', 'R', 'library')
+            )
+          }
+        }
+      } finally {
+        vi.unstubAllEnvs()
+      }
+    }
+  )
   it.each(['python', 'r'] as const)(
     'fresh %s inspection bypasses cache and does not publish state',
     async (language) => {

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -942,8 +942,31 @@ class EnvironmentStateTracker {
 
   async inspectPackages(
     target: EnvironmentCaptureTarget,
-    requestedPackages: string[]
+    requestedPackages: string[],
+    options?: { fresh?: boolean }
   ): Promise<PackageInspectionResult> {
+    if (options?.fresh) {
+      // Installation preflight needs current evidence, without publishing a mutation or lock.
+      return this.serializeTarget(target, async () => {
+        const inventory = await this.inspectInstalled(target)
+        const packages = sortPackages(inventory.packages)
+        const lookup = requestedPackageIndex(target.language, packages)
+        return {
+          inventory: { source: 'full-scan', validation: 'full-scan' },
+          packages: requestedPackages.map((requested) => {
+            const inspected = inspectRequestedPackage(target, requested, packages, lookup)
+            const candidates = lookup(requested)
+            // Multiple Python distributions with different versions cannot prove satisfaction.
+            if (
+              target.language === 'python' &&
+              candidates.some((pkg) => pkg.version !== inspected.version)
+            )
+              return { ...inspected, status: 'unknown' as const }
+            return inspected
+          })
+        }
+      })
+    }
     const prepared = await this.prepareRun(target)
     return this.serializeTarget(target, async () => {
       const cache = await this.readBinding(target)

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -18,7 +18,8 @@ import {
   type NotebookPackageSource,
   type NotebookPackageInstallerAttempt
 } from '../../shared/notebook'
-import { condaActivatedPath } from './runtime-paths'
+import { condaActivatedPath, runtimeRoot } from './runtime-paths'
+import { buildManagedRuntimeProcessEnvironment } from './process-environment'
 import { runtimeChildProcessErrorFields, type RuntimeDiagnosticLogger } from './runtime-diagnostics'
 import { EnvironmentLockCaptureOwner, type EnvironmentLockWorkspace } from './environment-lock'
 
@@ -867,18 +868,31 @@ const parseInventory = (
 const inspectInstalledDefault = async (
   target: EnvironmentCaptureTarget,
   platform: NodeJS.Platform = process.platform,
-  execute: EnvironmentExecFile = execFileAsync
+  execute: EnvironmentExecFile = execFileAsync,
+  managedRoot?: string
 ): Promise<InstalledEnvironmentInventory> => {
+  if (managedRoot && !target.condaPrefix)
+    throw new Error('Managed package inspection requires its prefix.')
   const args = [
     ...(target.args ?? []),
     ...(target.language === 'python'
-      ? ['-c', PYTHON_INVENTORY_SCRIPT]
+      ? [...(managedRoot ? ['-I'] : []), '-c', PYTHON_INVENTORY_SCRIPT]
       : ['--vanilla', '--slave', '-e', R_INVENTORY_SCRIPT])
   ]
   const { stdout } = await execute(target.command, args, {
     timeout: INSPECTION_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
-    env: environmentCaptureProcessEnv(target, process.env, platform)
+    env: environmentCaptureProcessEnv(
+      target,
+      managedRoot
+        ? buildManagedRuntimeProcessEnvironment(managedRoot, {
+            language: target.language,
+            prefix: target.condaPrefix,
+            platform
+          })
+        : process.env,
+      platform
+    )
   })
   return parseInventory(target.language, stdout)
 }
@@ -909,7 +923,8 @@ const captureFingerprintDefault = async (
 
 class EnvironmentStateTracker {
   private readonly inspectInstalled: (
-    target: EnvironmentCaptureTarget
+    target: EnvironmentCaptureTarget,
+    fresh?: boolean
   ) => Promise<InstalledEnvironmentInventory>
   private readonly captureFingerprint: (
     target: EnvironmentCaptureTarget
@@ -929,7 +944,13 @@ class EnvironmentStateTracker {
     this.execute = execute
     this.inspectInstalled =
       options.inspectInstalled ??
-      ((target) => inspectInstalledDefault(target, this.platform, execute))
+      ((target, fresh) =>
+        inspectInstalledDefault(
+          target,
+          this.platform,
+          execute,
+          fresh && target.runtimeSource === 'managed' ? runtimeRoot(options.dataRoot) : undefined
+        ))
     this.captureFingerprint =
       options.captureFingerprint ??
       ((target) => captureFingerprintDefault(target, this.platform, execute))
@@ -948,7 +969,7 @@ class EnvironmentStateTracker {
     if (options?.fresh) {
       // Installation preflight needs current evidence, without publishing a mutation or lock.
       return this.serializeTarget(target, async () => {
-        const inventory = await this.inspectInstalled(target)
+        const inventory = await this.inspectInstalled(target, true)
         const packages = sortPackages(inventory.packages)
         const lookup = requestedPackageIndex(target.language, packages)
         return {

--- a/src/main/notebook/environment-state-tracker.ts
+++ b/src/main/notebook/environment-state-tracker.ts
@@ -26,7 +26,7 @@ import { EnvironmentLockCaptureOwner, type EnvironmentLockWorkspace } from './en
 type EnvironmentExecFile = (
   command: string,
   args: string[],
-  options: { timeout: number; maxBuffer: number; env: NodeJS.ProcessEnv }
+  options: { timeout: number; maxBuffer: number; env: NodeJS.ProcessEnv; signal?: AbortSignal }
 ) => Promise<{ stdout: string; stderr?: string }>
 
 const execFileAsync = promisify(execFile) as EnvironmentExecFile
@@ -869,7 +869,8 @@ const inspectInstalledDefault = async (
   target: EnvironmentCaptureTarget,
   platform: NodeJS.Platform = process.platform,
   execute: EnvironmentExecFile = execFileAsync,
-  managedRoot?: string
+  managedRoot?: string,
+  signal?: AbortSignal
 ): Promise<InstalledEnvironmentInventory> => {
   if (managedRoot && !target.condaPrefix)
     throw new Error('Managed package inspection requires its prefix.')
@@ -880,6 +881,7 @@ const inspectInstalledDefault = async (
       : ['--vanilla', '--slave', '-e', R_INVENTORY_SCRIPT])
   ]
   const { stdout } = await execute(target.command, args, {
+    ...(signal ? { signal } : {}),
     timeout: INSPECTION_TIMEOUT_MS,
     maxBuffer: 16 * 1024 * 1024,
     env: environmentCaptureProcessEnv(
@@ -924,7 +926,8 @@ const captureFingerprintDefault = async (
 class EnvironmentStateTracker {
   private readonly inspectInstalled: (
     target: EnvironmentCaptureTarget,
-    fresh?: boolean
+    fresh?: boolean,
+    signal?: AbortSignal
   ) => Promise<InstalledEnvironmentInventory>
   private readonly captureFingerprint: (
     target: EnvironmentCaptureTarget
@@ -944,12 +947,13 @@ class EnvironmentStateTracker {
     this.execute = execute
     this.inspectInstalled =
       options.inspectInstalled ??
-      ((target, fresh) =>
+      ((target, fresh, signal) =>
         inspectInstalledDefault(
           target,
           this.platform,
           execute,
-          fresh && target.runtimeSource === 'managed' ? runtimeRoot(options.dataRoot) : undefined
+          fresh && target.runtimeSource === 'managed' ? runtimeRoot(options.dataRoot) : undefined,
+          signal
         ))
     this.captureFingerprint =
       options.captureFingerprint ??
@@ -964,12 +968,13 @@ class EnvironmentStateTracker {
   async inspectPackages(
     target: EnvironmentCaptureTarget,
     requestedPackages: string[],
-    options?: { fresh?: boolean }
+    options?: { fresh?: boolean; signal?: AbortSignal }
   ): Promise<PackageInspectionResult> {
     if (options?.fresh) {
       // Installation preflight needs current evidence, without publishing a mutation or lock.
       return this.serializeTarget(target, async () => {
-        const inventory = await this.inspectInstalled(target, true)
+        options.signal?.throwIfAborted()
+        const inventory = await this.inspectInstalled(target, true, options.signal)
         const packages = sortPackages(inventory.packages)
         const lookup = requestedPackageIndex(target.language, packages)
         return {

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -252,10 +252,13 @@ describe('NotebookPackageMutationOwner', () => {
   it('honors cancellation after the metadata probe without starting an installer', async () => {
     const { owner, options, target } = ownerHarness()
     const controller = new AbortController()
-    vi.mocked(options.environmentStateTracker.inspectPackages).mockImplementation(async () => {
-      controller.abort(new Error('cancelled during probe'))
-      throw new Error('probe failed')
-    })
+    vi.mocked(options.environmentStateTracker.inspectPackages).mockImplementation(
+      async (_target, _packages, probeOptions) => {
+        expect(probeOptions?.signal).toBe(controller.signal)
+        controller.abort(new Error('cancelled during probe'))
+        throw new Error('probe failed')
+      }
+    )
     await expect(owner.mutate({ target, mirror: {} }, controller.signal)).rejects.toThrow(
       'cancelled during probe'
     )

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -235,6 +235,7 @@ describe('NotebookPackageMutationOwner', () => {
     { packages: ['--force-reinstall'] },
     { packages: [] },
     { channels: ['bioconda'] },
+    { language: 'python' as const, usePip: true },
     { operation: 'uninstall' as const },
     { language: 'r' as const, packages: ['r-ggplot2'] },
     { language: 'r' as const, packages: ['bioconductor-deseq2'] },

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -142,7 +142,14 @@ describe('NotebookPackageMutationOwner', () => {
         return {
           inventory: { source: 'full-scan', validation: 'full-scan' },
           packages: [
-            { requested: spec, name, status: 'installed', version: '2.0', versionStatus: 'known' }
+            {
+              requested: spec,
+              name,
+              status: 'installed',
+              version: '2.0',
+              versionStatus: 'known',
+              libraryScope: 'environment'
+            }
           ]
         }
       }
@@ -191,6 +198,37 @@ describe('NotebookPackageMutationOwner', () => {
     }
   )
 
+  it.each(['user', 'system', 'unknown', undefined] as const)(
+    'does not satisfy an R install from library scope %s',
+    async (libraryScope) => {
+      const { owner, options, target } = ownerHarness()
+      const request = { ...target.request, language: 'r' as const, packages: ['ggplot2'] }
+      vi.mocked(options.environmentStateTracker.inspectPackages).mockResolvedValue({
+        inventory: { source: 'full-scan', validation: 'full-scan' },
+        packages: [
+          {
+            requested: 'ggplot2',
+            name: 'ggplot2',
+            status: 'installed',
+            version: '4.0.3',
+            versionStatus: 'known',
+            libraryScope
+          }
+        ]
+      })
+      await owner.mutate({
+        target: {
+          ...target,
+          request,
+          environmentCaptureTarget: { ...target.environmentCaptureTarget, language: 'r' }
+        },
+        mirror: {}
+      })
+      expect(options.installPackages).toHaveBeenCalledWith(request, expect.anything())
+      expect(options.environmentStateTracker.markPackageMutationDirty).toHaveBeenCalled()
+    }
+  )
+
   it.each([
     { packages: ['numpy>=2'] },
     { packages: ['numpy[extra]'] },
@@ -198,6 +236,8 @@ describe('NotebookPackageMutationOwner', () => {
     { packages: [] },
     { channels: ['bioconda'] },
     { operation: 'uninstall' as const },
+    { language: 'r' as const, packages: ['r-ggplot2'] },
+    { language: 'r' as const, packages: ['bioconductor-deseq2'] },
     { language: 'r' as const, installer: 'github' as const, packages: ['owner/repo'] }
   ])('does not preflight unsupported request %j', async (overrides) => {
     const { owner, options, target } = ownerHarness()

--- a/src/main/notebook/package-mutation.test.ts
+++ b/src/main/notebook/package-mutation.test.ts
@@ -74,6 +74,10 @@ const ownerHarness = (
       logPackageResult: vi.fn()
     },
     environmentStateTracker: {
+      inspectPackages: vi.fn().mockResolvedValue({
+        inventory: { source: 'unavailable', validation: 'unavailable' },
+        packages: []
+      }),
       markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
       refreshAfterPackageMutation: vi.fn().mockResolvedValue({ result: 'success' })
     },
@@ -84,6 +88,7 @@ const ownerHarness = (
       method: 'conda'
     }),
     recheckRepair: vi.fn(() => undefined),
+    canSkipInstall: vi.fn(() => true),
     runtimeRepair: {
       quarantineProtectedIdentity: vi.fn().mockResolvedValue(undefined),
       completeInterruptedInstall: vi.fn().mockResolvedValue(undefined)
@@ -98,6 +103,125 @@ const pending = (runtimeRoot: string): ReturnType<RuntimeOperationJournal['pendi
   RuntimeOperationJournal.forPath(operationJournalPath(runtimeRoot)).pending()
 
 describe('NotebookPackageMutationOwner', () => {
+  it('retains the install recovery path when repair is required', async () => {
+    const { owner, options, target } = ownerHarness({ canSkipInstall: () => false })
+    await owner.mutate({ target, mirror: {} })
+    expect(options.environmentStateTracker.inspectPackages).not.toHaveBeenCalled()
+    expect(options.installPackages).toHaveBeenCalled()
+    expect(options.runtimeRepair.completeInterruptedInstall).toHaveBeenCalled()
+  })
+  it.each([
+    ['python', 'numpy==2.0', 'numpy'],
+    ['python', 'numpy', 'numpy'],
+    ['r', 'ggplot2', 'ggplot2']
+  ] as const)('skips all mutation resources for satisfied %s %s', async (language, spec, name) => {
+    const retainWorkingCache = vi.fn()
+    const { owner, options, target, runtimeRoot } = ownerHarness({ retainWorkingCache })
+    const mirror = vi.fn().mockResolvedValue({})
+    const request = { ...target.request, language, packages: [spec] }
+    const environmentCaptureTarget = { ...target.environmentCaptureTarget, language }
+    if (!target.journalTarget) throw new Error('Expected managed prefix')
+    mkdirSync(target.journalTarget, { recursive: true })
+    const marker = importedEnvironmentLockMarkerPath(target.journalTarget)
+    writeFileSync(marker, 'a'.repeat(64))
+    let locked = false
+    options.environmentOperations.runMutation = async (_name, operation) => {
+      locked = true
+      try {
+        return await operation()
+      } finally {
+        locked = false
+      }
+    }
+    vi.mocked(options.environmentStateTracker.inspectPackages).mockImplementation(
+      async (capture, packages, freshness) => {
+        expect(locked).toBe(true)
+        expect(capture).toEqual(environmentCaptureTarget)
+        expect(packages).toEqual([spec])
+        expect(freshness).toEqual({ fresh: true })
+        return {
+          inventory: { source: 'full-scan', validation: 'full-scan' },
+          packages: [
+            { requested: spec, name, status: 'installed', version: '2.0', versionStatus: 'known' }
+          ]
+        }
+      }
+    )
+    await expect(
+      owner.mutate({ target: { ...target, request, environmentCaptureTarget }, mirror })
+    ).resolves.toMatchObject({
+      ok: true,
+      needsRestart: false,
+      packageChanges: [{ name, change: 'unchanged', afterVersion: '2.0' }]
+    })
+    expect(mirror).not.toHaveBeenCalled()
+    expect(retainWorkingCache).not.toHaveBeenCalled()
+    expect(options.installPackages).not.toHaveBeenCalled()
+    expect(options.environmentStateTracker.markPackageMutationDirty).not.toHaveBeenCalled()
+    expect(options.runtimeRepair.completeInterruptedInstall).not.toHaveBeenCalled()
+    expect(existsSync(marker)).toBe(true)
+    expect(existsSync(operationJournalPath(runtimeRoot))).toBe(false)
+  })
+
+  it.each(['mismatch', 'missing', 'unknown', 'failed-probe', 'mixed'])(
+    'keeps the original installer request for %s evidence',
+    async (scenario) => {
+      const { owner, options, target } = ownerHarness()
+      const request = {
+        ...target.request,
+        packages: scenario === 'mixed' ? ['numpy==2.0', 'pandas'] : ['numpy==2.0']
+      }
+      const inspect = vi.mocked(options.environmentStateTracker.inspectPackages)
+      inspect.mockResolvedValue({
+        inventory: { source: 'full-scan', validation: 'full-scan' },
+        packages: [
+          {
+            requested: 'numpy==2.0',
+            name: 'numpy',
+            status:
+              scenario === 'missing' ? 'missing' : scenario === 'unknown' ? 'unknown' : 'installed',
+            version: scenario === 'mismatch' ? '1.0' : '2.0',
+            versionStatus: 'known'
+          }
+        ]
+      })
+      if (scenario === 'failed-probe') inspect.mockRejectedValue(new Error('metadata unavailable'))
+      await owner.mutate({ target: { ...target, request }, mirror: {} })
+      expect(options.installPackages).toHaveBeenCalledWith(request, expect.anything())
+    }
+  )
+
+  it.each([
+    { packages: ['numpy>=2'] },
+    { packages: ['numpy[extra]'] },
+    { packages: ['--force-reinstall'] },
+    { packages: [] },
+    { channels: ['bioconda'] },
+    { operation: 'uninstall' as const },
+    { language: 'r' as const, installer: 'github' as const, packages: ['owner/repo'] }
+  ])('does not preflight unsupported request %j', async (overrides) => {
+    const { owner, options, target } = ownerHarness()
+    await owner.mutate({
+      target: { ...target, request: { ...target.request, ...overrides } },
+      mirror: {}
+    })
+    expect(options.environmentStateTracker.inspectPackages).not.toHaveBeenCalled()
+    expect(options.installPackages).toHaveBeenCalled()
+  })
+
+  it('honors cancellation after the metadata probe without starting an installer', async () => {
+    const { owner, options, target } = ownerHarness()
+    const controller = new AbortController()
+    vi.mocked(options.environmentStateTracker.inspectPackages).mockImplementation(async () => {
+      controller.abort(new Error('cancelled during probe'))
+      throw new Error('probe failed')
+    })
+    await expect(owner.mutate({ target, mirror: {} }, controller.signal)).rejects.toThrow(
+      'cancelled during probe'
+    )
+    expect(options.installPackages).not.toHaveBeenCalled()
+  })
+
   it('passes caller cancellation to the package installer', async () => {
     const installPackages = vi.fn().mockResolvedValue({
       ok: true,
@@ -190,6 +314,10 @@ describe('NotebookPackageMutationOwner', () => {
         logPackageResult: vi.fn(() => order.push('diagnostic'))
       },
       environmentStateTracker: {
+        inspectPackages: vi.fn().mockResolvedValue({
+          inventory: { source: 'unavailable', validation: 'unavailable' },
+          packages: []
+        }),
         markPackageMutationDirty: vi.fn(async (_target, mutation) => {
           operationId = mutation.operationId
           expect((await pending(runtimeRoot))[0]).toMatchObject({
@@ -539,6 +667,10 @@ describe('NotebookPackageMutationOwner', () => {
     let operationId = ''
     const { owner, target, runtimeRoot } = ownerHarness({
       environmentStateTracker: {
+        inspectPackages: vi.fn().mockResolvedValue({
+          inventory: { source: 'unavailable', validation: 'unavailable' },
+          packages: []
+        }),
         markPackageMutationDirty: vi.fn(async (_target, mutation) => {
           operationId = mutation.operationId
         }),
@@ -587,6 +719,10 @@ describe('NotebookPackageMutationOwner', () => {
     const dirtyFailure = new Error('dirty marker denied')
     const { owner, options, target, runtimeRoot } = ownerHarness({
       environmentStateTracker: {
+        inspectPackages: vi.fn().mockResolvedValue({
+          inventory: { source: 'unavailable', validation: 'unavailable' },
+          packages: []
+        }),
         markPackageMutationDirty: vi.fn().mockRejectedValue(dirtyFailure),
         refreshAfterPackageMutation: vi.fn()
       }
@@ -621,6 +757,10 @@ describe('NotebookPackageMutationOwner', () => {
   it('turns an unverifiable successful installer result into the existing structured failure', async () => {
     const { owner, options, target } = ownerHarness({
       environmentStateTracker: {
+        inspectPackages: vi.fn().mockResolvedValue({
+          inventory: { source: 'unavailable', validation: 'unavailable' },
+          packages: []
+        }),
         markPackageMutationDirty: vi.fn().mockResolvedValue(undefined),
         refreshAfterPackageMutation: vi.fn().mockRejectedValue(new Error('scan failed'))
       }
@@ -717,6 +857,10 @@ describe('NotebookPackageMutationOwner', () => {
     const { owner, options, target, runtimeRoot } = ownerHarness({
       retainWorkingCache: vi.fn(() => release),
       environmentStateTracker: {
+        inspectPackages: vi.fn().mockResolvedValue({
+          inventory: { source: 'unavailable', validation: 'unavailable' },
+          packages: []
+        }),
         markPackageMutationDirty: vi.fn(async (_target, mutation) => {
           operationId = mutation.operationId
         }),

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -37,7 +37,7 @@ const isArchiveEvidenceIncompleteError = (error: unknown): boolean =>
 
 type NotebookPackageMutationInput = Readonly<{
   target: NotebookPackageAdmittedTarget
-  mirror: PackageMirror
+  mirror: PackageMirror | (() => Promise<PackageMirror>)
 }>
 
 type NotebookPackageMutationOwnerOptions = {
@@ -49,7 +49,7 @@ type NotebookPackageMutationOwnerOptions = {
   >
   environmentStateTracker: Pick<
     EnvironmentStateTracker,
-    'markPackageMutationDirty' | 'refreshAfterPackageMutation'
+    'inspectPackages' | 'markPackageMutationDirty' | 'refreshAfterPackageMutation'
   >
   installPackages: (
     request: NotebookPackageAdmittedTarget['request'],
@@ -57,6 +57,7 @@ type NotebookPackageMutationOwnerOptions = {
   ) => Promise<InstallResult>
   packageSpawn?: (target: NotebookPackageAdmittedTarget, mirror: PackageMirror) => InstallSpawn
   micromambaRunner?: Pick<MicromambaRunner, 'resolve'>
+  canSkipInstall: (target: NotebookPackageAdmittedTarget) => boolean
   recheckRepair: (
     target: NotebookPackageAdmittedTarget
   ) => Extract<NotebookPackageAdmission, { status: 'refused' }> | undefined
@@ -72,8 +73,69 @@ type NotebookPackageMutationOwnerOptions = {
 class NotebookPackageMutationOwner {
   constructor(private readonly options: NotebookPackageMutationOwnerOptions) {}
 
+  private async alreadySatisfied(
+    target: NotebookPackageAdmittedTarget
+  ): Promise<InstallResult | undefined> {
+    const { request, environmentCaptureTarget } = target
+    if (
+      environmentCaptureTarget.runtimeSource !== 'managed' ||
+      request.operation === 'uninstall' ||
+      request.installer ||
+      request.channels?.length ||
+      request.packages.length === 0 ||
+      (request.language === 'r' && request.usePip)
+    )
+      return undefined
+    const specPattern =
+      request.language === 'python'
+        ? /^[A-Za-z0-9][A-Za-z0-9._-]*(?:==[0-9]+(?:\.[0-9]+)*)?$/u
+        : /^[A-Za-z][A-Za-z0-9.]*$/u
+    if (request.packages.some((spec) => !specPattern.test(spec))) return undefined
+    try {
+      const inspection = await this.options.environmentStateTracker.inspectPackages(
+        environmentCaptureTarget,
+        request.packages,
+        { fresh: true }
+      )
+      if (
+        inspection.inventory.validation !== 'full-scan' ||
+        inspection.packages.length !== request.packages.length ||
+        inspection.packages.some((pkg, index) => {
+          const exact = request.packages[index].split('==')[1]
+          return (
+            pkg.requested !== request.packages[index] ||
+            pkg.status !== 'installed' ||
+            pkg.versionStatus !== 'known' ||
+            !pkg.version ||
+            (exact !== undefined && pkg.version !== exact)
+          )
+        })
+      )
+        return undefined
+      return {
+        ok: true,
+        needsRestart: false,
+        attempts: [],
+        log: 'Requested packages are already installed at satisfactory versions.',
+        packageChanges: inspection.packages.map((pkg) => ({
+          name: pkg.name,
+          ecosystem: request.language,
+          relationship: 'requested',
+          change: 'unchanged',
+          beforeVersion: pkg.version,
+          afterVersion: pkg.version,
+          ...(pkg.libraryRank !== undefined ? { libraryRank: pkg.libraryRank } : {}),
+          ...(pkg.libraryScope ? { libraryScope: pkg.libraryScope } : {})
+        }))
+      }
+    } catch {
+      // Metadata failure must leave the installer available to repair a missing/broken package.
+      return undefined
+    }
+  }
+
   async mutate(
-    { target, mirror }: NotebookPackageMutationInput,
+    { target, mirror: requestedMirror }: NotebookPackageMutationInput,
     signal?: AbortSignal
   ): Promise<InstallResult> {
     const {
@@ -93,9 +155,7 @@ class NotebookPackageMutationOwner {
       this.options.retainWorkingCache !== undefined &&
       request.usePip !== true &&
       request.installer === undefined
-    const releaseWorkingCache = archiveCacheTransaction
-      ? await this.options.retainWorkingCache?.(runtimeRoot, operationId)
-      : undefined
+    let releaseWorkingCache: Awaited<ReturnType<MicromambaWorkingCacheRetainer>> | undefined
     let result: InstallResult | undefined
     let retainForRecovery = false
     let begun = false
@@ -114,6 +174,17 @@ class NotebookPackageMutationOwner {
             result = repairRefusal.result
             return result
           }
+          result = this.options.canSkipInstall(target)
+            ? await this.alreadySatisfied(target)
+            : undefined
+          signal?.throwIfAborted()
+          if (result) return result
+          const mirror =
+            typeof requestedMirror === 'function' ? await requestedMirror() : requestedMirror
+          signal?.throwIfAborted()
+          releaseWorkingCache = archiveCacheTransaction
+            ? await this.options.retainWorkingCache?.(runtimeRoot, operationId)
+            : undefined
           await journal.begin({
             operationId,
             kind: 'install',
@@ -425,7 +496,7 @@ class NotebookPackageMutationOwner {
       }
     }
     if (!result) throw new Error('package mutation completed without an installer result')
-    if (result.ok) await this.options.runtimeRepair.completeInterruptedInstall(target)
+    if (begun && result.ok) await this.options.runtimeRepair.completeInterruptedInstall(target)
     return result
   }
 }

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -107,6 +107,7 @@ class NotebookPackageMutationOwner {
             pkg.status !== 'installed' ||
             pkg.versionStatus !== 'known' ||
             !pkg.version ||
+            (request.language === 'r' && pkg.libraryScope !== 'environment') ||
             (exact !== undefined && pkg.version !== exact)
           )
         })

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -74,7 +74,8 @@ class NotebookPackageMutationOwner {
   constructor(private readonly options: NotebookPackageMutationOwnerOptions) {}
 
   private async alreadySatisfied(
-    target: NotebookPackageAdmittedTarget
+    target: NotebookPackageAdmittedTarget,
+    signal?: AbortSignal
   ): Promise<InstallResult | undefined> {
     const { request, environmentCaptureTarget } = target
     if (
@@ -86,6 +87,8 @@ class NotebookPackageMutationOwner {
       (request.language === 'r' && request.usePip)
     )
       return undefined
+    // Deliberately optimize only literal numeric pins. Equivalent spellings and richer version
+    // syntax remain installer decisions; a missed shortcut is preferable to a false success.
     const specPattern =
       request.language === 'python'
         ? /^[A-Za-z0-9][A-Za-z0-9._-]*(?:==[0-9]+(?:\.[0-9]+)*)?$/u
@@ -95,7 +98,7 @@ class NotebookPackageMutationOwner {
       const inspection = await this.options.environmentStateTracker.inspectPackages(
         environmentCaptureTarget,
         request.packages,
-        { fresh: true }
+        { fresh: true, ...(signal ? { signal } : {}) }
       )
       if (
         inspection.inventory.validation !== 'full-scan' ||
@@ -176,7 +179,7 @@ class NotebookPackageMutationOwner {
             return result
           }
           result = this.options.canSkipInstall(target)
-            ? await this.alreadySatisfied(target)
+            ? await this.alreadySatisfied(target, signal)
             : undefined
           signal?.throwIfAborted()
           if (result) return result

--- a/src/main/notebook/package-mutation.ts
+++ b/src/main/notebook/package-mutation.ts
@@ -82,9 +82,9 @@ class NotebookPackageMutationOwner {
       environmentCaptureTarget.runtimeSource !== 'managed' ||
       request.operation === 'uninstall' ||
       request.installer ||
+      request.usePip === true ||
       request.channels?.length ||
-      request.packages.length === 0 ||
-      (request.language === 'r' && request.usePip)
+      request.packages.length === 0
     )
       return undefined
     // Deliberately optimize only literal numeric pins. Equivalent spellings and richer version

--- a/src/main/notebook/package-operations.test.ts
+++ b/src/main/notebook/package-operations.test.ts
@@ -163,7 +163,14 @@ describe('NotebookPackageOperations', () => {
       vi.mocked(options.environmentStateTracker.inspectPackages).mockResolvedValue({
         inventory: { source: 'full-scan', validation: 'full-scan' },
         packages: [
-          { requested: name, name, status: 'installed', version: '2.0', versionStatus: 'known' }
+          {
+            requested: name,
+            name,
+            status: 'installed',
+            version: '2.0',
+            versionStatus: 'known',
+            libraryScope: 'environment'
+          }
         ]
       })
       const result = await owner.manage({

--- a/src/main/notebook/package-operations.test.ts
+++ b/src/main/notebook/package-operations.test.ts
@@ -151,6 +151,41 @@ const harness = (
 }
 
 describe('NotebookPackageOperations', () => {
+  it.each(['python', 'r'] as const)(
+    'returns satisfied %s packages without mirror lookup or restart',
+    async (language) => {
+      const active = session(
+        'satisfied',
+        binding(language, '/managed/interpreter', 'managed', 'analysis')
+      )
+      const { owner, options } = harness(active)
+      const name = language === 'python' ? 'numpy' : 'ggplot2'
+      vi.mocked(options.environmentStateTracker.inspectPackages).mockResolvedValue({
+        inventory: { source: 'full-scan', validation: 'full-scan' },
+        packages: [
+          { requested: name, name, status: 'installed', version: '2.0', versionStatus: 'known' }
+        ]
+      })
+      const result = await owner.manage({
+        language,
+        packages: [name],
+        projectId: 'project',
+        sessionId: 'satisfied'
+      })
+      expect(result).toMatchObject({
+        ok: true,
+        needsRestart: false,
+        environmentName: 'analysis',
+        target: { runtimeSource: 'managed' },
+        packageChanges: [{ name, change: 'unchanged', afterVersion: '2.0' }]
+      })
+      expect(options.resolvePackageMirror).not.toHaveBeenCalled()
+      expect(options.installPackages).not.toHaveBeenCalled()
+      expect(options.environmentOperations.recommendRestart).not.toHaveBeenCalled()
+      expect(options.notifyChanged).not.toHaveBeenCalled()
+    }
+  )
+
   it.each(['install', 'uninstall'] as const)(
     'E06 does not recommend restart after an unstructured R %s preflight failure',
     async (operation) => {

--- a/src/main/notebook/package-operations.ts
+++ b/src/main/notebook/package-operations.ts
@@ -146,6 +146,12 @@ class NotebookPackageOperations {
       micromambaRunner: options.micromambaRunner,
       retainWorkingCache: options.retainWorkingCache,
       recheckRepair: (target) => this.admission.recheckRepair(target),
+      canSkipInstall: (target) =>
+        !options.repairPolicy.requirement(
+          target.request.language,
+          target.environmentName,
+          target.binding
+        ).required,
       runtimeRepair: options.runtimeRepair,
       blockUnconfirmedChild: ({ repairRuntimeId, journalTarget }) => {
         options.recovery.markRuntimeLiveUnconfirmed(repairRuntimeId)
@@ -241,14 +247,20 @@ class NotebookPackageOperations {
     const resolution = await this.admission.resolveTarget(request)
     try {
       await this.options.ensureRecovered()
-      const mirror = await effectiveMirrorAsync(
-        await this.resolvePackageMirror(),
-        this.options.locale,
-        this.options.mirrorProbe
-      )
       const admission = await this.admission.admit(request, resolution)
       if (admission.status === 'refused') return admission.result
-      const result = await this.mutation.mutate({ target: admission.target, mirror }, signal)
+      const result = await this.mutation.mutate(
+        {
+          target: admission.target,
+          mirror: async () =>
+            effectiveMirrorAsync(
+              await this.resolvePackageMirror(),
+              this.options.locale,
+              this.options.mirrorProbe
+            )
+        },
+        signal
+      )
       if (result.needsRestart && request.language === 'r') {
         this.options.environmentOperations.recommendRestart('r', admission.target.environmentName)
         for (const session of this.options.sessions()) this.options.notifyChanged(session)

--- a/src/main/notebook/runtime-service.test.ts
+++ b/src/main/notebook/runtime-service.test.ts
@@ -10583,7 +10583,7 @@ describe('notebook runtime service', () => {
       expect(calls[0][1]?.spawn).toBeTypeOf('function')
     })
 
-    it('resolves the mirror before returning a package admission refusal', async () => {
+    it('does not resolve a mirror for a package admission refusal', async () => {
       const root = await createStorageRoot()
       const probe = vi.fn(async () => {
         throw new Error('probe unreachable (test)')
@@ -10604,7 +10604,7 @@ describe('notebook runtime service', () => {
         sessionId: 'unloaded-session'
       })
 
-      expect(probe).toHaveBeenCalled()
+      expect(probe).not.toHaveBeenCalled()
       expect(result.error).toContain('RUNTIME_SESSION_UNAVAILABLE')
       expect(result.target).toEqual({ language: 'python', selection: 'unresolved' })
     })
@@ -14392,6 +14392,7 @@ describe('v4 runtime bindings & agent tools', () => {
     repairRegistryKeys
       .mockReturnValueOnce([DEFAULT_PY_ENV, managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')])
       .mockReturnValueOnce([DEFAULT_PY_ENV, managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')])
+      .mockReturnValueOnce([DEFAULT_PY_ENV, managedRepairRegistryKey(DEFAULT_PY_ENV, 'python')])
       .mockReturnValueOnce([
         DEFAULT_PY_ENV,
         managedRepairRegistryKey(DEFAULT_PY_ENV, 'python'),
@@ -14401,7 +14402,7 @@ describe('v4 runtime bindings & agent tools', () => {
     const result = await service.managePackages({ language: 'python', packages: ['numpy'] })
 
     expect(result.ok).toBe(true)
-    expect(repairRegistryKeys).toHaveBeenCalledTimes(3)
+    expect(repairRegistryKeys).toHaveBeenCalledTimes(4)
     expect(isRepairRequired(runtimeRoot, postInstallAlias)).toBe(false)
   })
 

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx
@@ -208,6 +208,69 @@ describe('WorkspaceActivityGroup i18n', () => {
     expect(container.textContent).not.toContain('manage_packages()')
   })
 
+  it.each(['python', 'r'] as const)(
+    'does not invent an installer for satisfied %s packages',
+    (language) => {
+      const name = language === 'python' ? 'numpy' : 'ggplot2'
+      act(() => {
+        root.render(
+          <WorkspaceActivityGroup
+            group={{
+              id: 'satisfied-group',
+              type: 'activity-group',
+              createdAt: 1,
+              sortIndex: 1,
+              activities: [
+                {
+                  id: 'satisfied',
+                  kind: 'tool',
+                  title: 'open-science-notebook.manage_packages',
+                  status: 'completed',
+                  eventIds: [],
+                  sortIndex: 1,
+                  createdAt: 1,
+                  updatedAt: 100,
+                  rawInput: { language, packages: [name] },
+                  rawOutput: {
+                    structuredContent: {
+                      ok: true,
+                      needsRestart: false,
+                      attempts: [],
+                      environmentName: 'analysis',
+                      packageChanges: [
+                        {
+                          name,
+                          relationship: 'requested',
+                          change: 'unchanged',
+                          afterVersion: '2.0'
+                        }
+                      ]
+                    }
+                  }
+                }
+              ]
+            }}
+            isExpanded={true}
+            onToggleGroup={vi.fn()}
+            expansionOverrides={{ satisfied: true }}
+            onToggleRow={vi.fn()}
+          />
+        )
+      })
+      expect(container.textContent).toContain(
+        language === 'python' ? 'Python · analysis' : 'R · analysis'
+      )
+      expect(container.textContent).not.toContain('conda')
+      expect(container.textContent).not.toContain('kernel restart')
+      expect(
+        container.querySelector('[data-testid="manage-packages-package-status"]')?.textContent
+      ).toBe('Unchanged')
+      expect(
+        container.querySelector('[data-testid="manage-packages-package-version"]')?.textContent
+      ).toBe('2.0')
+    }
+  )
+
   it('shows the version transition for an updated package', () => {
     act(() => {
       root.render(

--- a/src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx
@@ -208,9 +208,14 @@ describe('WorkspaceActivityGroup i18n', () => {
     expect(container.textContent).not.toContain('manage_packages()')
   })
 
-  it.each(['python', 'r'] as const)(
-    'does not invent an installer for satisfied %s packages',
-    (language) => {
+  it.each([
+    ['python', false],
+    ['python', true],
+    ['r', false],
+    ['r', true]
+  ] as const)(
+    'does not invent an installer for satisfied %s packages (compacted: %s)',
+    (language, compacted) => {
       const name = language === 'python' ? 'numpy' : 'ggplot2'
       act(() => {
         root.render(
@@ -235,7 +240,7 @@ describe('WorkspaceActivityGroup i18n', () => {
                     structuredContent: {
                       ok: true,
                       needsRestart: false,
-                      attempts: [],
+                      ...(compacted ? {} : { attempts: [] }),
                       environmentName: 'analysis',
                       packageChanges: [
                         {

--- a/src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx
@@ -208,8 +208,16 @@ const WorkspaceManagePackagesActivityRow = ({
     .filter((detail) => detail.name)
   const languageLabel =
     input?.language === 'r' ? 'R' : input?.language === 'python' ? 'Python' : null
-  const installer =
-    typeof result?.method === 'string' && result.method.trim()
+  const noInstallerNeeded =
+    result?.ok === true &&
+    !result.method &&
+    Array.isArray(result.attempts) &&
+    result.attempts.length === 0 &&
+    packageChanges.length > 0 &&
+    packageChanges.every((change) => change.change === 'unchanged')
+  const installer = noInstallerNeeded
+    ? null
+    : typeof result?.method === 'string' && result.method.trim()
       ? result.method === 'biocmanager'
         ? t('Bioconductor')
         : result.method === 'github'

--- a/src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceManagePackagesActivityRow.tsx
@@ -211,8 +211,6 @@ const WorkspaceManagePackagesActivityRow = ({
   const noInstallerNeeded =
     result?.ok === true &&
     !result.method &&
-    Array.isArray(result.attempts) &&
-    result.attempts.length === 0 &&
     packageChanges.length > 0 &&
     packageChanges.every((change) => change.change === 'unchanged')
   const installer = noInstallerNeeded


### PR DESCRIPTION
## Problem

Repeated `manage_packages` requests invoke mirror discovery and installer transactions even when the target managed Python or R environment already satisfies every requested package. Presence-only `installed` metadata cannot by itself establish version satisfaction.

## Proposed change

Check fresh interpreter-native metadata under the existing environment mutation lease before mirror resolution, cache retention, journal/dirty markers or imported-lock invalidation. Managed Python probes use the canonical managed environment and isolated mode; R probes use the canonical managed library environment and activated PATH.

Return the existing successful result with unchanged package versions and no installer attempts only when all requirements are proven satisfied. Cover bare Python/R names and strictly equal numeric Python pins. Keep complete original requests for partial/missing/uncertain matches, explicit installers (including `usePip: true`), sources/channels, complex specs, external environments, uninstalls and repair-required targets. Do not create a new restart recommendation or clear an existing repair marker on a no-op. Fresh probes receive cancellation signals. The renderer no longer guesses Conda for a confirmed no-installer result, including results compacted by MCP.

## Scope and non-goals

No new result fields, enum values, persistent formats, database migrations or historical-data rewrites. The fresh path does not write inventory state. Imported environment locks remain intact. No new dependency/version solver, partial-request filtering or implicit upgrade workflow. Ordinary cached inspection is unchanged.

## Acceptance criteria and validation

Checks after the final material edit at `80bd94a1d`:

- Fresh package metadata, fallback and explicit-installer intent, Python/R full and compacted result rendering -> `npx vitest run src/main/notebook/package-mutation.test.ts src/main/notebook/package-operations.test.ts src/main/notebook/environment-state-tracker.test.ts src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts` -> 239 passed, 13 existing opt-in skips. Includes real subprocess cancellation tests for both probe paths.
- Runtime binding and repair consumers -> `npx vitest run src/main/notebook/runtime-service.test.ts -t 'managePackages|repair aliases|runtime bindings'` -> 132 passed, 254 outside selection.
- Main/renderer/sandbox types -> `npm run typecheck` -> passed; `npm run lint` and `git diff --check` -> passed.

Additional baseline contract/translation coverage at `d6cae0b60` (not rerun after the final edit):

- Current metadata, Python/R identity and versions, source/repair/cancellation fallback, no mutation side effects -> `npx vitest run src/main/notebook/package-mutation.test.ts src/main/notebook/package-operations.test.ts src/main/notebook/package-admission.test.ts src/main/notebook/environment-state-tracker.test.ts src/main/notebook/mcp-server.test.ts src/renderer/src/pages/workspace/WorkspaceActivityGroup.i18n.render.test.tsx src/renderer/src/pages/workspace/workspace-tool-activity-details.test.ts src/renderer/src/i18n/resources.test.ts` -> 1,165 passed, 13 existing opt-in cases skipped.
- Runtime binding and repair consumers -> `npx vitest run src/main/notebook/runtime-service.test.ts -t 'managePackages|repair aliases|runtime bindings'` -> 132 passed, 254 outside selection.
- Main/renderer/sandbox types -> `npm run typecheck` -> passed.
- Source standards -> `npm run lint` and `git diff --check` -> passed.
- Real renderer component fixture in Ego Browser -> Python/R version and unchanged rows shown, with no guessed Conda or restart prompt. Screenshot retained locally; this is component presentation evidence, not a live installation E2E.
- Independent Standards review confirmed the impact map; independent Spec review caught host-library contamination, then confirmed the final fix resolved it.

The impact explainer selects full fallback because the tracker test has no registered module owner. Per maintainer instruction, no full local suite was run; PR CI remains the complete/platform authority. Explicit local ownership is tracker/mutation/operations -> runtime-service/MCP -> renderer result consumers. No ACP wire contract changed, so four-provider protocol matrices are outside this diff.

Limitations: Windows/macOS/Linux process-environment cases are simulated locally; live Windows/R probe timing and runtime behavior remain CI/runtime checks. An expanded local runtime-service run had an unrelated Shell exit-code failure in the linked worktree; the isolated corresponding test passed in primary main. No unrelated Shell changes were made. Package-specific final tests pass.

## Review focus

Fail-safe fallback on uncertain metadata; isolation from host Python/R libraries; preservation of repair and imported-lock evidence; both language paths and legacy renderer results.
