### PR TITLE
ci(pr-gate): classify window shortcuts as Windows-sensitive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,6 +116,7 @@ jobs:
           --testTimeout=30000
           --shard=${{ matrix.shard }}/3
           --reporter=blob
+          --reporter=github-actions
           --outputFile=vitest-reports/blob-${{ matrix.shard }}.json
       - name: Upload full-suite blob report
         if: ${{ always() }}

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -459,6 +459,7 @@ jobs:
           --testTimeout=30000
           --shard=${{ matrix.shard }}/3
           --reporter=blob
+          --reporter=github-actions
           --outputFile=vitest-reports/blob-${{ matrix.shard }}.json
       - name: Upload full-suite blob report
         if: ${{ always() }}

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -207,6 +207,7 @@
         "src/main/storage-root.ts",
         "src/main/storage/**",
         "src/main/tray.ts",
+        "src/main/window-shortcuts.ts",
         "src/main/update/create-strategy.ts",
         "src/main/update/electron-updater-strategy.ts",
         "src/main/wsl/**",

--- a/scripts/ci/classify-pr-changes.test.ts
+++ b/scripts/ci/classify-pr-changes.test.ts
@@ -391,7 +391,8 @@ describe('pull request change classification', () => {
     ['managed CodeBuddy', 'src/main/settings/managed-codebuddy.ts'],
     ['immutable notebook inputs', 'src/main/immutable-input-authority.ts'],
     ['notebook package process sandbox', 'src/main/notebook/package-process-sandbox.ts'],
-    ['WSL setup ownership', 'src/main/wsl/wsl-setup-owner.ts']
+    ['WSL setup ownership', 'src/main/wsl/wsl-setup-owner.ts'],
+    ['window shortcuts', 'src/main/window-shortcuts.ts']
   ])('adds native Windows lanes for %s changes', (_category, path) => {
     const plan = classifyChanges([{ path, status: 'modified' }])
 

--- a/scripts/ci/npm-ci.mjs
+++ b/scripts/ci/npm-ci.mjs
@@ -9,9 +9,19 @@ export const GITHUB_ELECTRON_MIRROR = 'https://github.com/electron/electron/rele
 export const GITHUB_ELECTRON_BUILDER_BINARIES_MIRROR =
   'https://github.com/electron-userland/electron-builder-binaries/releases/download/'
 export const DEFAULT_NPM_CI_ARGS = ['--no-audit']
+export const WINDOWS_CI_RETRY_DELAY_MS = 5_000
+export const WINDOWS_CI_ATTEMPTS = 2
 
 export function shouldForceGitHubElectronMirrors(env = process.env) {
   return env.GITHUB_ACTIONS === 'true'
+}
+
+export function npmCiAttemptCount({ platform = process.platform, env = process.env } = {}) {
+  return platform === 'win32' && env.GITHUB_ACTIONS === 'true' ? WINDOWS_CI_ATTEMPTS : 1
+}
+
+const defaultSleep = (ms) => {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms)
 }
 
 export function githubElectronMirrorEnv(env = process.env) {
@@ -34,14 +44,30 @@ export function runNpmCi({
   args = process.argv.slice(2),
   env = process.env,
   platform = process.platform,
+  sleep = defaultSleep,
   spawn = spawnSync
 } = {}) {
-  const result = spawn(npmCiCommand(platform), ['ci', ...DEFAULT_NPM_CI_ARGS, ...args], {
+  const attempts = npmCiAttemptCount({ platform, env })
+  const command = npmCiCommand(platform)
+  const spawnArgs = ['ci', ...DEFAULT_NPM_CI_ARGS, ...args]
+  const options = {
     env: npmCiEnv(env),
     stdio: 'inherit',
     shell: platform === 'win32'
-  })
-  return result.status ?? 1
+  }
+
+  let status = 1
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    status = spawn(command, spawnArgs, options).status ?? 1
+    if (status === 0) return 0
+    if (attempt < attempts) {
+      console.error(
+        `npm-ci: Windows GitHub Actions install failed (attempt ${attempt}/${attempts}); retrying after ${WINDOWS_CI_RETRY_DELAY_MS}ms`
+      )
+      sleep(WINDOWS_CI_RETRY_DELAY_MS)
+    }
+  }
+  return status
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {

--- a/scripts/ci/npm-ci.test.ts
+++ b/scripts/ci/npm-ci.test.ts
@@ -63,6 +63,47 @@ describe('npm ci Electron mirror policy', () => {
     expect(DEFAULT_NPM_CI_ARGS).toEqual(['--no-audit'])
   })
 
+  it('retries a failed Windows GitHub Actions install once after a short delay', () => {
+    const spawn = vi.fn().mockReturnValueOnce({ status: 1 }).mockReturnValueOnce({ status: 0 })
+    const sleep = vi.fn()
+
+    expect(
+      runNpmCi({
+        env: { GITHUB_ACTIONS: 'true' },
+        platform: 'win32',
+        sleep,
+        spawn
+      })
+    ).toBe(0)
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(sleep).toHaveBeenCalledTimes(1)
+    expect(sleep).toHaveBeenCalledWith(5_000)
+  })
+
+  it('does not retry a failed install outside Windows GitHub Actions', () => {
+    const spawn = vi.fn(() => ({ status: 1 }))
+    const sleep = vi.fn()
+
+    expect(
+      runNpmCi({
+        env: { GITHUB_ACTIONS: 'true' },
+        platform: 'linux',
+        sleep,
+        spawn
+      })
+    ).toBe(1)
+    expect(
+      runNpmCi({
+        env: {},
+        platform: 'win32',
+        sleep,
+        spawn
+      })
+    ).toBe(1)
+    expect(spawn).toHaveBeenCalledTimes(2)
+    expect(sleep).not.toHaveBeenCalled()
+  })
+
   it('routes Electron-installing workflow npm ci through the GitHub mirror helper and disables audit for direct installs', () => {
     const workflowDir = join(process.cwd(), '.github', 'workflows')
     const leftover: string[] = []

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -456,6 +456,7 @@ describe('PR Gate workflow', () => {
         '--testTimeout=30000',
         '--shard=${{ matrix.shard }}/3',
         '--reporter=blob',
+        '--reporter=github-actions',
         '--outputFile=vitest-reports/blob-${{ matrix.shard }}.json'
       ].join(' ')
     })

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -439,6 +439,8 @@ describe('build verification throughput', () => {
     })
     expect(step(tests, 'Test complete suite shard').run).toContain('--shard=${{ matrix.shard }}/3')
     expect(step(tests, 'Test complete suite shard').run).toContain('--coverage')
+    expect(step(tests, 'Test complete suite shard').run).toContain('--reporter=blob')
+    expect(step(tests, 'Test complete suite shard').run).toContain('--reporter=github-actions')
     expect(step(tests, 'Enforce full-suite shard').if).toBe('${{ always() }}')
     expect(step(verify, 'Check translation catalogs').run).toBe(
       'npx vitest run src/renderer/src/i18n/resources.test.ts'


### PR DESCRIPTION
## Problem

Recent PRs and Nightly fail the same portable-suite check after #2455 landed on `main`. The merged coverage job reports:

```
scripts/ci/classify-pr-changes.test.ts > covers every production source file with an explicit Windows runtime signal
AssertionError: expected [ 'src/main/window-shortcuts.ts' ] to deeply equal []
```

#2455 added a `process.platform !== 'win32'` zoom-in handler to `src/main/window-shortcuts.ts`. That file does not match the existing `*windows*` glob, and it was not added to the trusted `windows_sensitive` overlay. The coverage test then fails on every full portable shard (Ubuntu shard 3/3), which also fails merged coverage and PR Gate for unrelated branches.

This is the same class of omission as #1850 / #1705. `scripts/ci/change-impact.json` is a protected gate control-plane file, so the feature PR could not carry the overlay update.

Two additional CI stability gaps showed up while landing that fix:

- Hosted Windows `npm ci` can fail native rebuilds (`node-gyp` EPERM / `Completion callback never invoked`) while another job on the same SHA succeeds.
- Portable shards use only `--reporter=blob`, so the failing test is invisible in the shard log and only appears later in the merge job.

## Proposed change

- Register `src/main/window-shortcuts.ts` in the `windows_sensitive` overlay and pin the same path in the classifier's native-Windows-lane examples.
- Retry `scripts/ci/npm-ci.mjs` once after 5s on Windows GitHub Actions only. Local and non-Windows installs stay single-attempt.
- Keep the blob reporter for merged coverage and add `--reporter=github-actions` so shard jobs annotate the exact failing test.

## Scope and non-goals

- Classifier overlay, Windows CI install retry, and shard log visibility. No production behavior, schema, or locale changes.
- Does not change zoom shortcut handling.
- Does not address intermittent Windows E2E flakes that retry green under `--fail-on-flaky-tests` (`workspace-conversation` and `workspace-files` specs). Those remain a separate follow-up.

## Acceptance criteria and validation

The listed checks ran after the last material edit, from the worktree at `.worktree/classify-window-shortcuts`:

| Behavior | Command | Result |
| --- | --- | --- |
| Windows-signal files must select `windows_sensitive` plus Windows E2E lanes; `src/main/window-shortcuts.ts` is included | `npx vitest run scripts/ci/classify-pr-changes.test.ts` | 73/73 passed |
| Windows GitHub Actions `npm ci` retries once; other platforms do not | `npx vitest run scripts/ci/npm-ci.test.ts` | 6/6 passed |
| PR Gate / Nightly shard commands keep blob output and add GitHub annotations | `npx vitest run scripts/ci/pr-gate-workflow.test.ts scripts/ci/release-workflows.test.ts` | passed with the related integrity suite |
| Related classifier and integrity unit tests still pass | `npx vitest run scripts/ci/pr-gate-workflow.test.ts scripts/ci/release-workflows.test.ts scripts/ci/check-ci-integrity.test.ts` | 165/165 combined with npm-ci and classifier in the last targeted run |
| Changed TypeScript stays lint-clean | `npx eslint scripts/ci/npm-ci.mjs scripts/ci/npm-ci.test.ts scripts/ci/pr-gate-workflow.test.ts scripts/ci/release-workflows.test.ts` | 0 errors |

Excluded: full `npm test`, process typechecks, and E2E. Changing `scripts/ci/**` and `.github/workflows/pr-gate.yml` selects the full plan; PR Gate on this branch remains the complete portable/platform authority.

**CI Integrity:** this change touches `scripts/ci/change-impact.json` and `.github/workflows/pr-gate.yml`, established gate control-plane files. CI Integrity is expected to fail with `protected-gate-control-plane` and requires the existing maintainer ruleset bypass to merge, same as #1850 and #1705.

## Review focus

- Confirm the `win32` zoom-in handler in `src/main/window-shortcuts.ts` is a real Windows runtime concern, not a comment-only false positive.
- Confirm the Windows `npm ci` retry is limited to GitHub Actions and still fail-closed after two attempts.
- Confirm shard jobs still write blob reports for coverage merge.

## Historical compatibility

None. No persisted data, settings schema, or migration is involved.

## New state / enum values

None.

## Data persistence

None.

## UI / interaction

None.

Refs: #2455