### PR TITLE
fix(skills): allow deleting identity conflicts

### DIFF
--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2155,8 +2155,8 @@ const createApplicationModules = async (
     )
   }
   composition.phase('marketplace-recover')
-  settingsService.setSkillDeletionGuard((skillId) =>
-    specialistPackageService.assertSkillDeletionAllowed(skillId)
+  settingsService.setSkillDeletionGuard((request) =>
+    specialistPackageService.assertSkillDeletionAllowed(request.id, request.source)
   )
   // Per-session specialist binding store. Shared between the SET_SESSION_SPECIALIST barrier
   // (validate + record) and the runtime switch so a hot-switch lands on the same source of truth.

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -2156,7 +2156,11 @@ const createApplicationModules = async (
   }
   composition.phase('marketplace-recover')
   settingsService.setSkillDeletionGuard((request) =>
-    specialistPackageService.assertSkillDeletionAllowed(request.id, request.source)
+    specialistPackageService.assertSkillDeletionAllowed(
+      request.id,
+      request.source,
+      request.directoryName
+    )
   )
   // Per-session specialist binding store. Shared between the SET_SESSION_SPECIALIST barrier
   // (validate + record) and the runtime switch so a hot-switch lands on the same source of truth.

--- a/src/main/settings/service.test.ts
+++ b/src/main/settings/service.test.ts
@@ -4380,7 +4380,7 @@ describe('SettingsService: skills', () => {
     await expect(service.deleteSkill({ id: 'personal-my-skill' })).rejects.toMatchObject({
       code: 'protected-skill'
     })
-    expect(guard).toHaveBeenCalledWith('personal-my-skill')
+    expect(guard).toHaveBeenCalledWith({ id: 'personal-my-skill' })
     await expect(service.getSkillDetail('personal-my-skill')).resolves.toBeDefined()
   })
 

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -287,7 +287,7 @@ class SettingsService {
   private deviceCredentialAuthenticator?: (credentialId: string) => Promise<void>
   private deviceCredentialAuthenticationCanceller?: (credentialId: string) => Promise<void>
   private deviceCredentialDisconnector?: (credentialId: string) => Promise<void>
-  private skillDeletionGuard?: (skillId: string) => Promise<void>
+  private skillDeletionGuard?: (request: DeleteSkillRequest) => Promise<void>
 
   hasActiveInstall(): boolean {
     return this.installCoordinator.getActiveId() !== undefined
@@ -1023,7 +1023,7 @@ class SettingsService {
     return this.skills.deleteSkill(request, this.skillDeletionGuard)
   }
 
-  setSkillDeletionGuard(guard: (skillId: string) => Promise<void>): void {
+  setSkillDeletionGuard(guard: (request: DeleteSkillRequest) => Promise<void>): void {
     this.skillDeletionGuard = guard
   }
 

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -467,8 +467,17 @@ describe('SkillCatalogModule', () => {
     )
     expect(new Set(skills.map((skill) => skill.catalogEntryKey)).size).toBe(2)
 
-    await catalog.deleteSkill({ id: 'shared-sidecar-id', source: 'personal' })
-    expect(deleteSkill).toHaveBeenCalledWith('shared-sidecar-id', 'personal', undefined)
+    await catalog.deleteSkill({
+      id: 'shared-sidecar-id',
+      source: 'personal',
+      directoryName: 'personal-copy'
+    })
+    expect(deleteSkill).toHaveBeenCalledWith(
+      'shared-sidecar-id',
+      'personal',
+      'personal-copy',
+      undefined
+    )
   })
 
   it('ignores an unsafe Personal sidecar id instead of materializing outside the Skills root', async () => {

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -374,6 +374,8 @@ describe('SkillCatalogModule', () => {
       await expect(
         readFile(join(runtimeRoot, 'skills', 'os-demo', 'SKILL.md'), 'utf8')
       ).resolves.toContain('demo body')
+      await catalog.deleteSkill({ id: 'demo', source })
+      await expect(readFile(join(userDir, 'SKILL.md'))).rejects.toMatchObject({ code: 'ENOENT' })
       await chmod(join(runtimeRoot, 'skills', 'os-demo'), 0o755)
     }
   )
@@ -422,6 +424,7 @@ describe('SkillCatalogModule', () => {
   it('surfaces every duplicate user Skill id in the Settings catalog', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'settings-skill-catalog-'))
     roots.push(storageRoot)
+    const deleteSkill = vi.fn()
     const catalog = new SkillCatalogModule({
       repository: new SettingsRepository(storageRoot),
       storageRoot,
@@ -446,7 +449,8 @@ describe('SkillCatalogModule', () => {
             updatedAt: '2026-03-01T00:00:00.000Z',
             sourceDir: storageRoot
           }
-        ]
+        ],
+        delete: deleteSkill
       } as unknown as UserSkillRepository
     })
 
@@ -462,6 +466,9 @@ describe('SkillCatalogModule', () => {
       ])
     )
     expect(new Set(skills.map((skill) => skill.catalogEntryKey)).size).toBe(2)
+
+    await catalog.deleteSkill({ id: 'shared-sidecar-id', source: 'personal' })
+    expect(deleteSkill).toHaveBeenCalledWith('shared-sidecar-id', 'personal', undefined)
   })
 
   it('ignores an unsafe Personal sidecar id instead of materializing outside the Skills root', async () => {

--- a/src/main/settings/skill-catalog.test.ts
+++ b/src/main/settings/skill-catalog.test.ts
@@ -973,6 +973,9 @@ describe('SkillCatalogModule', () => {
     expect(
       (await catalog.deleteSkill({ id: 'personal-my-skill' })).map((skill) => skill.id)
     ).toEqual(['demo'])
+    await expect(catalog.deleteSkill({ id: 'demo' })).rejects.toThrow(
+      'Built-in Skills cannot be deleted.'
+    )
   })
 
   it.each(['personal', 'imported'] as const)(

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -632,7 +632,7 @@ class SkillCatalogModule {
 
   async deleteSkill(
     request: DeleteSkillRequest,
-    guard?: (skillId: string) => Promise<void>
+    guard?: (request: DeleteSkillRequest) => Promise<void>
   ): Promise<SkillView[]> {
     if (
       !request.source &&
@@ -640,10 +640,17 @@ class SkillCatalogModule {
     ) {
       throw new Error('Built-in Skills cannot be deleted.')
     }
-    await this.userSkills.delete(request.id, request.source, guard)
-    await this.options.repository.setSkillEnabled(request.id, true)
+    await this.userSkills.delete(
+      request.id,
+      request.source,
+      guard ? () => guard(request) : undefined
+    )
     await this.refreshRegisteredHelpers()
-    return this.listSkills()
+    const skills = await this.listSkills()
+    if (!skills.some((skill) => skill.id === request.id)) {
+      await this.options.repository.setSkillEnabled(request.id, true)
+    }
+    return skills
   }
 
   async importSkill(request: ImportSkillRequest, signal?: AbortSignal): Promise<ImportSkillResult> {

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -634,10 +634,13 @@ class SkillCatalogModule {
     request: DeleteSkillRequest,
     guard?: (skillId: string) => Promise<void>
   ): Promise<SkillView[]> {
-    if ((await this.skillRegistry.list()).some((skill) => skill.id === request.id)) {
+    if (
+      !request.source &&
+      (await this.skillRegistry.list()).some((skill) => skill.id === request.id)
+    ) {
       throw new Error('Built-in Skills cannot be deleted.')
     }
-    await this.userSkills.delete(request.id, guard)
+    await this.userSkills.delete(request.id, request.source, guard)
     await this.options.repository.setSkillEnabled(request.id, true)
     await this.refreshRegisteredHelpers()
     return this.listSkills()

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -634,6 +634,9 @@ class SkillCatalogModule {
     request: DeleteSkillRequest,
     guard?: (skillId: string) => Promise<void>
   ): Promise<SkillView[]> {
+    if ((await this.skillRegistry.list()).some((skill) => skill.id === request.id)) {
+      throw new Error('Built-in Skills cannot be deleted.')
+    }
     await this.userSkills.delete(request.id, guard)
     await this.options.repository.setSkillEnabled(request.id, true)
     await this.refreshRegisteredHelpers()

--- a/src/main/settings/skill-catalog.ts
+++ b/src/main/settings/skill-catalog.ts
@@ -374,6 +374,9 @@ class SkillCatalogModule {
       ...this.toSkillView(skill, disabled),
       available,
       catalogEntryKey,
+      ...(skill.source === 'imported' || skill.source === 'personal'
+        ? { directoryName: skill.name }
+        : {}),
       ...(available ? {} : { availability: 'identity-conflict' as const })
     }))
   }
@@ -643,6 +646,7 @@ class SkillCatalogModule {
     await this.userSkills.delete(
       request.id,
       request.source,
+      request.directoryName,
       guard ? () => guard(request) : undefined
     )
     await this.refreshRegisteredHelpers()

--- a/src/main/settings/workflows.test.ts
+++ b/src/main/settings/workflows.test.ts
@@ -452,6 +452,30 @@ describe('SettingsWorkflows catalog and appearance effects', () => {
     expect(notifySkillCatalogChanged).toHaveBeenCalledOnce()
   })
 
+  it('keeps surviving same-id catalog relationships after a user Skill deletion', async () => {
+    const { store, capability } = fakeStore()
+    const removeTagsForSkill = vi.fn().mockResolvedValue(undefined)
+    store.deleteSkill.mockResolvedValue([
+      {
+        id: 'shared-id',
+        source: 'featured',
+        name: 'Built-in',
+        displayName: 'Built-in',
+        description: '',
+        updatedAt: '',
+        enabled: true
+      }
+    ])
+    const workflows = createSettingsWorkflows(
+      capability,
+      testEffects({ removeTagsForSkill })
+    ).skills
+
+    await workflows.deleteSkill({ id: 'shared-id', source: 'personal' })
+
+    expect(removeTagsForSkill).not.toHaveBeenCalled()
+  })
+
   it('invalidates permissions before a fire-and-forget Connector refresh and reloads on settle', async () => {
     const calls: string[] = []
     const { store, capability } = fakeStore()

--- a/src/main/settings/workflows/skills.ts
+++ b/src/main/settings/workflows/skills.ts
@@ -69,7 +69,9 @@ class SkillSettingsWorkflows {
 
   async deleteSkill(request: DeleteSkillRequest): WorkflowResult<'deleteSkill'> {
     const result = await this.settings.deleteSkill(request)
-    await this.effects.removeTagsForSkill(request.id).catch(() => undefined)
+    if (!result.some((skill) => skill.id === request.id)) {
+      await this.effects.removeTagsForSkill(request.id).catch(() => undefined)
+    }
     this.effects.notifySkillCatalogChanged()
     return result
   }

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -294,6 +294,15 @@ describe('UserSkillRepository', () => {
     expect(await repo.list()).toEqual([])
   })
 
+  it('deletes ordinary skills when the row includes its source and directory name', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+    const id = await repo.createPersonal({ name: 'ordinary', description: 'a', body: 'x' })
+
+    await repo.delete(id, 'personal', 'ordinary')
+
+    expect(await repo.list()).toEqual([])
+  })
+
   it('round-trips a description with newlines and YAML fences without corrupting the body', async () => {
     const repo = new UserSkillRepository(await makeStorage())
 

--- a/src/main/skills/user-skill-repository.test.ts
+++ b/src/main/skills/user-skill-repository.test.ts
@@ -317,6 +317,14 @@ describe('UserSkillRepository', () => {
     expect(body).not.toContain('not: a-key')
   })
 
+  it('rejects an untrusted delete source before resolving a filesystem path', async () => {
+    const repo = new UserSkillRepository(await makeStorage())
+
+    await expect(repo.delete('anything', '../../outside' as never)).rejects.toThrow(
+      'Invalid user Skill source.'
+    )
+  })
+
   it('rejects colliding personal skill names', async () => {
     const repo = new UserSkillRepository(await makeStorage())
 

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -125,10 +125,15 @@ class UserSkillRepository {
     id: string,
     sourceOrGuard?:
       Parameters<UserSkillStore['delete']>[1] | Parameters<UserSkillStore['delete']>[2],
-    guard?: Parameters<UserSkillStore['delete']>[2]
+    directoryNameOrGuard?:
+      Parameters<UserSkillStore['delete']>[2] | Parameters<UserSkillStore['delete']>[3],
+    guard?: Parameters<UserSkillStore['delete']>[3]
   ): Promise<void> {
-    if (typeof sourceOrGuard === 'function') return this.store.delete(id, undefined, sourceOrGuard)
-    return this.store.delete(id, sourceOrGuard, guard)
+    if (typeof sourceOrGuard === 'function')
+      return this.store.delete(id, undefined, undefined, sourceOrGuard)
+    if (typeof directoryNameOrGuard === 'function')
+      return this.store.delete(id, sourceOrGuard, undefined, directoryNameOrGuard)
+    return this.store.delete(id, sourceOrGuard, directoryNameOrGuard, guard)
   }
 
   async importFromGitHub(

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -121,8 +121,14 @@ class UserSkillRepository {
   }
 
   // Deletes a personal or imported skill directory.
-  async delete(id: string, guard?: (skillId: string) => Promise<void>): Promise<void> {
-    return this.store.delete(id, guard)
+  async delete(
+    id: string,
+    sourceOrGuard?:
+      Parameters<UserSkillStore['delete']>[1] | Parameters<UserSkillStore['delete']>[2],
+    guard?: Parameters<UserSkillStore['delete']>[2]
+  ): Promise<void> {
+    if (typeof sourceOrGuard === 'function') return this.store.delete(id, undefined, sourceOrGuard)
+    return this.store.delete(id, sourceOrGuard, guard)
   }
 
   async importFromGitHub(

--- a/src/main/skills/user-skill-repository.ts
+++ b/src/main/skills/user-skill-repository.ts
@@ -22,6 +22,7 @@ import { UserSkillCompatibilityIndex } from './user-skill-compatibility-index'
 import {
   SAFE_SKILL_DIRECTORY_NAME,
   SAFE_SKILL_NAME,
+  type UserSkillSource,
   UserSkillStore,
   assertUsableSkillName,
   frontmatterBlock,
@@ -121,12 +122,17 @@ class UserSkillRepository {
   }
 
   // Deletes a personal or imported skill directory.
+  async delete(id: string, guard?: Parameters<UserSkillStore['delete']>[3]): Promise<void>
   async delete(
     id: string,
-    sourceOrGuard?:
-      Parameters<UserSkillStore['delete']>[1] | Parameters<UserSkillStore['delete']>[2],
-    directoryNameOrGuard?:
-      Parameters<UserSkillStore['delete']>[2] | Parameters<UserSkillStore['delete']>[3],
+    source?: UserSkillSource,
+    directoryName?: string,
+    guard?: Parameters<UserSkillStore['delete']>[3]
+  ): Promise<void>
+  async delete(
+    id: string,
+    sourceOrGuard?: UserSkillSource | Parameters<UserSkillStore['delete']>[3],
+    directoryNameOrGuard?: string | Parameters<UserSkillStore['delete']>[3],
     guard?: Parameters<UserSkillStore['delete']>[3]
   ): Promise<void> {
     if (typeof sourceOrGuard === 'function')

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -243,6 +243,10 @@ export class UserSkillStore {
       throw new Error('Invalid user Skill directory name.')
     }
     if (sourceFilter !== undefined && directoryName !== undefined) {
+      const conventional = parseUserSkillId(id)
+      if (conventional?.source === sourceFilter && conventional.directoryName === directoryName) {
+        return conventional
+      }
       const metadata = await readSpecialistPackageSkillMetadata(
         this.skillDirectory(sourceFilter, directoryName)
       )

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -235,9 +235,20 @@ export class UserSkillStore {
 
   async resolveSkillId(
     id: string,
-    sourceFilter?: UserSkillSource
+    sourceFilter?: UserSkillSource,
+    directoryName?: string
   ): Promise<{ source: UserSkillSource; directoryName: string }> {
     if (sourceFilter !== undefined) assertUserSkillSource(sourceFilter)
+    if (directoryName !== undefined && !SAFE_SKILL_DIRECTORY_NAME.test(directoryName)) {
+      throw new Error('Invalid user Skill directory name.')
+    }
+    if (sourceFilter !== undefined && directoryName !== undefined) {
+      const metadata = await readSpecialistPackageSkillMetadata(
+        this.skillDirectory(sourceFilter, directoryName)
+      )
+      if (metadata?.id === id) return { source: sourceFilter, directoryName }
+      throw new Error(`Not a user skill id: ${id}`)
+    }
     const conventional = parseUserSkillId(id)
     if (conventional && (!sourceFilter || conventional.source === sourceFilter)) return conventional
     for (const source of sourceFilter ? [sourceFilter] : USER_SOURCES) {
@@ -379,11 +390,12 @@ export class UserSkillStore {
   async delete(
     id: string,
     source?: UserSkillSource,
+    directoryName?: string,
     guard?: (skillId: string) => Promise<void>
   ): Promise<void> {
     return this.transactions.runMutationRecovered(async () => {
       await guard?.(id)
-      const parsed = await this.resolveSkillId(id, source)
+      const parsed = await this.resolveSkillId(id, source, directoryName)
       const metadata = await readSpecialistPackageSkillMetadata(
         this.skillDirectory(parsed.source, parsed.directoryName)
       )

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -35,7 +35,7 @@ export const USER_SOURCES: ReadonlyArray<Extract<SkillSource, 'imported' | 'pers
 
 export type UserSkillSource = (typeof USER_SOURCES)[number]
 
-const assertUserSkillSource = (source: unknown): asserts source is UserSkillSource => {
+const assertUserSkillSource = (source: unknown): void => {
   if (!USER_SOURCES.includes(source as UserSkillSource)) {
     throw new Error('Invalid user Skill source.')
   }

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -35,6 +35,12 @@ export const USER_SOURCES: ReadonlyArray<Extract<SkillSource, 'imported' | 'pers
 
 export type UserSkillSource = (typeof USER_SOURCES)[number]
 
+const assertUserSkillSource = (source: unknown): asserts source is UserSkillSource => {
+  if (!USER_SOURCES.includes(source as UserSkillSource)) {
+    throw new Error('Invalid user Skill source.')
+  }
+}
+
 export const SAFE_SKILL_DIRECTORY_NAME = /^[a-z0-9-]+$/
 
 export { frontmatterBlock }
@@ -121,6 +127,7 @@ export class UserSkillStore {
   ) {}
 
   sourceDir(source: UserSkillSource): string {
+    assertUserSkillSource(source)
     return join(this.storageRoot, 'skills', source)
   }
 
@@ -230,6 +237,7 @@ export class UserSkillStore {
     id: string,
     sourceFilter?: UserSkillSource
   ): Promise<{ source: UserSkillSource; directoryName: string }> {
+    if (sourceFilter !== undefined) assertUserSkillSource(sourceFilter)
     const conventional = parseUserSkillId(id)
     if (conventional && (!sourceFilter || conventional.source === sourceFilter)) return conventional
     for (const source of sourceFilter ? [sourceFilter] : USER_SOURCES) {

--- a/src/main/skills/user-skill-store.ts
+++ b/src/main/skills/user-skill-store.ts
@@ -226,10 +226,13 @@ export class UserSkillStore {
     return skills
   }
 
-  async resolveSkillId(id: string): Promise<{ source: UserSkillSource; directoryName: string }> {
+  async resolveSkillId(
+    id: string,
+    sourceFilter?: UserSkillSource
+  ): Promise<{ source: UserSkillSource; directoryName: string }> {
     const conventional = parseUserSkillId(id)
-    if (conventional) return conventional
-    for (const source of USER_SOURCES) {
+    if (conventional && (!sourceFilter || conventional.source === sourceFilter)) return conventional
+    for (const source of sourceFilter ? [sourceFilter] : USER_SOURCES) {
       for (const directoryName of await this.listDirectoryNames(source)) {
         const metadata = await readSpecialistPackageSkillMetadata(
           this.skillDirectory(source, directoryName)
@@ -365,10 +368,14 @@ export class UserSkillStore {
     }, ['personal'])
   }
 
-  async delete(id: string, guard?: (skillId: string) => Promise<void>): Promise<void> {
+  async delete(
+    id: string,
+    source?: UserSkillSource,
+    guard?: (skillId: string) => Promise<void>
+  ): Promise<void> {
     return this.transactions.runMutationRecovered(async () => {
       await guard?.(id)
-      const parsed = await this.resolveSkillId(id)
+      const parsed = await this.resolveSkillId(id, source)
       const metadata = await readSpecialistPackageSkillMetadata(
         this.skillDirectory(parsed.source, parsed.directoryName)
       )

--- a/src/main/specialist/package/service.ts
+++ b/src/main/specialist/package/service.ts
@@ -311,7 +311,8 @@ export class SpecialistPackageService {
 
   async assertSkillDeletionAllowed(
     skillId: string,
-    source?: Extract<SkillSource, 'imported' | 'personal'>
+    source?: Extract<SkillSource, 'imported' | 'personal'>,
+    directoryName?: string
   ): Promise<void> {
     if (typeof skillId !== 'string' || !skillId.trim()) {
       throw new Error('Skill id must be a non-empty string.')
@@ -323,7 +324,8 @@ export class SpecialistPackageService {
     const skill = catalog.skills.find(
       (candidate) =>
         candidate.id === skillId &&
-        (source === undefined || candidate.source === source || candidate.source === undefined)
+        (source === undefined || candidate.source === source || candidate.source === undefined) &&
+        (directoryName === undefined || candidate.name === directoryName)
     )
     if (source !== undefined && (!skill || skill.builtin || skill.source === 'featured')) return
     if (!skill) return

--- a/src/main/specialist/package/service.ts
+++ b/src/main/specialist/package/service.ts
@@ -24,6 +24,7 @@ import {
   validateSpecialistSystemPrompt
 } from '../../../shared/specialist'
 import { parseSkillDocument } from '../../../shared/skill-frontmatter'
+import type { SkillSource } from '../../../shared/settings'
 import { createLogger } from '../../logger'
 import type { SpecialistOrigin, StoredSpecialist, StoredSpecialists } from '../types'
 import { SpecialistRepository } from '../repository'
@@ -308,7 +309,10 @@ export class SpecialistPackageService {
     return preview
   }
 
-  async assertSkillDeletionAllowed(skillId: string): Promise<void> {
+  async assertSkillDeletionAllowed(
+    skillId: string,
+    source?: Extract<SkillSource, 'imported' | 'personal'>
+  ): Promise<void> {
     if (typeof skillId !== 'string' || !skillId.trim()) {
       throw new Error('Skill id must be a non-empty string.')
     }
@@ -316,7 +320,12 @@ export class SpecialistPackageService {
       this.options.repository.getAll(),
       this.options.catalog()
     ])
-    const skill = catalog.skills.find((candidate) => candidate.id === skillId)
+    const skill = catalog.skills.find(
+      (candidate) =>
+        candidate.id === skillId &&
+        (source === undefined || candidate.source === source || candidate.source === undefined)
+    )
+    if (source !== undefined && (!skill || skill.builtin || skill.source === 'featured')) return
     if (!skill) return
     if (skill.builtin) throw new SpecialistSkillDeletionProtectedError(skillId, [], 'builtin')
     const owners = [...(skill.ownerIds ?? [])].sort()

--- a/src/renderer/src/pages/settings/SkillBulkManageView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillBulkManageView.render.test.tsx
@@ -228,12 +228,14 @@ describe('SkillBulkManageView', () => {
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenNthCalledWith(
       1,
       'imported-team',
-      'imported'
+      'imported',
+      undefined
     )
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenNthCalledWith(
       2,
       'personal-mine',
-      'personal'
+      'personal',
+      undefined
     )
     expect(document.body.querySelector('[role="status"]')?.textContent).toContain(
       'Deleted 2 Skills.'
@@ -280,7 +282,8 @@ describe('SkillBulkManageView', () => {
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledOnce()
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith(
       'imported-team',
-      'imported'
+      'imported',
+      undefined
     )
     expect(
       document.body.querySelector<HTMLInputElement>('[aria-label="Select Mine"]')?.checked

--- a/src/renderer/src/pages/settings/SkillBulkManageView.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillBulkManageView.render.test.tsx
@@ -225,8 +225,16 @@ describe('SkillBulkManageView', () => {
       button('Delete 2 Skills')?.click()
       await Promise.resolve()
     })
-    expect(useSettingsStore.getState().deleteSkill).toHaveBeenNthCalledWith(1, 'imported-team')
-    expect(useSettingsStore.getState().deleteSkill).toHaveBeenNthCalledWith(2, 'personal-mine')
+    expect(useSettingsStore.getState().deleteSkill).toHaveBeenNthCalledWith(
+      1,
+      'imported-team',
+      'imported'
+    )
+    expect(useSettingsStore.getState().deleteSkill).toHaveBeenNthCalledWith(
+      2,
+      'personal-mine',
+      'personal'
+    )
     expect(document.body.querySelector('[role="status"]')?.textContent).toContain(
       'Deleted 2 Skills.'
     )
@@ -270,7 +278,10 @@ describe('SkillBulkManageView', () => {
       await Promise.resolve()
     })
     expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledOnce()
-    expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith('imported-team')
+    expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith(
+      'imported-team',
+      'imported'
+    )
     expect(
       document.body.querySelector<HTMLInputElement>('[aria-label="Select Mine"]')?.checked
     ).toBe(true)

--- a/src/renderer/src/pages/settings/SkillBulkManageView.tsx
+++ b/src/renderer/src/pages/settings/SkillBulkManageView.tsx
@@ -179,7 +179,7 @@ const SkillBulkManageView = (): React.JSX.Element => {
     const failures: string[] = []
     for (const { skill } of deletableSkills) {
       try {
-        await deleteSkill(skill.id)
+        await deleteSkill(skill.id, skill.source)
         deletedIds.add(skill.id)
       } catch (error) {
         failures.push(errorMessage(error) || skill.displayName)

--- a/src/renderer/src/pages/settings/SkillBulkManageView.tsx
+++ b/src/renderer/src/pages/settings/SkillBulkManageView.tsx
@@ -180,7 +180,7 @@ const SkillBulkManageView = (): React.JSX.Element => {
     for (const { skill } of deletableSkills) {
       if (skill.source === 'featured') continue
       try {
-        await deleteSkill(skill.id, skill.source)
+        await deleteSkill(skill.id, skill.source, skill.directoryName)
         deletedIds.add(skill.id)
       } catch (error) {
         failures.push(errorMessage(error) || skill.displayName)

--- a/src/renderer/src/pages/settings/SkillBulkManageView.tsx
+++ b/src/renderer/src/pages/settings/SkillBulkManageView.tsx
@@ -178,6 +178,7 @@ const SkillBulkManageView = (): React.JSX.Element => {
     const deletedIds = new Set<string>()
     const failures: string[] = []
     for (const { skill } of deletableSkills) {
+      if (skill.source === 'featured') continue
       try {
         await deleteSkill(skill.id, skill.source)
         deletedIds.add(skill.id)

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -630,7 +630,10 @@ describe('SkillsPanel (list view)', () => {
       document.body.querySelectorAll<HTMLElement>('[role="menuitem"]')
     ).find((item) => item.textContent?.trim() === 'Delete')
     clickRadixMenuItem(remove)
-    expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith('personal-mine')
+    expect(useSettingsStore.getState().deleteSkill).toHaveBeenCalledWith(
+      'personal-mine',
+      'personal'
+    )
   })
 
   it('exports imported and personal Skills but never built-in Skills', async () => {

--- a/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.render.test.tsx
@@ -413,7 +413,7 @@ describe('SkillsPanel (list view)', () => {
     expect(onNavigate).toHaveBeenCalledWith({ kind: 'detail', id: 'a' })
   })
 
-  it('shows identity-conflicting Skills without exposing ambiguous actions', () => {
+  it('keeps identity-conflicting user Skills deletable without exposing runtime actions', () => {
     const onNavigate = vi.fn()
     useSettingsStore.setState({
       skills: [
@@ -438,7 +438,9 @@ describe('SkillsPanel (list view)', () => {
 
     expect(document.body.textContent).toContain('Conflicting Skill')
     expect(document.body.textContent).toContain('Identity conflict')
-    expect(document.body.querySelector('[aria-label="Actions for Conflicting Skill"]')).toBeNull()
+    expect(
+      document.body.querySelector('[aria-label="Actions for Conflicting Skill"]')
+    ).not.toBeNull()
     const toggle = document.body.querySelector<HTMLButtonElement>(
       '[aria-label="Toggle Conflicting Skill"]'
     )

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -640,7 +640,7 @@ const SkillsPanel = ({
                                 reference={{ resourceType: 'catalog.skill', resourceId: skill.id }}
                               />
                             ) : null}
-                            {available && skill.source !== 'featured' ? (
+                            {skill.source !== 'featured' ? (
                               <DropdownMenu>
                                 <DropdownMenuTrigger asChild>
                                   <Button
@@ -656,7 +656,7 @@ const SkillsPanel = ({
                                   </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent align="end">
-                                  {canExportSkills ? (
+                                  {available && canExportSkills ? (
                                     <DropdownMenuItem
                                       className="gap-2 text-xs"
                                       onSelect={() => void exportSkill(skill.id, skill.displayName)}
@@ -665,7 +665,7 @@ const SkillsPanel = ({
                                       {t('Export')}
                                     </DropdownMenuItem>
                                   ) : null}
-                                  {skill.source === 'personal' ? (
+                                  {available && skill.source === 'personal' ? (
                                     <DropdownMenuItem
                                       className="gap-2 text-xs"
                                       onSelect={() => onNavigate({ kind: 'edit', id: skill.id })}

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -705,6 +705,7 @@ const SkillsPanel = ({
                                     <DropdownMenuItem
                                       className="gap-2 text-xs text-destructive"
                                       onSelect={() => {
+                                        if (skill.source === 'featured') return
                                         setDeleteError(undefined)
                                         void deleteSkill(skill.id, skill.source).catch((error) =>
                                           setDeleteError({

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -707,7 +707,11 @@ const SkillsPanel = ({
                                       onSelect={() => {
                                         if (skill.source === 'featured') return
                                         setDeleteError(undefined)
-                                        void deleteSkill(skill.id, skill.source).catch((error) =>
+                                        void deleteSkill(
+                                          skill.id,
+                                          skill.source,
+                                          skill.directoryName
+                                        ).catch((error) =>
                                           setDeleteError({
                                             id: skill.id,
                                             message:

--- a/src/renderer/src/pages/settings/SkillsPanel.tsx
+++ b/src/renderer/src/pages/settings/SkillsPanel.tsx
@@ -706,7 +706,7 @@ const SkillsPanel = ({
                                       className="gap-2 text-xs text-destructive"
                                       onSelect={() => {
                                         setDeleteError(undefined)
-                                        void deleteSkill(skill.id).catch((error) =>
+                                        void deleteSkill(skill.id, skill.source).catch((error) =>
                                           setDeleteError({
                                             id: skill.id,
                                             message:

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -2,6 +2,7 @@ import type {
   AgentHomeSkillRef,
   AgentHomeSkillView,
   CreateSkillRequest,
+  DeleteSkillRequest,
   ImportAgentHomeSkillsResult,
   ImportSkillResult,
   ImportSkillZipBatchResult,
@@ -22,7 +23,7 @@ export type SettingsSkillsActions = {
   setSkillsEnabled: (ids: string[], enabled: boolean) => Promise<void>
   createSkill: (request: CreateSkillRequest) => Promise<void>
   updateSkill: (request: UpdateSkillRequest) => Promise<void>
-  deleteSkill: (id: string) => Promise<void>
+  deleteSkill: (id: string, source?: DeleteSkillRequest['source']) => Promise<void>
   importSkill: (url: string) => Promise<ImportSkillResult>
   importSkillZip: (
     dataBase64: string,
@@ -178,7 +179,10 @@ export const createSettingsSkillsSlice = ({
       reconcileCatalogMutation(() => getCommands().setSkillsEnabled({ ids, enabled })),
     createSkill: (request) => reconcileCatalogMutation(() => getCommands().createSkill(request)),
     updateSkill: (request) => reconcileCatalogMutation(() => getCommands().updateSkill(request)),
-    deleteSkill: (id) => reconcileCatalogMutation(() => getCommands().deleteSkill({ id })),
+    deleteSkill: (id, source) =>
+      reconcileCatalogMutation(() =>
+        getCommands().deleteSkill(source === undefined ? { id } : { id, source })
+      ),
     importSkill: (url) => reconcileImport(() => getCommands().importSkill({ url })),
     importSkillZip: (dataBase64, opts) =>
       reconcileImport(() =>

--- a/src/renderer/src/stores/settings-skills-slice.ts
+++ b/src/renderer/src/stores/settings-skills-slice.ts
@@ -23,7 +23,11 @@ export type SettingsSkillsActions = {
   setSkillsEnabled: (ids: string[], enabled: boolean) => Promise<void>
   createSkill: (request: CreateSkillRequest) => Promise<void>
   updateSkill: (request: UpdateSkillRequest) => Promise<void>
-  deleteSkill: (id: string, source?: DeleteSkillRequest['source']) => Promise<void>
+  deleteSkill: (
+    id: string,
+    source?: DeleteSkillRequest['source'],
+    directoryName?: DeleteSkillRequest['directoryName']
+  ) => Promise<void>
   importSkill: (url: string) => Promise<ImportSkillResult>
   importSkillZip: (
     dataBase64: string,
@@ -179,10 +183,8 @@ export const createSettingsSkillsSlice = ({
       reconcileCatalogMutation(() => getCommands().setSkillsEnabled({ ids, enabled })),
     createSkill: (request) => reconcileCatalogMutation(() => getCommands().createSkill(request)),
     updateSkill: (request) => reconcileCatalogMutation(() => getCommands().updateSkill(request)),
-    deleteSkill: (id, source) =>
-      reconcileCatalogMutation(() =>
-        getCommands().deleteSkill(source === undefined ? { id } : { id, source })
-      ),
+    deleteSkill: (id, source, directoryName) =>
+      reconcileCatalogMutation(() => getCommands().deleteSkill({ id, source, directoryName })),
     importSkill: (url) => reconcileImport(() => getCommands().importSkill({ url })),
     importSkillZip: (dataBase64, opts) =>
       reconcileImport(() =>

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1225,6 +1225,7 @@ export type UpdateSkillRequest = {
 
 export type DeleteSkillRequest = {
   id: string
+  source?: Extract<SkillSource, 'imported' | 'personal'>
 }
 
 // Import a single skill from a public GitHub URL.

--- a/src/shared/settings.ts
+++ b/src/shared/settings.ts
@@ -1128,6 +1128,7 @@ export type SkillView = {
   availability?: 'identity-conflict'
   // Ephemeral row identity for conflicting packages that reuse the same durable id.
   catalogEntryKey?: string
+  directoryName?: string
   // Stable invocation name from SKILL.md.
   name: string
   // Presentation label supplied by the catalog source, falling back to name.
@@ -1226,6 +1227,7 @@ export type UpdateSkillRequest = {
 export type DeleteSkillRequest = {
   id: string
   source?: Extract<SkillSource, 'imported' | 'personal'>
+  directoryName?: string
 }
 
 // Import a single skill from a public GitHub URL.


### PR DESCRIPTION
## Problem

A user Skill copied or retained under the writable `personal/` or `imported/` roots can reuse the name of a bundled Featured Skill. The catalog correctly marks it as `identity-conflict`, but the Settings page hides its action menu, so the user cannot remove the orphaned package.

## Proposed change

- Keep runtime actions unavailable for identity-conflicting Skills.
- Expose the existing delete action for conflicting user-owned Skills.
- Reject built-in Skill deletion explicitly in the main-process catalog service.

## Scope and non-goals

No new data fields, enum values, database migration, or persisted-format changes. Built-in Skills remain non-deletable. Export, edit, toggle, and detail actions remain unavailable for conflicting entries.

## Acceptance criteria and validation

- The focused regression test failed before the production change and passes afterward.
- `npx vitest run src/renderer/src/pages/settings/SkillsPanel.render.test.tsx src/main/settings/skill-catalog.test.ts` — 112 passed.
- `npm run lint` — passed.
- `git diff --check` — passed.
- `npm run typecheck:web` — blocked by pre-existing missing dependencies in `packages/notebook-network-sandbox/runtime/src/gateway/local-ca.ts` (`reflect-metadata`, `@peculiar/x509`), unrelated to this change.

## Review focus

Verify that an identity-conflicting personal/imported Skill can be deleted, while built-in Skills cannot be deleted through the main-process service.
