### PR TITLE
fix(opencode): send required Go session header

### DIFF
--- a/src/main/agent-framework/opencode-session-header.integration.test.ts
+++ b/src/main/agent-framework/opencode-session-header.integration.test.ts
@@ -1,0 +1,199 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process'
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { createServer, type Server } from 'node:http'
+import type { AddressInfo } from 'node:net'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { Readable, Writable } from 'node:stream'
+
+import * as acp from '@agentclientprotocol/sdk'
+import { expect, it } from 'vitest'
+
+import { OpenAiProviderBridge } from '../settings/openai-provider-bridge'
+import { createOpencodeFramework } from './opencode'
+
+const opencodePath = process.env.OPENCODE_ACP_PATH
+
+const listen = async (server: Server): Promise<string> => {
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  const address = server.address() as AddressInfo
+  return `http://127.0.0.1:${address.port}`
+}
+
+const close = async (server: Server): Promise<void> => {
+  if (!server.listening) return
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve()))
+  )
+}
+
+const completePrompt = async (session: acp.ActiveSession): Promise<void> => {
+  session.prompt('Reply with ok.')
+  for (;;) {
+    const update = await session.nextUpdate()
+    if (update.kind === 'stop') return
+  }
+}
+
+const terminate = async (child: ChildProcessWithoutNullStreams): Promise<void> => {
+  if (child.exitCode !== null) return
+  child.kill('SIGTERM')
+  await new Promise<void>((resolve) => {
+    const timeout = setTimeout(() => {
+      if (child.exitCode === null) child.kill('SIGKILL')
+      resolve()
+    }, 2_000)
+    child.once('exit', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+  })
+}
+
+it.runIf(opencodePath)(
+  'sends a stable, conversation-specific x-opencode-session through a real OpenCode ACP process',
+  async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-opencode-go-header-'))
+    const workspace = join(root, 'workspace')
+    await mkdir(workspace)
+    const requests: Array<{
+      affinity?: string
+      nativeSession?: string
+      opencodeSession?: string
+    }> = []
+    const sessionIds: string[] = []
+    const upstream = createServer((request, response) => {
+      const chunks: Buffer[] = []
+      request.on('data', (chunk: Buffer) => chunks.push(chunk))
+      request.on('end', () => {
+        requests.push({
+          ...(typeof request.headers['x-session-affinity'] === 'string'
+            ? { affinity: request.headers['x-session-affinity'] }
+            : {}),
+          ...(typeof request.headers['x-session-id'] === 'string'
+            ? { nativeSession: request.headers['x-session-id'] }
+            : {}),
+          ...(typeof request.headers['x-opencode-session'] === 'string'
+            ? { opencodeSession: request.headers['x-opencode-session'] }
+            : {})
+        })
+        const model = (JSON.parse(Buffer.concat(chunks).toString('utf8')) as { model: string })
+          .model
+        response.writeHead(200, { 'content-type': 'text/event-stream' })
+        response.end(
+          [
+            `data: ${JSON.stringify({ id: 'chatcmpl-probe', object: 'chat.completion.chunk', created: 1, model, choices: [{ index: 0, delta: { role: 'assistant', content: 'ok' }, finish_reason: null }] })}`,
+            `data: ${JSON.stringify({ id: 'chatcmpl-probe', object: 'chat.completion.chunk', created: 1, model, choices: [{ index: 0, delta: {}, finish_reason: 'stop' }] })}`,
+            'data: [DONE]',
+            ''
+          ].join('\n\n')
+        )
+      })
+    })
+    const upstreamBaseUrl = `${await listen(upstream)}/v1`
+    const bridge = new OpenAiProviderBridge(
+      [
+        {
+          id: 'opencode-go/probe-model',
+          wire: 'chat-completions',
+          endpoint: `${upstreamBaseUrl}/chat/completions`,
+          key: 'upstream-key',
+          model: 'probe-model'
+        }
+      ],
+      'opencode-go/probe-model'
+    )
+    const connection = await bridge.start()
+    const framework = createOpencodeFramework()
+    const modelConfig = framework.prepareModelConfig(
+      {
+        type: 'official',
+        vendorId: 'opencode-go',
+        agentProviderId: 'open-science-opencode-go-probe',
+        baseUrl: connection.baseUrl,
+        openaiBaseUrl: `${connection.baseUrl}/v1`,
+        apiEndpoints: ['openai'],
+        model: 'probe-model',
+        key: connection.token
+      },
+      { storageRoot: root, executablePath: opencodePath! }
+    )
+    for (const file of modelConfig.configFiles ?? []) {
+      await mkdir(dirname(file.path), { recursive: true })
+      await writeFile(file.path, file.content, 'utf8')
+    }
+
+    const child: ChildProcessWithoutNullStreams = spawn(opencodePath!, ['acp'], {
+      cwd: workspace,
+      env: { ...process.env, ...modelConfig.env },
+      stdio: ['pipe', 'pipe', 'pipe']
+    })
+    const stderr: string[] = []
+    child.stderr.on('data', (chunk) => stderr.push(chunk.toString('utf8')))
+
+    try {
+      const stream = acp.ndJsonStream(
+        Writable.toWeb(child.stdin) as WritableStream<Uint8Array>,
+        Readable.toWeb(child.stdout) as ReadableStream<Uint8Array>
+      )
+      await acp
+        .client({ name: 'open-science-opencode-go-header-contract' })
+        .onRequest(acp.methods.client.session.requestPermission, (ctx) => ({
+          outcome: { outcome: 'selected', optionId: ctx.params.options[0].optionId }
+        }))
+        .onRequest(acp.methods.client.fs.readTextFile, () => ({ content: '' }))
+        .onRequest(acp.methods.client.fs.writeTextFile, () => ({}))
+        .connectWith(stream, async (ctx) => {
+          await ctx.request(acp.methods.agent.initialize, {
+            protocolVersion: acp.PROTOCOL_VERSION,
+            clientInfo: { name: 'open-science-opencode-go-header-contract', version: '1.0.0' },
+            clientCapabilities: { fs: { readTextFile: true, writeTextFile: true } }
+          })
+          await ctx
+            .buildSession({ cwd: workspace, mcpServers: [] })
+            .withSession(async (session) => {
+              sessionIds.push(session.sessionId)
+              await completePrompt(session)
+              await completePrompt(session)
+            })
+          await ctx
+            .buildSession({ cwd: workspace, mcpServers: [] })
+            .withSession(async (session) => {
+              sessionIds.push(session.sessionId)
+              await completePrompt(session)
+            })
+        })
+
+      expect(sessionIds).toHaveLength(2)
+      expect(sessionIds[0]).not.toBe(sessionIds[1])
+      expect(requests.every((request) => request.opencodeSession !== undefined)).toBe(true)
+      expect(
+        requests.every(
+          (request) =>
+            request.opencodeSession === request.nativeSession &&
+            request.opencodeSession === request.affinity
+        )
+      ).toBe(true)
+      expect(
+        requests.filter((request) => request.opencodeSession === sessionIds[0]).length
+      ).toBeGreaterThanOrEqual(2)
+      expect(
+        requests.filter((request) => request.opencodeSession === sessionIds[1]).length
+      ).toBeGreaterThanOrEqual(1)
+      expect(new Set(requests.map((request) => request.opencodeSession))).toEqual(
+        new Set(sessionIds)
+      )
+    } catch (error) {
+      throw new Error(`${String(error)}\n${stderr.join('')}`)
+    } finally {
+      await terminate(child)
+      await bridge.close()
+      await close(upstream)
+      await rm(root, { recursive: true, force: true, maxRetries: 10, retryDelay: 100 })
+    }
+  },
+  30_000
+)

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -202,6 +202,60 @@ describe('opencodeFramework.prepareModelConfig', () => {
     expect(config.env?.OPENCODE_DISABLE_PROJECT_CONFIG).toBe('true')
   })
 
+  it('injects the native session id as x-opencode-session only for OpenCode Go providers', () => {
+    const goProvider = {
+      type: 'official' as const,
+      vendorId: 'opencode-go' as const,
+      agentProviderId: 'open-science-go-model',
+      baseUrl: 'http://127.0.0.1:41001/v1',
+      apiEndpoints: ['openai' as const],
+      model: 'glm-5.3-flash',
+      key: 'local-go-token'
+    }
+    const otherProvider = {
+      type: 'official' as const,
+      vendorId: 'deepseek' as const,
+      agentProviderId: 'open-science-deepseek-model',
+      baseUrl: 'http://127.0.0.1:41002/v1',
+      apiEndpoints: ['openai' as const],
+      model: 'deepseek-v4-flash',
+      key: 'local-deepseek-token'
+    }
+    const config = opencodeFramework.prepareModelConfig(goProvider, {
+      storageRoot: '/data',
+      executablePath: '/bin/opencode',
+      providerModelCatalog: [{ provider: goProvider }, { provider: otherProvider }]
+    })
+
+    const plugin = config.configFiles?.find((file) =>
+      file.path.endsWith('plugins/open-science-opencode-go-session.js')
+    )
+    expect(plugin?.content).toContain('new Set(["open-science-go-model"])')
+    expect(plugin?.content).not.toContain('open-science-deepseek-model')
+    expect(plugin?.content).toContain('if (!providerIDs.has(input.model.providerID)) return')
+    expect(plugin?.content).toContain('output.headers["x-opencode-session"] = input.sessionID')
+  })
+
+  it('rewrites the OpenCode Go session plugin as an inert module for other vendors', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      {
+        type: 'official',
+        vendorId: 'deepseek',
+        agentProviderId: 'open-science-deepseek-model',
+        baseUrl: 'http://127.0.0.1:41002/v1',
+        apiEndpoints: ['openai'],
+        model: 'deepseek-v4-flash',
+        key: 'local-deepseek-token'
+      },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const plugin = config.configFiles?.find((file) =>
+      file.path.endsWith('plugins/open-science-opencode-go-session.js')
+    )
+    expect(plugin?.content).toContain('new Set([])')
+  })
+
   it('pins the authoritative provider/model/baseURL (not just permission) in OPENCODE_CONFIG_CONTENT', () => {
     const config = opencodeFramework.prepareModelConfig(
       {

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -92,6 +92,11 @@ const OPENCODE_ENDPOINT_PROVIDER: Record<'anthropic' | 'openai', { id: string; n
 // plaintext key OFF disk — opencode.json only ever holds the reference, never the secret.
 const OPENCODE_API_KEY_ENV = 'OPENCODE_APP_API_KEY'
 
+// OpenCode Go requires this exact header even though OpenCode also sends its own x-session-id and
+// x-session-affinity headers. A native plugin is the only layer that has the current OpenCode session
+// id, so generate one inside the isolated app-owned config and scope it to Go-backed provider ids.
+const OPENCODE_GO_SESSION_PLUGIN = 'open-science-opencode-go-session.js'
+
 // OpenCode rejects a model limit that declares context without output. Keep maxOutputTokens optional
 // in the provider model, but reserve a conservative adapter-only output budget when it is absent so
 // the generated config remains valid and OpenCode can calculate its native compaction threshold.
@@ -247,6 +252,32 @@ const opencodeModelCatalog = (
     models.set(`${endpoint.providerId}/${endpoint.bareModel}`, entry)
   }
   return [...models.values()]
+}
+
+const buildOpencodeGoSessionPlugin = (
+  provider: ResolvedProvider,
+  reasoningEffort: ModelReasoningEffort | undefined,
+  catalog: readonly AgentModelCatalogEntry[]
+): string => {
+  const providerIds = [
+    ...new Set(
+      opencodeModelCatalog(provider, reasoningEffort, catalog)
+        .filter((entry) => entry.provider.vendorId === 'opencode-go')
+        .map((entry) => resolveOpencodeEndpoint(entry.provider).providerId)
+    )
+  ]
+
+  return [
+    `const providerIDs = new Set(${JSON.stringify(providerIds)})`,
+    '',
+    'export const OpenScienceOpencodeGoSession = async () => ({',
+    '  "chat.headers": async (input, output) => {',
+    '    if (!providerIDs.has(input.model.providerID)) return',
+    '    output.headers["x-opencode-session"] = input.sessionID',
+    '  }',
+    '})',
+    ''
+  ].join('\n')
 }
 
 const buildOpencodeModelConfig = (
@@ -454,7 +485,19 @@ export const createOpencodeFramework = ({
     const dataHome = opencodeDataHome(ctx.storageRoot)
     const opencodeDir = join(configHome, 'opencode')
     const configPath = join(opencodeDir, 'opencode.json')
-    const configFiles = [{ path: configPath, content: '' }]
+    const configFiles = [
+      { path: configPath, content: '' },
+      {
+        path: join(opencodeDir, 'plugins', OPENCODE_GO_SESSION_PLUGIN),
+        // Always rewrite the app-owned plugin, including with an empty provider set, so switching
+        // away from Go cannot leave a previously generated provider match active on disk.
+        content: buildOpencodeGoSessionPlugin(
+          provider,
+          ctx.reasoningEffort,
+          ctx.providerModelCatalog ?? []
+        )
+      }
+    ]
 
     // Stable app guidance belongs in OpenCode's native instructions layer, never ordinary user prompt
     // history. Keep connector conventions separate so their independent lifecycle remains explicit;


### PR DESCRIPTION
## Problem

OpenCode Go rejects requests from the OpenCode framework because the generated custom provider route does not send the required `x-opencode-session` header. This prevents efficient routing and prompt-cache affinity.

Fixes #2421.

## Proposed change

- Materialize an app-owned OpenCode `chat.headers` plugin in the isolated OpenCode config.
- Set `x-opencode-session` from the current native OpenCode session ID.
- Restrict injection to generated provider IDs backed by OpenCode Go and rewrite the plugin inert when no Go provider is active.
- Add unit coverage and a gated real-OpenCode ACP contract test.

## Scope and non-goals

This does not change provider credentials, public configuration formats, non-Go provider headers, or OpenCode session ownership. It does not call the paid OpenCode Go production endpoint.

## Acceptance criteria and validation

Checks below ran after the final material edit and independent Standards and Spec review.

- Header generation and vendor scoping -> `npx vitest run src/main/agent-framework/opencode.test.ts` -> 65 passed.
- Real session stability and separation across OpenCode ACP, the app provider bridge, and an upstream HTTP server -> `OPENCODE_ACP_PATH=/opt/homebrew/bin/opencode npx vitest run src/main/agent-framework/opencode-session-header.integration.test.ts` -> 1 passed with OpenCode 1.18.14.
- Main, sandbox, and renderer types -> `npm run typecheck` -> passed.
- Repository lint -> `npm run lint` -> passed.
- Exact base-to-head impact classification -> `npm run test:affected -- --base origin/main --head HEAD` -> classified fail-closed to the complete Vitest suite because the new live contract has no module owner.
- The complete suite was also started under the required Node 22.22.1. It was stopped after unrelated process-heavy tests caused resource contention with the locally running app; individually investigated baseline failures passed under Node 22.

## Review focus

Please review the generated plugin isolation, OpenCode Go provider-ID scoping, and the live contract assertions for same-session stability and cross-session separation.

## Uncovered risks

The contract exercises a real OpenCode 1.18.14 ACP process and the actual app bridge against a local upstream server. It does not send a billed request to the production OpenCode Go endpoint. The complete repository suite did not finish in one run because it interfered with the local Electron app; the affected implementation tests, typecheck, and lint all passed.
