### PR TITLE
feat(provider): add Kimi K2.8 coding model

### DIFF
--- a/src/shared/provider-registry.test.ts
+++ b/src/shared/provider-registry.test.ts
@@ -844,7 +844,7 @@ describe('provider registry', () => {
 
     it('returns true only for KimiForCode k3 model', () => {
       expect(isVendorModelMultimodal('kimiforcode', 'kimi-k3')).toBe(true)
-      expect(isVendorModelMultimodal('kimiforcode', 'kimi-for-coding')).toBe(false)
+      expect(isVendorModelMultimodal('kimiforcode', 'kimi-for-coding')).toBe(true)
       expect(isVendorModelMultimodal('kimiforcode', 'kimi-for-coding-highspeed')).toBe(false)
     })
 

--- a/src/shared/provider-registry.ts
+++ b/src/shared/provider-registry.ts
@@ -474,11 +474,11 @@ export const OFFICIAL_VENDORS: OfficialVendor[] = [
     apiKeyUrl: 'https://www.kimi.com/code/docs',
     models: [
       { id: 'kimi-k3', contextWindow: 1_000_000, reasoningEffort: 'standard-5' },
-      { id: 'kimi-for-coding', contextWindow: 256_000 },
+      { id: 'kimi-for-coding', contextWindow: 1_048_576 },
       { id: 'kimi-for-coding-highspeed', contextWindow: 256_000 }
     ],
     // Only the k3 model in this plan is vision-capable; the coding-tuned ids are text-only.
-    multimodal: { multimodalModels: ['kimi-k3'] }
+    multimodal: { multimodalModels: ['kimi-k3', 'kimi-for-coding'] }
   },
   {
     id: 'minimax',


### PR DESCRIPTION
## Problem
Kimi Code upgraded `kimi-for-coding` to K2.8 Preview, but the provider catalog still advertised the old 256K text-only capabilities.

## Proposed change
Update the existing Kimi For Coding model to 1M context and mark it vision-capable, preserving the existing model ID for compatibility.

## Validation
- `npm test -- src/shared/provider-registry.test.ts src/shared/configured-model-catalog.test.ts` (74 passed)

Checks ran after the last material edit.