### PR TITLE
fix(skills): preserve scVI counts and validate X fallback

### DIFF
--- a/resources/skills/scvi-tools/SKILL.md
+++ b/resources/skills/scvi-tools/SKILL.md
@@ -28,15 +28,16 @@ that drops into the scanpy neighbors → leiden → umap pipeline.
 
 This is a **pure skill** — `kernel.py` is deterministic Python and _you_ (the
 base model) do all the reasoning. There is no `host` runtime and no LLM API.
-The only helper here is `h5ad_safe_obs`, which coerces an obs/var frame so
-`anndata.write_h5ad()` succeeds. Load it once per session in a Python cell:
+The helpers are `prepare_scvi_counts` for input validation and `h5ad_safe_obs`
+for obs/var frames that `anndata.write_h5ad()` can serialize. Load them once
+per session in a Python cell:
 
 ```python
-exec(open("scvi-tools/kernel.py").read())   # path to this skill's kernel.py
+exec(open("scvi-tools/kernel.py", encoding="utf-8").read())   # path to this skill's kernel.py
 ```
 
-Nothing auto-loads it outside Claude Science. Then call `h5ad_safe_obs(...)`
-directly. If it raises `NameError`, you haven't exec'd kernel.py.
+Nothing auto-loads it outside Claude Science. Then call the helpers directly.
+If a helper raises `NameError`, you haven't exec'd kernel.py.
 
 Dependencies: `pip install scvi-tools scanpy anndata`. Training needs a
 CUDA-capable GPU — see [Remote compute](#remote-compute-rent-a-gpu) to fall out
@@ -46,12 +47,28 @@ to a rented GPU when you don't have one locally.
 
 ### scVI — batch-corrected latent space
 
+`prepare_scvi_counts(adata)` checks and preserves existing `counts`. If absent,
+it checks `.X` before copying it to `counts`. Values must be finite, nonnegative,
+and integer-valued, with at least one positive count. Invalid existing counts
+raise instead of being replaced by `.X`; sparse matrices stay sparse.
+
+These numerical checks cannot prove raw-count provenance. Check the dataset
+documentation or preprocessing history; do not round or exponentiate transformed
+values to make them pass. If the history is unclear, resolve it before training.
+The helper does not use `.raw.X`, which may be normalized or have a different
+gene axis. Use an in-memory AnnData object; materialize backed data or copy views
+only within the available memory budget.
+
 ```python
 import scanpy as sc
 import scvi
 
 adata = sc.read_h5ad("dataset.h5ad")
-adata.layers["counts"] = adata.X.copy()          # preserve raw BEFORE any normalize/log1p
+# Verify count provenance from the input documentation or preprocessing history.
+# Preserve counts if present; otherwise validate .X before copying it to counts.
+counts_record = prepare_scvi_counts(adata)
+print(counts_record)       # numerical checks only; does not certify provenance
+adata.X = adata.layers["counts"].copy()        # derive plotting/HVG data from verified counts
 sc.pp.normalize_total(adata); sc.pp.log1p(adata) # optional, for HVG / plotting only
 sc.pp.highly_variable_genes(adata, n_top_genes=2000, batch_key="batch", subset=True)
 
@@ -151,10 +168,11 @@ def main():
     train.remote()   # blocks until done; then read /data/out.h5ad from the volume
 ```
 
-`h5ad_safe_obs` is loaded via `exec` in your **local** session (see **Setup**);
-inside `pipeline.py` running remotely it is not defined, so paste the helper at
-the top of that script (or inline the `pd.Index(np.asarray(..., dtype=object))`
-coercion) before `.write_h5ad()`.
+Helpers loaded via `exec` in your **local** session (see **Setup**) are not
+defined in a remote `pipeline.py`. Include `prepare_scvi_counts` from `kernel.py`
+before the remote preprocessing/training recipe, and `h5ad_safe_obs` before
+`.write_h5ad()`. Copy the helper definitions into that script or ship and load
+`kernel.py` there; keep the documented count-source selection and validation.
 
 For a local/cluster GPU, just run `pipeline.py` directly where CUDA is visible —
 no wrapper needed. (For a fuller Modal workflow see the `remote-compute-modal`
@@ -167,7 +185,7 @@ skill.)
 | `differential_expression()` defaults to `mode="vanilla"` (scvi-tools ≥1.4) | `KeyError: 'lfc_mean'` / `'proba_de'` when sorting — pass `mode="change"` to get `lfc_*`/`proba_de`/`is_de_fdr_*`; in vanilla mode sort on `bayes_factor`.                                                                                                                                                                                                                                                                                                                                                                                                                         |
 | `adata.obs` index/columns are `string[pyarrow]` (`ArrowStringArray`)       | `.write_h5ad()` dies with `IORegistryError: No method registered for writing <class 'pandas.arrays.ArrowStringArray'>` (anndata #2377). Coerce before writing: `adata.obs = h5ad_safe_obs(adata.obs)` (kernel helper — load it via `exec` locally, see Setup; inline the coercion in a remote `pipeline.py`). **`.astype(str)` alone is not enough** — on a pyarrow-backed Index/Series it returns another Arrow-backed array; round-trip through `np.asarray(..., dtype=object)`. `anndata.settings.allow_write_nullable_strings = True` does **not** cover Arrow-backed strings. |
 | `use_gpu=` kwarg                                                           | Removed in 1.x → `TypeError: train() got an unexpected keyword argument 'use_gpu'`. Use `accelerator="gpu", devices=1`.                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-| Log-normalized data fed to `setup_anndata`                                 | Silent garbage — scVI's NB likelihood needs raw integer counts. Stash counts in `adata.layers["counts"]` _before_ normalize/log1p and pass `layer="counts"`.                                                                                                                                                                                                                                                                                                                                                                                                                       |
+| Log-normalized data fed to `setup_anndata`                                 | Silent garbage — scVI's NB likelihood needs raw integer counts. Verify count provenance, call `prepare_scvi_counts`, and pass `layer="counts"`. Never overwrite counts from an unverified `.X`.                                                                                                                                                                                                                                                                                                                                                                                    |
 
 ## Troubleshooting
 

--- a/resources/skills/scvi-tools/kernel.py
+++ b/resources/skills/scvi-tools/kernel.py
@@ -1,14 +1,56 @@
 """
-scvi-tools kernel helpers. Auto-loaded into the python kernel by the host
-when the skill loads:
+scvi-tools kernel helpers. Load these definitions as described in SKILL.md:
 
     h5ad_safe_obs
+    prepare_scvi_counts
 
 Module top level is definition-only (functions + literal constants) and
 stdlib-only so the sidecar AST gate accepts it and it loads under the
-``python3 -I -S`` skeleton check; numpy/pandas are imported lazily inside
-the function body.
+``python3 -I -S`` skeleton check; numpy/pandas/scipy are imported lazily inside
+function bodies.
 """
+
+
+def prepare_scvi_counts(adata):
+    """Validate existing counts, using X only when the counts layer is absent.
+
+    Numerical checks cannot establish raw-count provenance. The caller must
+    identify the source from dataset documentation or preprocessing code.
+    Existing counts are never overwritten. No rounding, exponentiation, or
+    sparse-to-dense conversion is used to make an invalid input pass.
+    """
+    import numpy as np
+    from scipy import sparse
+
+    if adata.isbacked or adata.is_view:
+        raise ValueError("Use an in-memory AnnData object, copying a view before preparation.")
+    source = "counts" if "counts" in adata.layers else "X"
+    matrix = adata.layers["counts"] if source == "counts" else adata.X
+    if matrix is None or matrix.shape != adata.shape or 0 in matrix.shape:
+        raise ValueError("Counts must be a nonempty cell-by-gene matrix aligned with AnnData.")
+    if sparse.issparse(matrix):
+        # CSR/CSC data can be checked directly; other SciPy formats remain sparse.
+        values = matrix.data if matrix.format in ("csr", "csc") else matrix.tocoo().data
+    elif isinstance(matrix, np.ndarray):
+        values = matrix
+    else:
+        raise ValueError("Load counts as a NumPy array or SciPy sparse matrix before validation.")
+    if values.dtype.kind not in "iuf":
+        raise ValueError("Raw counts must contain real numeric values, not booleans or strings.")
+    # Bound temporary allocations even for large dense expression matrices.
+    positive = False
+    for start in range(0, values.size, 65536):
+        block = values.flat[start:start + 65536]
+        if not np.isfinite(block).all() or (block < 0).any():
+            raise ValueError("Raw counts must be finite and nonnegative.")
+        if values.dtype.kind == "f" and (block != np.floor(block)).any():
+            raise ValueError("Fractional values are not raw integer counts; do not round or invert normalization.")
+        positive = positive or bool((block > 0).any())
+    if not positive:
+        raise ValueError("The count matrix contains no positive counts; check the input and QC.")
+    if "counts" not in adata.layers:
+        adata.layers["counts"] = matrix.copy()
+    return {"source": source, "checks": "finite, nonnegative, integer-valued"}
 
 
 def h5ad_safe_obs(df):

--- a/resources/skills/scvi-tools/test_kernel.py
+++ b/resources/skills/scvi-tools/test_kernel.py
@@ -1,0 +1,109 @@
+"""Run from the repository root: python -m unittest discover -s resources/skills/scvi-tools -v"""
+import tempfile
+import unittest
+from pathlib import Path
+
+import anndata as ad
+import numpy as np
+from scipy import sparse
+
+from kernel import prepare_scvi_counts
+
+
+class PrepareCountsTests(unittest.TestCase):
+    def test_existing_counts_survive_normalized_x_and_h5ad_roundtrip(self):
+        counts = np.array([[0, 2], [3, 1]])
+        data = ad.AnnData(np.log1p(counts), layers={"counts": counts.copy()})
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "input.h5ad"
+            data.write_h5ad(path)
+            loaded = ad.read_h5ad(path)
+            existing = loaded.layers["counts"]
+            prepare_scvi_counts(loaded)
+            self.assertIs(loaded.layers["counts"], existing)
+            np.testing.assert_array_equal(loaded.X, np.log1p(counts))
+            np.testing.assert_array_equal(loaded.layers["counts"], counts)
+            loaded.X = loaded.layers["counts"].copy()
+            loaded.X[0, 0] = 99
+            np.testing.assert_array_equal(loaded.layers["counts"], counts)
+            # Preparation does not write back to the user's input file.
+            np.testing.assert_array_equal(ad.read_h5ad(path).X, np.log1p(counts))
+
+    def test_sparse_counts_remain_sparse_without_toarray(self):
+        from unittest.mock import patch
+        for cls in (sparse.csr_matrix, sparse.csc_matrix, sparse.csr_array, sparse.csc_array):
+            with self.subTest(format=cls.__name__):
+                matrix = cls(np.array([[0, 2], [3, 0]]))
+                data = ad.AnnData(matrix)
+                with patch.object(cls, "toarray", side_effect=AssertionError("densified")):
+                    prepare_scvi_counts(data)
+                self.assertIsInstance(data.layers["counts"], cls)
+                self.assertEqual((data.layers["counts"] != matrix).nnz, 0)
+
+    def test_rejects_fractional_value_beyond_first_chunk(self):
+        matrix = np.ones((2, 40000))
+        matrix[-1, -1] = 0.5
+        data = ad.AnnData(matrix)
+        with self.assertRaisesRegex(ValueError, "Fractional"):
+            prepare_scvi_counts(data)
+        self.assertNotIn("counts", data.layers)
+
+    def test_invalid_existing_counts_do_not_fall_back_to_x(self):
+        data = ad.AnnData(np.ones((2, 2)), layers={"counts": np.full((2, 2), 0.5)})
+        with self.assertRaisesRegex(ValueError, "Fractional"):
+            prepare_scvi_counts(data)
+        np.testing.assert_array_equal(data.layers["counts"], np.full((2, 2), 0.5))
+
+    def test_absent_counts_defaults_to_x_without_using_raw(self):
+        for sparse_input in (False, True):
+            with self.subTest(sparse=sparse_input):
+                matrix = np.array([[1., 0.], [2., 3.]])
+                data = ad.AnnData(sparse.csr_matrix(matrix) if sparse_input else matrix.copy())
+                data.raw = ad.AnnData(np.full((2, 2), 99))
+                record = prepare_scvi_counts(data)
+                self.assertEqual(record["source"], "X")
+                if sparse_input:
+                    self.assertTrue(sparse.issparse(data.layers["counts"]))
+                    self.assertEqual((data.layers["counts"] != data.X).nnz, 0)
+                    self.assertFalse(np.shares_memory(data.X.data, data.layers["counts"].data))
+                else:
+                    np.testing.assert_array_equal(data.layers["counts"], matrix)
+                    self.assertFalse(np.shares_memory(data.X, data.layers["counts"]))
+
+    def test_absent_counts_with_invalid_x_does_not_create_counts(self):
+        for value in (0.25, -1, float("nan"), float("inf")):
+            for sparse_input in (False, True):
+                with self.subTest(value=value, sparse=sparse_input):
+                    matrix = np.array([[1., 0.], [2., value]])
+                    data = ad.AnnData(sparse.csr_matrix(matrix) if sparse_input else matrix)
+                    data.raw = ad.AnnData(np.ones((2, 2)))
+                    with self.assertRaises(ValueError):
+                        prepare_scvi_counts(data)
+                    self.assertNotIn("counts", data.layers)
+
+    def test_rejects_empty_zero_and_nonnumeric_counts(self):
+        for matrix in (np.empty((0, 2)), np.zeros((2, 2)), np.ones((2, 2), dtype=bool),
+                       np.ones((2, 2), dtype=complex), np.full((2, 2), "1")):
+            with self.subTest(dtype=matrix.dtype, shape=matrix.shape):
+                data = ad.AnnData(matrix)
+                with self.assertRaises(ValueError):
+                    prepare_scvi_counts(data)
+                self.assertNotIn("counts", data.layers)
+
+    def test_rejects_views_and_backed_objects(self):
+        data = ad.AnnData(np.ones((2, 2)))
+        with self.assertRaisesRegex(ValueError, "in-memory"):
+            prepare_scvi_counts(data[:1])
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "input.h5ad"
+            data.write_h5ad(path)
+            backed = ad.read_h5ad(path, backed="r")
+            try:
+                with self.assertRaisesRegex(ValueError, "in-memory"):
+                    prepare_scvi_counts(backed)
+            finally:
+                backed.file.close()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

The scVI recipe copied `.X` into `layers["counts"]` immediately after reading an
arbitrary h5ad file. For a file with normalized `.X` and genuine raw counts in an
existing layer, this replaced the correct model input with transformed values.

## Proposed change

Add `prepare_scvi_counts` and use it before normalization and model registration.
Validate the existing counts layer by default. When it is absent, validate `.X`
and copy it into a new counts layer if the numerical checks pass. Invalid existing
counts raise without falling back to another matrix. `.raw.X` is never selected.
Validate finite,
nonnegative, integer-valued counts, and reject empty/all-zero or unsupported inputs
before creating a layer. Validate sparse values without densification.

Derive plotting/HVG data from a copy of verified counts. Explain that matrix
names and integer checks do not establish provenance. Keep source verification
in the analysis guidance without requiring a free-text provenance argument.
Retain the same input checks in remote scripts. Load the helper file explicitly
as UTF-8.

## Scope and non-goals

Only the bundled scVI skill, its Python helper, and focused tests change. This is
a raw integer-count workflow; it does not infer data history, reconstruct counts
from normalized expression, or address HVG/DE methodology. No UI, TypeScript
runtime interface, persistence format, or model-training implementation changes.

## Acceptance criteria and validation

All checks below were run after the final material edit from the new worktree,
based on fetched `origin/main` at `e1ea7d51`. An independent read-only review
confirmed the final counts-first/default-X behavior and coverage. Checks were
rerun after removing the optional source-selection API and redundant tests.

| Behavior | Command/check | Result |
| --- | --- | --- |
| Preserve existing counts with normalized X, validated dense/sparse X fallback when absent, h5ad round trips, independent copies, invalid inputs, views/backed inputs | `D:/science/.validation/scvi-counts/Scripts/python.exe -B -m unittest discover -s resources/skills/scvi-tools -v` | 8 tests passed |
| Helper remains definition-only and loads without third-party imports | `python -I -S` AST check and execution of UTF-8 `kernel.py` | Passed |
| Skill document structure and examples | YAML frontmatter parse and AST parse of all 5 Python example blocks | Passed |
| Skill frontmatter/materialization consumers and registry | `npm test -- src/main/skills/frontmatter.test.ts src/main/skills/materializer.test.ts src/main/skills/registry.test.ts` | All 3 files passed: 49 tests passed, 2 explicitly skipped on Windows |
| Markdown formatting | `node node_modules/prettier/bin/prettier.cjs --check resources/skills/scvi-tools/SKILL.md` | Passed |
| Repository lint | `npm run lint` | Passed |
| Patch whitespace | `git diff --check` | Passed |

Python tests used an isolated environment with NumPy 2.5.3, SciPy 1.18.1, and
AnnData 0.13.3.post0. Node checks reused existing repository dependencies through
a local node_modules junction. The existing Electron 39.8.10 dependency was
completed with its install script and bundled checksum verification after an
incomplete binary installation initially blocked the registry suite. The rerun
passed without changing test assertions or application source.

The Python suite must be invoked explicitly; it is not automatically run by
`npm test`. No full scVI training, live agent evaluation, or GPU test was run.
TS typechecks, migrations, and platform/E2E lanes were excluded because the
diff changes no corresponding runtime contracts. The two materializer tests
explicitly skip Windows and remain outside this local run's coverage.

## Review focus

Check that existing counts cannot be overwritten, automatic X fallback happens
only when counts are absent, and invalid data is rejected before mutation. Confirm
source verification remains clear in the instructions, sparse inputs remain
sparse, and the recipe uses the verified layer for scVI setup.
