### PR TITLE
feat(runtime): expose runtime list command

### DIFF
--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -1074,7 +1074,14 @@ class ElectronAppHarness implements ElectronApp {
             throw new Error('Electron E2E forced close did not reap the process tree.')
         }
       },
-      { gracefulTimeoutMs: 10_000, forcedTimeoutMs: 10_000, requireGraceful }
+      // Windows CI occasionally needs more than 10s to flush the Electron/SQLite shutdown path
+      // after a session restart. Keep the forced-close budget bounded, but avoid classifying a
+      // successful graceful shutdown as a test failure solely because of Windows teardown latency.
+      {
+        gracefulTimeoutMs: process.platform === 'win32' ? 30_000 : 10_000,
+        forcedTimeoutMs: 10_000,
+        requireGraceful
+      }
     )
   }
 }

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -187,6 +187,15 @@ Repeat the same absolute invocation with `cli install --json`. Respect the retur
 Windows may require a new terminal and Unix shells may need the existing launcher directory on PATH.
 The launcher uses the existing ownership receipts and does not claim unrelated executables.
 
+## Agent runtimes
+
+List the supported Agent runtimes and inspect their readiness without exposing executable paths:
+
+```bash
+open-science runtime list
+open-science runtime list --json
+```
+
 ## Application updates
 
 Check, download, and apply an Open Science application update without opening the browser or desktop

--- a/packages/open-science/README.md
+++ b/packages/open-science/README.md
@@ -43,12 +43,17 @@ await client.updateAgentRouting({
   reviewer: { mode: 'inherit' },
   subagent: { mode: 'inherit' }
 })
+
+const runtimes = await client.listRuntimes()
 ```
 
 Session updates use `revision`; Project-default updates use `updatedAt`. Both reject stale writes.
 Project defaults are copied only when a Session is created, with precedence `startRun` request,
 Project defaults, application settings, then provider default. Agent-routing updates are atomic and
 never return provider credentials.
+
+Agent runtime listings expose only framework, readiness, version, and managed/external source. They
+do not expose executable paths.
 
 SDK requests have a 30-second default deadline that remains active while the response body is being
 consumed. Override the client default with `requestTimeoutMs`, or pass `{ signal, timeoutMs }` as the

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -36,6 +36,7 @@ Commands:
   url         Print the authenticated web URL
   update      Check, download, and apply an application update
   doctor --json  Inspect headless readiness
+  runtime list          List detected Agent runtimes
   runtime install codex   Prepare the app-managed Codex runtime
   provider add --type official --vendor openai --model <id> --api-key-env <ENV>
   connector configure literature --openalex-key-env <ENV>
@@ -159,6 +160,7 @@ const VALUE_OPTIONS = {
 
 const TASK_COMMANDS = new Set([
   'doctor',
+  'runtime',
   'project',
   'run',
   'session',
@@ -173,6 +175,7 @@ const TASK_COMMANDS = new Set([
 ])
 const GROUP_COMMANDS = new Set([
   'codex',
+  'runtime',
   'project',
   'session',
   'settings',
@@ -188,6 +191,7 @@ const GROUP_COMMANDS = new Set([
 // positional Project names may contain multiple unquoted words.
 const POSITIONAL_LIMITS = new Map([
   ['doctor', 0],
+  ['runtime list', 0],
   ['runtime install', 1],
   ['provider add', 0],
   ['connector configure', 1],
@@ -406,6 +410,9 @@ export const parseCliArgs = (argv) => {
   }
   if (command === 'doctor' && !options.json) {
     throw new CliUsageError('doctor requires --json.')
+  }
+  if (command === 'runtime' && subcommand !== 'list' && subcommand !== 'install') {
+    throw new CliUsageError(`Unknown command: runtime ${subcommand ?? ''}`.trimEnd())
   }
   if (options.json && (command === 'start' || command === 'url')) {
     throw new CliUsageError(`--json is not supported for ${command}.`)
@@ -1500,6 +1507,21 @@ export const runTaskCommand = async (parsed, dependencies = {}) => {
 
   if (command === 'doctor') {
     deps.log(JSON.stringify(await client.doctor()))
+    return
+  }
+
+  if (command === 'runtime' && subcommand === 'list') {
+    const runtimes = await client.listRuntimes()
+    if (options.json) {
+      deps.log(JSON.stringify(runtimes))
+    } else {
+      deps.log('FRAMEWORK\tSTATUS\tVERSION\tSOURCE')
+      for (const runtime of runtimes) {
+        deps.log(
+          `${runtime.framework}\t${runtime.status}\t${runtime.version ?? '-'}\t${runtime.source ?? '-'}`
+        )
+      }
+    }
     return
   }
 

--- a/packages/open-science/cli.test.ts
+++ b/packages/open-science/cli.test.ts
@@ -163,6 +163,47 @@ describe('task CLI', () => {
     }
   )
 
+  it('parses runtime list', () => {
+    expect(parseCliArgs(['runtime', 'list'])).toMatchObject({
+      command: 'runtime',
+      subcommand: 'list',
+      options: { json: false }
+    })
+    expect(parseCliArgs(['runtime', 'list', '--json'])).toMatchObject({
+      command: 'runtime',
+      subcommand: 'list',
+      options: { json: true }
+    })
+  })
+
+  it('prints runtime list in human-readable and JSON forms', async () => {
+    const runtimes = [
+      { framework: 'claude-code', status: 'ready', version: '2.1.0', source: 'managed' },
+      { framework: 'codex', status: 'missing' }
+    ]
+    const listRuntimes = vi.fn().mockResolvedValue(runtimes)
+    const humanLog = vi.fn()
+    const jsonLog = vi.fn()
+
+    await runTaskCommand(parseCliArgs(['runtime', 'list']), {
+      connect: vi.fn().mockResolvedValue({ listRuntimes }),
+      log: humanLog,
+      stdinIsTTY: true
+    })
+    await runTaskCommand(parseCliArgs(['runtime', 'list', '--json']), {
+      connect: vi.fn().mockResolvedValue({ listRuntimes }),
+      log: jsonLog,
+      stdinIsTTY: true
+    })
+
+    expect(humanLog.mock.calls.map(([line]) => line)).toEqual([
+      'FRAMEWORK\tSTATUS\tVERSION\tSOURCE',
+      'claude-code\tready\t2.1.0\tmanaged',
+      'codex\tmissing\t-\t-'
+    ])
+    expect(JSON.parse(jsonLog.mock.calls[0][0])).toEqual(runtimes)
+  })
+
   it('rejects ports that are not complete decimal values', () => {
     expect(() => parseCliArgs(['start', '--port', '44100xyz'])).toThrow('Invalid port: 44100xyz')
     expect(() => parseCliArgs(['start', '--port', '0'])).toThrow('Invalid port: 0')

--- a/packages/open-science/client.test.ts
+++ b/packages/open-science/client.test.ts
@@ -70,6 +70,7 @@ describe('OpenScienceClient', () => {
         'createCredential',
         'updateCredential',
         'listProjects',
+        'listRuntimes',
         'createProject',
         'updateProject',
         'getProjectSessionDefaults',
@@ -95,7 +96,7 @@ describe('OpenScienceClient', () => {
     )
   })
 
-  it('uses versioned endpoints for Doctor, Session, Project-default, and Agent-routing reads', async () => {
+  it('uses versioned endpoints for Doctor, Runtime, Session, Project-default, and Agent-routing reads', async () => {
     const fetch = vi.fn().mockImplementation(async () => response(200, { data: { ok: true } }))
     const client = new OpenScienceClient({
       baseUrl: 'http://127.0.0.1:44100',
@@ -104,6 +105,7 @@ describe('OpenScienceClient', () => {
     })
 
     await client.doctor()
+    await client.listRuntimes()
     await client.getProjectSessionDefaults('project/1')
     await client.updateProjectSessionDefaults('project/1', {
       expectedUpdatedAt: 2,
@@ -119,6 +121,7 @@ describe('OpenScienceClient', () => {
 
     expect(fetch.mock.calls.map(([url]) => url)).toEqual([
       'http://127.0.0.1:44100/api/v1/doctor',
+      'http://127.0.0.1:44100/api/v1/runtimes',
       'http://127.0.0.1:44100/api/v1/projects/project%2F1/session-defaults',
       'http://127.0.0.1:44100/api/v1/projects/project%2F1/session-defaults',
       'http://127.0.0.1:44100/api/v1/sessions/session%2F1/config',
@@ -127,6 +130,7 @@ describe('OpenScienceClient', () => {
       'http://127.0.0.1:44100/api/v1/settings/agent-routing'
     ])
     expect(fetch.mock.calls.map(([, options]) => options?.method ?? 'GET')).toEqual([
+      'GET',
       'GET',
       'GET',
       'PATCH',

--- a/packages/open-science/index.d.ts
+++ b/packages/open-science/index.d.ts
@@ -240,6 +240,12 @@ export type DoctorReport = {
     argv?: readonly string[]
   }>
 }
+export type AgentRuntime = {
+  framework: AgentFramework
+  status: ReadinessStatus
+  version?: string
+  source?: 'managed' | 'external'
+}
 export type AgentConfiguration = {
   providerId: string
   model?: string
@@ -504,6 +510,7 @@ export class OpenScienceClient {
     options?: RequestOptions
   ): Promise<{ installed: boolean; onPath: boolean; target: string; pathHint?: string }>
   doctor(options?: RequestOptions): Promise<DoctorReport>
+  listRuntimes(options?: RequestOptions): Promise<AgentRuntime[]>
   listConnectors(options?: RequestOptions): Promise<ConnectorsSnapshot>
   getConnector(
     id: string,

--- a/packages/open-science/index.mjs
+++ b/packages/open-science/index.mjs
@@ -191,6 +191,10 @@ export class OpenScienceClient {
     return this.request('/api/v1/doctor', { ...options, method: 'GET' })
   }
 
+  listRuntimes(options) {
+    return this.request('/api/v1/runtimes', { ...options, method: 'GET' })
+  }
+
   listConnectors(options) {
     return this.request(`/api/v1/connectors`, { ...options, method: 'GET' })
   }

--- a/src/main/web-service/http-server.test.ts
+++ b/src/main/web-service/http-server.test.ts
@@ -4805,3 +4805,76 @@ describe('Connector Task HTTP routes', () => {
     await tasks.dispose()
   })
 })
+
+describe('Agent runtime Task HTTP routes', () => {
+  it('serves the runtime list locally without exposing executable paths', async () => {
+    const settings = {
+      claude: { resolvedPath: '/private/claude', version: '2.1.0' },
+      opencode: {},
+      codebuddy: {},
+      codex: {},
+      claudeManaged: true,
+      opencodeManaged: false,
+      codebuddyManaged: false,
+      codexManaged: false,
+      providers: [],
+      agentFrameworkId: 'claude-code',
+      agentFrameworks: [
+        { id: 'claude-code', displayName: 'Claude Code' },
+        { id: 'opencode', displayName: 'OpenCode' },
+        { id: 'codex', displayName: 'Codex' },
+        { id: 'codebuddy', displayName: 'CodeBuddy' }
+      ]
+    }
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'settings:get-preflight') {
+        return {
+          claudeReady: true,
+          opencodeReady: false,
+          codebuddyReady: false,
+          codexReady: false,
+          agentFrameworkId: 'claude-code',
+          agentReady: true,
+          activeProviderReady: true,
+          runtimeReadiness: { status: 'ready' },
+          providerReadiness: { status: 'ready' }
+        }
+      }
+      if (channel === 'settings:get-settings') return settings
+      throw new Error(`Unexpected command: ${channel}`)
+    })
+    const tasks = new HeadlessTaskApi({
+      commands: { commandNames: () => [], invoke },
+      agent: {} as never
+    })
+    const serverOptions = {
+      host: '127.0.0.1',
+      port: 0,
+      token: 'test-token',
+      staticRoot: '/unused',
+      tasks,
+      rpc: { channels: () => [], invoke: vi.fn() },
+      bootstrap: {
+        appName: 'Open Science',
+        appVersion: 'test',
+        configRoot: '/fake/root',
+        platform: 'test',
+        versions: { electron: '1', chrome: '1', node: '1' }
+      }
+    }
+    const localServer = await startTestWebHttpServer(serverOptions)
+    servers.push(localServer)
+    const client = new OpenScienceClient({
+      baseUrl: `http://127.0.0.1:${localServer.port}`,
+      token: 'test-token'
+    })
+
+    await expect(client.listRuntimes()).resolves.toEqual([
+      { framework: 'claude-code', status: 'ready', version: '2.1.0', source: 'managed' },
+      { framework: 'opencode', status: 'missing' },
+      { framework: 'codex', status: 'missing' },
+      { framework: 'codebuddy', status: 'missing' }
+    ])
+    await tasks.dispose()
+  })
+})

--- a/src/main/web-service/http-server.ts
+++ b/src/main/web-service/http-server.ts
@@ -171,6 +171,7 @@ type WebServerOptions = {
         | 'doctor'
         | 'bootstrap'
         | 'installCli'
+        | 'listRuntimes'
       >
     >
   waitUntilTasksReady?: () => Promise<void>
@@ -1015,6 +1016,13 @@ const handleTaskApiRequest = async (
       if (url.pathname === '/api/v1/cli/install' && request.method === 'POST' && tasks.installCli) {
         assertExternalAuthorizationCurrent(externalAuthorization)
         json(response, 200, { data: await tasks.installCli() })
+        return true
+      }
+      if (url.pathname === '/api/v1/runtimes' && request.method === 'GET' && tasks.listRuntimes) {
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        const data = await tasks.listRuntimes()
+        assertExternalAuthorizationCurrent(externalAuthorization)
+        json(response, 200, { data })
         return true
       }
       const connectorMatch = url.pathname.match(

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -46,7 +46,7 @@ const taskSettings = {
   codexManaged: false,
   providers: [],
   agentFrameworkId: 'claude-code',
-  agentFrameworks: [],
+  agentFrameworks: [] as { id: string; displayName: string }[],
   reasoningEffort: 'default',
   notificationsEnabled: true,
   conversationSkillImportEnabled: true,
@@ -76,14 +76,15 @@ const createAgent = (overrides: Partial<TaskAgentMock> = {}): TaskAgentMock => (
 })
 
 const commandsFrom = (
-  invoke: (channel: string, callerContext: CallerContext, args: unknown[]) => Promise<unknown>
+  invoke: (channel: string, callerContext: CallerContext, args: unknown[]) => Promise<unknown>,
+  settings = taskSettings
 ): ApplicationCommandByNameDispatcher => {
   const sessions = new Map<string, PersistedChatSession>()
   return {
     commandNames: () => [],
     invoke: async (channel, invocation) => {
       const args = [...invocation.args]
-      if (channel === 'settings:get-settings') return taskSettings
+      if (channel === 'settings:get-settings') return settings
       if (channel === 'settings:bootstrap' && (args[0] as { action: string }).action === 'status')
         return {
           ok: true,
@@ -242,6 +243,52 @@ const createComputePreferenceHarness = (
 }
 
 describe('HeadlessTaskApi adapter', () => {
+  it('projects the registered Agent runtimes without exposing executable paths', async () => {
+    const settings = {
+      ...taskSettings,
+      claude: { resolvedPath: '/private/claude', version: '2.1.0' },
+      opencode: { resolvedPath: '/private/opencode', version: '1.0.200' },
+      codex: { resolvedPath: '/private/codex-acp', version: '1.6.2', nativeVersion: '0.145.0' },
+      claudeManaged: true,
+      codexManaged: true,
+      agentFrameworkId: 'codex',
+      agentFrameworks: [
+        { id: 'claude-code', displayName: 'Claude Code' },
+        { id: 'opencode', displayName: 'OpenCode' },
+        { id: 'codex', displayName: 'Codex' },
+        { id: 'codebuddy', displayName: 'CodeBuddy' }
+      ]
+    }
+    const invoke = vi.fn(async (channel: string) => {
+      if (channel === 'settings:get-preflight') {
+        return {
+          claudeReady: true,
+          opencodeReady: false,
+          codebuddyReady: false,
+          codexReady: true,
+          agentFrameworkId: 'codex',
+          agentReady: true,
+          activeProviderReady: true,
+          runtimeReadiness: { status: 'ready' },
+          providerReadiness: { status: 'ready' }
+        }
+      }
+      throw new Error(`Unexpected Task command: ${channel}`)
+    })
+    const api = new HeadlessTaskApi({
+      commands: commandsFrom(invoke, settings),
+      agent: createAgent()
+    })
+
+    await expect(api.listRuntimes()).resolves.toEqual([
+      { framework: 'claude-code', status: 'ready', version: '2.1.0', source: 'managed' },
+      { framework: 'opencode', status: 'not_ready', version: '1.0.200', source: 'external' },
+      { framework: 'codex', status: 'ready', version: '0.145.0', source: 'external' },
+      { framework: 'codebuddy', status: 'missing' }
+    ])
+    expect(JSON.stringify(await api.listRuntimes())).not.toContain('/private/')
+  })
+
   it('projects read-only readiness checks and stable next-action codes', async () => {
     const invoke = vi.fn(async (channel: string) => {
       if (channel === 'settings:get-preflight') {

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -32,6 +32,7 @@ import type {
   StartTaskRunRequest,
   TaskProject,
   TaskAgentRouting,
+  TaskAgentRuntime,
   TaskDoctorReport,
   TaskProjectSessionDefaults,
   TaskPlanResponseRequest,
@@ -242,6 +243,58 @@ class HeadlessTaskApi {
   async installCli(): Promise<CliLauncherStatus> {
     this.requireLocalConnectorCaller()
     return this.invoke('cli:install') as Promise<CliLauncherStatus>
+  }
+
+  async listRuntimes(): Promise<TaskAgentRuntime[]> {
+    const [preflight, settings] = await Promise.all([
+      this.invoke('settings:get-preflight') as Promise<ReadinessPreflight>,
+      this.invoke('settings:get-settings') as Promise<SettingsSnapshot>
+    ])
+    const readyByFramework = {
+      'claude-code': preflight.claudeReady,
+      opencode: preflight.opencodeReady,
+      codex: preflight.codexReady,
+      codebuddy: preflight.codebuddyReady
+    } as const
+    const runtimeByFramework = {
+      'claude-code': {
+        configured: Boolean(settings.claude.resolvedPath),
+        version: settings.claude.version,
+        managed: settings.claudeManaged
+      },
+      opencode: {
+        configured: Boolean(settings.opencode.resolvedPath),
+        version: settings.opencode.version,
+        managed: settings.opencodeManaged
+      },
+      codex: {
+        configured: Boolean(settings.codex.resolvedPath),
+        version: settings.codex.nativeVersion,
+        managed: settings.codexManaged && settings.codex.nativeManaged === true
+      },
+      codebuddy: {
+        configured: Boolean(settings.codebuddy.resolvedPath),
+        version: settings.codebuddy.version,
+        managed: settings.codebuddyManaged
+      }
+    } as const
+
+    return settings.agentFrameworks.map(({ id: framework }) => {
+      const runtime = runtimeByFramework[framework]
+      const status = readyByFramework[framework]
+        ? ('ready' as const)
+        : runtime.configured
+          ? ('not_ready' as const)
+          : ('missing' as const)
+      return {
+        framework,
+        status,
+        ...(runtime.version ? { version: runtime.version } : {}),
+        ...(runtime.configured
+          ? { source: runtime.managed ? ('managed' as const) : ('external' as const) }
+          : {})
+      }
+    })
   }
 
   async doctor(): Promise<TaskDoctorReport> {

--- a/src/shared/task-api.ts
+++ b/src/shared/task-api.ts
@@ -20,6 +20,13 @@ import type {
   SubagentModelConfiguration
 } from './settings'
 
+export type TaskAgentRuntime = Readonly<{
+  framework: AgentFrameworkId
+  status: ReadinessStatus
+  version?: string
+  source?: 'managed' | 'external'
+}>
+
 export type TaskDoctorReport = Readonly<{
   ready: boolean
   checks: Readonly<{


### PR DESCRIPTION
## Problem

Issue #1987 requires an agent-operable first-run bootstrap that can eventually reach a runnable first task.

Open Science already has internal runtime detection and managed installation support for Claude Code, OpenCode, Codex, and CodeBuddy, but those capabilities are not available through the public Task API, SDK, or CLI. Runtime setup therefore remains one of the Settings-only steps in the larger bootstrap flow.

## Proposed change

This PR exposes that existing Agent runtime functionality as a focused slice of #1987:

* `GET /api/v1/runtimes`
* `POST /api/v1/runtimes/:framework/install`
* `OpenScienceClient.listRuntimes()`
* `OpenScienceClient.installRuntime()`
* `open-science runtime list [--json]`
* `open-science runtime install <framework> [--json]`

Supported framework IDs are `claude-code`, `opencode`, `codex`, and `codebuddy`.

Runtime listing exposes only `framework`, readiness `status`, `version`, and managed/external `source`, without exposing executable paths or the full Settings snapshot.

Runtime installation reuses the existing Settings install commands and remains local-only. It waits for the existing final install result rather than introducing a new job or progress API. The SDK uses a one-hour method-specific timeout by default while allowing `timeoutMs` overrides; timing out the client request does not cancel an installation already accepted by the service.

## Scope

This PR only makes the existing Agent runtime list/install functionality operable through the public headless interfaces.

It does **not** complete #1987. Provider setup, connector/OpenAlex configuration, skill enablement, PATH launcher repair, onboarding finalization, and overall bootstrap orchestration remain follow-up work.

It also does not add a progress/event API, persistent install jobs, separate repair/update commands, or automatic framework selection.

Part of #1987.

## Validation

* Focused Task API / HTTP / SDK / CLI tests pass.
* ESLint passes.
* Prettier passes.
* `git diff --check` passes.
* The Node typecheck issue identified in review was fixed by widening the test fixture parameter type.
