### PR TITLE
fix(connectors): dismiss queued credential requests together

### DIFF
--- a/src/main/connectors/credential-request-broker.test.ts
+++ b/src/main/connectors/credential-request-broker.test.ts
@@ -3,6 +3,76 @@ import { describe, expect, it, vi } from 'vitest'
 import { CredentialRequestBroker } from './credential-request-broker'
 
 describe('CredentialRequestBroker', () => {
+  it.each(['session-1', undefined])(
+    'does not replay another credential prompt after Not now in %s',
+    async (sessionId) => {
+      let sequence = 0
+      const replay = vi.fn()
+      const broker = new CredentialRequestBroker({
+        generateId: () => `credential-${++sequence}`,
+        broadcast: vi.fn(),
+        replay
+      })
+      const info = {
+        credentialId: 'openalex' as const,
+        connector: 'literature',
+        method: 'openalex_search_works',
+        sessionId
+      }
+      const first = broker.request(info)
+      const second = broker.request({ ...info, method: 'openalex_get_work' })
+      try {
+        broker.respond('credential-1', false)
+        await expect(first).resolves.toBe(false)
+        broker.replayPending()
+        expect(replay).not.toHaveBeenCalled()
+        await expect(second).resolves.toBe(false)
+      } finally {
+        broker.cancelAll()
+      }
+    }
+  )
+
+  it('keeps other sessions waiting and allows a later request after declining a group', async () => {
+    let sequence = 0
+    const onSettled = vi.fn()
+    const broker = new CredentialRequestBroker({
+      generateId: () => `credential-${++sequence}`,
+      broadcast: vi.fn(),
+      onSettled
+    })
+    const info = {
+      credentialId: 'openalex' as const,
+      connector: 'literature',
+      method: 'openalex_search_works'
+    }
+    const controller = new AbortController()
+    const calls = [
+      broker.request({ ...info, sessionId: 'session-1' }, controller.signal),
+      broker.request({ ...info, sessionId: 'session-1' }, controller.signal),
+      broker.request({ ...info, sessionId: 'session-2' }),
+      broker.request(info)
+    ]
+    try {
+      broker.respond('credential-1', false)
+      expect(onSettled.mock.calls).toEqual([
+        ['credential-1', false],
+        ['credential-2', false]
+      ])
+      expect(controller.signal.aborted).toBe(false)
+      expect(broker.getPending('credential-3')).not.toBeNull()
+      expect(broker.getPending('credential-4')).not.toBeNull()
+      calls.push(broker.request({ ...info, sessionId: 'session-1' }))
+      expect(broker.getPending('credential-5')).not.toBeNull()
+      controller.abort()
+      broker.respond('credential-1', false)
+      expect(onSettled).toHaveBeenCalledTimes(2)
+    } finally {
+      broker.cancelAll()
+      await Promise.all(calls)
+    }
+  })
+
   it('broadcasts public metadata and resumes the parked caller after configuration', async () => {
     const broadcast = vi.fn()
     const onSettled = vi.fn()

--- a/src/main/connectors/credential-request-broker.ts
+++ b/src/main/connectors/credential-request-broker.ts
@@ -71,17 +71,19 @@ export class CredentialRequestBroker {
 
   respond(id: string, configured: boolean): void {
     const entry = this.pending.get(id)
-    if (!entry || !configured) {
-      this.settle(id, configured)
-      return
-    }
+    if (!entry) return
 
-    // One successful save satisfies every call parked on the same credential. Settle the whole
-    // group before returning so queued renderer requests cannot surface redundant follow-up dialogs.
+    // Saving satisfies every caller; declining only dismisses the current Session's group (or the
+    // sessionless fallback group). Settle queued calls so Not now cannot reveal the next identical
+    // prompt. Later calls remain eligible to request the credential again.
     const matchingIds = [...this.pending.entries()]
-      .filter(([, candidate]) => candidate.request.credentialId === entry.request.credentialId)
+      .filter(
+        ([, candidate]) =>
+          candidate.request.credentialId === entry.request.credentialId &&
+          (configured || candidate.request.sessionId === entry.request.sessionId)
+      )
       .map(([pendingId]) => pendingId)
-    for (const pendingId of matchingIds) this.settle(pendingId, true)
+    for (const pendingId of matchingIds) this.settle(pendingId, configured)
   }
 
   cancelAll(): void {

--- a/src/main/connectors/service.test.ts
+++ b/src/main/connectors/service.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { ConnectorService } from './service'
 import { ParserEngine } from './engine'
+import { CredentialRequestBroker } from './credential-request-broker'
 import { McpClientManager, McpToolCallError } from './mcp-client-manager'
 import type { SpecialistView } from '../../shared/specialist'
 import type { CustomMcpServerConfig } from './mcp-client-manager'
@@ -12,6 +13,49 @@ const jsonRes = (body: unknown): Response =>
   ({ ok: true, status: 200, json: async () => body }) as Response
 
 describe('ConnectorService', () => {
+  it('returns credential errors for all declined queued calls without aborting the session', async () => {
+    let sequence = 0
+    const broadcast = vi.fn()
+    const broker = new CredentialRequestBroker({
+      generateId: () => `credential-${++sequence}`,
+      broadcast
+    })
+    const fetchImpl = vi.fn()
+    const svc = new ConnectorService({
+      engine: new ParserEngine({ fetchImpl }),
+      getConnectors: () => ({ enabledIds: [], autoAllowIds: [] }),
+      resolveApiKey: () => undefined,
+      requestCredential: (info, signal) => broker.request(info, signal)
+    })
+    const controller = new AbortController()
+    const calls = ['CRISPR', 'genomics'].map((query) =>
+      svc
+        .call(
+          'literature',
+          'openalex_search_works',
+          { query, max_records: 1 },
+          { ...internal, sessionId: 'session-1' },
+          controller.signal
+        )
+        .catch((error: unknown) => error)
+    )
+    try {
+      await vi.waitFor(() => expect(broadcast).toHaveBeenCalledTimes(2))
+      broker.respond('credential-1', false)
+      expect(broker.getPending('credential-2')).toBeNull()
+      for (const error of await Promise.all(calls)) {
+        expect(error).toBeInstanceOf(Error)
+        expect((error as Error).message).toContain('credential_required')
+        expect((error as Error).message).toContain('Do not retry until the user adds it')
+      }
+      expect(fetchImpl).not.toHaveBeenCalled()
+      expect(controller.signal.aborted).toBe(false)
+    } finally {
+      broker.cancelAll()
+      await Promise.all(calls)
+    }
+  })
+
   it('parks an OpenAlex call for credential recovery and resumes the exact call after save', async () => {
     let connectors = {
       enabledIds: [] as string[],

--- a/src/renderer/src/pages/settings/ConnectorCredentialDialog.render.test.tsx
+++ b/src/renderer/src/pages/settings/ConnectorCredentialDialog.render.test.tsx
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { createInitialSettingsState, useSettingsStore } from '@/stores/settings-store'
 import { ConnectorCredentialControls, ConnectorCredentialDialog } from './ConnectorCredentialDialog'
+import { CredentialRequestBroker } from '../../../../main/connectors/credential-request-broker'
 
 let container: HTMLDivElement
 let root: Root
@@ -60,6 +61,36 @@ afterEach(() => {
 })
 
 describe('ConnectorCredentialDialog', () => {
+  it('closes queued credential dialogs after one Not now response', async () => {
+    let sequence = 0
+    const broker = new CredentialRequestBroker({
+      generateId: () => `queued-${++sequence}`,
+      broadcast: (request) => useSettingsStore.getState().enqueueCredentialRequest(request),
+      onSettled: (id) => useSettingsStore.getState().dismissCredentialRequest(id)
+    })
+    useSettingsStore.setState({
+      pendingCredentialRequests: [],
+      respondCredentialRequest: async (id, configured) => broker.respond(id, configured)
+    })
+    const info = {
+      credentialId: 'openalex' as const,
+      connector: 'literature',
+      method: 'openalex_search_works'
+    }
+    const first = broker.request(info)
+    const second = broker.request({ ...info, method: 'openalex_get_work' })
+    try {
+      act(() => root.render(<ConnectorCredentialDialog />))
+      expect(document.body.querySelector('[role="dialog"]')).not.toBeNull()
+      await act(async () => button('Not now')?.click())
+      await flush()
+      expect(document.body.querySelector('[role="dialog"]')).toBeNull()
+      await expect(Promise.all([first, second])).resolves.toEqual([false, false])
+    } finally {
+      act(() => broker.cancelAll())
+    }
+  })
+
   it('keeps concurrent embedded and fallback fields uniquely labelled', () => {
     act(() =>
       root.render(


### PR DESCRIPTION
## Problem

When multiple OpenAlex calls were waiting for credentials, clicking **Not now** settled only the visible request. The next queued request could immediately present the same prompt, without any HTTP retry or new Agent call.

## Proposed change

Decline all currently pending requests for the same credential and session through the existing settlement callbacks. Sessionless requests form a separate fallback-dialog group. Other sessions remain pending; successful saves still resolve that credential across sessions.

Each declined call receives the existing `credential_required` error and instruction not to retry until configured. No network call is dispatched and the session is not aborted.

## Scope and non-goals

- One production file changed; no new fields, enums, storage formats, migrations, or historical compatibility requirements.
- Existing notification records settle through the existing persistence path.
- No provider adapter or session lifecycle changes; no permanent or turn-wide suppression. Later calls can prompt again.
- Existing UI copy and layout remain unchanged.

## Acceptance criteria and validation

Five new regression cases fail against the original broker because a queued request or dialog remains, and pass with the fix. The smallest reproduction failed repeatedly before implementation. Tests use existing public boundaries, including the real Not now button, broker and store actions; no production test seam was introduced.

All final checks below ran after the last material edit:

| Behavior | Check | Result |
| --- | --- | --- |
| Group dismissal, scope isolation, later requests and settlement | `credential-request-broker.test.ts` | Passed |
| Caller errors, no fetch and no session abort | `service.test.ts` | Passed |
| Application and notification lifecycle | `application.test.ts`, notification `task-notifications.test.ts`, `electron-wiring.test.ts`, `notification-inbox-repository.test.ts` | Passed |
| Button behavior, settings and event consumers | `ConnectorCredentialDialog.render.test.tsx`, `settings-connectors-slice.test.ts`, `App.test.tsx` | Passed |
| Main and renderer types | `npm run typecheck:node`, `npm run typecheck:web` | Passed |
| Lint | `npm run lint` | Passed |

The targeted `npm test -- <nine files above>` run passed **325 tests**. The full local suite was intentionally not run, as requested; PR CI remains authoritative.

A Playwright click in installed Edge also passed with no page errors. Screenshots were delivered locally using a clearly labelled fixture with the production broker, dialog, store and CSS. This is not a full Agent-session screenshot: the current headless backend disables credential prompts.

## Review focus

Check session isolation, sessionless grouping, and preservation of cross-session successful saves. No changes affect framework protocols, history replay or branch selection; live sessions with claude-code, opencode, codex-response and codex-bridge were not run. The actual reporter's original trigger remains unconfirmed; this PR fixes the reproducible queued-request path. Independent review and platform CI are pending.
