### PR TITLE
fix(side-chat): allow Codex subscription in the workspace

### DIFF
--- a/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx
@@ -7,6 +7,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type * as React from 'react'
 
+import { useSettingsStore } from '@/stores/settings-store'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { createInitialMemoryState, useMemoryStore } from '@/stores/memory-store'
 import {
@@ -252,6 +253,38 @@ describe('WorkspacePage send gate while compacting', () => {
       )
     })
   }
+
+  it.each(['codex-shared', 'codex-isolated'] as const)(
+    'keeps Side chat available when the global main provider changes to %s',
+    async (type) => {
+      useSessionStore.setState({ sessions: [createReviewableSession()] })
+      await renderPage()
+      await act(async () => {
+        conversationProps.composer.actions.changeDoc(textDoc('Ask on the side'))
+      })
+      expect(conversationProps.view.sideChatDisabledReason).toBeUndefined()
+
+      await act(async () => {
+        useSettingsStore.setState({
+          activeProviderId: 'builtin-codex-subscription',
+          activeModel: 'gpt-5.6-luna',
+          providers: [
+            {
+              id: 'builtin-codex-subscription',
+              type,
+              name: 'Codex subscription',
+              models: ['gpt-5.6-luna'],
+              hasKey: true,
+              needsKey: false,
+              supportsImageInput: true
+            }
+          ]
+        })
+      })
+
+      expect(conversationProps.view.sideChatDisabledReason).toBeUndefined()
+    }
+  )
 
   it('saves the selected branch before stopping its Subagents', async () => {
     let releaseSave: (() => void) | undefined

--- a/src/renderer/src/pages/workspace/WorkspacePage.tsx
+++ b/src/renderer/src/pages/workspace/WorkspacePage.tsx
@@ -49,7 +49,6 @@ import {
 import { resolveEffectiveSpecialistSkills } from '../../../../shared/specialist'
 import { revealNotebookWhenProjectActive } from './notebook-preview-availability'
 import { invalidateSessionNotebookCache } from './session-notebook-data'
-import { isCodexSubscriptionProvider } from '../../../../shared/settings'
 import { hasCurrentRunningDelegatedAttempt } from '../../../../shared/delegated-work-projection'
 import {
   appendArtifactMention,
@@ -150,10 +149,6 @@ const WorkspacePage = ({
   const goHome = useNavigationStore((state) => state.goHome)
   const openProjectLiterature = useNavigationStore((state) => state.openProjectLiterature)
   const openSettings = useSettingsStore((state) => state.openSettings)
-  const activeProviderId = useSettingsStore((state) => state.activeProviderId)
-  const activeProviderType = useSettingsStore(
-    (state) => state.providers.find((provider) => provider.id === activeProviderId)?.type
-  )
   const defaultPermissionProfile = useSettingsStore((state) => state.defaultPermissionProfile)
   const settingsSkills = useSettingsStore((state) => state.skills)
   const catalogSkills = useMemo(
@@ -532,10 +527,7 @@ const WorkspacePage = ({
   const awaitsHistoryReplay = sessionAwaitsHistoryReplay(activeSession)
   const sideChatDisabledReason = awaitsHistoryReplay
     ? t('Resolve the current Session operation first.')
-    : (sideChat.unavailableReason ??
-      (activeProviderType !== undefined && isCodexSubscriptionProvider(activeProviderType)
-        ? 'Side chat is unavailable for Codex subscription because strict tool isolation cannot be enforced.'
-        : undefined))
+    : sideChat.unavailableReason
   const canArchiveSession = sessionController.lifecycle.canArchive
   const visiblePermissionRequests = useMemo(
     () =>


### PR DESCRIPTION
## Problem

Setting **Settings → Models → Main model** to Codex subscription disables Side chat with “strict tool isolation cannot be enforced,” even though native subscription startup and resume are supported by #2394. Selecting the same provider only in an existing Session does not trigger the warning: the stale guard reads the global provider.

## Proposed change

Remove the obsolete provider-specific renderer guard. Keep the existing Side chat restoration/closing and pending Session-operation guards. Add regression coverage for switching the global main provider to both `codex-shared` and `codex-isolated`, using `gpt-5.6-luna` as the selected model.

## Scope and non-goals

Only WorkspacePage and its send-gate tests change. Backend tool isolation, authentication, persistence, and model routing are unchanged.

## Acceptance criteria and validation

Changing the global main provider to Codex subscription must not itself disable Side chat. Existing operation and lifecycle restrictions must continue to apply.

All listed final checks ran after the last material edit:

| Behavior / boundary | Command | Result |
| --- | --- | --- |
| Workspace provider gate and pending-operation restrictions | `npm test -- src/renderer/src/pages/workspace/WorkspacePage.send-gate.test.tsx` | Passed in the combined run below |
| Send-menu consumer and Side chat controller lifecycle | `npm test -- src/renderer/src/pages/workspace/ConversationPanel.interaction.test.tsx src/renderer/src/pages/workspace/use-side-chat-controller.test.ts` | Passed in the combined run below |
| Existing restricted backend lifecycle and i18n guards | `npm test -- src/main/side-chat/runtime-owner.test.ts src/renderer/src/i18n/resources.test.ts` | Passed in the combined run below |
| Renderer type contracts | `npm run typecheck:web` | Passed |
| Source lint | `npm run lint` | Passed |

The five test files above were run together with `npm test -- <all five paths>`: **5 files, 1060 tests passed**. This is targeted verification, not the full portable suite. Both new regression cases failed with the original English warning before the fix and passed afterward.

The original bug was reproduced manually in installed macOS v0.28.0: changing the Session model alone left Side chat enabled; changing the global main model displayed the warning. The fixed build has not been exercised with a live model request or packaged-app E2E. No platform-specific, migration, or main-process implementation changed, so platform/build lanes and node typechecking were excluded from the local impact set; CI and independent review remain pending.

## Review focus

Confirm that removing the stale frontend gate matches the subscription support introduced in #2394 and that the remaining lifecycle restrictions cover the final behavior.
