### PR TITLE
fix(skills): decouple built-in imports from Python

### DIFF
--- a/src/main/settings/skill-catalog.python-availability.test.ts
+++ b/src/main/settings/skill-catalog.python-availability.test.ts
@@ -11,6 +11,15 @@ vi.mock('node:child_process', async (importOriginal) => {
   const actual = await importOriginal<typeof import('node:child_process')>()
   return {
     ...actual,
+    execFile: ((
+      command: string,
+      args: readonly string[],
+      options: unknown,
+      callback: (error: Error) => void
+    ) =>
+      callback(
+        Object.assign(new Error(`spawn ${command} ENOENT`), { code: 'ENOENT' })
+      )) as typeof actual.execFile,
     spawn: (command: string, args: readonly string[], options: SpawnOptions) =>
       actual.spawn(command, args, {
         ...options,
@@ -34,7 +43,6 @@ import { SkillCatalogModule } from './skill-catalog'
 const roots: string[] = []
 
 afterEach(async () => {
-  vi.unstubAllEnvs()
   await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
 })
 
@@ -85,7 +93,6 @@ it.each(['zip', 'github'] as const)(
       })
     ).toString('base64')
 
-    vi.stubEnv('PATH', '')
     await expect(
       source === 'zip'
         ? catalog.importSkillZip({ dataBase64 })
@@ -115,7 +122,6 @@ it('imports the same text-only Skill without Python when no bundled helper exist
     })
   ).toString('base64')
 
-  vi.stubEnv('PATH', '')
   await expect(catalog.importSkillZip({ dataBase64 })).resolves.toMatchObject({
     id: 'imported-text-only'
   })

--- a/src/main/settings/skill-catalog.python-availability.test.ts
+++ b/src/main/settings/skill-catalog.python-availability.test.ts
@@ -16,10 +16,11 @@ vi.mock('node:child_process', async (importOriginal) => {
       args: readonly string[],
       options: unknown,
       callback: (error: Error) => void
-    ) =>
-      callback(
-        Object.assign(new Error(`spawn ${command} ENOENT`), { code: 'ENOENT' })
-      )) as typeof actual.execFile,
+    ) => {
+      void args
+      void options
+      callback(Object.assign(new Error(`spawn ${command} ENOENT`), { code: 'ENOENT' }))
+    }) as typeof actual.execFile,
     spawn: (command: string, args: readonly string[], options: SpawnOptions) =>
       actual.spawn(command, args, {
         ...options,

--- a/src/main/settings/skill-catalog.python-availability.test.ts
+++ b/src/main/settings/skill-catalog.python-availability.test.ts
@@ -1,0 +1,122 @@
+import type { SpawnOptions } from 'node:child_process'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { strToU8, zipSync } from 'fflate'
+import { afterEach, expect, it, vi } from 'vitest'
+
+// Exercise real process launch failures on a host without Python. An explicit empty
+// child PATH prevents POSIX's implicit /usr/bin lookup from finding the test host's Python.
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>()
+  return {
+    ...actual,
+    spawn: (command: string, args: readonly string[], options: SpawnOptions) =>
+      actual.spawn(command, args, {
+        ...options,
+        env: { ...options?.env, PATH: '' }
+      })
+  }
+})
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf8')
+  }
+}))
+
+import { SkillRegistry } from '../skills/registry'
+import { SettingsRepository } from './repository'
+import { SkillCatalogModule } from './skill-catalog'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  vi.unstubAllEnvs()
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+it.each(['zip', 'github'] as const)(
+  'imports a text-only Skill through %s without Python when the production bundled helpers are installed',
+  async (source) => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'skill-import-no-python-'))
+    roots.push(storageRoot)
+    const catalog = new SkillCatalogModule({
+      storageRoot,
+      repository: new SettingsRepository(storageRoot),
+      skillRegistry: new SkillRegistry(resolve(__dirname, '../../../resources/skills')),
+      githubFetch: async (url) => {
+        if (url === 'https://api.github.com/repos/example/text-only/contents/?ref=main') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => [
+              {
+                type: 'file',
+                name: 'SKILL.md',
+                path: 'SKILL.md',
+                download_url: 'https://raw.githubusercontent.com/example/text-only/main/SKILL.md'
+              }
+            ],
+            arrayBuffer: async () => new ArrayBuffer(0)
+          }
+        }
+        if (url === 'https://raw.githubusercontent.com/example/text-only/main/SKILL.md') {
+          return {
+            ok: true,
+            status: 200,
+            json: async () => ({}),
+            arrayBuffer: async () =>
+              new TextEncoder().encode(
+                '---\nname: text-only\ndescription: Text instructions\n---\nRead carefully.\n'
+              ).buffer
+          }
+        }
+        throw new Error(`Unexpected fixture URL: ${url}`)
+      }
+    })
+    const dataBase64 = Buffer.from(
+      zipSync({
+        'SKILL.md': strToU8(
+          '---\nname: text-only\ndescription: Text instructions\n---\nRead carefully.\n'
+        )
+      })
+    ).toString('base64')
+
+    vi.stubEnv('PATH', '')
+    await expect(
+      source === 'zip'
+        ? catalog.importSkillZip({ dataBase64 })
+        : catalog.importSkill({ url: 'https://github.com/example/text-only/tree/main' })
+    ).resolves.toMatchObject({
+      id: 'imported-text-only'
+    })
+    expect(await catalog.listSkills()).toContainEqual(
+      expect.objectContaining({ id: 'imported-text-only' })
+    )
+  }
+)
+
+it('imports the same text-only Skill without Python when no bundled helper exists', async () => {
+  const storageRoot = await mkdtemp(join(tmpdir(), 'skill-import-no-helpers-'))
+  roots.push(storageRoot)
+  const catalog = new SkillCatalogModule({
+    storageRoot,
+    repository: new SettingsRepository(storageRoot),
+    skillRegistry: { list: async () => [] } as unknown as SkillRegistry
+  })
+  const dataBase64 = Buffer.from(
+    zipSync({
+      'SKILL.md': strToU8(
+        '---\nname: text-only\ndescription: Text instructions\n---\nRead carefully.\n'
+      )
+    })
+  ).toString('base64')
+
+  vi.stubEnv('PATH', '')
+  await expect(catalog.importSkillZip({ dataBase64 })).resolves.toMatchObject({
+    id: 'imported-text-only'
+  })
+})

--- a/src/main/skills/registered-helper-catalog.ts
+++ b/src/main/skills/registered-helper-catalog.ts
@@ -256,9 +256,9 @@ const preparePackage = async (entry: RegisteredSkillPackage): Promise<PreparedHe
       entry.packageRoot,
       descriptor.implementation
     )
-    await validateNotebookHelperExports(descriptor.id, source, descriptor.exports, {
-      trustedSource: entry.origin === 'builtin'
-    })
+    if (entry.origin !== 'builtin') {
+      await validateNotebookHelperExports(descriptor.id, source, descriptor.exports)
+    }
     loaded.push({ descriptor, bytes, digest: sourceDigest(bytes) })
   }
   const generation = generationDigest(skillId, entry.origin, loaded)


### PR DESCRIPTION
## Problem

Importing a text-only Skill runs callable validation for the app's bundled `figure-composer` helper. On a host without a discoverable Python 3 executable, ZIP and GitHub imports fail with `spawn py/python3 ENOENT`.

## Proposed change

Skip runtime Python callable validation for trusted bundled helpers. Keep source containment, UTF-8, size, digest, duplicate ID, dependency graph, authorization, immutable generation, and persistence checks. Personal and Imported helpers continue to use isolated callable validation.

## Scope and non-goals

- No database fields, migrations, enums, new persistence format, or UI changes.
- No automatic Python installation or runtime manager.
- Existing helper IDs, generations, and catalog bindings remain compatible.
- External Python helpers still require Python when they are validated.

## Acceptance criteria and validation

- The public ZIP and GitHub import paths reproduce the issue and pass after the fix.
- A no-bundled-helper control remains passing.
- Targeted command after the final edit:
  `node node_modules/vitest/vitest.mjs run src/main/settings/skill-catalog.python-availability.test.ts src/main/notebook/python-command.test.ts`
  Result: 15 passed, 0 failed.
- Pre-fix red runs were repeated twice with identical results: 2 failures and 1 control pass.
- ESLint and Prettier pass for changed files.
- `npm run typecheck:node` passes in the final worktree.
- The broader four-file run had 201 passed and one unrelated pre-existing failure in `registered-helper-catalog.test.ts`'s real Python loop case; it is outside this change and is recorded in the local evidence.

## Review focus

Confirm that Built-in origin is trusted only from the app-owned registry and that external helper validation remains unchanged.

Refs #2390

