### PR TITLE
fix(literature): preserve preprint types, surname particles and RIS abbreviations

### DIFF
--- a/src/main/literature/citation-exchange.ts
+++ b/src/main/literature/citation-exchange.ts
@@ -32,7 +32,7 @@ const lineValue = (value: string): string => value.replace(/[\r\n]+/gu, ' ').tri
 const nameText = (name: CslName): string =>
   name.literal ?? `${name.family ?? ''}, ${name.given ?? ''}`
 
-// BOOK A3/editor, A4/translator and ET/edition follow Zotero's RIS mappings.
+// BOOK A3/editor, A4/translator, ET/edition and J2/journal abbreviation follow Zotero's RIS mappings.
 // Labeled N1 notes preserve identifiers without misusing DOI or accession-number tags.
 // These notes are readable by other tools; structured recovery is our explicit adapter contract.
 export const exportRisFields = (item: CslItem): string => {
@@ -52,6 +52,7 @@ export const exportRisFields = (item: CslItem): string => {
     })
   }
   if (item.edition) fields.push(['ET', item.edition])
+  if (item['container-title-short']) fields.push(['J2', item['container-title-short']])
   return fields.map(([tag, value]) => `${tag}  - ${lineValue(value)}\n`).join('')
 }
 
@@ -93,6 +94,7 @@ export const importRisFields = (
         }
       }
     } else if (tag === 'ET') result.edition = value
+    else if (tag === 'J2') result['container-title-short'] = value
     else if (tag === 'A4' || tag === 'ED' || tag === editorTag) {
       const comma = value.indexOf(',')
       const name =

--- a/src/main/literature/citation-formatter.test.ts
+++ b/src/main/literature/citation-formatter.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'vitest'
 import { LITERATURE_CITATION_STYLES, type LiteratureItemInput } from '../../shared/literature'
 import { LiteratureCitationFormatter } from './citation-formatter'
 import { toCslItem } from '../../shared/literature-csl'
+import { importRisFields } from './citation-exchange'
 import { citationResourceDirectory, LiteratureCitationStyleLibrary } from './citation-style-library'
 
 const reference: LiteratureItemInput = {
@@ -32,6 +33,84 @@ const reference: LiteratureItemInput = {
 }
 
 describe('LiteratureCitationFormatter', () => {
+  it.each([
+    ['PT  - Preprint', 'preprint'],
+    ['PT  - Journal Article\nPT  - Preprint', 'preprint'],
+    ['PT  - Review\nPT  - Preprint', 'preprint'],
+    ['PT  - Review', 'review'],
+    ['PT  - Journal Article', 'journalArticle']
+  ])('preserves PubMed publication type for %s', async (publicationTypes, itemType) => {
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      `PMID- 12345\nTI  - Publication type fixture\n${publicationTypes}\n`
+    )
+    expect(parsed.errors).toEqual([])
+    expect(parsed.items[0]?.itemType).toBe(itemType)
+  })
+
+  it('retains surname particles in BibTeX imports, citations and RIS round trips', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const parsed = await formatter.parseReferences(
+      '@article{names, title={Name preservation}, author={van Dijk, Jan and de la Cruz, Ana}, journal={Journal}, year={2024}}'
+    )
+    expect(parsed.errors).toEqual([])
+    const item = parsed.items[0]!
+    expect(item.creators).toMatchObject([
+      { givenName: 'Jan', familyName: 'van Dijk' },
+      { givenName: 'Ana', familyName: 'de la Cruz' }
+    ])
+    const references = [{ id: 'names', item }]
+    const [formatted] = await formatter.formatReferences(references, 'vancouver', 'en-US')
+    // The style can move particles after the initials; the name parts must survive.
+    expect(formatted?.reference).toContain('Dijk')
+    expect(formatted?.reference).toContain('van')
+    expect(formatted?.reference).toContain('Cruz')
+    expect(formatted?.reference).toContain('de la')
+    const reimported = await formatter.parseReferences(
+      await formatter.exportReferences(references, 'ris')
+    )
+    expect(reimported.errors).toEqual([])
+    expect(reimported.items[0]?.creators).toEqual(item.creators)
+  })
+
+  it('preserves PubMed journal abbreviations through RIS export and reimport', async () => {
+    const formatter = new LiteratureCitationFormatter()
+    const parsed = await formatter.parseReferences(
+      'PMID- 12345\nTI  - Useful paper\nJT  - Journal of Useful Results\nTA  - J Useful Results\n'
+    )
+    const ris = await formatter.exportReferences([{ id: 'paper', item: parsed.items[0]! }], 'ris')
+    expect(ris).toContain('J2  - J Useful Results\n')
+    const reimported = await formatter.parseReferences(ris)
+    expect(reimported.errors).toEqual([])
+    expect(reimported.items[0]).toMatchObject({
+      containerTitle: 'Journal of Useful Results',
+      shortTitle: '',
+      typeFields: { journalAbbreviation: 'J Useful Results' }
+    })
+  })
+
+  it('imports RIS journal abbreviations separately from article short titles and adjacent records', async () => {
+    expect(
+      importRisFields('J2  - J Useful Results\nER  - \n', {
+        'title-short': 'Short paper title'
+      })
+    ).toMatchObject({
+      'title-short': 'Short paper title',
+      'container-title-short': 'J Useful Results'
+    })
+    const parsed = await new LiteratureCitationFormatter().parseReferences(
+      'TY  - JOUR\nTI  - Useful paper\nJO  - Journal of Useful Results\nJ2  - J Useful Results\nER  - \n\n' +
+        'TY  - JOUR\nTI  - Another paper\nJO  - Another Journal\nER  - \n'
+    )
+    expect(parsed.errors).toEqual([])
+    expect(parsed.items).toHaveLength(2)
+    expect(parsed.items[0]).toMatchObject({
+      containerTitle: 'Journal of Useful Results',
+      shortTitle: '',
+      typeFields: { journalAbbreviation: 'J Useful Results' }
+    })
+    expect(parsed.items[1]?.typeFields).not.toHaveProperty('journalAbbreviation')
+  })
+
   it('renders the journal abbreviation without replacing the article title in a short-title style', async () => {
     const root = await mkdtemp(join(tmpdir(), 'open-science-pubmed-csl-'))
     try {

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -187,7 +187,11 @@ const parseNbib = (input: string): ParsedCitationRecords | undefined => {
     const authors = nbibCreators(record)
     warnings.push(authors.uncertain.length ? ['uncertain-author-name'] : [])
     items.push({
-      itemType: publicationTypes.includes('review') ? 'review' : 'journalArticle',
+      itemType: publicationTypes.includes('preprint')
+        ? 'preprint'
+        : publicationTypes.includes('review')
+          ? 'review'
+          : 'journalArticle',
       title,
       abstract: nbibText(record, 'AB'),
       issuedText,

--- a/src/shared/literature-csl.test.ts
+++ b/src/shared/literature-csl.test.ts
@@ -249,6 +249,37 @@ describe('fromCslItem', () => {
     })
   })
 
+  it.each(['author', 'editor', 'translator'] as const)(
+    'preserves both CSL name particles for %s without changing literal names',
+    (role) => {
+      const source = fromCslItem({
+        title: 'Name preservation',
+        type: 'article-journal',
+        [role]: [
+          { given: 'Jan', family: 'Dijk', 'non-dropping-particle': 'van' },
+          { given: 'Tawfiq', family: 'Hakim', 'non-dropping-particle': 'al-' },
+          { given: 'Jean', family: 'Alembert', 'dropping-particle': "d'" },
+          {
+            given: 'Ana',
+            family: 'Cruz',
+            'dropping-particle': 'de',
+            'non-dropping-particle': 'la'
+          },
+          { literal: 'Research Group', family: 'Ignored', 'dropping-particle': 'Ignored' }
+        ]
+      })
+      expect(source.creators).toMatchObject([
+        { creatorType: role, givenName: 'Jan', familyName: 'van Dijk' },
+        { creatorType: role, givenName: 'Tawfiq', familyName: 'al-Hakim' },
+        { creatorType: role, givenName: 'Jean', familyName: "d'Alembert" },
+        { creatorType: role, givenName: 'Ana', familyName: 'de la Cruz' },
+        { creatorType: role, nameMode: 'organization', literalName: 'Research Group' }
+      ])
+      const roundTrip = fromCslItem(toCslItem('names', source))
+      expect(roundTrip.creators).toEqual(source.creators)
+    }
+  )
+
   it('rejects imported entries without a title', () => {
     expect(() => fromCslItem({ id: 'missing-title', type: 'article' })).toThrow()
   })

--- a/src/shared/literature-csl.ts
+++ b/src/shared/literature-csl.ts
@@ -266,7 +266,18 @@ const creatorsFromCsl = (
           return [{ nameMode: 'organization' as const, literalName, creatorType }]
         }
         const givenName = stringField(name, 'given')
-        const familyName = stringField(name, 'family')
+        // Library names have no separate particle fields. Keep both CSL particle
+        // categories in the surname so display and subsequent exports retain them.
+        const familyName = [
+          stringField(name, 'dropping-particle'),
+          stringField(name, 'non-dropping-particle'),
+          stringField(name, 'family')
+        ]
+          .filter(Boolean)
+          .reduce(
+            (surname, part) => `${surname}${surname && !/[-'’]$/u.test(surname) ? ' ' : ''}${part}`,
+            ''
+          )
         return givenName || familyName
           ? [{ nameMode: 'person' as const, givenName, familyName, creatorType }]
           : []


### PR DESCRIPTION
## Problem

Literature conversion misclassifies PubMed preprints and loses surname particles and RIS journal abbreviations.

## Proposed change

- Import PubMed Preprint records as preprints.
- Preserve surname particles, including names such as van Dijk, al-Hakim and d'Alembert.
- Preserve journal abbreviations through RIS J2 import/export without overwriting article short titles.
- Add regression tests for these conversions.

## Scope and non-goals

Five files changed. No UI or database schema changes. BibTeX abbreviation support is outside this change. This preserves surname text within the existing name schema; it does not add separate CSL particle sorting semantics or recover previously lost metadata.

## Acceptance criteria and validation

Checks ran after the final changes:

- Nine targeted test files: **437 passed**, covering conversion, citation output, import/export round trips, PubMed and LaTeX consumers, and Library/editor UI behavior.
- `npm run typecheck`: **passed**.
- `npm run lint`: **passed**.
- Independent code and test-impact review: **passed**.

<details>
<summary>Targeted test command</summary>

Run with Node 22 and `VITEST_WINDOWS_FULL_TEST=1`:

```sh
npm test -- src/main/literature/citation-formatter.test.ts src/shared/literature-csl.test.ts src/main/literature/export-roundtrip.test.ts src/main/literature/citation-fidelity.test.ts src/main/literature/citation-document.test.ts src/renderer/src/pages/literature/LiteratureMetadataEditor.test.tsx src/renderer/src/pages/literature/LiteratureLibraryPage.render.test.tsx src/main/literature/reference-resolver.test.ts src/main/literature/latex-bundle.test.ts --maxWorkers=1 --testTimeout=60000 --hookTimeout=60000
```

</details>

## Review focus

Publication-type precedence, surname particle spacing, and RIS abbreviation preservation without changing article short titles.
