### PR TITLE
feat(notebook): expand managed R runtime baseline

### DIFF
--- a/.github/workflows/stage-runtime-bundle.yml
+++ b/.github/workflows/stage-runtime-bundle.yml
@@ -17,7 +17,7 @@ on:
       version:
         description: Runtime bundle version to publish
         required: true
-        default: '1'
+        default: '2'
         type: string
 
 # Read-only on the repo; writes go to S3, not back to git.

--- a/scripts/stage-default-envs.mjs
+++ b/scripts/stage-default-envs.mjs
@@ -54,7 +54,7 @@ export const VERSIONS = {
 export const floorPackages = (language, version) =>
   language === 'python'
     ? [`python=${version}`, 'matplotlib-base', 'nomkl']
-    : [`r-base=${version}`, 'r-jsonlite']
+    : [`r-base=${version}`, 'r-jsonlite', 'r-biocmanager', 'r-ggplot2']
 
 // packId = `<language>-<version>` (mirrors bundle-manifest.ts::packId). Keys the lock filename,
 // the CDN object and the manifest.packs map.

--- a/scripts/stage-default-envs.test.ts
+++ b/scripts/stage-default-envs.test.ts
@@ -58,7 +58,7 @@ describe('curated version matrix', () => {
     expect(py311).toMatchObject({ language: 'python', version: '3.11' })
     expect(py311?.packages).toEqual(['python=3.11', 'matplotlib-base', 'nomkl'])
     const r43 = matrix.find((p) => p.id === 'r-4.3')
-    expect(r43?.packages).toEqual(['r-base=4.3', 'r-jsonlite'])
+    expect(r43?.packages).toEqual(['r-base=4.3', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2'])
   })
 })
 

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1868,7 +1868,9 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
 
     await provisioner.createNamedEnvironment('r-stats', 'r')
 
-    expect(argvs[0]).toEqual(expect.arrayContaining(['r-base', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2']))
+    expect(argvs[0]).toEqual(
+      expect.arrayContaining(['r-base', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2'])
+    )
   })
 
   it('holds the shared pkgs cache lock, so a concurrent exclusive repair cannot run mid-create', async () => {

--- a/src/main/notebook/provisioner.test.ts
+++ b/src/main/notebook/provisioner.test.ts
@@ -1345,7 +1345,7 @@ describe('default specs', () => {
       name: DEFAULT_R_ENV,
       language: 'r',
       version: '4.4',
-      packages: ['r-base=4.4', 'r-jsonlite']
+      packages: ['r-base=4.4', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2']
     })
     expect(DEFAULT_MANAGED_VERSION).toEqual({ python: '3.12', r: '4.4' })
     // version drives the packId-keyed offline lock the local bundle adapter looks up.
@@ -1355,7 +1355,7 @@ describe('default specs', () => {
 
   it('the named-env base floor constants stay lean', () => {
     expect(BASE_PYTHON_PACKAGES).toEqual(['python=3.12', 'matplotlib-base', 'nomkl'])
-    expect(BASE_R_PACKAGES).toEqual(['r-base', 'r-jsonlite'])
+    expect(BASE_R_PACKAGES).toEqual(['r-base', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2'])
   })
 })
 
@@ -1868,7 +1868,7 @@ describe('DefaultRuntimeProvisioner.createNamedEnvironment', () => {
 
     await provisioner.createNamedEnvironment('r-stats', 'r')
 
-    expect(argvs[0]).toEqual(expect.arrayContaining(['r-base', 'r-jsonlite']))
+    expect(argvs[0]).toEqual(expect.arrayContaining(['r-base', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2']))
   })
 
   it('holds the shared pkgs cache lock, so a concurrent exclusive repair cannot run mid-create', async () => {

--- a/src/main/notebook/provisioner.ts
+++ b/src/main/notebook/provisioner.ts
@@ -167,7 +167,7 @@ export const DEFAULT_R_SPEC: EnvSpec = {
   name: DEFAULT_R_ENV,
   language: 'r',
   version: DEFAULT_MANAGED_VERSION.r,
-  packages: [`r-base=${DEFAULT_MANAGED_VERSION.r}`, 'r-jsonlite']
+  packages: [`r-base=${DEFAULT_MANAGED_VERSION.r}`, 'r-jsonlite', 'r-biocmanager', 'r-ggplot2']
 }
 
 // Named-env base floor (design D2/OQ2): the minimal exec-loop-protocol requirement, distinct from the
@@ -175,7 +175,7 @@ export const DEFAULT_R_SPEC: EnvSpec = {
 // implements the R loop's line-based JSON framing. Deliberately lean — convenience packages (numpy,
 // pandas, …) are left to a follow-up manage_packages call.
 export const BASE_PYTHON_PACKAGES: string[] = ['python=3.12', 'matplotlib-base', 'nomkl']
-export const BASE_R_PACKAGES: string[] = ['r-base', 'r-jsonlite']
+export const BASE_R_PACKAGES: string[] = ['r-base', 'r-jsonlite', 'r-biocmanager', 'r-ggplot2']
 
 // Injected dependencies so the orchestration unit-tests without network or real subprocesses
 // (mirrors globalenv.rs::provision_with).

--- a/src/main/notebook/runtime-paths.test.ts
+++ b/src/main/notebook/runtime-paths.test.ts
@@ -86,7 +86,7 @@ describe('runtime-paths layout', () => {
       isWin ? join('/e', 'Lib', 'R', 'bin', 'Rscript.exe') : join('/e', 'bin', 'Rscript')
     )
     expect(readyMarkerPath('/r')).toBe(join('/r', '.env-ready'))
-    expect(DEFAULT_ENV_VERSION).toBe(1)
+    expect(DEFAULT_ENV_VERSION).toBe(2)
     expect(DEFAULT_R_ENV).toBe('default-r')
   })
 

--- a/src/main/notebook/runtime-paths.ts
+++ b/src/main/notebook/runtime-paths.ts
@@ -16,7 +16,7 @@ import type { NotebookLanguage } from '../../shared/notebook'
 //   3. run stage-runtime-bundle with the matching explicit version before releasing the app. A
 //      deliberate republish replaces that version, and build.yml verifies the matching platform
 //      manifest is live before packaging an installer.
-export const DEFAULT_ENV_VERSION = 1
+export const DEFAULT_ENV_VERSION = 2
 
 export const DEFAULT_RUNTIME_CDN_BASE = 'https://statics.aipoch.com/open-science'
 


### PR DESCRIPTION
## Problem
The managed R runtime baseline only included the kernel protocol floor (`r-base` and `r-jsonlite`), so common plotting and Bioconductor workflows required an immediate package installation.

## Proposed change
Add `r-biocmanager` and `r-ggplot2` to the managed R baseline and staged runtime packs. Bump the immutable runtime bundle version from 1 to 2 so existing cached environments remain reproducible. Python is unchanged.

## Scope and non-goals
No database, persistence, enum, or UI changes. Other R packages remain on-demand.

## Acceptance criteria and validation
- Focused staging and provisioning tests pass (141 tests).
- Node typecheck was started; full CI remains authoritative for packaging and bundle publication.
- Bundle size impact is limited to R runtime archives for each platform/version.

## Review focus
Confirm the package names match conda-forge availability and that runtime bundle version 2 is published before release packaging.
