### PR TITLE
fix(tasks): preserve artifact version identity for downloads

### DIFF
--- a/src/main/application-command-composition.test.ts
+++ b/src/main/application-command-composition.test.ts
@@ -373,6 +373,7 @@ describe('application command composition', () => {
       'reviewer:get-for-session',
       'reviewer:run',
       'artifacts:finalize-run',
+      'artifacts:resolve-version-descriptors',
       'preview-resources:acquire',
       'preview-resources:release'
     ])

--- a/src/main/application-command-composition.ts
+++ b/src/main/application-command-composition.ts
@@ -199,6 +199,7 @@ const TASK_COMMAND_NAMES = Object.freeze([
   'reviewer:get-for-session',
   'reviewer:run',
   'artifacts:finalize-run',
+  'artifacts:resolve-version-descriptors',
   'preview-resources:acquire',
   'preview-resources:release'
 ])

--- a/src/main/tasks/task-runner.test.ts
+++ b/src/main/tasks/task-runner.test.ts
@@ -100,7 +100,11 @@ const configuredSettings: SettingsSnapshot = {
 
 class RetainedRunEventPayload {}
 
-type TaskRunnerOverrides = Omit<Partial<TaskRunnerDependencies>, 'agent' | 'sessions'> & {
+type TaskRunnerOverrides = Omit<
+  Partial<TaskRunnerDependencies>,
+  'agent' | 'sessions' | 'artifacts'
+> & {
+  artifacts?: Partial<TaskRunnerDependencies['artifacts']>
   agent?: Partial<TaskAgentPort>
   sessions?: Omit<
     Partial<TaskSessionPort>,
@@ -197,9 +201,6 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
       acquire: async () => ({ id: 'resource-1', url: 'preview://resource-1', size: 0 }),
       release: async () => undefined
     },
-    artifacts: {
-      finalizeRun: async () => ({ ok: true, artifacts: [] })
-    },
     runtimeEvents: { subscribe: () => () => undefined },
     settings: { get: async () => settings },
     specialists: { resolve: async (reference) => ({ id: reference }) },
@@ -214,6 +215,11 @@ const createRunner = (overrides: TaskRunnerOverrides = {}): TaskRunner => {
     createId: () => 'generated-id',
     now: () => 1,
     ...overrides,
+    artifacts: {
+      finalizeRun: async () => ({ ok: true, artifacts: [] }),
+      resolveVersionDescriptors: async () => [],
+      ...overrides.artifacts
+    },
     agent: { ...defaultAgent, ...overrides.agent },
     sessions: {
       ...defaultSessions,
@@ -3209,6 +3215,10 @@ describe('TaskRunner', () => {
           artifacts: [
             {
               id: 'artifact-file',
+              artifactId: 'artifact-lineage',
+              versionId: 'artifact-file',
+              versionNumber: 2,
+              checksum: 'a'.repeat(64),
               projectId: project.id,
               sessionId: 'session-artifact',
               messageId: 'artifact-agent',
@@ -3247,7 +3257,14 @@ describe('TaskRunner', () => {
       artifactIds: ['artifact-file']
     })
     expect(savedSessions.at(-1)?.artifacts).toEqual([
-      expect.objectContaining({ id: 'artifact-file', createdAt: 10 })
+      expect.objectContaining({
+        id: 'artifact-file',
+        createdAt: 10,
+        artifactId: 'artifact-lineage',
+        versionId: 'artifact-file',
+        versionNumber: 2,
+        sha256: 'a'.repeat(64)
+      })
     ])
   })
 

--- a/src/main/tasks/task-runner.ts
+++ b/src/main/tasks/task-runner.ts
@@ -15,8 +15,10 @@ import {
 import type {
   ArtifactFile,
   FinalizeRunArtifactsRequest,
-  FinalizeRunArtifactsResult
+  FinalizeRunArtifactsResult,
+  ResolveArtifactVersionDescriptorsRequest
 } from '../../shared/artifacts'
+import type { ArtifactVersionDescriptor } from '../../shared/artifact-provenance'
 import { artifactCreatedAtMs } from '../../shared/artifacts'
 import { DEFAULT_PERMISSION_PROFILE } from '../../shared/permission-profiles'
 import type { PermissionProfileId } from '../../shared/permission-profiles'
@@ -204,6 +206,9 @@ type TaskAgentPort = {
 }
 
 type TaskArtifactPort = {
+  resolveVersionDescriptors(
+    request: ResolveArtifactVersionDescriptorsRequest
+  ): Promise<ArtifactVersionDescriptor[]>
   finalizeRun(request: FinalizeRunArtifactsRequest): Promise<FinalizeRunArtifactsResult>
 }
 
@@ -539,6 +544,10 @@ const toPersistedArtifact = (
       : undefined)
   return {
     id: artifact.id,
+    artifactId: artifact.artifactId,
+    versionId: artifact.versionId,
+    versionNumber: artifact.versionNumber,
+    sha256: artifact.checksum,
     kind: 'managed-file',
     path: artifact.path,
     fileUrl: artifact.fileUrl,
@@ -1205,11 +1214,24 @@ class TaskRunner {
       throw new TaskRunnerError('artifact_not_found', `Artifact not found: ${artifactId}`)
     }
     const { artifact, session } = owner
+    // Older Task completions omitted native identity fields. Resolve their Version id through
+    // the owning Project/Session authority; paths and the latest head are not version identities.
+    const descriptor =
+      !artifact.artifactId || !artifact.versionId
+        ? (
+            await this.dependencies.artifacts.resolveVersionDescriptors({
+              projectId: session.projectId,
+              appSessionId: session.id,
+              versionIds: [artifact.versionId ?? artifact.id]
+            })
+          )[0]
+        : undefined
+    const versionId = artifact.versionId ?? descriptor?.versionId
     const resource = await this.dependencies.previewResources.acquire({
       source: 'artifact',
       projectId: session.projectId,
-      fileId: artifact.artifactId ?? artifact.id,
-      ...(artifact.versionId ? { versionId: artifact.versionId } : {}),
+      fileId: artifact.artifactId ?? descriptor?.artifactId ?? artifact.id,
+      ...(versionId ? { versionId } : {}),
       mimeType: artifact.mimeType
     })
     return {

--- a/src/main/web-service/artifact-download.integration.test.ts
+++ b/src/main/web-service/artifact-download.integration.test.ts
@@ -1,0 +1,316 @@
+// @ts-expect-error The published ESM entry uses a sibling index.d.ts.
+import { OpenScienceClient } from '../../../packages/open-science/index.mjs'
+// @ts-expect-error The public CLI entry is JavaScript.
+import { runTaskCommand } from '../../../packages/open-science/cli.mjs'
+import { join } from 'node:path'
+import { createHash } from 'node:crypto'
+import { readFile } from 'node:fs/promises'
+import { net } from 'electron'
+import { expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  net: { fetch: vi.fn() },
+  protocol: {},
+  ipcMain: { handle: vi.fn() },
+  BrowserWindow: { getAllWindows: () => [] },
+  app: { isPackaged: true, getPath: () => '/unused-artifact-download-config' }
+}))
+
+import { createLinearConversationGraph } from '../../shared/conversation-graph'
+import type { PersistedChatSession } from '../../shared/session-persistence'
+import type { ResolveArtifactVersionDescriptorsRequest } from '../../shared/artifacts'
+import type {
+  AcquireManagedPreviewRequest,
+  ReleaseManagedPreviewRequest
+} from '../../shared/preview-resources'
+import { ApplicationEventHub } from '../application-events'
+import { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
+import { createProvenanceTestFixture } from '../artifacts/provenance-test-fixtures'
+import { createManagedPreviewOwnerRegistry } from '../managed-preview-ipc'
+import { createManagedPreviewProtocolHandler } from '../managed-preview-protocol'
+import { ManagedPreviewResources } from '../managed-preview-resources'
+import { ManagedFileVersionService } from '../managed-file-versions/service'
+import { SessionRepository } from '../session-persistence/repository'
+import { startWebHttpServer } from './http-server'
+import { HeadlessTaskApi } from './task-api'
+
+it.each(['historical', 'native'] as const)(
+  'downloads a %s Task artifact by its listed Version id through HTTP',
+  async (identity) => {
+    const fixture = await createProvenanceTestFixture()
+    const sessions = new SessionRepository(fixture.storageRoot)
+    const messages: PersistedChatSession['messages'] = [
+      {
+        id: 'prompt-1',
+        role: 'user',
+        content: 'Save a report',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 1,
+        updatedAt: 1
+      },
+      {
+        id: 'answer-1',
+        role: 'agent',
+        content: 'Saved',
+        status: 'complete',
+        eventIds: [],
+        createdAt: 2,
+        updatedAt: 2
+      }
+    ]
+    const conversationGraph = createLinearConversationGraph({
+      sessionId: 'session-1',
+      messages,
+      frameworkId: 'codex',
+      createdAt: 1,
+      updatedAt: 2
+    })
+    let session: PersistedChatSession = {
+      id: 'session-1',
+      projectId: 'project-1',
+      title: 'Download fixture',
+      cwd: fixture.storageRoot,
+      status: 'idle',
+      messages,
+      conversationGraph,
+      createdAt: 1,
+      updatedAt: 2
+    }
+    const provenance = new ArtifactProvenanceRepository({
+      ...fixture.repositoryOptions,
+      loadSession: (projectId, sessionId) => sessions.loadSession(projectId, sessionId)
+    })
+    const versions = new ManagedFileVersionService({
+      storageRoot: fixture.storageRoot,
+      getClient: () => Promise.resolve(fixture.client)
+    })
+    const resources = new ManagedPreviewResources({
+      resolvePath: async () => {
+        throw new Error('Artifact downloads must use managed identities.')
+      },
+      openLatestManagedFile: (source, request) => versions.openLatest({ source, ...request }),
+      openManagedFileVersion: (source, request) =>
+        versions.openVersion({ source, ...request }, request.versionId)
+    })
+    const owners = createManagedPreviewOwnerRegistry(resources)
+    const acquiredIds: string[] = []
+    const tasks = new HeadlessTaskApi({
+      commands: {
+        commandNames: () => [],
+        invoke: async (name, { args, callerLease }) => {
+          if (name === 'sessions:load-all') return sessions.loadAll()
+          if (name === 'artifacts:resolve-version-descriptors') {
+            return provenance.resolveVersionDescriptors(
+              args[0] as ResolveArtifactVersionDescriptorsRequest
+            )
+          }
+          if (name === 'preview-resources:acquire') {
+            const resource = await owners.acquire(
+              callerLease,
+              args[0] as AcquireManagedPreviewRequest
+            )
+            acquiredIds.push(resource.id)
+            return resource
+          }
+          if (name === 'preview-resources:release') {
+            return owners.release(callerLease, args[0] as ReleaseManagedPreviewRequest)
+          }
+          throw new Error(`Unexpected download command: ${name}`)
+        }
+      },
+      agent: {} as never
+    })
+    // Only the Electron transport is bridged; capability resolution, verified file handles,
+    // protocol streaming, HTTP and the public client all execute their production implementations.
+    const protocol = createManagedPreviewProtocolHandler(resources)
+    vi.mocked(net.fetch).mockImplementation((url, options) =>
+      protocol(new Request(String(url), options))
+    )
+    let server: Awaited<ReturnType<typeof startWebHttpServer>> | undefined
+    try {
+      await fixture.client.project.create({ data: { id: 'project-1', name: 'Download fixture' } })
+      await sessions.saveSession(session)
+      const content = '# Synthetic report\n\nExact immutable bytes.\n'
+      const context = {
+        rootFrameId: conversationGraph.rootFrameId,
+        agentFrameId: conversationGraph.activeFrameId,
+        messageBranchId: conversationGraph.branches[0].id,
+        runtimeSegmentId: conversationGraph.runtimeSegments[0].id,
+        promptMessageId: 'prompt-1'
+      }
+      await fixture.compatibilityRepository.writePendingFile({
+        projectId: session.projectId,
+        sessionId: session.id,
+        runId: 'run-1',
+        filename: 'report.md',
+        source: { kind: 'inline', content, encoding: 'utf8' }
+      })
+      const version = await provenance.createVersion({
+        projectId: session.projectId,
+        appSessionId: session.id,
+        artifactStorageSessionId: session.id,
+        artifactRunId: 'run-1',
+        writeOperationId: 'write-1',
+        writeRequestChecksum: 'a'.repeat(64),
+        ...context,
+        filename: 'report.md',
+        contentType: 'text/markdown'
+      })
+      const finalization = {
+        projectId: session.projectId,
+        appSessionId: session.id,
+        artifactRunId: 'run-1',
+        artifactVersionIds: [version.versionId],
+        ...context,
+        messageId: 'answer-1'
+      }
+      await provenance.finalizeRun(finalization)
+      await provenance.activateFinalizedRun(finalization)
+      // Reproduce the old Task projection: the row id is a Version id, but native identity
+      // fields were omitted. Persist and reload it rather than supplying an acquisition stub.
+      session = await sessions.saveSession({
+        ...session,
+        artifacts: [
+          {
+            id: version.id,
+            ...(identity === 'native'
+              ? { artifactId: version.artifactId, versionId: version.versionId }
+              : {}),
+            kind: 'managed-file',
+            path: version.path,
+            name: version.name,
+            fileUrl: version.fileUrl,
+            size: version.size,
+            mimeType: version.mimeType
+          }
+        ]
+      })
+      // Publish another save under the same Lineage. The listed older Version must still
+      // download its own bytes, rather than silently substituting the current head.
+      await fixture.compatibilityRepository.writePendingFile({
+        projectId: session.projectId,
+        sessionId: session.id,
+        runId: 'run-2',
+        filename: 'report.md',
+        source: { kind: 'inline', content: 'newer content', encoding: 'utf8' }
+      })
+      const newer = await provenance.createVersion({
+        projectId: session.projectId,
+        appSessionId: session.id,
+        artifactStorageSessionId: session.id,
+        artifactRunId: 'run-2',
+        writeOperationId: 'write-2',
+        writeRequestChecksum: 'b'.repeat(64),
+        ...context,
+        filename: 'report.md',
+        contentType: 'text/markdown'
+      })
+      const newerFinalization = {
+        ...finalization,
+        artifactRunId: 'run-2',
+        artifactVersionIds: [newer.versionId]
+      }
+      await provenance.finalizeRun(newerFinalization)
+      await provenance.activateFinalizedRun(newerFinalization)
+      expect(newer.artifactId).toBe(version.artifactId)
+      expect(await readFile(version.path, 'utf8')).toBe(content)
+      const emptyCommands = { commandNames: () => [], invoke: async () => undefined }
+      server = await startWebHttpServer({
+        host: '127.0.0.1',
+        port: 0,
+        token: 'synthetic-download-token',
+        staticRoot: fixture.storageRoot,
+        applicationCommands: {
+          localWeb: emptyCommands,
+          remoteWeb: { ...emptyCommands, rejectedCommandNames: () => [] }
+        },
+        applicationEvents: new ApplicationEventHub(),
+        tasks,
+        bootstrap: {
+          appName: 'Open Science',
+          appVersion: 'test',
+          configRoot: fixture.storageRoot,
+          platform: process.platform,
+          versions: { electron: 'test', chrome: 'test', node: process.versions.node }
+        }
+      })
+      const baseUrl = `http://127.0.0.1:${server.port}`
+      expect((await fetch(`${baseUrl}/api/v1/artifacts/${version.id}/content`)).status).toBe(401)
+      expect(acquiredIds).toEqual([])
+      const client = new OpenScienceClient({ baseUrl, token: 'synthetic-download-token' })
+      await expect(client.downloadArtifact('missing-version')).rejects.toMatchObject({
+        status: 404,
+        code: 'artifact_not_found'
+      })
+      await expect(client.downloadArtifact(version.artifactId)).rejects.toMatchObject({
+        status: 404,
+        code: 'artifact_not_found'
+      })
+      const listed = await client.listArtifacts(session.id)
+      expect(listed).toHaveLength(1)
+      expect(listed[0].id).toBe(version.versionId)
+      const httpResponse = await fetch(`${baseUrl}/api/v1/artifacts/${listed[0].id}/content`, {
+        headers: { authorization: 'Bearer synthetic-download-token' }
+      })
+      const httpBody = await httpResponse.text()
+      expect({ status: httpResponse.status, body: httpBody }).toEqual({
+        status: 200,
+        body: content
+      })
+      const response = await client.downloadArtifact(listed[0].id)
+      const bytes = Buffer.from(await response.arrayBuffer())
+      expect(bytes.toString()).toBe(content)
+      expect(createHash('sha256').update(bytes).digest('hex')).toBe(version.checksum)
+      expect(response.headers.get('content-disposition')).toContain('report.md')
+      const output = join(fixture.storageRoot, 'downloaded-report.md')
+      await runTaskCommand(
+        {
+          command: 'artifacts',
+          subcommand: 'download',
+          positionals: [listed[0].id],
+          options: { output, json: true }
+        },
+        { connect: async () => client, log: () => undefined }
+      )
+      expect(await readFile(output)).toEqual(bytes)
+      expect(acquiredIds).toHaveLength(3)
+      for (const resourceId of acquiredIds) {
+        await expect(resources.resolveProtocolResource(resourceId)).rejects.toThrow()
+      }
+      // The same Session record must not make finalized-but-unpublished bytes downloadable.
+      await fixture.client.artifactVersion.update({
+        where: { id: version.versionId },
+        data: { managedVisibleAt: null }
+      })
+      await expect(client.downloadArtifact(listed[0].id)).rejects.toMatchObject({ status: 500 })
+      expect(acquiredIds).toHaveLength(3)
+      await fixture.client.artifactVersion.update({
+        where: { id: version.versionId },
+        data: { managedVisibleAt: new Date() }
+      })
+      await fixture.client.project.create({ data: { id: 'other-project', name: 'Other project' } })
+      await fixture.client.fileOriginSession.create({
+        data: { projectId: 'other-project', sessionId: session.id }
+      })
+      await fixture.client.artifactLineage.update({
+        where: { id: version.artifactId },
+        data: { projectId: 'other-project' }
+      })
+      // A listed id and a known path cannot grant access across the Session's Project boundary.
+      await expect(client.downloadArtifact(listed[0].id)).rejects.toMatchObject({ status: 500 })
+      expect(acquiredIds).toHaveLength(3)
+      // Download must not repair historical records by writing back to Session storage.
+      expect((await sessions.loadSession(session.projectId, session.id))?.artifacts).toEqual(
+        session.artifacts
+      )
+    } finally {
+      await server?.close()
+      await tasks.dispose()
+      vi.mocked(net.fetch).mockReset()
+      await fixture.dispose()
+    }
+  },
+  // Exercise the real publication retry window as well as SQLite setup on slower CI hosts.
+  30_000
+)

--- a/src/main/web-service/task-api.test.ts
+++ b/src/main/web-service/task-api.test.ts
@@ -1000,6 +1000,7 @@ describe('HeadlessTaskApi adapter', () => {
       if (channel === 'sessions:load-all') {
         return { sessions: [session], manifest: { version: 1 } }
       }
+      if (channel === 'artifacts:resolve-version-descriptors') return []
       if (channel === 'preview-resources:acquire') {
         return {
           id: 'resource-query',
@@ -1037,6 +1038,11 @@ describe('HeadlessTaskApi adapter', () => {
     })
     await api.releaseArtifact('resource-query')
 
+    expect(invoke).toHaveBeenCalledWith(
+      'artifacts:resolve-version-descriptors',
+      taskCallerContext(),
+      [{ projectId: project.id, appSessionId: session.id, versionIds: ['artifact-query'] }]
+    )
     expect(invoke).toHaveBeenCalledWith('preview-resources:acquire', taskCallerContext(), [
       {
         source: 'artifact',

--- a/src/main/web-service/task-api.ts
+++ b/src/main/web-service/task-api.ts
@@ -3,6 +3,7 @@ import type { CliLauncherStatus } from '../../shared/cli'
 import { AsyncLocalStorage } from 'node:async_hooks'
 import { randomUUID } from 'node:crypto'
 
+import type { ArtifactVersionDescriptor } from '../../shared/artifact-provenance'
 import type { AcpRuntimeEvent } from '../../shared/acp'
 import type {
   FinalizeRunArtifactsRequest,
@@ -151,6 +152,10 @@ class HeadlessTaskApi {
           this.withCurrentCaller(() => this.ports.agent.cancelPrompt(sessionId))
       },
       artifacts: {
+        resolveVersionDescriptors: (request) =>
+          this.invoke('artifacts:resolve-version-descriptors', request) as Promise<
+            ArtifactVersionDescriptor[]
+          >,
         finalizeRun: (request: FinalizeRunArtifactsRequest) =>
           this.invoke('artifacts:finalize-run', request) as Promise<FinalizeRunArtifactsResult>
       },


### PR DESCRIPTION
Task completion dropped the existing native Artifact identity fields when persisting its Session projection. `artifacts list` consequently returned a Version ID that download treated as a Lineage ID, causing HTTP 500 even though the published immutable file existed.

Preserve `artifactId`, `versionId`, `versionNumber`, and checksum (`sha256`) in new Task projections. Resolve missing historical identity through the existing Project/Session-scoped Artifact descriptor command, then acquire the exact Version through the unchanged managed-preview capability. Existing fully identified and compatibility Lineage records retain their acquisition behavior. No arbitrary path access, publication bypass, schema migration, new field/enum/state, or historical record rewrite.

Validation of commit `42017ff38` (final production implementation; no subsequent code changes):

- Before the fix, the public CLI reproduced exit 1/internal_error. The synthetic SQLite/filesystem/HTTP regression returned the same HTTP 500 payload; the Task completion regression showed the four omitted fields. Both passed with the fix.
- Task projection/acquisition, adapter/command allowlist, authenticated HTTP streaming, public client and CLI: 7 test files / 349 tests passed. The new integration covers real persisted files, exact old-Version bytes after a newer publication, CLI output writes, authentication, missing IDs, unpublished/cross-Project rejection, and capability release. It bridges Electron transport to the production protocol handler only; all file/HTTP paths are real.
- Artifact descriptors, managed-file/preview authority and Session serialization: 8 test files / 516 tests passed. Combined final groups: 15 files / 865 passing tests, run with `--maxWorkers=2` after the final test change.
- `npm run typecheck:node` (including sandbox types) and `npm run build:e2e`: passed. `npm run lint`: passed.
- Real rebuilt Electron backend: original Version download exited 0; 1,843 bytes matched the preserved source byte-for-byte and SHA-256 `92aea7fc4d746b0d26b1a217c652233f842f4dca1dee5c5337dc4f48171171cb`. Backend stopped through CLI and port closure verified. No model invocation or credential handling was needed.

Independent Standards and Spec reviews found no actionable implementation findings or missing affected verification boundary. The explicit test groups cover the changed Task owner and its adapters/Artifact dependencies; full local testing was intentionally not run at the user's request. The change is downstream of provider execution, with no ACP protocol/subscription or renderer behavior change. Native macOS was exercised; full-suite and Windows/Linux verification remain CI coverage.

Review focus: historical ID recovery must continue to use the existing Project scope, selected Version, and managed publication/access authority. No local plans, credentials, logs, or acceptance data are included in this PR.

<details>
<summary>Focused test commands (865 passed)</summary>

```sh
npm test -- src/main/tasks/task-runner.test.ts src/main/web-service/task-api.test.ts src/main/application-command-composition.test.ts src/main/web-service/artifact-download.integration.test.ts src/main/web-service/http-server.test.ts packages/open-science/client.test.ts packages/open-science/cli.test.ts --maxWorkers=2
npm test -- src/main/managed-file-versions/service.integration.test.ts src/main/managed-preview-resources.test.ts src/main/managed-preview-protocol.test.ts src/main/managed-preview-ipc.test.ts src/main/artifacts/provenance-repository.test.ts src/main/artifacts/ipc.test.ts src/main/data-content-application-commands.test.ts src/shared/session-persistence.test.ts --maxWorkers=2
```

</details>
