### PR TITLE
fix(artifacts): serialize complete saves in main process

### DIFF
--- a/src/main/acp/artifact-turn-owner.test.ts
+++ b/src/main/acp/artifact-turn-owner.test.ts
@@ -285,22 +285,12 @@ describe('ArtifactTurnOwner', () => {
       expect.objectContaining({
         executionId: 'root-execution',
         artifactRunId: 'artifact-run-100-1',
-        allowedMethods: [
-          'artifactReserveWrite',
-          'artifactReleaseWrite',
-          'artifactCreateVersion',
-          'artifactReplayVersion'
-        ]
+        allowedMethods: ['artifactSaveVersion']
       }),
       expect.objectContaining({
         executionId: 'parallel-execution',
         artifactRunId: 'artifact-run-100-2',
-        allowedMethods: [
-          'artifactReserveWrite',
-          'artifactReleaseWrite',
-          'artifactCreateVersion',
-          'artifactReplayVersion'
-        ]
+        allowedMethods: ['artifactSaveVersion']
       })
     ])
     expect(owner.activeRunIds()).toEqual(['artifact-run-100-2'])
@@ -457,12 +447,7 @@ describe('ArtifactTurnOwner', () => {
         artifactStorageSessionId: 'artifact-session-1',
         artifactRunId: 'artifact-run-123-1',
         notebookSessionId: 'session-1',
-        allowedMethods: [
-          'artifactReserveWrite',
-          'artifactReleaseWrite',
-          'artifactCreateVersion',
-          'artifactReplayVersion'
-        ]
+        allowedMethods: ['artifactSaveVersion']
       })
     ])
     expect(notebookContexts).toEqual([

--- a/src/main/acp/artifact-turn-owner.ts
+++ b/src/main/acp/artifact-turn-owner.ts
@@ -31,6 +31,7 @@ type ArtifactTurnProvenanceContext = {
 
 type OpenExecutionArtifactTurnRequest = {
   executionId: string
+  workspaceCwd?: string
   appSessionId: string
   artifactStorageSessionId: string
   projectId: string
@@ -86,6 +87,10 @@ type NotebookArtifactSourceScopeProvider = (
 ) => NotebookArtifactSourceScope
 
 type ArtifactTurnProvenance = {
+  withSessionMutation?<Result>(
+    scope: { projectId: string; appSessionId: string },
+    operation: () => Promise<Result>
+  ): Promise<Result>
   listRunVersions: (request: {
     projectId: string
     appSessionId: string
@@ -147,6 +152,7 @@ type ArtifactTurnOwnerOptions = {
 
 type ArtifactTurn = {
   executionId: string
+  workspaceCwd?: string
   updatesSessionNotebookContext: boolean
   appSessionId: string
   artifactStorageSessionId: string
@@ -232,12 +238,18 @@ class ArtifactTurnOwner {
         ...(turn.notebookArtifactSourceScope
           ? { notebookSessionId: turn.notebookArtifactSourceScope.notebookSessionId }
           : {}),
-        allowedMethods: [
-          'artifactReserveWrite',
-          'artifactReleaseWrite',
-          'artifactCreateVersion',
-          'artifactReplayVersion'
-        ]
+        sourceScope: {
+          allowedImportRoots: [
+            ...(turn.workspaceCwd ? [turn.workspaceCwd] : []),
+            ...(turn.notebookArtifactSourceScope
+              ? [turn.notebookArtifactSourceScope.notebookSessionRoot]
+              : [])
+          ],
+          workspaceCwd: turn.workspaceCwd,
+          notebookDataDir: turn.notebookArtifactSourceScope?.notebookDataDir,
+          notebookSessionRoot: turn.notebookArtifactSourceScope?.notebookSessionRoot
+        },
+        allowedMethods: ['artifactSaveVersion']
       })
       if (turn.rpcCapabilityToken) runContext.rpcCapabilityToken = turn.rpcCapabilityToken
 
@@ -444,6 +456,7 @@ class ArtifactTurnOwner {
     )
     const turn: ArtifactTurn = {
       executionId: request.executionId,
+      workspaceCwd: request.workspaceCwd,
       updatesSessionNotebookContext: rootTransport,
       appSessionId: request.appSessionId,
       artifactStorageSessionId: request.artifactStorageSessionId,
@@ -520,7 +533,19 @@ class ArtifactTurnOwner {
 
   private async finalizeTurn(turn: ArtifactTurn): Promise<ArtifactTurnPublication | undefined> {
     await this.closeWrites(turn)
+    const prepare = (): Promise<ArtifactTurnPublication | undefined> =>
+      this.prepareFinalization(turn)
+    return this.options.provenance?.withSessionMutation
+      ? this.options.provenance.withSessionMutation(
+          { projectId: turn.projectId, appSessionId: turn.appSessionId },
+          prepare
+        )
+      : prepare()
+  }
 
+  private async prepareFinalization(
+    turn: ArtifactTurn
+  ): Promise<ArtifactTurnPublication | undefined> {
     let artifacts: ArtifactFile[]
     let artifactVersionIds: string[] | undefined
     if (this.options.provenance) {

--- a/src/main/acp/mcp-http-host.test.ts
+++ b/src/main/acp/mcp-http-host.test.ts
@@ -1,7 +1,6 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { createArtifactSaveFixture } from '../artifacts/save-test-fixtures'
+import { rm } from 'node:fs/promises'
 import { createServer, request as httpRequest, type Server } from 'node:http'
-import { tmpdir } from 'node:os'
-import { join } from 'node:path'
 
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -12,12 +11,15 @@ import { literatureItemInputSchema } from '../../shared/literature'
 import { ArtifactRepository } from '../artifacts/repository'
 
 describe('AgentMcpHttpHost', () => {
+  let saveFixture: Awaited<ReturnType<typeof createArtifactSaveFixture>> | undefined
   let host: AgentMcpHttpHost | undefined
   let rpcServer: Server | undefined
   let root: string | undefined
 
   afterEach(async () => {
     await host?.close()
+    await saveFixture?.dispose()
+    saveFixture = undefined
     host = undefined
     if (rpcServer) {
       rpcServer.closeAllConnections()
@@ -34,25 +36,22 @@ describe('AgentMcpHttpHost', () => {
   })
 
   it('serves the artifact MCP tools over http and writes a file for the active run', async () => {
-    root = await mkdtemp(join(tmpdir(), 'mcp-http-host-'))
+    saveFixture = await createArtifactSaveFixture()
+    root = saveFixture.storageRoot
     const projectId = 'default-project'
     const artifactSessionId = 'artifact-session-1'
     const runId = 'artifact-run-1'
     // The artifact tool reads the active run id from this main-process-owned handoff file.
-    const currentRunFile = join(root, 'current-run.json')
-    await writeFile(currentRunFile, JSON.stringify({ runId }), 'utf8')
+    const environment = await saveFixture.environment(
+      { allowedImportRoots: [root], workspaceCwd: root },
+      { projectId }
+    )
 
     host = new AgentMcpHttpHost()
     const { endpoint, token } = await host.ensureStarted()
     expect(endpoint).toMatch(/^http:\/\/127\.0\.0\.1:\d+$/)
 
-    host.registerArtifact(artifactSessionId, {
-      storageRoot: root,
-      projectId,
-      sessionId: artifactSessionId,
-      currentRunFile,
-      allowedImportRoots: [root]
-    })
+    host.registerArtifact(artifactSessionId, environment)
 
     const client = new Client({ name: 'test-client', version: '0.0.0' })
     const transport = new StreamableHTTPClientTransport(
@@ -85,22 +84,19 @@ describe('AgentMcpHttpHost', () => {
   })
 
   it('accepts a JSON-stringified artifact source from an MCP model call', async () => {
-    root = await mkdtemp(join(tmpdir(), 'mcp-http-host-'))
+    saveFixture = await createArtifactSaveFixture()
+    root = saveFixture.storageRoot
     const projectId = 'default-project'
     const artifactSessionId = 'artifact-session-1'
     const runId = 'artifact-run-1'
-    const currentRunFile = join(root, 'current-run.json')
-    await writeFile(currentRunFile, JSON.stringify({ runId }), 'utf8')
+    const environment = await saveFixture.environment(
+      { allowedImportRoots: [root], workspaceCwd: root },
+      { projectId }
+    )
 
     host = new AgentMcpHttpHost()
     const { token } = await host.ensureStarted()
-    host.registerArtifact(artifactSessionId, {
-      storageRoot: root,
-      projectId,
-      sessionId: artifactSessionId,
-      currentRunFile,
-      allowedImportRoots: [root]
-    })
+    host.registerArtifact(artifactSessionId, environment)
 
     const client = new Client({ name: 'test-client', version: '0.0.0' })
     const transport = new StreamableHTTPClientTransport(

--- a/src/main/acp/runtime-prompt-composition.ts
+++ b/src/main/acp/runtime-prompt-composition.ts
@@ -107,6 +107,7 @@ const composeAcpRuntimePromptOwners = (
     if (!base.artifactTurns) return undefined
     return base.artifactTurns.openRootExecution({
       executionId,
+      workspaceCwd: session.sessionRegistry.lookup(sessionId)?.aggregate.snapshot().cwd,
       appSessionId: sessionId,
       artifactStorageSessionId:
         base.sessionCapabilities.artifactRoutingIdFor(sessionId) ?? sessionId,

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1,3 +1,5 @@
+import { createFrameNotebookLane } from '../notebook/lane-identity'
+import { createArtifactSaveFixture } from '../artifacts/save-test-fixtures'
 import sharp from 'sharp'
 import * as attachmentMedia from '../uploads/attachment-media'
 import * as acp from '@agentclientprotocol/sdk'
@@ -10192,7 +10194,9 @@ describe('ACP runtime session management', () => {
     // under a pre-start alias, but kernels write under the FINAL ACP session id. The per-turn handoff
     // must pin the kernel dir/root by that final id so a relative/bare artifact write resolves — and
     // the write must succeed even though the static allowedImportRoots only knew the alias.
-    const root = await createTemporaryRoot()
+    const fixture = await createArtifactSaveFixture()
+    temporaryDisconnections.push(() => fixture.dispose())
+    const root = fixture.storageRoot
     const artifactRepository = new ArtifactRepository(root)
     const finalSessionId = 'remote-session-1'
     // The kernel's real cwd for this session, keyed by the FINAL id (not the notebook alias).
@@ -10216,6 +10220,51 @@ describe('ACP runtime session management', () => {
           const currentRunFile = join(projectDir, artifactSessionId, '.pending', 'current-run.json')
           capturedContext = JSON.parse(await readFile(currentRunFile, 'utf8'))
 
+          const graph = capturedContext as {
+            rootFrameId: string
+            agentFrameId: string
+            messageBranchId: string
+            runtimeSegmentId: string
+            promptMessageId: string
+          }
+          const sourcePath = join(notebookDataDir, 'sine.png')
+          const observed = await stat(sourcePath)
+          await fixture.notebookRepository.loadOrCreate({
+            projectId: 'default-project',
+            sessionId: finalSessionId,
+            lane: createFrameNotebookLane('default-project', finalSessionId, graph.agentFrameId),
+            workspaceCwd: '/workspace'
+          })
+          await fixture.notebookRepository.appendRun({
+            projectId: 'default-project',
+            sessionId: finalSessionId,
+            lane: createFrameNotebookLane('default-project', finalSessionId, graph.agentFrameId),
+            run: {
+              ...graph,
+              runId: 'notebook-source-run',
+              cellId: 'plot-cell',
+              script: 'save_plot()',
+              source: 'agent',
+              kernelKind: 'python',
+              status: 'completed',
+              startedAt: observed.mtimeMs - 100,
+              endedAt: observed.mtimeMs + 100,
+              text: { stdout: '', stderr: '', traceback: '', plain: [] },
+              outputs: [],
+              artifacts: [],
+              inputFiles: [],
+              workingFiles: [
+                {
+                  path: sourcePath,
+                  relativePath: 'data/sine.png',
+                  kind: 'other',
+                  size: observed.size,
+                  mtimeMs: observed.mtimeMs,
+                  createdByRunId: 'notebook-source-run'
+                }
+              ]
+            }
+          })
           // A bare filename with no source must resolve against the handoff's notebook data dir.
           const artifact = await writeArtifactFileForCurrentRun(
             artifactRepository,
@@ -10224,6 +10273,7 @@ describe('ACP runtime session management', () => {
               projectId: 'default-project',
               sessionId: artifactSessionId,
               currentRunFile,
+              rpcEndpoint: fixture.connection.endpoint,
               allowedImportRoots: [] // authorization must come from the handoff session root
             },
             { filename: 'sine.png', mimeType: 'image/png' }
@@ -10248,7 +10298,11 @@ describe('ACP runtime session management', () => {
         dataRoot: root,
         projectId: 'default-project',
         mcpEntryPath: '/app/out/main/index.js',
-        repository: artifactRepository
+        repository: artifactRepository,
+        provenance: fixture.repository,
+        getRpcConnection: () => Promise.resolve(fixture.connection),
+        issueRpcCapability: (binding) => fixture.server.issueArtifactRunCapability(binding),
+        revokeRpcCapability: (token) => fixture.server.revokeArtifactRunCapability(token)
       }
     })
 
@@ -10335,12 +10389,7 @@ describe('ACP runtime session management', () => {
         appSessionId: session.sessionId,
         artifactRunId: capturedContext?.artifactRunId,
         rootFrameId: 'root-frame-1',
-        allowedMethods: [
-          'artifactReserveWrite',
-          'artifactReleaseWrite',
-          'artifactCreateVersion',
-          'artifactReplayVersion'
-        ]
+        allowedMethods: ['artifactSaveVersion']
       })
     ])
     expect(revokedTokens).toEqual(['run-capability-1'])
@@ -21832,10 +21881,11 @@ describe('ACP runtime session management', () => {
     const rpcServer = new NotebookLocalRpcServer(notebookService, {
       transport: 'tcp',
       artifactProvenance: {
-        createVersion: async (request, signal) => {
+        createVersion: (request, signal) => durableProvenance.createVersion(request, signal),
+        saveVersion: async (request, sourceScope, signal) => {
           rpcWriteStarted.resolve()
           await releaseRpcWrite.promise
-          return durableProvenance.createVersion(request, signal)
+          return durableProvenance.saveVersion(request, sourceScope, signal)
         },
         reserveWrite: (request) => durableProvenance.reserveWrite(request),
         releaseWriteReservation: (request) => durableProvenance.releaseWriteReservation(request),
@@ -21851,8 +21901,6 @@ describe('ACP runtime session management', () => {
     let currentRunFile = ''
     const rpcFilename = 'rpc-late.txt'
     const rpcContent = 'accepted RPC bytes'
-    const rpcSizeBytes = Buffer.byteLength(rpcContent)
-    const rpcChecksum = createHash('sha256').update(rpcContent).digest('hex')
     const process = new FakeAgentProcess()
     const fakeAgent = startFakeAgent(process, ['remote-session-1'], {
       onPrompt: async ({ sessionId }) => {
@@ -21870,34 +21918,6 @@ describe('ACP runtime session management', () => {
           fakeAgent.newSessions[0].mcpServers[0],
           'OPEN_SCIENCE_ARTIFACT_SESSION_ID'
         )
-        await repository.writePendingFile({
-          projectId: 'project-1',
-          sessionId: artifactStorageSessionId,
-          runId: context.artifactRunId,
-          filename: rpcFilename,
-          source: { kind: 'inline', content: rpcContent, encoding: 'utf8' }
-        })
-        const reservationResponse = await fetch(rpcConnection.endpoint, {
-          method: 'POST',
-          headers: {
-            authorization: `Bearer ${context.rpcCapabilityToken}`,
-            'content-type': 'application/json'
-          },
-          body: JSON.stringify({
-            method: 'artifactReserveWrite',
-            params: {
-              projectId: 'project-1',
-              appSessionId: sessionId,
-              artifactStorageSessionId,
-              artifactRunId: context.artifactRunId,
-              writeOperationId: 'write-rpc-late',
-              filename: rpcFilename,
-              fileBytes: rpcSizeBytes
-            }
-          })
-        })
-        expect(reservationResponse.status).toBe(200)
-        const reservation = (await reservationResponse.json()) as { result: { id: string } }
         rpcWrite = fetch(rpcConnection.endpoint, {
           method: 'POST',
           headers: {
@@ -21905,17 +21925,18 @@ describe('ACP runtime session management', () => {
             'content-type': 'application/json'
           },
           body: JSON.stringify({
-            method: 'artifactCreateVersion',
+            method: 'artifactSaveVersion',
             params: {
               projectId: 'project-1',
               appSessionId: sessionId,
               artifactStorageSessionId,
               artifactRunId: context.artifactRunId,
               writeOperationId: 'write-rpc-late',
-              writeRequestChecksum: 'c'.repeat(64),
-              resourceReservationId: reservation.result.id,
-              resourceSizeBytes: rpcSizeBytes,
-              resourceChecksum: rpcChecksum,
+              source: {
+                kind: 'inline',
+                content: Buffer.from(rpcContent).toString('base64'),
+                encoding: 'base64'
+              },
               rootFrameId: context.rootFrameId,
               agentFrameId: context.agentFrameId,
               messageBranchId: context.messageBranchId,
@@ -21941,6 +21962,8 @@ describe('ACP runtime session management', () => {
         repository,
         provenance: {
           listRunVersions,
+          withSessionMutation: (scope, operation) =>
+            durableProvenance.withSessionMutation(scope, operation),
           writeAppGeneratedVersion: (request) => durableProvenance.writeAppGeneratedVersion(request)
         },
         getRpcConnection: () => Promise.resolve(rpcConnection),

--- a/src/main/acp/runtime.ts
+++ b/src/main/acp/runtime.ts
@@ -445,7 +445,10 @@ type AcpRuntimeArtifactOptions = {
     Partial<
       Pick<
         import('../artifacts/provenance-repository').ArtifactProvenanceRepository,
-        'recordLiteraturePdfRead' | 'recordLiteratureAbstractRead' | 'recordLiteratureSearch'
+        | 'recordLiteraturePdfRead'
+        | 'recordLiteratureAbstractRead'
+        | 'recordLiteratureSearch'
+        | 'withSessionMutation'
       >
     >
   managedFileVersions?: Pick<

--- a/src/main/artifacts/artifact-save-crash.integration.test.ts
+++ b/src/main/artifacts/artifact-save-crash.integration.test.ts
@@ -1,0 +1,124 @@
+import { pathToFileURL } from 'node:url'
+import { fork, type ChildProcess } from 'node:child_process'
+import { mkdtemp, readFile, readdir, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { build } from 'esbuild'
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+
+type ChildResult = {
+  phase?: string
+  replayedVersionId?: string
+  recovered: { recoveredMessageArtifacts: unknown[] }
+  versions: Array<{ id: string; state: string; messageId: string }>
+}
+
+let testRoot: string
+let entry: string
+beforeAll(async () => {
+  testRoot = await mkdtemp(join(tmpdir(), 'artifact-save-crash-'))
+  entry = join(testRoot, 'child.cjs')
+  await build({
+    entryPoints: [resolve('src/main/artifacts/test-support/save-crash-child.ts')],
+    outfile: entry,
+    define: { 'import.meta.url': JSON.stringify(pathToFileURL(entry).href) },
+    bundle: true,
+    platform: 'node',
+    format: 'cjs',
+    packages: 'external',
+    logLevel: 'silent'
+  })
+})
+afterAll(async () => {
+  await rm(testRoot, { recursive: true, force: true })
+})
+const start = (
+  root: string,
+  phase: string
+): { child: ChildProcess; message: Promise<ChildResult>; exited: Promise<void> } => {
+  const child = fork(entry, [root, phase], {
+    silent: true,
+    env: { ...process.env, NODE_PATH: resolve('node_modules') }
+  })
+  let stderr = ''
+  child.stderr!.on('data', (data) => {
+    stderr += data
+  })
+  const message = new Promise<ChildResult>((resolve, reject) => {
+    child.once('message', (value) => resolve(value as ChildResult))
+    child.once('error', reject)
+    child.once('exit', (code) => {
+      if (code !== 0) reject(new Error(`child failed (${code}): ${stderr}`))
+    })
+  })
+  const exited = new Promise<void>((resolve) => {
+    child.once('exit', () => resolve())
+  })
+  return { child, message, exited }
+}
+
+describe('Artifact save durability across process termination', () => {
+  it.each(['copying', 'before-version', 'staging', 'committed', 'prepared', 'partial-publication'])(
+    'recovers %s with a newly started process and database connection',
+    async (phase) => {
+      const root = join(testRoot, phase)
+      const writer = start(root, phase)
+      try {
+        expect(await writer.message).toEqual({ phase })
+      } finally {
+        writer.child.kill('SIGKILL')
+        await writer.exited
+      }
+      const recovery = start(root, 'recover')
+      try {
+        const result = await recovery.message
+        await recovery.exited
+        if (phase === 'copying') {
+          expect(result.versions).toEqual([])
+          expect(result.recovered.recoveredMessageArtifacts).toEqual([])
+          const pending = await readdir(
+            join(root, 'artifacts/project-1/artifact-session-1/.pending/artifact-run-1')
+          )
+          expect(pending.some((name) => name.endsWith('.tmp'))).toBe(true)
+        } else if (phase === 'before-version') {
+          expect(result.versions).toEqual([])
+          expect(result.recovered.recoveredMessageArtifacts).toEqual([])
+          expect(
+            await readFile(
+              join(
+                root,
+                'artifacts/project-1/artifact-session-1/.pending/artifact-run-1/first.txt'
+              ),
+              'utf8'
+            )
+          ).toBe('first crash-safe bytes')
+        } else if (phase === 'staging' || phase === 'committed') {
+          expect(result.replayedVersionId).toBe(result.versions[0].id)
+          expect(result.versions).toEqual([
+            expect.objectContaining({ state: 'pending', messageId: null })
+          ])
+        } else {
+          expect(result.versions).toHaveLength(2)
+          expect(
+            result.versions.every(
+              (version: { state: string; messageId: string }) =>
+                version.state === 'finalized' && version.messageId === 'message-1'
+            )
+          ).toBe(true)
+          expect(
+            await readFile(join(root, 'artifacts/project-1/session-1/message-1/first.txt'), 'utf8')
+          ).toBe('first crash-safe bytes')
+          expect(
+            await readFile(join(root, 'artifacts/project-1/session-1/message-1/second.txt'), 'utf8')
+          ).toBe('second crash-safe bytes')
+        }
+      } finally {
+        if (recovery.child.exitCode === null) {
+          recovery.child.kill('SIGKILL')
+          await recovery.exited
+        }
+      }
+    },
+    30_000
+  )
+})

--- a/src/main/artifacts/artifact-save.integration.test.ts
+++ b/src/main/artifacts/artifact-save.integration.test.ts
@@ -1,0 +1,780 @@
+import { createArtifactHandlers } from './ipc'
+import { ArtifactRunRegistry } from './run-registry'
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import { strToU8, zipSync } from 'fflate'
+import { ARTIFACT_LITERATURE_SIDECAR_SUFFIX } from '../../shared/artifact-literature'
+import * as boundedIo from '../bounded-file-io'
+import { defaultArtifactDurability } from './durability'
+import { createHash } from 'node:crypto'
+import { mkdir, readFile, rm, truncate, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createArtifactSaveFixture } from './save-test-fixtures'
+import { writeArtifactFileForCurrentRun } from './mcp-server'
+import { ArtifactProvenanceRepository } from './provenance-repository'
+import { ArtifactWriteBudgetOwner } from './write-budget-owner'
+
+const fixtures: Awaited<ReturnType<typeof createArtifactSaveFixture>>[] = []
+const setup = async (): Promise<Awaited<ReturnType<typeof createArtifactSaveFixture>>> => {
+  const f = await createArtifactSaveFixture()
+  fixtures.push(f)
+  return f
+}
+const deferred = (): { promise: Promise<void>; resolve: () => void } => {
+  let resolve!: () => void
+  const promise = new Promise<void>((r) => {
+    resolve = r
+  })
+  return { promise, resolve }
+}
+afterEach(async () => {
+  vi.restoreAllMocks()
+  await Promise.all(fixtures.splice(0).map((f) => f.dispose()))
+})
+const hash = (data: string): string => createHash('sha256').update(data).digest('hex')
+
+describe('complete Artifact save over the production local RPC', () => {
+  it('saves five mixed files on their first concurrent calls without MCP pending writes', async () => {
+    const f = await setup()
+    const workspace = join(f.storageRoot, 'workspace')
+    await mkdir(workspace)
+    const env = await f.environment({ allowedImportRoots: [workspace], workspaceCwd: workspace })
+    const pendingSpy = vi.spyOn(f.compatibilityRepository, 'withPendingFileTransaction')
+    const calls = Array.from({ length: 5 }, (_, i) => ({
+      filename: `report-${i}.txt`,
+      content: `report ${i}`
+    }))
+    await Promise.all(calls.map((c) => writeFile(join(workspace, c.filename), c.content)))
+    const results = await Promise.all(
+      calls.map((c, i) =>
+        writeArtifactFileForCurrentRun(
+          // A separate repository makes any accidental MCP write observable.
+          {
+            withPendingFileTransaction: () => {
+              throw new Error('MCP wrote pending')
+            }
+          } as never,
+          env,
+          i % 2 ? { filename: c.filename, source: { kind: 'localPath', path: c.filename } } : c,
+          { requestId: i }
+        )
+      )
+    )
+    expect(pendingSpy).toHaveBeenCalledTimes(5)
+    expect(await f.client.artifactVersion.count()).toBe(5)
+    for (let i = 0; i < results.length; i++) {
+      expect(await readFile(results[i].path, 'utf8')).toBe(calls[i].content)
+      expect(results[i]).toMatchObject({
+        checksum: hash(calls[i].content),
+        sessionId: 'session-1',
+        runId: 'artifact-run-1'
+      })
+    }
+  })
+
+  it('replays after local source deletion and rejects changed inline content without touching a newer version', async () => {
+    const f = await setup()
+    const workspace = join(f.storageRoot, 'workspace')
+    await mkdir(workspace)
+    const env = await f.environment({ allowedImportRoots: [workspace], workspaceCwd: workspace })
+    const path = join(workspace, 'report.txt')
+    await writeFile(path, 'local')
+    const input = { filename: 'report.txt', source: { kind: 'localPath' as const, path } }
+    const first = await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, input, {
+      requestId: 'local'
+    })
+    await rm(path)
+    expect(
+      await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, input, {
+        requestId: 'local'
+      })
+    ).toEqual(first)
+    const inline = { filename: 'same.txt', content: 'original' }
+    const original = await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, inline, {
+      requestId: 'inline'
+    })
+    const newer = await writeArtifactFileForCurrentRun(
+      f.compatibilityRepository,
+      env,
+      { ...inline, content: 'newer' },
+      { requestId: 'newer' }
+    )
+    await expect(
+      writeArtifactFileForCurrentRun(
+        f.compatibilityRepository,
+        env,
+        { ...inline, content: 'conflict' },
+        { requestId: 'inline' }
+      )
+    ).rejects.toThrow(/reused/)
+    expect(
+      await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, inline, {
+        requestId: 'inline'
+      })
+    ).toEqual(original)
+    expect(await readFile(newer.path, 'utf8')).toBe('newer')
+    expect(await f.client.artifactVersion.count()).toBe(3)
+  })
+
+  it('cancels queued work promptly, drains accepted saves, and serializes another repository instance', async () => {
+    const f = await setup()
+    const env = await f.environment()
+    const entered = deferred()
+    const proceed = deferred()
+    const reserve = ArtifactWriteBudgetOwner.prototype.reserve
+    let reservations = 0
+    vi.spyOn(ArtifactWriteBudgetOwner.prototype, 'reserve').mockImplementation(async function (
+      this: ArtifactWriteBudgetOwner,
+      request
+    ) {
+      reservations++
+      if (reservations === 1) {
+        entered.resolve()
+        await proceed.promise
+      }
+      return reserve.call(this, request)
+    })
+    const first = writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'first.txt',
+      content: 'first'
+    })
+    await entered.promise
+    const queuedEntered = deferred()
+    const save = f.repository.saveVersion.bind(f.repository)
+    vi.spyOn(f.repository, 'saveVersion').mockImplementation((request, scope, signal) => {
+      const result = save(request, scope, signal)
+      if (request.filename === 'cancel.txt') queuedEntered.resolve()
+      return result
+    })
+    const controller = new AbortController()
+    const queued = writeArtifactFileForCurrentRun(
+      f.compatibilityRepository,
+      env,
+      { filename: 'cancel.txt', content: 'cancel' },
+      { signal: controller.signal }
+    )
+    const cancelled = expect(queued).rejects.toThrow()
+    await queuedEntered.promise
+    controller.abort()
+    await cancelled
+    await expect(queued).rejects.toThrow()
+    const other = new ArtifactProvenanceRepository(f.repositoryOptions)
+    const app = other.writeAppGeneratedVersion({
+      ...f.binding,
+      messageBranchAncestry: undefined,
+      messageAncestry: undefined,
+      filename: 'app.txt',
+      content: 'app'
+    })
+    const context = JSON.parse(await readFile(env.currentRunFile, 'utf8'))
+    let drained = false
+    const drain = f.server.revokeArtifactRunCapability(context.rpcCapabilityToken).then(() => {
+      drained = true
+    })
+    await Promise.resolve()
+    expect(drained).toBe(false)
+    expect(reservations).toBe(1)
+    proceed.resolve()
+    await Promise.all([first, app, drain])
+    expect(reservations).toBe(2)
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+        filename: 'late.txt',
+        content: 'late'
+      })
+    ).rejects.toThrow(/Invalid/)
+    expect(await f.client.artifactVersion.count()).toBe(2)
+  })
+  it('restores an overwritten file and metadata on pre-commit failure before the next budget check', async () => {
+    const f = await setup()
+    const env = await f.environment()
+    const first = await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'same.txt',
+      content: 'old content'
+    })
+    const pending = join(
+      f.storageRoot,
+      'artifacts/project-1/artifact-session-1/.pending/artifact-run-1/same.txt'
+    )
+    const before = await readFile(pending)
+    const sync = defaultArtifactDurability.syncFile
+    let fail = true
+    vi.spyOn(defaultArtifactDurability, 'syncFile').mockImplementation(async (path) => {
+      if (fail && path.includes('.staging') && path.endsWith('content')) {
+        fail = false
+        throw new Error('injected pre-commit failure')
+      }
+      return sync(path)
+    })
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+        filename: 'same.txt',
+        content: 'x'
+      })
+    ).rejects.toThrow('injected')
+    expect(await readFile(pending)).toEqual(before)
+    expect(
+      (
+        await f.compatibilityRepository.listPendingRunFiles({
+          projectId: 'project-1',
+          sessionId: 'artifact-session-1',
+          runId: 'artifact-run-1'
+        })
+      )[0]
+    ).toMatchObject({ versionId: first.versionId })
+    await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'next.txt',
+      content: 'next'
+    })
+    expect(await f.client.artifactVersion.count()).toBe(2)
+  })
+
+  it('cancels an active bounded copy, rolls back, and lets the following save execute', async () => {
+    const f = await setup()
+    const workspace = join(f.storageRoot, 'workspace')
+    await mkdir(workspace)
+    await writeFile(join(workspace, 'source.txt'), 'bounded source')
+    const env = await f.environment({ allowedImportRoots: [workspace], workspaceCwd: workspace })
+    const entered = deferred()
+    const release = deferred()
+    const aborted = deferred()
+    const controller = new AbortController()
+    const copy = boundedIo.copyOpenFileWithinBudget
+    vi.spyOn(boundedIo, 'copyOpenFileWithinBudget').mockImplementationOnce(async (...args) => {
+      args[3]!.addEventListener('abort', () => aborted.resolve(), { once: true })
+      entered.resolve()
+      await release.promise
+      return copy(...args)
+    })
+    const context = JSON.parse(await readFile(env.currentRunFile, 'utf8'))
+    const save = writeArtifactFileForCurrentRun(
+      f.compatibilityRepository,
+      env,
+      { filename: 'copy.txt', source: { kind: 'localPath', path: 'source.txt' } },
+      { signal: controller.signal }
+    )
+    await entered.promise
+    const rejected = expect(save).rejects.toThrow()
+    controller.abort()
+    await aborted.promise
+    release.resolve()
+    await rejected
+    await f.server.revokeArtifactRunCapability(context.rpcCapabilityToken)
+    expect(await f.client.artifactVersion.count()).toBe(0)
+    expect(
+      await f.compatibilityRepository.listPendingRunFiles({
+        projectId: context.projectId,
+        sessionId: context.artifactStorageSessionId,
+        runId: context.artifactRunId
+      })
+    ).toEqual([])
+    const newEnv = await f.environment()
+    // ensureStarted rotates transport after close, so use the new live endpoint.
+    const connection = await f.server.ensureStarted()
+    await writeArtifactFileForCurrentRun(
+      f.compatibilityRepository,
+      { ...newEnv, rpcEndpoint: connection.endpoint },
+      { filename: 'after.txt', content: 'after' }
+    )
+  })
+
+  it('preserves durable staging bytes after cancellation and recovers the original operation', async () => {
+    const f = await setup()
+    const env = await f.environment()
+    const controller = new AbortController()
+    const save = f.repository.saveVersion.bind(f.repository)
+    vi.spyOn(f.repository, 'saveVersion').mockImplementationOnce((request, scope, signal) =>
+      save(request, scope, AbortSignal.any([controller.signal, ...(signal ? [signal] : [])]))
+    )
+    const sync = defaultArtifactDurability.syncFile
+    let fail = true
+    vi.spyOn(defaultArtifactDurability, 'syncFile').mockImplementation(async (path) => {
+      await sync(path)
+      if (fail && path.includes('.staging') && path.endsWith('evidence.json')) {
+        fail = false
+        controller.abort(new Error('cancel at durable staging'))
+      }
+    })
+    const input = { filename: 'staged.txt', content: 'recoverable' }
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, input, {
+        requestId: 'staging'
+      })
+    ).rejects.toThrow(/aborted/)
+    expect(await f.client.artifactVersion.findFirst()).toMatchObject({ state: 'staging' })
+    const restored = new ArtifactProvenanceRepository(f.repositoryOptions)
+    await restored.reconcileSession('project-1', 'session-1')
+    const replay = await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, input, {
+      requestId: 'staging'
+    })
+    expect(await readFile(replay.path, 'utf8')).toBe('recoverable')
+    expect(await f.client.artifactVersion.count()).toBe(1)
+  })
+
+  it('rejects the seventeenth accepted session request and recovers admission after queued cancellations', async () => {
+    const f = await setup()
+    const env = await f.environment()
+    const context = JSON.parse(await readFile(env.currentRunFile, 'utf8'))
+    const entered = deferred()
+    const release = deferred()
+    const allEntered = deferred()
+    const reserve = ArtifactWriteBudgetOwner.prototype.reserve
+    vi.spyOn(ArtifactWriteBudgetOwner.prototype, 'reserve').mockImplementationOnce(async function (
+      this: ArtifactWriteBudgetOwner,
+      request
+    ) {
+      entered.resolve()
+      await release.promise
+      return reserve.call(this, request)
+    })
+    let count = 0
+    const save = f.repository.saveVersion.bind(f.repository)
+    vi.spyOn(f.repository, 'saveVersion').mockImplementation((...args) => {
+      const result = save(...args)
+      if (++count === 16) allEntered.resolve()
+      return result
+    })
+    const first = writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'first.txt',
+      content: 'first'
+    })
+    await entered.promise
+    const aborts = Array.from({ length: 15 }, () => new AbortController())
+    const queued = aborts.map((abort, i) =>
+      writeArtifactFileForCurrentRun(
+        f.compatibilityRepository,
+        env,
+        { filename: `queue-${i}.txt`, content: 'queued' },
+        { signal: abort.signal }
+      ).catch((error) => error)
+    )
+    await allEntered.promise
+    const response = await fetch(env.rpcEndpoint!, {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${context.rpcCapabilityToken}`,
+        'content-type': 'application/json'
+      },
+      body: JSON.stringify({ method: 'artifactSaveVersion', params: {} })
+    })
+    expect(response.status).toBe(429)
+    expect(await response.text()).toContain('ARTIFACT_SAVE_RESOURCE_LIMIT')
+    aborts.forEach((abort) => abort.abort())
+    await Promise.all(queued)
+    release.resolve()
+    await first
+    await f.server.revokeArtifactRunCapability(context.rpcCapabilityToken)
+    const fresh = await f.environment()
+    await writeArtifactFileForCurrentRun(f.compatibilityRepository, fresh, {
+      filename: 'reclaimed.txt',
+      content: 'ok'
+    })
+    expect(await f.client.artifactVersion.count()).toBe(2)
+  })
+
+  it('resolves prepared literature in main, checks its digest, and gives explicit literature precedence', async () => {
+    const f = await setup()
+    const workspace = join(f.storageRoot, 'workspace')
+    await mkdir(workspace)
+    const env = await f.environment({ allowedImportRoots: [workspace], workspaceCwd: workspace })
+    await f.client.literatureItem.create({
+      data: { id: 'paper', title: 'A cited paper', itemType: 'journalArticle' }
+    })
+    const bytes = Buffer.from(zipSync({ 'main.tex': strToU8('Scientific report') }))
+    const path = join(workspace, 'report.zip')
+    await writeFile(path, bytes)
+    const literature = {
+      styleId: 'apa',
+      locale: 'en-US',
+      citations: [{ citationId: 'cite-1', itemId: 'paper' }]
+    }
+    const sidecar = {
+      schemaVersion: 1,
+      contentChecksum: createHash('sha256').update(bytes).digest('hex'),
+      literature
+    }
+    await writeFile(path + ARTIFACT_LITERATURE_SIDECAR_SUFFIX, JSON.stringify(sidecar))
+    const input = { filename: 'report.zip', source: { kind: 'localPath' as const, path } }
+    const result = await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, input)
+    const row = await f.client.artifactVersion.findUniqueOrThrow({
+      where: { id: result.versionId },
+      include: { literatureManifest: true }
+    })
+    expect(row.literatureManifest?.manifestJson).toContain('A cited paper')
+    await writeFile(
+      path + ARTIFACT_LITERATURE_SIDECAR_SUFFIX,
+      JSON.stringify({ ...sidecar, contentChecksum: '0'.repeat(64) })
+    )
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, input)
+    ).rejects.toThrow('Prepared citation metadata does not match')
+    await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, { ...input, literature })
+    expect(await f.client.artifactVersion.count()).toBe(2)
+  })
+
+  it('rejects oversized prepared sidecars before pending mutation and leaves the next save usable', async () => {
+    const f = await setup()
+    const workspace = join(f.storageRoot, 'workspace')
+    await mkdir(workspace)
+    const env = await f.environment({ allowedImportRoots: [workspace], workspaceCwd: workspace })
+    const path = join(workspace, 'report.zip')
+    await writeFile(path, 'source')
+    const sidecar = path + ARTIFACT_LITERATURE_SIDECAR_SUFFIX
+    await writeFile(sidecar, '')
+    await truncate(sidecar, 64 * 1024 ** 2 + 1)
+    const reserve = vi.spyOn(ArtifactWriteBudgetOwner.prototype, 'reserve')
+    const pending = vi.spyOn(f.compatibilityRepository, 'withPendingFileTransaction')
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+        filename: 'report.zip',
+        source: { kind: 'localPath', path }
+      })
+    ).rejects.toThrow(/request budget exceeded/)
+    expect(reserve).not.toHaveBeenCalled()
+    expect(pending).not.toHaveBeenCalled()
+    expect(await f.client.artifactVersion.count()).toBe(0)
+    await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'after-sidecar.txt',
+      content: 'ok'
+    })
+    expect(await f.client.artifactVersion.count()).toBe(1)
+  })
+
+  it('transports 32 MiB of UTF-8 controls as base64 and preserves the existing request checksum', async () => {
+    const f = await setup()
+    const env = await f.environment()
+    const content = '\u0000'.repeat(32 * 1024 ** 2)
+    const result = await writeArtifactFileForCurrentRun(
+      f.compatibilityRepository,
+      env,
+      { filename: 'controls.bin', content },
+      { requestId: 'controls' }
+    )
+    expect(result.size).toBe(32 * 1024 ** 2)
+    const row = await f.client.artifactVersion.findUniqueOrThrow({
+      where: { id: result.versionId }
+    })
+    expect(row.writeRequestChecksum).toBe(
+      hash(
+        JSON.stringify({
+          contentChecksum: hash(content),
+          contentType: null,
+          filename: 'controls.bin',
+          producerRunId: null,
+          literature: null,
+          sourceKind: 'inline',
+          sourceFileObservation: null
+        })
+      )
+    )
+    expect(
+      await writeArtifactFileForCurrentRun(
+        f.compatibilityRepository,
+        env,
+        {
+          filename: 'controls.bin',
+          source: {
+            kind: 'inline',
+            content: Buffer.from(content).toString('base64'),
+            encoding: 'base64'
+          }
+        },
+        { requestId: 'controls' }
+      )
+    ).toEqual(result)
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+        filename: 'too-big.bin',
+        content: content + 'x'
+      })
+    ).rejects.toThrow(/budget/)
+    // The decoded content fits, but the complete request including metadata must still fit.
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+        filename: 'metadata-too-big.bin',
+        content,
+        mimeType: 'x'.repeat(22 * 1024 ** 2)
+      })
+    ).rejects.toThrow(/request.*budget/)
+    expect(await f.client.artifactVersion.count()).toBe(1)
+  })
+
+  it('rejects caller-provided roots and scope changes while another session can make progress', async () => {
+    const f = await setup()
+    const workspace = join(f.storageRoot, 'workspace')
+    await mkdir(workspace)
+    const outside = join(f.storageRoot, 'outside.txt')
+    await writeFile(outside, 'secret')
+    const env = await f.environment({ allowedImportRoots: [workspace], workspaceCwd: workspace })
+    await expect(
+      writeArtifactFileForCurrentRun(
+        f.compatibilityRepository,
+        { ...env, allowedImportRoots: [f.storageRoot] },
+        { filename: 'outside.txt', source: { kind: 'localPath', path: outside } }
+      )
+    ).rejects.toThrow(/outside allowed/)
+    const entered = deferred()
+    const release = deferred()
+    const locked = f.repository.withSessionMutation(f.binding, async () => {
+      entered.resolve()
+      await release.promise
+    })
+    await entered.promise
+    const waiting = writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'wait.txt',
+      content: 'wait'
+    })
+    const other = await f.environment(
+      { allowedImportRoots: [] },
+      {
+        appSessionId: 'other-session',
+        artifactStorageSessionId: 'other-storage',
+        artifactRunId: 'other-run'
+      }
+    )
+    const otherResult = await writeArtifactFileForCurrentRun(f.compatibilityRepository, other, {
+      filename: 'other.txt',
+      content: 'other'
+    })
+    expect(await readFile(otherResult.path, 'utf8')).toBe('other')
+    release.resolve()
+    await Promise.all([locked, waiting])
+  })
+
+  it('keeps old-run final publication ahead of new-run budget scans and retains exact message ownership', async () => {
+    const f = await setup()
+    const messages: PersistedChatSession['messages'] = [
+      {
+        id: 'prompt-1',
+        role: 'user',
+        content: 'write',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: 'message-1',
+        role: 'agent',
+        content: 'done',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ]
+    const graph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages,
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    const session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'publication',
+      cwd: f.storageRoot,
+      status: 'idle',
+      messages,
+      conversationGraph: graph,
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const context = {
+      rootFrameId: graph.rootFrameId,
+      agentFrameId: graph.activeFrameId,
+      messageBranchId: graph.branches[0].id,
+      runtimeSegmentId: graph.runtimeSegments[0].id,
+      promptMessageId: 'prompt-1'
+    }
+    const env = await f.environment({ allowedImportRoots: [] }, context)
+    const first = await writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'old.txt',
+      content: 'old version'
+    })
+    const oldVersions = [
+      first,
+      ...(await Promise.all(
+        Array.from({ length: 4 }, (_, i) =>
+          writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+            filename: `old-${i}.txt`,
+            content: `old ${i}`
+          })
+        )
+      ))
+    ]
+    const provenance = new ArtifactProvenanceRepository({
+      ...f.repositoryOptions,
+      loadSession: async () => session
+    })
+    const registry = new ArtifactRunRegistry()
+    const claimId = registry.register({
+      projectId: 'project-1',
+      sessionId: 'session-1',
+      artifactSessionId: 'artifact-session-1',
+      runId: 'artifact-run-1',
+      ...context,
+      artifactVersionIds: oldVersions.map((version) => version.versionId)
+    })
+    const handlers = createArtifactHandlers(f.compatibilityRepository, registry, { provenance })
+    const entered = deferred()
+    const release = deferred()
+    const publish = f.compatibilityRepository.finalizeRunArtifacts.bind(f.compatibilityRepository)
+    vi.spyOn(f.compatibilityRepository, 'finalizeRunArtifacts').mockImplementationOnce(
+      async (request) => {
+        entered.resolve()
+        await release.promise
+        return publish(request)
+      }
+    )
+    const finalization = handlers.finalizeRunArtifacts({ claimId, messageId: 'message-1' })
+    await entered.promise
+    const nextEntered = deferred()
+    let budgetStarted = false
+    const reserve = ArtifactWriteBudgetOwner.prototype.reserve
+    vi.spyOn(ArtifactWriteBudgetOwner.prototype, 'reserve').mockImplementation(async function (
+      this: ArtifactWriteBudgetOwner,
+      request
+    ) {
+      budgetStarted = true
+      return reserve.call(this, request)
+    })
+    const save = f.repository.saveVersion.bind(f.repository)
+    vi.spyOn(f.repository, 'saveVersion').mockImplementation((...args) => {
+      const result = save(...args)
+      nextEntered.resolve()
+      return result
+    })
+    const nextEnv = await f.environment(
+      { allowedImportRoots: [] },
+      { ...context, artifactRunId: 'next-run' }
+    )
+    const next = writeArtifactFileForCurrentRun(f.compatibilityRepository, nextEnv, {
+      filename: 'new.txt',
+      content: 'new version'
+    })
+    await nextEntered.promise
+    expect(budgetStarted).toBe(false)
+    release.resolve()
+    await Promise.all([finalization, next])
+    expect(budgetStarted).toBe(true)
+    expect(await f.client.artifactVersion.count({ where: { messageId: 'message-1' } })).toBe(5)
+    expect(
+      await f.client.artifactVersion.findUniqueOrThrow({ where: { id: first.versionId } })
+    ).toMatchObject({ state: 'finalized', messageId: 'message-1' })
+    expect(
+      await readFile(join(f.storageRoot, 'artifacts/project-1/session-1/message-1/old.txt'), 'utf8')
+    ).toBe('old version')
+    expect(
+      (await f.client.artifactVersion.findMany({ where: { artifactRunId: 'next-run' } }))[0]
+    ).toMatchObject({ state: 'pending', messageId: null })
+  })
+
+  it('keeps case and Unicode normalized names in one lineage under concurrent saves', async () => {
+    const f = await setup()
+    const env = await f.environment()
+    const results = await Promise.all(
+      ['Caf\u00e9.txt', 'cafe\u0301.TXT'].map((filename, i) =>
+        writeArtifactFileForCurrentRun(
+          f.compatibilityRepository,
+          env,
+          { filename, content: `version ${i}` },
+          { requestId: i }
+        )
+      )
+    )
+    expect(new Set(results.map((result) => result.artifactId)).size).toBe(1)
+    expect(results.map((result) => result.versionNumber).sort()).toEqual([1, 2])
+    expect(await readFile(results[0].path, 'utf8')).toBe('version 0')
+    expect(await readFile(results[1].path, 'utf8')).toBe('version 1')
+  })
+  it('uses the captured run source scope even when current-run changes while queued', async () => {
+    const f = await setup()
+    const originalRoot = join(f.storageRoot, 'original')
+    const replacementRoot = join(f.storageRoot, 'replacement')
+    await Promise.all([mkdir(originalRoot), mkdir(replacementRoot)])
+    await writeFile(join(originalRoot, 'source.txt'), 'original source')
+    await writeFile(join(replacementRoot, 'source.txt'), 'replacement source')
+    const env = await f.environment({
+      allowedImportRoots: [originalRoot],
+      workspaceCwd: originalRoot
+    })
+    const entered = deferred()
+    const release = deferred()
+    const accepted = deferred()
+    const lock = f.repository.withSessionMutation(f.binding, async () => {
+      entered.resolve()
+      await release.promise
+    })
+    await entered.promise
+    const save = f.repository.saveVersion.bind(f.repository)
+    vi.spyOn(f.repository, 'saveVersion').mockImplementationOnce((...args) => {
+      const result = save(...args)
+      accepted.resolve()
+      return result
+    })
+    const waiting = writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+      filename: 'output.txt',
+      source: { kind: 'localPath', path: 'source.txt' }
+    })
+    await accepted.promise
+    const replacement = await f.environment(
+      { allowedImportRoots: [replacementRoot], workspaceCwd: replacementRoot },
+      { artifactRunId: 'replacement-run' }
+    )
+    await writeFile(env.currentRunFile, await readFile(replacement.currentRunFile))
+    release.resolve()
+    await lock
+    const result = await waiting
+    expect(result.runId).toBe('artifact-run-1')
+    expect(await readFile(result.path, 'utf8')).toBe('original source')
+  })
+  it('enforces turn and session budgets for first-attempt concurrent saves without leaking reservations', async () => {
+    const f = await setup()
+    const bounded = new ArtifactProvenanceRepository({
+      ...f.repositoryOptions,
+      resourceBudgets: { artifactTurnBytes: 8, artifactSessionBytes: 12 }
+    })
+    vi.spyOn(f.repository, 'saveVersion').mockImplementation((...args) =>
+      bounded.saveVersion(...args)
+    )
+    const env = await f.environment()
+    const result = await Promise.allSettled(
+      ['aaaaaa', 'bbbbbb'].map((content, i) =>
+        writeArtifactFileForCurrentRun(f.compatibilityRepository, env, {
+          filename: `bounded-${i}.txt`,
+          content
+        })
+      )
+    )
+    expect(result.filter((item) => item.status === 'fulfilled')).toHaveLength(1)
+    expect(result.filter((item) => item.status === 'rejected')).toEqual([
+      expect.objectContaining({
+        reason: expect.objectContaining({
+          message: expect.stringContaining('turn budget exceeded')
+        })
+      })
+    ])
+    const next = await f.environment(
+      { allowedImportRoots: [] },
+      { artifactRunId: 'next-budget-run' }
+    )
+    await writeArtifactFileForCurrentRun(f.compatibilityRepository, next, {
+      filename: 'next.txt',
+      content: 'cccccc'
+    })
+    const last = await f.environment(
+      { allowedImportRoots: [] },
+      { artifactRunId: 'last-budget-run' }
+    )
+    await expect(
+      writeArtifactFileForCurrentRun(f.compatibilityRepository, last, {
+        filename: 'over.txt',
+        content: 'd'
+      })
+    ).rejects.toThrow('session budget exceeded')
+    expect(await f.client.artifactVersion.count()).toBe(2)
+  })
+})

--- a/src/main/artifacts/ipc.ts
+++ b/src/main/artifacts/ipc.ts
@@ -122,7 +122,8 @@ type ArtifactHandlerDependencies = {
     | 'getVersionMessages'
     | 'getVersionReview'
     | 'resolveVersionDescriptors'
-  >
+  > &
+    Partial<Pick<ArtifactProvenanceRepository, 'withSessionMutation'>>
   codeReconstruction?: {
     get(request: GetArtifactCodeReconstructionRequest): Promise<ArtifactCodeReconstructionState>
     generate(
@@ -189,13 +190,21 @@ const createArtifactHandlers = (
       ),
     reconcilePendingArtifacts: (request) =>
       withDataRootWrite(async () => {
-        const reconcileCompatibility = (pendingPaths: string[]): Promise<ArtifactFile[]> =>
-          repository.reconcilePendingArtifactPaths({
-            projectId: resolveProjectId(request),
-            sessionId: request.sessionId,
-            messageId: request.messageId,
-            pendingPaths
-          })
+        const reconcileCompatibility = (pendingPaths: string[]): Promise<ArtifactFile[]> => {
+          const reconcile = (): Promise<ArtifactFile[]> =>
+            repository.reconcilePendingArtifactPaths({
+              projectId: resolveProjectId(request),
+              sessionId: request.sessionId,
+              messageId: request.messageId,
+              pendingPaths
+            })
+          return dependencies.provenance?.withSessionMutation
+            ? dependencies.provenance.withSessionMutation(
+                { projectId: resolveProjectId(request), appSessionId: request.sessionId },
+                reconcile
+              )
+            : reconcile()
+        }
         if (dependencies.recoverPendingArtifacts) {
           const recovered = await dependencies.recoverPendingArtifacts(request)
           if (recovered) {
@@ -349,10 +358,28 @@ const finalizeRunArtifacts = async (
   provenance?: Pick<
     ArtifactProvenanceRepository,
     'finalizeRun' | 'activateFinalizedRun' | 'listRunVersions'
-  >,
+  > &
+    Partial<Pick<ArtifactProvenanceRepository, 'withSessionMutation'>>,
   logger: Pick<Logger, 'error'> = log
 ): Promise<ArtifactFile[]> => {
   const claim = runRegistry.resolve(request.claimId)
+  if (provenance?.withSessionMutation) {
+    return provenance.withSessionMutation(
+      { projectId: claim.projectId, appSessionId: claim.sessionId },
+      () =>
+        finalizeRunArtifacts(
+          repository,
+          runRegistry,
+          request,
+          {
+            finalizeRun: provenance.finalizeRun.bind(provenance),
+            activateFinalizedRun: provenance.activateFinalizedRun.bind(provenance),
+            listRunVersions: provenance.listRunVersions.bind(provenance)
+          },
+          logger
+        )
+    )
+  }
 
   if (claim.finalizedMessageId) {
     // A retry for the same message should return the final list; a different message is a bug.

--- a/src/main/artifacts/mcp-server.test.ts
+++ b/src/main/artifacts/mcp-server.test.ts
@@ -1,9 +1,6 @@
-import { mkdir, mkdtemp, readFile, realpath, rm, stat, writeFile } from 'node:fs/promises'
-import { createHash } from 'node:crypto'
+import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { tmpdir } from 'node:os'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { strToU8, zipSync } from 'fflate'
 import { z } from 'zod'
 
 const { log } = vi.hoisted(() => ({
@@ -15,22 +12,25 @@ vi.mock('../logger', async (importOriginal) => ({
   createLogger: () => log
 }))
 
-import { createPngBytes, createPngInlineSource } from './artifact-test-fixtures'
-import { ARTIFACT_LITERATURE_SIDECAR_SUFFIX } from '../../shared/artifact-literature'
+import { createPngBytes } from './artifact-test-fixtures'
 import { ArtifactRepository } from './repository'
 import {
   createArtifactMcpEnvironmentFromProcess,
   createArtifactMcpServerConfig,
   toWriteArtifactToolResult,
   writeArtifactFileToolDefinition,
-  writeArtifactFileForCurrentRun,
+  writeArtifactFileForCurrentRun as saveThroughMcp,
   type ArtifactMcpEnvironment
 } from './mcp-server'
 
+import { createArtifactSaveFixture } from './save-test-fixtures'
+
+let activeFixture: Awaited<ReturnType<typeof createArtifactSaveFixture>> | undefined
 let storageRoot: string | undefined
 
 const createStorageRoot = async (): Promise<string> => {
-  storageRoot = await mkdtemp(join(tmpdir(), 'open-science-artifact-mcp-'))
+  activeFixture = await createArtifactSaveFixture()
+  storageRoot = activeFixture.storageRoot
   return storageRoot
 }
 
@@ -51,9 +51,48 @@ const createEnvironment = async (
   }
 }
 
+const writeArtifactFileForCurrentRun: typeof saveThroughMcp = async (
+  repository,
+  env,
+  input,
+  invocation
+) => {
+  const context = JSON.parse(await readFile(env.currentRunFile, 'utf8'))
+  const run = context.artifactRunId ?? context.runId
+  if (!run) return saveThroughMcp(repository, env, input, invocation)
+  const binding = {
+    ...activeFixture!.binding,
+    projectId: env.projectId!,
+    artifactRunId: run,
+    artifactStorageSessionId: context.artifactStorageSessionId ?? env.sessionId,
+    sourceScope: {
+      allowedImportRoots: [
+        ...env.allowedImportRoots,
+        ...(context.notebookSessionRoot ? [context.notebookSessionRoot] : [])
+      ],
+      workspaceCwd: env.allowedImportRoots[0],
+      notebookDataDir: context.notebookDataDir,
+      notebookSessionRoot: context.notebookSessionRoot
+    }
+  }
+  const token = activeFixture!.server.issueArtifactRunCapability(binding)
+  await writeFile(
+    env.currentRunFile,
+    JSON.stringify({ ...context, ...binding, rpcCapabilityToken: token })
+  )
+  return saveThroughMcp(
+    repository,
+    { ...env, rpcEndpoint: activeFixture!.connection.endpoint },
+    input,
+    invocation
+  )
+}
+
 afterEach(async () => {
   vi.restoreAllMocks()
   vi.unstubAllGlobals()
+  await activeFixture?.dispose()
+  activeFixture = undefined
   if (storageRoot) {
     await rm(storageRoot, { recursive: true, force: true })
     storageRoot = undefined
@@ -97,33 +136,15 @@ describe('artifact MCP server', () => {
     })
 
     expect(artifact).toMatchObject({
-      id: 'session-1:run-1:plot.svg',
+      versionId: expect.any(String),
       projectId: 'default-project',
       sessionId: 'session-1',
       runId: 'run-1',
       name: 'plot.svg',
       mimeType: 'image/svg+xml'
     })
-    expect(artifact.path).toBe(
-      join(root, 'artifacts', 'default-project', 'session-1', '.pending', 'run-1', 'plot.svg')
-    )
     await expect(readFile(artifact.path, 'utf8')).resolves.toBe('<svg />')
-    expect(log.warn).toHaveBeenCalledWith(
-      'writing a legacy pending file without durable Provenance',
-      {
-        artifactRunId: 'run-1',
-        missingContext: [
-          'rpcEndpoint',
-          'rpcCapabilityToken',
-          'appSessionId',
-          'rootFrameId',
-          'agentFrameId',
-          'messageBranchId',
-          'runtimeSegmentId',
-          'promptMessageId'
-        ]
-      }
-    )
+    expect(log.warn).not.toHaveBeenCalled()
   })
 
   it('writes localPath artifact sources for the current run', async () => {
@@ -528,340 +549,6 @@ describe('artifact MCP server', () => {
     await expect(readFile(artifact.path, 'utf8')).resolves.toBe('a,b\n1,2\n')
   })
 
-  it('publishes a stable Version receipt through the main-process Provenance RPC', async () => {
-    const root = await createStorageRoot()
-    const repository = new ArtifactRepository(root)
-    const environment = {
-      ...(await createEnvironment(root, {
-        artifactRunId: 'artifact-run-1',
-        appSessionId: 'session-1',
-        rootFrameId: 'root-frame-1',
-        agentFrameId: 'root-frame-1',
-        messageBranchId: 'branch-1',
-        messageBranchAncestry: ['branch-parent', 'branch-1'],
-        messageAncestry: ['message-user-parent', 'message-user-1'],
-        runtimeSegmentId: 'runtime-1',
-        promptMessageId: 'message-user-1',
-        agentName: 'Codex',
-        notebookSessionId: 'session-1',
-        rpcCapabilityToken: 'run-capability'
-      })),
-      rpcEndpoint: 'http://127.0.0.1:9000'
-    }
-    const persisted = {
-      id: 'version-1',
-      artifactId: 'artifact-1',
-      versionId: 'version-1',
-      versionNumber: 1,
-      checksum: 'a'.repeat(64),
-      createdAt: '2026-07-27T00:00:00.000Z',
-      producerRunId: 'notebook-run-17',
-      environment: 'analysis-python',
-      projectId: 'default-project',
-      sessionId: 'session-1',
-      runId: 'artifact-run-1',
-      name: 'sin.png',
-      path: join(root, 'immutable-content'),
-      fileUrl: 'file:///immutable-content',
-      mimeType: 'image/png',
-      size: 4,
-      mtimeMs: 1
-    }
-    const calls: Array<{ url: string; init: RequestInit }> = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (url: string, init: RequestInit) => {
-        calls.push({ url, init })
-        const body = JSON.parse(String(init.body)) as { method: string }
-        const result =
-          body.method === 'artifactReserveWrite'
-            ? { id: `reservation-${calls.length}`, fileBytes: 4, expiresAt: Date.now() + 60_000 }
-            : persisted
-        return new Response(JSON.stringify({ result }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' }
-        })
-      })
-    )
-
-    const result = await writeArtifactFileForCurrentRun(
-      repository,
-      environment,
-      {
-        filename: 'sin.png',
-        mimeType: 'image/png',
-        source: createPngInlineSource('plot'),
-        producerRunId: 'notebook-run-17',
-        literature: {
-          styleId: 'apa',
-          locale: 'en-US',
-          citations: [{ citationId: 'citation-1', itemId: 'item-1' }]
-        }
-      },
-      { requestId: 'rpc-request-42' }
-    )
-    await writeArtifactFileForCurrentRun(
-      repository,
-      environment,
-      {
-        filename: 'sin.png',
-        mimeType: 'image/png',
-        source: createPngInlineSource('plot'),
-        producerRunId: 'notebook-run-17',
-        literature: {
-          styleId: 'apa',
-          locale: 'en-US',
-          citations: [{ citationId: 'citation-1', itemId: 'item-1' }]
-        }
-      },
-      { requestId: 'rpc-request-42' }
-    )
-
-    expect(result).toEqual(persisted)
-    expect(calls).toHaveLength(4)
-    expect(calls[0].url).toBe(environment.rpcEndpoint)
-    expect(calls[0].init.headers).toMatchObject({ authorization: 'Bearer run-capability' })
-    const bodies = calls.map(
-      (call) =>
-        JSON.parse(String(call.init.body)) as {
-          method: string
-          params: Record<string, unknown>
-        }
-    )
-    expect(bodies.map((body) => body.method)).toEqual([
-      'artifactReserveWrite',
-      'artifactCreateVersion',
-      'artifactReserveWrite',
-      'artifactCreateVersion'
-    ])
-    const body = bodies[1] as {
-      method: string
-      params: Record<string, unknown>
-    }
-    expect(body.method).toBe('artifactCreateVersion')
-    expect(body.params).toMatchObject({
-      projectId: 'default-project',
-      appSessionId: 'session-1',
-      artifactStorageSessionId: 'session-1',
-      artifactRunId: 'artifact-run-1',
-      writeOperationId: expect.stringMatching(/^artifact-write-[a-f0-9]{64}$/u),
-      agentName: 'Codex',
-      messageBranchAncestry: ['branch-parent', 'branch-1'],
-      messageAncestry: ['message-user-parent', 'message-user-1'],
-      producerRunId: 'notebook-run-17',
-      notebookSessionId: 'session-1',
-      sourceKind: 'inline',
-      filename: 'sin.png',
-      contentType: 'image/png',
-      literature: {
-        styleId: 'apa',
-        locale: 'en-US',
-        citations: [{ citationId: 'citation-1', itemId: 'item-1' }]
-      }
-    })
-    const retryBody = bodies[3]!
-    expect(retryBody.params.writeOperationId).toBe(body.params.writeOperationId)
-    expect(body.params).toMatchObject({
-      resourceReservationId: 'reservation-1',
-      resourceSizeBytes: expect.any(Number),
-      resourceChecksum: expect.stringMatching(/^[a-f0-9]{64}$/u)
-    })
-    expect(body.params.writeRequestChecksum).toMatch(/^[a-f0-9]{64}$/)
-    expect(toWriteArtifactToolResult(result)).toEqual({
-      artifact: {
-        artifact_id: 'artifact-1',
-        version_id: 'version-1',
-        version_number: 1,
-        filename: 'sin.png',
-        size_bytes: 4,
-        producer_run_id: 'notebook-run-17'
-      }
-    })
-    expect(JSON.stringify(toWriteArtifactToolResult(result))).not.toContain(root)
-    expect(JSON.stringify(toWriteArtifactToolResult(result))).not.toContain('checksum')
-    expect(JSON.stringify(toWriteArtifactToolResult(result))).not.toContain('environment')
-  })
-
-  it('discovers checksum-bound citation metadata beside a prepared LaTeX ZIP', async () => {
-    const root = await createStorageRoot()
-    const workspace = join(root, 'workspace')
-    await mkdir(workspace)
-    const sourcePath = join(workspace, 'review.latex.zip')
-    const content = Buffer.from(
-      zipSync({
-        '[Content_Types].xml': strToU8('<Types/>'),
-        'word/document.xml': strToU8('<w:document/>')
-      })
-    )
-    await writeFile(sourcePath, content)
-    await writeFile(
-      `${sourcePath}${ARTIFACT_LITERATURE_SIDECAR_SUFFIX}`,
-      JSON.stringify({
-        schemaVersion: 1,
-        contentChecksum: createHash('sha256').update(content).digest('hex'),
-        literature: {
-          styleId: 'apa',
-          locale: 'en-US',
-          citations: [{ citationId: 'open-science-1', itemId: 'item-1' }]
-        }
-      })
-    )
-    const repository = new ArtifactRepository(root)
-    const environment = {
-      ...(await createEnvironment(root, {
-        artifactRunId: 'artifact-run-1',
-        appSessionId: 'session-1',
-        rootFrameId: 'root-frame-1',
-        agentFrameId: 'root-frame-1',
-        messageBranchId: 'branch-1',
-        runtimeSegmentId: 'runtime-1',
-        promptMessageId: 'message-user-1',
-        rpcCapabilityToken: 'run-capability'
-      })),
-      allowedImportRoots: [workspace],
-      rpcEndpoint: 'http://127.0.0.1:9000'
-    }
-    const requests: Array<{ method: string; params: Record<string, unknown> }> = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: RequestInit) => {
-        const request = JSON.parse(String(init.body)) as {
-          method: string
-          params: Record<string, unknown>
-        }
-        requests.push(request)
-        const result =
-          request.method === 'artifactReplayVersion'
-            ? null
-            : request.method === 'artifactReserveWrite'
-              ? { id: 'reservation-1', fileBytes: content.length, expiresAt: Date.now() + 60_000 }
-              : {
-                  id: 'version-1',
-                  artifactId: 'artifact-1',
-                  versionId: 'version-1',
-                  versionNumber: 1,
-                  checksum: 'a'.repeat(64),
-                  createdAt: '2026-09-03T00:00:00.000Z',
-                  projectId: 'default-project',
-                  sessionId: 'session-1',
-                  runId: 'artifact-run-1',
-                  name: 'review.docx',
-                  path: join(root, 'immutable-content'),
-                  fileUrl: 'file:///immutable-content',
-                  size: content.length,
-                  mtimeMs: 1
-                }
-        return new Response(JSON.stringify({ result }), { status: 200 })
-      })
-    )
-
-    await writeArtifactFileForCurrentRun(repository, environment, {
-      filename: 'review.zip',
-      mimeType: 'application/zip',
-      source: { kind: 'localPath', path: sourcePath }
-    })
-
-    expect(requests.map(({ method }) => method)).toEqual([
-      'artifactReplayVersion',
-      'artifactReserveWrite',
-      'artifactCreateVersion'
-    ])
-    expect(requests[2]!.params.literature).toEqual({
-      styleId: 'apa',
-      locale: 'en-US',
-      citations: [{ citationId: 'open-science-1', itemId: 'item-1' }]
-    })
-  })
-
-  it('uses the execution handoff storage Session for a delegated durable write', async () => {
-    const root = await createStorageRoot()
-    const repository = new ArtifactRepository(root)
-    const environment = {
-      ...(await createEnvironment(root, {
-        artifactRunId: 'artifact-run-delegated',
-        appSessionId: 'parent-session-1',
-        artifactStorageSessionId: 'parent-session-1',
-        rootFrameId: 'root-frame-1',
-        agentFrameId: 'child-frame-1',
-        messageBranchId: 'child-branch-1',
-        runtimeSegmentId: 'child-runtime-1',
-        promptMessageId: 'child-prompt-1',
-        rpcCapabilityToken: 'delegated-run-capability'
-      })),
-      sessionId: 'child-routing-session',
-      rpcEndpoint: 'http://127.0.0.1:9000'
-    }
-    const rpcRequests: Record<string, unknown>[] = []
-    const pendingSessionsObserved: string[] = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: RequestInit) => {
-        const body = JSON.parse(String(init.body)) as {
-          method: string
-          params: Record<string, unknown>
-        }
-        rpcRequests.push({ method: body.method, ...body.params })
-        for (const sessionId of ['parent-session-1', 'child-routing-session']) {
-          const pendingPath = join(
-            root,
-            'artifacts',
-            'default-project',
-            sessionId,
-            '.pending',
-            'artifact-run-delegated',
-            'delegated.txt'
-          )
-          if (
-            await stat(pendingPath)
-              .then(() => true)
-              .catch(() => false)
-          ) {
-            pendingSessionsObserved.push(sessionId)
-          }
-        }
-        const result =
-          body.method === 'artifactReserveWrite'
-            ? { id: 'reservation-delegated', fileBytes: 17, expiresAt: Date.now() + 60_000 }
-            : {
-                id: 'version-delegated',
-                artifactId: 'artifact-delegated',
-                versionId: 'version-delegated',
-                versionNumber: 1,
-                checksum: 'b'.repeat(64),
-                createdAt: '2026-08-07T00:00:00.000Z',
-                projectId: 'default-project',
-                sessionId: 'parent-session-1',
-                runId: 'artifact-run-delegated',
-                name: 'delegated.txt',
-                path: join(root, 'immutable-delegated'),
-                fileUrl: 'file:///immutable-delegated',
-                size: 17,
-                mtimeMs: 1
-              }
-        return new Response(JSON.stringify({ result }), { status: 200 })
-      })
-    )
-
-    const result = await writeArtifactFileForCurrentRun(repository, environment, {
-      filename: 'delegated.txt',
-      source: { kind: 'inline', content: 'delegated content', encoding: 'utf8' }
-    })
-
-    expect(result).toMatchObject({ sessionId: 'parent-session-1' })
-    expect(pendingSessionsObserved).toEqual(['parent-session-1'])
-    expect(rpcRequests).toHaveLength(2)
-    expect(rpcRequests).toEqual([
-      expect.objectContaining({
-        method: 'artifactReserveWrite',
-        artifactStorageSessionId: 'parent-session-1'
-      }),
-      expect.objectContaining({
-        method: 'artifactCreateVersion',
-        artifactStorageSessionId: 'parent-session-1'
-      })
-    ])
-  })
-
   it('returns a compact legacy artifact receipt without echoing local paths', () => {
     const result = toWriteArtifactToolResult({
       id: 'legacy-artifact-1',
@@ -886,200 +573,5 @@ describe('artifact MCP server', () => {
       }
     })
     expect(JSON.stringify(result)).not.toContain('/private/session')
-  })
-
-  it('restores the previous pending file when a durable Version RPC rejects the write', async () => {
-    const root = await createStorageRoot()
-    const repository = new ArtifactRepository(root)
-    const environment = {
-      ...(await createEnvironment(root, {
-        artifactRunId: 'artifact-run-1',
-        appSessionId: 'session-1',
-        rootFrameId: 'root-frame-1',
-        agentFrameId: 'root-frame-1',
-        messageBranchId: 'branch-1',
-        runtimeSegmentId: 'runtime-1',
-        promptMessageId: 'message-user-1',
-        rpcCapabilityToken: 'run-capability'
-      })),
-      rpcEndpoint: 'http://127.0.0.1:9000'
-    }
-    const pendingPath = join(
-      root,
-      'artifacts',
-      'default-project',
-      'session-1',
-      '.pending',
-      'artifact-run-1',
-      'sin.png'
-    )
-    let createCallCount = 0
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: RequestInit) => {
-        const body = JSON.parse(String(init.body)) as { method: string }
-        if (body.method === 'artifactReserveWrite') {
-          return new Response(
-            JSON.stringify({
-              result: {
-                id: `reservation-${createCallCount + 1}`,
-                fileBytes: 8,
-                expiresAt: Date.now() + 60_000
-              }
-            }),
-            { status: 200 }
-          )
-        }
-        if (body.method === 'artifactReleaseWrite') {
-          return new Response(JSON.stringify({ result: null }), { status: 200 })
-        }
-        createCallCount += 1
-        if (createCallCount === 2) {
-          return new Response(JSON.stringify({ error: 'idempotency conflict' }), { status: 409 })
-        }
-        return new Response(
-          JSON.stringify({
-            result: {
-              id: 'version-1',
-              artifactId: 'artifact-1',
-              versionId: 'version-1',
-              versionNumber: 1,
-              checksum: 'a'.repeat(64),
-              createdAt: '2026-07-27T00:00:00.000Z',
-              projectId: 'default-project',
-              sessionId: 'session-1',
-              runId: 'artifact-run-1',
-              name: 'sin.png',
-              path: join(root, 'immutable-content'),
-              fileUrl: 'file:///immutable-content',
-              size: 8,
-              mtimeMs: 1
-            }
-          }),
-          { status: 200 }
-        )
-      })
-    )
-
-    await writeArtifactFileForCurrentRun(
-      repository,
-      environment,
-      { filename: 'sin.png', source: createPngInlineSource('original') },
-      { requestId: 'same-operation' }
-    )
-    await expect(
-      writeArtifactFileForCurrentRun(
-        repository,
-        environment,
-        { filename: 'sin.png', source: createPngInlineSource('conflicting replacement') },
-        { requestId: 'same-operation' }
-      )
-    ).rejects.toThrow('idempotency conflict')
-
-    await expect(readFile(pendingPath)).resolves.toEqual(createPngBytes('original'))
-  })
-
-  it('replays a localPath Version before reading a source file that no longer exists', async () => {
-    const root = await createStorageRoot()
-    const sourceRoot = join(root, 'notebook-session')
-    const sourcePath = join(sourceRoot, 'sin.png')
-    await mkdir(sourceRoot, { recursive: true })
-    await writeFile(sourcePath, createPngBytes('plot'))
-    const sourceStat = await stat(sourcePath)
-    const resolvedSourcePath = await realpath(sourcePath)
-    const repository = new ArtifactRepository(root)
-    const environment = {
-      ...(await createEnvironment(root, {
-        artifactRunId: 'artifact-run-1',
-        appSessionId: 'session-1',
-        rootFrameId: 'root-frame-1',
-        agentFrameId: 'root-frame-1',
-        messageBranchId: 'branch-1',
-        runtimeSegmentId: 'runtime-1',
-        promptMessageId: 'message-user-1',
-        notebookSessionId: 'session-1',
-        notebookSessionRoot: sourceRoot,
-        rpcCapabilityToken: 'run-capability'
-      })),
-      allowedImportRoots: [sourceRoot],
-      rpcEndpoint: 'http://127.0.0.1:9000'
-    }
-    const persisted = {
-      id: 'version-1',
-      artifactId: 'artifact-1',
-      versionId: 'version-1',
-      versionNumber: 1,
-      checksum: 'a'.repeat(64),
-      createdAt: '2026-07-27T00:00:00.000Z',
-      producerRunId: 'notebook-run-17',
-      environment: 'analysis-python',
-      projectId: 'default-project',
-      sessionId: 'session-1',
-      runId: 'artifact-run-1',
-      name: 'sin.png',
-      path: join(root, 'immutable-content'),
-      fileUrl: 'file:///immutable-content',
-      mimeType: 'image/png',
-      size: 4,
-      mtimeMs: 1
-    }
-    const methods: string[] = []
-    const requests: Array<{ method: string; params: Record<string, unknown> }> = []
-    vi.stubGlobal(
-      'fetch',
-      vi.fn(async (_url: string, init: RequestInit) => {
-        const body = JSON.parse(String(init.body)) as {
-          method: string
-          params: Record<string, unknown>
-        }
-        requests.push(body)
-        methods.push(body.method)
-        const result =
-          body.method === 'artifactReplayVersion' && methods.length === 1
-            ? null
-            : body.method === 'artifactReserveWrite'
-              ? {
-                  id: 'reservation-local-path',
-                  fileBytes: body.params.fileBytes,
-                  expiresAt: Date.now() + 60_000
-                }
-              : persisted
-        return new Response(JSON.stringify({ result }), {
-          status: 200,
-          headers: { 'content-type': 'application/json' }
-        })
-      })
-    )
-    const input = {
-      filename: 'sin.png',
-      mimeType: 'image/png',
-      source: { kind: 'localPath' as const, path: sourcePath },
-      producerRunId: 'notebook-run-17'
-    }
-
-    await expect(
-      writeArtifactFileForCurrentRun(repository, environment, input, {
-        requestId: 'same-local-operation'
-      })
-    ).resolves.toEqual(persisted)
-    await rm(sourcePath)
-    await expect(
-      writeArtifactFileForCurrentRun(repository, environment, input, {
-        requestId: 'same-local-operation'
-      })
-    ).resolves.toEqual(persisted)
-
-    expect(methods).toEqual([
-      'artifactReplayVersion',
-      'artifactReserveWrite',
-      'artifactCreateVersion',
-      'artifactReplayVersion'
-    ])
-    expect(requests[2]?.params.sourceFileObservation).toEqual({
-      path: resolvedSourcePath,
-      sizeBytes: sourceStat.size,
-      mtimeMs: sourceStat.mtimeMs
-    })
-    expect(requests[2]?.params.sourceKind).toBe('localPath')
   })
 })

--- a/src/main/artifacts/mcp-server.ts
+++ b/src/main/artifacts/mcp-server.ts
@@ -2,7 +2,7 @@ import type { McpServerStdio } from '@agentclientprotocol/sdk'
 import { McpServer as ModelContextProtocolServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import { createHash, randomUUID } from 'node:crypto'
-import { readFile, stat } from 'node:fs/promises'
+import { readFile } from 'node:fs/promises'
 import { z } from 'zod'
 
 import type {
@@ -11,30 +11,22 @@ import type {
   ArtifactWriteSource
 } from '../../shared/artifacts'
 import type {
-  ArtifactWriteReservation,
   ArtifactVersionFile,
-  CreateArtifactVersionRequest,
-  ReleaseArtifactWriteReservationRequest,
-  ReserveArtifactWriteRequest,
-  ReplayArtifactVersionRequest
+  SaveArtifactVersionRequest
 } from '../../shared/artifact-provenance'
 import {
-  ARTIFACT_LITERATURE_SIDECAR_SUFFIX,
   artifactLiteratureRequestSchema,
-  artifactLiteratureSidecarSchema,
   type ArtifactLiteratureRequest
 } from '../../shared/artifact-literature'
 import { resolveProjectId } from '../../shared/project-scope'
 import type { ProjectIdScope } from '../../shared/project-scope'
 import { ARTIFACT_MCP_SERVER_ARG } from '../mcp-server-args'
 import { fetchLocalRpc } from '../local-rpc-transport'
-import { createLogger } from '../logger'
-import { LOCAL_RESOURCE_BUDGETS } from '../resource-budget'
+import { LOCAL_RESOURCE_BUDGETS, assertWithinResourceBudget } from '../resource-budget'
 import { ArtifactRepository } from './repository'
-import { resolveAllowedImportFilePath } from './storage-access'
+import { inlineDecodedSize } from '../bounded-file-io'
 
 const ARTIFACT_MCP_SERVER_NAME = 'open-science-artifacts'
-const log = createLogger('artifacts:mcp')
 
 type ArtifactMcpEnvironment = ProjectIdScope & {
   storageRoot: string
@@ -219,10 +211,20 @@ const readCurrentRunContext = async (currentRunFile: string): Promise<ArtifactRu
 
 type ArtifactRpcResponse<Result> = { result?: Result | null; error?: string }
 
+const serializeArtifactSaveRequest = (request: SaveArtifactVersionRequest): string => {
+  const body = JSON.stringify({ method: 'artifactSaveVersion', params: request })
+  assertWithinResourceBudget(
+    'request',
+    Buffer.byteLength(body),
+    LOCAL_RESOURCE_BUDGETS.requestBytes
+  )
+  return body
+}
+
 const callArtifactRpc = async (
   environment: ArtifactMcpEnvironment,
   capabilityToken: string,
-  request: CreateArtifactVersionRequest,
+  request: SaveArtifactVersionRequest,
   signal?: AbortSignal
 ): Promise<ArtifactVersionFile> => {
   if (!environment.rpcEndpoint) {
@@ -240,7 +242,7 @@ const callArtifactRpc = async (
         authorization: `Bearer ${capabilityToken}`,
         'content-type': 'application/json'
       },
-      body: JSON.stringify({ method: 'artifactCreateVersion', params: request }),
+      body: serializeArtifactSaveRequest(request),
       signal
     },
     'Artifact Provenance RPC'
@@ -253,97 +255,6 @@ const callArtifactRpc = async (
     )
   }
   return payload.result
-}
-
-const callArtifactReplayRpc = async (
-  environment: ArtifactMcpEnvironment,
-  capabilityToken: string,
-  request: ReplayArtifactVersionRequest,
-  signal?: AbortSignal
-): Promise<ArtifactVersionFile | undefined> => {
-  if (!environment.rpcEndpoint) {
-    throw new Error('Artifact Provenance RPC connection is not configured.')
-  }
-  const response = await fetchLocalRpc(
-    {
-      endpoint: environment.rpcEndpoint,
-      socketPath: environment.rpcSocketPath
-    },
-    {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${capabilityToken}`,
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({ method: 'artifactReplayVersion', params: request }),
-      signal
-    },
-    'Artifact Provenance RPC'
-  )
-  const payload = (await response.json()) as ArtifactRpcResponse<ArtifactVersionFile>
-  if (!response.ok || payload.error) {
-    throw new Error(
-      payload.error ?? `Artifact Provenance RPC failed with status ${response.status}`
-    )
-  }
-  return payload.result ?? undefined
-}
-
-const callArtifactReserveRpc = async (
-  environment: ArtifactMcpEnvironment,
-  capabilityToken: string,
-  request: ReserveArtifactWriteRequest,
-  signal?: AbortSignal
-): Promise<ArtifactWriteReservation> => {
-  if (!environment.rpcEndpoint) {
-    throw new Error('Artifact Provenance RPC connection is not configured.')
-  }
-  const response = await fetchLocalRpc(
-    { endpoint: environment.rpcEndpoint, socketPath: environment.rpcSocketPath },
-    {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${capabilityToken}`,
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({ method: 'artifactReserveWrite', params: request }),
-      signal
-    },
-    'Artifact write reservation RPC'
-  )
-  const payload = (await response.json()) as ArtifactRpcResponse<ArtifactWriteReservation>
-  if (!response.ok || payload.error || !payload.result) {
-    throw new Error(
-      payload.error ?? `Artifact reservation RPC failed with status ${response.status}`
-    )
-  }
-  return payload.result
-}
-
-const callArtifactReleaseRpc = async (
-  environment: ArtifactMcpEnvironment,
-  capabilityToken: string,
-  request: ReleaseArtifactWriteReservationRequest
-): Promise<void> => {
-  if (!environment.rpcEndpoint) return
-  const response = await fetchLocalRpc(
-    { endpoint: environment.rpcEndpoint, socketPath: environment.rpcSocketPath },
-    {
-      method: 'POST',
-      headers: {
-        authorization: `Bearer ${capabilityToken}`,
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({ method: 'artifactReleaseWrite', params: request })
-    },
-    'Artifact write reservation release RPC'
-  )
-  if (!response.ok) {
-    const payload = (await response.json()) as ArtifactRpcResponse<never>
-    throw new Error(
-      payload.error ?? `Artifact reservation release RPC failed with status ${response.status}`
-    )
-  }
 }
 
 // Normalizes the legacy content/encoding shape and the new source shape into one repository input.
@@ -387,55 +298,13 @@ const normalizeArtifactToolWriteInput = (
 // The kernel-relative interpretation stays first so an explicit `data/plot.png` saved by user code
 // still resolves to `<dataDir>/data/plot.png`; only a missing first candidate falls through to the
 // same current Notebook Session root, never to an unrelated workspace or process cwd.
-const isNotebookWorkingFilePath = (source: ArtifactWriteSource): boolean => {
-  if (source.kind !== 'localPath') return false
-  const segments = source.path
-    .replaceAll('\\', '/')
-    .split('/')
-    .filter((segment) => segment.length > 0 && segment !== '.')
-
-  return segments[0] === 'data' && !segments.includes('..')
-}
-
-const isMissingFileError = (error: unknown): boolean =>
-  typeof error === 'object' &&
-  error !== null &&
-  'code' in error &&
-  (error as { code?: unknown }).code === 'ENOENT'
-
-const readPreparedLiteratureSidecar = async (
-  source: ArtifactWriteSource,
-  allowedImportRoots: string[],
-  relativeBaseDirs: string[]
-): Promise<ReturnType<typeof artifactLiteratureSidecarSchema.parse> | undefined> => {
-  if (source.kind !== 'localPath' || !/\.(?:docx|zip)$/iu.test(source.path)) {
-    return undefined
-  }
-  const sourcePath = await resolveAllowedImportFilePath(
-    source.path,
-    allowedImportRoots,
-    relativeBaseDirs
-  )
-  const candidate = `${sourcePath}${ARTIFACT_LITERATURE_SIDECAR_SUFFIX}`
-  try {
-    await stat(candidate)
-  } catch (error) {
-    if (isMissingFileError(error)) return undefined
-    throw error
-  }
-  const sidecarPath = await resolveAllowedImportFilePath(candidate, allowedImportRoots)
-  return artifactLiteratureSidecarSchema.parse(
-    JSON.parse(await readFile(sidecarPath, 'utf8')) as unknown
-  )
-}
-
 // Writes one tool call into the current pending run selected by the main process.
 const writeArtifactFileForCurrentRun = async (
-  repository: ArtifactRepository,
+  _repository: ArtifactRepository,
   environment: ArtifactMcpEnvironment,
   input: ArtifactToolWriteInput,
   invocation: ArtifactWriteInvocation = {}
-): Promise<ArtifactFile | ArtifactVersionFile> => {
+): Promise<ArtifactVersionFile> => {
   const projectId = resolveProjectId(environment)
   const context = await readCurrentRunContext(environment.currentRunFile)
   const artifactStorageSessionId = context.artifactStorageSessionId ?? environment.sessionId
@@ -443,65 +312,21 @@ const writeArtifactFileForCurrentRun = async (
     input,
     Boolean(context.notebookDataDir || environment.allowedImportRoots[0])
   )
-  // Native Agent file tools keep writing to the session workspace even when Notebook is available,
-  // while Notebook code writes to the kernel cwd. Prefer the active Notebook locations, then fall
-  // back to the trusted session workspace so the Agent can pass the same relative path either tool
-  // returned instead of rediscovering its absolute path or duplicating the file as inline content.
-  const relativeBaseDirs = context.notebookDataDir
-    ? [
-        context.notebookDataDir,
-        ...(context.notebookSessionRoot && isNotebookWorkingFilePath(source)
-          ? [context.notebookSessionRoot]
-          : []),
-        ...environment.allowedImportRoots.slice(0, 1)
-      ]
-    : environment.allowedImportRoots.slice(0, 1)
-  const writeRequest = {
-    projectId,
-    sessionId: artifactStorageSessionId,
-    runId: context.artifactRunId,
-    filename: input.filename,
-    mimeType: input.mimeType,
-    source
+  if (
+    !environment.rpcEndpoint ||
+    !context.rpcCapabilityToken ||
+    !context.appSessionId ||
+    !context.rootFrameId ||
+    !context.agentFrameId ||
+    !context.messageBranchId ||
+    !context.runtimeSegmentId ||
+    !context.promptMessageId
+  ) {
+    throw new Error(
+      'Artifact save protocol requires a complete active run capability. Restart the Agent MCP connection.'
+    )
   }
-  const writeOptions = {
-    // The kernel's final session root (from the per-turn handoff) is the authoritative import root
-    // for notebook writes; add it to the static roots so a resolved relative path is accepted even
-    // when the env was built under a pre-start alias. Authorization-only: it must NOT also join
-    // relativeBaseDirs unless it is the bounded `data/...` workingFiles representation.
-    allowedImportRoots: context.notebookSessionRoot
-      ? [...environment.allowedImportRoots, context.notebookSessionRoot]
-      : environment.allowedImportRoots,
-    relativeBaseDirs,
-    signal: invocation.signal
-  }
-  // Old handoff files remain writable during migration. New production handoffs always include the
-  // graph locators and RPC capability; only that complete trusted envelope may create a durable
-  // Version in SQLite.
-  const missingProvenanceContext = [
-    !environment.rpcEndpoint ? 'rpcEndpoint' : undefined,
-    !context.rpcCapabilityToken ? 'rpcCapabilityToken' : undefined,
-    !context.appSessionId ? 'appSessionId' : undefined,
-    !context.rootFrameId ? 'rootFrameId' : undefined,
-    !context.agentFrameId ? 'agentFrameId' : undefined,
-    !context.messageBranchId ? 'messageBranchId' : undefined,
-    !context.runtimeSegmentId ? 'runtimeSegmentId' : undefined,
-    !context.promptMessageId ? 'promptMessageId' : undefined
-  ].filter((field): field is string => field !== undefined)
-  if (missingProvenanceContext.length > 0) {
-    log.warn('writing a legacy pending file without durable Provenance', {
-      artifactRunId: context.artifactRunId,
-      missingContext: missingProvenanceContext
-    })
-    return repository.writePendingFile(writeRequest, writeOptions)
-  }
-  const rpcCapabilityToken = context.rpcCapabilityToken!
-  const appSessionId = context.appSessionId!
-  const rootFrameId = context.rootFrameId!
-  const agentFrameId = context.agentFrameId!
-  const messageBranchId = context.messageBranchId!
-  const runtimeSegmentId = context.runtimeSegmentId!
-  const promptMessageId = context.promptMessageId!
+  const appSessionId = context.appSessionId
   const writeOperationId =
     invocation.writeOperationId ??
     (invocation.requestId !== undefined
@@ -512,117 +337,41 @@ const writeArtifactFileForCurrentRun = async (
           .digest('hex')}`
       : `artifact-write-${randomUUID()}`)
 
-  // A local path is mutable and may disappear after a successful first call. Ask SQLite whether the
-  // app-owned operation already committed before copying or reading that path. Inline content remains
-  // byte-checked below so reusing an operation with different inline bytes is still a hard conflict.
-  if (source.kind === 'localPath') {
-    const replay = await callArtifactReplayRpc(
-      environment,
-      rpcCapabilityToken,
-      {
-        projectId,
-        appSessionId,
-        artifactStorageSessionId,
-        artifactRunId: context.artifactRunId,
-        writeOperationId,
-        filename: input.filename,
-        contentType: input.mimeType,
-        producerRunId: input.producerRunId
-      },
-      invocation.signal
+  let transportedSource = source
+  if (source.kind === 'inline') {
+    const encoding = source.encoding ?? 'utf8'
+    assertWithinResourceBudget(
+      'file',
+      inlineDecodedSize(source.content, encoding),
+      LOCAL_RESOURCE_BUDGETS.artifactInlineBytes
     )
-    if (replay) return replay
-  }
-
-  const preparedLiterature = input.literature
-    ? undefined
-    : await readPreparedLiteratureSidecar(source, writeOptions.allowedImportRoots, relativeBaseDirs)
-  const literature = input.literature ?? preparedLiterature?.literature
-
-  const nativeWriteOptions = {
-    ...writeOptions,
-    reserveFile: (fileBytes: number) =>
-      callArtifactReserveRpc(
-        environment,
-        rpcCapabilityToken,
-        {
-          projectId,
-          appSessionId,
-          artifactStorageSessionId,
-          artifactRunId: context.artifactRunId,
-          writeOperationId,
-          filename: input.filename,
-          fileBytes
-        },
-        invocation.signal
-      ),
-    releaseFileReservation: (reservationId: string) =>
-      callArtifactReleaseRpc(environment, rpcCapabilityToken, {
-        projectId,
-        appSessionId,
-        artifactStorageSessionId,
-        artifactRunId: context.artifactRunId,
-        reservationId
-      })
-  }
-
-  return repository.withPendingFileTransaction(
-    writeRequest,
-    nativeWriteOptions,
-    async (_pendingFile, sourceFileObservation, _bindVersionRouting, fileDigest, reservation) => {
-      if (!reservation) throw new Error('Artifact write reservation was not created.')
-      if (preparedLiterature && preparedLiterature.contentChecksum !== fileDigest.checksum) {
-        throw new Error(
-          'Prepared citation metadata does not match this file. Run the Literature preparation tool again.'
-        )
-      }
-      const contentChecksum = fileDigest.checksum
-      const writeRequestChecksum = createHash('sha256')
-        .update(
-          JSON.stringify({
-            contentChecksum,
-            contentType: input.mimeType ?? null,
-            filename: input.filename,
-            producerRunId: input.producerRunId ?? null,
-            literature: literature ?? null,
-            sourceKind: source.kind,
-            sourceFileObservation: sourceFileObservation ?? null
-          })
-        )
-        .digest('hex')
-
-      return callArtifactRpc(
-        environment,
-        rpcCapabilityToken,
-        {
-          projectId,
-          appSessionId,
-          artifactStorageSessionId,
-          artifactRunId: context.artifactRunId,
-          writeOperationId,
-          writeRequestChecksum,
-          rootFrameId,
-          agentFrameId,
-          messageBranchId,
-          messageBranchAncestry: context.messageBranchAncestry,
-          messageAncestry: context.messageAncestry,
-          runtimeSegmentId,
-          promptMessageId,
-          agentName: context.agentName,
-          notebookSessionId: context.notebookSessionId,
-          producerRunId: input.producerRunId,
-          sourceKind: source.kind,
-          sourceFileObservation,
-          filename: input.filename,
-          contentType: input.mimeType,
-          resourceReservationId: reservation.id,
-          resourceSizeBytes: fileDigest.sizeBytes,
-          resourceChecksum: fileDigest.checksum,
-          ...(literature ? { literature } : {})
-        },
-        invocation.signal
-      )
+    transportedSource = {
+      kind: 'inline',
+      content: Buffer.from(source.content, encoding).toString('base64'),
+      encoding: 'base64'
     }
+  }
+  return callArtifactRpc(
+    environment,
+    context.rpcCapabilityToken,
+    {
+      projectId,
+      appSessionId,
+      artifactStorageSessionId,
+      artifactRunId: context.artifactRunId,
+      writeOperationId,
+      rootFrameId: context.rootFrameId,
+      agentFrameId: context.agentFrameId,
+      messageBranchId: context.messageBranchId,
+      runtimeSegmentId: context.runtimeSegmentId,
+      promptMessageId: context.promptMessageId,
+      filename: input.filename,
+      contentType: input.mimeType,
+      producerRunId: input.producerRunId,
+      literature: input.literature,
+      source: transportedSource
+    },
+    invocation.signal
   )
 }
 

--- a/src/main/artifacts/pending-file-transaction.ts
+++ b/src/main/artifacts/pending-file-transaction.ts
@@ -24,6 +24,7 @@ type PendingFileTransactionOptions = {
   maxFileBytes?: number
   maxInlineBytes?: number
   diskReserveBytes?: number
+  preserveRecoveryState?: () => Promise<boolean>
   signal?: AbortSignal
   reserveFile?: (fileBytes: number) => Promise<{ id: string; fileBytes: number }>
   releaseFileReservation?: (reservationId: string) => Promise<void>
@@ -208,6 +209,23 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
     return result
   } catch (error) {
     const recoveryErrors: unknown[] = []
+    let preserveReplacement = versionRoutingPublished
+    // Durable staging owns these pending bytes even if publishing its routing was interrupted.
+    // A failed ownership lookup must also preserve the evidence for later recovery.
+    try {
+      if (
+        !versionRoutingPublished &&
+        replacementPublished &&
+        (await options.writeOptions.preserveRecoveryState?.())
+      ) {
+        preserveReplacement = true
+      }
+    } catch (ownershipError) {
+      preserveReplacement = true
+      preserveFileBackup = true
+      preserveMetadataBackup = true
+      recoveryErrors.push(ownershipError)
+    }
     if (reservation && options.writeOptions.releaseFileReservation) {
       try {
         await options.writeOptions.releaseFileReservation(reservation.id)
@@ -216,13 +234,13 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
       }
     }
     await rm(temporaryPath, { force: true }).catch(() => undefined)
-    if (replacementPublished && !versionRoutingPublished) {
+    if (replacementPublished && !preserveReplacement) {
       await Promise.all([
         rm(filePath, { force: true }).catch(() => undefined),
         rm(metadataPath, { force: true }).catch(() => undefined)
       ])
     }
-    if (fileBackedUp && !versionRoutingPublished) {
+    if (fileBackedUp && !preserveReplacement) {
       try {
         await rename(backupPath, filePath)
       } catch (recoveryError) {
@@ -230,7 +248,7 @@ const runPendingFileTransaction = async <Result, Routing>(options: {
         recoveryErrors.push(recoveryError)
       }
     }
-    if (metadataBackedUp && !versionRoutingPublished) {
+    if (metadataBackedUp && !preserveReplacement) {
       try {
         await mkdir(dirname(metadataPath), { recursive: true })
         await rename(metadataBackupPath, metadataPath)

--- a/src/main/artifacts/prepared-literature-sidecar.test.ts
+++ b/src/main/artifacts/prepared-literature-sidecar.test.ts
@@ -1,0 +1,56 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { ARTIFACT_LITERATURE_SIDECAR_SUFFIX } from '../../shared/artifact-literature'
+import { PendingRequestBudget } from '../resource-budget'
+import { readPreparedLiteratureSidecar } from './prepared-literature-sidecar'
+
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+const fixture = async (): Promise<{ root: string; path: string }> => {
+  const root = await mkdtemp(join(tmpdir(), 'artifact-sidecar-'))
+  roots.push(root)
+  const path = join(root, 'report.zip')
+  await writeFile(path, 'source')
+  await writeFile(path + ARTIFACT_LITERATURE_SIDECAR_SUFFIX, ' '.repeat(256 * 1024) + '{}')
+  return { root, path }
+}
+
+describe('prepared literature bounded reads', () => {
+  it('aborts during a real streamed read before parsing or retaining the rest of the file', async () => {
+    const { root, path } = await fixture()
+    const controller = new AbortController()
+    let bytes = 0
+    await expect(
+      readPreparedLiteratureSidecar({ kind: 'localPath', path }, [root], [], {
+        signal: controller.signal,
+        onBytes: (count) => {
+          bytes += count
+          controller.abort()
+        }
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(bytes).toBeGreaterThan(0)
+    expect(bytes).toBeLessThan(256 * 1024)
+  })
+
+  it('charges derived metadata to the existing admission lease and releases it on failure', async () => {
+    const { root, path } = await fixture()
+    const budget = new PendingRequestBudget()
+    const admission = budget.acquire('session')
+    admission.addBytes(128 * 1024 ** 2 - 1)
+    await expect(
+      readPreparedLiteratureSidecar({ kind: 'localPath', path }, [root], [], {
+        onBytes: admission.addBytes
+      })
+    ).rejects.toThrow('ARTIFACT_SAVE_RESOURCE_LIMIT')
+    admission.release()
+    const next = budget.acquire('session')
+    expect(() => next.addBytes(128 * 1024 ** 2)).not.toThrow()
+    next.release()
+  })
+})

--- a/src/main/artifacts/prepared-literature-sidecar.ts
+++ b/src/main/artifacts/prepared-literature-sidecar.ts
@@ -1,0 +1,59 @@
+import { createReadStream } from 'node:fs'
+import { stat } from 'node:fs/promises'
+import { LOCAL_RESOURCE_BUDGETS, assertWithinResourceBudget } from '../resource-budget'
+import type { ArtifactWriteSource } from '../../shared/artifacts'
+import {
+  ARTIFACT_LITERATURE_SIDECAR_SUFFIX,
+  artifactLiteratureSidecarSchema
+} from '../../shared/artifact-literature'
+import { resolveAllowedImportFilePath } from './storage-access'
+
+const isMissingFileError = (error: unknown): boolean =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: unknown }).code === 'ENOENT'
+
+const readPreparedLiteratureSidecar = async (
+  source: ArtifactWriteSource,
+  allowedImportRoots: string[],
+  relativeBaseDirs: string[],
+  options?: { signal?: AbortSignal; maxBytes?: number; onBytes?: (bytes: number) => void }
+): Promise<ReturnType<typeof artifactLiteratureSidecarSchema.parse> | undefined> => {
+  if (source.kind !== 'localPath' || !/\.(?:docx|zip)$/iu.test(source.path)) {
+    return undefined
+  }
+  options?.signal?.throwIfAborted()
+  const maxBytes = options?.maxBytes ?? LOCAL_RESOURCE_BUDGETS.requestBytes
+  const sourcePath = await resolveAllowedImportFilePath(
+    source.path,
+    allowedImportRoots,
+    relativeBaseDirs
+  )
+  const candidate = `${sourcePath}${ARTIFACT_LITERATURE_SIDECAR_SUFFIX}`
+  try {
+    const metadata = await stat(candidate)
+    assertWithinResourceBudget('request', metadata.size, maxBytes)
+  } catch (error) {
+    if (isMissingFileError(error)) return undefined
+    throw error
+  }
+  const sidecarPath = await resolveAllowedImportFilePath(candidate, allowedImportRoots)
+  const chunks: Buffer[] = []
+  let bytes = 0
+  // Recheck actual bytes, because the sidecar can grow after stat. Aborting destroys the stream.
+  for await (const chunk of createReadStream(sidecarPath, { signal: options?.signal })) {
+    options?.signal?.throwIfAborted()
+    const buffer = chunk as Buffer
+    bytes += buffer.byteLength
+    assertWithinResourceBudget('request', bytes, maxBytes)
+    options?.onBytes?.(buffer.byteLength)
+    chunks.push(buffer)
+  }
+  options?.signal?.throwIfAborted()
+  return artifactLiteratureSidecarSchema.parse(
+    JSON.parse(Buffer.concat(chunks, bytes).toString('utf8')) as unknown
+  )
+}
+
+export { readPreparedLiteratureSidecar }

--- a/src/main/artifacts/provenance-repository.architecture.test.ts
+++ b/src/main/artifacts/provenance-repository.architecture.test.ts
@@ -220,6 +220,8 @@ describe('Artifact Provenance repository architecture', () => {
   it('keeps the established public facade and private projection helpers', () => {
     expect(methods(facade, 'public')).toEqual(
       [
+        'saveVersion',
+        'withSessionMutation',
         'activateFinalizedRun',
         'createVersion',
         'deleteProjectProvenance',
@@ -254,6 +256,10 @@ describe('Artifact Provenance repository architecture', () => {
     )
     expect(methods(facade, 'private')).toEqual(
       [
+        'writeGeneratedVersion',
+        'replayVersionWithinSession',
+        'replayRoutingPublisher',
+        'reconcileSessionWithinSession',
         'inspectVersionContent',
         'openVersionContent',
         'resolveOwnedVersion',

--- a/src/main/artifacts/provenance-repository.ts
+++ b/src/main/artifacts/provenance-repository.ts
@@ -8,6 +8,8 @@ import { ManagedFileVersionService } from '../managed-file-versions/service'
 
 import type {
   AppGeneratedArtifactProducer,
+  SaveArtifactVersionRequest,
+  ArtifactWriteSourceScope,
   ArtifactLineageProvenance,
   ArtifactVersionDescriptor,
   ArtifactVersionFile,
@@ -36,6 +38,7 @@ import { defaultArtifactDurability, type ArtifactDurability } from './durability
 import {
   ArtifactProvenanceVersionWriter,
   normalizeArtifactFilename as normalizeFilename,
+  type PublishCompatibilityRouting,
   type PersistedVersionFileRecord
 } from './provenance-version-writer'
 import { getNotebookSessionRoot, NotebookRunRepository } from '../notebook/repository'
@@ -60,7 +63,7 @@ import type { PersistedChatSession } from '../../shared/session-persistence'
 import { ArtifactProvenanceDependencyReader } from './provenance-dependency-reader'
 import type { HostLineageDependencyRelation, HostLineageDirection } from '../../shared/host-lineage'
 import { requireAgentArtifactVersion } from './provenance-version-kind'
-import type { LocalResourceBudgetOverrides } from '../resource-budget'
+import { LOCAL_RESOURCE_BUDGETS, type LocalResourceBudgetOverrides } from '../resource-budget'
 import { ArtifactWriteBudgetOwner } from './write-budget-owner'
 import {
   NodeVersionFileOperator,
@@ -85,6 +88,8 @@ import {
   type RecordArtifactLiteraturePdfReadRequest,
   type RecordArtifactLiteratureSearchRequest
 } from './literature-manifest'
+import { readPreparedLiteratureSidecar } from './prepared-literature-sidecar'
+import { validateArtifactSaveSource } from './save-request'
 import type { NotebookDependencyAnalyzer } from '../notebook/dependency-analysis'
 
 const SAFE_SEGMENT_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/
@@ -562,85 +567,216 @@ class ArtifactProvenanceRepository {
     request: WriteAppGeneratedArtifactVersionRequest
   ): Promise<ArtifactVersionFile> {
     const { content, encoding = 'utf8', kind, producer, ...versionRequest } = request
-    const writeOperationId = `artifact-app-write-${this.createId()}`
-    const reservationScope = {
-      projectId: request.projectId,
-      appSessionId: request.appSessionId,
-      artifactStorageSessionId: request.artifactStorageSessionId,
-      artifactRunId: request.artifactRunId
+    return this.writeGeneratedVersion(
+      {
+        ...versionRequest,
+        writeOperationId: `artifact-app-write-${this.createId()}`,
+        source: { kind: 'inline', content, encoding }
+      },
+      { allowedImportRoots: [] },
+      undefined,
+      { kind, producer, encoding }
+    )
+  }
+
+  withSessionMutation<Result>(
+    scope: { projectId: string; appSessionId: string },
+    operation: () => Promise<Result>
+  ): Promise<Result> {
+    return this.versionWriter.withSessionWrite(scope, operation)
+  }
+
+  async saveVersion(
+    request: SaveArtifactVersionRequest,
+    sourceScope: ArtifactWriteSourceScope,
+    signal?: AbortSignal,
+    onMetadataBytes?: (bytes: number) => void
+  ): Promise<ArtifactVersionFile> {
+    validateArtifactSaveSource(request.source)
+    if (!sourceScope || !Array.isArray(sourceScope.allowedImportRoots)) {
+      throw new Error('Artifact save requires a trusted source scope.')
     }
+    return this.writeGeneratedVersion(request, sourceScope, signal, undefined, onMetadataBytes)
+  }
 
-    return this.versionWriter.withSessionWrite(versionRequest, (writeVersion) =>
-      this.compatibilityRepository.withPendingFileTransaction(
-        {
-          projectId: request.projectId,
-          sessionId: request.artifactStorageSessionId,
-          runId: request.artifactRunId,
-          filename: request.filename,
-          mimeType: request.contentType,
-          kind,
-          source: { kind: 'inline', content, encoding }
-        },
-        {
-          reserveFile: (fileBytes) =>
-            this.writeBudgetOwner.reserve({
-              ...reservationScope,
-              writeOperationId,
-              filename: request.filename,
-              fileBytes
-            }),
-          releaseFileReservation: (reservationId) =>
-            this.writeBudgetOwner.release({ ...reservationScope, reservationId })
-        },
-        async (
-          _pendingFile,
-          _sourceFileObservation,
-          bindVersionRouting,
-          fileDigest,
-          reservation
-        ) => {
-          if (!reservation) throw new Error('App-owned Artifact write reservation was not created.')
-          const contentChecksum = fileDigest.checksum
-          const writeRequestChecksum = sha256(
-            canonicalJson({
-              contentChecksum,
-              contentType: request.contentType ?? null,
-              encoding,
-              filename: request.filename,
-              literature: request.literature ?? null,
-              producerRunId: null,
-              sourceKind: 'inline',
-              sourceFileObservation: null
-            })
-          )
-
+  private writeGeneratedVersion(
+    request: SaveArtifactVersionRequest,
+    sourceScope: ArtifactWriteSourceScope,
+    signal?: AbortSignal,
+    app?: {
+      kind?: 'plan'
+      producer?: AppGeneratedArtifactProducer
+      encoding: ArtifactWriteEncoding
+    },
+    onMetadataBytes?: (bytes: number) => void
+  ): Promise<ArtifactVersionFile> {
+    return this.versionWriter.withSessionWrite(
+      request,
+      async (writeVersion) => {
+        signal?.throwIfAborted()
+        if (request.source.kind === 'localPath') {
+          const replay = await this.replayVersionWithinSession(request)
+          if (replay) return replay
+        }
+        if (
+          !app &&
+          request.source.kind === 'inline' &&
+          (await (
+            await this.options.getClient()
+          ).artifactVersion.findUnique({
+            where: { writeOperationId: request.writeOperationId },
+            select: { id: true }
+          }))
+        ) {
+          const { source, ...versionRequest } = request
           return writeVersion(
             {
               ...versionRequest,
-              writeOperationId,
-              writeRequestChecksum,
               sourceKind: 'inline',
-              resourceReservationId: reservation.id,
-              resourceSizeBytes: fileDigest.sizeBytes,
-              resourceChecksum: fileDigest.checksum
+              writeRequestChecksum: sha256(
+                JSON.stringify({
+                  contentChecksum: sha256(Buffer.from(source.content, source.encoding)),
+                  contentType: request.contentType ?? null,
+                  filename: request.filename,
+                  producerRunId: request.producerRunId ?? null,
+                  literature: request.literature ?? null,
+                  sourceKind: 'inline',
+                  sourceFileObservation: null
+                })
+              )
             },
-            async (version) =>
-              bindVersionRouting(
-                {
-                  artifactId: version.artifactId,
-                  versionId: version.id,
-                  versionNumber: version.versionNumber,
-                  artifactRunId: version.artifactRunId,
-                  checksum: version.checksum,
-                  mimeType: version.contentType ?? undefined
-                },
-                resolveStorageKey(this.options.storageRoot, version.contentStorageKey)
-              ),
-            undefined,
-            producer
+            this.replayRoutingPublisher(
+              request.projectId,
+              request.artifactStorageSessionId,
+              request.filename
+            ),
+            signal
           )
         }
-      )
+        const segments =
+          request.source.kind === 'localPath'
+            ? request.source.path
+                .replaceAll('\\', '/')
+                .split('/')
+                .filter((part) => part && part !== '.')
+            : []
+        const workingPath = segments[0] === 'data' && !segments.includes('..')
+        const relativeBaseDirs = [
+          ...(sourceScope.notebookDataDir ? [sourceScope.notebookDataDir] : []),
+          ...(workingPath && sourceScope.notebookSessionRoot
+            ? [sourceScope.notebookSessionRoot]
+            : []),
+          ...(sourceScope.workspaceCwd ? [sourceScope.workspaceCwd] : [])
+        ]
+        const prepared = request.literature
+          ? undefined
+          : await readPreparedLiteratureSidecar(
+              request.source,
+              sourceScope.allowedImportRoots,
+              relativeBaseDirs,
+              {
+                signal,
+                maxBytes: Math.max(
+                  0,
+                  LOCAL_RESOURCE_BUDGETS.requestBytes -
+                    Buffer.byteLength(
+                      JSON.stringify({ method: 'artifactSaveVersion', params: request })
+                    )
+                ),
+                onBytes: onMetadataBytes
+              }
+            )
+        const literature = request.literature ?? prepared?.literature
+        const { source, ...versionRequest } = request
+        let replacementChecksum: string | undefined
+        return this.compatibilityRepository.withPendingFileTransaction(
+          {
+            projectId: request.projectId,
+            sessionId: request.artifactStorageSessionId,
+            runId: request.artifactRunId,
+            filename: request.filename,
+            mimeType: request.contentType,
+            source,
+            kind: app?.kind
+          },
+          {
+            allowedImportRoots: sourceScope.allowedImportRoots,
+            relativeBaseDirs,
+            signal,
+            reserveFile: (fileBytes) => this.writeBudgetOwner.reserve({ ...request, fileBytes }),
+            releaseFileReservation: (reservationId) =>
+              this.writeBudgetOwner.release({ ...request, reservationId }),
+            preserveRecoveryState: async () => {
+              const client = await this.options.getClient()
+              const version = await client.artifactVersion.findUnique({
+                where: { writeOperationId: request.writeOperationId },
+                select: { checksum: true }
+              })
+              return version !== null && version.checksum === replacementChecksum
+            }
+          },
+          async (_file, sourceFileObservation, bindVersionRouting, fileDigest, reservation) => {
+            replacementChecksum = fileDigest.checksum
+            if (!reservation) throw new Error('Artifact write reservation was not created.')
+            if (prepared && prepared.contentChecksum !== fileDigest.checksum) {
+              throw new Error(
+                'Prepared citation metadata does not match this file. Run the Literature preparation tool again.'
+              )
+            }
+            const writeRequestChecksum = app
+              ? sha256(
+                  canonicalJson({
+                    contentChecksum: fileDigest.checksum,
+                    contentType: request.contentType ?? null,
+                    encoding: app.encoding,
+                    filename: request.filename,
+                    literature: request.literature ?? null,
+                    producerRunId: null,
+                    sourceKind: 'inline',
+                    sourceFileObservation: null
+                  })
+                )
+              : sha256(
+                  JSON.stringify({
+                    contentChecksum: fileDigest.checksum,
+                    contentType: request.contentType ?? null,
+                    filename: request.filename,
+                    producerRunId: request.producerRunId ?? null,
+                    literature: literature ?? null,
+                    sourceKind: source.kind,
+                    sourceFileObservation: sourceFileObservation ?? null
+                  })
+                )
+            return writeVersion(
+              {
+                ...versionRequest,
+                literature,
+                writeRequestChecksum,
+                sourceKind: source.kind,
+                sourceFileObservation,
+                resourceReservationId: reservation.id,
+                resourceSizeBytes: fileDigest.sizeBytes,
+                resourceChecksum: fileDigest.checksum
+              },
+              (version) =>
+                bindVersionRouting(
+                  {
+                    artifactId: version.artifactId,
+                    versionId: version.id,
+                    versionNumber: version.versionNumber,
+                    artifactRunId: version.artifactRunId,
+                    checksum: version.checksum,
+                    mimeType: version.contentType ?? undefined
+                  },
+                  resolveStorageKey(this.options.storageRoot, version.contentStorageKey)
+                ),
+              signal,
+              app?.producer
+            )
+          }
+        )
+      },
+      signal
     )
   }
 
@@ -695,6 +831,51 @@ class ArtifactProvenanceRepository {
   async replayVersion(
     request: ReplayArtifactVersionRequest
   ): Promise<ArtifactVersionFile | undefined> {
+    return this.versionWriter.withSessionWrite(request, () =>
+      this.replayVersionWithinSession(request)
+    )
+  }
+
+  private replayRoutingPublisher(
+    projectId: string,
+    artifactStorageSessionId: string,
+    filename: string
+  ): PublishCompatibilityRouting {
+    return async (version, options) => {
+      // Retrying an older successful operation must not replace a newer same-run publication.
+      // Validate/repair the durable successor's route while returning the originally requested Version.
+      const client = await this.options.getClient()
+      const successor = await client.artifactVersion.findFirst({
+        where: {
+          artifactId: version.artifactId,
+          artifactRunId: version.artifactRunId,
+          versionNumber: { gt: version.versionNumber },
+          state: { in: ['pending', 'finalized'] }
+        },
+        orderBy: { versionNumber: 'desc' }
+      })
+      if (successor) {
+        await this.stagingRecovery.routingPublisher(
+          projectId,
+          artifactStorageSessionId,
+          successor.filename
+        )(requireAgentArtifactVersion(successor), {
+          replaceUnroutedBytes: true,
+          signal: options?.signal
+        })
+      } else {
+        await this.stagingRecovery.routingPublisher(
+          projectId,
+          artifactStorageSessionId,
+          filename
+        )(version, options)
+      }
+    }
+  }
+
+  private async replayVersionWithinSession(
+    request: ReplayArtifactVersionRequest
+  ): Promise<ArtifactVersionFile | undefined> {
     const projectId = assertSafeSegment(request.projectId, 'project id')
     const appSessionId = assertSafeSegment(request.appSessionId, 'session id')
     const artifactStorageSessionId = assertSafeSegment(
@@ -734,14 +915,14 @@ class ArtifactProvenanceRepository {
         projectId,
         appSessionId,
         request.filename,
-        this.stagingRecovery.routingPublisher(projectId, artifactStorageSessionId, request.filename)
+        this.replayRoutingPublisher(projectId, artifactStorageSessionId, request.filename)
       )
     }
     if (agentVersion.state !== 'pending' && agentVersion.state !== 'finalized') {
       throw new Error(`Artifact write has an invalid lifecycle state: ${writeOperationId}`)
     }
     if (agentVersion.state === 'pending') {
-      await this.stagingRecovery.routingPublisher(
+      await this.replayRoutingPublisher(
         projectId,
         artifactStorageSessionId,
         request.filename
@@ -799,6 +980,29 @@ class ArtifactProvenanceRepository {
   }
 
   async reconcileSession(
+    projectIdInput: string,
+    appSessionIdInput: string,
+    durableSession?: PersistedChatSession,
+    options?: {
+      removeOrphanStaging?: boolean
+      projectReconciliation?: ArtifactProjectReconciliationSnapshot
+      artifactRunIds?: string[]
+      artifactVersionIds?: string[]
+    }
+  ): Promise<ArtifactStorageReconciliationResult> {
+    return this.versionWriter.withSessionWrite(
+      { projectId: projectIdInput, appSessionId: appSessionIdInput },
+      () =>
+        this.reconcileSessionWithinSession(
+          projectIdInput,
+          appSessionIdInput,
+          durableSession,
+          options
+        )
+    )
+  }
+
+  private async reconcileSessionWithinSession(
     projectIdInput: string,
     appSessionIdInput: string,
     durableSession?: PersistedChatSession,

--- a/src/main/artifacts/provenance-version-writer.ts
+++ b/src/main/artifacts/provenance-version-writer.ts
@@ -194,7 +194,8 @@ class ArtifactProvenanceVersionWriter {
 
   async withSessionWrite<Result>(
     request: Pick<CreateArtifactVersionRequest, 'projectId' | 'appSessionId'>,
-    operation: (writeVersion: WriteVersionWithinSession) => Promise<Result>
+    operation: (writeVersion: WriteVersionWithinSession) => Promise<Result>,
+    signal?: AbortSignal
   ): Promise<Result> {
     const sessionKey = `${this.options.storageRoot}\0${request.projectId}\0${request.appSessionId}`
     const previous =
@@ -205,16 +206,35 @@ class ArtifactProvenanceVersionWriter {
     })
     const tail = previous.then(() => current)
     ArtifactProvenanceVersionWriter.sessionWrites.set(sessionKey, tail)
-    await previous
-
-    try {
-      return await operation((...args) => this.writeVersionWithinSession(...args))
-    } finally {
-      release()
-      if (ArtifactProvenanceVersionWriter.sessionWrites.get(sessionKey) === tail) {
-        ArtifactProvenanceVersionWriter.sessionWrites.delete(sessionKey)
+    let queuedOperation: typeof operation | undefined = operation
+    // Cancellation drops the queued payload immediately, but its place in the chain remains
+    // behind the running writer. Never release a predecessor's transaction early.
+    return new Promise<Result>((resolve, reject) => {
+      const abort = (): void => {
+        queuedOperation = undefined
+        reject(signal!.reason)
       }
-    }
+      if (signal?.aborted) abort()
+      else signal?.addEventListener('abort', abort, { once: true })
+      void previous.then(async () => {
+        const execute = queuedOperation
+        queuedOperation = undefined
+        signal?.removeEventListener('abort', abort)
+        try {
+          if (execute) {
+            signal?.throwIfAborted()
+            resolve(await execute((...args) => this.writeVersionWithinSession(...args)))
+          }
+        } catch (error) {
+          reject(error)
+        } finally {
+          release()
+          if (ArtifactProvenanceVersionWriter.sessionWrites.get(sessionKey) === tail) {
+            ArtifactProvenanceVersionWriter.sessionWrites.delete(sessionKey)
+          }
+        }
+      })
+    })
   }
 
   private async writeVersionWithinSession(

--- a/src/main/artifacts/provenance-write-contract.test.ts
+++ b/src/main/artifacts/provenance-write-contract.test.ts
@@ -64,6 +64,8 @@ const canonicalize = (value: unknown): unknown => {
 }
 
 const PUBLIC_METHODS = [
+  'saveVersion',
+  'withSessionMutation',
   'writeAppGeneratedVersion',
   'createVersion',
   'reserveWrite',

--- a/src/main/artifacts/save-request.test.ts
+++ b/src/main/artifacts/save-request.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import { validateArtifactSaveSource } from './save-request'
+import { LOCAL_RESOURCE_BUDGETS, PendingRequestBudget } from '../resource-budget'
+
+describe('Artifact payload admission', () => {
+  it('bounds per-session and process counts and bytes, and releases rejected/cancelled payloads exactly once', () => {
+    const limits = {
+      ...LOCAL_RESOURCE_BUDGETS,
+      artifactSaveSessionRequests: 2,
+      artifactSaveProcessRequests: 3,
+      artifactSaveSessionPayloadBytes: 10,
+      artifactSaveProcessPayloadBytes: 15
+    }
+    const budget = new PendingRequestBudget(limits)
+    const first = budget.acquire('one')
+    first.addBytes(6)
+    const second = budget.acquire('one')
+    second.addBytes(4)
+    expect(() => second.addBytes(1)).toThrow('ARTIFACT_SAVE_RESOURCE_LIMIT')
+    expect(() => budget.acquire('one')).toThrow('ARTIFACT_SAVE_RESOURCE_LIMIT')
+    const third = budget.acquire('two')
+    third.addBytes(5)
+    expect(() => third.addBytes(1)).toThrow('ARTIFACT_SAVE_RESOURCE_LIMIT')
+    expect(() => budget.acquire('three')).toThrow('ARTIFACT_SAVE_RESOURCE_LIMIT')
+    second.release()
+    second.release()
+    first.release()
+    third.release()
+    const replacement = budget.acquire('one')
+    replacement.addBytes(10)
+    replacement.release()
+  })
+
+  it('keeps explicit production limits and accepts the full 32 MiB decoded inline budget', () => {
+    expect(LOCAL_RESOURCE_BUDGETS).toMatchObject({
+      artifactSaveSessionRequests: 16,
+      artifactSaveProcessRequests: 64,
+      artifactSaveSessionPayloadBytes: 128 * 1024 ** 2,
+      artifactSaveProcessPayloadBytes: 512 * 1024 ** 2
+    })
+    const content = Buffer.alloc(LOCAL_RESOURCE_BUDGETS.artifactInlineBytes).toString('base64')
+    expect(() =>
+      validateArtifactSaveSource({ kind: 'inline', content, encoding: 'base64' })
+    ).not.toThrow()
+    expect(() =>
+      validateArtifactSaveSource({
+        kind: 'inline',
+        content: content.slice(0, -4) + 'AAAA',
+        encoding: 'base64'
+      })
+    ).toThrow(/budget/)
+  })
+
+  it.each(['a', '====', 'a===', 'YQ=!', 'YQ==\n', 'YR=='])(
+    'rejects malformed wire encoding %j before file I/O',
+    (content) => {
+      expect(() =>
+        validateArtifactSaveSource({ kind: 'inline', content, encoding: 'base64' })
+      ).toThrow(/encoding/)
+    }
+  )
+})

--- a/src/main/artifacts/save-request.ts
+++ b/src/main/artifacts/save-request.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod'
+import { artifactLiteratureRequestSchema } from '../../shared/artifact-literature'
+import { LOCAL_RESOURCE_BUDGETS, assertWithinResourceBudget } from '../resource-budget'
+
+export const artifactSaveRequestSchema = z.object({
+  projectId: z.string().min(1),
+  appSessionId: z.string().min(1),
+  artifactStorageSessionId: z.string().min(1),
+  artifactRunId: z.string().min(1),
+  writeOperationId: z.string().min(1),
+  rootFrameId: z.string().min(1),
+  agentFrameId: z.string().min(1),
+  messageBranchId: z.string().min(1),
+  runtimeSegmentId: z.string().min(1),
+  promptMessageId: z.string().min(1),
+  messageBranchAncestry: z.array(z.string()).optional(),
+  messageAncestry: z.array(z.string()).optional(),
+  agentName: z.string().optional(),
+  notebookSessionId: z.string().optional(),
+  producerRunId: z.string().min(1).optional(),
+  filename: z.string().min(1),
+  contentType: z.string().min(1).optional(),
+  literature: artifactLiteratureRequestSchema.optional(),
+  source: z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('localPath'), path: z.string().min(1) }),
+    z.object({ kind: z.literal('inline'), content: z.string(), encoding: z.literal('base64') })
+  ])
+})
+
+export const validateArtifactSaveSource = (source: unknown): void => {
+  const parsed = artifactSaveRequestSchema.shape.source.parse(source)
+  if (parsed.kind !== 'inline') return
+  // Transport is canonical base64; validate before decoding or reserving file budget.
+  const content = parsed.content
+  if (
+    content.length % 4 !== 0 ||
+    /[^A-Za-z0-9+/=]/u.test(content) ||
+    !/^[A-Za-z0-9+/]*={0,2}$/u.test(content)
+  )
+    throw new Error('Invalid Artifact inline base64 encoding.')
+  const bytes =
+    (content.length / 4) * 3 - (content.endsWith('==') ? 2 : content.endsWith('=') ? 1 : 0)
+  assertWithinResourceBudget('file', bytes, LOCAL_RESOURCE_BUDGETS.artifactInlineBytes)
+  if (Buffer.from(content, 'base64').toString('base64') !== content)
+    throw new Error('Invalid Artifact inline base64 encoding.')
+}

--- a/src/main/artifacts/save-test-fixtures.ts
+++ b/src/main/artifacts/save-test-fixtures.ts
@@ -1,0 +1,66 @@
+import { writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import type {
+  ArtifactRpcCapabilityBinding,
+  ArtifactWriteSourceScope
+} from '../../shared/artifact-provenance'
+import { NotebookLocalRpcServer } from '../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../notebook/runtime-service'
+import { createProvenanceTestFixture, provenanceGraph } from './provenance-test-fixtures'
+import { type ArtifactMcpEnvironment } from './mcp-server'
+
+// The fixture exposes the exact composed production services to barrier-based integration tests.
+// eslint-disable-next-line @typescript-eslint/explicit-function-return-type
+export const createArtifactSaveFixture = async () => {
+  const fixture = await createProvenanceTestFixture()
+  const service = new NotebookRuntimeService({
+    configRoot: fixture.storageRoot,
+    dataRoot: fixture.storageRoot,
+    projectId: 'project-1',
+    repository: fixture.notebookRepository
+  })
+  const server = new NotebookLocalRpcServer(service, {
+    transport: 'tcp',
+    artifactProvenance: fixture.repository
+  })
+  const connection = await server.ensureStarted()
+  const binding: ArtifactRpcCapabilityBinding = {
+    ...provenanceGraph,
+    projectId: 'project-1',
+    appSessionId: 'session-1',
+    artifactStorageSessionId: 'artifact-session-1',
+    artifactRunId: 'artifact-run-1'
+  }
+  const environment = async (
+    scope: ArtifactWriteSourceScope = { allowedImportRoots: [] },
+    overrides: Partial<ArtifactRpcCapabilityBinding> = {}
+  ): Promise<ArtifactMcpEnvironment> => {
+    const bound = { ...binding, ...overrides, sourceScope: scope }
+    const token = server.issueArtifactRunCapability(bound)
+    const currentRunFile = join(fixture.storageRoot, `${bound.artifactRunId}-${token}.json`)
+    await writeFile(
+      currentRunFile,
+      JSON.stringify({ ...bound, ...scope, rpcCapabilityToken: token })
+    )
+    return {
+      storageRoot: fixture.storageRoot,
+      projectId: bound.projectId,
+      sessionId: bound.artifactStorageSessionId,
+      currentRunFile,
+      allowedImportRoots: scope.workspaceCwd ? [scope.workspaceCwd] : [],
+      rpcEndpoint: connection.endpoint,
+      rpcSocketPath: connection.socketPath
+    }
+  }
+  return {
+    ...fixture,
+    server,
+    connection,
+    binding,
+    environment,
+    dispose: async () => {
+      await server.close()
+      await fixture.dispose()
+    }
+  }
+}

--- a/src/main/artifacts/test-support/save-crash-child.ts
+++ b/src/main/artifacts/test-support/save-crash-child.ts
@@ -1,0 +1,246 @@
+// Executed in a disposable process by the crash recovery integration suite.
+import fs, { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { createProjectDbClient, migrateApplicationDatabase } from '../../projects/prisma-client'
+import { ArtifactProvenanceRepository } from '../provenance-repository'
+import { ArtifactRepository } from '../repository'
+import { ArtifactStorageAccess } from '../storage-access'
+import { defaultArtifactDurability } from '../durability'
+import { NotebookLocalRpcServer } from '../../notebook/local-rpc-server'
+import { NotebookRuntimeService } from '../../notebook/runtime-service'
+import { NotebookRunRepository } from '../../notebook/repository'
+import { writeArtifactFileForCurrentRun } from '../mcp-server'
+import { createLinearConversationGraph } from '../../../shared/conversation-graph'
+import type { PersistedChatSession } from '../../../shared/session-persistence'
+
+const [root, phase] = process.argv.slice(2)
+const pause = async (): Promise<never> => {
+  process.send?.({ phase })
+  return new Promise(() => undefined)
+}
+const main = async (): Promise<void> => {
+  await mkdir(root, { recursive: true })
+  const client = createProjectDbClient(root)
+  await migrateApplicationDatabase(client)
+  const compatibility = new ArtifactRepository(root)
+  const messages: PersistedChatSession['messages'] = [
+    {
+      id: 'prompt-1',
+      role: 'user',
+      content: 'save',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 1,
+      updatedAt: 1
+    },
+    {
+      id: 'message-1',
+      role: 'agent',
+      content: 'done',
+      status: 'complete',
+      eventIds: [],
+      createdAt: 2,
+      updatedAt: 2
+    }
+  ]
+  const graph = createLinearConversationGraph({
+    sessionId: 'session-1',
+    messages,
+    frameworkId: 'codex',
+    createdAt: 1,
+    updatedAt: 2
+  })
+  let session: PersistedChatSession = {
+    id: 'session-1',
+    projectId: 'project-1',
+    title: 'crash',
+    cwd: root,
+    status: 'idle',
+    messages,
+    conversationGraph: graph,
+    createdAt: 1,
+    updatedAt: 2
+  }
+  const binding = {
+    projectId: 'project-1',
+    appSessionId: 'session-1',
+    artifactStorageSessionId: 'artifact-session-1',
+    artifactRunId: 'artifact-run-1',
+    rootFrameId: graph.rootFrameId,
+    agentFrameId: graph.activeFrameId,
+    messageBranchId: graph.branches[0].id,
+    runtimeSegmentId: graph.runtimeSegments[0].id,
+    promptMessageId: 'prompt-1',
+    sourceScope: { allowedImportRoots: [root], workspaceCwd: root }
+  }
+  const repository = new ArtifactProvenanceRepository({
+    storageRoot: root,
+    getClient: () => Promise.resolve(client),
+    compatibilityRepository: compatibility,
+    loadSession: async () => session,
+    durability: {
+      ...defaultArtifactDurability,
+      syncFile: async (path) => {
+        await defaultArtifactDurability.syncFile(path)
+        if (phase === 'before-version' && path.includes('.staging') && path.endsWith('content'))
+          await pause()
+        if (phase === 'staging' && path.includes('.staging') && path.endsWith('evidence.json'))
+          await pause()
+      }
+    }
+  })
+  if (phase === 'recover') {
+    try {
+      session = JSON.parse(await readFile(join(root, 'session.json'), 'utf8'))
+    } catch {
+      /* no durable message before save */
+    }
+    const result = await repository.reconcileSession('project-1', 'session-1', session)
+    const versions = await client.artifactVersion.findMany({
+      select: { id: true, state: true, checksum: true, messageId: true, writeOperationId: true }
+    })
+    let replayedVersionId: string | undefined
+    if (versions.length === 1 && versions[0].state === 'pending') {
+      const replay = await repository.saveVersion(
+        {
+          ...binding,
+          writeOperationId: versions[0].writeOperationId!,
+          filename: 'first.txt',
+          source: {
+            kind: 'inline',
+            content: Buffer.from('first crash-safe bytes').toString('base64'),
+            encoding: 'base64'
+          }
+        },
+        binding.sourceScope
+      )
+      replayedVersionId = replay.versionId
+      if ((await client.artifactVersion.count()) !== 1)
+        throw new Error('Crash replay created another Version.')
+    }
+    process.send?.({ recovered: result, versions, replayedVersionId })
+    await client.$disconnect()
+    return
+  }
+  const copySourcePath = join(root, 'copy-source.txt')
+  if (phase === 'copying') {
+    await writeFile(copySourcePath, Buffer.alloc(128 * 1024, 97))
+    const resolvedSource = await fs.realpath(copySourcePath)
+    const open = fs.open
+    fs.open = async (...args: Parameters<typeof fs.open>) => {
+      const handle = await open(...args)
+      if (args[0] === resolvedSource) {
+        const read = handle.read.bind(handle)
+        let reads = 0
+        handle.read = (async (...input: Parameters<typeof read>) => {
+          if (++reads === 2) await pause()
+          return read(...input)
+        }) as typeof handle.read
+      }
+      return handle
+    }
+  }
+  const service = new NotebookRuntimeService({
+    configRoot: root,
+    dataRoot: root,
+    projectId: 'project-1',
+    repository: new NotebookRunRepository(root)
+  })
+  const server = new NotebookLocalRpcServer(service, {
+    transport: 'tcp',
+    artifactProvenance: {
+      createVersion: (request, signal) => repository.createVersion(request, signal),
+      saveVersion: async (request, scope, signal) => {
+        const result = await repository.saveVersion(request, scope, signal)
+        if (phase === 'committed') await pause()
+        return result
+      }
+    }
+  })
+  const connection = await server.ensureStarted()
+  const currentRunFile = join(root, 'current-run.json')
+  await writeFile(
+    currentRunFile,
+    JSON.stringify({ ...binding, rpcCapabilityToken: server.issueArtifactRunCapability(binding) })
+  )
+  const env = {
+    storageRoot: root,
+    sessionId: binding.artifactStorageSessionId,
+    projectId: binding.projectId,
+    currentRunFile,
+    allowedImportRoots: [],
+    rpcEndpoint: connection.endpoint
+  }
+  const first = await writeArtifactFileForCurrentRun(
+    compatibility,
+    env,
+    phase === 'copying'
+      ? { filename: 'first.txt', source: { kind: 'localPath', path: copySourcePath } }
+      : { filename: 'first.txt', content: 'first crash-safe bytes' },
+    { requestId: 'first' }
+  )
+  const second = await writeArtifactFileForCurrentRun(
+    compatibility,
+    env,
+    { filename: 'second.txt', content: 'second crash-safe bytes' },
+    { requestId: 'second' }
+  )
+  session.messages[1].artifactIds = [first.id, second.id]
+  session.artifacts = [first, second].map((file) => ({
+    ...file,
+    kind: 'managed-file' as const,
+    createdAt: Date.parse(file.createdAt)
+  }))
+  session.conversationGraph!.messages.find((message) => message.id === 'message-1')!.artifactIds = [
+    first.id,
+    second.id
+  ]
+  await writeFile(join(root, 'session.json'), JSON.stringify(session))
+  const provenanceContext = {
+    rootFrameId: binding.rootFrameId,
+    agentFrameId: binding.agentFrameId,
+    messageBranchId: binding.messageBranchId,
+    runtimeSegmentId: binding.runtimeSegmentId,
+    promptMessageId: binding.promptMessageId
+  }
+  const request = {
+    ...binding,
+    artifactVersionIds: [first.versionId!, second.versionId!],
+    messageId: 'message-1'
+  }
+  await compatibility.prepareRunFinalization({
+    projectId: binding.projectId,
+    sessionId: binding.appSessionId,
+    sourceSessionId: binding.artifactStorageSessionId,
+    runId: binding.artifactRunId,
+    artifactVersionIds: request.artifactVersionIds,
+    provenanceContext
+  })
+  if (phase === 'prepared') await pause()
+  const moveMetadata = ArtifactStorageAccess.prototype.moveArtifactMetadata
+  ArtifactStorageAccess.prototype.moveArtifactMetadata = async function (...args) {
+    if (phase === 'partial-publication') await pause()
+    return moveMetadata.apply(this, args)
+  }
+  await repository.withSessionMutation(binding, async () => {
+    await repository.finalizeRun(request)
+    await compatibility.finalizeRunArtifacts({
+      projectId: binding.projectId,
+      sessionId: binding.appSessionId,
+      sourceSessionId: binding.artifactStorageSessionId,
+      runId: binding.artifactRunId,
+      messageId: request.messageId,
+      artifactVersionIds: request.artifactVersionIds,
+      provenanceContext
+    })
+    await repository.activateFinalizedRun(request)
+  })
+  await server.close()
+  await client.$disconnect()
+}
+void main().catch((error) => {
+  process.stderr.write(
+    `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`
+  )
+  process.exit(1)
+})

--- a/src/main/compute/compute-job-workflow-owner.test.ts
+++ b/src/main/compute/compute-job-workflow-owner.test.ts
@@ -5,7 +5,7 @@ import { join, resolve } from 'node:path'
 import { describe, expect, it, vi, afterEach, beforeEach } from 'vitest'
 
 import type { ComputeHost } from '../../shared/compute'
-import { ArtifactRepository } from '../artifacts/repository'
+import { createArtifactSaveFixture } from '../artifacts/save-test-fixtures'
 import { writeArtifactFileForCurrentRun } from '../artifacts/mcp-server'
 import { decodeDataPath } from '../storage/data-path'
 import {
@@ -1482,28 +1482,34 @@ describe('ComputeJobWorkflowOwner.getJobResult', () => {
     expect(result.producer_run_id).toBe('notebook-run-submit')
     expect(result.featured_files).toEqual(['hpc/job-result-1/featured/results.bin'])
 
-    const currentRunFile = join(tmpDir, 'current-run.json')
-    await writeFile(currentRunFile, JSON.stringify({ runId: 'analysis-run-1' }), 'utf8')
-    const artifact = await writeArtifactFileForCurrentRun(
-      new ArtifactRepository(tmpDir),
-      {
-        storageRoot: tmpDir,
-        projectId: 'proj-1',
-        sessionId: 'sess-1',
-        currentRunFile,
-        allowedImportRoots: [localOutputRoot!]
-      },
-      {
-        filename: 'results.bin',
-        mimeType: 'application/octet-stream',
-        source: {
-          kind: 'localPath',
-          path: join(localOutputRoot!, result.featured_files[0]!)
+    const artifacts = await createArtifactSaveFixture()
+    try {
+      const environment = await artifacts.environment(
+        { allowedImportRoots: [localOutputRoot!] },
+        {
+          projectId: 'proj-1',
+          appSessionId: 'sess-1',
+          artifactStorageSessionId: 'sess-1',
+          artifactRunId: 'analysis-run-1'
         }
-      }
-    )
-
-    await expect(readFile(artifact.path)).resolves.toEqual(bytes)
+      )
+      const artifact = await writeArtifactFileForCurrentRun(
+        artifacts.compatibilityRepository,
+        environment,
+        {
+          filename: 'results.bin',
+          mimeType: 'application/octet-stream',
+          source: {
+            kind: 'localPath',
+            path: join(localOutputRoot!, result.featured_files[0]!)
+          }
+        }
+      )
+      await expect(readFile(artifact.path)).resolves.toEqual(bytes)
+      expect(await artifacts.client.artifactVersion.count()).toBe(1)
+    } finally {
+      await artifacts.dispose()
+    }
   })
 
   it('reads attach_job results from the data-root workspace when config and data roots differ', async () => {

--- a/src/main/delegation/delegated-artifact-evidence.ts
+++ b/src/main/delegation/delegated-artifact-evidence.ts
@@ -32,6 +32,7 @@ const createDelegatedArtifactEvidence = (
   async open(scope) {
     const handle = await options.turns.openExecution({
       executionId: scope.executionId,
+      workspaceCwd: scope.workspaceCwd,
       appSessionId: scope.session.sessionId,
       artifactStorageSessionId: options.artifactStorageSessionId(scope.session),
       projectId: scope.session.projectId,

--- a/src/main/delegation/delegated-turn-lifecycle.ts
+++ b/src/main/delegation/delegated-turn-lifecycle.ts
@@ -11,6 +11,7 @@ type SessionKey = Readonly<{ projectId: string; sessionId: string }>
 
 type DelegatedArtifactScope = Readonly<{
   session: SessionKey
+  workspaceCwd?: string
   executionId: string
   attemptId: string
   rootFrameId: string
@@ -58,7 +59,7 @@ const createDelegatedTurnLifecycle = (options: {
   now(): number
   createMessageId(): string
 }): Readonly<{
-  openInitial(context: TurnContext): Promise<void>
+  openInitial(context: TurnContext, workspaceCwd?: string): Promise<void>
   currentArtifact(): DelegatedArtifactHandle | undefined
   lastTurnMessage(): DurableMessage | undefined
   unstagedRuntimeScope(context: TurnContext | undefined): TurnContext | undefined
@@ -66,6 +67,7 @@ const createDelegatedTurnLifecycle = (options: {
   finalizeFallback(terminalMessageId: string): Promise<void>
   dispose(): Promise<void>
 }> => {
+  let workspaceCwd: string | undefined
   let currentArtifact: DelegatedArtifactHandle | undefined
   const artifactHandles: DelegatedArtifactHandle[] = []
   let artifactHandoffFile: string | undefined
@@ -78,6 +80,7 @@ const createDelegatedTurnLifecycle = (options: {
   const openArtifact = async (context: TurnContext, executionId: string): Promise<void> => {
     const artifact = await options.artifactEvidence?.open({
       session: options.session,
+      workspaceCwd,
       executionId,
       attemptId: options.attemptId,
       rootFrameId: context.rootFrameId,
@@ -95,7 +98,10 @@ const createDelegatedTurnLifecycle = (options: {
   }
 
   return {
-    openInitial: (context) => openArtifact(context, options.attemptId),
+    openInitial: (context, cwd) => {
+      workspaceCwd = cwd
+      return openArtifact(context, options.attemptId)
+    },
     currentArtifact: () => currentArtifact,
     lastTurnMessage: () => completedTurnMessage,
     unstagedRuntimeScope: (context) =>

--- a/src/main/delegation/durable-delegated-work.ts
+++ b/src/main/delegation/durable-delegated-work.ts
@@ -220,7 +220,7 @@ const createDurableDelegatedWork = (
         if (cancelRequested || !latest || currentAttempt(latest).status !== 'running') {
           throw new Error('delegate execution was cancelled before launch establishment')
         }
-        await turnLifecycle.openInitial(startedContext)
+        await turnLifecycle.openInitial(startedContext, workspace?.cwd)
         const artifact = turnLifecycle.currentArtifact()
         const runningAttempt = running.get(child.frameId)
         if (runningAttempt?.attemptId === attempt.id) runningAttempt.artifact = artifact

--- a/src/main/delegation/production-composition.test.ts
+++ b/src/main/delegation/production-composition.test.ts
@@ -2841,14 +2841,7 @@ describe('production delegated-work composition', () => {
     })
     server = new NotebookLocalRpcServer({ execute: async () => ({}) } as never, {
       transport: 'tcp',
-      artifactProvenance: {
-        createVersion: (request, signal) => provenance.createVersion(request, signal),
-        replayVersion: (request) => provenance.replayVersion(request),
-        reserveWrite: (request) => provenance.reserveWrite(request),
-        releaseWriteReservation: (request) => provenance.releaseWriteReservation(request),
-        releaseRunWriteReservations: (request) => provenance.releaseRunWriteReservations(request),
-        releaseAllWriteReservations: () => provenance.releaseAllWriteReservations()
-      }
+      artifactProvenance: provenance
     })
     const connection = await server.ensureStarted()
     const turns = new ArtifactTurnOwner({

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2975,6 +2975,8 @@ const createApplicationModules = async (
         return runtime.requestUserInput(request)
       },
       artifactProvenance: {
+        saveVersion: (request, sourceScope, signal, onMetadataBytes) =>
+          artifactProvenanceRepository.saveVersion(request, sourceScope, signal, onMetadataBytes),
         reserveWrite: (request) => artifactProvenanceRepository.reserveWrite(request),
         releaseWriteReservation: (request) =>
           artifactProvenanceRepository.releaseWriteReservation(request),

--- a/src/main/notebook/local-rpc-server.test.ts
+++ b/src/main/notebook/local-rpc-server.test.ts
@@ -3161,523 +3161,150 @@ describe('notebook local RPC server', () => {
     }
   })
 
-  it('dispatches Artifact Version creation through the authenticated main-process bridge', async () => {
+  it('binds complete Artifact saves to immutable capability scope and drains accepted work', async () => {
     const root = await createStorageRoot()
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
-      projectId: 'default-project',
-      repository: new NotebookRunRepository(root)
-    })
-    const requests: unknown[] = []
-    const server = new NotebookLocalRpcServer(service, {
-      transport: 'tcp',
-      token: 'secret-token',
-      artifactProvenance: {
-        createVersion: async (request) => {
-          requests.push(request)
-          return {
-            id: 'version-1',
-            artifactId: 'artifact-1',
-            versionId: 'version-1',
-            versionNumber: 1,
-            checksum: 'a'.repeat(64),
-            createdAt: '2026-07-27T00:00:00.000Z',
-            projectId: 'project-1',
-            sessionId: 'session-1',
-            runId: 'artifact-run-1',
-            name: 'sin.png',
-            path: '/managed/content',
-            fileUrl: 'file:///managed/content',
-            mimeType: 'image/png',
-            size: 12,
-            mtimeMs: 1
-          }
-        }
-      }
-    })
-    const connection = await server.ensureStarted()
-    const artifactToken = server.issueArtifactRunCapability(artifactCapabilityBinding)
-    const request = {
       projectId: 'project-1',
-      appSessionId: 'session-1',
-      artifactStorageSessionId: 'artifact-session-1',
-      artifactRunId: 'artifact-run-1',
-      writeOperationId: 'write-1',
-      writeRequestChecksum: 'b'.repeat(64),
-      resourceReservationId: 'reservation-1',
-      resourceSizeBytes: 12,
-      resourceChecksum: 'a'.repeat(64),
-      rootFrameId: 'frame-root',
-      agentFrameId: 'frame-root',
-      messageBranchId: 'branch-root',
-      messageBranchAncestry: ['forged-branch'],
-      messageAncestry: ['forged-message'],
-      runtimeSegmentId: 'runtime-1',
-      promptMessageId: 'message-user-1',
-      agentName: 'forged-agent',
-      notebookSessionId: 'forged-notebook-session',
-      filename: 'sin.png',
-      contentType: 'image/png'
-    }
-
-    try {
-      const response = await fetch(connection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${artifactToken}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({ method: 'artifactCreateVersion', params: request })
-      })
-      const payload = (await response.json()) as {
-        result: { artifactId: string; versionId: string }
-      }
-
-      expect(response.status).toBe(200)
-      expect(payload.result).toMatchObject({ artifactId: 'artifact-1', versionId: 'version-1' })
-      expect(requests).toEqual([
-        {
-          ...request,
-          messageBranchAncestry: ['branch-parent', 'branch-root'],
-          messageAncestry: ['message-parent', 'message-user-1'],
-          agentName: 'Claude Code',
-          notebookSessionId: 'notebook-session-1'
-        }
-      ])
-    } finally {
-      await server.close()
-    }
-  })
-
-  it('binds Artifact reservations to the capability and releases ownership on revoke and close', async () => {
-    const reserveWrite = vi.fn(async () => ({
-      id: 'reservation-1',
-      fileBytes: 12,
-      expiresAt: Date.now() + 60_000
-    }))
-    const releaseWriteReservation = vi.fn(async () => undefined)
-    const releaseRunWriteReservations = vi.fn(async () => undefined)
-    const releaseAllWriteReservations = vi.fn(async () => undefined)
-    const createVersion = vi.fn()
-    const server = new NotebookLocalRpcServer({} as never, {
-      transport: 'tcp',
-      token: 'secret-token',
-      artifactProvenance: {
-        createVersion,
-        reserveWrite,
-        releaseWriteReservation,
-        releaseRunWriteReservations,
-        releaseAllWriteReservations
-      }
-    })
-    const connection = await server.ensureStarted()
-    const token = server.issueArtifactRunCapability(artifactCapabilityBinding)
-    let closed = false
-    const call = (method: string, params: Record<string, unknown>): Promise<Response> =>
-      fetch(connection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${token}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({ method, params })
-      })
-
-    try {
-      const reserved = await call('artifactReserveWrite', {
-        projectId: 'project-1',
-        appSessionId: 'session-1',
-        artifactStorageSessionId: 'artifact-session-1',
-        artifactRunId: 'artifact-run-1',
-        writeOperationId: 'write-1',
-        filename: 'sin.png',
-        fileBytes: 12
-      })
-      await expect(reserved.json()).resolves.toEqual({
-        result: expect.objectContaining({ id: 'reservation-1', fileBytes: 12 })
-      })
-      expect(reserveWrite).toHaveBeenCalledWith({
-        projectId: 'project-1',
-        appSessionId: 'session-1',
-        artifactStorageSessionId: 'artifact-session-1',
-        artifactRunId: 'artifact-run-1',
-        writeOperationId: 'write-1',
-        filename: 'sin.png',
-        fileBytes: 12
-      })
-
-      const released = await call('artifactReleaseWrite', {
-        projectId: 'project-1',
-        appSessionId: 'session-1',
-        artifactStorageSessionId: 'artifact-session-1',
-        artifactRunId: 'artifact-run-1',
-        reservationId: 'reservation-1'
-      })
-      expect(released.status).toBe(200)
-      expect(releaseWriteReservation).toHaveBeenCalledWith({
-        projectId: 'project-1',
-        appSessionId: 'session-1',
-        artifactStorageSessionId: 'artifact-session-1',
-        artifactRunId: 'artifact-run-1',
-        reservationId: 'reservation-1'
-      })
-
-      const bypass = await call('artifactCreateVersion', {
-        ...artifactCapabilityBinding,
-        writeOperationId: 'write-without-reservation',
-        writeRequestChecksum: 'a'.repeat(64),
-        filename: 'bypass.txt'
-      })
-      expect(bypass.status).toBe(400)
-      await expect(bypass.json()).resolves.toEqual({
-        error: 'Artifact Version creation requires a write reservation.'
-      })
-      expect(createVersion).not.toHaveBeenCalled()
-
-      await server.revokeArtifactRunCapability(token)
-      expect(releaseRunWriteReservations).toHaveBeenCalledWith({
-        projectId: 'project-1',
-        appSessionId: 'session-1',
-        artifactStorageSessionId: 'artifact-session-1',
-        artifactRunId: 'artifact-run-1'
-      })
-      await server.close()
-      closed = true
-      expect(releaseAllWriteReservations).toHaveBeenCalledOnce()
-    } finally {
-      if (!closed) await server.close()
-    }
-  })
-
-  it('revokes new Artifact requests while draining one already-authorized write', async () => {
-    const root = await createStorageRoot()
-    const service = new NotebookRuntimeService({
-      configRoot: root,
-      dataRoot: root,
-      projectId: 'default-project',
       repository: new NotebookRunRepository(root)
     })
-    const createStarted = createDeferred()
-    const releaseCreate = createDeferred()
-    let now = 1_000
+    let release!: () => void
+    let entered!: () => void
+    const gate = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const accepted = new Promise<void>((resolve) => {
+      entered = resolve
+    })
+    const saveVersion = vi.fn(async () => {
+      entered()
+      await gate
+      return { versionId: 'version-1' } as never
+    })
     const server = new NotebookLocalRpcServer(service, {
       transport: 'tcp',
-      token: 'secret-token',
-      now: () => now,
-      artifactProvenance: {
-        createVersion: async () => {
-          createStarted.resolve()
-          await releaseCreate.promise
-          return {
-            id: 'version-1',
-            artifactId: 'artifact-1',
-            versionId: 'version-1',
-            versionNumber: 1,
-            checksum: 'a'.repeat(64),
-            createdAt: '2026-07-27T00:00:00.000Z',
-            projectId: 'project-1',
-            sessionId: 'session-1',
-            runId: 'artifact-run-1',
-            name: 'sin.png',
-            path: '/managed/content',
-            fileUrl: 'file:///managed/content',
-            mimeType: 'image/png',
-            size: 12,
-            mtimeMs: 1
-          }
-        }
-      }
+      artifactProvenance: { createVersion: vi.fn(), saveVersion }
     })
     const connection = await server.ensureStarted()
-    const token = server.issueArtifactRunCapability(artifactCapabilityBinding, 100)
-    const call = (): Promise<Response> =>
+    const roots = [root]
+    const binding = {
+      ...artifactCapabilityBinding,
+      sourceScope: { allowedImportRoots: roots, workspaceCwd: root }
+    }
+    const token = server.issueArtifactRunCapability(binding)
+    roots.push('/forged-after-issuance')
+    const params = {
+      ...artifactCapabilityBinding,
+      filename: 'result.txt',
+      writeOperationId: 'write-1',
+      source: { kind: 'inline', content: 'b2s=', encoding: 'base64' },
+      agentName: 'forged',
+      sourceScope: { allowedImportRoots: ['/'] }
+    }
+    const call = (
+      capability = token,
+      request = params,
+      method = 'artifactSaveVersion'
+    ): Promise<Response> =>
       fetch(connection.endpoint, {
         method: 'POST',
-        headers: {
-          authorization: `Bearer ${token}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({
-          method: 'artifactCreateVersion',
-          params: {
-            ...artifactCapabilityBinding,
-            writeOperationId: 'write-drain',
-            writeRequestChecksum: 'a'.repeat(64),
-            resourceReservationId: 'reservation-drain',
-            resourceSizeBytes: 12,
-            resourceChecksum: 'a'.repeat(64),
-            filename: 'sin.png'
-          }
-        })
+        headers: { authorization: `Bearer ${capability}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ method, params: request })
       })
-
     try {
-      const acceptedRequest = call()
-      await createStarted.promise
-      now = 1_101
-      const expiredRequest = await call()
-      expect(expiredRequest.status).toBe(401)
-      await expect(expiredRequest.json()).resolves.toEqual({
-        error: 'Artifact RPC capability expired.'
-      })
-
+      const pending = call()
+      await accepted
+      expect(saveVersion).toHaveBeenCalledWith(
+        expect.objectContaining({
+          agentName: 'Claude Code',
+          messageBranchAncestry: [...artifactCapabilityBinding.messageBranchAncestry]
+        }),
+        { allowedImportRoots: [root], workspaceCwd: root },
+        expect.any(AbortSignal),
+        expect.any(Function)
+      )
       let drained = false
-      const firstDrain = Promise.resolve(server.revokeArtifactRunCapability(token)).then(() => {
+      const drain = server.revokeArtifactRunCapability(token).then(() => {
         drained = true
       })
-      const repeatedDrain = Promise.resolve(server.revokeArtifactRunCapability(token))
-      await Promise.resolve()
+      expect((await call()).status).toBe(401)
       expect(drained).toBe(false)
-
-      const rejectedRequest = await call()
-      expect(rejectedRequest.status).toBe(401)
-
-      releaseCreate.resolve()
-      await expect(acceptedRequest.then((response) => response.status)).resolves.toBe(200)
-      await expect(Promise.all([firstDrain, repeatedDrain])).resolves.toEqual([
-        undefined,
-        undefined
-      ])
+      release()
+      expect((await pending).status).toBe(200)
+      await drain
       expect(drained).toBe(true)
     } finally {
-      releaseCreate.resolve()
+      release()
       await server.close()
     }
   })
 
-  it('rejects an Artifact capability when the request names a different run', async () => {
+  it('rejects mismatched, expired, missing-scope and old split Artifact protocols before dispatch', async () => {
     const root = await createStorageRoot()
     const service = new NotebookRuntimeService({
       configRoot: root,
       dataRoot: root,
-      projectId: 'default-project',
+      projectId: 'project-1',
       repository: new NotebookRunRepository(root)
     })
+    let now = 0
+    const saveVersion = vi.fn()
     const createVersion = vi.fn()
     const server = new NotebookLocalRpcServer(service, {
       transport: 'tcp',
-      token: 'secret-token',
-      artifactProvenance: { createVersion }
-    })
-    const connection = await server.ensureStarted()
-    const artifactToken = server.issueArtifactRunCapability(artifactCapabilityBinding)
-
-    try {
-      const response = await fetch(connection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${artifactToken}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({
-          method: 'artifactCreateVersion',
-          params: {
-            ...artifactCapabilityBinding,
-            artifactRunId: 'artifact-run-forged',
-            writeOperationId: 'write-forged',
-            writeRequestChecksum: 'a'.repeat(64),
-            filename: 'sin.png'
-          }
-        })
-      })
-
-      expect(response.status).toBe(403)
-      await expect(response.json()).resolves.toEqual({
-        error: 'Artifact RPC capability does not match artifactRunId.'
-      })
-      expect(createVersion).not.toHaveBeenCalled()
-    } finally {
-      await server.close()
-    }
-  })
-
-  it('rejects expired and revoked Artifact run capabilities', async () => {
-    const root = await createStorageRoot()
-    let now = 1_000
-    const service = new NotebookRuntimeService({
-      configRoot: root,
-      dataRoot: root,
-      projectId: 'default-project',
-      repository: new NotebookRunRepository(root)
-    })
-    const createVersion = vi.fn()
-    const server = new NotebookLocalRpcServer(service, {
-      transport: 'tcp',
-      token: 'secret-token',
       now: () => now,
-      artifactProvenance: { createVersion }
+      artifactProvenance: { createVersion, saveVersion }
     })
     const connection = await server.ensureStarted()
-    const expiredToken = server.issueArtifactRunCapability(artifactCapabilityBinding, 100)
-    now = 1_101
-
-    const call = (token: string): Promise<Response> =>
+    const binding = { ...artifactCapabilityBinding, sourceScope: { allowedImportRoots: [] } }
+    const token = server.issueArtifactRunCapability(binding, 100)
+    const params = {
+      ...artifactCapabilityBinding,
+      filename: 'result.txt',
+      writeOperationId: 'write-1',
+      source: { kind: 'inline', content: '', encoding: 'base64' }
+    }
+    const call = (
+      capability: string,
+      method: string,
+      request: Record<string, unknown> = params
+    ): Promise<Response> =>
       fetch(connection.endpoint, {
         method: 'POST',
-        headers: {
-          authorization: `Bearer ${token}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({
-          method: 'artifactCreateVersion',
-          params: {
-            ...artifactCapabilityBinding,
-            writeOperationId: 'write-1',
-            writeRequestChecksum: 'a'.repeat(64),
-            filename: 'sin.png'
-          }
-        })
+        headers: { authorization: `Bearer ${capability}`, 'content-type': 'application/json' },
+        body: JSON.stringify({ method, params: request })
       })
-
     try {
-      const expired = await call(expiredToken)
-      expect(expired.status).toBe(401)
-      await expect(expired.json()).resolves.toEqual({ error: 'Artifact RPC capability expired.' })
-
-      const replayOnlyToken = server.issueArtifactRunCapability({
-        ...artifactCapabilityBinding,
-        allowedMethods: ['artifactReplayVersion']
-      })
-      const disallowed = await call(replayOnlyToken)
-      expect(disallowed.status).toBe(403)
-      await expect(disallowed.json()).resolves.toEqual({
-        error: 'Artifact RPC capability does not allow artifactCreateVersion.'
-      })
-
-      const revokedToken = server.issueArtifactRunCapability(artifactCapabilityBinding)
-      server.revokeArtifactRunCapability(revokedToken)
-      const revoked = await call(revokedToken)
-      expect(revoked.status).toBe(401)
-      await expect(revoked.json()).resolves.toEqual({ error: 'Invalid notebook RPC token.' })
+      expect(
+        (await call(token, 'artifactSaveVersion', { ...params, artifactRunId: 'forged-run' }))
+          .status
+      ).toBe(403)
+      expect(
+        (
+          await call(
+            server.issueArtifactRunCapability(artifactCapabilityBinding),
+            'artifactSaveVersion'
+          )
+        ).status
+      ).toBe(403)
+      for (const method of [
+        'artifactCreateVersion',
+        'artifactReserveWrite',
+        'artifactReleaseWrite',
+        'artifactReplayVersion'
+      ] as const) {
+        const legacy = server.issueArtifactRunCapability({ ...binding, allowedMethods: [method] })
+        const response = await call(legacy, method)
+        expect(response.status).toBe(409)
+        expect(await response.text()).toContain('Restart')
+      }
+      now = 101
+      expect((await call(token, 'artifactSaveVersion')).status).toBe(401)
+      expect(saveVersion).not.toHaveBeenCalled()
       expect(createVersion).not.toHaveBeenCalled()
     } finally {
       await server.close()
-    }
-  })
-
-  it('keeps the default Artifact capability valid throughout a long-running turn', async () => {
-    const root = await createStorageRoot()
-    let now = 1_000
-    const service = new NotebookRuntimeService({
-      configRoot: root,
-      dataRoot: root,
-      projectId: 'default-project',
-      repository: new NotebookRunRepository(root)
-    })
-    const createVersion = vi.fn().mockResolvedValue({ versionId: 'version-1' })
-    const server = new NotebookLocalRpcServer(service, {
-      transport: 'tcp',
-      token: 'secret-token',
-      now: () => now,
-      artifactProvenance: { createVersion }
-    })
-    const connection = await server.ensureStarted()
-    const token = server.issueArtifactRunCapability(artifactCapabilityBinding)
-    now += 31 * 60 * 1_000
-
-    try {
-      const response = await fetch(connection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${token}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({
-          method: 'artifactCreateVersion',
-          params: {
-            ...artifactCapabilityBinding,
-            writeOperationId: 'write-long-turn',
-            writeRequestChecksum: 'a'.repeat(64),
-            resourceReservationId: 'reservation-long-turn',
-            resourceSizeBytes: 12,
-            resourceChecksum: 'a'.repeat(64),
-            filename: 'sin.png'
-          }
-        })
-      })
-
-      expect(response.status).toBe(200)
-      expect(createVersion).toHaveBeenCalledOnce()
-    } finally {
-      await server.close()
-    }
-  })
-
-  it('dispatches exact Artifact Version replays and reports an unconfigured replay bridge', async () => {
-    const root = await createStorageRoot()
-    const service = new NotebookRuntimeService({
-      configRoot: root,
-      dataRoot: root,
-      projectId: 'default-project',
-      repository: new NotebookRunRepository(root)
-    })
-    const replayRequests: unknown[] = []
-    const request = {
-      projectId: 'project-1',
-      appSessionId: 'session-1',
-      artifactStorageSessionId: 'artifact-session-1',
-      artifactRunId: 'artifact-run-1',
-      writeOperationId: 'write-1',
-      writeRequestChecksum: 'b'.repeat(64),
-      rootFrameId: 'frame-root',
-      agentFrameId: 'frame-root',
-      messageBranchId: 'branch-root',
-      runtimeSegmentId: 'runtime-1',
-      promptMessageId: 'message-user-1'
-    }
-    const server = new NotebookLocalRpcServer(service, {
-      transport: 'tcp',
-      token: 'secret-token',
-      artifactProvenance: {
-        createVersion: vi.fn(),
-        replayVersion: async (replayRequest) => {
-          replayRequests.push(replayRequest)
-          return undefined
-        }
-      }
-    })
-    const connection = await server.ensureStarted()
-    const replayToken = server.issueArtifactRunCapability(artifactCapabilityBinding)
-
-    try {
-      const response = await fetch(connection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${replayToken}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({ method: 'artifactReplayVersion', params: request })
-      })
-      await expect(response.json()).resolves.toEqual({})
-      expect(response.status).toBe(200)
-      expect(replayRequests).toEqual([request])
-    } finally {
-      await server.close()
-    }
-
-    const unconfigured = new NotebookLocalRpcServer(service, {
-      transport: 'tcp',
-      token: 'secret-token',
-      artifactProvenance: { createVersion: vi.fn() }
-    })
-    const unconfiguredConnection = await unconfigured.ensureStarted()
-    const unconfiguredToken = unconfigured.issueArtifactRunCapability(artifactCapabilityBinding)
-    try {
-      const response = await fetch(unconfiguredConnection.endpoint, {
-        method: 'POST',
-        headers: {
-          authorization: `Bearer ${unconfiguredToken}`,
-          'content-type': 'application/json'
-        },
-        body: JSON.stringify({ method: 'artifactReplayVersion', params: request })
-      })
-      await expect(response.json()).resolves.toEqual({
-        error: 'Artifact Provenance persistence is not configured.'
-      })
-      expect(response.status).toBe(500)
-    } finally {
-      await unconfigured.close()
     }
   })
 

--- a/src/main/notebook/local-rpc-server.ts
+++ b/src/main/notebook/local-rpc-server.ts
@@ -1,3 +1,4 @@
+import { artifactSaveRequestSchema } from '../artifacts/save-request'
 import { createHash, randomUUID } from 'node:crypto'
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http'
 
@@ -39,6 +40,8 @@ import type {
 } from '../skills/conversation-import'
 import type {
   ArtifactRpcCapabilityBinding,
+  SaveArtifactVersionRequest,
+  ArtifactWriteSourceScope,
   ArtifactRpcMethod,
   ArtifactWriteReservation,
   ArtifactVersionFile,
@@ -71,6 +74,8 @@ import { createLogger, errorLogFields } from '../logger'
 import {
   LOCAL_RESOURCE_BUDGETS,
   ResourceBudgetExceededError,
+  PendingRequestBudget,
+  PendingRequestLimitError,
   readBoundedJsonBody
 } from '../resource-budget'
 import { PlanCommandError } from '../../shared/session-plan/contract'
@@ -233,6 +238,12 @@ type NotebookLocalRpcServerOptions = {
   }
   requestUserInput?: (request: AgentUserChoiceRequest) => Promise<AgentUserChoiceResult>
   artifactProvenance?: {
+    saveVersion?(
+      request: SaveArtifactVersionRequest,
+      sourceScope: ArtifactWriteSourceScope,
+      signal?: AbortSignal,
+      onMetadataBytes?: (bytes: number) => void
+    ): Promise<ArtifactVersionFile>
     createVersion(
       request: CreateArtifactVersionRequest,
       signal?: AbortSignal
@@ -476,6 +487,7 @@ class BackgroundHostMethodUnsafeError extends RpcHttpError {
 }
 
 const ARTIFACT_RPC_METHODS = new Set<ArtifactRpcMethod>([
+  'artifactSaveVersion',
   'artifactReserveWrite',
   'artifactReleaseWrite',
   'artifactCreateVersion',
@@ -670,6 +682,7 @@ class NotebookLocalRpcServer {
   private readonly activeArtifactTurnBindings = new Map<string, ActiveArtifactTurnBinding>()
   private readonly activeInputRunLeases = new Map<string, Set<NotebookInputRunLease>>()
   private readonly inputRunLeaseIds = new WeakMap<NotebookInputRunLease, string>()
+  private static readonly artifactRequestBudget = new PendingRequestBudget()
   private readonly artifactRpcCapabilities = new Map<string, ArtifactRpcCapability>()
   private readonly drainingArtifactRpcCapabilities = new Map<string, Promise<void>>()
   private readonly executionAuthorizations = new Map<
@@ -737,18 +750,17 @@ class NotebookLocalRpcServer {
     const token = randomUUID()
     this.artifactRpcCapabilities.set(token, {
       ...binding,
+      sourceScope: binding.sourceScope
+        ? {
+            ...binding.sourceScope,
+            allowedImportRoots: [...binding.sourceScope.allowedImportRoots]
+          }
+        : undefined,
       messageBranchAncestry: binding.messageBranchAncestry
         ? [...binding.messageBranchAncestry]
         : undefined,
       messageAncestry: binding.messageAncestry ? [...binding.messageAncestry] : undefined,
-      allowedMethods: new Set(
-        binding.allowedMethods ?? [
-          'artifactReserveWrite',
-          'artifactReleaseWrite',
-          'artifactCreateVersion',
-          'artifactReplayVersion'
-        ]
-      ),
+      allowedMethods: new Set(binding.allowedMethods ?? ['artifactSaveVersion']),
       expiresAt: this.now() + ttlMs,
       inFlightRequests: 0,
       drainWaiters: new Set()
@@ -1526,20 +1538,25 @@ class NotebookLocalRpcServer {
       throw new RpcHttpError(403, `Artifact RPC capability does not allow ${method}.`)
     }
 
-    const boundFields =
-      method === 'artifactCreateVersion'
-        ? [
-            'projectId',
-            'appSessionId',
-            'artifactStorageSessionId',
-            'artifactRunId',
-            'rootFrameId',
-            'agentFrameId',
-            'messageBranchId',
-            'runtimeSegmentId',
-            'promptMessageId'
-          ]
-        : ['projectId', 'appSessionId', 'artifactStorageSessionId', 'artifactRunId']
+    if (method !== 'artifactSaveVersion') {
+      throw new RpcHttpError(
+        409,
+        'Artifact save protocol changed. Restart the Agent MCP connection.'
+      )
+    }
+    if (!capability.sourceScope)
+      throw new RpcHttpError(403, 'Artifact save requires a trusted source scope.')
+    const boundFields = [
+      'projectId',
+      'appSessionId',
+      'artifactStorageSessionId',
+      'artifactRunId',
+      'rootFrameId',
+      'agentFrameId',
+      'messageBranchId',
+      'runtimeSegmentId',
+      'promptMessageId'
+    ] as const
     for (const field of boundFields) {
       const expected = capability[field as keyof ArtifactRpcCapabilityBinding]
       if (params[field] !== expected) {
@@ -1547,35 +1564,24 @@ class NotebookLocalRpcServer {
       }
     }
 
-    const sanitizedParams = { ...params }
-    delete sanitizedParams.messageBranchAncestry
-    delete sanitizedParams.messageAncestry
-    delete sanitizedParams.agentName
-    delete sanitizedParams.notebookSessionId
-
     const trustedParams = {
-      ...sanitizedParams,
+      ...params,
+      sourceScope: capability.sourceScope,
       projectId: capability.projectId,
       appSessionId: capability.appSessionId,
       artifactStorageSessionId: capability.artifactStorageSessionId,
       artifactRunId: capability.artifactRunId,
-      ...(method === 'artifactCreateVersion'
-        ? {
-            rootFrameId: capability.rootFrameId,
-            agentFrameId: capability.agentFrameId,
-            messageBranchId: capability.messageBranchId,
-            messageBranchAncestry: capability.messageBranchAncestry
-              ? [...capability.messageBranchAncestry]
-              : undefined,
-            messageAncestry: capability.messageAncestry
-              ? [...capability.messageAncestry]
-              : undefined,
-            runtimeSegmentId: capability.runtimeSegmentId,
-            promptMessageId: capability.promptMessageId,
-            agentName: capability.agentName,
-            notebookSessionId: capability.notebookSessionId
-          }
-        : {})
+      rootFrameId: capability.rootFrameId,
+      agentFrameId: capability.agentFrameId,
+      messageBranchId: capability.messageBranchId,
+      messageBranchAncestry: capability.messageBranchAncestry
+        ? [...capability.messageBranchAncestry]
+        : undefined,
+      messageAncestry: capability.messageAncestry ? [...capability.messageAncestry] : undefined,
+      runtimeSegmentId: capability.runtimeSegmentId,
+      promptMessageId: capability.promptMessageId,
+      agentName: capability.agentName,
+      notebookSessionId: capability.notebookSessionId
     }
     capability.inFlightRequests += 1
     let released = false
@@ -1676,6 +1682,7 @@ class NotebookLocalRpcServer {
   ): Promise<void> {
     const disconnect = new AbortController()
     let writeProducerSignal: AbortSignal | undefined
+    let artifactAdmission: ReturnType<PendingRequestBudget['acquire']> | undefined
     const activeRequest: NotebookRpcRequestLifecycle = {
       request,
       response,
@@ -1730,7 +1737,14 @@ class NotebookLocalRpcServer {
       }
       let payload: unknown
       try {
-        payload = await readBoundedJsonBody(request, this.requestBytes)
+        if (artifactCapability) {
+          artifactAdmission = NotebookLocalRpcServer.artifactRequestBudget.acquire(
+            `${artifactCapability.projectId}\0${artifactCapability.appSessionId}`
+          )
+        }
+        payload = await readBoundedJsonBody(request, this.requestBytes, {
+          onBytes: artifactAdmission?.addBytes
+        })
       } catch (error) {
         if (error instanceof SyntaxError) throw new RpcHttpError(400, error.message)
         throw error
@@ -2118,7 +2132,13 @@ class NotebookLocalRpcServer {
             ? await withDataRootWrite(() =>
                 this.dispatch(method, resolvedParams, dispatchSignal, checkMemoryAccess)
               )
-            : await this.dispatch(method, resolvedParams, dispatchSignal, checkMemoryAccess)
+            : await this.dispatch(
+                method,
+                resolvedParams,
+                dispatchSignal,
+                checkMemoryAccess,
+                artifactAdmission?.addBytes
+              )
 
       writeJson(response, 200, { result })
     } catch (error) {
@@ -2149,7 +2169,10 @@ class NotebookLocalRpcServer {
                   }
                 : message
 
-      if (error instanceof ResourceBudgetExceededError) {
+      if (
+        error instanceof ResourceBudgetExceededError ||
+        error instanceof PendingRequestLimitError
+      ) {
         closeRequestAfterResponse(request, response)
       }
 
@@ -2163,7 +2186,9 @@ class NotebookLocalRpcServer {
             ? 403
             : error instanceof ResourceBudgetExceededError
               ? 413
-              : 500,
+              : error instanceof PendingRequestLimitError
+                ? 429
+                : 500,
         { error: serializedError }
       )
     } finally {
@@ -2171,6 +2196,7 @@ class NotebookLocalRpcServer {
       response.off('close', abortDisconnectedResponse)
       lifecycle.activeRequests.delete(activeRequest)
       releaseArtifactRequest?.()
+      artifactAdmission?.release()
       releaseDelegatedNotebookRequest?.()
     }
   }
@@ -2180,7 +2206,8 @@ class NotebookLocalRpcServer {
     method: string,
     params: Record<string, unknown>,
     signal: AbortSignal,
-    checkMemoryAccess?: () => Promise<void>
+    checkMemoryAccess?: () => Promise<void>,
+    onArtifactMetadataBytes?: (bytes: number) => void
   ): Promise<unknown> {
     if (WSL_SETUP_RPC_METHODS.has(method)) {
       if (!this.wslSetup || !this.wslSetupSessions) {
@@ -2287,37 +2314,15 @@ class NotebookLocalRpcServer {
     // Artifact stdio/HTTP MCP handlers cannot own SQLite connections. Route the trusted run-bound
     // save envelope back into the main process, where the Provenance repository owns transactions,
     // immutable Version publication, and idempotency.
-    if (method === 'artifactCreateVersion') {
-      if (!this.artifactProvenance) {
-        throw new Error('Artifact Provenance persistence is not configured.')
-      }
-      const request = params as CreateArtifactVersionRequest
-      if (!request.resourceReservationId) {
-        throw new RpcHttpError(400, 'Artifact Version creation requires a write reservation.')
-      }
-      return this.artifactProvenance.createVersion(request, signal)
-    }
-    if (method === 'artifactReserveWrite') {
-      if (!this.artifactProvenance?.reserveWrite) {
-        throw new Error('Artifact write reservation is not configured.')
-      }
-      return this.artifactProvenance.reserveWrite(params as ReserveArtifactWriteRequest)
-    }
-    if (method === 'artifactReleaseWrite') {
-      if (!this.artifactProvenance?.releaseWriteReservation) {
-        throw new Error('Artifact write reservation is not configured.')
-      }
-      await this.artifactProvenance.releaseWriteReservation(
-        params as ReleaseArtifactWriteReservationRequest
+    if (method === 'artifactSaveVersion') {
+      if (!this.artifactProvenance?.saveVersion) throw new Error('Artifact save is unavailable.')
+      const request = artifactSaveRequestSchema.parse(params)
+      return this.artifactProvenance.saveVersion(
+        request,
+        params.sourceScope as ArtifactWriteSourceScope,
+        signal,
+        onArtifactMetadataBytes
       )
-      return { released: true }
-    }
-    if (method === 'artifactReplayVersion') {
-      if (!this.artifactProvenance?.replayVersion) {
-        throw new Error('Artifact Provenance persistence is not configured.')
-      }
-
-      return this.artifactProvenance.replayVersion(params as ReplayArtifactVersionRequest)
     }
 
     if (method === 'skillImport') {

--- a/src/main/resource-budget.ts
+++ b/src/main/resource-budget.ts
@@ -5,6 +5,10 @@ const GIB = 1024 * MIB
 
 const LOCAL_RESOURCE_BUDGETS = Object.freeze({
   requestBytes: 64 * MIB,
+  artifactSaveSessionRequests: 16,
+  artifactSaveProcessRequests: 64,
+  artifactSaveSessionPayloadBytes: 128 * MIB,
+  artifactSaveProcessPayloadBytes: 512 * MIB,
   artifactInlineBytes: 32 * MIB,
   artifactFileBytes: 1 * GIB,
   artifactTurnBytes: 2 * GIB,
@@ -60,7 +64,7 @@ const declaredContentLength = (request: IncomingMessage): number | undefined => 
 const readBoundedJsonBody = async <Result = unknown>(
   request: IncomingMessage,
   maxBytes = LOCAL_RESOURCE_BUDGETS.requestBytes,
-  options?: { emptyValue: Result }
+  options?: { emptyValue?: Result; onBytes?: (bytes: number) => void }
 ): Promise<Result> => {
   const declared = declaredContentLength(request)
   if (declared !== undefined) assertWithinResourceBudget('request', declared, maxBytes)
@@ -71,10 +75,11 @@ const readBoundedJsonBody = async <Result = unknown>(
     const buffer = typeof chunk === 'string' ? Buffer.from(chunk) : Buffer.from(chunk)
     observedBytes += buffer.byteLength
     assertWithinResourceBudget('request', observedBytes, maxBytes)
+    options?.onBytes?.(buffer.byteLength)
     chunks.push(buffer)
   }
 
-  if (chunks.length === 0 && options) return options.emptyValue
+  if (chunks.length === 0 && options && 'emptyValue' in options) return options.emptyValue as Result
   return JSON.parse(Buffer.concat(chunks, observedBytes).toString('utf8')) as Result
 }
 
@@ -86,3 +91,61 @@ export {
 }
 export type { ResourceBudgetDimension }
 export type { LocalResourceBudgetOverrides }
+
+export class PendingRequestLimitError extends Error {
+  readonly code = 'ARTIFACT_SAVE_RESOURCE_LIMIT'
+  constructor() {
+    super('ARTIFACT_SAVE_RESOURCE_LIMIT: too many pending Artifact requests or payload bytes.')
+  }
+}
+
+// Admission accounts for bodies while they arrive as well as while dispatch is queued/running.
+// It owns no file reservations and never waits for a session write queue.
+export class PendingRequestBudget {
+  private count = 0
+  private bytes = 0
+  private readonly sessions = new Map<string, { count: number; bytes: number }>()
+  constructor(
+    private readonly limits: {
+      [Key in keyof typeof LOCAL_RESOURCE_BUDGETS]: number
+    } = LOCAL_RESOURCE_BUDGETS
+  ) {}
+
+  acquire(sessionKey: string): { addBytes(bytes: number): void; release(): void } {
+    const session = this.sessions.get(sessionKey) ?? { count: 0, bytes: 0 }
+    if (
+      session.count >= this.limits.artifactSaveSessionRequests ||
+      this.count >= this.limits.artifactSaveProcessRequests
+    )
+      throw new PendingRequestLimitError()
+    session.count++
+    this.count++
+    this.sessions.set(sessionKey, session)
+    let bytes = 0
+    let released = false
+    return {
+      addBytes: (amount) => {
+        if (released) throw new Error('Request admission is already released.')
+        if (!Number.isSafeInteger(amount) || amount < 0)
+          throw new TypeError('Invalid request payload byte count.')
+        if (
+          session.bytes + amount > this.limits.artifactSaveSessionPayloadBytes ||
+          this.bytes + amount > this.limits.artifactSaveProcessPayloadBytes
+        )
+          throw new PendingRequestLimitError()
+        bytes += amount
+        session.bytes += amount
+        this.bytes += amount
+      },
+      release: () => {
+        if (released) return
+        released = true
+        session.count--
+        this.count--
+        session.bytes -= bytes
+        this.bytes -= bytes
+        if (session.count === 0) this.sessions.delete(sessionKey)
+      }
+    }
+  }
+}

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -632,6 +632,7 @@ describe('Settings backend ownership architecture', () => {
 
   it('locks the complete Notebook local-RPC capability inventory', () => {
     expect(stringSetValues(settingsPaths.notebookLocalRpcServer, 'ARTIFACT_RPC_METHODS')).toEqual([
+      'artifactSaveVersion',
       'artifactReserveWrite',
       'artifactReleaseWrite',
       'artifactCreateVersion',

--- a/src/shared/artifact-provenance.ts
+++ b/src/shared/artifact-provenance.ts
@@ -59,6 +59,26 @@ export type CreateArtifactVersionRequest = {
   literature?: ArtifactLiteratureRequest
 }
 
+// The source scope is supplied only by the main-process capability issuer.
+export type ArtifactWriteSourceScope = {
+  allowedImportRoots: string[]
+  workspaceCwd?: string
+  notebookDataDir?: string
+  notebookSessionRoot?: string
+}
+
+export type SaveArtifactVersionRequest = Omit<
+  CreateArtifactVersionRequest,
+  | 'writeRequestChecksum'
+  | 'sourceKind'
+  | 'sourceFileObservation'
+  | 'resourceReservationId'
+  | 'resourceSizeBytes'
+  | 'resourceChecksum'
+> & {
+  source: ArtifactWriteSource
+}
+
 export type ReserveArtifactWriteRequest = {
   projectId: string
   appSessionId: string
@@ -95,6 +115,7 @@ export type ReplayArtifactVersionRequest = {
 }
 
 export type ArtifactRpcMethod =
+  | 'artifactSaveVersion'
   | 'artifactReserveWrite'
   | 'artifactReleaseWrite'
   | 'artifactCreateVersion'
@@ -117,6 +138,7 @@ export type ArtifactRpcCapabilityBinding = {
   promptMessageId: string
   agentName?: string
   notebookSessionId?: string
+  sourceScope?: ArtifactWriteSourceScope
   allowedMethods?: ArtifactRpcMethod[]
 }
 


### PR DESCRIPTION
## Problem

Concurrent artifact saves can interleave pending-file replacement and budget scans across the MCP process and main, so one save observes another transaction's temporary or disappearing path. Artifacts need a complete transaction boundary across saves, recovery and finalization.

## Proposed change

Route each agent save through one `artifactSaveVersion` RPC and the existing main-process session queue, shared with app-generated saves, recovery and final publication. Bind source roots at capability issuance; preserve operation IDs, checksum semantics, immutable Versions, producer/literature evidence and historical recovery formats.

Bound queued request counts/bytes, canonicalize inline transport, cancel queued work promptly, and retain durable staging evidence on interrupted publication. Independent review identified an unbounded literature-sidecar read moved into main; it now uses cancellable bounded reads and the same admission accounting. Replaying an older operation preserves the newer compatibility file.

```mermaid
flowchart LR
  MCP[Agent MCP] --> RPC[Complete save RPC]
  RPC --> Admission[Capability and payload admission]
  Admission --> Queue[Existing session writer queue]
  App[App-generated save] --> Queue
  Recovery[Recovery / final publication] --> Queue
  Queue --> Save[Validate / reserve / copy / publish / cleanup]
```

## Scope and non-goals

No storage migration, schema change, renderer UI change, or unrelated startup-load fix. Old split-write MCP connections must reconnect. Same-session saves serialize; other sessions remain independent.

## Acceptance criteria and validation

Independent Standards and Spec reviews completed; the sidecar finding was fixed and independently re-reviewed. The final impact map was independently confirmed. The full portable suite and focused checks below were run for the reviewed implementation. The source and test trees are unchanged by the history cleanup removing docs/ and scripts/ changes.

| Behavior | Command | Result |
| --- | --- | --- |
| Metadata bounds/cancellation/admission, save RPC, crashes, logging guard | `npm test -- src/main/artifacts/prepared-literature-sidecar.test.ts src/main/artifacts/artifact-save.integration.test.ts src/main/notebook/local-rpc-server.test.ts src/main/logger.test.ts src/main/artifacts/artifact-save-crash.integration.test.ts` | 199 passed |
| Harvested binary publication and RPC inventory | `npm test -- src/main/compute/compute-job-workflow-owner.test.ts src/main/settings/settings-backend.architecture.test.ts` | 63 passed |
| All owner/interface/consumer portable regressions | `npm test` | 33,481 passed, 61 failed, 553 skipped; 6 failed files including one collection error (details below) |
| Repository rules | `npm run lint` | Passed |
| Main/sandbox and renderer contracts | `npm run typecheck:node`; `npm run typecheck:web` | Existing shared installation lacks declared `reflect-metadata` and `@peculiar/x509`; standard checks blocked |
| Supplemental main/sandbox/web type checks using temporary mappings to the two already-declared dependencies | `tsc --noEmit -p <temporary extending config> --composite false`, preserving each project config and mapping only the two missing packages | All three passed |

Integration tests cover six fresh-process SIGKILL recovery scenarios and the preserved history/producer/source-authority tests. Five concurrent files (1/4/8/16/32 MiB) took a median 409 ms before and 430 ms after; a same-session 1 KiB save behind 128 MiB took 565 ms after serialization. These local measurements are not general throughput guarantees.

Final full fallback completed after the last material source/test edit: 1,723 files passed, 6 failed, 36 skipped (719.58 s). All Artifact/compute/RPC and affected architecture checks passed. Remaining failures are outside changed files: 54 sandbox tests and one literature collection failure cannot resolve `reflect-metadata`; one release backfill test fails with “Path is a directory” (reproduced on baseline); six sandbox network-enforcement failures form an incomplete-cleanup/active-owner cascade, also reproduced exactly on baseline (separate from the dependency failures). Standard typechecks also report missing `@peculiar/x509`. The PR remains draft and is **not claimed fully verified**.

Windows named-pipe, remote-host and packaging/E2E lanes were not run locally; CI remains authoritative. Local Node is 23.11.0 (CONTRIBUTING recommends 22). No dependencies or lockfiles were changed during review.

## Review focus

Queue ownership and drain-before-finalization ordering; rollback versus durable staging recovery; capability-bound imports and derived metadata limits; compatibility routing on old-operation replay.

