### PR TITLE
fix(skills): resolve canonical names in runtime projections

### DIFF
--- a/src/main/skills/runtime-mcp-server.test.ts
+++ b/src/main/skills/runtime-mcp-server.test.ts
@@ -122,6 +122,42 @@ describe('Skill runtime MCP loader', () => {
       await server.close()
     }
   })
+
+  it('resolves a canonical Skill name from a namespaced Codex projection', async () => {
+    const root = await seedProjection()
+    const skillsDirectory = join(root, 'skills')
+    const canonicalName = 'crypto-research-design'
+    const projectedDirectory = 'os-personal-crypto-research-design'
+    await mkdir(join(skillsDirectory, projectedDirectory), { recursive: true })
+    await writeFile(
+      join(skillsDirectory, projectedDirectory, 'SKILL.md'),
+      `---\nname: ${canonicalName}\ndescription: Imported research design.\n---\nCANONICAL_BODY\n`
+    )
+
+    const server = await createSkillRuntimeMcpServer({
+      root,
+      skillsDirectory,
+      allowedNames: new Set([canonicalName])
+    })
+    const client = new Client({ name: 'codex-namespaced-loader-test', version: '1' })
+    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+    try {
+      await server.connect(serverTransport)
+      await client.connect(clientTransport)
+      expect(JSON.stringify(await client.listTools())).toContain(canonicalName)
+      expect(
+        JSON.stringify(
+          await client.callTool({
+            name: LOAD_SKILL_TOOL_NAME,
+            arguments: { skill: canonicalName }
+          })
+        )
+      ).toContain('CANONICAL_BODY')
+    } finally {
+      await client.close()
+      await server.close()
+    }
+  })
   it('advertises projected Skills to Claude without application metadata', async () => {
     const root = await seedProjection('fixture-data-summary')
     await seedSkill(root, 'fixture-diagram-renderer', 'Render synthetic diagrams for tests.')

--- a/src/main/skills/runtime-mcp-server.ts
+++ b/src/main/skills/runtime-mcp-server.ts
@@ -134,16 +134,12 @@ const readSkillRuntimeCatalog = async (
   const discoveryBudget = MAX_SKILL_CATALOG_SCHEMA_BYTES - SKILL_CATALOG_SCHEMA_RESERVED_BYTES
   let catalogBytes = 0
   for (const entry of entries) {
-    const name = entry.name
-    if (
-      !SAFE_PROJECTED_SKILL_NAME.test(name) ||
-      name.includes('..') ||
-      (environment.allowedNames && !environment.allowedNames.has(name))
-    ) {
+    const directoryName = entry.name
+    if (!SAFE_PROJECTED_SKILL_NAME.test(directoryName) || directoryName.includes('..')) {
       continue
     }
 
-    const skillDir = join(skillsDir, name)
+    const skillDir = join(skillsDir, directoryName)
     const skillMetadata = await lstat(skillDir)
     if (skillMetadata.isSymbolicLink() || !skillMetadata.isDirectory()) continue
     const documentPath = join(skillDir, 'SKILL.md')
@@ -160,7 +156,13 @@ const readSkillRuntimeCatalog = async (
     const { fields } = parseFrontmatter(
       await readSkillCatalogFrontmatter(documentPath, documentMetadata.size)
     )
-    if (fields.name !== name || fields['disable-model-invocation']?.toLowerCase() === 'true') {
+    const name = fields.name
+    if (
+      !SAFE_PROJECTED_SKILL_NAME.test(name) ||
+      (environment.allowedNames && !environment.allowedNames.has(name)) ||
+      fields['disable-model-invocation']?.toLowerCase() === 'true' ||
+      (directoryName !== name && !directoryName.startsWith('os-'))
+    ) {
       continue
     }
     const description = (fields.description ?? '')
@@ -275,16 +277,39 @@ const readSkillDocument = async (
 
   try {
     const skillsDir = await skillCatalogDirectory(environment)
-    const skillDir = join(skillsDir, name)
-    await requireRealDirectory(skillDir, 'Skill package')
-    const documentPath = join(skillDir, 'SKILL.md')
-    const documentMetadata = await lstat(documentPath)
-    if (documentMetadata.isSymbolicLink() || !documentMetadata.isFile()) {
-      throw new Error('Skill document is not a regular file.')
+    const candidates = [name, ...(await readdir(skillsDir))]
+    let skillDir: string | undefined
+    let documentPath: string | undefined
+    let documentMetadata: Awaited<ReturnType<typeof lstat>> | undefined
+    for (const directoryName of [...new Set(candidates)]) {
+      if (!SAFE_PROJECTED_SKILL_NAME.test(directoryName) || directoryName.includes('..')) continue
+      const candidateDir = join(skillsDir, directoryName)
+      try {
+        await requireRealDirectory(candidateDir, 'Skill package')
+        const candidatePath = join(candidateDir, 'SKILL.md')
+        const candidateMetadata = await lstat(candidatePath)
+        if (
+          candidateMetadata.isSymbolicLink() ||
+          !candidateMetadata.isFile() ||
+          candidateMetadata.size > SKILL_IMPORT_LIMITS.maxFileBytes
+        ) {
+          continue
+        }
+        const { fields } = parseFrontmatter(
+          await readSkillCatalogFrontmatter(candidatePath, candidateMetadata.size)
+        )
+        if (fields.name !== name || (directoryName !== name && !directoryName.startsWith('os-'))) {
+          continue
+        }
+        skillDir = candidateDir
+        documentPath = candidatePath
+        documentMetadata = candidateMetadata
+        break
+      } catch {
+        continue
+      }
     }
-    if (documentMetadata.size > SKILL_IMPORT_LIMITS.maxFileBytes) {
-      throw new Error('Skill document is too large.')
-    }
+    if (!skillDir || !documentPath || !documentMetadata) throw new Error('Skill not found.')
     return {
       document: applySkillArguments(await readFile(documentPath, 'utf8'), args),
       skillDir

--- a/src/main/skills/runtime-mcp-server.ts
+++ b/src/main/skills/runtime-mcp-server.ts
@@ -295,6 +295,14 @@ const readSkillDocument = async (
         ) {
           continue
         }
+        // Agent-facing projections may be supplied by CodeBuddy without frontmatter. Preserve the
+        // existing direct-directory contract; frontmatter is required only for namespaced lookup.
+        if (directoryName === name) {
+          skillDir = candidateDir
+          documentPath = candidatePath
+          documentMetadata = candidateMetadata
+          break
+        }
         const { fields } = parseFrontmatter(
           await readSkillCatalogFrontmatter(candidatePath, candidateMetadata.size)
         )


### PR DESCRIPTION
## Problem

Imported Specialist Skills can be selected explicitly in Codex but fail automatic loading when their canonical name differs from the namespaced runtime projection directory. For example, `crypto-research-design` is projected as `os-personal-crypto-research-design`, so `load_skill({ skill: "crypto-research-design" })` returns `Unknown skill`.

## Proposed change

Resolve canonical Skill names from `SKILL.md` frontmatter when scanning the app-owned `os-*` runtime projection directories. Keep the existing runtime root, regular-file, symlink, and allowlist checks.

## Scope and non-goals

- No database fields, enum values, migrations, or persisted-format changes.
- No projection-directory rename or historical data migration.
- No UI or interaction changes.
- Only the runtime MCP loader and its regression coverage change.

## Acceptance criteria and validation

- A canonical name resolves to a namespaced `os-*` projection.
- Discovery metadata advertises the canonical name.
- The allowlist remains enforced.
- The regression test fails on the pre-fix code with `Unknown skill: crypto-research-design` and passes after the fix.

Checks run after the last material edit:

- `npx vitest run src/main/skills/runtime-mcp-server.test.ts` — passed (15 tests).
- `npx eslint src/main/skills/runtime-mcp-server.ts src/main/skills/runtime-mcp-server.test.ts` — passed.
- `npm run typecheck:node` — blocked by existing missing sandbox dependencies: `reflect-metadata` and `@peculiar/x509`.

## Review focus

Please review the canonical-name lookup boundary and confirm that accepting canonical names from app-owned `os-*` projections is the desired compatibility behavior.

Fixes #2481
