### PR TITLE
fix(window-shortcuts): support Windows zoom-in aliases

### DIFF
--- a/e2e/windows-window-system.spec.ts
+++ b/e2e/windows-window-system.spec.ts
@@ -16,6 +16,39 @@ test.describe('Windows window system', () => {
   test.skip(process.platform !== 'win32', 'Windows window behavior requires a Windows host.')
   test.use({ windowMode: 'normal' })
 
+  test('zooms with Windows plus aliases and preserves native zoom shortcuts', async ({
+    app
+  }, testInfo) => {
+    const page = await app.completeOnboarding()
+    await app.setMainWindowZoomFactor(1)
+    const pixelRatio = (): Promise<number> => page.evaluate(() => window.devicePixelRatio)
+    const baseline = await pixelRatio()
+    await testInfo.attach('zoom-before', {
+      body: await page.screenshot(),
+      contentType: 'image/png'
+    })
+
+    for (const key of ['=', 'numadd']) {
+      for (let step = 1; step <= 3; step++) {
+        await app.pressMainWindowShortcut(key, ['control'])
+        await expect
+          .poll(async () => (await pixelRatio()) / baseline)
+          .toBeCloseTo(1.2 ** (step * 0.5), 4)
+      }
+      await testInfo.attach(`zoom-after-${key === '=' ? 'equal' : 'numpad'}`, {
+        body: await page.screenshot(),
+        contentType: 'image/png'
+      })
+      await app.pressMainWindowShortcut('0', ['control'])
+      await expect.poll(pixelRatio).toBeCloseTo(baseline, 4)
+    }
+
+    await app.pressMainWindowShortcut('+', ['control', 'shift'])
+    await expect.poll(async () => (await pixelRatio()) / baseline).toBeCloseTo(1.2 ** 0.5, 4)
+    await app.pressMainWindowShortcut('-', ['control'])
+    await expect.poll(pixelRatio).toBeCloseTo(baseline, 4)
+  })
+
   test('persists minimize-to-tray across titlebar close, relaunch, and Ctrl+W', async ({ app }) => {
     let page = await app.completeOnboarding()
     let settings = await openGeneralSettings(page)

--- a/src/main/window-shortcuts.test.ts
+++ b/src/main/window-shortcuts.test.ts
@@ -10,7 +10,7 @@ vi.mock('@electron-toolkit/utils', () => ({
   }
 }))
 
-import type { App } from 'electron'
+import type { App, Input } from 'electron'
 import { installWindowShortcuts } from './window-shortcuts'
 
 // Regression guard for issue #336: without `zoom: true`, electron-toolkit's helper calls
@@ -21,6 +21,7 @@ describe('installWindowShortcuts', () => {
   let appOnSpy: ReturnType<typeof vi.fn>
 
   beforeEach(() => {
+    vi.restoreAllMocks()
     appOnSpy = vi.fn()
     watchWindowShortcuts.mockReset()
   })
@@ -32,7 +33,7 @@ describe('installWindowShortcuts', () => {
     expect(appOnSpy).toHaveBeenCalledWith('browser-window-created', expect.any(Function))
 
     const handler = appOnSpy.mock.calls[0]![1] as (event: unknown, window: unknown) => void
-    const fakeWindow = { id: 42 }
+    const fakeWindow = { id: 42, webContents: { on: vi.fn() } }
     handler(null, fakeWindow)
 
     expect(watchWindowShortcuts).toHaveBeenCalledTimes(1)
@@ -43,11 +44,69 @@ describe('installWindowShortcuts', () => {
     installWindowShortcuts({ on: appOnSpy } as unknown as App, { escToCloseWindow: true })
 
     const handler = appOnSpy.mock.calls[0]![1] as (event: unknown, window: unknown) => void
-    handler(null, {})
+    handler(null, { webContents: { on: vi.fn() } })
 
     expect(watchWindowShortcuts).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ escToCloseWindow: true, zoom: true })
     )
+  })
+
+  const createShortcut = (
+    platform: NodeJS.Platform = 'win32'
+  ): {
+    webContents: Record<'on' | 'getZoomLevel' | 'setZoomLevel', ReturnType<typeof vi.fn>>
+    dispatch: (overrides?: Partial<Input>) => { preventDefault: ReturnType<typeof vi.fn> }
+  } => {
+    vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+    installWindowShortcuts({ on: appOnSpy } as unknown as App)
+    const webContents = { on: vi.fn(), getZoomLevel: vi.fn(() => 1), setZoomLevel: vi.fn() }
+    appOnSpy.mock.calls[0]![1](null, { webContents })
+    const dispatch = (
+      overrides: Partial<Input> = {}
+    ): { preventDefault: ReturnType<typeof vi.fn> } => {
+      const event = { preventDefault: vi.fn() }
+      webContents.on.mock.calls[0]?.[1](event, {
+        type: 'keyDown',
+        key: '=',
+        code: 'Equal',
+        control: true,
+        shift: false,
+        alt: false,
+        meta: false,
+        ...overrides
+      })
+      return event
+    }
+    return { webContents, dispatch }
+  }
+
+  it.each([
+    { key: '=', code: 'Equal' },
+    { key: '+', code: 'NumpadAdd' }
+  ])('zooms once for the Windows alias $code', (input) => {
+    const { webContents, dispatch } = createShortcut()
+    expect(dispatch(input).preventDefault).toHaveBeenCalledOnce()
+    expect(webContents.setZoomLevel).toHaveBeenCalledExactlyOnceWith(1.5)
+  })
+
+  it.each([
+    { type: 'keyUp' },
+    { control: false },
+    { alt: true },
+    { meta: true },
+    { key: '+', shift: true },
+    { key: '-' },
+    { key: '0' },
+    { key: 'Process' }
+  ] satisfies Partial<Input>[])('leaves native chords and unrelated input alone: %j', (input) => {
+    const { webContents, dispatch } = createShortcut()
+    expect(dispatch(input).preventDefault).not.toHaveBeenCalled()
+    expect(webContents.setZoomLevel).not.toHaveBeenCalled()
+  })
+
+  it.each(['darwin', 'linux'] as const)('preserves native shortcuts on %s', (platform) => {
+    const { webContents } = createShortcut(platform)
+    expect(webContents.on).not.toHaveBeenCalled()
   })
 })

--- a/src/main/window-shortcuts.ts
+++ b/src/main/window-shortcuts.ts
@@ -9,6 +9,27 @@ import { optimizer, type shortcutOptions } from '@electron-toolkit/utils'
 const installWindowShortcuts = (app: App, options?: Omit<shortcutOptions, 'zoom'>): void => {
   app.on('browser-window-created', (_event: unknown, window: BrowserWindow) => {
     optimizer.watchWindowShortcuts(window, { ...options, zoom: true })
+
+    if (process.platform !== 'win32') return
+    window.webContents.on('before-input-event', (event, input) => {
+      if (
+        input.type !== 'keyDown' ||
+        !input.control ||
+        input.shift ||
+        input.alt ||
+        input.meta ||
+        !(
+          (input.key === '=' && input.code === 'Equal') ||
+          (input.key === '+' && input.code === 'NumpadAdd')
+        )
+      )
+        return
+
+      // Windows' native Plus accelerator covers Ctrl+Shift+=, but not these aliases.
+      // Match Electron's zoomIn role step and suppress a second renderer/menu action.
+      event.preventDefault()
+      window.webContents.setZoomLevel(window.webContents.getZoomLevel() + 0.5)
+    })
   })
 }
 


### PR DESCRIPTION
## Problem

On Windows, Ctrl+= and Ctrl+NumpadAdd do not enlarge the window. Enabling toolkit zoom only allows Electron's existing accelerators; the native zoomIn role binds CommandOrControl+Plus (Ctrl+Shift+=), leaving both aliases unhandled.

## Proposed change

Handle only the two missing Windows chords in the existing window-shortcuts owner, using Electron's native 0.5 zoom-level step. Prevent duplicate renderer/menu dispatch. Keep Ctrl+Shift+=, Ctrl+-, Ctrl+0 and macOS/Linux native handling unchanged; exclude keyUp, plain typing and Alt/Meta/Shift combinations.

No new fields, states/enums, persistence, data migration, historical compatibility work, or architecture changes. The only interaction change adds two aliases for existing window zoom.

## Acceptance criteria and validation

After the final behavioral edits:
- Alias dispatch and modifier/platform boundaries; window consumer regressions -> `npm test -- src/main/window-shortcuts.test.ts src/main/windows.test.ts` -> 95 passed. Both new alias tests failed before the production fix.
- Actual Windows Electron integration -> `npm run build:e2e`, then `npm run test:e2e -- e2e/windows-window-system.spec.ts -g 'zooms with Windows' --reporter=html` -> build passed, 1 E2E passed. Covers three successive steps for each alias, reset, native zoom in/out and no double step. Before/after screenshots are attached to the Playwright report.
- `npm run typecheck:node` -> environment failure: shared node_modules lacks reflect-metadata and @peculiar/x509, referenced by existing notebook-network-sandbox local-ca.ts. No type errors reported in changed files.
- Full portable tests intentionally deferred to exact-head PR CI per maintainer request. Native Windows coverage is required; other OS paths are unchanged and guarded in unit tests. Alternate keyboard layouts and embedded third-party page focus are not exhaustively covered locally.

## Review focus

Keep native Ctrl+Shift+= dispatch single and preserve unrelated key input. Confirm exact-head CI and independent review before treating the full change as verified.

Final formatting validation: full `npm run lint` passed; focused lint for all three changed files passed without warnings. Only return-type annotations/formatting changed after the E2E run; the 95 focused tests passed after the annotations. Working tree is clean.
