### PR TITLE
fix(reproducibility): resolve the downloads directory lazily

### DIFF
--- a/src/main/artifacts/artifact-reproducibility-export.test.ts
+++ b/src/main/artifacts/artifact-reproducibility-export.test.ts
@@ -256,7 +256,7 @@ describe('Artifact reproducibility verification export', () => {
     )
     value.receiptChecksum = sha256(canonicalJson(payload as CanonicalJson))
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: async () => value,
       readOutput: async () => actual,
       readOriginalOutput: async () => original,
@@ -300,7 +300,7 @@ describe('Artifact reproducibility verification export', () => {
       const value = receipt()
       const writeArchive = vi.fn()
       const exporter = createArtifactReproducibilityReceiptExporter({
-        downloadsDirectory: '/downloads',
+        downloadsDirectory: () => '/downloads',
         readReceipt: async () => value,
         readVersion: async () => ({
           versionId: value.artifactVersion.versionId,
@@ -316,6 +316,24 @@ describe('Artifact reproducibility verification export', () => {
       expect(writeArchive).not.toHaveBeenCalled()
     }
   )
+  it('resolves the downloads directory only when a save dialog needs it', async () => {
+    const value = receipt()
+    const downloadsDirectory = vi.fn(() => '/downloads')
+    const exporter = createArtifactReproducibilityReceiptExporter({
+      downloadsDirectory,
+      readReceipt: async () => value,
+      readVersion: async () => ({
+        versionId: value.artifactVersion.versionId,
+        artifactId: value.artifactVersion.artifactId,
+        checksum: value.artifactVersion.targetChecksum,
+        versionNumber: 3
+      }),
+      showSaveDialog: async () => ({ canceled: true })
+    })
+    expect(downloadsDirectory).not.toHaveBeenCalled()
+    await expect(exporter.export(undefined, request(value))).resolves.toEqual({ saved: false })
+    expect(downloadsDirectory).toHaveBeenCalledTimes(1)
+  })
   it('previews and exports receipt-bound bytes, with original output remaining optional', async () => {
     const current = receipt()
     const bytes = Buffer.from('group,n\nCtrl,34\n')
@@ -349,7 +367,7 @@ describe('Artifact reproducibility verification export', () => {
       clearedReceiptChecksums: [] as string[]
     }))
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: async () => value,
       readOutput,
       readOriginalOutput,
@@ -452,7 +470,7 @@ describe('Artifact reproducibility verification export', () => {
       versionNumber: 3
     }))
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt,
       readCheckLog,
       readVersion,
@@ -496,7 +514,7 @@ describe('Artifact reproducibility verification export', () => {
     const { receipt: value } = receiptWithCheckLog()
     const showSaveDialog = vi.fn()
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: vi.fn(async () => value),
       readCheckLog: vi.fn(async () => undefined),
       showSaveDialog,
@@ -513,7 +531,7 @@ describe('Artifact reproducibility verification export', () => {
     const value = receipt()
     const writeArchive = vi.fn()
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: vi.fn(async () => value),
       showSaveDialog: vi.fn(async () => ({ canceled: true })),
       writeArchive
@@ -530,7 +548,7 @@ describe('Artifact reproducibility verification export', () => {
       value: ArtifactReproducibilityReceipt | undefined
     ): ReturnType<typeof createArtifactReproducibilityReceiptExporter> =>
       createArtifactReproducibilityReceiptExporter({
-        downloadsDirectory: '/downloads',
+        downloadsDirectory: () => '/downloads',
         readReceipt: vi.fn(async () => value),
         showSaveDialog,
         writeArchive: vi.fn()
@@ -555,7 +573,7 @@ describe('Artifact reproducibility verification export', () => {
     const value = receipt()
     const readReceipt = vi.fn()
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt,
       showSaveDialog: vi.fn(),
       writeArchive: vi.fn()
@@ -792,7 +810,7 @@ describe('Artifact Environment lock export', () => {
     }))
     const writeArchive = vi.fn(async () => undefined)
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: vi.fn(),
       readExecution,
       readEnvironmentLock,
@@ -829,7 +847,7 @@ describe('Artifact Environment lock export', () => {
       contents?: string
     ): ReturnType<typeof createArtifactReproducibilityReceiptExporter> =>
       createArtifactReproducibilityReceiptExporter({
-        downloadsDirectory: '/downloads',
+        downloadsDirectory: () => '/downloads',
         readReceipt: vi.fn(),
         readExecution: vi.fn(async () => execution),
         readEnvironmentLock: vi.fn(async () => contents),
@@ -867,7 +885,7 @@ describe('Artifact Environment lock export', () => {
       reused: false
     }))
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: vi.fn(),
       showSaveDialog: vi.fn(),
       showOpenDialog: vi.fn(async () => ({ canceled: false, filePaths: [archivePath] })),
@@ -897,7 +915,7 @@ describe('Artifact Environment lock export', () => {
       reused: false
     }))
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: vi.fn(),
       readExecution: vi.fn(async () => environmentLockExecution),
       readEnvironmentLock: vi.fn(async () => environmentLockContents),
@@ -927,7 +945,7 @@ describe('Artifact Environment lock export', () => {
     }))
     const showOpenDialog = vi.fn(async () => ({ canceled: false, filePaths: [archivePath] }))
     const exporter = createArtifactReproducibilityReceiptExporter({
-      downloadsDirectory: '/downloads',
+      downloadsDirectory: () => '/downloads',
       readReceipt: vi.fn(),
       showSaveDialog: vi.fn(),
       showOpenDialog,

--- a/src/main/artifacts/artifact-reproducibility-export.ts
+++ b/src/main/artifacts/artifact-reproducibility-export.ts
@@ -87,7 +87,9 @@ type ArtifactReproducibilityReceiptExporterDependencies = {
   readOutputStorage?: (
     request: ArtifactReproducibilityReceiptScope
   ) => Promise<ArtifactReproducibilityOutputStorage>
-  downloadsDirectory: string
+  // Resolved lazily: Electron's 'downloads' path can be unavailable in isolated profiles, and
+  // wiring-time resolution once broke packaged startup (only save dialogs actually need it).
+  downloadsDirectory: () => string
   readReceipt: (
     request: ArtifactReproducibilityReceiptScope,
     receiptChecksum: string
@@ -799,7 +801,7 @@ const createArtifactReproducibilityReceiptExporter = (
         const selected = await dependencies.showSaveDialog(owner, {
           title: (dependencies.translate ?? englishNativeTranslator)('Save file'),
           defaultPath: join(
-            dependencies.downloadsDirectory,
+            dependencies.downloadsDirectory(),
             outputFilename(selectedOutput.relativePath)
           ),
           filters: []
@@ -823,7 +825,7 @@ const createArtifactReproducibilityReceiptExporter = (
       const selected = await dependencies.showSaveDialog(owner, {
         title: translate('Save file'),
         defaultPath: join(
-          dependencies.downloadsDirectory,
+          dependencies.downloadsDirectory(),
           verificationArchiveName(request.suggestedName, validated.completedAt)
         ),
         filters: [{ name: translate('ZIP archive'), extensions: ['zip'] }]
@@ -891,7 +893,7 @@ const createArtifactReproducibilityReceiptExporter = (
       const selected = await dependencies.showSaveDialog(owner, {
         title: translate('Save file'),
         defaultPath: join(
-          dependencies.downloadsDirectory,
+          dependencies.downloadsDirectory(),
           environmentLockArchiveName(request.lockChecksum)
         ),
         filters: [{ name: translate('ZIP archive'), extensions: ['zip'] }]

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -4510,7 +4510,7 @@ const createApplicationModules = async (
         withDataRootWrite(() =>
           getArtifactReproducibilityOutputStorage(artifactProvenanceRepository, request)
         ),
-      downloadsDirectory: app.getPath('downloads'),
+      downloadsDirectory: () => app.getPath('downloads'),
       readOutput: (request, checksum, entityId) =>
         withDataRootWrite(() =>
           getArtifactReproducibilityOutput(


### PR DESCRIPTION
## Problem

The v0.28.0 release pipeline is blocked: the packaged Windows installer smoke fails deterministically with `Installed app exited before becoming healthy (0)`. Two retried release runs (reusing the immutable build artifacts) fail with the identical signature, and the macOS/Linux smokes pass, so it is a real packaged-Windows startup regression, not a flake.

Root cause (reproduced on a throwaway diagnostic branch that builds the installer from v0.28.0 plus an unstripped startup-error print and runs the real smoke): application composition aborts with `Error: Failed to get 'downloads' path`. #2438 wired `app.getPath('downloads')` eagerly while installing the artifacts runtime adapter, and Electron throws when it cannot resolve the Downloads known folder — which happens under the smoke's isolated `USERPROFILE` profile. Everything downstream (`Notebook recovery coordinator is disposed`, the 5-second quit-guard `app.exit(0)`) is cascade. On ordinary machines the path resolves, which is why nothing else caught it: package smoke only runs in the Release/Nightly workflows, and the last successful nightly certification predates the regression window.

## Proposed change

Resolve the downloads directory lazily:

- `createArtifactReproducibilityReceiptExporter` now takes `downloadsDirectory: () => string` and calls it only when building a save-dialog default path (receipt archive, check-log output, and environment-lock export).
- The IPC wiring passes `() => app.getPath('downloads')`, so composition never evaluates it; an export surfaces any resolution failure at the moment a save dialog actually needs the directory.
- Regression test: the resolver must not be called at construction and exactly once per export.

## Scope and non-goals

- No schema, persistence, IPC contract, or UI changes; behavior on machines where the Downloads folder resolves is unchanged.
- Other `getPath('downloads')` call sites (file save, manual update download, compute harvest, ipynb save) were audited: all resolve on demand inside user actions, not during composition.

## Acceptance criteria and validation

- Behavior → command → result (run after the last material edit, in `.worktree/fix-downloads-lazy`):
  - Exporter laziness + full receipt-export contract → `vitest run src/main/artifacts/artifact-reproducibility-export.test.ts` → 28 passed (27 existing + 1 new).
  - Changed-process types → `tsc --noEmit -p tsconfig.node.json --composite false` → no errors in changed files (two pre-existing local-only `notebook-network-sandbox` module-resolution errors reproduce identically on an unmodified checkout; the sandbox package's own typecheck and CI install cover them).
  - Formatting → `prettier --check` on the three changed files → clean.
- Packaging-level proof will come from the Release/Nightly workflow once this merges; the diagnostic branch run that captured the unstripped error reproduces the failure against a v0.28.0-equivalent build and is the before-state evidence.

## Release

This unblocks v0.28.0: after merge, the `v0.28.0` tag moves to the new merge commit (no release was published from the current tag — publish was skipped) and the Release workflow reruns.
