### PR TITLE
fix(opencode): disable native Todo tools

### DIFF
--- a/src/main/acp/permission-broker.test.ts
+++ b/src/main/acp/permission-broker.test.ts
@@ -1076,12 +1076,37 @@ describe('ACP permission broker', () => {
     expect(broker.listGrants('session-1')).toEqual([])
   })
 
+  it.each(['todoread', 'todowrite'])(
+    'rejects the OpenCode native %s tool without exposing an approval path',
+    async (toolName) => {
+      const emitted: EmittedPermissionRequest[] = []
+      const broker = new AcpPermissionBroker((request) => emitted.push(request))
+
+      const response = broker.requestPermission(
+        createToolPermissionRequest({
+          title: toolName,
+          providerToolName: 'other',
+          kind: 'other',
+          rawInput: {}
+        }),
+        { profile: 'full', frameworkId: 'opencode' }
+      )
+
+      expect(emitted).toEqual([])
+      await expect(response).resolves.toEqual({ outcome: { outcome: 'cancelled' } })
+    }
+  )
+
   it('keeps non-OpenCode and unknown OpenCode tools on the normal approval path', () => {
     const emitted: EmittedPermissionRequest[] = []
     const broker = new AcpPermissionBroker((request) => emitted.push(request))
 
     void broker.requestPermission(
       createToolPermissionRequest({ title: 'skill', kind: 'other', rawInput: {} }),
+      { profile: 'ask', frameworkId: 'claude-code' }
+    )
+    void broker.requestPermission(
+      createToolPermissionRequest({ title: 'todowrite', kind: 'other', rawInput: {} }),
       { profile: 'ask', frameworkId: 'claude-code' }
     )
     void broker.requestPermission(
@@ -1093,7 +1118,7 @@ describe('ACP permission broker', () => {
       { profile: 'ask', frameworkId: 'opencode' }
     )
 
-    expect(emitted).toHaveLength(3)
+    expect(emitted).toHaveLength(4)
   })
 
   it('requires a stable server and tool identity before offering MCP session scope', () => {

--- a/src/main/acp/permission-broker.ts
+++ b/src/main/acp/permission-broker.ts
@@ -138,6 +138,20 @@ const CODEX_POLICY_AMENDMENT_OPTION_ID_PATTERN = /^accept_.*policy_amendment$/
 // position) is robust to option reordering — tests pin this contract.
 const CODEX_MCP_PERSISTENT_ALLOW_OPTION_ID = 'allow_always'
 const CODEX_EXEC_POLICY_AMENDMENT_OPTION_ID = 'accept_execpolicy_amendment'
+const OPENCODE_DISABLED_NATIVE_TODO_TOOLS = new Set(['todoread', 'todowrite'])
+
+const isDisabledOpenCodeNativeTodoRequest = (
+  request: RequestPermissionRequest,
+  policyContext?: PermissionPolicyContext
+): boolean => {
+  if (policyContext?.frameworkId !== 'opencode') return false
+
+  return [extractProviderToolName(request.toolCall), request.toolCall.title].some(
+    (toolName) =>
+      typeof toolName === 'string' &&
+      OPENCODE_DISABLED_NATIVE_TODO_TOOLS.has(toolName.trim().toLowerCase())
+  )
+}
 
 const metadataRecord = (value: unknown): Record<string, unknown> | undefined =>
   value && typeof value === 'object' && !Array.isArray(value)
@@ -961,6 +975,12 @@ class AcpPermissionBroker {
     params: RequestPermissionRequest,
     policyContext?: PermissionPolicyContext
   ): Promise<RequestPermissionResponse> {
+    // Current OpenCode releases surface configured native-tool denials as ACP approval requests.
+    // Reject Todo here before profile/grant resolution so no UI or Full-access path can re-enable it.
+    if (isDisabledOpenCodeNativeTodoRequest(params, policyContext)) {
+      return Promise.resolve({ outcome: { outcome: 'cancelled' } })
+    }
+
     const cancellationGeneration = this.cancellationGeneration
     const requestId = randomUUID()
     const mcpServerNames = policyContext?.mcpServerNames ?? []

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -12648,6 +12648,43 @@ describe('ACP runtime session management', () => {
     expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([])
   })
 
+  it('rejects OpenCode native Todo even when the Session uses Full access', async () => {
+    const process = new FakeAgentProcess()
+    const permissionRequests: AcpPermissionRequest[] = []
+    let permissionResponse: unknown
+    startPermissionProbeAgent(process, {
+      newSessionId: 'opencode-todo-session',
+      toolCallId: 'opencode-todo-call',
+      toolTitle: 'todowrite',
+      toolKind: 'other',
+      toolRawInput: { todos: [{ content: 'shadow plan', status: 'pending' }] },
+      permissionOptions: [
+        { optionId: 'once', kind: 'allow_once', name: 'Allow once' },
+        { optionId: 'always', kind: 'allow_always', name: 'Always allow' },
+        { optionId: 'reject', kind: 'reject_once', name: 'Reject' }
+      ],
+      onPermissionResponse: (response) => {
+        permissionResponse = response
+      }
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.1.0',
+      defaultCwd: '/workspace',
+      spawnAgent: () => asAgentProcess(process),
+      framework: opencodeFramework,
+      callbacks: {
+        onPermissionRequest: (request) => permissionRequests.push(request)
+      }
+    })
+    const session = await runtime.createSession({ cwd: '/workspace', permissionProfile: 'full' })
+
+    await runtime.sendPrompt({ sessionId: session.sessionId, text: 'write a native todo' })
+
+    expect(permissionRequests).toEqual([])
+    expect(permissionResponse).toEqual({ outcome: { outcome: 'cancelled' } })
+    expect(runtime.getSnapshot().permissionGrants[session.sessionId]).toEqual([])
+  })
+
   it('does not trust an isolated OpenCode permission title as native Skill identity', async () => {
     const process = new FakeAgentProcess()
     const permissionRequests: AcpPermissionRequest[] = []

--- a/src/main/agent-framework/opencode.test.ts
+++ b/src/main/agent-framework/opencode.test.ts
@@ -162,6 +162,23 @@ describe('opencodeFramework.prepareModelConfig', () => {
     })
   })
 
+  it('disables OpenCode native todo tools in app-managed Sessions', () => {
+    const config = opencodeFramework.prepareModelConfig(
+      { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
+      { storageRoot: '/data', executablePath: '/bin/opencode' }
+    )
+
+    const authoritativeConfig = JSON.parse(config.env?.OPENCODE_CONFIG_CONTENT ?? '{}')
+    expect(authoritativeConfig.tools).toEqual({
+      todoread: false,
+      todowrite: false
+    })
+    expect(authoritativeConfig.permission).toMatchObject({
+      todoread: 'deny',
+      todowrite: 'deny'
+    })
+  })
+
   it('redirects opencode home to an app-owned dir so the user ~/.opencode cannot inject config', () => {
     const config = opencodeFramework.prepareModelConfig(
       { type: 'custom', baseUrl: 'https://gw/v1', model: 'm', key: 'k' },
@@ -647,6 +664,27 @@ describe('opencodeFramework.prepareModelConfig', () => {
 })
 
 describe('buildOpencodeConfig', () => {
+  it('keeps native todo tools disabled while preserving unrelated tool configuration', () => {
+    const config = JSON.parse(
+      buildOpencodeConfig(
+        { type: 'custom', baseUrl: 'https://gw/v1', model: 'm' },
+        {
+          tools: {
+            custom_tool: true,
+            todoread: true,
+            todowrite: true
+          }
+        }
+      )
+    )
+
+    expect(config.tools).toEqual({
+      custom_tool: true,
+      todoread: false,
+      todowrite: false
+    })
+  })
+
   it('registers the model under provider.models and selects it', () => {
     const config = JSON.parse(
       buildOpencodeConfig({

--- a/src/main/agent-framework/opencode.ts
+++ b/src/main/agent-framework/opencode.ts
@@ -135,6 +135,10 @@ const OPENCODE_PERMISSION_RULES: Record<string, 'ask' | 'allow' | 'deny'> = {
   // work graph. Deny it at the highest-precedence config layer: asking is insufficient because an
   // approval would still create an invisible child that bypasses Attempt authority and lifecycle.
   task: 'deny',
+  // Open Science owns durable planning and progress through Session Plans. Keep OpenCode's transient
+  // native Todo list unavailable so it cannot create a competing, non-durable progress surface.
+  todoread: 'deny',
+  todowrite: 'deny',
   // Skill loading only reads definitions already provisioned into the isolated OpenCode config.
   // Permission for creating/editing/enabling those definitions remains app-owned elsewhere.
   skill: 'allow',
@@ -150,6 +154,11 @@ const OPENCODE_DISABLED_NATIVE_AGENTS = {
   general: { disable: true },
   explore: { disable: true },
   scout: { disable: true }
+} as const
+
+const OPENCODE_DISABLED_NATIVE_TOOLS = {
+  todoread: false,
+  todowrite: false
 } as const
 
 const asRecord = (value: unknown): Record<string, unknown> =>
@@ -380,6 +389,7 @@ const buildAppConfigContent = (
 
   return {
     ...(bareModel ? { model: `${providerId}/${bareModel}` } : {}),
+    tools: { ...OPENCODE_DISABLED_NATIVE_TOOLS },
     permission: { ...OPENCODE_PERMISSION_RULES },
     agent: { ...OPENCODE_DISABLED_NATIVE_AGENTS },
     provider: buildOpencodeProviders(provider, reasoningEffort, catalog)
@@ -402,6 +412,7 @@ const buildOpencodeConfig = (
 
   const baseProviders = asRecord(baseConfig.provider)
   const basePermission = asRecord(baseConfig.permission)
+  const baseTools = asRecord(baseConfig.tools)
   // Preserve any instructions the base config already declared, then append ours (de-duplicated).
   const baseInstructions = Array.isArray(baseConfig.instructions)
     ? baseConfig.instructions.filter((entry): entry is string => typeof entry === 'string')
@@ -420,6 +431,10 @@ const buildOpencodeConfig = (
     permission: {
       ...basePermission,
       ...OPENCODE_PERMISSION_RULES
+    },
+    tools: {
+      ...baseTools,
+      ...OPENCODE_DISABLED_NATIVE_TOOLS
     },
     agent: {
       ...asRecord(baseConfig.agent),


### PR DESCRIPTION
## Problem

OpenCode's native `todoread` and `todowrite` tools create a transient progress list that overlaps with Open Science Session Plans. That gives a Session two competing sources of planning/progress truth, and the native list is not persisted or surfaced through the app-owned plan lifecycle.

## Proposed change

- Force-disable `todoread` and `todowrite` in the authoritative app-managed OpenCode config while preserving unrelated tool configuration.
- Deny the matching OpenCode permissions at the config layer.
- Fail closed in the ACP permission broker before profile/grant resolution, because OpenCode 1.18.14 can surface a configured denial as an ACP approval request.
- Add config, broker-boundary, and runtime integration coverage.

## Scope and non-goals

- Scope is limited to OpenCode's native Todo tools.
- Other OpenCode tools, custom tools, MCP tools, providers, and non-OpenCode frameworks retain their existing permission flow.
- Session Plan behavior, UI, persistence, and translations are unchanged.

## Acceptance criteria and validation

- Native Todo is disabled in authoritative and merged OpenCode configs; unrelated tool config remains intact: covered by `src/main/agent-framework/opencode.test.ts`.
- OpenCode Todo requests cannot be approved through Ask/Full access and do not create grants or approval UI; non-OpenCode and unknown OpenCode tools keep the normal path: covered by `src/main/acp/permission-broker.test.ts`.
- Runtime-level OpenCode Full access still rejects native Todo: covered by `src/main/acp/runtime.test.ts`.
- Focused affected-module suite: **792 passed**.
- `npm run typecheck`: **passed**.
- `npm run lint`: **passed**.
- `git diff --check`: **passed**.
- Manual dev-app validation with OpenCode 1.18.14: native Todo was cancelled under Full access without an approval card, a normal native read still succeeded, and a Session Plan generated, approved, updated, and completed.
- Exact-head `npm run test:affected -- --base origin/main --head HEAD` selected the required full fallback: **33,597 passed, 553 skipped, 2 pre-existing failures**. Both failing surfaces are unchanged from `origin/main`:
  - `scripts/ci/classify-pr-changes.test.ts`: `src/main/window-shortcuts.ts` is missing a Windows runtime manifest signal.
  - `scripts/release-publication-regressions.test.ts`: Node 23 reports `Path is a directory` while removing a fixture `scripts` directory.

Consumer/platform coverage: this is an Electron main-process ACP/OpenCode integration change. No platform-specific branch was added. Ownership for the touched broker test is unknown to the impact manifest, so the repository correctly selected the complete Vitest suite.

## Review focus

- The layered config-plus-broker compatibility guard for current OpenCode behavior.
- The exact `frameworkId === 'opencode'` boundary and preservation of normal permission handling elsewhere.
- Whether future OpenCode releases rename the native Todo tool identities; the current names are pinned by tests and dev-app validation.
