### PR TITLE
ci(pr-gate): share platform setup across E2E shards

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -774,9 +774,88 @@ jobs:
           check windows_path "$WINDOWS_PATH_OUTCOME"
           exit "$failed"
 
+  macos_e2e_setup:
+    name: Prepare macOS E2E
+    needs: preflight
+    if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'macos_e2e') }}
+    runs-on: macos-14
+    timeout-minutes: 15
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      node_version: ${{ steps.node.outputs.node-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        id: node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: node scripts/ci/npm-ci.mjs
+      - name: Build Electron application
+        run: npm run build:e2e
+      - name: Build web application
+        run: npm run build:web
+      - name: Test snapshot transport
+        run: npx vitest run scripts/ci/e2e-setup-snapshot.test.ts
+      - name: Pack E2E setup
+        run: node scripts/ci/e2e-setup-snapshot.mjs pack "$RUNNER_TEMP/e2e-setup"
+      - name: Upload E2E setup
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-setup-macos-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-setup/
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
+  windows_e2e_setup:
+    name: Prepare Windows E2E
+    needs: preflight
+    if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'windows_e2e') }}
+    runs-on: windows-latest
+    timeout-minutes: 15
+    outputs:
+      artifact_id: ${{ steps.upload.outputs.artifact-id }}
+      node_version: ${{ steps.node.outputs.node-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          persist-credentials: false
+      - name: Setup Node
+        id: node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install dependencies
+        run: node scripts/ci/npm-ci.mjs --prefer-offline --no-audit --fund=false
+      - name: Build Electron application
+        run: npm run build:e2e
+      - name: Test snapshot transport
+        run: npx vitest run scripts/ci/e2e-setup-snapshot.test.ts
+      - name: Pack E2E setup
+        shell: bash
+        run: node scripts/ci/e2e-setup-snapshot.mjs pack "$RUNNER_TEMP/e2e-setup"
+      - name: Upload E2E setup
+        id: upload
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: e2e-setup-windows-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/e2e-setup/
+          retention-days: 1
+          compression-level: 0
+          if-no-files-found: error
+
   macos_e2e:
     name: macOS build and E2E (${{ matrix.group }})
-    needs: preflight
+    needs: [preflight, macos_e2e_setup]
     if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'macos_e2e') }}
     runs-on: macos-14
     timeout-minutes: 30
@@ -792,10 +871,18 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 22
-          cache: npm
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci.mjs
+          node-version: ${{ needs.macos_e2e_setup.outputs.node_version }}
+          package-manager-cache: false
+      # Artifact IDs survive failed-job reruns without selecting another producer attempt.
+      - name: Download E2E setup
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.macos_e2e_setup.outputs.artifact_id }}
+          path: ${{ runner.temp }}/e2e-setup/
+          merge-multiple: true
+      - name: Restore E2E setup
+        id: setup
+        run: node scripts/ci/e2e-setup-snapshot.mjs restore "$RUNNER_TEMP/e2e-setup"
       - name: Test macOS-native behavior
         id: unit_macos_native
         if: ${{ matrix.group == 'journeys' && fromJSON(needs.preflight.outputs.plan).mode == 'full' }}
@@ -808,18 +895,9 @@ jobs:
             src/main/notebook/managed-runtime-guard.test.ts
           npx vitest run src/main/notebook/kernel-executor.test.ts \
             -t 'executes the repl loop through the production network sandbox'
-      - name: Build Electron application
-        id: build_electron
-        continue-on-error: true
-        run: npm run build:e2e
-      - name: Build web application
-        id: build_web
-        if: ${{ matrix.group == 'regressions' || (matrix.group == 'journeys' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'build')) }}
-        continue-on-error: true
-        run: npm run build:web
       - name: Run functional journeys
         id: e2e_functional_macos
-        if: ${{ matrix.group == 'journeys' && steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_macos') }}
+        if: ${{ matrix.group == 'journeys' && steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_macos') }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/functional_macos
@@ -838,7 +916,7 @@ jobs:
           if-no-files-found: warn
       - name: Run workspace journeys
         id: e2e_workspace_macos
-        if: ${{ matrix.group == 'journeys' && steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_macos') }}
+        if: ${{ matrix.group == 'journeys' && steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_macos') }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/workspace_macos
@@ -860,7 +938,7 @@ jobs:
         run: npx playwright install chromium --only-shell
       - name: Run supplemental regressions
         id: e2e_regressions_macos
-        if: ${{ matrix.group == 'regressions' && steps.build_electron.outcome == 'success' && steps.build_web.outcome == 'success' }}
+        if: ${{ matrix.group == 'regressions' && steps.setup.outcome == 'success' }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/regressions_macos
@@ -868,7 +946,7 @@ jobs:
         run: npm run test:e2e:regressions -- --fail-on-flaky-tests --global-timeout=1200000
       - name: Run supplemental delegation
         id: e2e_delegation_macos
-        if: ${{ matrix.group == 'delegation' && steps.build_electron.outcome == 'success' }}
+        if: ${{ matrix.group == 'delegation' && steps.setup.outcome == 'success' }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/delegation_macos
@@ -884,7 +962,7 @@ jobs:
         run: npm run test:e2e:browser -- --fail-on-flaky-tests --global-timeout=300000
       - name: Run accessibility checks
         id: e2e_accessibility_macos
-        if: ${{ matrix.group == 'presentation' && steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_macos') }}
+        if: ${{ matrix.group == 'presentation' && steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_macos') }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/accessibility-macos
@@ -903,7 +981,7 @@ jobs:
           if-no-files-found: warn
       - name: Run visual regression
         id: e2e_visual_macos
-        if: ${{ matrix.group == 'presentation' && steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_visual_macos') }}
+        if: ${{ matrix.group == 'presentation' && steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_visual_macos') }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/visual_macos
@@ -937,8 +1015,7 @@ jobs:
         shell: bash
         env:
           RENDERER_LAYOUT_OUTCOME: ${{ steps.renderer_layout.outcome }}
-          BUILD_ELECTRON_OUTCOME: ${{ steps.build_electron.outcome }}
-          BUILD_WEB_OUTCOME: ${{ steps.build_web.outcome }}
+          SETUP_OUTCOME: ${{ steps.setup.outcome }}
           E2E_ACCESSIBILITY_OUTCOME: ${{ steps.e2e_accessibility_macos.outcome }}
           E2E_FUNCTIONAL_OUTCOME: ${{ steps.e2e_functional_macos.outcome }}
           E2E_VISUAL_OUTCOME: ${{ steps.e2e_visual_macos.outcome }}
@@ -957,8 +1034,7 @@ jobs:
             fi
           }
           check renderer_layout "$RENDERER_LAYOUT_OUTCOME"
-          check build_electron "$BUILD_ELECTRON_OUTCOME"
-          check build_web "$BUILD_WEB_OUTCOME"
+          check setup "$SETUP_OUTCOME"
           check e2e_functional_macos "$E2E_FUNCTIONAL_OUTCOME"
           check e2e_workspace_macos "$E2E_WORKSPACE_OUTCOME"
           check e2e_accessibility_macos "$E2E_ACCESSIBILITY_OUTCOME"
@@ -971,7 +1047,7 @@ jobs:
 
   windows_e2e:
     name: Windows E2E (shard ${{ matrix.shard }}/3)
-    needs: preflight
+    needs: [preflight, windows_e2e_setup]
     if: ${{ needs.preflight.result == 'success' && contains(fromJSON(needs.preflight.outputs.plan).bundles, 'windows_e2e') }}
     runs-on: windows-latest
     timeout-minutes: 35
@@ -987,14 +1063,18 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
-          node-version: 22
-          cache: npm
-      - name: Install dependencies
-        run: node scripts/ci/npm-ci.mjs --prefer-offline --no-audit --fund=false
-      - name: Build Electron application
-        id: build_electron
-        continue-on-error: true
-        run: npm run build:e2e
+          node-version: ${{ needs.windows_e2e_setup.outputs.node_version }}
+          package-manager-cache: false
+      - name: Download E2E setup
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          artifact-ids: ${{ needs.windows_e2e_setup.outputs.artifact_id }}
+          path: ${{ runner.temp }}/e2e-setup/
+          merge-multiple: true
+      - name: Restore E2E setup
+        id: setup
+        shell: bash
+        run: node scripts/ci/e2e-setup-snapshot.mjs restore "$RUNNER_TEMP/e2e-setup"
       - name: Install headless Chromium
         if: ${{ matrix.shard == 1 }}
         run: npx playwright install chromium --only-shell
@@ -1008,7 +1088,7 @@ jobs:
         run: npm run test:e2e:browser -- --fail-on-flaky-tests --global-timeout=180000
       - name: Run functional journeys
         id: e2e_functional_windows
-        if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_windows') }}
+        if: ${{ steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_functional_windows') }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/functional_windows
@@ -1028,7 +1108,7 @@ jobs:
           if-no-files-found: warn
       - name: Run workspace journeys
         id: e2e_workspace_windows
-        if: ${{ steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_windows') }}
+        if: ${{ steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_workspace_windows') }}
         continue-on-error: true
         env:
           PLAYWRIGHT_BLOB_OUTPUT_DIR: blob-report/workspace_windows
@@ -1049,7 +1129,7 @@ jobs:
       # The new manifest never emits it, so ordinary PRs do not pay this Windows accessibility cost.
       - name: Run legacy Windows accessibility compatibility
         id: e2e_accessibility_windows
-        if: ${{ matrix.shard == 1 && steps.build_electron.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_windows') }}
+        if: ${{ matrix.shard == 1 && steps.setup.outcome == 'success' && contains(fromJSON(needs.preflight.outputs.plan).lanes, 'e2e_accessibility_windows') }}
         continue-on-error: true
         run: npm run test:e2e:accessibility -- --fail-on-flaky-tests
       - name: Upload legacy accessibility failure artifacts
@@ -1080,7 +1160,7 @@ jobs:
         shell: bash
         env:
           RENDERER_LAYOUT_OUTCOME: ${{ steps.renderer_layout.outcome }}
-          BUILD_ELECTRON_OUTCOME: ${{ steps.build_electron.outcome }}
+          SETUP_OUTCOME: ${{ steps.setup.outcome }}
           E2E_ACCESSIBILITY_OUTCOME: ${{ steps.e2e_accessibility_windows.outcome }}
           E2E_FUNCTIONAL_OUTCOME: ${{ steps.e2e_functional_windows.outcome }}
           E2E_WORKSPACE_OUTCOME: ${{ steps.e2e_workspace_windows.outcome }}
@@ -1094,7 +1174,7 @@ jobs:
             fi
           }
           check renderer_layout "$RENDERER_LAYOUT_OUTCOME"
-          check build_electron "$BUILD_ELECTRON_OUTCOME"
+          check setup "$SETUP_OUTCOME"
           check e2e_functional_windows "$E2E_FUNCTIONAL_OUTCOME"
           check e2e_workspace_windows "$E2E_WORKSPACE_OUTCOME"
           check e2e_accessibility_windows "$E2E_ACCESSIBILITY_OUTCOME"

--- a/scripts/ci/e2e-execution-ownership.test.ts
+++ b/scripts/ci/e2e-execution-ownership.test.ts
@@ -77,7 +77,7 @@ it.each(['regressions', 'delegation'])(
     const steps = workflow.jobs.macos_e2e.steps
     const execution = steps.find(({ id }) => id === `e2e_${group}_macos`)!
     expect(execution.if).toBe(
-      `\${{ matrix.group == '${group}' && steps.build_electron.outcome == 'success'${group === 'regressions' ? " && steps.build_web.outcome == 'success'" : ''} }}`
+      `\${{ matrix.group == '${group}' && steps.setup.outcome == 'success' }}`
     )
     expect(execution.run).toContain(`npm run test:e2e:${group} -- --fail-on-flaky-tests`)
     const enforce = steps.find(({ name }) => name === 'Enforce selected macOS checks')!

--- a/scripts/ci/e2e-setup-snapshot.mjs
+++ b/scripts/ci/e2e-setup-snapshot.mjs
@@ -1,0 +1,181 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+import { execFileSync, spawn } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import { createReadStream, createWriteStream } from 'node:fs'
+import {
+  access,
+  appendFile,
+  lstat,
+  mkdir,
+  readFile,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { dirname, join, relative, resolve } from 'node:path'
+import { pipeline } from 'node:stream/promises'
+import { fileURLToPath } from 'node:url'
+import { createGzip, createGunzip } from 'node:zlib'
+
+const archiveName = 'setup.tar.gz'
+const manifestName = 'setup.json'
+
+// npm's Windows junctions carry absolute producer paths. Archive the package targets and recreate
+// only these lockfile-owned links in the consumer, while tar preserves other links and file modes.
+export function localPackageLinks(lock) {
+  return Object.entries(lock.packages)
+    .filter(([, value]) => value.link)
+    .map(([path, value]) => {
+      if (
+        !/^node_modules\/(?:@[\w.-]+\/)?[\w.-]+$/.test(path) ||
+        !/^packages\/[\w-]+$/.test(value.resolved)
+      ) {
+        throw new Error(`Unsupported local package link: ${path} -> ${value.resolved}`)
+      }
+      return { path, target: value.resolved }
+    })
+}
+
+export function validateIdentity(actual, expected) {
+  for (const [key, value] of Object.entries(expected)) {
+    if (actual[key] !== value) throw new Error(`E2E setup ${key} mismatch`)
+  }
+}
+
+async function identity(cwd, env) {
+  if (!env.GITHUB_RUN_ID) throw new Error('E2E snapshots require GITHUB_RUN_ID')
+  return {
+    revision: execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf8' }).trim(),
+    runId: env.GITHUB_RUN_ID,
+    platform: process.platform,
+    arch: process.arch,
+    node: process.version,
+    lockHash: createHash('sha256')
+      .update(await readFile(join(cwd, 'package-lock.json')))
+      .digest('hex')
+  }
+}
+
+async function digest(path) {
+  const hash = createHash('sha256')
+  for await (const chunk of createReadStream(path)) hash.update(chunk)
+  return hash.digest('hex')
+}
+
+function tarProcess(args, cwd, env) {
+  // Git Bash also ships tar; use the OS implementation consistently on Windows.
+  const executable =
+    process.platform === 'win32'
+      ? join(env.SystemRoot ?? env.SYSTEMROOT, 'System32', 'tar.exe')
+      : 'tar'
+  const child = spawn(executable, args, { cwd, env, stdio: ['pipe', 'pipe', 'inherit'] })
+  const completed = new Promise((fulfill, reject) => {
+    child.once('error', reject)
+    child.once('close', (code) => {
+      if (code === 0) fulfill()
+      else reject(new Error(`tar exited with ${code}`))
+    })
+  })
+  return { child, completed }
+}
+
+export async function packSnapshot(cwd, directory, env = process.env) {
+  // The output must live outside the archived workspace paths (RUNNER_TEMP in CI).
+  const metadata = await identity(cwd, env)
+  const links = localPackageLinks(
+    JSON.parse(await readFile(join(cwd, 'package-lock.json'), 'utf8'))
+  )
+  const paths = ['node_modules', 'out', ...links.map(({ target }) => target)]
+  for (const path of paths) {
+    if (!(await lstat(join(cwd, path))).isDirectory()) {
+      throw new Error(`Snapshot input must be a real directory: ${path}`)
+    }
+  }
+  await mkdir(directory, { recursive: true })
+  const archive = join(directory, archiveName)
+  const { child, completed } = tarProcess(
+    ['-cf', '-', ...links.map(({ path }) => `--exclude=${path}`), ...paths],
+    cwd,
+    env
+  )
+  child.stdin.end()
+  await Promise.all([
+    completed,
+    pipeline(child.stdout, createGzip({ level: 1 }), createWriteStream(archive, { flags: 'wx' }))
+  ])
+  await writeFile(
+    join(directory, manifestName),
+    JSON.stringify({ ...metadata, sha256: await digest(archive) }) + '\n',
+    { flag: 'wx' }
+  )
+  return (await stat(archive)).size
+}
+
+export async function restoreSnapshot(cwd, directory, env = process.env) {
+  const metadata = JSON.parse(await readFile(join(directory, manifestName), 'utf8'))
+  validateIdentity(metadata, await identity(cwd, env))
+  const archive = join(directory, archiveName)
+  if ((await digest(archive)) !== metadata.sha256) throw new Error('E2E setup checksum mismatch')
+  // Never extract through an existing dependency junction or combine two builds.
+  for (const path of ['node_modules', 'out']) {
+    try {
+      await lstat(join(cwd, path))
+    } catch (error) {
+      if (error.code === 'ENOENT') continue
+      throw error
+    }
+    throw new Error(`E2E setup restore requires an absent ${path}`)
+  }
+  const { child, completed } = tarProcess(['-xf', '-'], cwd, env)
+  child.stdout.resume()
+  await Promise.all([completed, pipeline(createReadStream(archive), createGunzip(), child.stdin)])
+  const links = localPackageLinks(
+    JSON.parse(await readFile(join(cwd, 'package-lock.json'), 'utf8'))
+  )
+  for (const { path, target } of links) {
+    const link = join(cwd, path)
+    await mkdir(dirname(link), { recursive: true })
+    await symlink(
+      process.platform === 'win32'
+        ? resolve(cwd, target)
+        : relative(dirname(link), join(cwd, target)),
+      link,
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+  }
+  return (await stat(archive)).size
+}
+
+export async function verifySnapshot(cwd, web = false) {
+  const require = createRequire(join(cwd, 'package.json'))
+  for (const entry of ['out/main/index.js', 'out/preload/index.js', 'out/renderer/index.html']) {
+    await access(join(cwd, entry))
+  }
+  if (web) await access(join(cwd, 'out/web/index.html'))
+  await access(require('electron'))
+  if (typeof require('@prisma/client').PrismaClient !== 'function') {
+    throw new Error('Snapshot has no generated Prisma client')
+  }
+  require('@aipoch/process-tree-native')
+  require('@aipoch/safe-file-publisher-native')
+  require.resolve('@playwright/test')
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const [mode, directory] = process.argv.slice(2)
+  if (!['pack', 'restore'].includes(mode) || !directory) {
+    throw new Error('Usage: node scripts/ci/e2e-setup-snapshot.mjs <pack|restore> <directory>')
+  }
+  const started = performance.now()
+  const cwd = process.cwd()
+  if (mode === 'pack') await verifySnapshot(cwd, process.platform === 'darwin')
+  const bytes = await (mode === 'pack' ? packSnapshot : restoreSnapshot)(cwd, resolve(directory))
+  if (mode === 'restore') await verifySnapshot(cwd, process.platform === 'darwin')
+  const summary = `E2E setup ${mode}: ${(bytes / 1024 / 1024).toFixed(1)} MiB, ${((performance.now() - started) / 1000).toFixed(1)} seconds`
+  console.log(summary)
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(process.env.GITHUB_STEP_SUMMARY, `- ${summary}\n`)
+  }
+}

--- a/scripts/ci/e2e-setup-snapshot.mjs
+++ b/scripts/ci/e2e-setup-snapshot.mjs
@@ -17,7 +17,7 @@ import { createRequire } from 'node:module'
 import { dirname, join, relative, resolve } from 'node:path'
 import { pipeline } from 'node:stream/promises'
 import { fileURLToPath } from 'node:url'
-import { createGzip, createGunzip } from 'node:zlib'
+import { createGzip } from 'node:zlib'
 
 const archiveName = 'setup.tar.gz'
 const manifestName = 'setup.json'
@@ -128,9 +128,12 @@ export async function restoreSnapshot(cwd, directory, env = process.env) {
     }
     throw new Error(`E2E setup restore requires an absent ${path}`)
   }
-  const { child, completed } = tarProcess(['-xf', '-'], cwd, env)
+  // GNU tar can exit successfully at the end marker before a pipe writer has sent the trailing
+  // padding. Let tar own decompression so successful extraction cannot race Node's stdin pipeline.
+  const { child, completed } = tarProcess(['-xzf', archive], cwd, env)
+  child.stdin.end()
   child.stdout.resume()
-  await Promise.all([completed, pipeline(createReadStream(archive), createGunzip(), child.stdin)])
+  await completed
   const links = localPackageLinks(
     JSON.parse(await readFile(join(cwd, 'package-lock.json'), 'utf8'))
   )

--- a/scripts/ci/e2e-setup-snapshot.test.ts
+++ b/scripts/ci/e2e-setup-snapshot.test.ts
@@ -1,4 +1,5 @@
 import { execFileSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
 import {
   chmod,
   lstat,
@@ -13,6 +14,7 @@ import {
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join, relative } from 'node:path'
+import { gunzipSync, gzipSync } from 'node:zlib'
 
 import { afterEach, describe, expect, it } from 'vitest'
 
@@ -76,6 +78,24 @@ async function fixture(): Promise<{ producer: string; consumer: string; archive:
 }
 
 describe('same-run E2E setup snapshots', () => {
+  it('accepts a valid archive when tar finishes before consuming its trailing padding', async () => {
+    const { producer, consumer, archive } = await fixture()
+    await packSnapshot(producer, archive, environment)
+    const archivePath = join(archive, 'setup.tar.gz')
+    // Tar ends at zero records. A reader may exit successfully without consuming every padded byte.
+    // Make the padding exceed pipe buffers so the producer cannot finish writing before tar exits.
+    const padded = gzipSync(
+      Buffer.concat([gunzipSync(await readFile(archivePath)), Buffer.alloc(4 * 1024 * 1024)])
+    )
+    await writeFile(archivePath, padded)
+    const manifestPath = join(archive, 'setup.json')
+    const metadata = JSON.parse(await readFile(manifestPath, 'utf8'))
+    metadata.sha256 = createHash('sha256').update(padded).digest('hex')
+    await writeFile(manifestPath, JSON.stringify(metadata))
+    await restoreSnapshot(consumer, archive, environment)
+    expect(await readFile(join(consumer, 'out/main/index.js'), 'utf8')).toBe('current build')
+  })
+
   it('moves generated files and executable modes, rebasing local links to the consumer', async () => {
     const { producer, consumer, archive } = await fixture()
     expect(await packSnapshot(producer, archive, environment)).toBeGreaterThan(0)

--- a/scripts/ci/e2e-setup-snapshot.test.ts
+++ b/scripts/ci/e2e-setup-snapshot.test.ts
@@ -1,0 +1,161 @@
+import { execFileSync } from 'node:child_process'
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  realpath,
+  rm,
+  stat,
+  symlink,
+  writeFile
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join, relative } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  localPackageLinks,
+  packSnapshot,
+  restoreSnapshot,
+  validateIdentity
+} from './e2e-setup-snapshot.mjs'
+
+const roots: string[] = []
+const environment = { ...process.env, GITHUB_RUN_ID: '1234' }
+
+afterEach(async () => {
+  for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true })
+})
+
+async function fixture(): Promise<{ producer: string; consumer: string; archive: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'e2e-snapshot-'))
+  roots.push(root)
+  const producer = join(root, 'producer')
+  const consumer = join(root, 'consumer')
+  const archive = join(root, 'archive')
+  await mkdir(producer)
+  const git = (args: string[]): string =>
+    execFileSync('git', args, {
+      cwd: producer,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe']
+    })
+  git(['init'])
+  await writeFile(join(producer, 'package.json'), '{}')
+  await writeFile(
+    join(producer, 'package-lock.json'),
+    JSON.stringify({
+      packages: { 'node_modules/@local/native': { link: true, resolved: 'packages/native' } }
+    })
+  )
+  git(['add', '.'])
+  git(['-c', 'user.name=CI Test', '-c', 'user.email=ci@example.invalid', 'commit', '-m', 'fixture'])
+  git(['clone', '--no-hardlinks', producer, consumer])
+  for (const [path, content] of Object.entries({
+    'node_modules/.prisma/client/index.js': 'generated Prisma fixture',
+    'node_modules/.bin/tool': '#!/bin/sh\nexit 0\n',
+    'packages/native/build/Release/native.node': 'native fixture',
+    'out/main/index.js': 'current build'
+  })) {
+    await mkdir(dirname(join(producer, path)), { recursive: true })
+    await writeFile(join(producer, path), content)
+  }
+  await chmod(join(producer, 'node_modules/.bin/tool'), 0o755)
+  const link = join(producer, 'node_modules/@local/native')
+  const target = join(producer, 'packages/native')
+  await mkdir(dirname(link), { recursive: true })
+  await symlink(
+    process.platform === 'win32' ? target : relative(dirname(link), target),
+    link,
+    process.platform === 'win32' ? 'junction' : 'dir'
+  )
+  return { producer, consumer, archive }
+}
+
+describe('same-run E2E setup snapshots', () => {
+  it('moves generated files and executable modes, rebasing local links to the consumer', async () => {
+    const { producer, consumer, archive } = await fixture()
+    expect(await packSnapshot(producer, archive, environment)).toBeGreaterThan(0)
+    // Rerunning a consumer must not require the current attempt to equal the producer attempt.
+    await restoreSnapshot(consumer, archive, { ...environment, GITHUB_RUN_ATTEMPT: '2' })
+    expect(await readFile(join(consumer, 'node_modules/.prisma/client/index.js'), 'utf8')).toBe(
+      'generated Prisma fixture'
+    )
+    expect(await readFile(join(consumer, 'out/main/index.js'), 'utf8')).toBe('current build')
+    expect(await realpath(join(consumer, 'node_modules/@local/native'))).toBe(
+      await realpath(join(consumer, 'packages/native'))
+    )
+    expect(
+      await readFile(join(consumer, 'node_modules/@local/native/build/Release/native.node'), 'utf8')
+    ).toBe('native fixture')
+    expect((await lstat(join(producer, 'node_modules/@local/native'))).isSymbolicLink()).toBe(true)
+    if (process.platform !== 'win32') {
+      expect((await stat(join(consumer, 'node_modules/.bin/tool'))).mode & 0o111).toBe(0o111)
+    }
+  })
+
+  it('rejects a different run before extracting files', async () => {
+    const { producer, consumer, archive } = await fixture()
+    await packSnapshot(producer, archive, environment)
+    await expect(
+      restoreSnapshot(consumer, archive, { ...environment, GITHUB_RUN_ID: 'other' })
+    ).rejects.toThrow('runId mismatch')
+    await expect(lstat(join(consumer, 'node_modules'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('rejects a corrupted archive before extracting files', async () => {
+    const { producer, consumer, archive } = await fixture()
+    await packSnapshot(producer, archive, environment)
+    await writeFile(join(archive, 'setup.tar.gz'), 'corrupted')
+    await expect(restoreSnapshot(consumer, archive, environment)).rejects.toThrow(
+      'checksum mismatch'
+    )
+    await expect(lstat(join(consumer, 'node_modules'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it('refuses to restore through a pre-existing shared dependency junction', async () => {
+    const { producer, consumer, archive } = await fixture()
+    await packSnapshot(producer, archive, environment)
+    await symlink(
+      join(producer, 'node_modules'),
+      join(consumer, 'node_modules'),
+      process.platform === 'win32' ? 'junction' : 'dir'
+    )
+    await expect(restoreSnapshot(consumer, archive, environment)).rejects.toThrow(
+      'absent node_modules'
+    )
+    expect(await readFile(join(producer, 'node_modules/.prisma/client/index.js'), 'utf8')).toBe(
+      'generated Prisma fixture'
+    )
+  })
+
+  it('does not publish a snapshot when required build output is absent', async () => {
+    const { producer, archive } = await fixture()
+    await rm(join(producer, 'out'), { recursive: true })
+    await expect(packSnapshot(producer, archive, environment)).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+    await expect(lstat(join(archive, 'setup.json'))).rejects.toMatchObject({ code: 'ENOENT' })
+  })
+
+  it.each(['revision', 'platform', 'arch', 'node', 'lockHash'])(
+    'rejects mismatched %s identity',
+    (key) => {
+      expect(() => validateIdentity({ [key]: 'old' }, { [key]: 'current' })).toThrow(
+        `${key} mismatch`
+      )
+    }
+  )
+
+  it.each(['../unowned', 'packages/../unowned', '/absolute', 'C:\\unowned'])(
+    'rejects unsupported local package target %s',
+    (resolved) => {
+      expect(() =>
+        localPackageLinks({ packages: { 'node_modules/local': { link: true, resolved } } })
+      ).toThrow('Unsupported local package link')
+    }
+  )
+})

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -6,6 +6,8 @@ import { join } from 'node:path'
 import { load } from 'js-yaml'
 import { describe, expect, it } from 'vitest'
 
+import { evaluatePrGate } from './evaluate-pr-gate.mjs'
+
 type Step = {
   'continue-on-error'?: boolean
   env?: Record<string, string>
@@ -514,8 +516,74 @@ describe('PR Gate workflow', () => {
     })
   })
 
-  it('shares dependency installation and Electron builds inside platform bundles', () => {
-    for (const bundle of ['static', 'unit_shard', 'windows_core', 'macos_e2e']) {
+  it.each(['macos', 'windows'])(
+    'prepares %s E2E once and restores its exact artifact in every consumer',
+    (platform) => {
+      const bundle = `${platform}_e2e`
+      const producerId = `${bundle}_setup`
+      const producer = workflow.jobs[producerId]
+      const consumer = workflow.jobs[bundle]
+      expect(producer.needs).toBe('preflight')
+      expect(producer.if).toBe(consumer.if)
+      expect(producer.strategy).toBeUndefined()
+      expect(producer['runs-on']).toBe(consumer['runs-on'])
+      expect(consumer.needs).toEqual(['preflight', producerId])
+      // Without an always()/!cancelled() override, a failed producer skips its consumers.
+      expect(consumer.if).not.toMatch(/always\(|cancelled\(/)
+      expect(producer.outputs).toEqual({
+        artifact_id: '${{ steps.upload.outputs.artifact-id }}',
+        node_version: '${{ steps.node.outputs.node-version }}'
+      })
+      expect(producer.steps?.filter(({ run }) => run === 'npm run build:e2e')).toHaveLength(1)
+      expect(producer.steps?.filter(({ run }) => run === 'npm run build:web')).toHaveLength(
+        platform === 'macos' ? 1 : 0
+      )
+      const upload = producer.steps?.find(({ id }) => id === 'upload')
+      expect(upload?.['continue-on-error']).not.toBe(true)
+      expect(upload?.with).toMatchObject({
+        name: `e2e-setup-${platform}-\${{ github.run_id }}-\${{ github.run_attempt }}`,
+        'retention-days': 1,
+        'compression-level': 0,
+        'if-no-files-found': 'error'
+      })
+      expect(upload?.with).not.toHaveProperty('overwrite')
+      const node = consumer.steps?.find(({ name }) => name === 'Setup Node')
+      expect(node?.with).toEqual({
+        'node-version': `\${{ needs.${producerId}.outputs.node_version }}`,
+        'package-manager-cache': false
+      })
+      const download = consumer.steps?.find(({ name }) => name === 'Download E2E setup')
+      expect(download?.with).toEqual({
+        'artifact-ids': `\${{ needs.${producerId}.outputs.artifact_id }}`,
+        path: '${{ runner.temp }}/e2e-setup/',
+        'merge-multiple': true
+      })
+      const restore = consumer.steps?.find(({ id }) => id === 'setup')
+      expect(restore?.run).toContain('e2e-setup-snapshot.mjs restore')
+      expect(restore?.['continue-on-error']).not.toBe(true)
+      expect(
+        consumer.steps?.some(({ run }) => /npm-ci\.mjs|npm ci|npm run build:/.test(run ?? ''))
+      ).toBe(false)
+      // The trusted evaluator already rejects a selected bundle skipped by a failed/cancelled setup.
+      const lane = `e2e_functional_${platform}`
+      const result = evaluatePrGate(
+        {
+          schemaVersion: 1,
+          mode: 'selective',
+          lanes: ['policy', lane],
+          bundles: ['policy', bundle],
+          roots: ['manual:e2e'],
+          reasonChains: []
+        },
+        { preflight: 'success', policy: 'success', [bundle]: 'skipped' },
+        { executionMode: 'bundles' }
+      )
+      expect(result.ok).toBe(false)
+    }
+  )
+
+  it('preserves test commands while moving matrix setup into platform producers', () => {
+    for (const bundle of ['static', 'unit_shard', 'windows_core', 'macos_e2e_setup']) {
       expect(
         workflow.jobs[bundle].steps?.filter(({ run }) => run === 'node scripts/ci/npm-ci.mjs'),
         `${bundle} must install dependencies exactly once`
@@ -527,7 +595,7 @@ describe('PR Gate workflow', () => {
       )
     ).toHaveLength(2)
     expect(
-      workflow.jobs.windows_e2e.steps?.filter(({ name }) => name === 'Install dependencies')
+      workflow.jobs.windows_e2e_setup.steps?.filter(({ name }) => name === 'Install dependencies')
     ).toEqual([
       expect.objectContaining({
         run: 'node scripts/ci/npm-ci.mjs --prefer-offline --no-audit --fund=false'
@@ -535,7 +603,7 @@ describe('PR Gate workflow', () => {
     ])
 
     const macosRuns = workflow.jobs.macos_e2e.steps?.map(({ run }) => run).filter(Boolean)
-    expect(macosRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
+    expect(macosRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(0)
     expect(macosRuns).toEqual(
       expect.arrayContaining([
         'npm run test:e2e:journey -- --fail-on-flaky-tests --global-timeout=600000',
@@ -546,7 +614,7 @@ describe('PR Gate workflow', () => {
     )
 
     const windowsRuns = workflow.jobs.windows_e2e.steps?.map(({ run }) => run).filter(Boolean)
-    expect(windowsRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(1)
+    expect(windowsRuns?.filter((run) => run === 'npm run build:e2e')).toHaveLength(0)
     expect(windowsRuns).toEqual(
       expect.arrayContaining([
         'npm run test:e2e:journey -- --workers=1 --fully-parallel --shard=${{ matrix.shard }}/3 --fail-on-flaky-tests --global-timeout=600000',


### PR DESCRIPTION
## Problem

Every Windows E2E shard and macOS E2E group installs the same platform dependencies and builds Electron independently. The existing npm download cache does not avoid these repeated installs or builds. The reference is [PR #2441's run](https://github.com/aipoch/open-science/actions/runs/34558044460).

## Proposed change

Prepare dependencies and Electron output once per platform, including the macOS web build, then restore the exact same-run artifact in each E2E consumer. This follows GitHub's documented [artifact sharing between jobs](https://docs.github.com/en/actions/tutorials/store-and-share-data). Keep Ubuntu and Windows core unchanged. Local package targets include their generated native bindings; reconstruct their links against each consumer checkout. Validate the run, checked-out revision, platform, architecture, exact Node version, lockfile hash, archive checksum, and required runtime entrypoints before testing.

```mermaid
flowchart LR
  P[Preflight] --> W[Windows setup]
  P --> M[macOS setup]
  W --> WS[Three Windows shards]
  M --> MS[Four macOS groups]
  WS --> G[Existing PR Gate]
  MS --> G
```

## Scope and non-goals

- Preserve selected E2E commands, shard assignments, native macOS checks, fail-on-flaky flags, and trusted gate evaluation. A failed producer cannot yield a successful selected bundle.
- The preparation jobs own the artifacts; exact artifact IDs are recorded as job outputs. Names distinguish platform/run/producer attempt, consumers can reuse successful producers during failed-job reruns, and artifacts expire after one day. Missing or expired artifacts fail without cross-run fallback; rerun preparation to recreate them. Snapshots contain dependency/build files, not credentials or application data.
- No new application states, persisted application formats, historical-data migrations, UI changes, or cross-platform dependency reuse. Existing legacy lane compatibility is preserved. No long-lived installed-dependency cache is introduced.

## Acceptance criteria and validation

Final local checks ran after the last material edit on `da642991cbcdeddd493bc01f8844083a644722c4`:

- Snapshot roundtrip, local-link relocation, file modes, corruption/identity rejection, and existing-junction preservation -> `npm test -- scripts/ci/e2e-setup-snapshot.test.ts` -> pass.
- Producer/consumer wiring, trusted gate failure propagation, CI integrity contracts, and unchanged E2E ownership -> `npm test -- scripts/ci/pr-gate-workflow.test.ts scripts/ci/evaluate-pr-gate.test.ts scripts/ci/check-ci-integrity.test.ts scripts/ci/ci-integrity-workflow.test.ts scripts/ci/e2e-execution-ownership.test.ts` -> pass. The combined six-file invocation reported 107 passed and three existing platform-conditional skips.
- Linted scripts/tests -> `npm run lint` -> pass.
- Changed YAML/scripts/tests -> focused Prettier check and `git diff --check` -> pass.
- Independent Standards and Spec reviews of the final code -> no findings. GitHub's final-head Codex review also reported mergeable with no actionable findings.
- Prior-revision Windows/macOS transport baseline (`a3cba61ed`) -> existing `workflow_dispatch`, `dry_run=e2e`, [run 34560667422](https://github.com/aipoch/open-science/actions/runs/34560667422). Both preparation jobs and all seven native-runtime restoration checks passed; each preparation job also passed the 14 snapshot contract tests on its native OS. All seven E2E jobs, the merged report, and PR Gate passed.

No full local portable suite was run, as explicitly requested by the maintainer. Both changed platform paths run in the focused remote dry-run; Ubuntu/application runtime behavior is unchanged. Final-head PR CI remains authoritative for the complete test plan.



Final follow-up `da642991c` addresses a Linux transport failure found by the first PR run: GNU tar may finish at a valid end marker while Node still writes padding, resulting in `ERR_STREAM_PREMATURE_CLOSE`/`EPIPE` even though tar exits 0. A local real GNU tar harness reproduced `EPIPE` with exit 0; making tar read the compressed file directly passed the same harness. The new padded-archive regression and all six focused suites pass. Final-head [PR CI run 34563585562](https://github.com/aipoch/open-science/actions/runs/34563585562) passed all three Ubuntu full-suite shards, coverage aggregation, static checks, Windows core, Linux isolation, both preparation jobs, all seven E2E consumers, and PR Gate. The earlier dry-run remains timing baseline evidence.

The first PR run also encountered Windows error 32 while an unchanged Rust sandbox test cleaned temporary files. The exact test and its full 28-test Rust module passed locally without source changes; Windows core passed on the final head.

Final-head attempt 1 retained the existing fail-on-flaky policy and rejected two retry-passing workspace cases: Windows shard 3's reply wait (with transaction wait timeouts in its main log) and macOS journeys' message layout stability assertion. One failed-job rerun, without code or threshold changes, passed both suites without flakes (Windows workspace 12 passed; macOS workspace 38 passed). The rerun reused the successful attempt-1 preparation artifacts, verifying the intended retry path; restore took 24.5 seconds on Windows and 28.1 seconds on macOS.
### Observed timing

| Platform | Cumulative setup steps, reference → dry-run | Preflight completion → last platform E2E completion |
| --- | --- | --- |
| Windows | 999 s → 561 s (44% lower) | 20:40 → 20:30 |
| macOS | 660 s → 570 s (14% lower) | 28:08 → 23:31 |

The setup totals include Node setup, dependency install, Electron/web builds, and all new snapshot contract-test/pack/upload/download/restore steps. They exclude checkout, queueing, and test execution. Windows packed 701.9 MiB in 38 s and uploaded it in 6 s; macOS packed 637.1 MiB in 59 s and uploaded it in 8 s. Total snapshot storage is approximately 1.31 GiB/run, with one-day retention.

This is a single observational comparison against run 34558044460, not a controlled same-commit benchmark: source revisions, runners, queues, and test durations differ. Windows wall-clock time was essentially unchanged. Do not attribute the entire macOS wall-clock improvement to snapshot sharing or promise the same reduction for subsequent PRs.
## Review focus

Review artifact completeness, preservation of native modules and links, failure propagation, rerun identity, and the transport-versus-repeated-setup tradeoff. Cumulative runner savings are distinct from wall-clock latency: a new producer adds a scheduling boundary, and queue conditions differ between runs.

`CI Integrity` deliberately protects `.github/workflows/pr-gate.yml`; this PR requires the repository's explicit maintainer ruleset bypass for that protected workflow change. The protection itself is unchanged.
