### PR TITLE
feat(cli): add terminal profile initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,10 +363,11 @@ A: Enable the **Remote Compute (SSH)** skill under **Settings → Skills**, regi
 
 ### Is there a command-line interface?
 
-A: Yes. Install it in one click from **Settings → General → Command line tool → Install command** (adds `open-science` to your PATH; no separate Node.js needed). The CLI controls the local service and submits research tasks without opening a browser:
+A: Yes. Install it in one click from **Settings → General → Command line tool → Install command** (adds `open-science` to your PATH; no separate Node.js needed). Initialize the local profile, then control the service and submit research tasks without opening a browser:
 
 ```bash
-# Start the service in the background
+# Initialize the local CLI profile and start the service in the background
+open-science init
 open-science start --no-open
 
 # Create a project and run a task by its exact name

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -35,6 +35,17 @@ node packages/open-science/cli.mjs
 
 ## Service lifecycle
 
+Initialize the local configuration directory from a terminal. This is safe to repeat and does not
+start the desktop application:
+
+```bash
+open-science init
+open-science init --config-root /absolute/path/to/profile --json
+```
+
+`init` prepares the profile directory; the first `start` creates the authenticated service state and
+token. It does not migrate or modify an existing profile beyond creating the directory when needed.
+
 Start the service without opening a browser, check its status, or stop it:
 
 ```bash

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -45,6 +45,8 @@ open-science init --config-root /absolute/path/to/profile --json
 
 `init` prepares the profile directory; the first `start` creates the authenticated service state and
 token. It does not migrate or modify an existing profile beyond creating the directory when needed.
+Use `--profile` as a portable alias for `--config-root`; the alias is reserved for future standalone
+CLI distributions and currently follows the same development-profile restrictions.
 
 Start the service without opening a browser, check its status, or stop it:
 

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -571,7 +571,15 @@ export const isProcessAlive = (pid) => {
 }
 
 export const initCommand = async (options, deps = DEFAULT_DEPS) => {
-  const configRoot = resolveConfigRoot({ override: options.configRoot, packaged: true })
+  const app = await (deps.locateApp ?? locateApp)({ appPath: options.appPath })
+  if (app.packaged && options.configRoot) {
+    throw new Error('--config-root is only supported for development builds.')
+  }
+  const configRoot = resolveConfigRoot({
+    override: options.configRoot,
+    packaged: app.packaged,
+    env: app.packaged ? {} : process.env
+  })
   await mkdir(configRoot, { recursive: true, mode: 0o700 })
   const result = { configRoot, initialized: true }
   deps.log(options.json ? JSON.stringify(result) : `Open Science is initialized at ${configRoot}.`)

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -29,6 +29,7 @@ const MAX_DOWNLOAD_SYMLINK_HOPS = 40
 const usage = `Usage: open-science <command> [options]
 
 Commands:
+  init        Create the local CLI configuration directory
   start       Start the headless backend and localhost web UI
   stop        Gracefully stop the backend
   status      Show backend status
@@ -184,6 +185,7 @@ const POSITIONAL_LIMITS = new Map([
   ['credential update', 1],
 
   ['start', 0],
+  ['init', 0],
   ['stop', 0],
   ['status', 0],
   ['url', 0],
@@ -564,6 +566,14 @@ export const isProcessAlive = (pid) => {
   } catch (error) {
     return error.code === 'EPERM'
   }
+}
+
+export const initCommand = async (options, deps = DEFAULT_DEPS) => {
+  const configRoot = resolveConfigRoot({ override: options.configRoot, packaged: true })
+  await mkdir(configRoot, { recursive: true, mode: 0o700 })
+  const result = { configRoot, initialized: true }
+  deps.log(options.json ? JSON.stringify(result) : `Open Science is initialized at ${configRoot}.`)
+  return result
 }
 
 const authenticatedUrl = async (state, deps = DEFAULT_DEPS) => {
@@ -1903,7 +1913,8 @@ export const runCli = async (argv = process.argv.slice(2), dependencies = {}) =>
     console.log(usage)
     return
   }
-  if (command === 'start') await startCommand(options)
+  if (command === 'init') await initCommand(options)
+  else if (command === 'start') await startCommand(options)
   else if (command === 'stop') await stopCommand(options)
   else if (command === 'status') await statusCommand(options)
   else if (command === 'url') await urlCommand(options)

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -66,6 +66,7 @@ Options:
   --port <port>          Web service port (default: 44100)
   --app-path <path>      Installed Open Science executable
   --config-root <path>   Config directory override
+  --profile <path>       Alias for --config-root (portable CLI profile)
   --data-root <path>     Current Data Root override (rollback only)
   --project <id-or-name> Project id or exact name
   --session <id>         Resume an existing session
@@ -117,6 +118,7 @@ const VALUE_OPTIONS = {
   '--port': 'port',
   '--app-path': 'appPath',
   '--config-root': 'configRoot',
+  '--profile': 'configRoot',
   '--data-root': 'dataRoot',
   '--project': 'project',
   '--session': 'session',

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -30,6 +30,12 @@ const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
 ]
 
 describe('task CLI', () => {
+  it('accepts --profile as the forward-compatible profile spelling', () => {
+    expect(parseCliArgs(['init', '--profile', '/tmp/open-science-profile']).options).toMatchObject({
+      configRoot: '/tmp/open-science-profile'
+    })
+  })
+
   it('initializes a config root without starting the desktop app', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-cli-init-'))
     const log = vi.fn()

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -39,13 +39,27 @@ describe('task CLI', () => {
   it('initializes a config root without starting the desktop app', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-cli-init-'))
     const log = vi.fn()
-    await expect(initCommand({ configRoot: root, json: true }, { log })).resolves.toEqual({
+    await expect(
+      initCommand(
+        { configRoot: root, json: true },
+        { log, locateApp: vi.fn().mockResolvedValue({ packaged: false }) }
+      )
+    ).resolves.toEqual({
       configRoot: root,
       initialized: true
     })
     expect(log).toHaveBeenCalledWith(JSON.stringify({ configRoot: root, initialized: true }))
     await expect(stat(root)).resolves.toMatchObject({ isDirectory: expect.any(Function) })
     await rm(root, { recursive: true, force: true })
+  })
+
+  it('rejects profile overrides for packaged initialization', async () => {
+    await expect(
+      initCommand(
+        { configRoot: '/tmp/profile', json: true },
+        { log: vi.fn(), locateApp: vi.fn().mockResolvedValue({ packaged: true }) }
+      )
+    ).rejects.toThrow('--config-root is only supported for development builds.')
   })
 
   it('requires JSON output for doctor', () => {

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -16,6 +16,7 @@ import { describe, expect, it, vi } from 'vitest'
 import { PUBLIC_TERMINAL_FIXTURE } from '../../test/fixtures/renderer-contract-certification'
 import {
   CliUsageError,
+  initCommand,
   parseCliArgs,
   reportCliError,
   rollbackCommand,
@@ -29,6 +30,18 @@ const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
 ]
 
 describe('task CLI', () => {
+  it('initializes a config root without starting the desktop app', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'open-science-cli-init-'))
+    const log = vi.fn()
+    await expect(initCommand({ configRoot: root, json: true }, { log })).resolves.toEqual({
+      configRoot: root,
+      initialized: true
+    })
+    expect(log).toHaveBeenCalledWith(JSON.stringify({ configRoot: root, initialized: true }))
+    await expect(stat(root)).resolves.toMatchObject({ isDirectory: expect.any(Function) })
+    await rm(root, { recursive: true, force: true })
+  })
+
   it('requires JSON output for doctor', () => {
     expect(() => parseCliArgs(['doctor'])).toThrow('doctor requires --json.')
   })


### PR DESCRIPTION
## Problem
The existing headless CLI can control Open Science without opening the desktop window, but it had no explicit terminal initialization command. Future standalone CLI work also needs a stable profile spelling without changing the current Electron-backed runtime.

## Proposed change
- Add `open-science init` to create the local configuration directory without starting the app.
- Add `--profile` as a forward-compatible alias for `--config-root`.
- Document the terminal-first initialization and headless workflow.

## Scope and non-goals
This PR does not publish an npm package, split the daemon, remove Electron, add a TUI, or change persistence formats. `start` continues to use the existing Electron headless runtime.

## Acceptance criteria and validation
- `open-science init --profile <path>` creates the profile directory and is repeatable.
- Existing lifecycle and task commands remain unchanged.
- CLI module tests pass: `npm run test:cli` (152 tests).
- ESLint passes for changed CLI files.
- Checks ran after the last material edit.

## Review focus
Please review the terminal workflow and whether `--profile` is an appropriate stable spelling to preserve if a standalone CLI is added later.
