### PR TITLE
fix(codex): propagate terminal provider errors to task runs

### DIFF
--- a/src/main/acp/prompt-error.test.ts
+++ b/src/main/acp/prompt-error.test.ts
@@ -108,6 +108,23 @@ describe('describePromptError', () => {
 })
 
 describe('isProviderPromptError', () => {
+  it.each([
+    [-32603, 'serverOverloaded', true],
+    [-32002, 'serverOverloaded', false],
+    [-32603, 'internalServerError', false],
+    [-32603, undefined, false]
+  ] as const)('classifies Codex code %s with detail %s structurally', (code, detail, expected) => {
+    const error = Object.assign(
+      new Error('Selected model is at capacity. Please try a different model.'),
+      {
+        code,
+        data: { codexErrorInfo: detail },
+        name: 'RequestError'
+      }
+    )
+    expect(isProviderPromptError(error)).toBe(expected)
+  })
+
   it('flags an upstream APIError (auth/rate/quota/5xx all share this tag)', () => {
     expect(isProviderPromptError(agentError('Invalid API key'))).toBe(true)
     expect(isProviderPromptError(agentError('429 Too Many Requests'))).toBe(true)

--- a/src/main/acp/prompt-error.ts
+++ b/src/main/acp/prompt-error.ts
@@ -209,6 +209,7 @@ const isProviderErrorKind = (error: unknown): boolean => {
 // broad human-message pattern matching:
 //   - the agent tagged the failure as an upstream `APIError` (covers auth/rate/quota/5xx/etc.), or
 //   - the agent tagged `data.errorKind: 'provider-error'` (the bridges' machine-readable marker), or
+//   - Codex attached its explicit serverOverloaded detail to an ACP internal error, or
 //   - Claude Code emitted its fixed ACP internal wrapper with an explicit provider 4xx status or
 //     a recognized transport failure, or
 //   - it is a provider "resource not found" (wrong model id / endpoint), which requires the same
@@ -217,6 +218,11 @@ export const isProviderPromptError = (error: unknown): boolean => {
   if (isApiError(error)) return true
   if (isProviderErrorKind(error)) return true
   if (isClaudeProviderApiError(error)) return true
+
+  // Codex's native error data already identifies capacity failures. Keep unknown/internal Codex
+  // failures reportable, and never infer provider ownership from the human-readable message.
+  const data = (error as { data?: { codexErrorInfo?: unknown } } | null)?.data
+  if (errorCode(error) === -32603 && data?.codexErrorInfo === 'serverOverloaded') return true
 
   const raw = rawErrorMessage(error)
 

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -22,6 +22,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { AcpRuntime } from './runtime.test-utils'
 import type { AcpPromptContentOwner } from './prompt-content-owner'
 import { createAcpTaskAgentPort } from './task-agent-port'
+import { loadManagedCodexErrorHandler } from '../settings/codex-error.test-utils'
 import type { AcpAgentConnectionAdapter } from './agent-connection-adapter'
 import type { AcpConnectionCloseWorkflow } from './connection-close-workflow'
 import { composeAcpRuntimePlanWorkflow } from './runtime-plan-composition'
@@ -1187,6 +1188,104 @@ afterEach(async () => {
 })
 
 describe('ACP runtime migration write-gate', () => {
+  it('propagates a normalized Codex capacity error through the ACP wire', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'acp-codex-capacity-'))
+    const capacityError = 'Selected model is at capacity. Please try a different model.'
+    const process = new FakeAgentProcess()
+    const runtime = new AcpRuntime({
+      appVersion: '0.28.0',
+      defaultCwd: root,
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      framework: codexFramework
+    })
+    try {
+      const adapter = await loadManagedCodexErrorHandler(root)
+      startFakeAgent(process, ['capacity-session'], {
+        modes: {
+          currentModeId: 'read-only',
+          availableModes: ['read-only', 'agent', 'agent-full-access'].map((id) => ({
+            id,
+            name: id
+          }))
+        },
+        onPrompt: async () => {
+          await adapter.createErrorEvent({
+            turnId: 'turn-1',
+            willRetry: false,
+            error: {
+              message: capacityError,
+              codexErrorInfo: 'serverOverloaded',
+              additionalDetails: null
+            }
+          })
+          const failure = adapter.getFailure()
+          if (failure) throw failure
+          return { stopReason: 'end_turn' }
+        }
+      })
+      const created = await runtime.createSession({ cwd: root })
+      await expect(
+        runtime.sendPrompt({ sessionId: created.sessionId, text: 'Write FINAL_ANSWER.txt.' })
+      ).rejects.toThrow(capacityError)
+      expect(runtime.getSnapshot().events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ kind: 'error', text: expect.stringContaining(capacityError) })
+        ])
+      )
+    } finally {
+      await runtime.disconnect()
+      await rm(root, { recursive: true, force: true })
+    }
+  })
+
+  it('does not infer failure from a Codex assistant message quoting a capacity error', async () => {
+    // Wire shape from codex-acp v1.6.2 createErrorEvent (no AIR capability):
+    // a non-auth, non-quota terminal error becomes assistant text plus end_turn.
+    const capacityError = 'Selected model is at capacity. Please try a different model.'
+    const process = new FakeAgentProcess()
+    const fakeAgent = startFakeAgent(process, ['capacity-session'], {
+      modes: {
+        currentModeId: 'read-only',
+        availableModes: ['read-only', 'agent', 'agent-full-access'].map((id) => ({ id, name: id }))
+      },
+      replyForPrompt: () => `${capacityError}\n\n`,
+      onPrompt: () => ({ stopReason: 'end_turn' })
+    })
+    const runtime = new AcpRuntime({
+      appVersion: '0.28.0',
+      defaultCwd: '/workspace',
+      resolveBackend: () => ({
+        framework: { ...codexFramework, spawn: () => asAgentProcess(process) },
+        executablePath: '/bin/codex-acp',
+        env: {}
+      }),
+      framework: codexFramework
+    })
+    try {
+      const created = await runtime.createSession({ cwd: '/workspace' })
+      await expect(
+        runtime.sendPrompt({ sessionId: created.sessionId, text: 'Write FINAL_ANSWER.txt.' })
+      ).resolves.toMatchObject({ stopReason: 'end_turn' })
+      expect(fakeAgent.initializeRequests[0].clientCapabilities?._meta).toBeUndefined()
+      expect(runtime.getSnapshot().events).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            kind: 'message',
+            role: 'assistant',
+            text: `${capacityError}\n\n`
+          })
+        ])
+      )
+      expect(runtime.getSnapshot().events.filter((event) => event.kind === 'error')).toEqual([])
+    } finally {
+      await runtime.disconnect()
+    }
+  })
+
   afterEach(() => {
     // migration-state is a module singleton; clear it so a pending gate can't leak between tests.
     clearMigrationPending()

--- a/src/main/acp/runtime.test.ts
+++ b/src/main/acp/runtime.test.ts
@@ -1233,7 +1233,11 @@ describe('ACP runtime migration write-gate', () => {
       ).rejects.toThrow(capacityError)
       expect(runtime.getSnapshot().events).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ kind: 'error', text: expect.stringContaining(capacityError) })
+          expect.objectContaining({
+            kind: 'error',
+            text: expect.stringContaining(capacityError),
+            providerError: true
+          })
         ])
       )
     } finally {

--- a/src/main/settings/codex-error.test-utils.ts
+++ b/src/main/settings/codex-error.test-utils.ts
@@ -1,0 +1,37 @@
+import { RequestError, type SessionNotification } from '@agentclientprotocol/sdk'
+import { readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { ensureManagedCodexContextUsage } from './managed-codex'
+
+export type CodexErrorNotification = {
+  turnId: string
+  willRetry: boolean
+  error: { message: string; codexErrorInfo: unknown; additionalDetails: string | null }
+}
+
+type PinnedCodexErrorHandler = {
+  sessionState: { authConfigured: boolean; currentTurnId: string | null }
+  createErrorEvent(params: CodexErrorNotification): Promise<SessionNotification['update'] | null>
+  getFailure(): RequestError | null
+}
+
+// Exercise installed-adapter normalization, then execute the verbatim upstream error translator.
+// The fixture is offline and pinned; neither a real model nor a new production test seam is needed.
+export const loadManagedCodexErrorHandler = async (
+  directory: string
+): Promise<PinnedCodexErrorHandler> => {
+  const source = await readFile(
+    new URL('./fixtures/codex-acp-1.6.2-error-handler.txt', import.meta.url),
+    'utf8'
+  )
+  const adapterPath = join(directory, 'index.js')
+  await writeFile(adapterPath, source)
+  await ensureManagedCodexContextUsage(adapterPath)
+  const normalized = await readFile(adapterPath, 'utf8')
+  const handlerSource = normalized.split('// Other pinned patch targets')[0]
+  return Function(
+    'RequestError',
+    'logger',
+    `${handlerSource}\nreturn new PinnedCodexErrorHandler()`
+  )(RequestError, { log: () => undefined }) as PinnedCodexErrorHandler
+}

--- a/src/main/settings/fixtures/codex-acp-1.6.2-error-handler.txt
+++ b/src/main/settings/fixtures/codex-acp-1.6.2-error-handler.txt
@@ -1,0 +1,126 @@
+// Extracted verbatim methods from @agentclientprotocol/codex-acp 1.6.2 (Apache-2.0).
+// npm tarball SHA-512 matches CODEX_ACP_INTEGRITY in managed-codex.ts.
+// Only the class construction scaffolding is local; the error translation is upstream code.
+function createAgentMessageChunk(content, messageId, meta3) {
+  if (messageId) {
+    return {
+      sessionUpdate: "agent_message_chunk",
+      messageId,
+      content,
+      ...meta3 ? { _meta: meta3 } : {}
+    };
+  }
+  return {
+    sessionUpdate: "agent_message_chunk",
+    content,
+    ...meta3 ? { _meta: meta3 } : {}
+  };
+}
+function createAgentTextMessageChunk(text, messageId, meta3) {
+  return createAgentMessageChunk({ type: "text", text }, messageId, meta3);
+}
+class PinnedCodexErrorHandler {
+  sessionState = { sessionId: 'session-created', currentTurnId: 'turn-1', authConfigured: true };
+  supportsTypedSessionFailures = false;
+  pendingErrors = [];
+  failure = null;
+  createCodexSessionInfoUpdate(meta) { return { sessionUpdate: 'session_info_update', _meta: { codex: meta } }; }
+  getFailure() {
+    return this.failure;
+  }
+  async createErrorEvent(params) {
+    const error51 = params.error.codexErrorInfo;
+    if (this.sessionState.currentTurnId === null) {
+      this.pendingErrors.push(params);
+      logger.log("Buffered app-server error until the active turn is known", {
+        sessionId: this.sessionState.sessionId,
+        turnId: params.turnId,
+        willRetry: params.willRetry
+      });
+      return null;
+    }
+    if (params.turnId !== this.sessionState.currentTurnId) {
+      if (this.supportsTypedSessionFailures) {
+        const failure = params.willRetry ? this.recordRetryWarning(params) : this.recordSessionFailure(
+          this.sessionFailureKind(params.error.codexErrorInfo),
+          params.turnId,
+          "error",
+          params.error.message
+        );
+        return this.createSessionFailureUpdate(failure);
+      }
+      return this.createCodexSessionInfoUpdate({
+        error: { ...params.error, turnId: params.turnId, willRetry: params.willRetry }
+      });
+    }
+    if (params.willRetry) {
+      if (this.supportsTypedSessionFailures) {
+        return this.createSessionFailureUpdate(this.recordRetryWarning(params));
+      }
+      return this.createCodexSessionInfoUpdate({
+        error: {
+          ...params.error,
+          turnId: params.turnId,
+          willRetry: true
+        }
+      });
+    }
+    if (this.supportsTypedSessionFailures) {
+      this.recordTypedSessionFailure(params);
+      return null;
+    }
+    if (error51 === "usageLimitExceeded") {
+      this.failure = RequestError.internalError(
+        this.createTurnErrorData(params.error)
+      );
+    } else if (this.isAuthenticationRequiredError(error51)) {
+      this.failure = this.sessionState.authConfigured ? RequestError.internalError(this.createTurnErrorData(params.error)) : RequestError.authRequired(this.createTurnErrorData(params.error), params.error.message);
+    }
+    return createAgentTextMessageChunk(`${params.error.message}
+
+`);
+  }
+  isAuthenticationRequiredError(error51) {
+    return error51 === "unauthorized" || this.getHttpStatusCode(error51) === 401;
+  }
+  getHttpStatusCode(error51) {
+    if (error51 === null || typeof error51 !== "object") return null;
+    const details = Object.values(error51)[0];
+    if (details === null || typeof details !== "object" || !("httpStatusCode" in details)) return null;
+    return typeof details.httpStatusCode === "number" ? details.httpStatusCode : null;
+  }
+  createTurnErrorData(error51) {
+    const data = {
+      message: error51.additionalDetails ?? error51.message
+    };
+    if (error51.codexErrorInfo !== null) {
+      data.codexErrorInfo = error51.codexErrorInfo;
+    }
+    if (error51.additionalDetails !== null) {
+      data.additionalDetails = error51.additionalDetails;
+    }
+    return data;
+  }
+}
+// Other pinned patch targets required by the existing installation normalization boundary.
+function buildPromptItems(prompt) {
+  return prompt.map((block) => {
+    switch (block.type) {
+      case "text":
+        return { type: "text", text: block.text, text_elements: [] };
+      default:
+        return null;
+    }
+  }).filter((block) => block !== null);
+}
+function startCodexConnection(codexPath, env) {
+  const spawnEnv = env ?? process.env;
+  let codex;
+  if (codexPath) {
+    codex = process.platform === "win32" ? spawn(`"${codexPath}" app-server`, { shell: true, env: spawnEnv }) : spawn(codexPath, ["app-server"], { env: spawnEnv });
+  } else {
+    const bundledCodexPath = createRequire(import.meta.url).resolve("@openai/codex/bin/codex.js");
+    codex = spawn(process.execPath, [bundledCodexPath, "app-server"], { env: spawnEnv });
+  }
+  return codex;
+}

--- a/src/main/settings/managed-codex.test.ts
+++ b/src/main/settings/managed-codex.test.ts
@@ -18,6 +18,7 @@ import { dirname, join, sep } from 'node:path'
 import { Readable } from 'node:stream'
 import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { loadManagedCodexErrorHandler } from './codex-error.test-utils'
 
 import {
   ACP_MODEL_CALL_USAGE_META_KEY,
@@ -187,6 +188,7 @@ import {
   spawnCodexWithInstallAdmission,
   patchCodexAcpContextUsageSource,
   patchCodexAcpModelCatalogStartupSource,
+  patchCodexAcpPromptFailureSource,
   patchCodexAcpSkillInputSource,
   patchCodexAcpTurnUsageSource,
   resolveManagedCodexPlatform,
@@ -1385,6 +1387,61 @@ describe('installManagedCodex', () => {
 
     await expect(readFile(managedCodexAdapterEntry(root))).rejects.toThrow()
     expect(await readFile(join(root, 'unrelated-runtime'), 'utf8')).toBe('keep-me')
+  })
+})
+
+describe('Codex terminal error normalization', () => {
+  it.each([
+    ['serverOverloaded', true, -32603],
+    ['usageLimitExceeded', true, -32603],
+    ['unauthorized', true, -32603],
+    ['unauthorized', false, -32000]
+  ] as const)(
+    'preserves %s with authConfigured=%s as an ACP error',
+    async (code, auth, rpcCode) => {
+      const root = await mkdtemp(join(tmpdir(), 'codex-terminal-error-'))
+      try {
+        const handler = await loadManagedCodexErrorHandler(root)
+        handler.sessionState.authConfigured = auth
+        await handler.createErrorEvent({
+          turnId: 'turn-1',
+          willRetry: false,
+          error: {
+            message: 'Provider could not finish.',
+            codexErrorInfo: code,
+            additionalDetails: null
+          }
+        })
+        expect(handler.getFailure()).toMatchObject({
+          code: rpcCode,
+          data: { codexErrorInfo: code, message: 'Provider could not finish.' }
+        })
+        const adapterPath = join(root, 'index.js')
+        const normalized = await readFile(adapterPath, 'utf8')
+        await ensureManagedCodexContextUsage(adapterPath)
+        expect(await readFile(adapterPath, 'utf8')).toBe(normalized)
+      } finally {
+        await rm(root, { recursive: true, force: true })
+      }
+    }
+  )
+
+  it('rejects a drifted or ambiguous upstream terminal error target', async () => {
+    const source = await readFile(
+      new URL('./fixtures/codex-acp-1.6.2-error-handler.txt', import.meta.url),
+      'utf8'
+    )
+    expect(() =>
+      patchCodexAcpPromptFailureSource(
+        source.replace(
+          'return createAgentTextMessageChunk(`${params.error.message}',
+          'return createAgentTextMessageChunk(`${params.error.detail}'
+        )
+      )
+    ).toThrow('Pinned Codex ACP prompt-failure patch no longer matches the adapter bundle')
+    expect(() => patchCodexAcpPromptFailureSource(`${source}\n${source}`)).toThrow(
+      'Pinned Codex ACP prompt-failure patch no longer matches the adapter bundle'
+    )
   })
 })
 

--- a/src/main/settings/managed-codex.ts
+++ b/src/main/settings/managed-codex.ts
@@ -819,11 +819,40 @@ export const patchCodexAcpModelCatalogStartupSource = (source: string): string =
   )
 }
 
+const CODEX_ACP_PROMPT_FAILURE_SOURCE =
+  '    return createAgentTextMessageChunk(`${params.error.message}\n\n`);'
+const CODEX_ACP_PROMPT_FAILURE_REPLACEMENT = [
+  '    if (!this.failure) {',
+  '      this.failure = RequestError.internalError(',
+  '        this.createTurnErrorData(params.error), params.error.message',
+  '      );',
+  '    }',
+  CODEX_ACP_PROMPT_FAILURE_SOURCE
+].join('\n')
+
+// 1.6.2 records only auth/quota failures for clients without the AIR extension. Other terminal
+// errors become assistant prose followed by end_turn. Preserve the existing RequestError boundary
+// after the upstream current-turn/retry guards, without interpreting assistant text in the app.
+export const patchCodexAcpPromptFailureSource = (source: string): string => {
+  if (source.includes(CODEX_ACP_PROMPT_FAILURE_REPLACEMENT)) return source
+  const matches = source.split(CODEX_ACP_PROMPT_FAILURE_SOURCE).length - 1
+  if (matches === 1) {
+    return source.replace(CODEX_ACP_PROMPT_FAILURE_SOURCE, CODEX_ACP_PROMPT_FAILURE_REPLACEMENT)
+  }
+  if (matches > 1 || source.includes('createErrorEvent(params)')) {
+    throw new Error('Pinned Codex ACP prompt-failure patch no longer matches the adapter bundle')
+  }
+  // Small installation fixtures omit the error handler, like the usage-patch fixtures above.
+  return source
+}
+
 export const ensureManagedCodexContextUsage = async (adapterPath: string): Promise<void> => {
   const source = await readFile(adapterPath, 'utf8')
   const patched = patchCodexAcpModelCatalogStartupSource(
     patchCodexAcpSkillInputSource(
-      patchCodexAcpTurnUsageSource(patchCodexAcpContextUsageSource(source))
+      patchCodexAcpTurnUsageSource(
+        patchCodexAcpContextUsageSource(patchCodexAcpPromptFailureSource(source))
+      )
     )
   )
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -21,6 +21,7 @@ import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
 import { loadManagedCodexErrorHandler } from '../settings/codex-error.test-utils'
+import { isProviderPromptError } from '../acp/prompt-error'
 import { FileTaskRunJournal, type TaskRunJournalEntry } from './task-run-journal'
 import {
   TASK_RUN_DISPOSAL_BUDGET_MS,
@@ -233,8 +234,14 @@ describe('TaskRunner', () => {
       const root = await mkdtemp(join(tmpdir(), 'codex-capacity-'))
       temporaryRoots.push(root)
       const adapter = await loadManagedCodexErrorHandler(root)
+      const savedSessions: PersistedChatSession[] = []
       let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
       const runner = createRunner({
+        sessions: {
+          save: async (saved) => {
+            savedSessions.push(structuredClone(saved))
+          }
+        },
         runtimeEvents: {
           subscribe: (listener) => {
             emitEvent = listener
@@ -275,7 +282,19 @@ describe('TaskRunner', () => {
                   : 'Retrieved references successfully.'
             })
             const failure = adapter.getFailure()
-            if (failure) throw failure
+            if (failure) {
+              emitEvent?.({
+                id: 'capacity-error',
+                timestamp: 3,
+                sessionId,
+                promptMessageId,
+                kind: 'error',
+                level: 'error',
+                text: failure.message,
+                providerError: isProviderPromptError(failure)
+              })
+              throw failure
+            }
           }
         }
       })
@@ -285,7 +304,13 @@ describe('TaskRunner', () => {
       })
       const result = await runner.waitForRun(started.id)
       expect(result.status).toBe(delivery === 'terminal-error' ? 'failed' : 'completed')
-      if (delivery === 'terminal-error') expect(result.error).toContain(capacityError)
+      if (delivery === 'terminal-error') {
+        expect(result.error).toContain(capacityError)
+        expect(savedSessions.at(-1)).toMatchObject({
+          status: 'error',
+          errorReportable: false
+        })
+      }
     }
   )
 

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -20,6 +20,7 @@ import {
 import type { TaskRun } from '../../shared/task-api'
 import { EnabledComputeHostsRegistry } from '../compute/enabled-hosts-registry'
 import { SessionEnabledComputeHostsOwner } from '../compute/session-enabled-hosts-owner'
+import { loadManagedCodexErrorHandler } from '../settings/codex-error.test-utils'
 import { FileTaskRunJournal, type TaskRunJournalEntry } from './task-run-journal'
 import {
   TASK_RUN_DISPOSAL_BUDGET_MS,
@@ -225,6 +226,69 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
   })
 }
 describe('TaskRunner', () => {
+  it.each(['terminal-error', 'retryable-error', 'foreign-error', 'assistant-quotation'] as const)(
+    'reports the pinned Codex capacity outcome correctly for %s',
+    async (delivery) => {
+      const capacityError = 'Selected model is at capacity. Please try a different model.'
+      const root = await mkdtemp(join(tmpdir(), 'codex-capacity-'))
+      temporaryRoots.push(root)
+      const adapter = await loadManagedCodexErrorHandler(root)
+      let emitEvent: ((event: AcpRuntimeEvent) => void) | undefined
+      const runner = createRunner({
+        runtimeEvents: {
+          subscribe: (listener) => {
+            emitEvent = listener
+            return () => undefined
+          }
+        },
+        agent: {
+          prompt: async ({ sessionId, promptMessageId }, observer) => {
+            await observer?.onPromptAdmitted?.()
+            observer?.onProviderPromptAccepted?.()
+            const update =
+              delivery === 'assistant-quotation'
+                ? {
+                    sessionUpdate: 'agent_message_chunk',
+                    content: { type: 'text', text: capacityError }
+                  }
+                : await adapter.createErrorEvent({
+                    turnId: delivery === 'foreign-error' ? 'old-turn' : 'turn-1',
+                    willRetry: delivery === 'retryable-error',
+                    error: {
+                      message: capacityError,
+                      codexErrorInfo: 'serverOverloaded',
+                      additionalDetails: null
+                    }
+                  })
+            // Match the adapter's prompt boundary: publish its update, then propagate getFailure().
+            emitEvent?.({
+              id: 'capacity-probe',
+              timestamp: 2,
+              sessionId,
+              promptMessageId,
+              kind: 'message',
+              level: 'info',
+              role: 'assistant',
+              text:
+                update?.sessionUpdate === 'agent_message_chunk' && update.content.type === 'text'
+                  ? update.content.text
+                  : 'Retrieved references successfully.'
+            })
+            const failure = adapter.getFailure()
+            if (failure) throw failure
+          }
+        }
+      })
+      const started = await runner.startRun({
+        project: project.id,
+        prompt: 'Find relevant papers and write the final answer to FINAL_ANSWER.txt.'
+      })
+      const result = await runner.waitForRun(started.id)
+      expect(result.status).toBe(delivery === 'terminal-error' ? 'failed' : 'completed')
+      if (delivery === 'terminal-error') expect(result.error).toContain(capacityError)
+    }
+  )
+
   it.each([
     ['claude-sonnet-4-6', 'claude-opus-4-6'],
     ['claude-opus-4-6', 'claude-sonnet-4-6']


### PR DESCRIPTION
## Problem

Codex ACP 1.6.2 turns some non-retryable provider errors into assistant text followed by `end_turn`. A capacity interruption can therefore appear as a successful CLI run even though the requested final answer was never produced. This addresses the capacity-error report in the body of #2348; its unrelated Session-continuation title is outside this change.

## Proposed change

Extend the existing managed-adapter normalization to record an ACP `RequestError` for terminal errors that do not already have one. The existing runtime and TaskRunner rejection paths then return `failed` with the provider message. Keep upstream retry, foreign-turn, authentication, and quota handling intact. Do not classify assistant prose by matching error text.

Recognize Codex's existing `codexErrorInfo: serverOverloaded` on ACP internal errors in the shared error classifier. This sets the existing runtime `providerError` and persisted Session `errorReportable: false` flags, so a capacity condition does not offer a GitHub application-bug report. Other internal errors and protocol not-found errors remain reportable. No additional adapter metadata or historical-data rewrite is needed.

## Scope and non-goals

- No new application fields, status values, architecture, persistence formats, or UI controls.
- Existing managed adapters receive the patch on their next resolution; new installations use the same atomic normalization path.
- Historical runs incorrectly recorded as completed are not rewritten. No data migration or historical-data compatibility work is added.
- Native Responses, compatibility, Chat bridge, and subscription Codex routes share this managed adapter. Claude Code and OpenCode implementations are unchanged.

## Acceptance criteria and validation

The TaskRunner regression executes verbatim error methods extracted from the integrity-verified, pinned 1.6.2 npm bundle through the existing installed-adapter normalization boundary. Before the fix, the same test failed twice with `expected failed; received completed`; after the fix it passes. Controls cover retryable errors, foreign-turn errors, and ordinary assistant text quoting the capacity message. No production test seam was added.

Checks ran after the final material changes:

The provider-classification regression was also run before its fix: the classifier returned false, the actual ACP wire path emitted `providerError: false`, and TaskRunner omitted the non-reportable Session flag. All three assertions passed afterward. Negative controls preserve reportability for unknown/internal errors and require the ACP internal-error code rather than classifying by prose.

Latest classification-change checks: `npm test -- src/main/acp/prompt-error.test.ts src/shared/run-error-classification.test.ts src/main/acp/prompt-outcome-finalizer.test.ts src/main/tasks/task-runner.test.ts src/main/settings/managed-codex.test.ts src/main/acp/provider-prompt-executor.test.ts src/main/acp/task-agent-port.test.ts packages/open-science/cli.test.ts` passed 334 tests (6 skipped). The focused capacity/classifier/runtime selection passed 10 tests. Existing renderer event and ConversationPanel report-button tests passed 9 tests. `npm run typecheck:node`, `npm run lint`, and `git diff --check` passed after this last material change; Web typecheck passed for the earlier adapter change, with renderer source unchanged in this follow-up.

| Behavior | Check | Result |
| --- | --- | --- |
| Capacity status, ACP error serialization, auth/quota preservation, patch drift | `npm test -- src/main/settings/managed-codex.test.ts src/main/tasks/task-runner.test.ts src/main/acp/runtime.test.ts -t 'capacity\|terminal error normalization'` | 11 passed |
| Normalization, TaskRunner, startup/routing, framework contracts, ACP consumers, CLI | Targeted suites listed below | 548 passed, 8 skipped; one Windows temporary-directory cleanup failure |
| Startup consumer rerun | `npm test -- src/main/settings/agent-runtime-manager.test.ts` | 42 passed |
| Main, sandbox, and renderer types | `npm run typecheck:node`; `npm run typecheck:web` | Passed |
| Source/style | `npm run lint`; `git diff --check` | Passed |

The broader targeted run included `managed-codex`, `task-runner`, `agent-runtime-manager`, `backend-resolver`, `provider-prompt-executor`, `task-agent-port`, `prompt-outcome-finalizer`, the Codex/Claude Code/OpenCode framework suites, and `packages/open-science/cli.test.ts`. It also included a temporary local full-bundle check: normalize the complete integrity-verified adapter twice, assert identical output, and run `node --check`. That local-only test was removed afterward; the offline regression fixture remains checked in.

No full local suite or live subscription capacity failure was induced. Exact-head CI and independent review remain authoritative; platform-sensitive installed-bundle replacement coverage is included locally, with non-Windows lanes left to CI. No UI screenshot is applicable because this changes error propagation through existing surfaces.

## Review focus

Check that the patch stays after the upstream turn/retry guards, retains existing auth/quota errors, applies idempotently through both installation and resolution, and does not infer failures from assistant text.

Refs #2348.
