### PR TITLE
feat(cli): add Codex first-run bootstrap

### DIFF
--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -143,7 +143,9 @@ open-science provider add --type official --vendor openai --model gpt-5.4 \
 
 Use a model supported by the installed application's OpenAI catalog. Setup probes that exact model
 before saving its protected credential reference and validation record. This initial command creates
-`cli-openai`; repeating it with the same key/model revalidates it. Different existing credentials,
+`cli-openai`; repeating it with the same key and currently selected model revalidates that target.
+If Settings changed the active model, Doctor suggests the selected model; revalidation preserves the
+provider default model and active selection. Different existing credentials,
 providers, or framework selections produce `configuration_conflict`, without overwriting them.
 Later account edits remain in Settings. Other runtime/provider bootstrap combinations are not yet
 supported. Existing run-time selection commands are unchanged.

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -159,7 +159,9 @@ requires the existing explicit `start --credential-store file` option on every s
 `doctor` keeps existing readiness/reason fields. If the daemon is absent, the CLI prints a report
 with `checks.daemon.status: "missing"` and `next: [{ code: "daemon_unavailable", argv: ["start",
 "--no-open"] }]`, exiting 3. This includes a stale state file whose loopback connection is refused; HTTP health
-rejections (including authorization failures) remain errors rather than missing-daemon reports. A running-daemon report still exits 0 even when readiness is false.
+rejections (including authorization failures) remain errors rather than missing-daemon reports.
+When probing both default profiles, a later refused connection does not hide an earlier HTTP or
+configuration error; a healthy later profile can still be selected. A running-daemon report still exits 0 even when readiness is false.
 Append the same development `--profile` argument when executing a suggested argv in an isolated
 profile. Doctor reports readiness, not a live third-party authorization or research-run guarantee.
 

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -110,9 +110,77 @@ Codex or validating expiry/revocation remotely; historical provider validation r
 
 `checks.skills.enabled` contains the sorted IDs of enabled, available Skills; Skills do not block
 overall readiness. `next` contains stable action codes such as
-`runtime_missing` and `provider_not_ready`, never commands that may not exist. A completed inspection
+`runtime_missing` and `provider_not_ready`, with an additive `argv` recovery command for the Codex bootstrap path. A completed inspection
 exits with code `0` even when `ready` is false; connection and command failures keep the existing
 nonzero CLI error codes.
+
+## First-run setup (Codex)
+
+The desktop application must already be installed. The standalone npm runtime remains deferred.
+`init` creates a configuration directory only; packaged builds do not accept `--profile` overrides.
+
+```bash
+open-science start --no-open
+open-science runtime install codex --json
+open-science codex login
+open-science connector configure literature --openalex-key-env OPENALEX_API_KEY --json
+open-science doctor --json
+open-science project create "First review" --json
+open-science run --project "First review" --framework codex --skill literature-review \
+  --prompt "Review the evidence for the research question in the project context" --wait --jsonl
+```
+
+Place credentials in the named environment variables through your existing secret-management flow.
+Do not put secret values in command arguments. The CLI reads only the variable explicitly named by
+`--api-key-env` or `--openalex-key-env`; it never imports external Codex credentials.
+
+For an OpenAI API-key provider instead of subscription login, prepare the runtime and then use:
+
+```bash
+open-science provider add --type official --vendor openai --model gpt-5.4 \
+  --api-key-env OPENAI_API_KEY --json
+```
+
+Use a model supported by the installed application's OpenAI catalog. Setup probes that exact model
+before saving its protected credential reference and validation record. This initial command creates
+`cli-openai`; repeating it with the same key/model revalidates it. Different existing credentials,
+providers, or framework selections produce `configuration_conflict`, without overwriting them.
+Later account edits remain in Settings. Other runtime/provider bootstrap combinations are not yet
+supported. Existing run-time selection commands are unchanged.
+
+OpenAlex keys are validated before persistence and Literature Graph enablement. Rejected keys or a
+configuration changed during the probe are not saved. A recognized key may still have exhausted
+quota (the existing probe accepts HTTP 429); a successful probe is not a completed literature run.
+
+All writes use existing Settings/runtime/credential owners and formats. No onboarding completion
+flag or database migration is added. OS storage remains the default; Linux file storage still
+requires the existing explicit `start --credential-store file` option on every start.
+
+`doctor` keeps existing readiness/reason fields. If the daemon is absent, the CLI prints a report
+with `checks.daemon.status: "missing"` and `next: [{ code: "daemon_unavailable", argv: ["start",
+"--no-open"] }]`, exiting 3. A running-daemon report still exits 0 even when readiness is false.
+Append the same development `--profile` argument when executing a suggested argv in an isolated
+profile. Doctor reports readiness, not a live third-party authorization or research-run guarantee.
+
+`bootstrap` SDK requests return `{ ok: true, providerId? }` or `{ ok: false, code }`. Codes are
+`invalid_request` (including unknown model/input), `configuration_conflict`, `runtime_unavailable`,
+`credential_invalid`, or `bootstrap_failed`. The CLI exits nonzero for failures; results never
+include the submitted secret or raw upstream error. Bootstrap/launcher writes require an
+authenticated local connection and are not exposed as research-agent tools.
+
+Install the PATH launcher with `open-science cli install --json`. Before a launcher exists, invoke
+the bundled CLI by absolute path using the application's Electron executable in Node mode (for
+example on macOS):
+
+```bash
+OPEN_SCIENCE_APP_PATH="/Applications/Open Science.app/Contents/MacOS/Open Science" \
+ELECTRON_RUN_AS_NODE=1 "/Applications/Open Science.app/Contents/MacOS/Open Science" \
+  "/Applications/Open Science.app/Contents/Resources/cli/index.mjs" start --no-open
+```
+
+Repeat the same absolute invocation with `cli install --json`. Respect the returned `pathHint`;
+Windows may require a new terminal and Unix shells may need the existing launcher directory on PATH.
+The launcher uses the existing ownership receipts and does not claim unrelated executables.
 
 ## Application updates
 
@@ -155,15 +223,14 @@ as `open-science start --no-sandbox`; prefer the Debian package or a sandbox-cap
 
 ## Codex subscription sign-in
 
-Sign the Open Science Codex profile in from a server terminal without starting the daemon or opening
-the Web UI:
+Sign the Open Science Codex profile in from a terminal without opening Settings:
 
 ```bash
 open-science codex login
 ```
 
-The command runs the native Codex version already configured by Open Science with OAuth device-code
-authentication. It prints a verification URL and one-time code in the current terminal; open the URL
+For first-run setup, start the daemon with `open-science start --no-open`. The command prepares
+the managed runtime and app-owned provider, then runs native Codex OAuth device-code authentication. It prints a verification URL and one-time code in the current terminal; open the URL
 on any browser-capable device, enter the code, and keep the terminal open until Codex reports
 success. Credentials are written only to the app-owned
 <code>codex-subscription/auth.json</code> profile.
@@ -171,7 +238,9 @@ success. Credentials are written only to the app-owned
 The native login follows the profile's saved Network proxy mode. Manual uses the configured proxy,
 Direct clears inherited proxy variables, and System uses the environment that launched the CLI.
 
-When that profile already contains credentials, the command exits without replacing them. Start a
+When that profile already contains credentials, the command validates and registers them without
+replacing them. Successful validation activates the initial provider; a different active provider is
+never replaced. Start a
 new device-code flow explicitly with:
 
 ```bash
@@ -179,8 +248,9 @@ open-science codex login --force
 ```
 
 The login command is interactive and intentionally does not support <code>--json</code> or
-<code>--jsonl</code>. It does not contact the Open Science daemon or expose the one-time code through
-daemon logs.
+<code>--jsonl</code>. Setup and readiness registration use the local daemon; the one-time code stays
+in the terminal process. Already configured profiles can still sign in while the daemon is stopped,
+but must repeat the command with the daemon running to register readiness.
 
 ### Linux AppImage sandbox fallback
 

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -126,7 +126,7 @@ open-science codex login
 open-science connector configure literature --openalex-key-env OPENALEX_API_KEY --json
 open-science doctor --json
 open-science project create "First review" --json
-open-science run --project "First review" --framework codex --skill literature-review \
+open-science run --project "First review" --skill literature-review \
   --prompt "Review the evidence for the research question in the project context" --wait --jsonl
 ```
 

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -158,7 +158,8 @@ requires the existing explicit `start --credential-store file` option on every s
 
 `doctor` keeps existing readiness/reason fields. If the daemon is absent, the CLI prints a report
 with `checks.daemon.status: "missing"` and `next: [{ code: "daemon_unavailable", argv: ["start",
-"--no-open"] }]`, exiting 3. A running-daemon report still exits 0 even when readiness is false.
+"--no-open"] }]`, exiting 3. This includes a stale state file whose loopback connection is refused; HTTP health
+rejections (including authorization failures) remain errors rather than missing-daemon reports. A running-daemon report still exits 0 even when readiness is false.
 Append the same development `--profile` argument when executing a suggested argv in an isolated
 profile. Doctor reports readiness, not a live third-party authorization or research-run guarantee.
 
@@ -250,7 +251,10 @@ open-science codex login --force
 The login command is interactive and intentionally does not support <code>--json</code> or
 <code>--jsonl</code>. Setup and readiness registration use the local daemon; the one-time code stays
 in the terminal process. Already configured profiles can still sign in while the daemon is stopped,
-but must repeat the command with the daemon running to register readiness.
+but must repeat the command with an updated daemon running to register readiness. A running older daemon
+without the bootstrap endpoint also permits this configured native-login path; it cannot register
+provider readiness. An empty profile instead receives `bootstrap_unavailable` with an instruction to
+update and restart the application. HTTP authorization failures do not trigger this fallback.
 
 ### Linux AppImage sandbox fallback
 

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -1485,7 +1485,8 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
   try {
     client = await deps.connect({ configRoot: options.configRoot })
   } catch (error) {
-    if (command !== 'doctor' || error?.code !== 'daemon_unavailable') throw error
+    if (command !== 'doctor' || error?.code !== 'daemon_unavailable' || error?.status !== undefined)
+      throw error
     deps.log(
       JSON.stringify({
         ready: false,

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -36,6 +36,10 @@ Commands:
   url         Print the authenticated web URL
   update      Check, download, and apply an application update
   doctor --json  Inspect headless readiness
+  runtime install codex   Prepare the app-managed Codex runtime
+  provider add --type official --vendor openai --model <id> --api-key-env <ENV>
+  connector configure literature --openalex-key-env <ENV>
+  cli install            Install the PATH launcher
   codex login [--force]
   connector list | show <id> | enable <id> | disable <id>
   connector add | update <id>      Read configuration JSON from stdin
@@ -119,6 +123,10 @@ const VALUE_OPTIONS = {
   '--app-path': 'appPath',
   '--config-root': 'configRoot',
   '--profile': 'configRoot',
+  '--type': 'providerType',
+  '--vendor': 'vendor',
+  '--api-key-env': 'apiKeyEnv',
+  '--openalex-key-env': 'openAlexKeyEnv',
   '--data-root': 'dataRoot',
   '--project': 'project',
   '--session': 'session',
@@ -158,7 +166,10 @@ const TASK_COMMANDS = new Set([
   'plan',
   'artifacts',
   'connector',
-  'credential'
+  'credential',
+  'runtime',
+  'provider',
+  'cli'
 ])
 const GROUP_COMMANDS = new Set([
   'codex',
@@ -168,12 +179,19 @@ const GROUP_COMMANDS = new Set([
   'plan',
   'artifacts',
   'connector',
-  'credential'
+  'credential',
+  'runtime',
+  'provider',
+  'cli'
 ])
 // Project create, update, and session-defaults intentionally remain unbounded because their
 // positional Project names may contain multiple unquoted words.
 const POSITIONAL_LIMITS = new Map([
   ['doctor', 0],
+  ['runtime install', 1],
+  ['provider add', 0],
+  ['connector configure', 1],
+  ['cli install', 0],
   ['connector list', 0],
   ['connector show', 1],
   ['connector enable', 1],
@@ -499,7 +517,7 @@ export const parseCliArgs = (argv) => {
   }
   const sessionOptionPresent =
     options.provider !== undefined ||
-    options.model !== undefined ||
+    (options.model !== undefined && !(command === 'provider' && subcommand === 'add')) ||
     options.providerDefaultModel ||
     options.reasoningEffort !== undefined ||
     options.approvalProfile !== undefined ||
@@ -1463,10 +1481,64 @@ const assertNoClearConflict = (clear, present, label) => {
 export const runTaskCommand = async (parsed, dependencies = {}) => {
   const deps = { ...TASK_DEPS, ...dependencies }
   const { command, subcommand, positionals = [], options } = parsed
-  const client = await deps.connect({ configRoot: options.configRoot })
+  let client
+  try {
+    client = await deps.connect({ configRoot: options.configRoot })
+  } catch (error) {
+    if (command !== 'doctor' || error?.code !== 'daemon_unavailable') throw error
+    deps.log(
+      JSON.stringify({
+        ready: false,
+        checks: { daemon: { status: 'missing' } },
+        next: [{ code: 'daemon_unavailable', argv: ['start', '--no-open'] }]
+      })
+    )
+    deps.setExitCode(3)
+    return
+  }
 
   if (command === 'doctor') {
     deps.log(JSON.stringify(await client.doctor()))
+    return
+  }
+
+  if (command === 'cli' && subcommand === 'install') {
+    outputValue(await client.installCli(), options, deps)
+    return
+  }
+  if (
+    command === 'runtime' ||
+    command === 'provider' ||
+    (command === 'connector' && subcommand === 'configure')
+  ) {
+    const readSecret = (name) => {
+      if (!name || !/^[A-Za-z_][A-Za-z0-9_]*$/.test(name))
+        throw new CliUsageError('Name a credential environment variable.')
+      const key = (dependencies.env ?? process.env)[name]?.trim()
+      if (!key) throw new CliUsageError('The credential environment variable is empty.')
+      return key
+    }
+    let request
+    if (command === 'runtime' && subcommand === 'install' && positionals[0] === 'codex')
+      request = { action: 'runtime' }
+    else if (
+      command === 'provider' &&
+      subcommand === 'add' &&
+      options.providerType === 'official' &&
+      options.vendor === 'openai' &&
+      options.model
+    ) {
+      request = { action: 'provider', key: readSecret(options.apiKeyEnv), model: options.model }
+    } else if (command === 'connector' && positionals[0] === 'literature')
+      request = { action: 'openalex', key: readSecret(options.openAlexKeyEnv) }
+    else
+      throw new CliUsageError(
+        'Supported setup commands: runtime install codex; provider add --type official --vendor openai --model <id> --api-key-env <ENV>; connector configure literature --openalex-key-env <ENV>.'
+      )
+    const result = await client.bootstrap(request, { timeoutMs: 600_000 })
+    if (!result.ok)
+      throw Object.assign(new Error(`Setup failed: ${result.code}.`), { code: result.code })
+    outputValue(result, options, deps)
     return
   }
 

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -145,6 +145,24 @@ describe('task CLI', () => {
     expect(setExitCode).toHaveBeenCalledWith(3)
   })
 
+  it.each([401, 403, 500])(
+    'does not describe an HTTP %s health rejection as a missing daemon',
+    async (status) => {
+      const log = vi.fn()
+      const error = Object.assign(new Error('health rejected'), {
+        code: 'daemon_unavailable',
+        status
+      })
+      await expect(
+        runTaskCommand(parseCliArgs(['doctor', '--json']), {
+          connect: vi.fn().mockRejectedValue(error),
+          log
+        })
+      ).rejects.toBe(error)
+      expect(log).not.toHaveBeenCalled()
+    }
+  )
+
   it('rejects ports that are not complete decimal values', () => {
     expect(() => parseCliArgs(['start', '--port', '44100xyz'])).toThrow('Invalid port: 44100xyz')
     expect(() => parseCliArgs(['start', '--port', '0'])).toThrow('Invalid port: 0')

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -30,6 +30,45 @@ const listProjects = async (): Promise<Array<{ id: string; name: string }>> => [
 ]
 
 describe('task CLI', () => {
+  it('prepares Codex through the public task client', async () => {
+    const bootstrap = vi.fn().mockResolvedValue({ ok: true })
+    await runTaskCommand(parseCliArgs(['runtime', 'install', 'codex', '--json']), {
+      connect: async () => ({ bootstrap }),
+      log: vi.fn()
+    })
+    expect(bootstrap).toHaveBeenCalledWith({ action: 'runtime' }, { timeoutMs: 600_000 })
+  })
+
+  it('reads only the named API credential environment variable and does not print it', async () => {
+    const bootstrap = vi.fn().mockResolvedValue({ ok: true, providerId: 'cli-openai' })
+    const log = vi.fn()
+    await runTaskCommand(
+      parseCliArgs([
+        'provider',
+        'add',
+        '--type',
+        'official',
+        '--vendor',
+        'openai',
+        '--model',
+        'gpt-test',
+        '--api-key-env',
+        'LAB_KEY',
+        '--json'
+      ]),
+      {
+        connect: async () => ({ bootstrap }),
+        env: { LAB_KEY: 'synthetic-secret', OTHER_KEY: 'ambient' },
+        log
+      }
+    )
+    expect(bootstrap).toHaveBeenCalledWith(
+      { action: 'provider', key: 'synthetic-secret', model: 'gpt-test' },
+      expect.any(Object)
+    )
+    expect(JSON.stringify(log.mock.calls)).not.toContain('synthetic-secret')
+    expect(() => parseCliArgs(['provider', 'add', '--api-key', 'secret'])).toThrow()
+  })
   it('accepts --profile as the forward-compatible profile spelling', () => {
     expect(parseCliArgs(['init', '--profile', '/tmp/open-science-profile']).options).toMatchObject({
       configRoot: '/tmp/open-science-profile'
@@ -86,6 +125,24 @@ describe('task CLI', () => {
     })
 
     expect(JSON.parse(log.mock.calls[0][0])).toEqual(report)
+  })
+
+  it('reports a concrete startup command when doctor cannot reach a daemon', async () => {
+    const log = vi.fn()
+    const setExitCode = vi.fn()
+    await runTaskCommand(parseCliArgs(['doctor', '--json']), {
+      connect: vi
+        .fn()
+        .mockRejectedValue(Object.assign(new Error('unavailable'), { code: 'daemon_unavailable' })),
+      log,
+      setExitCode
+    })
+    expect(JSON.parse(log.mock.calls[0][0])).toEqual({
+      ready: false,
+      checks: { daemon: { status: 'missing' } },
+      next: [{ code: 'daemon_unavailable', argv: ['start', '--no-open'] }]
+    })
+    expect(setExitCode).toHaveBeenCalledWith(3)
   })
 
   it('rejects ports that are not complete decimal values', () => {
@@ -1832,8 +1889,7 @@ describe('task CLI', () => {
       'compute',
       'notebook',
       'notebook-env',
-      'reviewer',
-      'runtime'
+      'reviewer'
     ]) {
       await expect(runCli([command])).rejects.toThrow(`Unknown command: ${command}`)
     }

--- a/packages/open-science/client-discovery.test.ts
+++ b/packages/open-science/client-discovery.test.ts
@@ -1,0 +1,81 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+
+const fixture = vi.hoisted(() => ({ home: '' }))
+vi.mock('node:os', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:os')>()),
+  homedir: () => fixture.home
+}))
+
+import { connectToOpenScience } from './index.mjs'
+import { parseCliArgs, runTaskCommand } from './cli.mjs'
+
+beforeEach(async () => {
+  fixture.home = await mkdtemp(join(tmpdir(), 'osci-discovery-'))
+  for (const [index, name] of ['.open-science-project', '.open-science'].entries()) {
+    const root = join(fixture.home, name)
+    await mkdir(root)
+    await writeFile(
+      join(root, 'web-service.json'),
+      JSON.stringify({ pid: process.pid, port: 44100 + index, startedAt: new Date().toISOString() })
+    )
+    await writeFile(join(root, 'web-token'), `fixture-token-${index}`)
+  }
+})
+afterEach(async () => {
+  await rm(fixture.home, { recursive: true, force: true })
+})
+
+const refused = (): TypeError =>
+  new TypeError('fetch failed', {
+    cause: Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' })
+  })
+
+it.each([401, 403, 500])(
+  'preserves HTTP %s over connection refusal in either candidate order',
+  async (status) => {
+    for (const reverse of [false, true]) {
+      const fetch = vi.fn(async (url: string) => {
+        if (url.includes(reverse ? ':44101/' : ':44100/')) return Response.json({}, { status })
+        throw refused()
+      })
+      const log = vi.fn()
+      await expect(
+        runTaskCommand(parseCliArgs(['doctor', '--json']), {
+          connect: () => connectToOpenScience({ env: {}, fetch }),
+          log
+        })
+      ).rejects.toMatchObject({ status })
+      expect(fetch).toHaveBeenCalledTimes(2)
+      expect(log).not.toHaveBeenCalled()
+    }
+  }
+)
+
+it('reports a missing daemon when both candidates refuse connections', async () => {
+  const log = vi.fn()
+  const setExitCode = vi.fn()
+  const fetch = vi.fn().mockRejectedValue(refused())
+  await runTaskCommand(parseCliArgs(['doctor', '--json']), {
+    connect: () => connectToOpenScience({ env: {}, fetch }),
+    log,
+    setExitCode
+  })
+  expect(fetch).toHaveBeenCalledTimes(2)
+  expect(JSON.parse(log.mock.calls[0][0])).toMatchObject({
+    ready: false,
+    checks: { daemon: { status: 'missing' } }
+  })
+  expect(setExitCode).toHaveBeenCalledWith(3)
+})
+
+it('still connects to a healthy later candidate after an earlier HTTP rejection', async () => {
+  const fetch = vi.fn(async (url: string) =>
+    Response.json({}, { status: url.includes(':44100/') ? 401 : 200 })
+  )
+  const client = await connectToOpenScience({ env: {}, fetch })
+  expect(client.baseUrl).toBe('http://127.0.0.1:44101')
+  expect(fetch).toHaveBeenCalledTimes(2)
+})

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -56,6 +56,8 @@ describe('OpenScienceClient', () => {
       [
         'constructor',
         'doctor',
+        'bootstrap',
+        'installCli',
         'health',
         'listConnectors',
         'getConnector',

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -1147,6 +1147,24 @@ describe('OpenScienceClient', () => {
     expect(ControllableWebSocket.instance.closed).toBe(true)
   })
 
+  it('reports unavailable when a stale state file points at a refused connection', async () => {
+    const configRoot = await mkdtemp(join(tmpdir(), 'open-science-stale-sdk-'))
+    roots.push(configRoot)
+    await writeFile(
+      join(configRoot, 'web-service.json'),
+      JSON.stringify({ pid: process.pid, port: 44100, startedAt: new Date().toISOString() })
+    )
+    await writeFile(join(configRoot, 'web-token'), 'fixture-token')
+    const fetch = vi.fn().mockRejectedValue(
+      new TypeError('fetch failed', {
+        cause: Object.assign(new Error('connection refused'), { code: 'ECONNREFUSED' })
+      })
+    )
+    await expect(connectToOpenScience({ configRoot, fetch })).rejects.toMatchObject({
+      code: 'daemon_unavailable'
+    })
+  })
+
   it('discovers a daemon from its state and token files before returning a client', async () => {
     const configRoot = await mkdtemp(join(tmpdir(), 'open-science-sdk-'))
     roots.push(configRoot)

--- a/packages/open-science/codex-login.mjs
+++ b/packages/open-science/codex-login.mjs
@@ -6,6 +6,7 @@ import { isAbsolute, join, normalize } from 'node:path'
 
 import { resolveConfigRoot } from './config-root.mjs'
 import { locateApp } from './locate-app.mjs'
+import { connectToOpenScience } from './index.mjs'
 
 const CODEX_CONFIG_OVERRIDE = 'cli_auth_credentials_store="file"'
 const CODEX_ENV_KEYS = [
@@ -198,6 +199,7 @@ export const runCodexProcess = (codexPath, args, options = {}) =>
   })
 
 const DEFAULT_DEPS = {
+  connect: connectToOpenScience,
   locateApp: (options) => locateApp(options),
   resolveConfigRoot: (options) => resolveConfigRoot(options),
   resolveConfiguration: (configRoot) => resolveCodexLoginConfiguration(configRoot),
@@ -221,6 +223,33 @@ export const codexLoginCommand = async (options, dependencies = {}) => {
     override: options.configRoot,
     env: app.packaged ? {} : process.env
   })
+  let client
+  try {
+    client = await deps.connect({ configRoot })
+  } catch {
+    // Already-configured profiles retain offline terminal login. First-run writes need the owner.
+    try {
+      await deps.resolveConfiguration(configRoot)
+    } catch {
+      throw new CodexLoginError(
+        'Start Open Science first: open-science start --no-open; then retry codex login.',
+        'daemon_unavailable'
+      )
+    }
+  }
+  const bootstrap = async (action) => {
+    if (!client) return
+    const result = await client.bootstrap({ action }, { timeoutMs: 600_000 })
+    if (!result.ok) throw new CodexLoginError(`Codex setup failed: ${result.code}.`, result.code)
+  }
+  await bootstrap('codex-prepare')
+  const complete = async () => {
+    if (client) await bootstrap('codex-complete')
+    else
+      deps.log(
+        'Sign-in saved. Start Open Science and run codex login again to validate and activate the provider.'
+      )
+  }
   const { codexPath, networkProxy } = await deps.resolveConfiguration(configRoot)
   const codexHome = join(configRoot, 'codex-subscription')
   await deps.mkdir(codexHome)
@@ -233,6 +262,7 @@ export const codexLoginCommand = async (options, dependencies = {}) => {
       inherit: false
     })
     if (status.code === 0) {
+      await complete()
       deps.log(
         'Codex is already signed in for Open Science. Use "open-science codex login --force" to sign in again.'
       )
@@ -256,5 +286,6 @@ export const codexLoginCommand = async (options, dependencies = {}) => {
       login.code ?? 1
     )
   }
+  await complete()
   deps.log('Codex is signed in for Open Science.')
 }

--- a/packages/open-science/codex-login.mjs
+++ b/packages/open-science/codex-login.mjs
@@ -226,7 +226,8 @@ export const codexLoginCommand = async (options, dependencies = {}) => {
   let client
   try {
     client = await deps.connect({ configRoot })
-  } catch {
+  } catch (error) {
+    if (error?.code !== 'daemon_unavailable' || error?.status !== undefined) throw error
     // Already-configured profiles retain offline terminal login. First-run writes need the owner.
     try {
       await deps.resolveConfiguration(configRoot)
@@ -242,12 +243,26 @@ export const codexLoginCommand = async (options, dependencies = {}) => {
     const result = await client.bootstrap({ action }, { timeoutMs: 600_000 })
     if (!result.ok) throw new CodexLoginError(`Codex setup failed: ${result.code}.`, result.code)
   }
-  await bootstrap('codex-prepare')
+  try {
+    await bootstrap('codex-prepare')
+  } catch (error) {
+    if (error?.status !== 404) throw error
+    // Older daemons cannot register readiness, but configured native login remains available.
+    try {
+      await deps.resolveConfiguration(configRoot)
+    } catch {
+      throw new CodexLoginError(
+        'Update and restart Open Science before setting up Codex for this profile.',
+        'bootstrap_unavailable'
+      )
+    }
+    client = undefined
+  }
   const complete = async () => {
     if (client) await bootstrap('codex-complete')
     else
       deps.log(
-        'Sign-in saved. Start Open Science and run codex login again to validate and activate the provider.'
+        'Sign-in saved. Use a running, updated Open Science daemon and run codex login again to validate and activate the provider.'
       )
   }
   const { codexPath, networkProxy } = await deps.resolveConfiguration(configRoot)

--- a/packages/open-science/codex-login.test.ts
+++ b/packages/open-science/codex-login.test.ts
@@ -56,6 +56,65 @@ describe('Codex CLI login', () => {
       await rm(root, { recursive: true, force: true })
     }
   })
+  it('preserves configured native login when an older daemon lacks bootstrap', async () => {
+    const deps = commandDeps(vi.fn().mockResolvedValue({ code: 0 }))
+    const bootstrap = vi
+      .fn()
+      .mockRejectedValue(Object.assign(new Error('Not found'), { status: 404 }))
+    deps.connect.mockResolvedValue({ bootstrap })
+    await codexLoginCommand({ configRoot }, deps)
+    expect(deps.runCodex).toHaveBeenCalledOnce()
+    expect(bootstrap).toHaveBeenCalledOnce()
+    expect(deps.log.mock.calls.flat().join(' ')).toContain('updated Open Science daemon')
+  })
+
+  it('requests a daemon update for an empty profile on an older daemon', async () => {
+    const deps = commandDeps()
+    deps.connect.mockResolvedValue({
+      bootstrap: vi.fn().mockRejectedValue(Object.assign(new Error('Not found'), { status: 404 }))
+    })
+    deps.resolveConfiguration.mockRejectedValue(new Error('not configured'))
+    await expect(codexLoginCommand({ configRoot }, deps)).rejects.toMatchObject({
+      code: 'bootstrap_unavailable'
+    })
+    expect(deps.runCodex).not.toHaveBeenCalled()
+  })
+
+  it.each([401, 403, 500])(
+    'does not bypass bootstrap HTTP %s errors with native login',
+    async (status) => {
+      const deps = commandDeps()
+      const error = Object.assign(new Error('failed'), { status })
+      deps.connect.mockResolvedValue({ bootstrap: vi.fn().mockRejectedValue(error) })
+      await expect(codexLoginCommand({ configRoot }, deps)).rejects.toBe(error)
+      expect(deps.runCodex).not.toHaveBeenCalled()
+    }
+  )
+
+  it('preserves configured native login when the daemon is unavailable', async () => {
+    const deps = commandDeps(vi.fn().mockResolvedValue({ code: 0 }))
+    deps.connect.mockRejectedValue(
+      Object.assign(new Error('stopped'), { code: 'daemon_unavailable' })
+    )
+    await codexLoginCommand({ configRoot }, deps)
+    expect(deps.runCodex).toHaveBeenCalledOnce()
+    expect(deps.log.mock.calls.flat().join(' ')).toContain('updated Open Science daemon')
+  })
+
+  it.each([401, 403, 500])(
+    'preserves connection health HTTP %s errors before native login',
+    async (status) => {
+      const deps = commandDeps()
+      const error = Object.assign(new Error('health rejected'), {
+        code: 'daemon_unavailable',
+        status
+      })
+      deps.connect.mockRejectedValue(error)
+      await expect(codexLoginCommand({ configRoot }, deps)).rejects.toBe(error)
+      expect(deps.runCodex).not.toHaveBeenCalled()
+    }
+  )
+
   it('isolates Codex credentials from the user environment', () => {
     const codexHome = resolve('profile', 'codex-subscription')
     const env = createCodexLoginEnvironment(

--- a/packages/open-science/codex-login.test.ts
+++ b/packages/open-science/codex-login.test.ts
@@ -1,4 +1,6 @@
 import { resolve } from 'node:path'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
 
 import { describe, expect, it, vi } from 'vitest'
 
@@ -17,6 +19,7 @@ const codexPath = resolve('managed-codex', process.platform === 'win32' ? 'codex
 // The exact Vitest mock tuple types are test-local implementation detail.
 // eslint-disable-next-line @typescript-eslint/explicit-function-return-type
 const commandDeps = (runCodex = vi.fn()) => ({
+  connect: vi.fn().mockResolvedValue({ bootstrap: vi.fn().mockResolvedValue({ ok: true }) }),
   locateApp: vi.fn().mockResolvedValue({ packaged: false }),
   resolveConfigRoot: vi.fn().mockReturnValue(configRoot),
   resolveConfiguration: vi.fn().mockResolvedValue({ codexPath }),
@@ -26,6 +29,33 @@ const commandDeps = (runCodex = vi.fn()) => ({
 })
 
 describe('Codex CLI login', () => {
+  it('prepares an empty profile before resolving the runtime and registers a successful login', async () => {
+    const root = await mkdtemp(resolve(tmpdir(), 'osci-first-login-'))
+    const nativePath = resolve(root, 'codex')
+    const bootstrap = vi.fn(async (request) => {
+      if (request.action === 'codex-prepare') {
+        await writeFile(nativePath, 'synthetic runtime')
+        await writeFile(resolve(root, 'settings.json'), JSON.stringify({ codex: { nativePath } }))
+      }
+      return { ok: true }
+    })
+    const deps = {
+      ...commandDeps(vi.fn().mockResolvedValue({ code: 0 })),
+      resolveConfigRoot: () => root,
+      resolveConfiguration: resolveCodexLoginConfiguration,
+      connect: vi.fn().mockResolvedValue({ bootstrap })
+    }
+    try {
+      await codexLoginCommand({ configRoot: root }, deps)
+      expect(bootstrap.mock.calls.map(([request]) => request.action)).toEqual([
+        'codex-prepare',
+        'codex-complete'
+      ])
+      expect(deps.runCodex).toHaveBeenCalledWith(nativePath, expect.any(Array), expect.any(Object))
+    } finally {
+      await rm(root, { recursive: true, force: true })
+    }
+  })
   it('isolates Codex credentials from the user environment', () => {
     const codexHome = resolve('profile', 'codex-subscription')
     const env = createCodexLoginEnvironment(

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -1,3 +1,19 @@
+export type BootstrapRequest =
+  | { action: 'status' | 'runtime' | 'codex-prepare' | 'codex-complete' }
+  | { action: 'provider'; key: string; model: string }
+  | { action: 'openalex'; key: string }
+export type BootstrapResult =
+  | { ok: true; providerId?: string; next?: { runtime?: string[]; provider?: string[] } }
+  | {
+      ok: false
+      code:
+        | 'invalid_request'
+        | 'configuration_conflict'
+        | 'runtime_unavailable'
+        | 'credential_invalid'
+        | 'bootstrap_failed'
+    }
+
 // Keep these standalone published types aligned with the safe Settings contracts.
 // connector-types.test.ts verifies complete request and response equivalence.
 export type ToolPermission = 'allow' | 'ask' | 'block'
@@ -221,6 +237,7 @@ export type DoctorReport = {
   }
   next: Array<{
     code: 'runtime_missing' | 'runtime_not_ready' | 'provider_missing' | 'provider_not_ready'
+    argv?: readonly string[]
   }>
 }
 export type AgentConfiguration = {
@@ -482,6 +499,10 @@ export class OpenScienceClient {
     requestTimeoutMs?: number
   })
   health(options?: RequestOptions): Promise<unknown>
+  bootstrap(request: BootstrapRequest, options?: RequestOptions): Promise<BootstrapResult>
+  installCli(
+    options?: RequestOptions
+  ): Promise<{ installed: boolean; onPath: boolean; target: string; pathHint?: string }>
   doctor(options?: RequestOptions): Promise<DoctorReport>
   listConnectors(options?: RequestOptions): Promise<ConnectorsSnapshot>
   getConnector(

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -179,6 +179,14 @@ export class OpenScienceClient {
     )
   }
 
+  bootstrap(request, options) {
+    return this.request('/api/v1/bootstrap', { ...options, method: 'POST', body: request })
+  }
+
+  installCli(options) {
+    return this.request('/api/v1/cli/install', { ...options, method: 'POST' })
+  }
+
   doctor(options) {
     return this.request('/api/v1/doctor', { ...options, method: 'GET' })
   }

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -734,7 +734,8 @@ export const connectToOpenScience = async ({
     }
   })
   if (!client) {
-    if (lastError) throw lastError
+    const transportCode = lastError?.cause?.code ?? lastError?.code
+    if (lastError && transportCode !== 'ECONNREFUSED') throw lastError
     throw new OpenScienceApiError(
       'Open Science is not running. Start it with "open-science start".',
       {

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -728,14 +728,15 @@ export const connectToOpenScience = async ({
         return true
       } catch (error) {
         signal?.throwIfAborted()
-        lastError = error
+        // A stale candidate must not hide an earlier authorization or configuration failure.
+        const transportCode = error?.cause?.code ?? error?.code
+        if (transportCode !== 'ECONNREFUSED') lastError = error
         return false
       }
     }
   })
   if (!client) {
-    const transportCode = lastError?.cause?.code ?? lastError?.code
-    if (lastError && transportCode !== 'ECONNREFUSED') throw lastError
+    if (lastError) throw lastError
     throw new OpenScienceApiError(
       'Open Science is not running. Start it with "open-science start".',
       {

--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -45,6 +45,35 @@ import { LocalFsService } from './local-fs/service'
 import type { ManagedPreviewResource, ManagedPreviewRangeResult } from '../shared/preview-resources'
 
 const EMPTY_OWNER = Object.freeze({})
+
+it('exposes bootstrap only to local Task callers without widening renderer management', async () => {
+  const bootstrap = vi.fn(async () => ({ ok: true }))
+  const composition = createApplicationCommandComposition({
+    ...dependencies(),
+    settingsCore: {
+      service: { bootstrap },
+      emitInstallEvent: vi.fn(),
+      snapshotCommits: { projectAfter: (pending: Promise<unknown>) => pending }
+    } as never
+  })
+  expect(composition.localWeb.commandNames()).not.toContain('settings:bootstrap')
+  expect(composition.remoteWeb.commandNames()).not.toContain('settings:bootstrap')
+  await expect(
+    composition.task.invoke('settings:bootstrap', {
+      ...invocation('remote'),
+      args: [{ action: 'runtime' }]
+    })
+  ).resolves.toEqual({ ok: false, code: 'invalid_request' })
+  expect(bootstrap).not.toHaveBeenCalled()
+  await expect(
+    composition.task.invoke('settings:bootstrap', {
+      ...invocation(),
+      args: [{ action: 'runtime' }]
+    })
+  ).resolves.toEqual({ ok: true })
+  expect(bootstrap).toHaveBeenCalledOnce()
+  composition.dispose()
+})
 const unexpectedCommand = defineApplicationCommand<'test:unexpected', readonly [], void>(
   'test:unexpected'
 )
@@ -309,6 +338,8 @@ describe('application command composition', () => {
     const composition = createApplicationCommandComposition(dependencies())
 
     expect(composition.task.commandNames()).toEqual([
+      'settings:bootstrap',
+      'cli:install',
       'settings:get-preflight',
       'settings:list-skills',
       'settings:list-connectors',

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -1,4 +1,8 @@
 import {
+  bootstrapApplicationCommandGroup,
+  registerBootstrapApplicationCommands
+} from './settings/bootstrap-application-commands'
+import {
   specialistApplicationCommandGroup,
   registerSpecialistApplicationCommands,
   type SpecialistApplicationOwner
@@ -148,6 +152,7 @@ const ELECTRON_NATIVE_COMMAND_NAMES = Object.freeze([
 ])
 
 const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
+  'settings:bootstrap',
   'settings:test-custom-server',
   'projects:update-session-defaults',
   'reviewer:abort',
@@ -159,6 +164,8 @@ const TASK_NATIVE_COMMAND_NAMES = Object.freeze([
 ])
 
 const TASK_COMMAND_NAMES = Object.freeze([
+  'settings:bootstrap',
+  'cli:install',
   'settings:get-preflight',
   'settings:list-skills',
   'settings:list-connectors',
@@ -222,6 +229,9 @@ const createApplicationCommandModules = (
   remoteAccess: RemoteAccessOwner
 ): readonly ApplicationCommandModuleDescriptor[] =>
   Object.freeze([
+    defineApplicationCommandModule([bootstrapApplicationCommandGroup], (registrar) =>
+      registerBootstrapApplicationCommands(registrar, dependencies.settingsCore)
+    ),
     defineApplicationCommandModule([acpApplicationCommands], (registrar) =>
       registerAcpCommands(registrar, dependencies.acp)
     ),

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -131,6 +131,73 @@ const createCodexDeps = (
 })
 
 describe('AgentRuntimeManager', () => {
+  it('bootstraps a missing Codex runtime once and persists a usable selection', async () => {
+    const install = vi.fn(async () => {
+      inventory.codexAdapter.set(managedAdapterPath, '1.6.2')
+      inventory.codexNative.set(managedCodexPath, '0.114.0')
+      return {
+        result: { installId: 'bootstrap', ok: true },
+        adapterPath: managedAdapterPath,
+        adapterVersion: '1.6.2',
+        codexPath: managedCodexPath,
+        codexVersion: '0.114.0'
+      }
+    })
+    manager = createManager({ installManagedCodexImpl: install })
+    await manager.bootstrapCodex(vi.fn())
+    await manager.bootstrapCodex(vi.fn())
+    expect(install).toHaveBeenCalledTimes(1)
+    expect(await new SettingsRepository(storageRoot).getSettings()).toMatchObject({
+      agentFrameworkId: 'codex',
+      codex: { nativePath: managedCodexPath, resolvedPath: managedAdapterPath }
+    })
+  })
+
+  it('repairs a cached pair that reports versions but cannot initialize ACP', async () => {
+    inventory.codexAdapter.set(managedAdapterPath, '1.6.2')
+    inventory.codexNative.set(managedCodexPath, '0.114.0')
+    await repository.setCodexInfo({
+      resolvedPath: managedAdapterPath,
+      version: '1.6.2',
+      nativePath: managedCodexPath,
+      nativeVersion: '0.114.0'
+    })
+    let repaired = false
+    const smokeInitialize = vi.fn(async () => repaired)
+    const install = vi.fn(async () => {
+      repaired = true
+      return {
+        result: { installId: 'repair', ok: true },
+        adapterPath: managedAdapterPath,
+        adapterVersion: '1.6.2',
+        codexPath: managedCodexPath,
+        codexVersion: '0.114.0'
+      }
+    })
+    manager = createManager({
+      codexDetectDeps: {
+        ...createCodexDeps(inventory, managedAdapterPath, managedCodexPath),
+        smokeInitialize
+      },
+      installManagedCodexImpl: install
+    })
+    await manager.bootstrapCodex(vi.fn())
+    await manager.bootstrapCodex(vi.fn())
+    expect(install).toHaveBeenCalledOnce()
+    expect(smokeInitialize).toHaveBeenCalledWith(
+      managedAdapterPath,
+      { codexPath: managedCodexPath },
+      expect.any(AbortSignal)
+    )
+  })
+
+  it('refuses to change an existing framework during bootstrap', async () => {
+    await repository.setAgentFramework('opencode')
+    await expect(manager.bootstrapCodex(vi.fn())).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect((await repository.getSettings()).agentFrameworkId).toBe('opencode')
+  })
   let storageRoot: string
   let repository: Repository
   let inventory: RuntimeInventory

--- a/src/main/settings/agent-runtime-manager.test.ts
+++ b/src/main/settings/agent-runtime-manager.test.ts
@@ -961,6 +961,47 @@ describe('AgentRuntimeManager', () => {
     })
   })
 
+  it('keeps bootstrap ACP initialization inside the runtime detection admission', async () => {
+    inventory.codexAdapter.set(managedAdapterPath, '1.6.2')
+    inventory.codexNative.set(managedCodexPath, '0.114.0')
+    await repository.setCodexInfo({
+      resolvedPath: managedAdapterPath,
+      version: '1.6.2',
+      nativePath: managedCodexPath,
+      nativeVersion: '0.114.0'
+    })
+    const started = Promise.withResolvers<void>()
+    const release = Promise.withResolvers<boolean>()
+    const install = vi.fn(async ({ installId }: { installId: string }) => ({
+      result: { installId, ok: false, error: 'installer reached' }
+    }))
+    manager = createManager({
+      codexDetectDeps: {
+        ...createCodexDeps(inventory, managedAdapterPath, managedCodexPath),
+        smokeInitialize: async () => {
+          started.resolve()
+          return release.promise
+        }
+      },
+      installManagedCodexImpl: install
+    })
+    const bootstrap = manager.bootstrapCodex(vi.fn())
+    await started.promise
+    try {
+      await expect(manager.installCodex({ source: 'managed' }, vi.fn())).resolves.toMatchObject({
+        ok: false,
+        error: 'Runtime detection is in progress. Retry after it finishes.'
+      })
+      expect(install).not.toHaveBeenCalled()
+    } finally {
+      release.resolve(true)
+      await bootstrap
+    }
+    await expect(manager.installCodex({ source: 'managed' }, vi.fn())).resolves.toMatchObject({
+      error: 'installer reached'
+    })
+  })
+
   it('rejects independent detection during installation and admits it after failure', async () => {
     const started = Promise.withResolvers<void>()
     const release = Promise.withResolvers<void>()

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -655,25 +655,24 @@ export class AgentRuntimeManager {
 
   async bootstrapCodex(onEvent: (event: ClaudeInstallEvent) => void): Promise<void> {
     await this.repository.selectBootstrapCodex()
-    const healthy = async (): Promise<boolean> => {
-      const settings = await this.repository.getSettings()
-      const codex = settings.codex
-      if (
-        !codex?.resolvedPath ||
-        !codex.nativePath ||
-        !codexVersionsFromProbe(
-          await this.probeConfiguredCodexRuntime(codex, this.shutdownAbort.signal)
+    const healthy = (): Promise<boolean> =>
+      this.trackDetection(async (signal) => {
+        const settings = await this.repository.getSettings()
+        const codex = settings.codex
+        if (
+          !codex?.resolvedPath ||
+          !codex.nativePath ||
+          !codexVersionsFromProbe(await this.probeConfiguredCodexRuntime(codex, signal))
         )
-      )
-        return false
-      const ready = await this.codexDetectDeps.smokeInitialize(
-        codex.resolvedPath,
-        { codexPath: codex.nativePath },
-        this.shutdownAbort.signal
-      )
-      this.shutdownAbort.signal.throwIfAborted()
-      return ready
-    }
+          return false
+        const ready = await this.codexDetectDeps.smokeInitialize(
+          codex.resolvedPath,
+          { codexPath: codex.nativePath },
+          signal
+        )
+        signal.throwIfAborted()
+        return ready
+      })
     if (await healthy()) return this.repository.selectBootstrapCodex()
     await this.detectCodex()
     if (await healthy()) return this.repository.selectBootstrapCodex()

--- a/src/main/settings/agent-runtime-manager.ts
+++ b/src/main/settings/agent-runtime-manager.ts
@@ -4,6 +4,7 @@ import { access, mkdir } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { createServer } from 'node:net'
 import { promisify } from 'node:util'
+import { BootstrapError } from '../../shared/bootstrap'
 
 import type {
   ClaudeDetectResult,
@@ -650,6 +651,36 @@ export class AgentRuntimeManager {
         if (cached && !(await this.pathExists(cached))) await this.repository.clearCodexInfo()
       }
     }, signal)
+  }
+
+  async bootstrapCodex(onEvent: (event: ClaudeInstallEvent) => void): Promise<void> {
+    await this.repository.selectBootstrapCodex()
+    const healthy = async (): Promise<boolean> => {
+      const settings = await this.repository.getSettings()
+      const codex = settings.codex
+      if (
+        !codex?.resolvedPath ||
+        !codex.nativePath ||
+        !codexVersionsFromProbe(
+          await this.probeConfiguredCodexRuntime(codex, this.shutdownAbort.signal)
+        )
+      )
+        return false
+      const ready = await this.codexDetectDeps.smokeInitialize(
+        codex.resolvedPath,
+        { codexPath: codex.nativePath },
+        this.shutdownAbort.signal
+      )
+      this.shutdownAbort.signal.throwIfAborted()
+      return ready
+    }
+    if (await healthy()) return this.repository.selectBootstrapCodex()
+    await this.detectCodex()
+    if (await healthy()) return this.repository.selectBootstrapCodex()
+    const installed = await this.installCodex({ source: 'managed' }, onEvent)
+    if (!installed.ok || !(await healthy())) throw new BootstrapError('runtime_unavailable')
+    // Installation may overlap a human Settings change; never change the selection back.
+    await this.repository.selectBootstrapCodex()
   }
 
   async installClaude(

--- a/src/main/settings/application-commands.ts
+++ b/src/main/settings/application-commands.ts
@@ -60,6 +60,7 @@ import type { LocalShellSettingsWorkflows } from './workflows/local-shell'
 
 type CoreSettingsCommandStore = Pick<
   SettingsService,
+  | 'bootstrap'
   | 'cancelClaudeLogin'
   | 'cancelCodexLogin'
   | 'cancelClaudeIsolatedLogin'

--- a/src/main/settings/bootstrap-application-commands.ts
+++ b/src/main/settings/bootstrap-application-commands.ts
@@ -1,0 +1,46 @@
+import type { BootstrapRequest, BootstrapResult } from '../../shared/bootstrap'
+import {
+  defineApplicationCommand,
+  defineApplicationCommandGroup,
+  type ApplicationCommandRegistrar,
+  type ApplicationCommandInstallation
+} from '../application-command-router'
+import type { SettingsService } from './service'
+import type { ClaudeInstallEvent } from '../../shared/settings'
+import type { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
+
+const bootstrapCommand = defineApplicationCommand<
+  'settings:bootstrap',
+  readonly [BootstrapRequest],
+  BootstrapResult
+>('settings:bootstrap')
+export const bootstrapApplicationCommandGroup = defineApplicationCommandGroup(
+  'settings-bootstrap',
+  [bootstrapCommand] as const
+)
+
+export const registerBootstrapApplicationCommands = (
+  registrar: ApplicationCommandRegistrar,
+  dependencies: {
+    service: Pick<SettingsService, 'bootstrap'>
+    emitInstallEvent: (event: ClaudeInstallEvent) => void
+    snapshotCommits: SettingsSnapshotCommitOwner
+  }
+): ApplicationCommandInstallation => {
+  const scope = registrar.createScope()
+  try {
+    scope.registerGroup(bootstrapApplicationCommandGroup, {
+      'settings:bootstrap': ({ args, callerContext }) => {
+        if (callerContext.location !== 'local') return { ok: false, code: 'invalid_request' }
+        const pending = dependencies.service.bootstrap(args[0], dependencies.emitInstallEvent)
+        return args[0]?.action === 'status'
+          ? pending
+          : dependencies.snapshotCommits.projectAfter(pending)
+      }
+    })
+    return scope.complete()
+  } catch (error) {
+    scope.rollback()
+    throw error
+  }
+}

--- a/src/main/settings/bootstrap.integration.test.ts
+++ b/src/main/settings/bootstrap.integration.test.ts
@@ -1,0 +1,280 @@
+import { mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it, vi } from 'vitest'
+import { createApplicationCommandRouter } from '../application-command-router'
+import type { ApplicationCommandByNameDispatcher } from '../application-command-composition'
+import { ApplicationEventHub } from '../application-events'
+import { SettingsSnapshotCommitOwner } from './settings-snapshot-commit-owner'
+import {
+  bootstrapApplicationCommandGroup,
+  registerBootstrapApplicationCommands
+} from './bootstrap-application-commands'
+import { HeadlessTaskApi } from '../web-service/task-api'
+import { startWebHttpServer, type RunningWebServer } from '../web-service/http-server'
+import { createProjectDbClient, migrateApplicationDatabase } from '../projects/prisma-client'
+import { ProjectRepository } from '../projects/repository'
+import { SessionRepository } from '../session-persistence/repository'
+import { SessionPersistenceCoordinator } from '../session-persistence/coordinator'
+import type { CodexAuthStatus } from './codex-auth'
+import type { OpenScienceClient as PublicClient } from '../../../packages/open-science/index'
+import type { TaskAgentPort } from '../tasks/task-runner'
+// @ts-expect-error The JavaScript CLI command intentionally has no declaration file.
+import { codexLoginCommand } from '../../../packages/open-science/codex-login.mjs'
+// @ts-expect-error The published ESM entry uses a sibling index.d.ts.
+import { OpenScienceClient } from '../../../packages/open-science/index.mjs'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/nonexistent', getAppPath: () => '/nonexistent', isPackaged: false },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString()
+  },
+  net: { fetch: (...args: Parameters<typeof fetch>) => fetch(...args) }
+}))
+
+const { SettingsService } = await import('./service')
+const { SettingsRepository } = await import('./repository')
+
+it('bootstraps through real local HTTP, restarts the profile, and submits a persisted Task', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'osci-bootstrap-integration-'))
+  const adapterPath = join(root, 'adapter.mjs')
+  const nativePath = join(root, 'codex')
+  let installed = false
+  const install = vi.fn(async () => {
+    await writeFile(nativePath, 'synthetic runtime')
+    await writeFile(adapterPath, 'synthetic adapter')
+    installed = true
+    return {
+      result: { installId: 'fixture', ok: true },
+      adapterPath,
+      adapterVersion: '1.6.2',
+      codexPath: nativePath,
+      codexVersion: '0.114.0'
+    }
+  })
+  const status = async (): Promise<CodexAuthStatus> => ({
+    mode: 'isolated' as const,
+    supported: true,
+    authenticated: await readFile(join(root, 'codex-subscription', 'auth.json'), 'utf8').then(
+      () => true,
+      () => false
+    )
+  })
+  const options = {
+    configRoot: root,
+    userClaudeDir: join(root, 'external-claude'),
+    userCodexDir: join(root, 'external-codex'),
+    userAgentsDir: join(root, 'external-agents'),
+    detectDeps: {
+      env: {},
+      homePath: root,
+      platform: process.platform,
+      isExecutable: async () => false,
+      getVersion: async () => undefined,
+      resolveNpmBinDirs: async () => []
+    },
+    codexDetectDeps: {
+      env: {},
+      homePath: root,
+      platform: process.platform,
+      managedAdapterPath: adapterPath,
+      managedCodexPath: nativePath,
+      isRunnable: async () => installed,
+      getAdapterVersion: async () => (installed ? '1.6.2' : undefined),
+      getCodexVersion: async () => (installed ? '0.114.0' : undefined),
+      smokeInitialize: async () => true,
+      resolveNpmBinDirs: async () => []
+    },
+    installManagedCodexImpl: install,
+    codexAuth: {
+      getStatus: status,
+      loginIsolated: status,
+      cancelLogin: async () => {},
+      logoutIsolated: status
+    }
+  }
+  let service = new SettingsService(options)
+  const db = createProjectDbClient(root)
+  await migrateApplicationDatabase(db)
+  const projects = new ProjectRepository(async () => db)
+  const sessions = new SessionRepository(root)
+  // No files are produced by the synthetic model; the real session coordinator owns all writes.
+  const coordinator = new SessionPersistenceCoordinator(sessions, {
+    syncSession: async () => [],
+    softDeleteSession: async () => 'deleted',
+    restoreSession: async () => {},
+    softDeleteProject: async () => 'deleted',
+    reconcileActiveSessions: async () => {},
+    reconcileProjectSessions: async () => {},
+    markReconciliationIncomplete: () => {}
+  })
+  let api: HeadlessTaskApi | undefined
+  let server: RunningWebServer | undefined
+  const prompt = vi.fn<TaskAgentPort['prompt']>(async () => {})
+  const start = async (): Promise<PublicClient> => {
+    const events = new ApplicationEventHub()
+    const router = createApplicationCommandRouter()
+    registerBootstrapApplicationCommands(router.registrar, {
+      service,
+      emitInstallEvent: () => {},
+      snapshotCommits: new SettingsSnapshotCommitOwner(service, events)
+    })
+    const commands: ApplicationCommandByNameDispatcher = {
+      commandNames: router.dispatcher.commandNames,
+      invoke: async (name, invocation) => {
+        const args = invocation.args
+        switch (name) {
+          case 'settings:get-settings':
+            return service.getSettingsView()
+          case 'projects:list':
+            return projects.list()
+          case 'sessions:load-all':
+            return sessions.loadAll()
+          case 'sessions:save-session':
+            return coordinator.saveSession(args[0] as Parameters<typeof coordinator.saveSession>[0])
+          case 'sessions:stage-task-completion':
+            return coordinator.stageTaskCompletion(
+              args[0] as Parameters<typeof coordinator.stageTaskCompletion>[0]
+            )
+          case 'sessions:settle-task-completion':
+            return coordinator.settleTaskCompletion(
+              args[0] as Parameters<typeof coordinator.settleTaskCompletion>[0]
+            )
+          case 'sessions:fail-task-run':
+            return coordinator.failTaskRun(args[0] as Parameters<typeof coordinator.failTaskRun>[0])
+          default: {
+            const command = bootstrapApplicationCommandGroup.commands.find(
+              (command) => command.name === name
+            )
+            if (!command) throw new Error(`Unexpected application command: ${name}`)
+            return router.dispatcher.invoke(command, {
+              ...invocation,
+              args: invocation.args as readonly [import('../../shared/bootstrap').BootstrapRequest]
+            })
+          }
+        }
+      }
+    }
+    api = new HeadlessTaskApi({
+      commands,
+      agent: {
+        withSessionAvailable: async (_project, _session, operation) => operation(),
+        listAttachedSessionIds: async () => [],
+        createSession: async () => {
+          const settings = await service.getSettingsView()
+          expect(settings.activeProviderId).toBe('builtin-codex-subscription')
+          return {
+            sessionId: 'first-cli-session',
+            frameworkId: settings.agentFrameworkId,
+            backendId: settings.activeProviderId
+          }
+        },
+        resumeSession: async (request) => ({ sessionId: request.sessionId }),
+        setPermissionProfile: async () => {},
+        setMemoryEnabled: async () => {},
+        prompt,
+        cancelPrompt: async () => {}
+      }
+    })
+    server = await startWebHttpServer({
+      host: '127.0.0.1',
+      port: 0,
+      token: 'fixture',
+      staticRoot: root,
+      applicationCommands: {
+        localWeb: commands,
+        remoteWeb: { ...commands, rejectedCommandNames: () => [] }
+      },
+      applicationEvents: events,
+      tasks: api,
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: 'test',
+        configRoot: root,
+        platform: process.platform,
+        versions: { electron: '', chrome: '', node: process.version }
+      }
+    })
+    return new OpenScienceClient({ baseUrl: `http://127.0.0.1:${server.port}`, token: 'fixture' })
+  }
+  let client = await start()
+  const runCodex = vi.fn(async (_path, args) => {
+    if (args.includes('--device-auth')) {
+      const home = join(root, 'codex-subscription')
+      await mkdir(home, { recursive: true })
+      await writeFile(
+        join(home, 'auth.json'),
+        JSON.stringify({
+          last_refresh: '2026-09-12T00:00:00Z',
+          tokens: {
+            access_token: 'synthetic-token',
+            refresh_token: 'synthetic-refresh',
+            id_token: 'eyJhbGciOiJub25lIn0.eyJzdWIiOiJ0ZXN0In0.signature'
+          }
+        })
+      )
+      return { code: 0 }
+    }
+    return { code: (await status()).authenticated ? 0 : 1 }
+  })
+  try {
+    const dependencies = {
+      locateApp: async () => ({ packaged: false }),
+      connect: async () => client,
+      runCodex,
+      log: vi.fn()
+    }
+    await codexLoginCommand({ configRoot: root }, dependencies)
+    expect(install).toHaveBeenCalledOnce()
+    const beforeStatus = await new SettingsRepository(root).getSettings()
+    expect(await service.bootstrap({ action: 'status' }, () => {})).toMatchObject({
+      ok: true,
+      next: { provider: ['codex', 'login', '--force'] }
+    })
+    expect(await new SettingsRepository(root).getSettings()).toEqual(beforeStatus)
+    expect((await service.getPreflight()).providerReadiness).toEqual({ status: 'ready' })
+    await server!.close()
+    await api!.dispose()
+    await service.dispose()
+    service = new SettingsService(options)
+    client = await start()
+    await codexLoginCommand({ configRoot: root }, dependencies)
+    expect(install).toHaveBeenCalledOnce()
+    expect(runCodex.mock.calls.filter(([, args]) => args.includes('--device-auth'))).toHaveLength(1)
+    expect((await new SettingsRepository(root).getSettings()).activeProviderId).toBe(
+      'builtin-codex-subscription'
+    )
+    expect((await service.getPreflight()).runtimeReadiness).toEqual({ status: 'ready' })
+    const project = await projects.create({ name: 'First CLI research' })
+    const run = await client.startRun({
+      project: project.id,
+      prompt: 'Synthetic first research task',
+      cwd: root
+    })
+    await expect.poll(async () => (await client.getRun(run.id)).status).toBe('completed')
+    expect(prompt).toHaveBeenCalledOnce()
+    const persisted = (await new SessionRepository(root).loadAll()).sessions.find(
+      (session) => session.id === run.sessionId
+    )
+    expect(persisted).toMatchObject({
+      projectId: project.id,
+      status: 'idle',
+      agentFrameworkId: 'codex'
+    })
+    expect(
+      persisted?.messages.some((message) => message.content === 'Synthetic first research task')
+    ).toBe(true)
+    expect(
+      // @ts-expect-error Exercise server-side validation independently of SDK types.
+      await client.bootstrap({ action: 'provider', key: 'secret', unexpected: true })
+    ).toEqual({ ok: false, code: 'invalid_request' })
+  } finally {
+    await server?.close()
+    await api?.dispose()
+    await service.dispose()
+    await db.$disconnect()
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/src/main/settings/connector-settings.test.ts
+++ b/src/main/settings/connector-settings.test.ts
@@ -43,6 +43,40 @@ const { ALL_CONNECTOR_IDS } = await import('../connectors/registry')
 
 // Exercises the durable Connector owner against a real on-disk repository.
 describe('ConnectorSettingsModule', () => {
+  it('validates OpenAlex before saving, persists enablement, and refuses to replace a key', async () => {
+    const probe = vi.fn<typeof fetch>().mockResolvedValue(new Response(null, { status: 401 }))
+    service = new ConnectorSettingsModule(repository, probe)
+    const before = await repository.getSettings()
+    await expect(service.bootstrapOpenAlex('synthetic-key')).rejects.toMatchObject({
+      code: 'credential_invalid'
+    })
+    expect(await repository.getSettings()).toEqual(before)
+    await repository.setConnectorDisabled('literature', true)
+    probe.mockResolvedValue(new Response(null, { status: 200 }))
+    await service.bootstrapOpenAlex('synthetic-key')
+    const first = await new SettingsRepository(dir).getSettings()
+    expect(first.connectors?.openAlexApiKeyRef).toBeTruthy()
+    expect(first.connectors?.disabledConnectorIds ?? []).not.toContain('literature')
+    await service.bootstrapOpenAlex('synthetic-key')
+    expect((await repository.getSettings()).connectors?.openAlexApiKeyRef).toBe(
+      first.connectors?.openAlexApiKeyRef
+    )
+    await expect(service.bootstrapOpenAlex('replacement')).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect(await repository.getSettings()).toEqual(first)
+  })
+
+  it('preserves an OpenAlex key changed while a bootstrap probe is pending', async () => {
+    service = new ConnectorSettingsModule(repository, async () => {
+      await service.setOpenAlexCredential({ apiKey: 'human-key' })
+      return new Response(null, { status: 200 })
+    })
+    await expect(service.bootstrapOpenAlex('synthetic-key')).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect(keychain.encryptedValues).toContain('human-key')
+  })
   let dir: string
   let service: InstanceType<typeof ConnectorSettingsModule>
   let repository: InstanceType<typeof SettingsRepository>

--- a/src/main/settings/connector-settings.ts
+++ b/src/main/settings/connector-settings.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { isDeepStrictEqual } from 'node:util'
+import { BootstrapError } from '../../shared/bootstrap'
 
 import type {
   AddCustomServerRequest,
@@ -591,6 +592,15 @@ class ConnectorSettingsModule {
     const apiKey = request.apiKey.trim()
     await this.repository.setOpenAlexCredential(apiKey ? encryptKey(apiKey) : undefined)
     return this.connectorsSnapshot()
+  }
+
+  async bootstrapOpenAlex(key: string): Promise<void> {
+    const existing = (await this.repository.getSettings()).connectors
+    const ref = existing?.openAlexApiKeyRef
+    if (ref && tryDecryptKey(ref) !== key) throw new BootstrapError('configuration_conflict')
+    const result = await this.validateOpenAlexCredential({ apiKey: key })
+    if (!result.valid) throw new BootstrapError('credential_invalid')
+    await this.repository.publishBootstrapOpenAlex(existing, ref ?? encryptKey(key))
   }
 
   async validateOpenAlexCredential(

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -67,6 +67,32 @@ describe('ProviderAccountsModule', () => {
     expect(validate).toHaveBeenCalledTimes(2)
   })
 
+  it.each([undefined, 'cli-openai'])(
+    'rejects bootstrap with coexisting providers when active provider is %s',
+    async (activeProviderId) => {
+      await repository.setAgentFramework('codex')
+      const validate = vi
+        .spyOn(module, 'validateProvider')
+        .mockResolvedValue({ ok: true, category: 'ok' })
+      await module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')
+      await repository.upsertProvider({
+        id: 'other-openai',
+        name: 'Existing account',
+        type: 'official',
+        vendorId: 'openai',
+        model: 'gpt-5.4'
+      })
+      await repository.setActiveProvider(activeProviderId)
+      const before = await repository.getSettings()
+      validate.mockClear()
+      await expect(module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')).rejects.toMatchObject({
+        code: 'configuration_conflict'
+      })
+      expect(validate).not.toHaveBeenCalled()
+      expect(await new SettingsRepository(dir).getSettings()).toEqual(before)
+    }
+  )
+
   it('does not publish API credentials if Settings changes during the probe', async () => {
     await repository.setAgentFramework('codex')
     vi.spyOn(module, 'validateProvider').mockImplementation(async () => {

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -67,6 +67,41 @@ describe('ProviderAccountsModule', () => {
     expect(validate).toHaveBeenCalledTimes(2)
   })
 
+  it('revalidates the selected model without replacing the provider default or key', async () => {
+    await repository.setAgentFramework('codex')
+    const validate = vi
+      .spyOn(module, 'validateProvider')
+      .mockResolvedValue({ ok: true, category: 'ok' })
+    await module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')
+    const existing = (await repository.getSettings()).providers[0]
+    const keyRef = existing.keyRef
+    await repository.upsertProvider({ ...existing, name: 'My research account' })
+    await repository.setActiveProvider('cli-openai', 'gpt-5.4-mini')
+    await expect(module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    await module.bootstrapOpenAi('synthetic-key', 'gpt-5.4-mini')
+    expect(validate).toHaveBeenLastCalledWith({
+      draft: { type: 'official', vendorId: 'openai', model: 'gpt-5.4-mini', key: 'synthetic-key' }
+    })
+    const saved = await new SettingsRepository(dir).getSettings()
+    expect(saved.activeModel).toBe('gpt-5.4-mini')
+    expect(saved.providers[0]).toMatchObject({
+      model: 'gpt-5.4',
+      name: 'My research account',
+      keyRef,
+      lastValidatedTarget: { model: 'gpt-5.4-mini', endpoint: 'responses' }
+    })
+    validate.mockImplementation(async () => {
+      await repository.setActiveProvider('cli-openai', 'gpt-5.4')
+      return { ok: true, category: 'ok' }
+    })
+    await expect(module.bootstrapOpenAi('synthetic-key', 'gpt-5.4-mini')).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect((await repository.getSettings()).activeModel).toBe('gpt-5.4')
+  })
+
   it.each([undefined, 'cli-openai'])(
     'rejects bootstrap with coexisting providers when active provider is %s',
     async (activeProviderId) => {

--- a/src/main/settings/provider-accounts.test.ts
+++ b/src/main/settings/provider-accounts.test.ts
@@ -44,6 +44,101 @@ const deferred = <T>(): {
 }
 
 describe('ProviderAccountsModule', () => {
+  it('publishes only validated API credentials, repeats safely, and refuses replacement', async () => {
+    await repository.setAgentFramework('codex')
+    const validate = vi
+      .spyOn(module, 'validateProvider')
+      .mockResolvedValue({ ok: true, category: 'ok' })
+    await module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')
+    const first = await repository.getSettings()
+    await module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')
+    const restored = await new SettingsRepository(dir).getSettings()
+    expect(restored.providers).toHaveLength(1)
+    expect(restored.providers[0].keyRef).toBe(first.providers[0].keyRef)
+    expect(restored.providers[0].lastValidatedTarget).toEqual({
+      model: 'gpt-5.4',
+      endpoint: 'responses'
+    })
+    expect(restored.activeProviderId).toBe('cli-openai')
+    await expect(module.bootstrapOpenAi('different-key', 'gpt-5.4')).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect(await repository.getSettings()).toEqual(restored)
+    expect(validate).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not publish API credentials if Settings changes during the probe', async () => {
+    await repository.setAgentFramework('codex')
+    vi.spyOn(module, 'validateProvider').mockImplementation(async () => {
+      await repository.setAgentFramework('opencode')
+      return { ok: true, category: 'ok' }
+    })
+    await expect(module.bootstrapOpenAi('synthetic-key', 'gpt-5.4')).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect((await repository.getSettings()).providers).toEqual([])
+  })
+  it('bootstraps an app-owned CLI login without deleting authentication and restores it after restart', async () => {
+    await repository.setAgentFramework('codex')
+    const home = codexSubscriptionStorageDir(dir)
+    await mkdir(home, { recursive: true })
+    const auth = JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'synthetic-cli-token' })
+    await writeFile(join(home, 'auth.json'), auth)
+    await module.prepareBootstrapCodex()
+    expect((await repository.getSettings()).activeProviderId).toBeUndefined()
+    expect(await readFile(join(home, 'auth.json'), 'utf8')).toBe(auth)
+    await module.completeBootstrapCodex()
+    await module.prepareBootstrapCodex()
+    await module.completeBootstrapCodex()
+    const restored = await new SettingsRepository(dir).getSettings()
+    expect(restored.providers).toHaveLength(1)
+    expect(restored.activeProviderId).toBe('builtin-codex-subscription')
+    expect(restored.providers[0].lastValidatedAt).toEqual(expect.any(Number))
+    expect(await readFile(join(home, 'auth.json'), 'utf8')).toBe(auth)
+  })
+
+  it('does not activate rejected subscription credentials', async () => {
+    await repository.setAgentFramework('codex')
+    await module.prepareBootstrapCodex()
+    vi.mocked(codexAuth.getStatus).mockResolvedValue({
+      mode: 'isolated',
+      supported: true,
+      authenticated: false
+    })
+    await expect(module.completeBootstrapCodex()).rejects.toMatchObject({
+      code: 'credential_invalid'
+    })
+    expect((await repository.getSettings()).activeProviderId).toBeUndefined()
+  })
+
+  it('does not activate a login if Settings changed during validation', async () => {
+    await repository.setAgentFramework('codex')
+    await module.prepareBootstrapCodex()
+    await writeFile(
+      join(codexSubscriptionStorageDir(dir), 'auth.json'),
+      JSON.stringify({ auth_mode: 'apikey', OPENAI_API_KEY: 'synthetic' })
+    )
+    vi.mocked(codexAuth.getStatus).mockImplementation(async () => {
+      await repository.setAgentFramework('opencode')
+      return { mode: 'isolated', supported: true, authenticated: true }
+    })
+    await expect(module.completeBootstrapCodex()).rejects.toMatchObject({
+      code: 'configuration_conflict'
+    })
+    expect((await repository.getSettings()).activeProviderId).toBeUndefined()
+  })
+
+  it('validates an API key before any provider or credential publication', async () => {
+    await repository.setAgentFramework('codex')
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('invalid key', { status: 401 })))
+    await expect(module.bootstrapOpenAi('synthetic-invalid-key', 'gpt-5.4')).rejects.toMatchObject({
+      code: 'credential_invalid'
+    })
+    const restored = await new SettingsRepository(dir).getSettings()
+    expect(restored.providers).toEqual([])
+    expect(restored.activeProviderId).toBeUndefined()
+    vi.unstubAllGlobals()
+  })
   let dir: string
   let repository: InstanceType<typeof SettingsRepository>
   let codexAuth: CodexAuthControllerPort

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -1,3 +1,5 @@
+import { BootstrapError } from '../../shared/bootstrap'
+import { ensureCodexAuthHome } from './codex-auth'
 import type {
   ChatApiEndpoint,
   ProviderDraft,
@@ -116,6 +118,108 @@ class ProviderAccountsModule {
 
   async dispose(): Promise<void> {
     await Promise.all([this.auth.dispose(), Promise.resolve().then(() => this.xai.cancelLogin())])
+  }
+
+  async prepareBootstrapCodex(): Promise<void> {
+    await this.auth.serializeAccountMutation(async () => {
+      const settings = await this.repository.getSettings()
+      const identity = codexSubscriptionProviderIdentity()
+      const existing = settings.providers.find(({ id }) => id === identity.id)
+      if (
+        (settings.providers.length > 0 && !existing) ||
+        (existing &&
+          (existing.type !== 'codex-isolated' || existing.codexAuthMode !== 'isolated')) ||
+        (settings.activeProviderId && settings.activeProviderId !== identity.id)
+      )
+        throw new BootstrapError('configuration_conflict')
+      // The historical CLI may have already signed in to this app-owned home. Creating the
+      // provider through ordinary upsert would clear that authentication; never import or clear it.
+      await ensureCodexAuthHome('isolated', this.options.storageRoot, existing?.codexTransport)
+      if (!existing)
+        await this.repository.publishBootstrapProvider(
+          settings,
+          {
+            ...identity,
+            type: 'codex-isolated',
+            codexAuthMode: 'isolated',
+            apiEndpoints: ['responses']
+          },
+          false
+        )
+    })
+  }
+
+  async completeBootstrapCodex(): Promise<string> {
+    return this.auth.serializeAccountMutation(async () => {
+      const settings = await this.repository.getSettings()
+      const identity = codexSubscriptionProviderIdentity()
+      const provider = settings.providers.find(({ id }) => id === identity.id)
+      if (provider?.type !== 'codex-isolated' || provider.codexAuthMode !== 'isolated')
+        throw new BootstrapError('configuration_conflict')
+      const result = await this.auth.validateProviderAuth(
+        this.resolveProvider(provider),
+        settings,
+        provider
+      )
+      if (!result?.ok || !(await this.auth.isProviderKeyUsable(provider)))
+        throw new BootstrapError('credential_invalid')
+      await this.repository.publishBootstrapProvider(
+        settings,
+        {
+          ...provider,
+          ...buildProviderValidationPatch(provider, result, undefined)
+        },
+        true
+      )
+      return provider.id
+    })
+  }
+
+  async bootstrapOpenAi(key: string, model: string): Promise<string> {
+    const settings = await this.repository.getSettings()
+    const id = 'cli-openai'
+    const existing = settings.providers.find((provider) => provider.id === id)
+    if (
+      settings.agentFrameworkId !== 'codex' ||
+      (settings.providers.length > 0 && !existing) ||
+      (settings.activeProviderId && settings.activeProviderId !== id) ||
+      (existing &&
+        (existing.type !== 'official' ||
+          existing.vendorId !== 'openai' ||
+          existing.model !== model ||
+          !existing.keyRef ||
+          tryDecryptKey(existing.keyRef) !== key))
+    )
+      throw new BootstrapError('configuration_conflict')
+    if (
+      this.resolveActiveModel(
+        existing ?? { id, type: 'official', vendorId: 'openai', name: 'OpenAI', model },
+        model
+      ) !== model
+    )
+      throw new BootstrapError('invalid_request')
+    const draft = { type: 'official' as const, vendorId: 'openai' as const, model, key }
+    const result = await this.validateProvider({ draft })
+    if (!result.ok) throw new BootstrapError('credential_invalid')
+    const provider: StoredProvider = {
+      ...existing,
+      id,
+      type: 'official',
+      vendorId: 'openai',
+      name: 'OpenAI',
+      model,
+      keyRef: existing?.keyRef ?? encryptKey(key),
+      keyMask: maskKey(key)
+    }
+    await this.repository.publishBootstrapProvider(
+      settings,
+      {
+        ...provider,
+        ...buildProviderValidationPatch(provider, result, { model, endpoint: 'responses' })
+      },
+      true
+    )
+    return id
   }
 
   // Keeps provider-before-Connector ordering in SettingsService's whole-settings migration path.

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -181,7 +181,7 @@ class ProviderAccountsModule {
     const existing = settings.providers.find((provider) => provider.id === id)
     if (
       settings.agentFrameworkId !== 'codex' ||
-      (settings.providers.length > 0 && !existing) ||
+      settings.providers.some((provider) => provider.id !== id) ||
       (settings.activeProviderId && settings.activeProviderId !== id) ||
       (existing &&
         (existing.type !== 'official' ||

--- a/src/main/settings/provider-accounts.ts
+++ b/src/main/settings/provider-accounts.ts
@@ -186,7 +186,7 @@ class ProviderAccountsModule {
       (existing &&
         (existing.type !== 'official' ||
           existing.vendorId !== 'openai' ||
-          existing.model !== model ||
+          (settings.activeModel ?? existing.model) !== model ||
           !existing.keyRef ||
           tryDecryptKey(existing.keyRef) !== key))
     )
@@ -206,8 +206,8 @@ class ProviderAccountsModule {
       id,
       type: 'official',
       vendorId: 'openai',
-      name: 'OpenAI',
-      model,
+      name: existing?.name ?? 'OpenAI',
+      model: existing?.model ?? model,
       keyRef: existing?.keyRef ?? encryptKey(key),
       keyMask: maskKey(key)
     }

--- a/src/main/settings/repository.ts
+++ b/src/main/settings/repository.ts
@@ -1,4 +1,5 @@
 import { isDeepStrictEqual } from 'node:util'
+import { BootstrapError } from '../../shared/bootstrap'
 import type {
   AgentFrameworkId,
   AppIconVariant,
@@ -93,6 +94,71 @@ class SettingsRepository {
   // Reads and sanitizes the settings document, returning empty settings when nothing is stored yet.
   async getSettings(): Promise<StoredSettings> {
     return this.store.read()
+  }
+
+  async selectBootstrapCodex(): Promise<void> {
+    await this.mutate((settings) => {
+      if (settings.agentFrameworkId && settings.agentFrameworkId !== 'codex')
+        throw new BootstrapError('configuration_conflict')
+      if (!settings.agentFrameworkId && settings.providers.length > 0)
+        throw new BootstrapError('configuration_conflict')
+      return settings.agentFrameworkId === 'codex'
+        ? settings
+        : { ...settings, agentFrameworkId: 'codex' }
+    })
+  }
+
+  async publishBootstrapProvider(
+    expected: StoredSettings,
+    provider: StoredProvider,
+    activate: boolean
+  ): Promise<void> {
+    await this.mutate((settings) => {
+      if (
+        settings.agentFrameworkId !== 'codex' ||
+        !isDeepStrictEqual(settings.providers, expected.providers) ||
+        settings.activeProviderId !== expected.activeProviderId ||
+        settings.activeModel !== expected.activeModel ||
+        (settings.activeProviderId && settings.activeProviderId !== provider.id)
+      )
+        throw new BootstrapError('configuration_conflict')
+      const providers = settings.providers.some(({ id }) => id === provider.id)
+        ? settings.providers.map((entry) => (entry.id === provider.id ? provider : entry))
+        : [...settings.providers, provider]
+      return {
+        ...settings,
+        providers,
+        ...(activate
+          ? {
+              activeProviderId: provider.id,
+              activeModel:
+                settings.activeProviderId === provider.id ? settings.activeModel : provider.model
+            }
+          : {})
+      }
+    })
+  }
+
+  async publishBootstrapOpenAlex(
+    expected: StoredConnectors | undefined,
+    apiKeyRef: string
+  ): Promise<void> {
+    await this.mutate((settings) => {
+      if (!isDeepStrictEqual(settings.connectors, expected))
+        throw new BootstrapError('configuration_conflict')
+      return {
+        ...settings,
+        connectors: {
+          enabledIds: [],
+          autoAllowIds: [],
+          ...settings.connectors,
+          openAlexApiKeyRef: apiKeyRef,
+          disabledConnectorIds: (settings.connectors?.disabledConnectorIds ?? []).filter(
+            (id) => id !== 'literature'
+          )
+        }
+      }
+    })
   }
 
   // Inserts or replaces a provider without reordering existing entries. existingId, when supplied,

--- a/src/main/settings/service.providers.test.ts
+++ b/src/main/settings/service.providers.test.ts
@@ -30,6 +30,38 @@ describe('SettingsService provider facade', () => {
     }
   })
 
+  it('builds read-only bootstrap recovery for the selected active model', async () => {
+    await repository.setAgentFramework('codex')
+    await repository.upsertProvider({
+      id: 'cli-openai',
+      name: 'OpenAI',
+      type: 'official',
+      vendorId: 'openai',
+      model: 'gpt-5.4'
+    })
+    await repository.setActiveProvider('cli-openai', 'gpt-5.4-mini')
+    const before = await repository.getSettings()
+    expect(await service.bootstrap({ action: 'status' }, () => {})).toMatchObject({
+      ok: true,
+      next: {
+        provider: [
+          'provider',
+          'add',
+          '--type',
+          'official',
+          '--vendor',
+          'openai',
+          '--model',
+          'gpt-5.4-mini',
+          '--api-key-env',
+          'OPENAI_API_KEY',
+          '--json'
+        ]
+      }
+    })
+    expect(await repository.getSettings()).toEqual(before)
+  })
+
   it('projects file storage capability and leaves legacy refs unchanged', async () => {
     configureCredentialStore(['--credential-store=file'], 'linux', true)
     try {

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1,6 +1,11 @@
 import { homedir } from 'node:os'
 import { readFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import {
+  BootstrapError,
+  bootstrapRequestSchema,
+  type BootstrapResult
+} from '../../shared/bootstrap'
 
 import type { CloseActionPreference } from '../../shared/window-controls'
 import type {
@@ -1115,6 +1120,69 @@ class SettingsService {
   // Computes the startup gates from a fresh or immediate startup-chain runtime probe.
   async getPreflight(): Promise<ReadinessPreflight> {
     return this.runtimeManager.getPreflight(this.providers)
+  }
+
+  async bootstrap(
+    input: unknown,
+    onEvent: (event: ClaudeInstallEvent) => void
+  ): Promise<BootstrapResult> {
+    const parsed = bootstrapRequestSchema.safeParse(input)
+    if (!parsed.success) return { ok: false, code: 'invalid_request' }
+    const request = parsed.data
+    try {
+      if (request.action === 'status') {
+        const settings = await this.repository.getSettings()
+        const canPrepareCodex =
+          settings.agentFrameworkId === 'codex' ||
+          (!settings.agentFrameworkId && settings.providers.length === 0)
+        const provider =
+          settings.providers.find(({ id }) => id === settings.activeProviderId) ??
+          settings.providers[0]
+        const providerArgv = !provider
+          ? ['codex', 'login']
+          : provider.type === 'codex-isolated' && provider.codexAuthMode === 'isolated'
+            ? ['codex', 'login', '--force']
+            : provider.id === 'cli-openai' &&
+                provider.type === 'official' &&
+                provider.vendorId === 'openai' &&
+                provider.model
+              ? [
+                  'provider',
+                  'add',
+                  '--type',
+                  'official',
+                  '--vendor',
+                  'openai',
+                  '--model',
+                  provider.model,
+                  '--api-key-env',
+                  'OPENAI_API_KEY',
+                  '--json'
+                ]
+              : undefined
+        return {
+          ok: true,
+          next: canPrepareCodex
+            ? { runtime: ['runtime', 'install', 'codex', '--json'], provider: providerArgv }
+            : {}
+        }
+      }
+      if (request.action === 'runtime' || request.action === 'codex-prepare') {
+        await this.runtimeManager.bootstrapCodex(onEvent)
+        if (request.action === 'codex-prepare') await this.providers.prepareBootstrapCodex()
+      } else if (request.action === 'codex-complete') {
+        return { ok: true, providerId: await this.providers.completeBootstrapCodex() }
+      } else if (request.action === 'provider') {
+        return {
+          ok: true,
+          providerId: await this.providers.bootstrapOpenAi(request.key, request.model)
+        }
+      } else await this.connectors.bootstrapOpenAlex(request.key)
+      return { ok: true }
+    } catch (error) {
+      // Installer/provider exceptions can contain secret inputs. Only return our closed codes.
+      return { ok: false, code: error instanceof BootstrapError ? error.code : 'bootstrap_failed' }
+    }
   }
 
   // Re-runs the complete host inspection on every app launch, for the SELECTED framework's runtime, so

--- a/src/main/settings/service.ts
+++ b/src/main/settings/service.ts
@@ -1154,7 +1154,7 @@ class SettingsService {
                   '--vendor',
                   'openai',
                   '--model',
-                  provider.model,
+                  settings.activeModel ?? provider.model,
                   '--api-key-env',
                   'OPENAI_API_KEY',
                   '--json'

--- a/src/main/settings/settings-backend.architecture.test.ts
+++ b/src/main/settings/settings-backend.architecture.test.ts
@@ -355,9 +355,12 @@ describe('Settings backend ownership architecture', () => {
       'markLegacyDataMovePromptDismissed',
       'markOnboardingComplete',
       'markPathsNormalized',
+      'publishBootstrapOpenAlex',
+      'publishBootstrapProvider',
       'rememberCodexAutoHttpsFallback',
       'removeCustomServer',
       'restoreLocalShellRuntime',
+      'selectBootstrapCodex',
       'setActiveProvider',
       'setAgentEnvironmentCreationEnabled',
       'setAgentFramework',
@@ -413,10 +416,12 @@ describe('Settings backend ownership architecture', () => {
     ])
     expect(publicOperationsOf(settingsPaths.providerAccounts, 'ProviderAccountsModule')).toEqual([
       'beginXaiOAuthLogin',
+      'bootstrapOpenAi',
       'cancelClaudeIsolatedLogin',
       'cancelClaudeLogin',
       'cancelCodexLogin',
       'cancelXaiOAuthLogin',
+      'completeBootstrapCodex',
       'deleteProvider',
       'dispose',
       'getClaudeIsolatedStatus',
@@ -432,6 +437,7 @@ describe('Settings backend ownership architecture', () => {
       'logoutIsolatedCodex',
       'logoutXaiOAuth',
       'migrateLegacyKeyRefs',
+      'prepareBootstrapCodex',
       'refreshProviderModels',
       'resolveActiveModel',
       'resolveProvider',
@@ -481,7 +487,7 @@ describe('Settings backend ownership architecture', () => {
   it('locks the SettingsService application interface', () => {
     expect(publicOperationsOf(settingsPaths.service, 'SettingsService')).toEqual(
       `
-        addCustomServer addManualInterpreter admitReviewerExecutionModel admitSessionDetailsExecutionTarget admitSubagentExecutionModel admitVisionModel allowNotebookNetworkDomain authenticateCustomServer authenticateDeviceCredential buildCustomServerTemplateExport
+        addCustomServer addManualInterpreter admitReviewerExecutionModel admitSessionDetailsExecutionTarget admitSubagentExecutionModel admitVisionModel allowNotebookNetworkDomain authenticateCustomServer authenticateDeviceCredential bootstrap buildCustomServerTemplateExport
         buildSkillExport beginXaiOAuthLogin cancelClaudeIsolatedLogin cancelClaudeLogin cancelCodexLogin cancelCustomServerAuthentication cancelDeviceCredentialAuthentication cancelXaiOAuthLogin captureActiveAgentBackendSelection captureActiveExplicitAgentBackendTarget checkEnvironment clearGrantedLocalRoots codeBuddySkillCatalog codexSkillCatalog
         codexSkillDescriptorsForIds createDeviceCredential createSkill deleteProvider deleteSkill detectClaude detectCodeBuddy detectCodex
         detectOpencode deviceCredentialConsumerIds deviceCredentialIdForServer disconnectCustomServer disconnectDeviceCredential dismissLegacyDataMovePrompt getActiveInstallId getAgentEnvironmentCreationEnabled getAppIconVariant getClosePreference
@@ -596,6 +602,7 @@ describe('Settings backend ownership architecture', () => {
     expect(importersOf(settingsPaths.service)).toEqual([
       'src/main/ipc.ts',
       'src/main/settings/application-commands.ts',
+      'src/main/settings/bootstrap-application-commands.ts',
       'src/main/settings/ipc.ts',
       'src/main/settings/service-capabilities.ts',
       'src/main/settings/workflows/appearance.ts',

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -4029,6 +4029,10 @@ describe('startWebHttpServer', () => {
       ((event: import('../../shared/task-api').TaskRunProgressEvent) => void) | undefined
     const tasks = {
       runWithCallerContext: runWithCapturedCallerContext,
+      bootstrap: vi.fn().mockResolvedValue({ ok: true }),
+      installCli: vi
+        .fn()
+        .mockResolvedValue({ installed: true, onPath: true, target: '/fixture/bin/open-science' }),
       doctor: vi.fn().mockResolvedValue({
         ready: false,
         checks: {
@@ -4148,6 +4152,17 @@ describe('startWebHttpServer', () => {
     servers.push(server)
     const base = `http://127.0.0.1:${server.port}`
     const headers = { authorization: 'Bearer test-token' }
+
+    const sdk = new OpenScienceClient({ baseUrl: base, token: 'test-token' })
+    expect(await sdk.bootstrap({ action: 'runtime' })).toEqual({ ok: true })
+    expect(tasks.bootstrap).toHaveBeenCalledWith({ action: 'runtime' })
+    expect(await sdk.installCli()).toMatchObject({ installed: true })
+    const unauthorizedBootstrap = await fetch(`${base}/api/v1/bootstrap`, {
+      method: 'POST',
+      body: '{}'
+    })
+    expect(unauthorizedBootstrap.status).toBe(401)
+    expect(tasks.bootstrap).toHaveBeenCalledOnce()
 
     const doctor = await fetch(`${base}/api/v1/doctor`, { headers })
     expect(doctor.status).toBe(200)

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -169,6 +169,8 @@ type WebServerOptions = {
         | 'getAgentRouting'
         | 'updateAgentRouting'
         | 'doctor'
+        | 'bootstrap'
+        | 'installCli'
       >
     >
   waitUntilTasksReady?: () => Promise<void>
@@ -994,6 +996,25 @@ const handleTaskApiRequest = async (
         const data = await tasks.doctor()
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, { data })
+        return true
+      }
+      if (url.pathname === '/api/v1/bootstrap' && request.method === 'POST' && tasks.bootstrap) {
+        const body = await readJsonBody(
+          request,
+          response,
+          requestBodyBudgetRegistry,
+          requestBodyClientId
+        )
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        const data = await tasks.bootstrap(
+          body as import('../../shared/bootstrap').BootstrapRequest
+        )
+        json(response, 200, { data })
+        return true
+      }
+      if (url.pathname === '/api/v1/cli/install' && request.method === 'POST' && tasks.installCli) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data: await tasks.installCli() })
         return true
       }
       const connectorMatch = url.pathname.match(

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -84,6 +84,11 @@ const commandsFrom = (
     invoke: async (channel, invocation) => {
       const args = [...invocation.args]
       if (channel === 'settings:get-settings') return taskSettings
+      if (channel === 'settings:bootstrap' && (args[0] as { action: string }).action === 'status')
+        return {
+          ok: true,
+          next: { runtime: ['runtime', 'install', 'codex', '--json'], provider: ['codex', 'login'] }
+        }
       try {
         const result = await invoke(channel, invocation.callerContext, args)
         if (channel === 'sessions:load-all') {
@@ -298,7 +303,10 @@ describe('HeadlessTaskApi adapter', () => {
         provider: { status: 'missing' },
         skills: { status: 'ready', enabled: ['literature-review', 'writing'] }
       },
-      next: [{ code: 'runtime_missing' }, { code: 'provider_missing' }]
+      next: [
+        { code: 'runtime_missing', argv: ['runtime', 'install', 'codex', '--json'] },
+        { code: 'provider_missing', argv: ['codex', 'login'] }
+      ]
     })
   })
 
@@ -330,7 +338,10 @@ describe('HeadlessTaskApi adapter', () => {
         provider: { status: 'not_ready', reason: 'credential_invalid' },
         skills: { status: 'ready', enabled: [] }
       },
-      next: [{ code: 'runtime_not_ready' }, { code: 'provider_not_ready' }]
+      next: [
+        { code: 'runtime_not_ready', argv: ['runtime', 'install', 'codex', '--json'] },
+        { code: 'provider_not_ready', argv: ['codex', 'login'] }
+      ]
     })
   })
 

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -1,3 +1,5 @@
+import type { BootstrapRequest, BootstrapResult } from '../../shared/bootstrap'
+import type { CliLauncherStatus } from '../../shared/cli'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
 
@@ -232,18 +234,35 @@ class HeadlessTaskApi {
     return this.runner.listProjects()
   }
 
+  async bootstrap(request: BootstrapRequest): Promise<BootstrapResult> {
+    this.requireLocalConnectorCaller()
+    return this.invoke('settings:bootstrap', request) as Promise<BootstrapResult>
+  }
+
+  async installCli(): Promise<CliLauncherStatus> {
+    this.requireLocalConnectorCaller()
+    return this.invoke('cli:install') as Promise<CliLauncherStatus>
+  }
+
   async doctor(): Promise<TaskDoctorReport> {
-    const [preflight, skills] = await Promise.all([
+    const [preflight, skills, bootstrap] = await Promise.all([
       this.invoke('settings:get-preflight') as Promise<ReadinessPreflight>,
-      this.invoke('settings:list-skills') as Promise<SkillView[]>
+      this.invoke('settings:list-skills') as Promise<SkillView[]>,
+      this.invoke('settings:bootstrap', { action: 'status' }) as Promise<BootstrapResult>
     ])
     const { runtimeReadiness, providerReadiness } = preflight
     const next: TaskDoctorReport['next'][number][] = []
     if (runtimeReadiness.status !== 'ready') {
-      next.push({ code: `runtime_${runtimeReadiness.status}` })
+      next.push({
+        code: `runtime_${runtimeReadiness.status}`,
+        ...(bootstrap.ok && bootstrap.next?.runtime ? { argv: bootstrap.next.runtime } : {})
+      })
     }
     if (providerReadiness.status !== 'ready') {
-      next.push({ code: `provider_${providerReadiness.status}` })
+      next.push({
+        code: `provider_${providerReadiness.status}`,
+        ...(bootstrap.ok && bootstrap.next?.provider ? { argv: bootstrap.next.provider } : {})
+      })
     }
     return {
       ready: runtimeReadiness.status === 'ready' && providerReadiness.status === 'ready',

--- a/src/shared/bootstrap.ts
+++ b/src/shared/bootstrap.ts
@@ -1,0 +1,35 @@
+import { z } from 'zod'
+
+export const bootstrapRequestSchema = z.discriminatedUnion('action', [
+  z.object({ action: z.literal('status') }).strict(),
+  z.object({ action: z.literal('runtime') }).strict(),
+  z.object({ action: z.literal('codex-prepare') }).strict(),
+  z.object({ action: z.literal('codex-complete') }).strict(),
+  z
+    .object({
+      action: z.literal('provider'),
+      key: z.string().trim().min(1).max(8192),
+      model: z.string().trim().min(1).max(256)
+    })
+    .strict(),
+  z.object({ action: z.literal('openalex'), key: z.string().trim().min(1).max(8192) }).strict()
+])
+
+export type BootstrapRequest = z.infer<typeof bootstrapRequestSchema>
+export type BootstrapResult =
+  | { ok: true; providerId?: string; next?: { runtime?: string[]; provider?: string[] } }
+  | {
+      ok: false
+      code:
+        | 'invalid_request'
+        | 'configuration_conflict'
+        | 'runtime_unavailable'
+        | 'credential_invalid'
+        | 'bootstrap_failed'
+    }
+
+export class BootstrapError extends Error {
+  constructor(readonly code: Exclude<BootstrapResult, { ok: true }>['code']) {
+    super(code)
+  }
+}

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -33,6 +33,7 @@ export type TaskDoctorReport = Readonly<{
   next: ReadonlyArray<
     Readonly<{
       code: 'runtime_missing' | 'runtime_not_ready' | 'provider_missing' | 'provider_not_ready'
+      argv?: readonly string[]
     }>
   >
 }>


### PR DESCRIPTION
## Problem

An empty installed profile cannot use `codex login`: the command requires a configured runtime, and terminal users cannot establish provider readiness without Settings. Addresses #1987.

## Proposed change

Add Codex runtime prepare/repair, terminal subscription registration, one initial OpenAI API-key provider, OpenAlex configure/enable, and PATH launcher commands. Doctor returns executable recovery argv. Authenticated local Task requests reuse the existing Settings, credential, installer, and launcher owners. A healthy runtime must pass ACP initialization as well as version probes.

## Scope and non-goals

- First-run Codex only; no standalone npm daemon, custom provider matrix, renderer settings expansion, or implicit runtime upgrade.
- Historical compatibility: preserve existing app-owned `codex-subscription` login material when creating the missing provider record; never import external `~/.codex` auth. Refuse conflicting configured framework/provider/key/model slots.
- New transient action literals: `status`, `runtime`, `codex-prepare`, `codex-complete`, `provider`, `openalex`. Result error codes: `invalid_request`, `configuration_conflict`, `runtime_unavailable`, `credential_invalid`, `bootstrap_failed`. No new persisted enum.
- Persistence: existing runtime/framework paths, provider credentials/validation/active selection, OpenAlex key/enablement, isolated auth files, managed runtime and PATH ownership receipts. No schema migration or bootstrap-complete flag.

## Acceptance criteria and validation

The final production implementation passes the following focused checks; no complete local `npm test` was run. PR CI remains the authority for complete and platform verification.

| Behavior | Check | Result |
| --- | --- | --- |
| Provider validation, native Responses/bridge routes, shared Settings consumers and owner boundaries | `npm run test:module -- settings_provider_accounts` | 22 files / 527 passed |
| CLI/SDK parsing and routing, HTTP auth, command registration, runtime/install/credential persistence, launcher and lifecycle consumers | Explicit Vitest Test Impact Set below | 36 files / 977 passed, 17 skipped |
| Empty profile -> local HTTP -> Settings -> restart -> Task submission and disk session | `npx vitest run src/main/settings/bootstrap.integration.test.ts` | Passed; synthetic external boundaries |
| Main/preload/shared and sandbox types | `npm run typecheck:node` | Passed |
| Renderer compatibility types | `npm run typecheck:web` | Passed |
| Source standards | `npm run lint` | Passed |
| Main/preload/renderer and authenticated Web bundles | `node node_modules/electron-vite/bin/electron-vite.js build`; `node node_modules/vite/bin/vite.js build --config vite.web.config.ts` | Passed |

The public CLI was also run on an empty development profile: `doctor --json` returns `daemon_unavailable` with `start --no-open` argv and exits 3; help lists the new setup commands. This verifies discovery/recovery output, not successful third-party login or research execution.

ACP wire behavior, history replay, permissions, lifecycle events, and subscription timing are unchanged. Codex response/bridge and Claude/OpenCode shared-owner compatibility are represented by the provider module's backend resolver/auth/validation suites; other launchers do not receive new bootstrap support. Local execution is macOS; Linux/Windows path/launcher fixtures are included, while native packaging/OS lanes remain CI responsibilities.

The integrated fixture uses real HTTP, Task routing, bootstrap command/snapshot owners, Settings/Session files and SQLite Project persistence. CLI connection discovery and the native runner are injected; external installation/version/ACP smoke probes, OAuth status, and model prompt are synthetic. Project fixture creation uses its repository and no output files are indexed. Real OAuth, third-party key acceptance, runtime download certification, and a live literature research result are not claimed.

<details>
<summary>Reproduce the explicit CLI/HTTP/runtime contract Test Impact Set</summary>

```sh
node node_modules/vitest/vitest.mjs run \
  src/main/settings/bootstrap.integration.test.ts \
  src/main/settings/connector-settings.test.ts \
  src/main/settings/repository.test.ts \
  src/main/settings/managed-codex.test.ts \
  src/main/settings/codex-detect.test.ts \
  src/main/settings/application-commands.test.ts \
  src/main/settings/integration-application-commands.test.ts \
  src/main/settings/provider-completion-races.test.ts \
  src/main/application-command-composition.test.ts \
  src/main/web-service/task-api.test.ts \
  src/main/web-service/http-server.test.ts \
  src/main/cli-install/launcher.test.ts \
  src/main/cli-install/ipc.test.ts \
  packages/open-science/cli.test.ts \
  packages/open-science/codex-login.test.ts \
  packages/open-science/client.test.ts \
  packages/open-science/connector.test.ts \
  packages/open-science/connector-types.test.ts cli
```

</details>

After the automated review correction rejecting coexisting providers, the provider module (527 tests), Node/sandbox typecheck, and lint were rerun and passed. The explicit contract set and main/preload/renderer build passed before this one-condition guard change; their boundaries are unchanged. Both new conflict regressions failed before the fix and pass afterward. Web-only typecheck/build precede the final main-only lifecycle wrapper; their source and contracts did not change. The final documentation-only correction removes unsupported `run --framework` syntax; the documented command sequence was checked against the CLI parser.

## Review focus

Validation before secret publication, first-slot compare-and-swap conflicts, preservation of historical app-owned auth, local-only command reachability, and repair of cached runtimes that cannot initialize ACP. Independent Standards and Spec review found no remaining blockers after the runtime-health and real-HTTP acceptance omissions were fixed.


## Review corrections and final CLI compatibility validation

- Preserve configured native Codex login when an older running daemon returns 404 for bootstrap; do not claim readiness registration. An empty profile receives the transient CLI `bootstrap_unavailable` error and an update/restart instruction. No data migration or persisted enum is added.
- Normalize a stale service record's explicit `ECONNREFUSED` to daemon unavailability. Preserve HTTP health/authentication failures as errors in doctor and Codex login rather than bypassing them.
- Regression tests failed before the fixes. After the final CLI behavior edit, `node node_modules/vitest/vitest.mjs run packages/open-science cli src/main/settings/bootstrap.integration.test.ts src/main/web-service/http-server.test.ts` passed: 28 files, 602 tests passed, 17 skipped. This includes real HTTP/bootstrap integration and 401/403/500 non-fallback coverage.
- Changes are JavaScript CLI/SDK behavior and tests/documentation; declared SDK types and application/renderer sources are unchanged. Previous process typechecks/builds and provider-module evidence remain applicable; current-head full/platform validation remains CI-owned.
- Independent review found no remaining blocker in these compatibility corrections.


### Multi-profile discovery trade-off

Preserve non-refusal errors across discovery candidates instead of allowing a later stale profile to hide an earlier HTTP authorization/configuration failure. Continue probing: a later healthy profile still wins. Only all-refused/no-state discovery produces the missing-daemon recovery report. This uses the existing discovery loop and adds no persisted state or public error code.

The regression uses two isolated, real state/token directories and exercises Doctor through the SDK; 401/403/500 errors are preserved in both candidate orders, all-refused candidates report missing, and a healthy later candidate succeeds. Before the fix: 3 failures / 2 passes. After the final production edit: the same explicit CLI/SDK/HTTP/bootstrap test command above passes **29 files / 607 tests, 17 skipped**; `npm run lint` also passes. Independent review confirmed the bounded error-precedence policy without further machinery.



### AI-review follow-up: selected-model recovery

Doctor recovery now uses the current active model after a Settings model change. Revalidation accepts that target with the same key and preserves the provider default model, account name, credential reference, and active selection. Existing compare-and-set publication rejects a model or provider change during validation.

Final evidence after the last material edit in `ff951cf`:
- Provider recovery, persistence preservation, and concurrent-selection protection → `npm run test:module -- settings_provider_accounts` → 529 passed.
- Bootstrap restart integration, Task adapter, and CLI consumers → explicit Vitest run of `src/main/settings/bootstrap.integration.test.ts`, `src/main/web-service/task-api.test.ts`, and `packages/open-science/cli.test.ts` → 118 passed.
- Main-process types → `npm run typecheck:node` → passed. Source checks → `npm run lint` → passed.
- Independent review confirmed the final diff and Test Impact Set; no actionable findings. No renderer or ACP protocol changes in this follow-up; cross-platform authority remains the new-head PR CI.

Historical compatibility: no migration or historical-format change. State: no new enum values. Persistence: updates the existing provider validation record for the selected model, preserving existing configuration and credentials.

The previous-head Windows E2E shard 3 timed out waiting for a deterministic reply in the uploads-expansion test, before its file-version assertions. Artifact inspection shows the first attempt timed out and the retry passed; the lane failed under `--fail-on-flaky-tests` (1 flaky, 11 passed). The fixture uses OpenCode and a custom provider, and its logs show successful ACP initialization/session creation. No bootstrap-path regression was identified, but missing prompt/notification timing prevents assigning a root cause. No timeout or test was weakened; the new-head Windows lane must still pass.
