### PR TITLE
test(visual): target the ErrorNotice recovery description

### DIFF
--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -362,7 +362,8 @@ test('keeps representative conversation, project, and recovery states visually s
   const recoveryAction = recoveryNotice.getByRole('button', {
     name: 'View affected conversations'
   })
-  const recoveryMessage = recoveryAlert.locator('p').nth(1)
+  // ErrorNotice puts the title in a heading and the body in a single description paragraph.
+  const recoveryMessage = recoveryAlert.locator('p')
   for (const width of [320, 375, 414, 768]) {
     await setViewport(page, width)
     const [alertBox, actionBox, messageBox] = await Promise.all([


### PR DESCRIPTION
## Problem

Nightly https://github.com/aipoch/open-science/actions/runs/34665319101 succeeded as a gate (portable tests, macOS native, all four package-smoke jobs including windows-x64). Advisory `regression / visual` failed:

```
e2e/visual-regression.spec.ts › keeps representative conversation, project, and recovery states visually stable
TimeoutError: waiting for getByRole('alert').filter({ hasText: 'Project archive needs attention' }).locator('p').nth(1)
```

Retry failed the same way. #2469 moved session recovery onto `ErrorNotice`: title is a heading, body is a single `p`. The visual test still expected a second paragraph.

## Proposed change

Measure the recovery description with `recoveryAlert.locator('p')`.

## Scope and non-goals

Desktop visual locator only. No ErrorNotice or SessionPersistenceAlert production changes.

## Acceptance criteria and validation

Locator now matches the ErrorNotice compact markup (one description `p` inside `role="alert"`). Full Electron visual suite is Nightly-authoritative; not run locally.

## Historical compatibility

None.

## New state / enum values

None.

## Data persistence

None.

## UI / interaction

None. Existing recovery copy and layout assertions stay; only the description locator changes.

Refs: https://github.com/aipoch/open-science/actions/runs/34665319101/job/103479462528