### PR TITLE
test(visual): allow compact recovery actions to wrap

### DIFF
--- a/e2e/visual-regression.spec.ts
+++ b/e2e/visual-regression.spec.ts
@@ -377,7 +377,9 @@ test('keeps representative conversation, project, and recovery states visually s
     expect(alertBox.x).toBeGreaterThanOrEqual(0)
     expect(alertBox.x + alertBox.width).toBeLessThanOrEqual(width)
     expect(actionBox.y).toBeGreaterThanOrEqual(messageBox.y + messageBox.height)
-    await expect(recoveryAction).toHaveCSS('white-space', 'nowrap')
+    expect(actionBox.x).toBeGreaterThanOrEqual(0)
+    expect(actionBox.x + actionBox.width).toBeLessThanOrEqual(width)
+    // Compact ErrorNotice actions wrap at narrow widths; nowrap would overflow the viewport.
   }
   await setViewport(page, 1280)
   await expectStableScreenshot(page, 'session-recovery-warning.png')


### PR DESCRIPTION
## Problem

Nightly https://github.com/aipoch/open-science/actions/runs/34669307476 succeeded as a gate (macOS native, all four package-smoke jobs including windows-x64). Advisory \`regression / visual\` failed after #2473:

\`\`\`
e2e/visual-regression.spec.ts › keeps representative conversation, project, and recovery states visually stable
expect(recoveryAction).toHaveCSS('white-space', 'nowrap')
Expected: nowrap
Received: normal
\`\`\`

Retry failed the same way. The locator from #2473 is correct. Compact \`ErrorNotice\` buttons set \`whitespace-normal text-left\` so long recovery labels wrap instead of overflowing. \`docs/error-surfaces.md\` says single-line is not a forced nowrap rule.

## Proposed change

Drop the nowrap assertion. Keep the stacked-layout check and require the action to stay inside the viewport at 320–768px.

## Scope and non-goals

Desktop visual assertions only. No ErrorNotice production change.

## Acceptance criteria and validation

The visual recovery loop now matches compact ErrorNotice wrapping. Full Electron visual suite is Nightly-authoritative; not run locally.

## Historical compatibility

None.

## New state / enum values

None.

## Data persistence

None.

## UI / interaction

None.

Refs: https://github.com/aipoch/open-science/actions/runs/34669307476/job/103490533818