### PR TITLE
test(wsl): keep modified-secret fixtures distinct from the token

### DIFF
--- a/src/main/wsl/wsl-setup-session-owner.test.ts
+++ b/src/main/wsl/wsl-setup-session-owner.test.ts
@@ -89,8 +89,11 @@ describe('WslSetupSessionOwner', () => {
     const owner = new WslSetupSessionOwner(root, { platform: 'win32' })
     const token = owner.mintLocalToken()
     const separator = token.indexOf('.')
-    const modified = `${token.slice(0, separator + 1)}x${token.slice(separator + 2)}`
+    const secretStart = token.slice(separator + 1, separator + 2)
+    const flipped = secretStart === 'x' ? 'y' : 'x'
+    const modified = `${token.slice(0, separator + 1)}${flipped}${token.slice(separator + 2)}`
 
+    expect(modified).not.toBe(token)
     expect(owner.authorizeToken(modified)).toBe(false)
     expect(owner.authorizeToken(token)).toBe(true)
   })


### PR DESCRIPTION
## Problem

Manual Nightly https://github.com/aipoch/open-science/actions/runs/34613052083 failed portable shard 1:

```
src/main/wsl/wsl-setup-session-owner.test.ts > WslSetupSessionOwner
> rejects a modified secret without consuming the valid token
AssertionError: expected true to be false
```

The fixture replaces the first character of a `base64url` secret with `x`. That alphabet is 64 characters, so about 1/64 of minted secrets already start with `x` and the "modified" token is identical. `authorizeToken` then correctly returns true.

Packaging on that Nightly already verified runtime-bundle v2. This is an independent test flake.

## Proposed change

Flip the first secret character to `y` when it is already `x`, and assert the mutated token differs before checking authorization.

## Scope and non-goals

Test-only. No production WSL setup behavior, schema, or UI changes.

## Acceptance criteria and validation

After the last material edit, from `.worktree/wsl-setup-modified-secret`:

| Behavior | Command | Result |
| --- | --- | --- |
| Modified secret is rejected and the original token remains usable | `npx vitest run src/main/wsl/wsl-setup-session-owner.test.ts` | 25/25 passed |
| Lint | `npx eslint src/main/wsl/wsl-setup-session-owner.test.ts` | 0 errors |

Excluded: full `npm test`. PR Gate remains authoritative.

## Historical compatibility

None.

## New state / enum values

None.

## Data persistence

None.

## UI / interaction

None.

Refs: https://github.com/aipoch/open-science/actions/runs/34613052083