### PR TITLE
ci(pr-gate): verify the published runtime bundle before merge

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -17,6 +17,7 @@ on:
           - classified
           - unit-coverage
           - i18n
+          - runtime-bundle
           - windows-e2e
           - e2e
 
@@ -158,6 +159,23 @@ jobs:
               '### Reason chains' \
               '' \
               '- `workflow_dispatch i18n -> focused dry-run`' \
+              >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          if [[ "$EVENT_NAME" == "workflow_dispatch" && "$DRY_RUN_MODE" == "runtime-bundle" ]]; then
+            plan='{"schemaVersion":1,"mode":"selective","roots":["manual:runtime-bundle"],"lanes":["policy","runtime_bundle"],"bundles":["policy","static"],"reasonChains":["workflow_dispatch runtime-bundle -> focused dry-run"]}'
+            echo "plan=$plan" >> "$GITHUB_OUTPUT"
+            echo 'lanes=["policy","runtime_bundle"]' >> "$GITHUB_OUTPUT"
+            printf '%s\n' \
+              '## PR Gate preflight' \
+              '' \
+              '- Mode: **selective (focused dry-run)**' \
+              '- Selected lanes: policy, runtime_bundle' \
+              '- Execution bundles: policy, static' \
+              '' \
+              '### Reason chains' \
+              '' \
+              '- `workflow_dispatch runtime-bundle -> focused dry-run`' \
               >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
@@ -389,6 +407,11 @@ jobs:
         if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'i18n') }}
         continue-on-error: true
         run: npx vitest run src/renderer/src/i18n/resources.test.ts
+      - name: Verify published runtime bundle
+        id: runtime_bundle
+        if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'runtime_bundle') }}
+        continue-on-error: true
+        run: node scripts/verify-runtime-bundle.mjs linux-64 osx-arm64 osx-64 win-64
       - name: Enforce selected static checks
         if: ${{ always() }}
         shell: bash
@@ -398,6 +421,7 @@ jobs:
           FORMAT_OUTCOME: ${{ steps.format.outcome }}
           I18N_OUTCOME: ${{ steps.i18n.outcome }}
           INTERFACE_CONTRACTS_OUTCOME: ${{ steps.interface_contracts.outcome }}
+          RUNTIME_BUNDLE_OUTCOME: ${{ steps.runtime_bundle.outcome }}
           LINT_OUTCOME: ${{ steps.lint.outcome }}
           TYPECHECK_NODE_OUTCOME: ${{ steps.typechecks.outputs.node }}
           TYPECHECKS_OUTCOME: ${{ steps.typechecks.outcome }}
@@ -420,6 +444,7 @@ jobs:
           check interface_contracts "$INTERFACE_CONTRACTS_OUTCOME"
           check cli_sdk "$CLI_SDK_OUTCOME"
           check i18n "$I18N_OUTCOME"
+          check runtime_bundle "$RUNTIME_BUNDLE_OUTCOME"
           exit "$failed"
 
   unit_shard:

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -212,6 +212,7 @@ jobs:
             'interface_contracts',
             'cli_sdk',
             'i18n',
+            'runtime_bundle',
             'unit_macos',
             'linux_runtime',
             'windows_runtime',

--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -410,7 +410,10 @@ jobs:
         run: npx vitest run src/renderer/src/i18n/resources.test.ts
       - name: Verify published runtime bundle
         id: runtime_bundle
-        if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'runtime_bundle') }}
+        # Trusted-base classification cannot name a lane that does not exist on main yet, so the
+        # introducing PR's full plan would otherwise skip this check. After merge, version-file
+        # changes select the overlay lane; full plans keep fail-closed CDN coverage.
+        if: ${{ contains(fromJSON(needs.preflight.outputs.plan).lanes, 'runtime_bundle') || fromJSON(needs.preflight.outputs.plan).mode == 'full' }}
         continue-on-error: true
         run: node scripts/verify-runtime-bundle.mjs linux-64 osx-arm64 osx-64 win-64
       - name: Enforce selected static checks

--- a/scripts/ci/change-impact.json
+++ b/scripts/ci/change-impact.json
@@ -11,6 +11,7 @@
     "interface_contracts",
     "cli_sdk",
     "i18n",
+    "runtime_bundle",
     "unit_macos",
     "linux_runtime",
     "windows_runtime",
@@ -42,6 +43,7 @@
     "interface_contracts": "static",
     "cli_sdk": "static",
     "i18n": "static",
+    "runtime_bundle": "static",
     "unit_macos": "unit",
     "linux_runtime": "linux_runtime",
     "windows_runtime": "windows_core",
@@ -260,6 +262,28 @@
       "role": "overlay",
       "paths": ["src/main/settings/ipc.ts"],
       "capabilities": ["settings_ipc"]
+    },
+    {
+      "id": "default_env_staging",
+      "role": "owner",
+      "paths": [
+        "scripts/stage-default-envs.mjs",
+        "scripts/stage-default-envs.test.ts",
+        "scripts/verify-runtime-bundle.mjs",
+        "scripts/verify-runtime-bundle.test.ts"
+      ],
+      "capabilities": ["runtime_bundle"]
+    },
+    {
+      "id": "runtime_bundle",
+      "role": "overlay",
+      "paths": [
+        "src/main/notebook/runtime-paths.ts",
+        "scripts/stage-default-envs.mjs",
+        "scripts/verify-runtime-bundle.mjs",
+        ".github/workflows/stage-runtime-bundle.yml"
+      ],
+      "capabilities": ["runtime_bundle"]
     }
   ],
   "capabilities": {
@@ -332,6 +356,10 @@
     "i18n_catalog": {
       "consumers": [],
       "lanes": ["i18n"]
+    },
+    "runtime_bundle": {
+      "consumers": [],
+      "lanes": ["runtime_bundle"]
     },
     "renderer_state": {
       "consumers": ["e2e_workspace"],

--- a/scripts/ci/classify-pr-changes.test.ts
+++ b/scripts/ci/classify-pr-changes.test.ts
@@ -401,6 +401,16 @@ describe('pull request change classification', () => {
     expect(plan.reasonChains).toContain(`${path} -> windows_sensitive`)
   })
 
+  it('requires a live CDN bundle when the immutable runtime version changes', () => {
+    const plan = classifyChanges([
+      { path: 'src/main/notebook/runtime-paths.ts', status: 'modified' }
+    ])
+
+    expect(plan.roots).toEqual(expect.arrayContaining(['main_runtime', 'runtime_bundle']))
+    expect(plan.lanes).toContain('runtime_bundle')
+    expect(plan.reasonChains).toContain('src/main/notebook/runtime-paths.ts -> runtime_bundle')
+  })
+
   it('does not add focused Windows lanes for platform-neutral Main changes', () => {
     const plan = classifyChanges([
       { path: 'src/main/notebook/runtime-service.ts', status: 'modified' }

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -404,6 +404,7 @@ describe('PR Gate workflow', () => {
       run: 'node scripts/verify-runtime-bundle.mjs linux-64 osx-arm64 osx-64 win-64'
     })
     expect(runtimeBundle?.if).toContain("'runtime_bundle'")
+    expect(runtimeBundle?.if).toContain("fromJSON(needs.preflight.outputs.plan).mode == 'full'")
     expect(enforce?.env).toMatchObject({
       RUNTIME_BUNDLE_OUTCOME: '${{ steps.runtime_bundle.outcome }}'
     })

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -190,6 +190,7 @@ describe('PR Gate workflow', () => {
       'node "$TRUSTED_CLASSIFIER_DIR/module-impact-authority.mjs" --base "$BASE_SHA" --head "$HEAD_SHA"'
     )
     expect(classify?.run).toContain("mode: 'full'")
+    expect(classify?.run).toContain("'runtime_bundle'")
     expect(classify?.run).not.toContain(
       'node scripts/ci/classify-pr-changes.mjs --base "$BASE_SHA" --head "$HEAD_SHA"'
     )
@@ -409,6 +410,10 @@ describe('PR Gate workflow', () => {
     expect(enforce?.run).toContain('check runtime_bundle "$RUNTIME_BUNDLE_OUTCOME"')
     expect(manifest.laneBundles.runtime_bundle).toBe('static')
     expect(manifest.laneOrder).toContain('runtime_bundle')
+    const classify = workflow.jobs.preflight.steps?.find(
+      ({ name }) => name === 'Classify change impact'
+    )
+    expect(classify?.run).toContain("'runtime_bundle'")
   })
 
   it('shards full portable tests on Ubuntu and merges coverage into the stable unit bundle', () => {

--- a/scripts/ci/pr-gate-workflow.test.ts
+++ b/scripts/ci/pr-gate-workflow.test.ts
@@ -120,7 +120,7 @@ describe('PR Gate workflow', () => {
           required: false,
           default: 'classified',
           type: 'choice',
-          options: ['classified', 'unit-coverage', 'i18n', 'windows-e2e', 'e2e']
+          options: ['classified', 'unit-coverage', 'i18n', 'runtime-bundle', 'windows-e2e', 'e2e']
         }
       }
     })
@@ -178,6 +178,9 @@ describe('PR Gate workflow', () => {
     )
     expect(classify?.run).toContain(
       '[[ "$EVENT_NAME" == "workflow_dispatch" && "$DRY_RUN_MODE" == "i18n" ]]'
+    )
+    expect(classify?.run).toContain(
+      '[[ "$EVENT_NAME" == "workflow_dispatch" && "$DRY_RUN_MODE" == "runtime-bundle" ]]'
     )
     expect(classify?.run).toContain('"lanes":["policy","unit_macos"]')
     expect(classify?.run).toContain('"bundles":["policy","unit"]')
@@ -384,6 +387,28 @@ describe('PR Gate workflow', () => {
     expect(enforce?.run).toContain('check i18n "$I18N_OUTCOME"')
     expect(manifest.laneBundles.i18n).toBe('static')
     expect(manifest.laneOrder).toContain('i18n')
+  })
+
+  it('verifies the published runtime bundle as a named static check', () => {
+    const runtimeBundle = workflow.jobs.static.steps?.find(
+      ({ name }) => name === 'Verify published runtime bundle'
+    )
+    const enforce = workflow.jobs.static.steps?.find(
+      ({ name }) => name === 'Enforce selected static checks'
+    )
+
+    expect(runtimeBundle).toMatchObject({
+      id: 'runtime_bundle',
+      'continue-on-error': true,
+      run: 'node scripts/verify-runtime-bundle.mjs linux-64 osx-arm64 osx-64 win-64'
+    })
+    expect(runtimeBundle?.if).toContain("'runtime_bundle'")
+    expect(enforce?.env).toMatchObject({
+      RUNTIME_BUNDLE_OUTCOME: '${{ steps.runtime_bundle.outcome }}'
+    })
+    expect(enforce?.run).toContain('check runtime_bundle "$RUNTIME_BUNDLE_OUTCOME"')
+    expect(manifest.laneBundles.runtime_bundle).toBe('static')
+    expect(manifest.laneOrder).toContain('runtime_bundle')
   })
 
   it('shards full portable tests on Ubuntu and merges coverage into the stable unit bundle', () => {

--- a/src/main/notebook/e2e.certification.test.ts
+++ b/src/main/notebook/e2e.certification.test.ts
@@ -450,6 +450,7 @@ gate('notebook capability certification (E2E)', () => {
       workspaceCwd: h.storageRoot,
       code: 'life_marker'
     })
+    const state = await h.service.state({ sessionId: SESSION, workspaceCwd: h.storageRoot })
     expect(afterRespawn.status).toBe('failed')
     expect(afterRespawn.text.traceback).toMatch(/name 'life_marker' is not defined/)
     evidence(
@@ -457,7 +458,6 @@ gate('notebook capability certification (E2E)', () => {
       afterRespawn.text.traceback.trim().split('\n').slice(-1)[0]
     )
 
-    const state = await h.service.state({ sessionId: SESSION, workspaceCwd: h.storageRoot })
     expect(state.kernelStatus).toBe('idle')
     evidence('kernel status after respawn run', state.kernelStatus)
   }, 30_000)


### PR DESCRIPTION
## Problem

Nightly run https://github.com/aipoch/open-science/actions/runs/34610179923 failed packaging on every platform:

```
[runtime-bundle] https://statics.aipoch.com/open-science/runtime-bundle/2/linux-64/manifest.json
returned HTTP 403 after 3 attempt(s)
```

`#2458` bumped `DEFAULT_ENV_VERSION` from 1 to 2 so the expanded R baseline (`r-biocmanager`, `r-ggplot2`) gets a new immutable CDN prefix. Version 1 is still live. Version 2 was never published (`stage-runtime-bundle` last succeeded in July). S3/CloudFront returns `AccessDenied` for the missing key. `build.yml` correctly fails closed before packaging.

A second, independent failure in the same run was the Linux source certification lifecycle test: after proving the respawned namespace was cleared, `kernelStatus` was `terminated` instead of `idle` because evidence logging ran after a 300ms idle timeout.

Portable shard 3 on that Nightly SHA is the already-merged `#2463` classifier gap (`window-shortcuts.ts`). That SHA is older than `#2463`.

## Proposed change

- Select a `runtime_bundle` static lane when the immutable version, pack matrix, or publisher workflow changes, and GET the four live manifests before merge.
- Add a `runtime-bundle` PR Gate dry-run.
- Read `kernelStatus` immediately after the respawned execute, before extra logging can lose the race with the idle timer.

The missing v2 objects are published with the existing `Stage runtime bundle` workflow (`version=2` on `main`), not by this PR.

## Scope and non-goals

- CI gate and one certification assertion ordering change. No production runtime behavior, schema, locale, or UI changes.
- Does not change pack contents; `#2458` already did that.
- Does not re-run the in-progress Nightly at the pre-`#2463` SHA.

## Acceptance criteria and validation

Checks ran after the last material edit from `.worktree/verify-live-runtime-bundle`:

| Behavior | Command | Result |
| --- | --- | --- |
| `runtime-paths.ts` selects `runtime_bundle` | `npx vitest run scripts/ci/classify-pr-changes.test.ts` | passed |
| Static job runs the live manifest check and dry-run exists | `npx vitest run scripts/ci/pr-gate-workflow.test.ts` | passed |
| Related integrity / shadow tests | `npx vitest run scripts/ci/check-ci-integrity.test.ts scripts/ci/module-impact-shadow.test.ts scripts/ci/evaluate-pr-gate.test.ts` | passed |
| Lint | `npx eslint` on the changed TS files | 0 errors |

Excluded: full `npm test` and E2E. Changing `scripts/ci/**` and `.github/workflows/pr-gate.yml` selects the full plan; PR Gate remains authoritative.

**CI Integrity:** `scripts/ci/change-impact.json` and `.github/workflows/pr-gate.yml` are protected control-plane files. CI Integrity is expected to fail with `protected-gate-control-plane` and needs the maintainer ruleset bypass, same as `#1850` / `#2463`.

## Review focus

- Confirm the overlay fires on version bumps and pack-matrix edits, not on unrelated Main changes.
- Confirm the live GET still fails closed after the existing 403 retry budget.

## Historical compatibility

`#2458` already chose an additive v2 prefix so existing v1 cached environments stay reproducible. This PR does not change that. Publishing v2 completes the packaging side of that bump. v1 remains on the CDN.

## New state / enum values

None.

## Data persistence

None in this PR. Ready markers already carry `defaultEnvVersion` from `#2458`.

## UI / interaction

None.

Refs: #2458, https://github.com/aipoch/open-science/actions/runs/34610179923