### PR TITLE
fix(installer-smoke): accept packaged artifactSaveVersion RPC

### DIFF
--- a/.github/workflows/windows-upgrade-smoke.yml
+++ b/.github/workflows/windows-upgrade-smoke.yml
@@ -70,13 +70,21 @@ jobs:
               exit 1
             }
           }
+          $artifactSaveCommit = '1a6faf134836d417b8bb1cdf89571f5d9dee2a0b'
           $artifactReservationCommit = 'f12fd1f871022c7a9b771d193202d9ecf98aca96'
+          $artifactSaveBase = git merge-base $artifactSaveCommit $releasedSha
+          if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactSaveBase)) {
+            Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
+            exit 1
+          }
           $artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
           if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactReservationBase)) {
             Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
             exit 1
           }
-          if ($artifactReservationBase -eq $artifactReservationCommit) {
+          if ($artifactSaveBase -eq $artifactSaveCommit) {
+            $artifactRpcContract = 'save'
+          } elseif ($artifactReservationBase -eq $artifactReservationCommit) {
             $artifactRpcContract = 'reservation'
           } else {
             $artifactRpcContract = 'legacy'

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -344,14 +344,22 @@ describe('release and scheduled workflow topology', () => {
     expect(released.run).toContain('Released migrations are not a continuous prefix')
     expect(released.run).toContain('"sha=$releasedSha"')
     expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
+    expect(released.run).toContain('1a6faf134836d417b8bb1cdf89571f5d9dee2a0b')
     expect(released.run).toContain('f12fd1f871022c7a9b771d193202d9ecf98aca96')
     expect(released.run)
-      .toContain(`$artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
+      .toContain(`$artifactSaveBase = git merge-base $artifactSaveCommit $releasedSha
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactSaveBase)) {
+  Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
+  exit 1
+}
+$artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactReservationBase)) {
   Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
   exit 1
 }
-if ($artifactReservationBase -eq $artifactReservationCommit) {
+if ($artifactSaveBase -eq $artifactSaveCommit) {
+  $artifactRpcContract = 'save'
+} elseif ($artifactReservationBase -eq $artifactReservationCommit) {
   $artifactRpcContract = 'reservation'
 } else {
   $artifactRpcContract = 'legacy'

--- a/scripts/windows-installer-smoke.mjs
+++ b/scripts/windows-installer-smoke.mjs
@@ -55,6 +55,18 @@ const RPC_SMOKE_ARTIFACT_SCOPE = {
   artifactStorageSessionId: 'installer-smoke-session',
   artifactRunId: 'installer-smoke-artifact-run'
 }
+const RPC_SMOKE_SAVE_PROVENANCE = {
+  rootFrameId: 'installer-smoke-root-frame',
+  agentFrameId: 'installer-smoke-agent-frame',
+  messageBranchId: 'installer-smoke-branch',
+  runtimeSegmentId: 'installer-smoke-runtime',
+  promptMessageId: 'installer-smoke-prompt'
+}
+const RPC_SMOKE_INLINE_SOURCE = {
+  kind: 'inline',
+  content: Buffer.from(RPC_SMOKE_CONTENT).toString('base64'),
+  encoding: 'base64'
+}
 
 const delay = (milliseconds) =>
   new Promise((resolveDelay) => setTimeout(resolveDelay, milliseconds))
@@ -443,12 +455,54 @@ const assertPackagedArtifactScope = (params, requireWriteOperationId) => {
   }
 }
 
-const packagedArtifactSmokeRpcResult = (body, workspace, artifactRpcContract = 'reservation') => {
+const packagedArtifactSmokeVersion = (workspace, fileBytes, checksum) => ({
+  id: 'installer-smoke-version',
+  artifactId: 'installer-smoke-artifact',
+  versionId: 'installer-smoke-version',
+  versionNumber: 1,
+  checksum,
+  createdAt: new Date(0).toISOString(),
+  projectId: 'installer-smoke-project',
+  sessionId: 'installer-smoke-session',
+  runId: 'installer-smoke-artifact-run',
+  name: 'windows-rpc-smoke.txt',
+  path: join(workspace, 'windows-rpc-smoke.txt'),
+  fileUrl: 'file:///windows-rpc-smoke.txt',
+  mimeType: 'text/plain',
+  size: fileBytes,
+  mtimeMs: 0,
+  producerRunId: 'installer-smoke-shell-run'
+})
+
+const packagedArtifactSmokeRpcResult = (body, workspace, artifactRpcContract = 'save') => {
   const params = body.params ?? {}
   const fileBytes = Buffer.byteLength(RPC_SMOKE_CONTENT)
+  const checksum = createHash('sha256').update(RPC_SMOKE_CONTENT).digest('hex')
+  if (body.method === 'artifactSaveVersion') {
+    if (artifactRpcContract !== 'save') {
+      throw new Error('Packaged Artifact save requests require the save RPC contract.')
+    }
+    assertPackagedArtifactScope(params, true)
+    if (
+      Object.entries(RPC_SMOKE_SAVE_PROVENANCE).some(
+        ([key, expectedValue]) => params[key] !== expectedValue
+      ) ||
+      params.filename !== 'windows-rpc-smoke.txt' ||
+      params.contentType !== 'text/plain' ||
+      params.producerRunId !== 'installer-smoke-shell-run' ||
+      !isDeepStrictEqual(params.source, RPC_SMOKE_INLINE_SOURCE)
+    ) {
+      throw new Error('Unexpected packaged Artifact save request.')
+    }
+    return packagedArtifactSmokeVersion(workspace, fileBytes, checksum)
+  }
   if (body.method === 'artifactReserveWrite') {
     if (artifactRpcContract !== 'reservation') {
-      throw new Error('Legacy packaged Artifact RPC must not reserve a write.')
+      throw new Error(
+        artifactRpcContract === 'legacy'
+          ? 'Legacy packaged Artifact RPC must not reserve a write.'
+          : 'Save packaged Artifact RPC must not reserve a write.'
+      )
     }
     assertPackagedArtifactScope(params, true)
     if (params.filename !== 'windows-rpc-smoke.txt' || params.fileBytes !== fileBytes) {
@@ -461,8 +515,12 @@ const packagedArtifactSmokeRpcResult = (body, workspace, artifactRpcContract = '
     }
   }
   if (body.method === 'artifactCreateVersion') {
+    if (artifactRpcContract === 'save') {
+      throw new Error(
+        'Save packaged Artifact RPC must not create a Version without a save request.'
+      )
+    }
     assertPackagedArtifactScope(params, true)
-    const checksum = createHash('sha256').update(RPC_SMOKE_CONTENT).digest('hex')
     if (artifactRpcContract === 'legacy') {
       if (
         params.resourceReservationId !== undefined ||
@@ -478,28 +536,15 @@ const packagedArtifactSmokeRpcResult = (body, workspace, artifactRpcContract = '
     ) {
       throw new Error('Unexpected packaged Artifact Version reservation metadata.')
     }
-    return {
-      id: 'installer-smoke-version',
-      artifactId: 'installer-smoke-artifact',
-      versionId: 'installer-smoke-version',
-      versionNumber: 1,
-      checksum,
-      createdAt: new Date(0).toISOString(),
-      projectId: 'installer-smoke-project',
-      sessionId: 'installer-smoke-session',
-      runId: 'installer-smoke-artifact-run',
-      name: 'windows-rpc-smoke.txt',
-      path: join(workspace, 'windows-rpc-smoke.txt'),
-      fileUrl: 'file:///windows-rpc-smoke.txt',
-      mimeType: 'text/plain',
-      size: fileBytes,
-      mtimeMs: 0,
-      producerRunId: 'installer-smoke-shell-run'
-    }
+    return packagedArtifactSmokeVersion(workspace, fileBytes, checksum)
   }
   if (body.method === 'artifactReleaseWrite') {
     if (artifactRpcContract !== 'reservation') {
-      throw new Error('Legacy packaged Artifact RPC must not release a write reservation.')
+      throw new Error(
+        artifactRpcContract === 'legacy'
+          ? 'Legacy packaged Artifact RPC must not release a write reservation.'
+          : 'Save packaged Artifact RPC must not release a write reservation.'
+      )
     }
     assertPackagedArtifactScope(params, false)
     if (params.reservationId !== RPC_SMOKE_RESERVATION_ID) {
@@ -561,7 +606,7 @@ const connectPackagedMcp = async ({ executable, entryPath, serverArg, env, cwd }
 const runPackagedLocalRpcSmoke = async ({
   installDirectory,
   env,
-  artifactRpcContract = 'reservation'
+  artifactRpcContract = 'save'
 }) => {
   const root = await mkdtemp(join(env.TEMP, RPC_SMOKE_ROOT_PREFIX))
   const workspace = join(root, 'workspace')
@@ -710,7 +755,9 @@ const runPackagedLocalRpcSmoke = async ({
     const expectedMethods =
       artifactRpcContract === 'legacy'
         ? ['state', 'executeShell', 'artifactCreateVersion']
-        : ['state', 'executeShell', 'artifactReserveWrite', 'artifactCreateVersion']
+        : artifactRpcContract === 'reservation'
+          ? ['state', 'executeShell', 'artifactReserveWrite', 'artifactCreateVersion']
+          : ['state', 'executeShell', 'artifactSaveVersion']
     if (JSON.stringify(methods) !== JSON.stringify(expectedMethods)) {
       throw new Error(`Unexpected packaged local RPC sequence: ${methods.join(' -> ')}`)
     }
@@ -1350,13 +1397,17 @@ const parseArguments = (argv) => {
   const installerDirectory = valueFor('--installer-dir')
   if (!installerDirectory)
     throw new Error(
-      'Usage: --installer-dir <path> [--previous-installer-dir <path>] [--artifact-rpc-contract <legacy|reservation>] [--expected-migration-count <count>] [--retain-installation] [--wsl-certification-distro <name> --wsl-certification-user <name>]'
+      'Usage: --installer-dir <path> [--previous-installer-dir <path>] [--artifact-rpc-contract <legacy|reservation|save>] [--expected-migration-count <count>] [--retain-installation] [--wsl-certification-distro <name> --wsl-certification-user <name>]'
     )
   const artifactRpcContractIndex = argv.indexOf('--artifact-rpc-contract')
   const artifactRpcContract =
-    artifactRpcContractIndex === -1 ? 'reservation' : argv[artifactRpcContractIndex + 1]
-  if (artifactRpcContract !== 'legacy' && artifactRpcContract !== 'reservation') {
-    throw new Error('Artifact RPC contract must be legacy or reservation.')
+    artifactRpcContractIndex === -1 ? 'save' : argv[artifactRpcContractIndex + 1]
+  if (
+    artifactRpcContract !== 'legacy' &&
+    artifactRpcContract !== 'reservation' &&
+    artifactRpcContract !== 'save'
+  ) {
+    throw new Error('Artifact RPC contract must be legacy, reservation, or save.')
   }
   const expectedMigrationCountIndex = argv.indexOf('--expected-migration-count')
   const expectedMigrationCountValue =

--- a/scripts/windows-installer-smoke.test.ts
+++ b/scripts/windows-installer-smoke.test.ts
@@ -85,7 +85,7 @@ describe('Windows installer smoke plan', () => {
 
   it('parses an optional positive released migration count', () => {
     expect(parseArguments(['--installer-dir', 'dist'])).toMatchObject({
-      artifactRpcContract: 'reservation',
+      artifactRpcContract: 'save',
       expectedMigrationCount: undefined,
       retainInstallation: false
     })
@@ -199,6 +199,14 @@ describe('Windows installer smoke plan', () => {
       parseArguments(['--installer-dir', 'dist', '--artifact-rpc-contract', 'legacy'])
         .artifactRpcContract
     ).toBe('legacy')
+    expect(
+      parseArguments(['--installer-dir', 'dist', '--artifact-rpc-contract', 'reservation'])
+        .artifactRpcContract
+    ).toBe('reservation')
+    expect(
+      parseArguments(['--installer-dir', 'dist', '--artifact-rpc-contract', 'save'])
+        .artifactRpcContract
+    ).toBe('save')
     for (const value of [undefined, 'automatic']) {
       expect(() =>
         parseArguments([
@@ -207,7 +215,7 @@ describe('Windows installer smoke plan', () => {
           '--artifact-rpc-contract',
           ...(value === undefined ? [] : [value])
         ])
-      ).toThrow(/Artifact RPC contract must be legacy or reservation/)
+      ).toThrow(/Artifact RPC contract must be legacy, reservation, or save/)
     }
   })
 
@@ -232,7 +240,8 @@ describe('Windows installer smoke plan', () => {
           fileBytes
         }
       },
-      workspace
+      workspace,
+      'reservation'
     )
     expect(reservation).toMatchObject({
       id: 'installer-smoke-reservation',
@@ -251,7 +260,8 @@ describe('Windows installer smoke plan', () => {
           resourceChecksum: checksum
         }
       },
-      workspace
+      workspace,
+      'reservation'
     )
     expect(version).toMatchObject({
       versionId: 'installer-smoke-version',
@@ -264,7 +274,8 @@ describe('Windows installer smoke plan', () => {
           method: 'artifactReleaseWrite',
           params: { ...artifactScope, reservationId: reservation.id }
         },
-        workspace
+        workspace,
+        'reservation'
       )
     ).toEqual({ released: true })
     expect(() =>
@@ -279,7 +290,8 @@ describe('Windows installer smoke plan', () => {
             resourceChecksum: checksum
           }
         },
-        workspace
+        workspace,
+        'reservation'
       )
     ).toThrow(/reservation metadata/)
     expect(() =>
@@ -294,9 +306,85 @@ describe('Windows installer smoke plan', () => {
             fileBytes
           }
         },
-        workspace
+        workspace,
+        'reservation'
       )
     ).toThrow(/write scope/)
+  })
+
+  it('models the packaged Artifact save RPC contract', () => {
+    const workspace = 'C:\\smoke\\workspace'
+    const fileBytes = Buffer.byteLength('windows-rpc-smoke\n')
+    const checksum = createHash('sha256').update('windows-rpc-smoke\n').digest('hex')
+    const writeOperationId = `artifact-write-${'a'.repeat(64)}`
+    const saveRequest = {
+      method: 'artifactSaveVersion',
+      params: {
+        projectId: 'installer-smoke-project',
+        appSessionId: 'installer-smoke-session',
+        artifactStorageSessionId: 'installer-smoke-session',
+        artifactRunId: 'installer-smoke-artifact-run',
+        writeOperationId,
+        rootFrameId: 'installer-smoke-root-frame',
+        agentFrameId: 'installer-smoke-agent-frame',
+        messageBranchId: 'installer-smoke-branch',
+        runtimeSegmentId: 'installer-smoke-runtime',
+        promptMessageId: 'installer-smoke-prompt',
+        filename: 'windows-rpc-smoke.txt',
+        contentType: 'text/plain',
+        producerRunId: 'installer-smoke-shell-run',
+        source: {
+          kind: 'inline',
+          content: Buffer.from('windows-rpc-smoke\n').toString('base64'),
+          encoding: 'base64'
+        }
+      }
+    }
+
+    expect(packagedArtifactSmokeRpcResult(saveRequest, workspace)).toMatchObject({
+      versionId: 'installer-smoke-version',
+      path: join(workspace, 'windows-rpc-smoke.txt'),
+      size: fileBytes,
+      checksum
+    })
+    expect(packagedArtifactSmokeRpcResult(saveRequest, workspace, 'save')).toMatchObject({
+      versionId: 'installer-smoke-version'
+    })
+    expect(() => packagedArtifactSmokeRpcResult(saveRequest, workspace, 'reservation')).toThrow(
+      /save RPC contract/
+    )
+    expect(() => packagedArtifactSmokeRpcResult(saveRequest, workspace, 'legacy')).toThrow(
+      /save RPC contract/
+    )
+    expect(() =>
+      packagedArtifactSmokeRpcResult(
+        {
+          method: 'artifactReserveWrite',
+          params: {
+            projectId: 'installer-smoke-project',
+            appSessionId: 'installer-smoke-session',
+            artifactStorageSessionId: 'installer-smoke-session',
+            artifactRunId: 'installer-smoke-artifact-run',
+            writeOperationId,
+            filename: 'windows-rpc-smoke.txt',
+            fileBytes
+          }
+        },
+        workspace
+      )
+    ).toThrow(/must not reserve/)
+    expect(() =>
+      packagedArtifactSmokeRpcResult(
+        {
+          ...saveRequest,
+          params: {
+            ...saveRequest.params,
+            filename: 'wrong.txt'
+          }
+        },
+        workspace
+      )
+    ).toThrow(/save request/)
   })
 
   it('supports the released legacy Artifact contract without weakening reservation enforcement', () => {

--- a/scripts/windows-release-workflows.test.ts
+++ b/scripts/windows-release-workflows.test.ts
@@ -509,14 +509,22 @@ describe('post-merge Windows validation', () => {
     expect(released.run).toContain('Released migrations are not a continuous prefix')
     expect(released.run).toContain('"sha=$releasedSha"')
     expect(released.run).toContain('"migration_count=$($migrationFiles.Count)"')
+    expect(released.run).toContain('1a6faf134836d417b8bb1cdf89571f5d9dee2a0b')
     expect(released.run).toContain('f12fd1f871022c7a9b771d193202d9ecf98aca96')
     expect(released.run)
-      .toContain(`$artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
+      .toContain(`$artifactSaveBase = git merge-base $artifactSaveCommit $releasedSha
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactSaveBase)) {
+  Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
+  exit 1
+}
+$artifactReservationBase = git merge-base $artifactReservationCommit $releasedSha
 if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($artifactReservationBase)) {
   Write-Error "Could not resolve the released Artifact RPC contract at $releasedSha."
   exit 1
 }
-if ($artifactReservationBase -eq $artifactReservationCommit) {
+if ($artifactSaveBase -eq $artifactSaveCommit) {
+  $artifactRpcContract = 'save'
+} elseif ($artifactReservationBase -eq $artifactReservationCommit) {
   $artifactRpcContract = 'reservation'
 } else {
   $artifactRpcContract = 'legacy'


### PR DESCRIPTION
## Problem

Nightly https://github.com/aipoch/open-science/actions/runs/34652611863 failed only `package-smoke / Smoke windows-x64`:

```
write_artifact_file did not return the expected packaged MCP result.
Unexpected installer smoke RPC method: artifactSaveVersion
```

#2457 changed packaged Artifact MCP to POST `{ method: 'artifactSaveVersion', params }` as a single save. The Windows installer smoke mock still handled only `artifactReserveWrite` / `artifactCreateVersion` / `artifactReleaseWrite`, so the mock returned HTTP 400 and the tool result failed.

Everything else on that Nightly succeeded, including portable shards, merged coverage, all four packaging jobs, runtime-certification, and linux/macos smoke. Runtime-bundle v2 and the WSL modified-secret flake are not involved.

## Proposed change

- Default `--artifact-rpc-contract` to `save` (Nightly `package-smoke` does not pass the flag).
- Mock `artifactSaveVersion` with the current inline base64 source, provenance frame ids, and `installer-smoke-version` result.
- Keep `legacy` and `reservation` for older tagged installers.
- Classify Windows upgrade-smoke released SHAs against `1a6faf134` (#2457) before the reservation commit.

## Scope and non-goals

Smoke harness and the upgrade-smoke contract classifier only. No production Artifact save path, schema, or UI changes.

## Acceptance criteria and validation

After the last material edit, from `.worktree/windows-smoke-artifact-save`:

| Behavior | Command | Result |
| --- | --- | --- |
| Save is the default contract; reservation and legacy stay explicit | `npx vitest run scripts/windows-installer-smoke.test.ts scripts/windows-release-workflows.test.ts scripts/ci/release-workflows.test.ts` | 72/72 passed |
| Lint | `npx eslint scripts/windows-installer-smoke.mjs scripts/windows-installer-smoke.test.ts scripts/windows-release-workflows.test.ts scripts/ci/release-workflows.test.ts` | 0 errors |

Excluded: full `npm test`, packaged Windows installer execution. PR Gate remains authoritative. Do not dispatch another Nightly until this lands.

## Historical compatibility

Additive. `legacy` and `reservation` remain for tagged installers that still emit create-only or reserve/create RPCs.

## New state / enum values

CLI `--artifact-rpc-contract save` only. Not persisted.

## Data persistence

None.

## UI / interaction

None.

Refs: https://github.com/aipoch/open-science/actions/runs/34652611863