### PR TITLE
fix(update): allow force update after install gate

### DIFF
--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -125,6 +125,7 @@
         "src/main/**/*powershell*.ts",
         "src/main/**/*path*.ts",
         "src/main/**/*acl*.ts",
+        "src/main/window-shortcuts.ts",
         "src/main/acp/agent-process.ts",
         "src/main/acp/claude-executable.ts",
         "src/main/acp/permission-broker.ts",

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -3815,9 +3815,9 @@ const createApplicationModules = async (
   )
   const updateStrategy = createUpdateStrategy(process.platform, {
     translate,
-    installGate: async () => {
+    installGate: async (options) => {
       releaseSettingsInstallAdmission = settingsService.holdInstallAdmission()
-      return updateInstallGate()
+      return updateInstallGate(options)
     },
     releaseInstallHandoff: abortUpdateHandoff
   })

--- a/src/main/update/electron-updater-strategy.test.ts
+++ b/src/main/update/electron-updater-strategy.test.ts
@@ -900,6 +900,63 @@ describe('ElectronUpdaterStrategy', () => {
     })
   })
 
+  it('forces active work through teardown and durability before installing', async () => {
+    const updater = new FakeUpdater()
+    let active = true
+    const teardown = vi.fn(async () => {
+      active = false
+      return { completed: true, reaped: true }
+    })
+    const durability = vi.fn(async () => true)
+    const strategy = createStrategy({
+      updater,
+      currentVersion: '0.2.0',
+      broadcast: vi.fn(),
+      installGate: createActiveResearchSafeInstallGate(
+        () => (active ? ['agent'] : []),
+        createDurableInstallGate(teardown, durability)
+      )
+    })
+    await markUpdateReady(strategy, updater)
+    await strategy.apply()
+    expect(teardown).not.toHaveBeenCalled()
+    await strategy.apply({ force: true })
+    expect(teardown).toHaveBeenCalledOnce()
+    expect(durability).toHaveBeenCalledOnce()
+    expect(teardown.mock.invocationCallOrder[0]).toBeLessThan(
+      durability.mock.invocationCallOrder[0]
+    )
+    expect(durability.mock.invocationCallOrder[0]).toBeLessThan(
+      updater.quitAndInstall.mock.invocationCallOrder[0]
+    )
+    expect(updater.quitAndInstall).toHaveBeenCalledOnce()
+  })
+
+  it.each(['migration', 'durability', 'unreaped', 'remaining-work'] as const)(
+    'does not force through %s refusal',
+    async (reason) => {
+      const updater = new FakeUpdater()
+      const teardown = vi.fn(async () => ({ completed: true, reaped: reason !== 'unreaped' }))
+      const durability = vi.fn(async () => reason !== 'durability')
+      const strategy = createStrategy({
+        updater,
+        currentVersion: '0.2.0',
+        broadcast: vi.fn(),
+        installGate: createActiveResearchSafeInstallGate(
+          () => (reason === 'remaining-work' ? ['agent'] : []),
+          createDurableInstallGate(teardown, durability),
+          () => reason === 'migration'
+        )
+      })
+      await markUpdateReady(strategy, updater)
+      const status = await strategy.apply({ force: true })
+      expect(status.state).toBe('ready')
+      expect(updater.quitAndInstall).not.toHaveBeenCalled()
+      if (reason === 'migration') expect(teardown).not.toHaveBeenCalled()
+      if (reason === 'unreaped') expect(durability).not.toHaveBeenCalled()
+    }
+  )
+
   it('blocks restart before backend teardown when delegated work is running', async () => {
     const updater = new FakeUpdater()
     const backendTeardownGate = vi.fn(async () => ({ completed: true, reaped: true }))

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -619,10 +619,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         operation.cancel({ reason: 'apply-interrupted' })
         return this.status
       }
-      if (
-        (!readiness.completed || !readiness.reaped) &&
-        (!options.force || !readiness.blockedBy?.length)
-      ) {
+      if ((!readiness.completed || !readiness.reaped) && !options.force) {
         this.releaseAbortedInstallHandoff()
         this.log.error('update install gate refused: backend teardown degraded', readiness)
         this.applying = false

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -619,7 +619,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         operation.cancel({ reason: 'apply-interrupted' })
         return this.status
       }
-      if (!readiness.completed || !readiness.reaped) {
+      if ((!readiness.completed || !readiness.reaped) && !options.force) {
         this.releaseAbortedInstallHandoff()
         this.log.error('update install gate refused: backend teardown degraded', readiness)
         this.applying = false

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -619,7 +619,10 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         operation.cancel({ reason: 'apply-interrupted' })
         return this.status
       }
-      if ((!readiness.completed || !readiness.reaped) && !options.force) {
+      if (
+        (!readiness.completed || !readiness.reaped) &&
+        (!options.force || !readiness.blockedBy?.length)
+      ) {
         this.releaseAbortedInstallHandoff()
         this.log.error('update install gate refused: backend teardown degraded', readiness)
         this.applying = false

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -619,10 +619,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
         operation.cancel({ reason: 'apply-interrupted' })
         return this.status
       }
-      if (
-        (!readiness.completed || !readiness.reaped) &&
-        (!options.force || !readiness.blockedBy?.length)
-      ) {
+      if (!readiness.completed || !readiness.reaped) {
         this.releaseAbortedInstallHandoff()
         this.log.error('update install gate refused: backend teardown degraded', readiness)
         this.applying = false

--- a/src/main/update/electron-updater-strategy.ts
+++ b/src/main/update/electron-updater-strategy.ts
@@ -601,7 +601,7 @@ export class ElectronUpdaterStrategy implements UpdateStrategy {
       operation.phase('install-gate')
       let readiness: Awaited<ReturnType<InstallGate>>
       try {
-        readiness = await this.installGate()
+        readiness = await this.installGate({ force: options.force })
       } catch (error) {
         this.releaseAbortedInstallHandoff()
         this.log.error('update install gate failed', error)

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -438,8 +438,9 @@ export class UpdateService implements UpdateStrategy {
 
   private async applyAdmitted(
     admittedStatus: UpdateStatus,
-    _options?: UpdateApplyOptions
+    options?: UpdateApplyOptions
   ): Promise<UpdateStatus> {
+    void options
     if (this.status !== admittedStatus) return this.status
     let ownedStatus = admittedStatus
     const operation = startDiagnosticOperation(this.log, {

--- a/src/main/update/service.ts
+++ b/src/main/update/service.ts
@@ -10,6 +10,7 @@ import { isCurrentInFlight } from '../../shared/in-flight-promise'
 import {
   isNewer,
   selectDownload,
+  type UpdateApplyOptions,
   type UpdateDownloadOptions,
   type UpdateStatus
 } from '../../shared/update'
@@ -422,11 +423,11 @@ export class UpdateService implements UpdateStrategy {
   // Opens the downloaded installer. A missing file drops back to 'available' for re-download. When
   // the file still exists but the OS cannot open it, keep the ready artifact and surface the reason so
   // the user can retry without another transfer. With no artifact, open the public download page.
-  apply(): Promise<UpdateStatus> {
+  apply(options?: UpdateApplyOptions): Promise<UpdateStatus> {
     if (this.applyLifecycle) return this.applyLifecycle
 
     const admittedStatus = this.status
-    const lifecycle = Promise.resolve().then(() => this.applyAdmitted(admittedStatus))
+    const lifecycle = Promise.resolve().then(() => this.applyAdmitted(admittedStatus, options))
     this.applyLifecycle = lifecycle
     const clearLifecycle = (): void => {
       if (this.applyLifecycle === lifecycle) this.applyLifecycle = undefined
@@ -435,7 +436,10 @@ export class UpdateService implements UpdateStrategy {
     return lifecycle
   }
 
-  private async applyAdmitted(admittedStatus: UpdateStatus): Promise<UpdateStatus> {
+  private async applyAdmitted(
+    admittedStatus: UpdateStatus,
+    _options?: UpdateApplyOptions
+  ): Promise<UpdateStatus> {
     if (this.status !== admittedStatus) return this.status
     let ownedStatus = admittedStatus
     const operation = startDiagnosticOperation(this.log, {

--- a/src/main/update/strategy.ts
+++ b/src/main/update/strategy.ts
@@ -17,7 +17,7 @@ export type InstallReadiness = {
 // Runs backend teardown before an in-place install and reports whether it is safe to proceed. The
 // in-place strategy receives it at construction and awaits it before quitAndInstall, so the installer
 // never starts while a background process still holds app files open.
-export type InstallGate = () => Promise<InstallReadiness>
+export type InstallGate = (options?: { force?: boolean }) => Promise<InstallReadiness>
 
 const restoreAfterFinalRefusal = (restore: () => void): void => {
   try {
@@ -36,12 +36,13 @@ export const createActiveResearchSafeInstallGate =
     isExclusiveHandoffActive: () => boolean = () => false,
     onFinalRefusal: () => void = () => undefined
   ): InstallGate =>
-  async () => {
+  async (options = {}) => {
     if (isExclusiveHandoffActive()) return { completed: false, reaped: false }
     const blockedBy = [...new Set(detectBlockers())]
-    if (blockedBy.length > 0) return { completed: false, reaped: false, blockedBy }
+    if (blockedBy.length > 0 && !options.force)
+      return { completed: false, reaped: false, blockedBy }
 
-    const readiness = await runTeardownGate()
+    const readiness = await runTeardownGate(options)
     if (!readiness.completed || !readiness.reaped) return readiness
     if (isExclusiveHandoffActive()) {
       restoreAfterFinalRefusal(onFinalRefusal)
@@ -75,8 +76,8 @@ export const createDataRootResearchSafeInstallGate = (
 // allows the still-open app to reconnect on the next action.
 export const createDurableInstallGate =
   (runTeardownGate: InstallGate, confirmRendererDurability: () => Promise<boolean>): InstallGate =>
-  async () => {
-    const readiness = await runTeardownGate()
+  async (options = {}) => {
+    const readiness = await runTeardownGate(options)
     if (!readiness.completed || !readiness.reaped) return readiness
     return (await confirmRendererDurability()) ? readiness : { completed: false, reaped: false }
   }

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -213,7 +213,7 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
                     <ExternalTextLink href={APP.update.downloadPage} className="mt-1 text-xs">
                       {t('Download manually')}
                     </ExternalTextLink>
-                    {isBackgroundProcessError && isReady ? (
+                    {dialogStatus.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR && isReady ? (
                       <button
                         type="button"
                         onClick={forceUpdate}

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -56,7 +56,15 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
   const isBackgroundProcessError =
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_ERROR ||
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
-  const forceUpdate = (): void => void apply({ force: true })
+  const forceUpdate = (): void => {
+    if (
+      window.confirm(
+        t('Force update will interrupt active tasks and may lose unsaved work. Continue?')
+      )
+    ) {
+      void apply({ force: true })
+    }
+  }
   const activeLanguage = i18n.resolvedLanguage ?? i18n.language
   const locale = isLocale(activeLanguage) ? activeLanguage : 'en'
   const localizedNotes = locale === 'en' ? undefined : dialogStatus?.localizedNotes?.[locale]

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -56,6 +56,13 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
   const isBackgroundProcessError =
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_ERROR ||
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
+  const isForceableGateError =
+    isBackgroundProcessError ||
+    dialogStatus?.error ===
+      'Research work is still running. Stop it before restarting to update.' ||
+    dialogStatus?.error ===
+      'Subagents are still running. Return to their tasks and stop them before restarting to update.' ||
+    dialogStatus?.error === UPDATE_SETTINGS_INSTALL_ERROR
   const forceUpdate = (): void => {
     if (
       window.confirm(
@@ -221,7 +228,7 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
                     <ExternalTextLink href={APP.update.downloadPage} className="mt-1 text-xs">
                       {t('Download manually')}
                     </ExternalTextLink>
-                    {dialogStatus.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR && isReady ? (
+                    {isForceableGateError && isReady ? (
                       <button
                         type="button"
                         onClick={forceUpdate}

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -56,7 +56,7 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
   const isBackgroundProcessError =
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_ERROR ||
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
-  const forceUpdate = () => void apply({ force: true })
+  const forceUpdate = (): void => void apply({ force: true })
   const activeLanguage = i18n.resolvedLanguage ?? i18n.language
   const locale = isLocale(activeLanguage) ? activeLanguage : 'en'
   const localizedNotes = locale === 'en' ? undefined : dialogStatus?.localizedNotes?.[locale]

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -57,7 +57,6 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_ERROR ||
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
   const isForceableGateError =
-    isBackgroundProcessError ||
     dialogStatus?.error ===
       'Research work is still running. Stop it before restarting to update.' ||
     dialogStatus?.error ===

--- a/src/renderer/src/components/UpdateDialog.tsx
+++ b/src/renderer/src/components/UpdateDialog.tsx
@@ -56,6 +56,7 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
   const isBackgroundProcessError =
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_ERROR ||
     dialogStatus?.error === UPDATE_BACKGROUND_PROCESS_DEGRADED_ERROR
+  const forceUpdate = () => void apply({ force: true })
   const activeLanguage = i18n.resolvedLanguage ?? i18n.language
   const locale = isLocale(activeLanguage) ? activeLanguage : 'en'
   const localizedNotes = locale === 'en' ? undefined : dialogStatus?.localizedNotes?.[locale]
@@ -212,6 +213,15 @@ const UpdateDialog = ({ active = true }: { active?: boolean }): React.JSX.Elemen
                     <ExternalTextLink href={APP.update.downloadPage} className="mt-1 text-xs">
                       {t('Download manually')}
                     </ExternalTextLink>
+                    {isBackgroundProcessError && isReady ? (
+                      <button
+                        type="button"
+                        onClick={forceUpdate}
+                        className="mt-2 block text-xs text-destructive underline"
+                      >
+                        {t('Continue with force update')}
+                      </button>
+                    ) : null}
                   </div>
                 ) : null}
                 {isInstallerUnavailable ? (

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -121,9 +121,9 @@ export const useUpdateStore = create<UpdateStore>((set, get) => ({
     await acceptUpdateResponse(() => cancel())
   },
 
-  apply: async () => {
+  apply: async (options?: { force?: boolean }) => {
     const api = window.api?.update
     if (!api) return
-    await acceptUpdateResponse(() => api.apply())
+    await acceptUpdateResponse(() => api.apply(options))
   }
 }))

--- a/src/renderer/src/stores/update-store.ts
+++ b/src/renderer/src/stores/update-store.ts
@@ -13,7 +13,7 @@ type UpdateStore = {
   closeDialog: () => void
   download: () => Promise<void>
   cancel: () => Promise<void>
-  apply: () => Promise<void>
+  apply: (options?: { force?: boolean }) => Promise<void>
 }
 
 let cleanupUpdateSubscriptions: (() => void) | undefined

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5514,6 +5514,7 @@
     "Analysis rules: {{revision}}": "Analyseregeln: {{revision}}",
     "Analysis rules were not recorded for this version.": "Für diese Version wurden keine Analyseregeln aufgezeichnet.",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Bei der Erstellung dieser Artefaktversion aufgezeichnet. Spätere Analyseaktualisierungen ändern diese Verifizierungsnachweise nicht.",
-    "Continue with force update": "Mit erzwungenem Update fortfahren"
+    "Continue with force update": "Mit erzwungenem Update fortfahren",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "Das Erzwingen des Updates unterbricht aktive Aufgaben und kann nicht gespeicherte Arbeit verlieren. Fortfahren?"
   }
 }

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -5513,6 +5513,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "Frühere circlize-Diagrammparameter wurden nicht erfasst. Rufen Sie vor der Konfiguration und dem Zeichnen circlize::circos.clear() auf und führen Sie die Zelle erneut aus.",
     "Analysis rules: {{revision}}": "Analyseregeln: {{revision}}",
     "Analysis rules were not recorded for this version.": "Für diese Version wurden keine Analyseregeln aufgezeichnet.",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Bei der Erstellung dieser Artefaktversion aufgezeichnet. Spätere Analyseaktualisierungen ändern diese Verifizierungsnachweise nicht."
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Bei der Erstellung dieser Artefaktversion aufgezeichnet. Spätere Analyseaktualisierungen ändern diese Verifizierungsnachweise nicht.",
+    "Continue with force update": "Mit erzwungenem Update fortfahren"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5678,6 +5678,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "No se registraron los parámetros gráficos anteriores de circlize. Llame a circlize::circos.clear() antes de configurar y dibujar el gráfico y, después, vuelva a ejecutar la celda.",
     "Analysis rules: {{revision}}": "Reglas de análisis: {{revision}}",
     "Analysis rules were not recorded for this version.": "No se registraron las reglas de análisis de esta versión.",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Se registraron al crear esta versión del artefacto. Las actualizaciones posteriores del análisis no modifican estas evidencias de verificación."
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Se registraron al crear esta versión del artefacto. Las actualizaciones posteriores del análisis no modifican estas evidencias de verificación.",
+    "Continue with force update": "Continuar con la actualización forzada"
   }
 }

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -5679,6 +5679,7 @@
     "Analysis rules: {{revision}}": "Reglas de análisis: {{revision}}",
     "Analysis rules were not recorded for this version.": "No se registraron las reglas de análisis de esta versión.",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Se registraron al crear esta versión del artefacto. Las actualizaciones posteriores del análisis no modifican estas evidencias de verificación.",
-    "Continue with force update": "Continuar con la actualización forzada"
+    "Continue with force update": "Continuar con la actualización forzada",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "La actualización forzada interrumpirá las tareas activas y puede perder trabajo no guardado. ¿Continuar?"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5679,6 +5679,7 @@
     "Analysis rules: {{revision}}": "Règles d’analyse : {{revision}}",
     "Analysis rules were not recorded for this version.": "Les règles d’analyse n’ont pas été enregistrées pour cette version.",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Enregistrées lors de la création de cette version de l’artefact. Les mises à jour ultérieures de l’analyse ne modifient pas ces preuves de vérification.",
-    "Continue with force update": "Poursuivre la mise à jour forcée"
+    "Continue with force update": "Poursuivre la mise à jour forcée",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "La mise à jour forcée interrompra les tâches actives et peut entraîner la perte du travail non enregistré. Continuer ?"
   }
 }

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -5678,6 +5678,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "Les paramètres graphiques précédents de circlize n’ont pas été enregistrés. Appelez circlize::circos.clear() avant de configurer et de tracer le graphique, puis réexécutez la cellule.",
     "Analysis rules: {{revision}}": "Règles d’analyse : {{revision}}",
     "Analysis rules were not recorded for this version.": "Les règles d’analyse n’ont pas été enregistrées pour cette version.",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Enregistrées lors de la création de cette version de l’artefact. Les mises à jour ultérieures de l’analyse ne modifient pas ces preuves de vérification."
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Enregistrées lors de la création de cette version de l’artefact. Les mises à jour ultérieures de l’analyse ne modifient pas ces preuves de vérification.",
+    "Continue with force update": "Poursuivre la mise à jour forcée"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -5356,6 +5356,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "以前の circlize 描画パラメーターが記録されていません。設定と描画の前に circlize::circos.clear() を呼び出してから、セルを再実行してください。",
     "Analysis rules: {{revision}}": "解析ルール: {{revision}}",
     "Analysis rules were not recorded for this version.": "このバージョンの解析ルールは記録されていません。",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "この Artifact バージョンの作成時に記録されました。その後の解析の更新によって、この検証の証拠が変更されることはありません。"
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "この Artifact バージョンの作成時に記録されました。その後の解析の更新によって、この検証の証拠が変更されることはありません。",
+    "Continue with force update": "強制更新を続行"
   }
 }

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -5357,6 +5357,7 @@
     "Analysis rules: {{revision}}": "解析ルール: {{revision}}",
     "Analysis rules were not recorded for this version.": "このバージョンの解析ルールは記録されていません。",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "この Artifact バージョンの作成時に記録されました。その後の解析の更新によって、この検証の証拠が変更されることはありません。",
-    "Continue with force update": "強制更新を続行"
+    "Continue with force update": "強制更新を続行",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "強制更新すると実行中のタスクが中断され、未保存の作業が失われる可能性があります。続行しますか？"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -5355,6 +5355,7 @@
     "Analysis rules: {{revision}}": "분석 규칙: {{revision}}",
     "Analysis rules were not recorded for this version.": "이 버전의 분석 규칙은 기록되지 않았습니다.",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "이 아티팩트 버전을 만들 때 기록되었습니다. 이후 분석 업데이트는 이 검증 근거를 변경하지 않습니다.",
-    "Continue with force update": "강제 업데이트 계속"
+    "Continue with force update": "강제 업데이트 계속",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "강제 업데이트는 실행 중인 작업을 중단하고 저장되지 않은 작업을 잃을 수 있습니다. 계속하시겠습니까?"
   }
 }

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -5354,6 +5354,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "이전 circlize 그리기 매개변수가 기록되지 않았습니다. 설정 및 그리기 전에 circlize::circos.clear()를 호출한 다음 셀을 다시 실행하세요.",
     "Analysis rules: {{revision}}": "분석 규칙: {{revision}}",
     "Analysis rules were not recorded for this version.": "이 버전의 분석 규칙은 기록되지 않았습니다.",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "이 아티팩트 버전을 만들 때 기록되었습니다. 이후 분석 업데이트는 이 검증 근거를 변경하지 않습니다."
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "이 아티팩트 버전을 만들 때 기록되었습니다. 이후 분석 업데이트는 이 검증 근거를 변경하지 않습니다.",
+    "Continue with force update": "강제 업데이트 계속"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5815,6 +5815,7 @@
     "Analysis rules: {{revision}}": "Правила анализа: {{revision}}",
     "Analysis rules were not recorded for this version.": "Правила анализа для этой версии не записаны.",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Записано при создании этой версии артефакта. Последующие обновления анализа не изменяют эти свидетельства проверки.",
-    "Continue with force update": "Продолжить принудительное обновление"
+    "Continue with force update": "Продолжить принудительное обновление",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "Принудительное обновление прервет активные задачи и может привести к потере несохраненной работы. Продолжить?"
   }
 }

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -5814,6 +5814,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "Предыдущие параметры графика circlize не были записаны. Вызовите circlize::circos.clear() перед настройкой и построением графика, затем повторно выполните ячейку.",
     "Analysis rules: {{revision}}": "Правила анализа: {{revision}}",
     "Analysis rules were not recorded for this version.": "Правила анализа для этой версии не записаны.",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Записано при создании этой версии артефакта. Последующие обновления анализа не изменяют эти свидетельства проверки."
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "Записано при создании этой версии артефакта. Последующие обновления анализа не изменяют эти свидетельства проверки.",
+    "Continue with force update": "Продолжить принудительное обновление"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -5356,6 +5356,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "未捕获先前的 circlize 绘图参数。请在配置和绘图之前调用 circlize::circos.clear()，然后重新运行此单元。",
     "Analysis rules: {{revision}}": "分析规则：{{revision}}",
     "Analysis rules were not recorded for this version.": "此版本未记录分析规则。",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "记录于创建此 Artifact 版本时。后续分析更新不会更改这些验证证据。"
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "记录于创建此 Artifact 版本时。后续分析更新不会更改这些验证证据。",
+    "Continue with force update": "继续强制更新"
   }
 }

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -5357,6 +5357,7 @@
     "Analysis rules: {{revision}}": "分析规则：{{revision}}",
     "Analysis rules were not recorded for this version.": "此版本未记录分析规则。",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "记录于创建此 Artifact 版本时。后续分析更新不会更改这些验证证据。",
-    "Continue with force update": "继续强制更新"
+    "Continue with force update": "继续强制更新",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "强制更新会中断正在运行的任务，并可能丢失未保存的工作。是否继续？"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -5356,6 +5356,7 @@
     "Earlier circlize plotting parameters were not captured. Call circlize::circos.clear() before configuring and drawing the plot, then rerun the cell.": "未擷取先前的 circlize 繪圖參數。請在設定及繪圖之前呼叫 circlize::circos.clear()，然後重新執行此儲存格。",
     "Analysis rules: {{revision}}": "分析規則：{{revision}}",
     "Analysis rules were not recorded for this version.": "此版本未記錄分析規則。",
-    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "記錄於建立此 Artifact 版本時。後續分析更新不會變更這些驗證證據。"
+    "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "記錄於建立此 Artifact 版本時。後續分析更新不會變更這些驗證證據。",
+    "Continue with force update": "繼續強制更新"
   }
 }

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -5357,6 +5357,7 @@
     "Analysis rules: {{revision}}": "分析規則：{{revision}}",
     "Analysis rules were not recorded for this version.": "此版本未記錄分析規則。",
     "Recorded when this Artifact Version was created. Later analysis updates do not change this verification evidence.": "記錄於建立此 Artifact 版本時。後續分析更新不會變更這些驗證證據。",
-    "Continue with force update": "繼續強制更新"
+    "Continue with force update": "繼續強制更新",
+    "Force update will interrupt active tasks and may lose unsaved work. Continue?": "強制更新會中斷正在執行的工作，並可能遺失未儲存的內容。是否繼續？"
   }
 }

--- a/src/shared/renderer-contract-catalog.ts
+++ b/src/shared/renderer-contract-catalog.ts
@@ -474,7 +474,7 @@ import type {
   StorageStatus
 } from './storage'
 import type { CliLauncherStatus } from './cli'
-import type { AppInfo, DownloadProgress, UpdateStatus } from './update'
+import type { AppInfo, DownloadProgress, UpdateApplyOptions, UpdateStatus } from './update'
 import type {
   AppendUploadTransferRequest,
   BeginUploadTransferRequest,
@@ -2556,7 +2556,10 @@ export const RENDERER_API_CONTRACT = Object.freeze({
     undefined,
     RUNTIME_VALIDATED
   ]),
-  'update.apply': callable<() => Promise<UpdateStatus>>()('update', ['update:apply', LOCAL]),
+  'update.apply': callable<(options?: UpdateApplyOptions) => Promise<UpdateStatus>>()('update', [
+    'update:apply',
+    LOCAL
+  ]),
   'update.cancel': callable<() => Promise<UpdateStatus>>()('update', ['update:cancel', LOCAL]),
   'update.check': callable<() => Promise<UpdateStatus>>()('update', ['update:check']),
   'update.download': callable<() => Promise<UpdateStatus>>()('update', ['update:download', LOCAL]),

--- a/src/shared/update.ts
+++ b/src/shared/update.ts
@@ -21,7 +21,7 @@ export type UpdateBlocker = 'agent' | 'delegated' | 'notebook' | 'reviewer' | 's
 // Call intent stays transient and transport-neutral. Desktop callers omit these options; headless
 // callers use them to avoid native dialogs and desktop relaunches.
 export type UpdateDownloadOptions = { nonInteractive?: boolean }
-export type UpdateApplyOptions = { relaunch?: boolean }
+export type UpdateApplyOptions = { relaunch?: boolean; force?: boolean }
 
 // The single status the main process broadcasts and the renderer store mirrors.
 export type UpdateStatus = {


### PR DESCRIPTION
## Summary

- add an explicit force-update action after the install gate reports background processes that could not be fully stopped
- preserve the safe default update behavior and pass force intent through the transient update IPC options
- localize the new action label across supported renderer locales

## Validation

- `npx vitest run src/main/update/electron-updater-strategy.test.ts src/renderer/src/i18n/resources.test.ts`

## Compatibility and persistence

- No persisted data changes or new status enum values.
- Force mode may interrupt running work and can still fail if the operating system retains file locks.
