### PR TITLE
test(notebook-sandbox): drop duplicate wrap setExecutionActive

### DIFF
--- a/src/main/notebook/network-sandbox-owner.test.ts
+++ b/src/main/notebook/network-sandbox-owner.test.ts
@@ -1782,7 +1782,6 @@ describe('R startup authorization admission', () => {
       backend.wrap.mockImplementationOnce(async (command: { cwd: string }) => ({
         argv: [process.execPath, '-e', 'console.log("OPEN_SCIENCE_R_ACCESS_OK")'],
         env: process.env,
-        setExecutionActive: backend.setExecutionActive,
         annotateStderr: (stderr: string) => stderr,
         resetNetworkConnections: backend.resetNetworkConnections,
         setExecutionActive: backend.setExecutionActive,


### PR DESCRIPTION
## Problem

Nightly https://github.com/aipoch/open-science/actions/runs/34681084265 failed `build / Verify static checks and CLI package` at Typecheck:

```
src/main/notebook/network-sandbox-owner.test.ts(1788,9): error TS1117: An object literal cannot have multiple properties with the same name.
```

#2477 and #2468 each inserted `setExecutionActive: backend.setExecutionActive` into the same Windows probe-lock wrap mock. The merge kept both copies.

## Proposed change

Keep one field, matching the sibling wrap mocks in the same file.

## Scope and non-goals

Test-only. No sandbox production change.

## Acceptance criteria and validation

After the last material edit, from `.worktree/network-sandbox-wrap-duplicate`:

| Behavior | Command | Result |
| --- | --- | --- |
| Node typecheck fails on main | `npx tsc --noEmit -p tsconfig.node.json --composite false` (repo root at `daaa7fd5b`) | `TS1117` at `network-sandbox-owner.test.ts:1788` |
| Node typecheck after the drop | same command in the worktree | TypeScript: No errors found |
| Owner tests | `npx vitest run src/main/notebook/network-sandbox-owner.test.ts` | 57 passed, 1 skipped (win32 lock test) |

Excluded: full `npm test`. PR Gate remains authoritative. Do not dispatch another Nightly while 34681084265 is still running.

## Historical compatibility

None.

## New state / enum values

None.

## Data persistence

None.

## UI / interaction

None.

Refs: https://github.com/aipoch/open-science/actions/runs/34681084265/job/103519741573