### PR TITLE
fix(reproducibility): expand clinical omics lineage capture

### DIFF
--- a/src/main/notebook/analysis-version.ts
+++ b/src/main/notebook/analysis-version.ts
@@ -1,4 +1,4 @@
 // Bump the revision whenever dependency or source-file analysis semantics change.
 // The format version is independent: rule additions do not require a data migration.
 export const NOTEBOOK_ANALYZER_VERSION = 1 as const
-export const NOTEBOOK_ANALYZER_REVISION = 'tree-sitter-in-process-103'
+export const NOTEBOOK_ANALYZER_REVISION = 'tree-sitter-in-process-104'

--- a/src/main/notebook/dependency-analysis-python.ts
+++ b/src/main/notebook/dependency-analysis-python.ts
@@ -857,8 +857,7 @@ const convertCallArgs = (node: Node | null): { args: PyNode[]; keywords: PyKeywo
       continue
     }
     if (child.type === 'list_splat') {
-      const value = child.namedChildren[0]
-      if (value) args.push(convertExpr(value, 'Load'))
+      args.push(convertExpr(child, 'Load'))
       continue
     }
     args.push(convertExpr(child, 'Load'))
@@ -7346,6 +7345,111 @@ const analyzePythonFileAccessTree = (
       unsupportedExternalState = true
       return
     }
+    if (
+      ['pysam.VariantFile', 'pysam.TabixFile'].includes(canonicalName) &&
+      importedNames.has(rawName.split('.')[0]!)
+    ) {
+      const args = Array.isArray(node.args) ? node.args : []
+      const keyword = (name: string): PyNode | undefined =>
+        (node.keywords ?? []).find((entry) => entry.arg === name)?.value
+      const tabix = canonicalName === 'pysam.TabixFile'
+      const modeNode = keyword('mode') ?? args[1]
+      const mode =
+        !modeNode || (modeNode.type === 'Constant' && modeNode.value === null)
+          ? 'r'
+          : resolveStaticString(modeNode, bindings)
+      const path = keyword('filename') ?? args[0]
+      if (mode && (tabix ? mode === 'r' : ['r', 'rb'].includes(mode))) {
+        recordHtsFileAccess('read', path)
+        const index = tabix ? (keyword('index') ?? args[3]) : (keyword('index_filename') ?? args[2])
+        if (index && !(index.type === 'Constant' && index.value === null))
+          recordHtsFileAccess('read', index)
+      } else if (!tabix && mode && ['w', 'wb', 'wbu', 'wb0', 'wz', 'wz0'].includes(mode)) {
+        recordHtsFileAccess('write', path)
+      } else {
+        unresolvedReads = true
+        unresolvedWrites = true
+      }
+      unsupportedExternalState = true
+      return
+    }
+    if (canonicalName === 'muon.read_10x_h5') {
+      const args = Array.isArray(node.args) ? node.args : []
+      recordFileAccess(
+        'read',
+        (node.keywords ?? []).find((entry) => entry.arg === 'filename')?.value ?? args[0]
+      )
+      const extended =
+        (node.keywords ?? []).find((entry) => entry.arg === 'extended')?.value ?? args[1]
+      if (
+        !(extended?.type === 'Constant' && extended.value === false) ||
+        (node.keywords ?? []).some((entry) => !entry.arg)
+      ) {
+        // Extended loading discovers annotation and fragment companions.
+        unresolvedReads = true
+        unsupportedExternalState = true
+      }
+      return
+    }
+    if (canonicalName === 'muon.read_h5mu') {
+      const args = Array.isArray(node.args) ? node.args : []
+      recordFileAccess(
+        'read',
+        (node.keywords ?? []).find((keyword) => keyword.arg === 'filename')?.value ?? args[0]
+      )
+      unresolvedReads = true
+      unsupportedExternalState = true
+      return
+    }
+    if (canonicalName === 'pyfaidx.Fasta') {
+      const args = Array.isArray(node.args) ? node.args : []
+      recordFileAccess(
+        'read',
+        (node.keywords ?? []).find((entry) => entry.arg === 'filename')?.value ?? args[0]
+      )
+      // Index creation and mutable FASTA access depend on constructor options and disk state.
+      unresolvedReads = true
+      unresolvedWrites = true
+      unsupportedExternalState = true
+      return
+    }
+    if (['wfdb.rdrecord', 'wfdb.rdann', 'wfdb.wrsamp'].includes(canonicalName)) {
+      // A record name identifies a group of header, signal and annotation files.
+      // It is not itself a filename; remote records also use the same argument.
+      if (canonicalName === 'wfdb.wrsamp') unresolvedWrites = true
+      else unresolvedReads = true
+      unsupportedExternalState = true
+      return
+    }
+    if (canonicalName === 'dask.DataFrame.to_parquet') {
+      // Building a delayed graph does not prove that its destination was written.
+      // Partition discovery, metadata and custom filesystems need runtime evidence.
+      const args = Array.isArray(node.args) ? node.args : []
+      const keyword = (name: string): PyNode | undefined =>
+        (node.keywords ?? []).find((entry) => entry.arg === name)?.value
+      const compute = keyword('compute')
+      const customFilesystem = [keyword('filesystem'), keyword('storage_options')].some(
+        (option) => option && !(option.type === 'Constant' && option.value === null)
+      )
+      const path = resolveStaticString(keyword('path') ?? args[0], bindings)
+      if (
+        (!compute || (compute.type === 'Constant' && compute.value === true)) &&
+        args.length <= 1 &&
+        !args.some((argument) => argument.type === 'Starred') &&
+        !(node.keywords ?? []).some((entry) => !entry.arg) &&
+        !customFilesystem &&
+        path &&
+        !pythonPathHasCollectionPattern(path) &&
+        !/^[a-z][a-z\d+.-]*:\/\//iu.test(path)
+      ) {
+        writes.add(path)
+        writeScopes.set(`directory\0${path}`, { kind: 'directory', path })
+      }
+      unresolvedReads = true
+      unresolvedWrites = true
+      unsupportedExternalState = true
+      return
+    }
     if (canonicalName === 'pysam.AlignmentFile' && importedNames.has(rawName.split('.')[0]!)) {
       // Only the file and mode positions are stable across documented versions.
       // Preserve explicitly named companions without guessing which implicit
@@ -7424,9 +7528,40 @@ const analyzePythonFileAccessTree = (
       return
     }
 
+    if (canonicalName === 'pyarrow.parquet.read_table') {
+      const args = Array.isArray(node.args) ? node.args : []
+      const keywords = node.keywords ?? []
+      const source = keywords.find((keyword) => keyword.arg === 'source')?.value ?? args[0]
+      const path = resolveStaticString(source, bindings)
+      if (
+        importedNames.has(rawName.split('.')[0]!) &&
+        args.length <= 1 &&
+        !keywords.some(
+          (keyword) =>
+            !keyword.arg || (keyword.arg === 'filesystem' && keyword.value.constKind !== 'none')
+        ) &&
+        path &&
+        !/^[a-z][a-z\d+.-]*:\/\//iu.test(path)
+      ) {
+        recordFileAccess('read', source)
+      }
+      // A string can name a directory dataset, even with a file-like suffix.
+      unresolvedReads = true
+      unsupportedExternalState = true
+      return
+    }
+    if (canonicalName.startsWith('squidpy.datasets.')) {
+      // Dataset helpers may download or resolve cache files outside the workspace.
+      unresolvedReads = true
+      unsupportedExternalState = true
+      return
+    }
     if (
       [
         'scanpy.read_10x_mtx',
+        'muon.read_10x_mtx',
+        'dask.dataframe.read_parquet',
+        'dask.dataframe.read_csv',
         'scanpy.read_visium',
         'pyarrow.dataset.dataset',
         'fsspec.open',
@@ -7434,6 +7569,14 @@ const analyzePythonFileAccessTree = (
         'fsspec.get_mapper'
       ].includes(canonicalName)
     ) {
+      if (['dask.dataframe.read_parquet', 'dask.dataframe.read_csv'].includes(canonicalName)) {
+        const args = Array.isArray(node.args) ? node.args : []
+        const parameter = canonicalName.endsWith('read_csv') ? 'urlpath' : 'path'
+        const fileArgument =
+          (node.keywords ?? []).find((entry) => entry.arg === parameter)?.value ?? args[0]
+        const path = resolveStaticString(fileArgument, bindings)
+        if (path && !/^[a-z][a-z\d+.-]*:\/\//iu.test(path)) recordFileAccess('read', fileArgument)
+      }
       unresolvedReads = true
       unsupportedExternalState = true
       return
@@ -7589,12 +7732,31 @@ const analyzePythonFileAccessTree = (
       isPyNode(node.func.value) &&
       node.func.value.type === 'Name' &&
       node.func.value.id &&
-      scientificObjectTypes.get(node.func.value.id) === 'astropy-table'
+      ['astropy-table', 'muon.MuData'].includes(scientificObjectTypes.get(node.func.value.id) ?? '')
     ) {
       const args = Array.isArray(node.args) ? node.args : []
       recordFileAccess(
         'write',
-        (node.keywords ?? []).find((keyword) => keyword.arg === 'output')?.value ?? args[0]
+        (node.keywords ?? []).find((keyword) =>
+          ['output', 'filename', 'path'].includes(keyword.arg ?? '')
+        )?.value ?? args[0]
+      )
+      return
+    }
+
+    if (
+      [
+        'muon.MuData.write',
+        'muon.MuData.write_h5mu',
+        'mudata.MuData.write',
+        'mudata.MuData.write_h5mu'
+      ].includes(canonicalName ?? '')
+    ) {
+      const args = Array.isArray(node.args) ? node.args : []
+      recordFileAccess(
+        'write',
+        (node.keywords ?? []).find((keyword) => ['filename', 'path'].includes(keyword.arg ?? ''))
+          ?.value ?? args[0]
       )
       return
     }
@@ -7960,7 +8122,11 @@ const analyzePythonFileAccessTree = (
           : undefined
       const configurationMapping =
         mapping && pythonLibraryMethodEffect(mapping, 'update')?.plottingState === 'write'
-      invalidateStaticValue(rootName(target), !configurationMapping)
+      const dataframeColumn =
+        target?.type === 'Subscript' &&
+        isPyNode(target.value) &&
+        scientificObjectType(target.value) === 'pandas.DataFrame'
+      invalidateStaticValue(rootName(target), !configurationMapping && !dataframeColumn)
     }
     if (node.type === 'Call' && MUTATING_METHODS.has(memberName(node.func) ?? '')) {
       const canonical = canonicalCallName(node)

--- a/src/main/notebook/dependency-analysis-r.ts
+++ b/src/main/notebook/dependency-analysis-r.ts
@@ -7221,7 +7221,10 @@ const rLocalFileWrappers = (
         'Spectra',
         'read.FCS',
         'read.flowSet',
-        'write.FCS'
+        'write.FCS',
+        'createArrowFiles',
+        'ArchRProject',
+        'saveArchRProject'
       ].includes(name ?? '') ||
       parameterIndex < 0 ||
       (effect.kind === 'write' &&
@@ -7354,6 +7357,9 @@ const analyzeRFileAccessTree = (
       const called = rCalledName(node) ?? ''
       const effect = R_FILE_CALL_EFFECTS.get(called)
       if (effect) effects.add(effect.kind)
+      // A single-path wrapper summary cannot preserve mixed I/O or directory scope.
+      if (called === 'createArrowFiles') effects.add('write')
+      if (called === 'ArchRProject' || called === 'saveArchRProject') effects.add('read')
       const helper = localDefinitions.get(called)
       if (helper && !visited.has(called)) {
         visited.add(called)
@@ -7804,7 +7810,14 @@ const analyzeRFileAccessTree = (
     ) {
       call = undefined
     }
-    if (call && (name === 'ArchRProject' || name === 'saveArchRProject')) {
+    const archRCall = Boolean(
+      call &&
+      name &&
+      ['ArchRProject', 'saveArchRProject', 'createArrowFiles'].includes(name) &&
+      call === R_FILE_CALL_EFFECTS.get(name) &&
+      (qualified?.package === 'ArchR' || (!qualified && !shadowedQuotationNames.has(name)))
+    )
+    if (archRCall && (name === 'ArchRProject' || name === 'saveArchRProject')) {
       fileArgumentOverride = {
         value: connectionArgument(
           expr,
@@ -8003,7 +8016,7 @@ const analyzeRFileAccessTree = (
       const commandIndex = libraryFread
         ? expr.names.findIndex((candidate) => candidate === 'cmd')
         : -1
-      if (name === 'createArrowFiles') {
+      if (archRCall && name === 'createArrowFiles') {
         // Arrow generation and QC/log companions remain incomplete even when
         // fragment inputs resolve to a bounded collection below.
         unresolvedWrites = true
@@ -8151,10 +8164,12 @@ const analyzeRFileAccessTree = (
       if (call.kind === 'read' && (name === 'Read10X' || name === 'Load10X_Spatial') && path) {
         unresolvedReads = true
       }
-      // ArchRProject consumes ArrowFiles and writes a project directory. Object
-      // inputs retain dependency lineage; file completeness remains uncertain.
-      if (name === 'ArchRProject') {
+      // Project creation and saving can read ArrowFiles referenced by the object.
+      // Their input file coverage remains incomplete without runtime evidence.
+      if (archRCall && (name === 'ArchRProject' || name === 'saveArchRProject')) {
         unresolvedReads = true
+      }
+      if (archRCall && name === 'ArchRProject') {
         const arrowArgument = connectionArgument(
           expr,
           ['ArrowFiles', 'outputDirectory'],
@@ -8223,7 +8238,7 @@ const analyzeRFileAccessTree = (
           else unresolvedWrites = true
         } else if (call.kind === 'write') {
           const target =
-            name === 'ArchRProject' || name === 'saveArchRProject'
+            archRCall && (name === 'ArchRProject' || name === 'saveArchRProject')
               ? 'directory'
               : rScientificWriteTarget(qualified, path)
           if (target === 'unsupported') {

--- a/src/main/notebook/dependency-analysis-r.ts
+++ b/src/main/notebook/dependency-analysis-r.ts
@@ -1456,6 +1456,7 @@ const analyzeRSource = (
     'arrow',
     'Biobase',
     'Biostrings',
+    'rtracklayer',
     'Cairo',
     'data.table',
     'dplyr',
@@ -1486,6 +1487,7 @@ const analyzeRSource = (
     'SingleCellExperiment',
     'SummarizedExperiment',
     'svglite',
+    'targets',
     'terra',
     'tibble',
     'tidyr',
@@ -2464,7 +2466,7 @@ const analyzeRSource = (
     (pkg === 'base' && name === 'requireNamespace') ||
     (pkg === 'flowCore' && ['read.FCS', 'read.flowSet', 'write.FCS'].includes(name)) ||
     (pkg === 'tximport' && name === 'tximport') ||
-    (pkg === 'Seurat' && name === 'Read10X_h5') ||
+    (pkg === 'Seurat' && ['Read10X', 'Read10X_h5', 'Load10X_Spatial'].includes(name)) ||
     (pkg === 'GEOquery' && name === 'getGEO') ||
     (pkg === 'base' &&
       (pureSafe.has(name) ||
@@ -3986,6 +3988,15 @@ const analyzeRSource = (
       }
       return
     }
+    const targetOptions = rTargetDefinitionOptions(expr)
+    if (targetOptions) {
+      const dependency = isSymbol(expr.callee) ? expr.callee.name : R_TARGET_FUNCTION.name
+      used.push(dependency)
+      if (!defined.includes(dependency)) priorUsed.push(dependency)
+      unknown.push('opaque-call')
+      targetOptions.forEach((argument) => walk(argument))
+      return
+    }
     const quoted = quotedDataCall(expr)
     if (quoted) {
       used.push(quoted.dependency)
@@ -4413,6 +4424,15 @@ const analyzeRSource = (
       if (contractAvailable('%>%', undefined, 'magrittr')) safeCallNames.push('%>%')
       else unknown.push('opaque-call')
       recordPackageRead('%>%')
+    }
+    const targetOptions = rTargetDefinitionOptions(expr)
+    if (targetOptions) {
+      const dependency = isSymbol(expr.callee) ? expr.callee.name : R_TARGET_FUNCTION.name
+      used.push(dependency)
+      if (!defined.includes(dependency)) priorUsed.push(dependency)
+      unknown.push('opaque-call')
+      targetOptions.forEach((argument) => walk(argument))
+      return
     }
     const quoted = quotedDataCall(expr)
     if (quoted) {
@@ -5372,6 +5392,15 @@ const analyzeRSource = (
           typeSummaries.push(R_GLUE_FUNCTION)
           typeBindings.push({ target: 'glue', typeName: R_GLUE_FUNCTION.name, argumentNames: [] })
         }
+        if (expr.resolvedFunction === 'targets::attach' && controlDepth === 0) {
+          defined.push('tar_target')
+          typeSummaries.push(R_TARGET_FUNCTION)
+          typeBindings.push({
+            target: 'tar_target',
+            typeName: R_TARGET_FUNCTION.name,
+            argumentNames: []
+          })
+        }
         used.push(op)
         if (!defined.includes(op)) priorUsed.push(op)
         safeCallNames.push(op)
@@ -6303,15 +6332,51 @@ const R_GLUE_FUNCTION: NotebookDependencyTypeSummary = {
   methods: [{ name: '__call__', effect: 'unknown', unknownScope: 'namespace' }]
 }
 
-// Track shadowed static helpers and attached glue in statement order, reusing the
+const R_TARGET_FUNCTION: NotebookDependencyTypeSummary = {
+  ...R_GLUE_FUNCTION,
+  name: 'targets::tar_target'
+}
+
+// Task commands are quoted; only configuration options are evaluated at definition time.
+// Tidy injection and scheduler execution still require external-state evidence.
+const rTargetDefinitionOptions = (expr: RExpr): RExpr[] | undefined => {
+  if (!isCall(expr)) return undefined
+  const qualified = rQualifiedCall(expr)
+  if (
+    expr.resolvedFunction !== R_TARGET_FUNCTION.name &&
+    !(qualified?.package === 'targets' && qualified.name === 'tar_target')
+  )
+    return undefined
+  const quotedParameters = ['name', 'command', 'pattern']
+  const namedQuoted = new Set(
+    quotedParameters.map((parameter) => rOptionArgumentIndex(expr.names, parameter))
+  )
+  let remainingQuoted = quotedParameters.filter(
+    (parameter) => rOptionArgumentIndex(expr.names, parameter) < 0
+  ).length
+  return expr.args.filter((_argument, index) => {
+    if (namedQuoted.has(index)) return false
+    if (!expr.names[index] && remainingQuoted > 0) {
+      remainingQuoted -= 1
+      return false
+    }
+    return true
+  })
+}
+
+// Track shadowed static helpers and attached functions in statement order, reusing the
 // existing R bindings. No new persistent import/package registry is needed.
 const resolveRStaticCallIdentities = (
   expressions: RExpr[],
   functions: NotebookSourceFileAccessContext['rFunctions'] = [],
   kernelNames: readonly string[] = []
 ): void => {
-  const known = new Set(
-    functions.filter(({ summary }) => summary.name === R_GLUE_FUNCTION.name).map(({ name }) => name)
+  const known = new Map(
+    functions
+      .filter(({ summary }) =>
+        [R_GLUE_FUNCTION.name, R_TARGET_FUNCTION.name].includes(summary.name)
+      )
+      .map(({ name, summary }) => [name, summary.name])
   )
   const assigned = new Set(
     [...kernelNames, ...functions.map(({ name }) => name)].filter((name) => !known.has(name))
@@ -6328,8 +6393,14 @@ const resolveRStaticCallIdentities = (
     if (exported && isSymbol(exported.callee))
       expr.staticDeviceShadowed = dynamicBindings || assigned.has(exported.callee.name)
     if (['function', 'quote', 'expression', '~'].includes(name ?? '')) return
+    if (!qualified && name && known.has(name)) expr.resolvedFunction = known.get(name)
+    const targetOptions = rTargetDefinitionOptions(expr)
+    if (targetOptions) {
+      for (const argument of targetOptions) visit(argument, false)
+      return
+    }
     if (['if', 'for', 'while', 'repeat', 'switch'].includes(name ?? '')) {
-      const before = new Set(known)
+      const before = new Map(known)
       if (name === 'for' && isSymbol(expr.args[0])) {
         known.delete(expr.args[0].name)
         assigned.add(expr.args[0].name)
@@ -6337,7 +6408,8 @@ const resolveRStaticCallIdentities = (
       for (const argument of expr.args) visit(argument, false)
       // Preserve existing identities only if every visited branch left them intact;
       // a conditional alias/import cannot establish a new identity after the branch.
-      for (const binding of known) if (!before.has(binding)) known.delete(binding)
+      for (const [binding, identity] of known)
+        if (before.get(binding) !== identity) known.delete(binding)
       return
     }
     if (['<-', '=', '->', '<<-', '->>'].includes(name ?? '')) {
@@ -6346,10 +6418,10 @@ const resolveRStaticCallIdentities = (
       const value = expr.args[rightward ? 0 : 1]
       if (value) visit(value, false)
       if (isSymbol(target)) {
-        const alias = isSymbol(value) && known.has(value.name)
+        const alias = isSymbol(value) && known.get(value.name)
         known.delete(target.name)
         assigned.add(target.name)
-        if (alias) known.add(target.name)
+        if (alias) known.set(target.name, alias)
       }
       return
     }
@@ -6360,17 +6432,18 @@ const resolveRStaticCallIdentities = (
         : isCharacter(argument)
           ? argument.value
           : undefined
+      const callable = pkg === 'glue' ? 'glue' : pkg === 'targets' ? 'tar_target' : undefined
       if (
         attachAllowed &&
         (!qualified || qualified.package === 'base') &&
         !assigned.has(name) &&
-        pkg === 'glue' &&
-        !assigned.has('glue') &&
+        callable &&
+        !assigned.has(callable) &&
         expr.args.length === 1 &&
         !expr.names.some(Boolean)
       ) {
-        known.add('glue')
-        expr.resolvedFunction = 'glue::attach'
+        known.set(callable, `${pkg}::${callable}`)
+        expr.resolvedFunction = `${pkg}::attach`
       } else known.clear()
       return
     }
@@ -6383,7 +6456,6 @@ const resolveRStaticCallIdentities = (
       dynamicBindings = true
       return
     }
-    if (!qualified && name && known.has(name)) expr.resolvedFunction = R_GLUE_FUNCTION.name
     const transparent = name === '{' || name === 'suppressPackageStartupMessages'
     for (const argument of expr.args) visit(argument, attachAllowed && transparent)
   }
@@ -6986,7 +7058,8 @@ const R_FILE_MAP_READERS = new Map([
   ),
   ...['read_csv', 'read_csv2', 'read_tsv', 'read_delim'].map((name) => [name, 'readr'] as const),
   ['readLines', 'base'],
-  ['read_json', 'jsonlite']
+  ['read_json', 'jsonlite'],
+  ['import', 'rtracklayer']
 ])
 
 const rLiteralNamedKeys = (expr: RExpr | null | undefined): string[] | undefined => {
@@ -7459,6 +7532,14 @@ const analyzeRFileAccessTree = (
       expr.args.forEach((argument) => visit(argument))
       return
     }
+    const targetOptions = rTargetDefinitionOptions(expr)
+    if (targetOptions) {
+      unresolvedReads = true
+      unresolvedWrites = true
+      unsupportedExternalState = true
+      targetOptions.forEach((argument) => visit(argument))
+      return
+    }
     const quoted = rQuotedDataCall(expr)
     if (quoted && (quoted.qualified || !shadowedQuotationNames.has(quoted.name))) return
     const fileMap = rBoundedFileMap(expr, bindings, collections, shadowedQuotationNames)
@@ -7710,6 +7791,28 @@ const analyzeRFileAccessTree = (
       qualified.package !== 'grDevices'
     )
       call = undefined
+    if (
+      call &&
+      name &&
+      qualified &&
+      ((['Read10X', 'Read10X_h5', 'Load10X_Spatial'].includes(name) &&
+        qualified.package !== 'Seurat') ||
+        (['ArchRProject', 'saveArchRProject', 'createArrowFiles'].includes(name) &&
+          qualified.package !== 'ArchR') ||
+        (name === 'readVcf' && qualified.package !== 'VariantAnnotation') ||
+        (name === 'read.vcfR' && qualified.package !== 'vcfR'))
+    ) {
+      call = undefined
+    }
+    if (call && (name === 'ArchRProject' || name === 'saveArchRProject')) {
+      fileArgumentOverride = {
+        value: connectionArgument(
+          expr,
+          [name === 'ArchRProject' ? 'ArrowFiles' : 'ArchRProj', 'outputDirectory'],
+          'outputDirectory'
+        )
+      }
+    }
     if (call && ['read.FCS', 'read.flowSet', 'write.FCS'].includes(name ?? '')) {
       if (qualified && qualified.package !== 'flowCore') call = undefined
       else if (qualified || !localWrappers.names.has(name!)) {
@@ -7900,6 +8003,71 @@ const analyzeRFileAccessTree = (
       const commandIndex = libraryFread
         ? expr.names.findIndex((candidate) => candidate === 'cmd')
         : -1
+      if (name === 'createArrowFiles') {
+        // Arrow generation and QC/log companions remain incomplete even when
+        // fragment inputs resolve to a bounded collection below.
+        unresolvedWrites = true
+        const parameters = [
+          'inputFiles',
+          'sampleNames',
+          'outputNames',
+          'validBarcodes',
+          'geneAnnotation',
+          'genomeAnnotation',
+          'minTSS',
+          'minFrags',
+          'maxFrags',
+          'minFragSize',
+          'maxFragSize',
+          'QCDir',
+          'nucLength',
+          'promoterRegion',
+          'TSSParams',
+          'excludeChr',
+          'nChunk',
+          'bcTag',
+          'gsubExpression',
+          'bamFlag',
+          'offsetPlus',
+          'offsetMinus',
+          'addTileMat',
+          'TileMatParams',
+          'addGeneScoreMat',
+          'GeneScoreMatParams',
+          'force',
+          'threads',
+          'parallelParam',
+          'subThreading',
+          'verbose',
+          'cleanTmp',
+          'logFile',
+          'filterFrags',
+          'filterTSS'
+        ]
+        const validNames = expr.names.every(
+          (parameter) =>
+            !parameter ||
+            parameters.includes(parameter) ||
+            parameters.filter((formal) => formal.startsWith(parameter)).length === 1
+        )
+        const outputNames = validNames
+          ? connectionArgument(expr, parameters, 'outputNames')
+          : undefined
+        const prefix = rStaticString(outputNames, bindings, collections)
+        const prefixes =
+          rStaticStringCollection(outputNames, bindings, collections)?.values ??
+          (prefix ? [prefix] : undefined)
+        if (prefixes && prefixes.length <= MAX_STATIC_FILE_LOOP_ITERATIONS) {
+          for (const prefix of prefixes) writes.add(`${prefix}.arrow`)
+        }
+        const qcPath = validNames
+          ? rStaticString(connectionArgument(expr, parameters, 'QCDir'), bindings, collections)
+          : undefined
+        if (qcPath) {
+          writes.add(qcPath)
+          writeScopes.set(`directory\0${qcPath}`, { kind: 'directory', path: qcPath })
+        }
+      }
       // Match all required formals together: named arguments consume their slots
       // before unnamed arguments, regardless of the order used at the call site.
       const pathEffects = [call, ...(call.additionalPaths ?? [])]
@@ -7978,6 +8146,26 @@ const analyzeRFileAccessTree = (
       const path = inMemoryRead
         ? undefined
         : (fileConnectionPath(argument) ?? rStaticString(argument, bindings, collections))
+      // These readers expand a directory into companion files at runtime. Keep
+      // the proven root path but do not claim complete input coverage.
+      if (call.kind === 'read' && (name === 'Read10X' || name === 'Load10X_Spatial') && path) {
+        unresolvedReads = true
+      }
+      // ArchRProject consumes ArrowFiles and writes a project directory. Object
+      // inputs retain dependency lineage; file completeness remains uncertain.
+      if (name === 'ArchRProject') {
+        unresolvedReads = true
+        const arrowArgument = connectionArgument(
+          expr,
+          ['ArrowFiles', 'outputDirectory'],
+          'ArrowFiles'
+        )
+        const arrowPaths = rStaticStringCollection(arrowArgument, bindings, collections)?.values
+        if (arrowPaths) {
+          for (const arrowPath of arrowPaths)
+            if (!definitelyWritten.has(arrowPath)) reads.add(arrowPath)
+        }
+      }
       // A device path may be a printf page template or a shell pipe, not an
       // exact output filename. Do not publish either as confirmed file evidence.
       const graphicsFileDevice = Boolean(
@@ -8034,7 +8222,10 @@ const analyzeRFileAccessTree = (
           if (call.kind === 'read') unresolvedReads = true
           else unresolvedWrites = true
         } else if (call.kind === 'write') {
-          const target = rScientificWriteTarget(qualified, path)
+          const target =
+            name === 'ArchRProject' || name === 'saveArchRProject'
+              ? 'directory'
+              : rScientificWriteTarget(qualified, path)
           if (target === 'unsupported') {
             unresolvedWrites = true
           } else {

--- a/src/main/notebook/dependency-analysis.omics-workflows.test.ts
+++ b/src/main/notebook/dependency-analysis.omics-workflows.test.ts
@@ -1,0 +1,329 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, it } from 'vitest'
+import type { NotebookRunRecord } from '../../shared/notebook'
+import { NotebookDependencyAnalyzer } from './dependency-analysis'
+import { analyzePythonNotebookSource } from './dependency-analysis-python'
+import { analyzeRNotebookSource } from './dependency-analysis-r'
+import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+
+import additionalWorkflows from './omics-workflows.fixture.json'
+
+const workflows = [
+  ...additionalWorkflows.map((workflow) => ({ ...workflow, language: 'python' as const })),
+  {
+    name: 'microbial abundance and diversity',
+    consumed: ['community'],
+    states: [
+      ['partial', 'partial', 'partial'],
+      ['partial', 'complete', 'complete'],
+      ['partial', 'complete', 'complete']
+    ],
+    language: 'r' as const,
+    cells: [
+      `library(phyloseq)
+library(ggplot2)
+counts <- read.csv("inputs/asv-counts.csv", row.names = 1, check.names = FALSE)
+taxonomy <- read.csv("inputs/taxonomy.csv", row.names = 1, check.names = FALSE)
+metadata <- read.csv("inputs/sample-metadata.csv", row.names = 1)
+shared_samples <- intersect(colnames(counts), rownames(metadata))
+counts <- as.matrix(counts[, shared_samples, drop = FALSE])
+taxonomy <- as.matrix(taxonomy[rownames(counts), , drop = FALSE])
+metadata <- metadata[shared_samples, , drop = FALSE]
+community <- phyloseq(otu_table(counts, taxa_are_rows = TRUE),
+                      tax_table(taxonomy), sample_data(metadata))`,
+      `diversity <- estimate_richness(community, measures = c("Observed", "Shannon"))
+filtered <- prune_taxa(taxa_sums(community) > 5, community)
+relative <- transform_sample_counts(filtered, function(values) values / sum(values))
+ordination <- ordinate(relative, method = "PCoA", distance = "bray")
+plot <- plot_ordination(relative, ordination, color = "group") + geom_point(size = 3)
+write.csv(diversity, "outputs/alpha-diversity.csv")
+saveRDS(relative, "outputs/relative-abundance.rds")
+ggsave("outputs/beta-diversity.png", plot, width = 7, height = 5)`,
+      `relative_copy <- readRDS("outputs/relative-abundance.rds")
+abundance <- as.data.frame(otu_table(relative_copy))
+write.csv(abundance, "outputs/abundance-matrix.csv")`
+    ],
+    reads: [
+      ['inputs/asv-counts.csv', 'inputs/sample-metadata.csv', 'inputs/taxonomy.csv'],
+      [],
+      ['outputs/relative-abundance.rds']
+    ],
+    writes: [
+      [],
+      [
+        'outputs/alpha-diversity.csv',
+        'outputs/beta-diversity.png',
+        'outputs/relative-abundance.rds'
+      ],
+      ['outputs/abundance-matrix.csv']
+    ]
+  },
+  {
+    name: 'mass spectrometry peak detection and grouping',
+    consumed: ['peaks', 'sample_groups'],
+    states: [
+      ['partial', 'partial', 'partial'],
+      ['partial', 'partial', 'partial'],
+      ['complete', 'complete', 'complete']
+    ],
+    language: 'r' as const,
+    cells: [
+      `library(MSnbase)
+library(xcms)
+raw_files <- c("inputs/control-a.mzML", "inputs/control-b.mzML", "inputs/treated-a.mzML", "inputs/treated-b.mzML")
+sample_groups <- c("control", "control", "treated", "treated")
+raw <- readMSData(files = raw_files, mode = "onDisk")
+ms1 <- filterMsLevel(raw, msLevel = 1L)
+window <- filterRt(ms1, rt = c(60, 600))
+parameters <- CentWaveParam(ppm = 15, peakwidth = c(5, 30), snthresh = 10)
+peaks <- findChromPeaks(window, param = parameters)`,
+      `aligned <- adjustRtime(peaks, param = ObiwarpParam(binSize = 1))
+grouping <- PeakDensityParam(sampleGroups = sample_groups, minFraction = 0.5, bw = 5)
+grouped <- groupChromPeaks(aligned, param = grouping)
+filled <- fillChromPeaks(grouped)
+intensity <- featureValues(filled, value = "into")
+features <- featureDefinitions(filled)
+write.csv(intensity, "outputs/feature-intensities.csv")
+write.csv(as.data.frame(features), "outputs/feature-definitions.csv")
+saveRDS(filled, "outputs/processed-spectra.rds")`,
+      `matrix <- read.csv("outputs/feature-intensities.csv", row.names = 1)
+keep <- rowSums(is.na(matrix)) <= 1
+complete <- matrix[keep, , drop = FALSE]
+write.csv(complete, "outputs/filtered-intensities.csv")`
+    ],
+    reads: [
+      [
+        'inputs/control-a.mzML',
+        'inputs/control-b.mzML',
+        'inputs/treated-a.mzML',
+        'inputs/treated-b.mzML'
+      ],
+      [],
+      ['outputs/feature-intensities.csv']
+    ],
+    writes: [
+      [],
+      [
+        'outputs/feature-definitions.csv',
+        'outputs/feature-intensities.csv',
+        'outputs/processed-spectra.rds'
+      ],
+      ['outputs/filtered-intensities.csv']
+    ]
+  },
+  {
+    name: 'clinical cohort harmonization and stratified summary',
+    consumed: ['cohort'],
+    states: [
+      ['complete', 'complete', 'complete'],
+      ['complete', 'complete', 'complete'],
+      ['complete', 'complete', 'complete']
+    ],
+    language: 'python' as const,
+    cells: [
+      `from pathlib import Path
+import pyreadstat as prs
+import pandas as pd
+source = Path("inputs") / "cohort.sav"
+raw, metadata = prs.read_sav(filename_path=source, output_format="pandas")
+cohort = pd.DataFrame(raw)
+followup = pd.read_csv("inputs/followup.csv")
+cohort = cohort.merge(followup, on="participant_id", how="inner")
+cohort = cohort.loc[cohort["age"] >= 18].copy()
+cohort["event"] = cohort["event"].fillna(0)`,
+      `summary = cohort.groupby("treatment").agg(participants=("participant_id", "count"), mean_age=("age", "mean"), events=("event", "sum"))
+summary.to_csv("outputs/stratified-summary.csv")
+prs.write_sav(cohort, dst_path="outputs/analysis-cohort.sav")`,
+      `exported, export_metadata = prs.read_sav(filename_path="outputs/analysis-cohort.sav")
+analysis = pd.DataFrame(exported)
+analysis.to_csv("outputs/analysis-cohort.csv", index=False)`
+    ],
+    reads: [
+      [join('inputs', 'cohort.sav'), 'inputs/followup.csv'].sort(),
+      [],
+      ['outputs/analysis-cohort.sav']
+    ],
+    writes: [
+      [],
+      ['outputs/analysis-cohort.sav', 'outputs/stratified-summary.csv'],
+      ['outputs/analysis-cohort.csv']
+    ]
+  }
+]
+
+it.each(workflows)('tracks input, output and cell dependencies: $name', async (workflow) => {
+  const storageRoot = await mkdtemp(join(tmpdir(), 'omics-lineage-'))
+  const runs: NotebookRunRecord[] = workflow.cells.map((script, index) => ({
+    runId: String(index),
+    cellId: String(index),
+    script,
+    kernelKind: workflow.language,
+    kernelEpochId: 'epoch',
+    environment: workflow.language,
+    source: 'agent',
+    status: 'completed',
+    kernelDispatched: true,
+    startedAt: index,
+    endedAt: index + 1,
+    text: { stdout: '', stderr: '', traceback: '', plain: [] },
+    outputs: [],
+    workingFiles: []
+  }))
+  try {
+    const analyzer = new NotebookDependencyAnalyzer({
+      storageRoot,
+      repository: { readSessionRuns: async () => runs }
+    })
+    const projection = await analyzer.project({ projectId: 'p', sessionId: 's', throughRunId: '2' })
+    if (workflow.name === 'clinical cohort harmonization and stratified summary')
+      expect(projection.dependenciesByRunId?.['1']).toContain('0')
+    else {
+      // Opaque package calls and unmodeled values currently prevent a reliable graph.
+      expect(projection.stalenessByRunId['1']?.state).toBe('unknown')
+      expect(projection.stalenessByRunId['1']).toMatchObject({
+        reasons: expect.arrayContaining(['opaque-call'])
+      })
+    }
+    const analyze = workflow.language === 'r' ? analyzeRNotebookSource : analyzePythonNotebookSource
+    const { facts } = await analyze(workflow.cells[1]!)
+    expect(facts.usedNames).toEqual(expect.arrayContaining(workflow.consumed))
+    for (const [index, run] of runs.entries()) {
+      const context = await analyzer.sourceFileAccessContext({
+        projectId: 'p',
+        sessionId: 's',
+        currentRunId: run.runId,
+        language: workflow.language,
+        environment: workflow.language,
+        kernelEpochId: 'epoch'
+      })
+      const access = await analyzeNotebookSourceFileAccess(workflow.language, run.script, context)
+      expect(access.reads).toEqual(workflow.reads[index])
+      expect(access.writes).toEqual(workflow.writes[index])
+      expect([access.readState, access.writeState, access.externalState]).toEqual(
+        workflow.states[index]
+      )
+    }
+  } finally {
+    await rm(storageRoot, { recursive: true, force: true })
+  }
+})
+
+it.each(['pandas', 'polars', 'dict'])(
+  'does not assign a DataFrame type to a pyreadstat tuple (%s)',
+  async (format) => {
+    const { facts } = await analyzePythonNotebookSource(`import pyreadstat
+result = pyreadstat.read_sav(filename_path="inputs/cohort.sav", output_format="${format}")`)
+    expect(facts.typeBindings?.find((binding) => binding.target === 'result')?.typeName).not.toBe(
+      'pandas.DataFrame'
+    )
+  }
+)
+
+it('keeps uncertainty after mutation of an opaque multiomics object', async () => {
+  const source = `import muon as mu
+import torch
+import pandas as pd
+mdata = mu.read_10x_h5("inputs/multiome.h5")
+labels = pd.read_csv("inputs/cell_labels.csv")
+mdata.obs = mdata.obs.join(labels.set_index("cell_id"))
+torch.save(mdata.obs["label"].to_numpy(), "outputs/labels.pt")
+mdata.write("outputs/multiome.h5mu")`
+  const access = await analyzeNotebookSourceFileAccess('python', source)
+  expect(access).toMatchObject({
+    reads: ['inputs/cell_labels.csv', 'inputs/multiome.h5'],
+    writes: ['outputs/labels.pt'],
+    externalState: 'partial'
+  })
+  // The opaque property setter invalidates the receiver namespace. The checkpoint
+  // remains uncaptured; external uncertainty must prevent a complete-capture claim.
+  expect(access.writes).not.toContain('outputs/multiome.h5mu')
+})
+
+it.each([
+  ['muon.read_10x_h5("inputs/multiome.h5")', ['inputs/multiome.h5']],
+  ['muon.read_10x_h5("inputs/multiome.h5", extended=enabled)', ['inputs/multiome.h5']],
+  ['muon.read_10x_mtx("inputs/matrix")', []]
+])('keeps unresolved multiomics companions visible: %s', async (expression, reads) => {
+  expect(
+    await analyzeNotebookSourceFileAccess('python', `import muon\nvalue = ${expression}`)
+  ).toMatchObject({
+    reads,
+    readState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it.each(['r', 'rb', 'w', 'wb', 'wz'])('respects the variant file mode %s', async (mode) => {
+  const reading = mode.startsWith('r')
+  expect(
+    await analyzeNotebookSourceFileAccess(
+      'python',
+      `import pysam
+handle = pysam.VariantFile("data/variants.bcf", mode="${mode}", index_filename="data/variants.csi", header=header)`
+    )
+  ).toMatchObject({
+    reads: reading ? ['data/variants.bcf', 'data/variants.csi'] : [],
+    writes: reading ? [] : ['data/variants.bcf'],
+    externalState: 'partial'
+  })
+})
+
+it('keeps a dynamic variant mode unresolved', async () => {
+  expect(
+    await analyzeNotebookSourceFileAccess(
+      'python',
+      `from pysam import VariantFile
+handle = VariantFile("data/variants.bcf", mode=mode)`
+    )
+  ).toMatchObject({
+    reads: [],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('does not invent partition files for deferred parquet output', async () => {
+  expect(
+    await analyzeNotebookSourceFileAccess(
+      'python',
+      `import dask.dataframe as dd
+frame = dd.read_parquet("inputs/partitions")
+job = frame.to_parquet("outputs/partitions", compute=False)`
+    )
+  ).toMatchObject({
+    reads: ['inputs/partitions'],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('retains uncertainty about FASTA indexes and mutable access', async () => {
+  expect(
+    await analyzeNotebookSourceFileAccess(
+      'python',
+      `from pyfaidx import Fasta
+reference = Fasta("inputs/reference.fa", mutable=True)`
+    )
+  ).toMatchObject({
+    reads: ['inputs/reference.fa'],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('does not borrow a clinical reader from an unrelated namespace', async () => {
+  expect(
+    await analyzeNotebookSourceFileAccess(
+      'python',
+      `import custom
+result = custom.read_sav("inputs/cohort.sav")`
+    )
+  ).toMatchObject({ reads: [], externalState: 'partial' })
+})

--- a/src/main/notebook/notebook-call-effects.ts
+++ b/src/main/notebook/notebook-call-effects.ts
@@ -245,8 +245,13 @@ const R_FILE_CALL_EFFECTS: ReadonlyMap<string, NotebookFileCallEffect> = new Map
   ['read.FCS', { kind: 'read', position: 0, keywords: ['filename'] }],
   ['read.flowSet', { kind: 'read', position: 0, keywords: ['files'], inputForm: 'paths' }],
   ['write.FCS', { kind: 'write', position: 1, keywords: ['filename'] }],
+  // ArchR keeps ArrowFiles/project as its first positional argument and the
+  // output directory as the second. Named outputDirectory still takes priority.
+  ['saveArchRProject', { kind: 'write', position: 1, keywords: ['outputDirectory'] }],
+  ['ArchRProject', { kind: 'write', position: 1, keywords: ['outputDirectory'] }],
   ['tximport', { kind: 'read', position: 0, keywords: ['files'], inputForm: 'paths' }],
   ['readMSData', { kind: 'read', position: 0, keywords: ['files'], inputForm: 'paths' }],
+  ['createArrowFiles', { kind: 'read', position: 0, keywords: ['inputFiles'], inputForm: 'paths' }],
   ['Spectra', { kind: 'read', position: 0, keywords: ['object'], inputForm: 'paths' }],
   ...[
     'dget',
@@ -301,6 +306,8 @@ const R_FILE_CALL_EFFECTS: ReadonlyMap<string, NotebookFileCallEffect> = new Map
     'read_xls',
     'read_xlsx',
     'read_xpt',
+    'readVcf',
+    'read.vcfR',
     'read_yaml',
     'read_xml',
     'h5read',
@@ -402,6 +409,8 @@ const R_FILE_CALL_EFFECTS: ReadonlyMap<string, NotebookFileCallEffect> = new Map
   ['read_outcome_data', { kind: 'read', position: 0, keywords: ['filename'] }],
   ['getGEO', { kind: 'read', position: 1, keywords: ['filename'] }],
   ['Read10X_h5', { kind: 'read', position: 0, keywords: ['filename'] }],
+  ['Read10X', { kind: 'read', position: 0, keywords: ['data.dir'] }],
+  ['Load10X_Spatial', { kind: 'read', position: 0, keywords: ['data.dir'] }],
   ...[
     'read_csv',
     'read_csv2',

--- a/src/main/notebook/omics-workflows.fixture.json
+++ b/src/main/notebook/omics-workflows.fixture.json
@@ -1,0 +1,46 @@
+[
+  {
+    "name": "metagenomic contig taxonomy and abundance",
+    "consumed": ["contigs", "abundance", "taxonomy"],
+    "cells": [
+      "from Bio import SeqIO\nimport pandas as pd\nimport numpy as np\ncontigs = pd.DataFrame([\n    {\"contig_id\": record.id, \"length_bp\": len(record.seq),\n     \"gc_fraction\": (record.seq.upper().count(\"G\") + record.seq.upper().count(\"C\")) / max(len(record.seq), 1)}\n    for record in SeqIO.parse(\"inputs/contigs.fasta\", \"fasta\")\n])\nabundance = pd.read_csv(\"inputs/contig_abundance.tsv\", sep=\"\\t\")\ntaxonomy = pd.read_csv(\"inputs/contig_taxonomy.tsv\", sep=\"\\t\")\nassert contigs[\"contig_id\"].is_unique\nassert taxonomy[\"contig_id\"].is_unique\nassert abundance[\"reads\"].ge(0).all()",
+      "merged = abundance.merge(contigs, on=\"contig_id\", how=\"left\", validate=\"many_to_one\")\nmerged = merged.merge(taxonomy[[\"contig_id\", \"taxon\"]], on=\"contig_id\", how=\"left\", validate=\"many_to_one\")\nassert merged[\"length_bp\"].notna().all()\nmerged[\"taxon\"] = merged[\"taxon\"].fillna(\"unclassified\")\ntaxon_abundance = merged.groupby([\"sample_id\", \"taxon\"], as_index=False)[\"reads\"].sum()\nsample_totals = taxon_abundance.groupby(\"sample_id\")[\"reads\"].transform(\"sum\")\ntaxon_abundance[\"relative_abundance\"] = taxon_abundance[\"reads\"].div(sample_totals.replace(0, np.nan)).fillna(0)\nmerged.to_csv(\"outputs/merged_contig_table.tsv\", sep=\"\\t\", index=False)\ntaxon_abundance.to_csv(\"outputs/taxon_abundance.tsv\", sep=\"\\t\", index=False)",
+      "import matplotlib.pyplot as plt\ndetected = taxon_abundance.loc[taxon_abundance[\"reads\"] > 0]\nsummary = detected.groupby(\"taxon\", as_index=False).agg(samples_detected=(\"sample_id\", \"nunique\"), total_reads=(\"reads\", \"sum\"))\nsummary.to_csv(\"outputs/taxon_summary.tsv\", sep=\"\\t\", index=False)\nplt.figure(figsize=(6, 4))\nplt.scatter(contigs[\"length_bp\"] / 1000, contigs[\"gc_fraction\"] * 100, s=8, alpha=0.5)\nplt.xlabel(\"Contig length (kb)\")\nplt.ylabel(\"GC (%)\")\nplt.tight_layout()\nplt.savefig(\"outputs/contig_qc.png\", dpi=150)\nplt.close()"
+    ],
+    "reads": [
+      ["inputs/contig_abundance.tsv", "inputs/contig_taxonomy.tsv", "inputs/contigs.fasta"],
+      [],
+      []
+    ],
+    "writes": [
+      [],
+      ["outputs/merged_contig_table.tsv", "outputs/taxon_abundance.tsv"],
+      ["outputs/contig_qc.png", "outputs/taxon_summary.tsv"]
+    ],
+    "states": [
+      ["partial", "partial", "partial"],
+      ["partial", "complete", "complete"],
+      ["partial", "complete", "complete"]
+    ]
+  },
+  {
+    "name": "metabolite quality control and principal components",
+    "consumed": ["filtered"],
+    "cells": [
+      "import pandas as pd\nimport numpy as np\nfeatures = pd.read_csv(\"inputs/metabolite_features.tsv\", sep=\"\\t\")\nmetadata = pd.read_csv(\"inputs/sample_metadata.tsv\", sep=\"\\t\")\nassert features[\"feature_id\"].is_unique\nassert metadata[\"sample_id\"].is_unique\nsample_ids = [column for column in features.columns if column != \"feature_id\"]\nassert set(sample_ids) <= set(metadata[\"sample_id\"])\nmatrix = features.set_index(\"feature_id\")[sample_ids].apply(pd.to_numeric, errors=\"coerce\")\nassert (matrix.fillna(0).to_numpy() >= 0).all()\nmissing = matrix.isna().mean(axis=1)\nfiltered = matrix.loc[missing <= 0.20].copy()\nfiltered = filtered.loc[filtered.median(axis=1) > 0]\nqc = pd.DataFrame({\"feature_id\": matrix.index, \"missing_fraction\": missing.to_numpy(), \"retained\": matrix.index.isin(filtered.index)})\nqc.to_csv(\"outputs/feature_qc.tsv\", sep=\"\\t\", index=False)",
+      "imputed = filtered.T.fillna(filtered.median(axis=1)).T\ntransformed = np.log1p(imputed)\nfeature_mean = transformed.mean(axis=1)\nfeature_sd = transformed.std(axis=1, ddof=1).replace(0, 1)\nscaled = transformed.sub(feature_mean, axis=0).div(feature_sd, axis=0)\nassert scaled.shape[0] >= 2 and scaled.shape[1] >= 2\nassert np.isfinite(scaled.to_numpy()).all()",
+      "from sklearn.decomposition import PCA\nimport matplotlib.pyplot as plt\npca = PCA(n_components=2, svd_solver=\"full\")\nvalues = pca.fit_transform(scaled.T)\nscores = pd.DataFrame(values, columns=[\"PC1\", \"PC2\"])\nscores.insert(0, \"sample_id\", sample_ids)\nscores = scores.merge(metadata, on=\"sample_id\", how=\"left\", validate=\"one_to_one\")\nreport = pd.DataFrame({\"component\": [\"PC1\", \"PC2\"], \"variance_ratio\": pca.explained_variance_ratio_})\nscores.to_csv(\"outputs/pca_scores.tsv\", sep=\"\\t\", index=False)\nreport.to_csv(\"outputs/pca_report.tsv\", sep=\"\\t\", index=False)\nplt.figure(figsize=(6, 4))\nplt.scatter(scores[\"PC1\"], scores[\"PC2\"], alpha=0.8)\nplt.xlabel(\"PC1\")\nplt.ylabel(\"PC2\")\nplt.tight_layout()\nplt.savefig(\"outputs/pca_scores.png\", dpi=150)\nplt.close()"
+    ],
+    "reads": [["inputs/metabolite_features.tsv", "inputs/sample_metadata.tsv"], [], []],
+    "writes": [
+      ["outputs/feature_qc.tsv"],
+      [],
+      ["outputs/pca_report.tsv", "outputs/pca_scores.png", "outputs/pca_scores.tsv"]
+    ],
+    "states": [
+      ["partial", "partial", "partial"],
+      ["partial", "complete", "complete"],
+      ["partial", "complete", "complete"]
+    ]
+  }
+]

--- a/src/main/notebook/python-library-effects.ts
+++ b/src/main/notebook/python-library-effects.ts
@@ -279,6 +279,19 @@ const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
       }
     }
   },
+  mudata: {
+    kind: 'module',
+    methods: {
+      MuData: { effect: 'read', returnType: 'mudata.MuData' }
+    }
+  },
+  'mudata.MuData': {
+    kind: 'type',
+    methods: {
+      write: { effect: 'read', file: { kind: 'write', position: 0, keywords: ['filename'] } },
+      write_h5mu: { effect: 'read', file: { kind: 'write', position: 0, keywords: ['filename'] } }
+    }
+  },
   'muon.MuData': {
     kind: 'type',
     methods: {

--- a/src/main/notebook/python-library-effects.ts
+++ b/src/main/notebook/python-library-effects.ts
@@ -230,7 +230,86 @@ const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
   torch: {
     kind: 'module',
     methods: {
-      load: { effect: 'read', unsafeNamespace: true }
+      load: { effect: 'read', unsafeNamespace: true },
+      save: { effect: 'read', file: { kind: 'write', position: 1, keywords: ['f'] } }
+    }
+  },
+  h5py: {
+    kind: 'module',
+    methods: {
+      File: {
+        effect: 'read',
+        returnType: 'h5py.File',
+        file: { kind: 'read', position: 0, keywords: ['name'] }
+      }
+    }
+  },
+  'dask.dataframe': {
+    kind: 'module',
+    methods: {
+      read_csv: {
+        effect: 'read',
+        returnType: 'dask.DataFrame',
+        file: { kind: 'read', position: 0, keywords: ['urlpath'] }
+      },
+      read_parquet: {
+        effect: 'read',
+        returnType: 'dask.DataFrame',
+        file: { kind: 'read', position: 0, keywords: ['path'] }
+      }
+    }
+  },
+  muon: {
+    kind: 'module',
+    methods: {
+      read_10x_h5: {
+        effect: 'read',
+        returnType: 'muon.MuData',
+        file: { kind: 'read', position: 0, keywords: ['filename'] }
+      },
+      read_h5mu: {
+        effect: 'read',
+        returnType: 'muon.MuData',
+        file: { kind: 'read', position: 0, keywords: ['filename'] }
+      },
+      read_10x_mtx: {
+        effect: 'read',
+        returnType: 'muon.MuData',
+        file: { kind: 'read', position: 0, keywords: ['path'] }
+      }
+    }
+  },
+  'muon.MuData': {
+    kind: 'type',
+    methods: {
+      write: { effect: 'read', file: { kind: 'write', position: 0, keywords: ['filename'] } },
+      write_h5mu: { effect: 'read', file: { kind: 'write', position: 0, keywords: ['filename'] } }
+    }
+  },
+  wfdb: {
+    kind: 'module',
+    methods: {
+      rdrecord: {
+        effect: 'read',
+        externalState: true,
+        file: { kind: 'read', position: 0, keywords: ['record_name'] }
+      },
+      rdann: {
+        effect: 'read',
+        externalState: true,
+        file: { kind: 'read', position: 0, keywords: ['record_name'] }
+      },
+      wrsamp: {
+        effect: 'read',
+        externalState: true,
+        file: { kind: 'write', position: 0, keywords: ['record_name'] }
+      }
+    }
+  },
+  'dask.DataFrame': {
+    kind: 'type',
+    methods: {
+      to_parquet: { effect: 'read', file: { kind: 'write', position: 0, keywords: ['path'] } }
     }
   },
   collections: {
@@ -735,6 +814,55 @@ const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
         firstArgumentKeyword: 'data',
         returnsPossibleAliasOf: 'firstArgument'
       }
+    }
+  },
+  pyreadstat: {
+    kind: 'module',
+    methods: {
+      // Readers return (data, metadata); output_format can change the data type.
+      ...Object.fromEntries(
+        ['read_dta', 'read_sas7bdat', 'read_sav', 'read_xport'].map((name) => [
+          name,
+          {
+            effect: 'read' as const,
+            file: { kind: 'read' as const, position: 0, keywords: ['filename_path'] }
+          }
+        ])
+      ),
+      write_sav: { effect: 'read', file: { kind: 'write', position: 1, keywords: ['dst_path'] } },
+      write_dta: { effect: 'read', file: { kind: 'write', position: 1, keywords: ['dst_path'] } },
+      write_xport: { effect: 'read', file: { kind: 'write', position: 1, keywords: ['dst_path'] } }
+    }
+  },
+  'pyarrow.parquet': {
+    kind: 'module',
+    methods: {
+      read_table: {
+        effect: 'read',
+        returnType: 'pyarrow.Table',
+        file: { kind: 'read', position: 0, keywords: ['source'] }
+      },
+      write_table: {
+        effect: 'read',
+        file: { kind: 'write', position: 1, keywords: ['where'] }
+      }
+    }
+  },
+  pyfaidx: {
+    kind: 'module',
+    methods: {
+      Fasta: {
+        effect: 'read',
+        returnType: 'pyfaidx.Fasta',
+        file: { kind: 'read', position: 0, keywords: ['filename'] }
+      }
+    }
+  },
+  pyranges: {
+    kind: 'module',
+    methods: {
+      read_bed: { effect: 'read', file: { kind: 'read', position: 0, keywords: ['f'] } },
+      read_gtf: { effect: 'read', file: { kind: 'read', position: 0, keywords: ['f'] } }
     }
   },
   'scipy.stats': {
@@ -1438,7 +1566,17 @@ const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
     methods: {
       // File mode and explicit index/reference paths are handled together by
       // file analysis. Implicit HTS indexes, reference caches and options remain external.
-      AlignmentFile: { effect: 'read', externalState: true }
+      AlignmentFile: { effect: 'read', externalState: true },
+      VariantFile: {
+        effect: 'read',
+        externalState: true,
+        file: { kind: 'read', position: 0, keywords: ['filename'] }
+      },
+      TabixFile: {
+        effect: 'read',
+        externalState: true,
+        file: { kind: 'read', position: 0, keywords: ['filename'] }
+      }
     }
   },
   'pyteomics.mgf': {
@@ -1541,6 +1679,10 @@ const PYTHON_LIBRARY_EFFECTS: PythonLibraryEffects = {
           inputForm: 'paths',
           singleFileSuffixes: medicalSingleFileSuffixes
         }
+      },
+      WriteTransform: {
+        effect: 'read',
+        file: { kind: 'write', position: 1, keywords: ['transformFileName'] }
       },
       WriteImage: {
         effect: 'read',

--- a/src/main/notebook/source-file-access-analysis.additional-omics.test.ts
+++ b/src/main/notebook/source-file-access-analysis.additional-omics.test.ts
@@ -1,0 +1,207 @@
+import { expect, it } from 'vitest'
+import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+
+it('captures a multi-stage ATAC and peak annotation workflow', async () => {
+  const source = `from pathlib import Path
+import subprocess
+import pandas as pd
+samples = pd.read_csv("inputs/atac-samples.csv")
+Path("work").mkdir(exist_ok=True)
+for row in samples.itertuples():
+    subprocess.run(["aligner", "-1", row.fastq_r1, "-2", row.fastq_r2, "-o", f"work/{row.sample}.bam"], check=True)
+    subprocess.run(["peakcaller", "--bam", f"work/{row.sample}.bam", "--out", f"work/{row.sample}.narrowPeak"], check=True)
+peaks = pd.read_csv("inputs/consensus-peaks.bed", sep="\\t")
+counts = pd.read_csv("work/peak-counts.tsv", sep="\\t")
+peaks.merge(counts, on="peak_id").to_csv("results/differential-peaks.csv", index=False)
+Path("results/qc-report.html").write_text("<html>qc</html>")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/atac-samples.csv', 'inputs/consensus-peaks.bed', 'work/peak-counts.tsv'],
+    writes: ['results/differential-peaks.csv', 'results/qc-report.html'],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a metagenomic assembly and abundance workflow', async () => {
+  const source = `from pathlib import Path
+import subprocess
+import pandas as pd
+manifest = pd.read_csv("inputs/metagenome-manifest.csv")
+for row in manifest.itertuples():
+    subprocess.run(["assembler", row.reads, "--output", f"work/{row.sample}/contigs.fasta"], check=True)
+    subprocess.run(["classifier", f"work/{row.sample}/contigs.fasta", "--database", "inputs/taxonomy-db"], check=True)
+tables = [pd.read_csv(f"work/{row.sample}/abundance.tsv", sep="\\t") for row in manifest.itertuples()]
+pd.concat(tables).to_parquet("results/taxon-abundance.parquet")
+Path("results/metagenome-report.html").write_text("<html>report</html>")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/metagenome-manifest.csv'],
+    writes: ['results/metagenome-report.html', 'results/taxon-abundance.parquet'],
+    readState: 'partial',
+    writeState: 'complete',
+    externalState: 'partial'
+  })
+})
+
+it('captures multimodal h5mu integration and export', async () => {
+  const source = `import muon as mu
+import pandas as pd
+multi = mu.read_h5mu("inputs/multiome.h5mu")
+clinical = pd.read_csv("inputs/cell-clinical.csv")
+multi.obs = multi.obs.join(clinical.set_index("cell_id"), on="cell_id")
+multi.mod["rna"].write_h5ad("results/rna-annotated.h5ad")
+multi.mod["atac"].write_h5ad("results/atac-annotated.h5ad")
+multi.write_h5mu("results/integrated.h5mu")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/cell-clinical.csv', 'inputs/multiome.h5mu'],
+    writes: ['results/atac-annotated.h5ad', 'results/rna-annotated.h5ad'],
+    readState: 'partial',
+    writeState: 'complete',
+    externalState: 'partial'
+  })
+})
+
+it('captures methylation normalization and differential report outputs', async () => {
+  const source = `library(minfi)
+library(limma)
+targets <- read.csv("inputs/idat-sample-sheet.csv")
+rg <- read.metharray.exp(targets = targets)
+mset <- preprocessNoob(rg)
+beta <- getBeta(mset)
+design <- model.matrix(~ targets$condition)
+fit <- eBayes(lmFit(beta, design))
+dmr <- topTable(fit, number = Inf)
+write.csv(dmr, "results/differential-methylation.csv")
+saveRDS(mset, "results/normalized-methylation.rds")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/idat-sample-sheet.csv'],
+    writes: ['results/differential-methylation.csv', 'results/normalized-methylation.rds'],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a VCF annotation and cohort burden workflow', async () => {
+  const source = `from pathlib import Path
+import pandas as pd
+import subprocess
+from cyvcf2 import VCF
+manifest = pd.read_csv("inputs/variant-manifest.csv")
+rows = []
+for sample in manifest.itertuples():
+    subprocess.run(["variant-annotator", sample.vcf, "--reference", "inputs/reference.fa", "--output", f"work/{sample.sample}.annotated.vcf.gz"], check=True)
+    for variant in VCF(f"work/{sample.sample}.annotated.vcf.gz"):
+        rows.append({"sample": sample.sample, "gene": variant.INFO.get("GENE"), "impact": variant.INFO.get("IMPACT")})
+burden = pd.DataFrame(rows).groupby(["sample", "gene"]).size().reset_index(name="count")
+burden.to_parquet("results/gene-burden.parquet")
+Path("results/variant-qc.json").write_text("{}")`
+  const access = await analyzeNotebookSourceFileAccess('python', source)
+  expect(access.writes).toEqual(['results/gene-burden.parquet', 'results/variant-qc.json'])
+  expect(access.reads).toContain('inputs/variant-manifest.csv')
+  expect(access.externalState).toBe('partial')
+})
+
+it('captures an R proteomics quantification and pathway workflow', async () => {
+  const source = `library(MSnbase)
+library(xcms)
+library(limma)
+metadata <- read.csv("inputs/proteomics-samples.csv")
+raw <- readMSData(metadata$file, mode = "onDisk")
+peaks <- findChromPeaks(raw, param = CentWaveParam())
+aligned <- adjustRtime(peaks, param = ObiwarpParam())
+features <- featureValues(aligned, value = "into")
+design <- model.matrix(~ metadata$condition)
+fit <- eBayes(lmFit(log2(features + 1), design))
+hits <- topTable(fit, number = Inf)
+write.csv(hits, "results/differential-proteins.csv")
+saveRDS(aligned, "results/aligned-features.rds")
+writeLines(capture.output(sessionInfo()), "results/proteomics-session.txt")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/proteomics-samples.csv'],
+    writes: [
+      'results/aligned-features.rds',
+      'results/differential-proteins.csv',
+      'results/proteomics-session.txt'
+    ],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a phyloseq microbiome differential abundance workflow', async () => {
+  const source = `library(phyloseq)
+library(DESeq2)
+counts <- read.csv("inputs/otu-counts.csv", row.names = 1)
+taxonomy <- read.csv("inputs/taxonomy.csv", row.names = 1)
+clinical <- read.csv("inputs/microbiome-clinical.csv")
+ps <- phyloseq(otu_table(as.matrix(counts), taxa_are_rows = TRUE), tax_table(as.matrix(taxonomy)), sample_data(clinical))
+dds <- phyloseq_to_deseq2(ps, ~ treatment + batch)
+dds <- DESeq(dds)
+results <- as.data.frame(results(dds, contrast = c("treatment", "case", "control")))
+write.csv(results, "results/differential-taxa.csv")
+saveRDS(ps, "results/phyloseq-object.rds")
+writeLines(capture.output(plot_richness(ps)), "results/richness-report.txt")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/microbiome-clinical.csv', 'inputs/otu-counts.csv', 'inputs/taxonomy.csv'],
+    writes: [
+      'results/differential-taxa.csv',
+      'results/phyloseq-object.rds',
+      'results/richness-report.txt'
+    ],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a radiomics cohort preprocessing and survival model workflow', async () => {
+  const source = `from pathlib import Path
+import pandas as pd
+import SimpleITK as sitk
+from radiomics import featureextractor
+from lifelines import CoxPHFitter
+manifest = pd.read_csv("inputs/radiomics-manifest.csv")
+features = []
+extractor = featureextractor.RadiomicsFeatureExtractor("inputs/radiomics.yaml")
+for row in manifest.itertuples():
+    image = sitk.ReadImage(row.image)
+    mask = sitk.ReadImage(row.mask)
+    values = extractor.execute(image, mask)
+    features.append({"patient_id": row.patient_id, **values})
+frame = pd.DataFrame(features).merge(pd.read_csv("inputs/outcomes.csv"), on="patient_id")
+frame.to_parquet("results/radiomics-features.parquet")
+CoxPHFitter().fit(frame, duration_col="time", event_col="event").print_summary()
+Path("results/radiomics-report.html").write_text("<html>report</html>")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/outcomes.csv', 'inputs/radiomics-manifest.csv', 'inputs/radiomics.yaml'],
+    writes: ['results/radiomics-features.parquet', 'results/radiomics-report.html'],
+    readState: 'partial',
+    writeState: 'complete',
+    externalState: 'partial'
+  })
+})
+
+it('captures an RNA velocity multi-stage export workflow', async () => {
+  const source = `import scanpy as sc
+import scvelo as scv
+import pandas as pd
+adata = scv.read("inputs/spliced-unspliced.loom", cache=True)
+metadata = pd.read_csv("inputs/cell-metadata.csv")
+adata.obs = adata.obs.join(metadata.set_index("cell_id"), on="cell_id")
+sc.pp.filter_and_normalize(adata, min_shared_counts=20)
+scv.pp.moments(adata, n_pcs=30, n_neighbors=30)
+scv.tl.velocity(adata, mode="dynamical")
+scv.tl.velocity_graph(adata)
+scv.pl.velocity_embedding_stream(adata, basis="umap", save="-velocity.pdf")
+adata.write("results/velocity.h5ad")
+adata.obs.to_csv("results/velocity-cell-metadata.csv")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/cell-metadata.csv'],
+    writes: ['results/velocity-cell-metadata.csv'],
+    readState: 'partial',
+    writeState: 'complete',
+    externalState: 'partial'
+  })
+})

--- a/src/main/notebook/source-file-access-analysis.clinical-formats.test.ts
+++ b/src/main/notebook/source-file-access-analysis.clinical-formats.test.ts
@@ -2,8 +2,107 @@ import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 
 import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+import { analyzeRNotebookSource } from './dependency-analysis-r'
 
 describe('clinical statistical file readers', () => {
+  it.each([
+    'ArchR::saveArchRProject(project, "outputs/project")',
+    'saveArchRProject(ArchRProj=project, outputDirectory="outputs/project")'
+  ])('preserves project input uncertainty when saving: %s', async (source) => {
+    const { fileAccess } = await analyzeRNotebookSource(source)
+    expect(fileAccess?.unresolvedReads).toBe(true)
+    const result = await analyzeNotebookSourceFileAccess('r', source, {
+      staticStrings: [],
+      staticCollections: [],
+      localFileWrappers: [],
+      resolvedKernelNames: ['project']
+    })
+    expect(result).toMatchObject({
+      reads: [],
+      readState: 'partial',
+      writes: ['outputs/project'],
+      writeScopes: [{ kind: 'directory', path: 'outputs/project' }]
+    })
+  })
+
+  it.each([
+    'ArchR::createArrowFiles(inputFiles=path, outputNames="outputs/arrows", QCDir="outputs/qc")',
+    'ArchR::ArchRProject(ArrowFiles=path, outputDirectory="outputs/project")'
+  ])('does not summarize mixed file effects as a single path: %s', async (call) => {
+    const { fileAccess } = await analyzeRNotebookSource(
+      `build <- function(path) ${call}\nbuild("inputs/fragments.tsv.gz")`
+    )
+    expect(fileAccess).toMatchObject({
+      unresolvedReads: true,
+      unresolvedWrites: true,
+      localFileWrappersComplete: false,
+      context: { localFileWrappers: [] }
+    })
+  })
+
+  it('preserves directory-output uncertainty through a project-saving wrapper', async () => {
+    const { fileAccess } = await analyzeRNotebookSource(
+      'save_project <- function(path) ArchR::saveArchRProject(project, path)\nsave_project("outputs/project")'
+    )
+    expect(fileAccess).toMatchObject({
+      unresolvedReads: true,
+      unresolvedWrites: true,
+      localFileWrappersComplete: false,
+      context: { localFileWrappers: [] }
+    })
+  })
+
+  it.each(['ArchRProject', 'saveArchRProject', 'createArrowFiles'])(
+    'preserves local and contextual file wrappers named %s',
+    async (name) => {
+      const call = `${name}("outputs/value.rds", "outputs/not-a-directory")`
+      const local = await analyzeNotebookSourceFileAccess(
+        'r',
+        `${name} <- function(path, unused) saveRDS(1, path)\n${call}`
+      )
+      const contextual = await analyzeNotebookSourceFileAccess('r', call, {
+        staticStrings: [],
+        staticCollections: [],
+        localFileWrappers: [
+          { name, kind: 'write', position: 0, keywords: ['path'], dependencyNames: ['saveRDS'] }
+        ]
+      })
+      for (const result of [local, contextual]) {
+        expect(result.writes).toEqual(['outputs/value.rds'])
+        expect(result.writeScopes ?? []).toEqual([])
+      }
+    }
+  )
+
+  it.each(['write', 'write_h5mu'])(
+    'captures direct multimodal constructor %s outputs',
+    async (method) => {
+      for (const constructor of [
+        'from mudata import MuData\nvalue = MuData({})',
+        'import mudata as md\nvalue = md.MuData({})'
+      ]) {
+        expect(
+          await analyzeNotebookSourceFileAccess(
+            'python',
+            `${constructor}\nvalue.${method}(filename="outputs/modalities.h5mu")`
+          )
+        ).toMatchObject({ writes: ['outputs/modalities.h5mu'] })
+      }
+    }
+  )
+
+  it.each([
+    'from mudata import MuData\nMuData = custom\nvalue = MuData({})',
+    'import mudata as md\nmd.MuData = custom\nvalue = md.MuData({})'
+  ])('does not trust replaced multimodal constructors: %s', async (source) => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        `${source}\nvalue.write("outputs/modalities.h5mu")`
+      )
+    ).toMatchObject({ writes: [] })
+  })
+
   it.each([
     ['"inputs/partitions"', 'inputs/partitions'],
     ['source="inputs/cohort.parquet"', 'inputs/cohort.parquet'],

--- a/src/main/notebook/source-file-access-analysis.clinical-formats.test.ts
+++ b/src/main/notebook/source-file-access-analysis.clinical-formats.test.ts
@@ -1,0 +1,1249 @@
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+
+describe('clinical statistical file readers', () => {
+  it.each([
+    ['"inputs/partitions"', 'inputs/partitions'],
+    ['source="inputs/cohort.parquet"', 'inputs/cohort.parquet'],
+    ['"inputs/partitions", filesystem=None', 'inputs/partitions']
+  ])('keeps parquet dataset discovery partial: %s', async (args, path) => {
+    const result = await analyzeNotebookSourceFileAccess(
+      'python',
+      `import pyarrow.parquet as pq\ntable = pq.read_table(${args})`
+    )
+    expect(result.reads).toEqual([path])
+    expect(result.readState).toBe('partial')
+  })
+
+  it.each([
+    'pq.read_table(path)',
+    'pq.read_table("inputs/partitions", filesystem=filesystem)',
+    'pq.read_table("inputs/partitions", **options)',
+    'pq.read_table("s3://bucket/partitions")'
+  ])('does not invent local parquet inputs for unproven sources: %s', async (call) => {
+    expect(
+      await analyzeNotebookSourceFileAccess('python', `import pyarrow.parquet as pq\n${call}`)
+    ).toMatchObject({ reads: [], readState: 'partial' })
+  })
+
+  it.each([
+    'pyarrow = custom\npyarrow.parquet.read_table("inputs/partitions")',
+    'import pyarrow.parquet as pq\npq.read_table = custom\npq.read_table("inputs/partitions")'
+  ])('does not trust replaced parquet readers: %s', async (source) => {
+    expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({ reads: [] })
+  })
+
+  it.each([
+    '"inputs/a.tsv.gz", "sample", "outputs/a", NULL, genes, genome, 4, 1000, 100000, 10, 2000, "outputs/qc"',
+    '"inputs/a.tsv.gz", QC="outputs/qc", outputNames="outputs/a"',
+    'sampleNames="sample", "inputs/a.tsv.gz", "outputs/a", NULL, genes, genome, 4, 1000, 100000, 10, 2000, "outputs/qc"'
+  ])('captures matched QC directory arguments: %s', async (args) => {
+    expect(
+      await analyzeNotebookSourceFileAccess('r', `ArchR::createArrowFiles(${args})`)
+    ).toMatchObject({
+      writes: ['outputs/a.arrow', 'outputs/qc'],
+      writeScopes: [{ kind: 'directory', path: 'outputs/qc' }],
+      writeState: 'partial'
+    })
+  })
+
+  it.each([
+    'inputFiles="inputs/a.tsv.gz", QC=qc_path',
+    'inputFiles="inputs/a.tsv.gz", o="outputs/ambiguous", QC="outputs/qc"',
+    '"inputs/a.tsv.gz", "sample", NULL, NULL, genes, genome, 4, 1000, 100000, 10, "outputs/not-qc"'
+  ])('does not invent QC outputs from unproven arguments: %s', async (args) => {
+    expect(
+      await analyzeNotebookSourceFileAccess('r', `ArchR::createArrowFiles(${args})`)
+    ).toMatchObject({ writes: [], writeState: 'partial' })
+  })
+
+  it.each([
+    ['"inputs/regions.gz", "r"', ['inputs/regions.gz']],
+    [
+      '"inputs/regions.gz", "r", None, "inputs/regions.csi"',
+      ['inputs/regions.csi', 'inputs/regions.gz']
+    ],
+    [
+      '"inputs/regions.gz", "r", None, index="inputs/regions.csi"',
+      ['inputs/regions.csi', 'inputs/regions.gz']
+    ],
+    [
+      'filename="inputs/regions.gz", mode="r", parser=None, index="inputs/regions.csi"',
+      ['inputs/regions.csi', 'inputs/regions.gz']
+    ]
+  ])('separates tabix mode, parser and index: %s', async (args, reads) => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        `import pysam\nhandle = pysam.TabixFile(${args})`
+      )
+    ).toMatchObject({ reads, writes: [], externalState: 'partial' })
+  })
+
+  it.each(['"w"', '"rb"', 'mode'])(
+    'does not infer tabix writes for unsupported modes: %s',
+    async (mode) => {
+      expect(
+        await analyzeNotebookSourceFileAccess(
+          'python',
+          `import pysam\nhandle = pysam.TabixFile("outputs/regions.gz", ${mode})`
+        )
+      ).toMatchObject({ reads: [], writes: [], readState: 'partial', writeState: 'partial' })
+    }
+  )
+
+  it.each([
+    ['compression="snappy"', true],
+    ['compression="snappy", compute=True', true],
+    ['"snappy"', false],
+    ['"snappy", compute=False', false],
+    ['"snappy", True, False, False, False, None, None, None, None, False', false],
+    ['"snappy", True, False, False, False, None, None, None, None, True', false],
+    ['"snappy", compute=enabled', false],
+    ['*options', false],
+    ['"snappy", **options', false],
+    ['"snappy", filesystem=filesystem', false]
+  ])('tracks parquet output only for supported method arguments: %s', async (options, eager) => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        `import dask.dataframe as dd\nframe = dd.read_parquet("inputs/partitions")\nframe.to_parquet("outputs/partitions", ${options})`
+      )
+    ).toMatchObject({
+      reads: ['inputs/partitions'],
+      writes: eager ? ['outputs/partitions'] : [],
+      writeState: 'partial'
+    })
+  })
+
+  it('records Arrow outputs before returning from static input collections', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'r',
+        'ArchR::createArrowFiles(inputFiles=c("inputs/a.tsv.gz", "inputs/b.tsv.gz"), outputNames=c("outputs/a", "outputs/b"), QCDir="outputs/qc")'
+      )
+    ).toMatchObject({
+      reads: ['inputs/a.tsv.gz', 'inputs/b.tsv.gz'],
+      writes: ['outputs/a.arrow', 'outputs/b.arrow', 'outputs/qc'],
+      writeScopes: [{ kind: 'directory', path: 'outputs/qc' }],
+      writeState: 'partial'
+    })
+  })
+
+  it('preserves Arrow write uncertainty without explicit output names', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'r',
+        'ArchR::createArrowFiles(inputFiles=c("inputs/a.tsv.gz"))'
+      )
+    ).toMatchObject({ reads: ['inputs/a.tsv.gz'], writes: [], writeState: 'partial' })
+  })
+
+  it('records project input collections and directory output scope', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'r',
+        'ArchR::ArchRProject(ArrowFiles=c("inputs/a.arrow", "inputs/b.arrow"), outputDirectory="outputs/project")'
+      )
+    ).toMatchObject({
+      reads: ['inputs/a.arrow', 'inputs/b.arrow'],
+      writes: ['outputs/project'],
+      writeScopes: [{ kind: 'directory', path: 'outputs/project' }]
+    })
+  })
+
+  it.each([
+    'other::createArrowFiles(inputFiles="inputs/a.tsv.gz", QCDir="outputs/qc")',
+    'other::Read10X("inputs/matrix")',
+    'other::ArchRProject("inputs/a.arrow", "outputs/project")',
+    'other::readVcf("inputs/variants.vcf")',
+    'other::read.vcfR("inputs/variants.vcf")'
+  ])('does not apply scientific contracts to unrelated packages: %s', async (source) => {
+    expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+      reads: [],
+      writes: []
+    })
+  })
+
+  it.each([
+    ['read_sav', 'inputs/registry.sav'],
+    ['read_dta', 'inputs/registry.dta'],
+    ['read_sas7bdat', 'inputs/registry.sas7bdat'],
+    ['read_xport', 'inputs/registry.xpt']
+  ])('captures the explicit pyreadstat %s input', async (reader, path) => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        `import pyreadstat\nframe, metadata = pyreadstat.${reader}(filename_path="${path}")`
+      )
+    ).toMatchObject({ reads: [path], writes: [] })
+  })
+
+  it('captures lineage across a complete single-cell analysis workflow', async () => {
+    const source = `import scanpy as sc
+import pandas as pd
+import matplotlib.pyplot as plt
+from pathlib import Path
+
+ROOT = Path("inputs")
+OUT = Path("outputs")
+meta = pd.read_csv(ROOT / "sample_metadata.csv")
+adata = sc.read_h5ad(ROOT / "cells.h5ad")
+adata.obs = adata.obs.join(meta.set_index("cell_id"), how="left")
+adata = adata[adata.obs["qc_pass"]].copy()
+sc.pp.normalize_total(adata, target_sum=1e4)
+sc.pp.log1p(adata)
+sc.tl.pca(adata, n_comps=20)
+sc.pl.pca(adata, color="diagnosis", show=False)
+plt.savefig(OUT / "pca.png")
+adata.write_h5ad(OUT / "filtered_cells.h5ad")
+adata.obs.to_csv(OUT / "cell_summary.csv")`
+    expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+      reads: [join('inputs', 'cells.h5ad'), join('inputs', 'sample_metadata.csv')].sort(),
+      writes: [
+        join('outputs', 'cell_summary.csv'),
+        join('outputs', 'filtered_cells.h5ad'),
+        join('outputs', 'pca.png')
+      ].sort()
+    })
+  })
+
+  it.each([
+    {
+      name: 'bulk RNA-seq quantification',
+      language: 'r' as const,
+      source:
+        'files <- c(A="inputs/A/quant.sf", B="inputs/B/quant.sf")\nmap <- read.csv("inputs/tx2gene.csv")\ntxi <- tximport::tximport(files, type="salmon", tx2gene=map, dropInfReps=TRUE)\nwrite.csv(txi$counts, "outputs/counts.csv")',
+      reads: ['inputs/A/quant.sf', 'inputs/B/quant.sf', 'inputs/tx2gene.csv'],
+      writes: ['outputs/counts.csv']
+    },
+    {
+      name: 'variant filtering',
+      language: 'python' as const,
+      source:
+        'from cyvcf2 import VCF, Writer\nvcf = VCF("inputs/cohort.vcf.gz")\nout = Writer("outputs/filtered.vcf", vcf)\nfor variant in vcf:\n    if variant.QUAL >= 30:\n        out.write_record(variant)\nout.close()',
+      reads: ['inputs/cohort.vcf.gz'],
+      writes: ['outputs/filtered.vcf']
+    },
+    {
+      name: 'clinical imaging mask',
+      language: 'python' as const,
+      source:
+        'import SimpleITK as sitk\nimage = sitk.ReadImage("inputs/ct.nii.gz")\nmask = sitk.ReadImage("inputs/tumor_mask.nii.gz")\nresult = sitk.Mask(image, mask)\nsitk.WriteImage(result, "outputs/tumor.nii.gz")',
+      reads: ['inputs/ct.nii.gz', 'inputs/tumor_mask.nii.gz'],
+      writes: ['outputs/tumor.nii.gz']
+    },
+    {
+      name: 'BAM coverage summary',
+      language: 'python' as const,
+      source:
+        'import pysam\nwith pysam.AlignmentFile("inputs/sample.bam", "rb") as bam:\n    rows = [(c, bam.count(c)) for c in bam.references]\nwith open("outputs/coverage.tsv", "w") as handle:\n    handle.write("chrom\\treads\\n")\n    handle.writelines(f"{c}\\t{n}\\n" for c, n in rows)',
+      reads: ['inputs/sample.bam'],
+      writes: ['outputs/coverage.tsv']
+    },
+    {
+      name: 'survival cohort export',
+      language: 'r' as const,
+      source:
+        'cohort <- readr::read_csv("inputs/patients.csv")\nfit <- survival::coxph(survival::Surv(time, status) ~ age + treatment, data=cohort)\nsummary <- broom::tidy(fit)\nreadr::write_csv(summary, "outputs/cox-summary.csv")',
+      reads: ['inputs/patients.csv'],
+      writes: ['outputs/cox-summary.csv']
+    }
+  ])('captures generated workflow: $name', async ({ language, source, reads, writes }) => {
+    expect(await analyzeNotebookSourceFileAccess(language, source)).toMatchObject({ reads, writes })
+  })
+
+  it.each([
+    {
+      name: 'ATAC-seq peak annotation',
+      language: 'r' as const,
+      source:
+        'peaks <- rtracklayer::import("inputs/peaks.bed.gz")\ngenes <- rtracklayer::import("inputs/genes.gtf.gz")\nannotated <- GenomicRanges::findOverlaps(peaks, genes)\nrtracklayer::export(peaks, "outputs/peaks-annotated.bed")',
+      reads: ['inputs/genes.gtf.gz', 'inputs/peaks.bed.gz'],
+      writes: ['outputs/peaks-annotated.bed']
+    },
+    {
+      name: 'protein quantification matrix',
+      language: 'python' as const,
+      source:
+        'import pandas as pd\nimport numpy as np\nraw = pd.read_csv("inputs/protein_intensity.tsv", sep="\\t")\nqc = raw.loc[raw["missing_fraction"] < 0.5].copy()\nqc["log2_intensity"] = np.log2(qc["intensity"].clip(lower=1))\nqc.to_parquet("outputs/protein-qc.parquet")',
+      reads: ['inputs/protein_intensity.tsv'],
+      writes: ['outputs/protein-qc.parquet']
+    }
+  ])('captures generated extended workflow: $name', async ({ language, source, reads, writes }) => {
+    expect(await analyzeNotebookSourceFileAccess(language, source)).toMatchObject({ reads, writes })
+  })
+
+  it('captures generated HDF5 and torch checkpoint lineage', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import h5py\nimport torch\nwith h5py.File(name="inputs/features.h5", mode="r") as source:\n    values = source["matrix"][:]\ntorch.save(values, f="outputs/features.pt")'
+      )
+    ).toMatchObject({ reads: ['inputs/features.h5'], writes: ['outputs/features.pt'] })
+  })
+
+  it('captures Dask cohort table lineage', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import dask.dataframe as dd\nframe = dd.read_parquet("inputs/cohort/*.parquet")\nframe.to_parquet("outputs/cohort")'
+      )
+    ).toMatchObject({
+      reads: [],
+      readState: 'partial',
+      writes: ['outputs/cohort'],
+      writeScopes: [{ kind: 'directory', path: 'outputs/cohort' }],
+      writeState: 'partial',
+      externalState: 'partial'
+    })
+  })
+
+  it.each([['muon.read_10x_h5("inputs/multiome.h5", extended=False)', 'inputs/multiome.h5']])(
+    'captures Muon multi-omics input: %s',
+    async (expression, path) => {
+      expect(
+        await analyzeNotebookSourceFileAccess('python', `import muon\ndata = ${expression}`)
+      ).toMatchObject({
+        reads: [path],
+        readState: 'complete'
+      })
+    }
+  )
+
+  it('captures explicit WFDB record and annotation roots conservatively', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import wfdb\nrecord = wfdb.rdrecord("inputs/patient01")\nann = wfdb.rdann("inputs/patient01", "atr")\nwfdb.wrsamp("patient01", fs=record.fs, units=record.units, sig_name=record.sig_name, p_signal=record.p_signal, write_dir="outputs")'
+      )
+    ).toMatchObject({
+      reads: [],
+      writes: [],
+      readState: 'partial',
+      writeState: 'partial',
+      externalState: 'partial'
+    })
+  })
+
+  it('captures an R genome annotation input', async () => {
+    const expression = 'rtracklayer::import("inputs/peaks.bed.gz")'
+    const path = 'inputs/peaks.bed.gz'
+    expect(await analyzeNotebookSourceFileAccess('r', `annotation <- ${expression}`)).toMatchObject(
+      {
+        reads: [path]
+      }
+    )
+  })
+
+  it.each([
+    [
+      'Seurat::Read10X(data.dir="inputs/filtered_feature_bc_matrix")',
+      'inputs/filtered_feature_bc_matrix'
+    ],
+    [
+      'Seurat::Read10X_h5(filename="inputs/filtered_feature_bc_matrix.h5")',
+      'inputs/filtered_feature_bc_matrix.h5'
+    ]
+  ])('captures a Seurat 10x input: %s', async (expression, path) => {
+    expect(await analyzeNotebookSourceFileAccess('r', `counts <- ${expression}`)).toMatchObject({
+      reads: [path]
+    })
+  })
+
+  it('maps positional ArchR project output directories', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'r',
+        'project <- ArchRProject(arrows, "outputs/archr-project")\nsaveArchRProject(project, "outputs/archr-project")'
+      )
+    ).toMatchObject({
+      reads: [],
+      writes: ['outputs/archr-project']
+    })
+  })
+
+  it('captures a pyreadstat clinical export as an output', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import pyreadstat\npyreadstat.write_sav(frame, dst_path="outputs/registry.sav")'
+      )
+    ).toMatchObject({ reads: [], writes: ['outputs/registry.sav'] })
+  })
+
+  it('captures explicit Arrow parquet read and write paths', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import pyarrow.parquet as pq\ntable = pq.read_table("inputs/cohort.parquet")\npq.write_table(table, where="outputs/cohort.parquet")'
+      )
+    ).toMatchObject({
+      reads: ['inputs/cohort.parquet'],
+      writes: ['outputs/cohort.parquet']
+    })
+  })
+
+  it.each([
+    ['pyfaidx.Fasta("inputs/reference.fa")', 'inputs/reference.fa'],
+    ['pyranges.read_bed("inputs/regions.bed")', 'inputs/regions.bed'],
+    ['pyranges.read_gtf(f="inputs/genes.gtf")', 'inputs/genes.gtf']
+  ])('captures a reference annotation reader: %s', async (expression, path) => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        `import pyfaidx, pyranges\nvalue = ${expression}`
+      )
+    ).toMatchObject({
+      reads: [path]
+    })
+  })
+
+  it.each([
+    ['VariantFile', 'inputs/variants.bcf'],
+    ['TabixFile', 'inputs/regions.bed.gz']
+  ])('captures the explicit pysam %s input', async (reader, path) => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        `import pysam\nhandle = pysam.${reader}("${path}")`
+      )
+    ).toMatchObject({ reads: [path], writes: [] })
+  })
+
+  it('captures an explicit pysam TabixFile index', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import pysam\nhandle = pysam.TabixFile("inputs/regions.bed.gz", index="inputs/regions.csi")'
+      )
+    ).toMatchObject({ reads: ['inputs/regions.bed.gz', 'inputs/regions.csi'], writes: [] })
+  })
+
+  it('retains a known pyreadstat input when the filename is dynamic', async () => {
+    expect(
+      await analyzeNotebookSourceFileAccess(
+        'python',
+        'import pyreadstat\nframe, metadata = pyreadstat.read_sav(filename_path=resolve_input())'
+      )
+    ).toMatchObject({ reads: [], readState: 'partial' })
+  })
+
+  it.each([
+    [
+      'VariantAnnotation::readVcf(file="inputs/variants.vcf.gz", genome="hg38")',
+      'inputs/variants.vcf.gz'
+    ],
+    ['vcfR::read.vcfR("inputs/variants.vcf")', 'inputs/variants.vcf']
+  ])('captures the explicit R variant reader input', async (source, path) => {
+    expect(await analyzeNotebookSourceFileAccess('r', `variants <- ${source}`)).toMatchObject({
+      reads: [path],
+      writes: []
+    })
+  })
+
+  it('captures a complete spatial transcriptomics workflow', async () => {
+    const source = `library(Seurat)
+library(ggplot2)
+sample <- Load10X_Spatial(data.dir = "inputs/visium_sample", filename = "filtered_feature_bc_matrix.h5")
+sample <- SCTransform(sample, assay = "Spatial", verbose = FALSE)
+sample <- RunPCA(sample, assay = "SCT")
+sample <- FindNeighbors(sample, dims = 1:20)
+sample <- FindClusters(sample, resolution = 0.5)
+p <- SpatialDimPlot(sample, label = TRUE)
+ggsave("outputs/spatial-clusters.png", p, width = 8, height = 6)
+saveRDS(sample, "outputs/spatial-object.rds")`
+    expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+      reads: ['inputs/visium_sample'],
+      writes: ['outputs/spatial-clusters.png', 'outputs/spatial-object.rds'],
+      readState: 'partial'
+    })
+  })
+
+  it.each([
+    {
+      name: 'methylation beta matrix',
+      language: 'python' as const,
+      source:
+        'import pandas as pd\nfrom pathlib import Path\nbeta = pd.read_parquet(Path("inputs") / "beta.parquet")\npheno = pd.read_csv("inputs/phenotype.csv")\nmerged = beta.join(pheno.set_index("sample_id"), how="inner")\nmerged.to_parquet("outputs/methylation-analysis.parquet")',
+      reads: [join('inputs', 'beta.parquet'), 'inputs/phenotype.csv'].sort(),
+      writes: ['outputs/methylation-analysis.parquet']
+    },
+    {
+      name: 'ChIP-seq peak table',
+      language: 'r' as const,
+      source:
+        'library(rtracklayer)\npeaks <- import("inputs/chip_peaks.narrowPeak")\nblacklist <- import("inputs/blacklist.bed")\nkept <- peaks[!overlapsAny(peaks, blacklist)]\nexport(kept, "outputs/filtered_peaks.bed")',
+      reads: ['inputs/blacklist.bed', 'inputs/chip_peaks.narrowPeak'],
+      writes: ['outputs/filtered_peaks.bed']
+    },
+    {
+      name: 'proteomics spectral conversion',
+      language: 'r' as const,
+      source:
+        'library(MSnbase)\nraw <- readMSData(files = c("inputs/sample-a.mzML", "inputs/sample-b.mzML"), mode = "onDisk")\nfiltered <- filterMz(raw, mz = c(500, 1000))\nsummary <- data.frame(retention_time = rtime(filtered), total_intensity = tic(filtered))\nwrite.csv(summary, "outputs/peaks.csv")',
+      reads: ['inputs/sample-a.mzML', 'inputs/sample-b.mzML'],
+      writes: ['outputs/peaks.csv']
+    }
+  ])('captures generated omics modality: $name', async ({ language, source, reads, writes }) => {
+    expect(await analyzeNotebookSourceFileAccess(language, source)).toMatchObject({ reads, writes })
+  })
+})
+
+it('captures a complete Python survival analysis report', async () => {
+  const source = `import pandas as pd
+import matplotlib.pyplot as plt
+from lifelines import KaplanMeierFitter, CoxPHFitter
+cohort = pd.read_csv("inputs/followup.csv")
+cohort = cohort.dropna(subset=["duration", "event", "treatment"])
+km = KaplanMeierFitter(label="all participants")
+km.fit(cohort["duration"], event_observed=cohort["event"])
+km.plot()
+plt.savefig("outputs/kaplan-meier.png", dpi=160)
+model = CoxPHFitter()
+model.fit(cohort[["duration", "event", "age", "treatment"]], duration_col="duration", event_col="event")
+model.summary.to_csv("outputs/cox-coefficients.csv")
+cohort.to_parquet("outputs/analysis-cohort.parquet")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/followup.csv'],
+    writes: [
+      'outputs/analysis-cohort.parquet',
+      'outputs/cox-coefficients.csv',
+      'outputs/kaplan-meier.png'
+    ],
+    readState: 'complete',
+    writeState: 'complete'
+  })
+})
+
+it('captures a multi-sample spatial integration workflow', async () => {
+  const source = `library(Seurat)
+library(ggplot2)
+control <- Load10X_Spatial(data.dir = "inputs/control", filename = "filtered_feature_bc_matrix.h5", slice = "control")
+treated <- Load10X_Spatial(data.dir = "inputs/treated", filename = "filtered_feature_bc_matrix.h5", slice = "treated")
+control <- SCTransform(control, assay = "Spatial", verbose = FALSE)
+treated <- SCTransform(treated, assay = "Spatial", verbose = FALSE)
+anchors <- FindIntegrationAnchors(object.list = list(control, treated), dims = 1:30)
+integrated <- IntegrateData(anchorset = anchors, dims = 1:30)
+integrated <- RunPCA(integrated, assay = "integrated")
+integrated <- FindNeighbors(integrated, dims = 1:20)
+integrated <- FindClusters(integrated, resolution = 0.4)
+plot <- SpatialDimPlot(integrated, group.by = "seurat_clusters")
+ggsave("outputs/integrated-spatial.png", plot, width = 10, height = 6)
+saveRDS(integrated, "outputs/integrated-spatial.rds")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/control', 'inputs/treated'],
+    writes: ['outputs/integrated-spatial.png', 'outputs/integrated-spatial.rds'],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('captures remote survival input and model serialization paths', async () => {
+  expect(
+    await analyzeNotebookSourceFileAccess(
+      'python',
+      `import pandas as pd
+from lifelines import CoxPHFitter
+cohort = pd.read_csv("https://data.example.test/cohort.csv")
+fit = CoxPHFitter().fit(cohort, "duration", "event")
+fit.save("outputs/remote-model.json")`
+    )
+  ).toMatchObject({
+    reads: ['https://data.example.test/cohort.csv'],
+    writes: ['outputs/remote-model.json'],
+    readState: 'complete',
+    writeState: 'complete',
+    externalState: 'complete'
+  })
+})
+
+it('captures a bulk RNA differential-expression workflow', async () => {
+  const source = `library(DESeq2)
+counts <- read.csv("inputs/gene-counts.csv", row.names = 1, check.names = FALSE)
+metadata <- read.csv("inputs/sample-sheet.csv", row.names = 1)
+metadata <- metadata[colnames(counts), , drop = FALSE]
+stopifnot(identical(rownames(metadata), colnames(counts)))
+dds <- DESeqDataSetFromMatrix(countData = round(as.matrix(counts)), colData = metadata, design = ~ batch + condition)
+dds <- dds[rowSums(counts(dds) >= 10) >= 2, ]
+dds <- DESeq(dds)
+res <- results(dds, contrast = c("condition", "treated", "control"))
+rld <- rlog(dds, blind = FALSE)
+write.csv(as.data.frame(res), "outputs/deseq2-results.csv")
+write.table(assay(rld), "outputs/rlog-matrix.tsv", sep = "\\t", quote = FALSE)
+saveRDS(dds, "outputs/deseq2-object.rds")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/gene-counts.csv', 'inputs/sample-sheet.csv'],
+    writes: ['outputs/deseq2-object.rds', 'outputs/deseq2-results.csv', 'outputs/rlog-matrix.tsv'],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('captures a scVI latent-embedding workflow', async () => {
+  const source = `import scanpy as sc
+import scvi
+import pandas as pd
+adata = sc.read_h5ad("inputs/normalized-cells.h5ad")
+metadata = pd.read_csv("inputs/cell-batches.csv")
+adata.obs = adata.obs.join(metadata.set_index("cell_id"), how="left")
+sc.pp.highly_variable_genes(adata, n_top_genes=2000, batch_key="batch")
+scvi.model.SCVI.setup_anndata(adata, layer="counts", batch_key="batch")
+model = scvi.model.SCVI(adata, n_latent=20)
+model.train(max_epochs=100)
+adata.obsm["X_scVI"] = model.get_latent_representation()
+adata.layers["scvi_normalized"] = model.get_normalized_expression(library_size=1e4)
+adata.write_h5ad("outputs/scvi-embedded.h5ad")
+model.save("outputs/scvi-model", overwrite=True)
+pd.DataFrame(adata.obsm["X_scVI"]).to_csv("outputs/scvi-latent.csv", index=False)`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/cell-batches.csv', 'inputs/normalized-cells.h5ad'],
+    writes: ['outputs/scvi-embedded.h5ad', 'outputs/scvi-latent.csv', 'outputs/scvi-model'],
+    readState: 'complete',
+    writeState: 'complete',
+    externalState: 'complete'
+  })
+})
+
+it('keeps Squidpy Visium companions unresolved', async () => {
+  const source = `import scanpy as sc
+import squidpy as sq
+adata = sq.datasets.visium_hne_adata()
+sc.pp.normalize_total(adata)
+sq.gr.spatial_neighbors(adata, coord_type="generic")
+sq.gr.spatial_autocorr(adata, mode="moran", genes=["CXCL9", "GZMB"])
+sq.pl.spatial_scatter(adata, color=["CXCL9", "GZMB"], save="_markers.png")
+adata.write_h5ad("outputs/visium-spatial.h5ad")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [],
+    writes: ['outputs/visium-spatial.h5ad'],
+    readState: 'partial',
+    writeState: 'complete',
+    externalState: 'partial'
+  })
+})
+
+it('captures a methylation array normalization workflow', async () => {
+  const source = `library(minfi)
+library(limma)
+targets <- read.csv("inputs/idat-sample-sheet.csv", stringsAsFactors = FALSE)
+base <- dirname(targets$Basename[1])
+rg <- read.metharray.exp(targets = targets)
+rg <- detectionP(rg)
+keep <- rowMeans(rg < 0.01) > 0.95
+mset <- preprocessFunnorm(rg)
+mvals <- getM(mset)[keep, , drop = FALSE]
+design <- model.matrix(~ 0 + targets$condition)
+fit <- eBayes(lmFit(mvals, design))
+contrasts <- makeContrasts(treated - control, levels = design)
+result <- topTable(contrasts.fit(fit, contrasts), number = Inf)
+write.csv(result, "outputs/methylation-differential.csv")
+saveRDS(mset, "outputs/normalized-methylation.rds")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/idat-sample-sheet.csv'],
+    writes: ['outputs/methylation-differential.csv', 'outputs/normalized-methylation.rds'],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('captures an ArchR chromatin-accessibility workflow', async () => {
+  const source = `library(ArchR)
+addArchRGenome("hg38")
+addArchRThreads(threads = 4)
+arrow_files <- createArrowFiles(inputFiles = c("inputs/sample-a-fragments.tsv.gz", "inputs/sample-b-fragments.tsv.gz"), sampleNames = c("A", "B"), filterTSS = 4, filterFrags = 1000)
+proj <- ArchRProject(ArrowFiles = arrow_files, outputDirectory = "outputs/archr-project", copyArrows = TRUE)
+proj <- addDoubletScores(input = proj, k = 10, knnMethod = "UMAP", LSIMethod = 1)
+proj <- addIterativeLSI(proj, useMatrix = "TileMatrix", name = "IterativeLSI", iterations = 2)
+proj <- addClusters(proj, reducedDims = "IterativeLSI", method = "Seurat", resolution = 0.8)
+proj <- addGroupCoverages(proj, groupBy = "Clusters")
+proj <- addReproduciblePeakSet(proj, groupBy = "Clusters", pathToMacs2 = "tools/macs2")
+markers <- getMarkerFeatures(proj, useMatrix = "PeakMatrix", groupBy = "Clusters", bias = c("TSSEnrichment", "log10(nFrags)"))
+write.csv(as.data.frame(markers$Markers), "outputs/archr-peak-markers.csv")
+saveArchRProject(proj, outputDirectory = "outputs/archr-project")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/sample-a-fragments.tsv.gz', 'inputs/sample-b-fragments.tsv.gz'],
+    writes: ['outputs/archr-peak-markers.csv', 'outputs/archr-project'],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('captures a two-image registration and radiomics workflow', async () => {
+  const source = `import SimpleITK as sitk
+import pandas as pd
+fixed = sitk.ReadImage("inputs/fixed_ct.nii.gz", sitk.sitkFloat32)
+moving = sitk.ReadImage("inputs/followup_ct.nii.gz", sitk.sitkFloat32)
+mask = sitk.ReadImage("inputs/fixed_mask.nii.gz", sitk.sitkUInt8)
+registration = sitk.ImageRegistrationMethod()
+registration.SetMetricAsMattesMutualInformation(numberOfHistogramBins=50)
+registration.SetOptimizerAsGradientDescent(learningRate=1.0, numberOfIterations=100)
+registration.SetInterpolator(sitk.sitkLinear)
+initial = sitk.CenteredTransformInitializer(fixed, moving, sitk.Euler3DTransform())
+registration.SetInitialTransform(initial)
+transform = registration.Execute(fixed, moving)
+registered = sitk.Resample(moving, fixed, transform, sitk.sitkLinear, 0.0, moving.GetPixelID())
+masked = sitk.Mask(registered, mask)
+sitk.WriteTransform(transform, "outputs/followup-to-baseline.tfm")
+sitk.WriteImage(masked, "outputs/registered-tumor.nii.gz")
+pixels = sitk.GetArrayViewFromImage(masked)
+pd.DataFrame({"mean": [pixels.mean()], "p95": [pd.Series(pixels.ravel()).quantile(0.95)]}).to_csv("outputs/radiomics-summary.csv", index=False)`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/fixed_ct.nii.gz', 'inputs/fixed_mask.nii.gz', 'inputs/followup_ct.nii.gz'],
+    writes: [
+      'outputs/followup-to-baseline.tfm',
+      'outputs/radiomics-summary.csv',
+      'outputs/registered-tumor.nii.gz'
+    ],
+    readState: 'complete',
+    writeState: 'complete'
+  })
+})
+
+it('captures a multi-sample single-cell integration workflow', async () => {
+  const source = `from pathlib import Path
+import scanpy as sc
+import pandas as pd
+import harmonypy as hm
+
+root = Path("inputs/processed")
+sample_sheet = pd.read_csv("inputs/sample-sheet.csv")
+objects = []
+for sample in sample_sheet.itertuples():
+    adata = sc.read_h5ad(root / f"{sample.sample_id}.h5ad")
+    adata.obs["sample_id"] = sample.sample_id
+    adata.obs["condition"] = sample.condition
+    objects.append(adata)
+merged = objects[0].concatenate(objects[1:], batch_key="batch")
+sc.pp.highly_variable_genes(merged, batch_key="batch")
+sc.pp.scale(merged, max_value=10)
+sc.tl.pca(merged, n_comps=50)
+harmonized = hm.run_harmony(merged.obsm["X_pca"], merged.obs, "batch")
+merged.obsm["X_harmony"] = harmonized.Z_corr.T
+sc.tl.umap(merged)
+merged.write_h5ad("outputs/integrated-atlas.h5ad")
+merged.obs.to_csv("outputs/integrated-cell-metadata.csv")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/sample-sheet.csv'],
+    writes: ['outputs/integrated-atlas.h5ad', 'outputs/integrated-cell-metadata.csv'],
+    readState: 'partial',
+    writeState: 'complete'
+  })
+})
+
+it('captures a clinical genomics survival and subgroup report workflow', async () => {
+  const source = `library(TCGAbiolinks)
+library(survival)
+library(survminer)
+library(readr)
+
+clinical <- GDCquery_clinic(project = "TCGA-COHORT", type = "clinical")
+expression <- read_csv("inputs/tcga-expression.csv")
+genes <- read_csv("inputs/signature-genes.csv")
+cohort <- merge(clinical, expression, by = "patient_id")
+cohort$risk <- rowMeans(cohort[genes$symbol], na.rm = TRUE)
+cohort$risk_group <- ifelse(cohort$risk >= median(cohort$risk), "high", "low")
+fit <- coxph(Surv(days_to_last_follow_up, vital_status) ~ risk_group + age_at_diagnosis, data = cohort)
+plot <- ggsurvplot(survfit(Surv(days_to_last_follow_up, vital_status) ~ risk_group, data = cohort))
+ggplot2::ggsave("outputs/survival-curve.png", plot$plot)
+write_csv(broom::tidy(fit), "outputs/cox-risk-results.csv")
+saveRDS(cohort, "outputs/clinical-risk-cohort.rds")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/signature-genes.csv', 'inputs/tcga-expression.csv'],
+    writes: [
+      'outputs/clinical-risk-cohort.rds',
+      'outputs/cox-risk-results.csv',
+      'outputs/survival-curve.png'
+    ],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a metabolomics QC batch correction and annotation workflow', async () => {
+  const source = `from pathlib import Path
+import pandas as pd
+import numpy as np
+from pycombat import Combat
+
+table = pd.read_csv("inputs/feature-table.csv")
+metadata = pd.read_csv("inputs/sample-metadata.csv")
+library = pd.read_json("inputs/compound-library.json")
+features = table.drop(columns=["sample_id"]).fillna(table.median(numeric_only=True))
+corrected = Combat().fit_transform(features, metadata["batch"])
+log_intensity = np.log2(np.maximum(corrected, 1e-6))
+annotated = pd.DataFrame(log_intensity, columns=features.columns).T.reset_index(names="feature")
+annotated = annotated.merge(library, on="feature", how="left")
+annotated.to_parquet("outputs/batch-corrected-metabolomics.parquet")
+annotated.to_csv("outputs/annotated-metabolites.csv", index=False)
+Path("outputs").joinpath("qc-complete.flag").write_text("ok")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [
+      'inputs/compound-library.json',
+      'inputs/feature-table.csv',
+      'inputs/sample-metadata.csv'
+    ],
+    writes: [
+      'outputs/annotated-metabolites.csv',
+      'outputs/batch-corrected-metabolomics.parquet',
+      'outputs/qc-complete.flag'
+    ],
+    readState: 'complete',
+    writeState: 'complete'
+  })
+})
+
+it('captures a QIIME2 amplicon denoising and differential abundance workflow', async () => {
+  const source = `import qiime2
+from qiime2 import Artifact, Metadata
+from qiime2.plugins import demux, dada2, feature_table, taxa, diversity
+
+manifest = Metadata.load("inputs/sample-metadata.tsv")
+demultiplexed = Artifact.import_data("SampleData[PairedEndSequencesWithQuality]", "inputs/manifest.csv", view_type="PairedEndFastqManifestPhred33V2")
+trimmed = demux.methods.emp_paired(demultiplexed)
+denoised = dada2.methods.denoise_paired(trimmed.per_sample_sequences, trunc_len_f=240, trunc_len_r=200)
+table = denoised.table
+taxonomy = Artifact.load("inputs/reference-taxonomy.qza")
+filtered = feature_table.methods.filter_samples(table, metadata=manifest, where="treatment IS NOT NULL")
+classified = taxa.methods.collapse(filtered.filtered_table, taxonomy=taxonomy, level=6)
+distance = diversity.pipelines.beta_phylogenetic(table=filtered.filtered_table, phylogeny=Artifact.load("inputs/tree.qza"), metric="unweighted_unifrac")
+table.save("outputs/feature-table.qza")
+classified.collapsed_table.save("outputs/genus-table.qza")
+distance.distance_matrix.save("outputs/beta-distance.qza")
+denoised.stats.save("outputs/denoising-stats.qza")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/reference-taxonomy.qza', 'inputs/sample-metadata.tsv', 'inputs/tree.qza'],
+    writes: [
+      'outputs/beta-distance.qza',
+      'outputs/denoising-stats.qza',
+      'outputs/feature-table.qza',
+      'outputs/genus-table.qza'
+    ],
+    readState: 'partial',
+    writeState: 'complete'
+  })
+})
+
+it('captures a paper-style multi-stage TCGA survival and validation workflow', async () => {
+  const source = `from pathlib import Path
+import pandas as pd
+from sklearn.model_selection import StratifiedKFold, cross_val_predict
+from sklearn.preprocessing import StandardScaler
+from sklearn.pipeline import make_pipeline
+from sklearn.linear_model import LogisticRegression
+from lifelines import CoxPHFitter
+
+root = Path("inputs")
+clinical = pd.read_excel(root / "TCGA-CDR-SupplementalTable.xlsx", sheet_name="BRCA")
+expression = pd.read_csv(root / "brca-expression.csv", index_col=0)
+signature = pd.read_csv(root / "risk-signature.csv")
+cohort = clinical.merge(expression, left_on="bcr_patient_barcode", right_index=True)
+features = cohort[signature["gene"].tolist()].fillna(0)
+cohort["risk_score"] = features.mul(signature["weight"].to_numpy(), axis=1).sum(axis=1)
+cohort[["bcr_patient_barcode", "risk_score", "vital_status"]].to_parquet("outputs/brca-risk-cohort.parquet")
+model = CoxPHFitter().fit(cohort[["days_to_death", "vital_status", "risk_score", "age_at_diagnosis"]], "days_to_death", "vital_status")
+model.summary.to_csv("outputs/cox-summary.csv")
+X = StandardScaler().fit_transform(features)
+y = cohort["vital_status"]
+pred = cross_val_predict(LogisticRegression(max_iter=2000), X, y, cv=StratifiedKFold(5), method="predict_proba")[:, 1]
+pd.DataFrame({"patient": cohort["bcr_patient_barcode"], "death_probability": pred}).to_csv("outputs/validation-predictions.csv", index=False)`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [
+      'inputs/TCGA-CDR-SupplementalTable.xlsx',
+      'inputs/brca-expression.csv',
+      'inputs/risk-signature.csv'
+    ],
+    writes: [
+      'outputs/brca-risk-cohort.parquet',
+      'outputs/cox-summary.csv',
+      'outputs/validation-predictions.csv'
+    ],
+    readState: 'complete',
+    writeState: 'complete'
+  })
+})
+
+it('captures an agent-generated multi-stage RNA-seq reproduction script', async () => {
+  const source = `library(data.table)
+library(DESeq2)
+project <- normalizePath(commandArgs(trailingOnly = TRUE)[1], mustWork = FALSE)
+inputs <- file.path(project, "inputs")
+work <- file.path(project, "work", format(Sys.time(), "%Y%m%d_%H%M%S"))
+outputs <- file.path(project, "outputs")
+dir.create(work, recursive = TRUE)
+dir.create(outputs, recursive = TRUE)
+samples <- fread(file.path(inputs, "sample_sheet.tsv"))
+samples[, trimmed := file.path(work, paste0(sample_id, ".trimmed.fastq.gz"))]
+for (i in seq_len(nrow(samples))) system2("fastp", c("-i", fastq_r1[i], "-o", trimmed[i]))
+system2("multiqc", c(file.path(work, "qc"), "-o", file.path(outputs, "multiqc")))
+counts <- fread(file.path(inputs, "gene_counts.tsv"))
+write.table(counts, file.path(work, "filtered_counts.tsv"), sep = "\\t")
+dds <- DESeq(DESeqDataSetFromMatrix(as.matrix(counts[, -1]), samples, ~ condition))
+write.table(counts(dds, normalized = TRUE), file.path(outputs, "normalized_counts.tsv"), sep = "\\t")
+fwrite(as.data.table(results(dds)), file.path(outputs, "differential_expression.tsv"), sep = "\\t")`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: [],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures an agent-generated metagenome classification and ML script', async () => {
+  const source = `from pathlib import Path
+import json, subprocess
+import pandas as pd
+from sklearn.decomposition import PCA
+from sklearn.ensemble import RandomForestClassifier
+
+project = Path(".").resolve()
+inputs, outputs = project / "inputs", project / "outputs"
+work = project / "work" / "run_dynamic"
+work.mkdir(parents=True, exist_ok=True); outputs.mkdir(exist_ok=True)
+metadata = pd.read_csv(inputs / "sample_metadata.tsv", sep="\\t")
+reads = sorted((inputs / "reads").glob("*.fastq.gz"))
+reports = []
+for read in reads:
+    report = work / (read.stem + ".kraken.report")
+    subprocess.run(["kraken2", "--db", str(inputs / "taxonomy_db"), "--report", str(report), str(read)], check=True)
+    reports.append(pd.read_csv(report, sep="\\t"))
+classified = pd.concat(reports)
+classified.to_csv(work / "classified_taxa.tsv", sep="\\t", index=False)
+relative = classified.pivot_table(index="taxon", columns="sample_id", values="reads", aggfunc="sum", fill_value=0)
+relative.to_csv(work / "relative_abundance.tsv", sep="\\t")
+coordinates = PCA(n_components=3).fit_transform(relative.T)
+pd.DataFrame(coordinates).to_csv(outputs / "pca_coordinates.tsv", sep="\\t", index=False)
+RandomForestClassifier(n_estimators=300).fit(relative.T, metadata["group"])
+(outputs / "run_manifest.json").write_text(json.dumps({"reports": [str(p) for p in reports]}))`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('preserves uncertainty for an agent-generated config-driven pipeline', async () => {
+  const source = `from pathlib import Path
+import json, subprocess, yaml
+import pandas as pd
+from sklearn.ensemble import RandomForestRegressor
+
+def load_config(path):
+    return yaml.safe_load(path.open())
+
+def run_qc(sample, report, tool):
+    report.parent.mkdir(parents=True, exist_ok=True)
+    with report.open("w") as handle:
+        subprocess.run([tool, "--input", str(sample)], stdout=handle, check=True)
+
+config_path = Path("inputs/pipeline.yaml").resolve()
+config = load_config(config_path)
+project = config_path.parent.parent
+input_dir = (project / config["input_dir"]).resolve()
+work_dir = (project / config["work_dir"]).resolve()
+output_dir = (project / config["output_dir"]).resolve()
+samples = sorted((input_dir / "samples").glob("*.tsv"))
+summaries = []
+for sample in samples:
+    report = work_dir / "qc" / f"{sample.stem}.txt"
+    run_qc(sample, report, config["external_tool"])
+    table = pd.read_csv(sample, sep="\\t")
+    summary = table.describe().T
+    summary.to_csv(work_dir / "summaries" / f"{sample.stem}.tsv", sep="\\t")
+    summaries.append(summary)
+features = pd.concat(summaries).fillna(0)
+model = RandomForestRegressor(n_estimators=250).fit(features, features.iloc[:, 0])
+pd.Series(model.feature_importances_).to_csv(output_dir / "model_feature_importance.tsv")
+(output_dir / "final_report.json").write_text(json.dumps({"config": str(config_path)}))`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('preserves uncertainty for an agent-generated R multi-stage study pipeline', async () => {
+  const source = `suppressPackageStartupMessages({library(yaml); library(data.table); library(edgeR)})
+cfg <- yaml.load_file("inputs/study.yml")
+root <- normalizePath(cfg$project_root, mustWork = FALSE)
+raw <- file.path(root, cfg$raw_dir)
+work <- file.path(root, cfg$work_dir)
+out <- file.path(root, cfg$output_dir)
+dir.create(work, recursive = TRUE); dir.create(out, recursive = TRUE)
+manifest <- fread(file.path(root, cfg$sample_sheet))
+for (i in seq_len(nrow(manifest))) {
+  bam <- file.path(raw, manifest$sample_id[i], "aligned.bam")
+  counts <- file.path(work, paste0(manifest$sample_id[i], ".counts.tsv"))
+  system2(cfg$counter, c("--bam", bam, "--gtf", file.path(root, cfg$annotation), "--out", counts))
+  saveRDS(fread(counts), file.path(work, paste0(manifest$sample_id[i], ".rds")))
+}
+tables <- lapply(manifest$sample_id, function(id) readRDS(file.path(work, paste0(id, ".rds"))))
+matrix <- do.call(cbind, lapply(tables, function(x) x$count))
+y <- DGEList(counts = matrix, samples = manifest)
+y <- calcNormFactors(y)
+fit <- glmQLFit(y, model.matrix(~ condition, manifest))
+res <- topTags(glmQLFTest(fit, coef = 2), n = Inf)$table
+fwrite(res, file.path(out, "differential-expression.tsv"), sep = "\\t")
+saveRDS(y, file.path(out, "normalized-dge-object.rds"))
+writeLines(capture.output(sessionInfo()), file.path(out, "session-info.txt"))`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/study.yml'],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures an agent-generated clinical prediction training pipeline', async () => {
+  const source = `from pathlib import Path
+import joblib
+import pandas as pd
+from sklearn.compose import ColumnTransformer
+from sklearn.impute import SimpleImputer
+from sklearn.linear_model import LogisticRegression
+from sklearn.metrics import roc_auc_score
+from sklearn.model_selection import StratifiedKFold, cross_val_predict
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import OneHotEncoder, StandardScaler
+
+root = Path("inputs")
+train = pd.read_parquet(root / "development-cohort.parquet")
+external = pd.read_parquet(root / "external-validation.parquet")
+schema = pd.read_json(root / "feature-schema.json")
+features = schema["feature"].tolist()
+target = "outcome_90d"
+numeric = train[features].select_dtypes(include="number").columns
+categorical = [c for c in features if c not in numeric]
+preprocess = ColumnTransformer([
+    ("num", Pipeline([("impute", SimpleImputer(strategy="median")), ("scale", StandardScaler())]), numeric),
+    ("cat", Pipeline([( "impute", SimpleImputer(strategy="most_frequent")), ("encode", OneHotEncoder(handle_unknown="ignore"))]), categorical),
+])
+model = Pipeline([( "preprocess", preprocess), ("classifier", LogisticRegression(max_iter=2000, class_weight="balanced"))])
+folds = StratifiedKFold(n_splits=5, shuffle=True, random_state=7)
+oof = cross_val_predict(model, train[features], train[target], cv=folds, method="predict_proba")[:, 1]
+model.fit(train[features], train[target])
+external["prediction"] = model.predict_proba(external[features])[:, 1]
+Path("outputs").mkdir(exist_ok=True)
+joblib.dump(model, "outputs/clinical-risk-model.joblib")
+pd.DataFrame({"patient_id": train["patient_id"], "oof_prediction": oof}).to_csv("outputs/oof-predictions.csv", index=False)
+external[["patient_id", "prediction"]].to_csv("outputs/external-validation.csv", index=False)
+Path("outputs/metrics.json").write_text(str({"oof_auc": roc_auc_score(train[target], oof)}))`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [
+      'inputs/development-cohort.parquet',
+      'inputs/external-validation.parquet',
+      'inputs/feature-schema.json'
+    ],
+    writes: [
+      'outputs/clinical-risk-model.joblib',
+      'outputs/external-validation.csv',
+      'outputs/metrics.json',
+      'outputs/oof-predictions.csv'
+    ],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('captures an agent-generated longitudinal clinical feature workflow', async () => {
+  const source = `import pandas as pd
+import numpy as np
+from pathlib import Path
+from lifelines import CoxTimeVaryingFitter
+
+root = Path("inputs")
+visits = pd.read_csv(root / "patient-visits.csv", parse_dates=["visit_date"])
+labs = pd.read_csv(root / "laboratory-results.csv")
+medications = pd.read_parquet(root / "medication-exposure.parquet")
+visits = visits.merge(labs, on=["patient_id", "visit_date"], how="left")
+visits = visits.sort_values(["patient_id", "visit_date"])
+visits["prior_admission"] = visits.groupby("patient_id")["admission"].shift(1).fillna(0)
+visits["rolling_creatinine"] = visits.groupby("patient_id")["creatinine"].transform(lambda x: x.rolling(3, min_periods=1).mean())
+long = visits.merge(medications, on="patient_id", how="left")
+Path("work/features").mkdir(parents=True, exist_ok=True)
+for patient_id, frame in long.groupby("patient_id"):
+    frame.to_parquet(Path("work/features") / f"{patient_id}.parquet")
+model = CoxTimeVaryingFitter().fit(long, id_col="patient_id", start_col="start", stop_col="stop", event_col="event")
+model.summary.to_csv("outputs/time-varying-cox.csv")
+long.to_csv("outputs/longitudinal-feature-table.csv", index=False)`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [
+      'inputs/laboratory-results.csv',
+      'inputs/medication-exposure.parquet',
+      'inputs/patient-visits.csv'
+    ],
+    writes: ['outputs/longitudinal-feature-table.csv', 'outputs/time-varying-cox.csv'],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('preserves uncertainty for an agent-generated alignment wrapper', async () => {
+  const source = `from pathlib import Path
+import json, subprocess
+import pandas as pd
+
+project = Path(".").resolve()
+config = json.loads((project / "inputs" / "alignment-config.json").read_text())
+annotation = project / config["annotation"]
+sample_sheet = pd.read_csv(project / "inputs" / "sample-sheet.csv")
+work = project / "work" / "alignment"
+out = project / "outputs"
+work.mkdir(parents=True, exist_ok=True); out.mkdir(exist_ok=True)
+for row in sample_sheet.itertuples():
+    bam = project / row.bam_path
+    sorted_bam = work / f"{row.sample_id}.sorted.bam"
+    subprocess.run(["samtools", "sort", "-o", str(sorted_bam), str(bam)], check=True)
+    subprocess.run(["samtools", "index", str(sorted_bam)], check=True)
+bams = [str(work / f"{sample}.sorted.bam") for sample in sample_sheet.sample_id]
+subprocess.run(["featureCounts", "-a", str(annotation), "-o", str(out / "gene-counts.tsv"), *bams], check=True)
+counts = pd.read_csv(out / "gene-counts.tsv", sep="\\t", comment="#")
+counts.to_parquet(out / "gene-counts.parquet")
+(out / "run.json").write_text(json.dumps({"samples": len(bams)}))`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: [],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a paper-style spatial model training and evaluation workflow', async () => {
+  const source = `from pathlib import Path
+import pandas as pd
+import torch
+import scanpy as sc
+
+data = Path("data")
+results = Path("results")
+results.mkdir(exist_ok=True)
+train = sc.read_h5ad(data / "slice-train.h5ad")
+test = sc.read_h5ad(data / "slice-test.h5ad")
+labels = pd.read_csv(data / "layer-labels.csv")
+train.obs = train.obs.join(labels.set_index("spot_id"), how="left")
+model = torch.nn.Sequential(torch.nn.Linear(train.n_vars, 32), torch.nn.ReLU(), torch.nn.Linear(32, 8))
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+for _ in range(10):
+    optimizer.zero_grad(); loss = model(torch.as_tensor(train.X)).pow(2).mean(); loss.backward(); optimizer.step()
+torch.save(model.state_dict(), results / "spatial-model.pt")
+embedding = model(torch.as_tensor(test.X)).detach().numpy()
+pd.DataFrame(embedding).to_csv(results / "test-embedding.csv", index=False)
+pd.DataFrame({"metric": [float(embedding.mean())]}).to_csv(results / "evaluation.csv", index=False)`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['data/layer-labels.csv', 'data/slice-test.h5ad', 'data/slice-train.h5ad'],
+    writes: ['results/evaluation.csv', 'results/spatial-model.pt', 'results/test-embedding.csv'],
+    readState: 'partial',
+    writeState: 'partial'
+  })
+})
+
+it('preserves uncertainty for a declarative R single-cell workflow', async () => {
+  const source = `library(targets)
+library(SingleCellExperiment)
+library(scater)
+library(scran)
+
+config <- yaml::read_yaml("inputs/project.yml")
+samples <- read.csv("inputs/samples.csv", stringsAsFactors = FALSE)
+tar_option_set(packages = c("DropletUtils", "scater", "scran"))
+list(
+  targets::tar_target(sample_table, samples),
+  targets::tar_target(raw_paths, file.path(config$input_root, sample_table$sample_id, "matrix")),
+  targets::tar_target(raw_sce, DropletUtils::read10xCounts(raw_paths), pattern = map(raw_paths)),
+  targets::tar_target(qc_sce, scater::addPerCellQC(raw_sce)),
+  targets::tar_target(filtered_sce, qc_sce[, qc_sce$sum > config$min_counts]),
+  targets::tar_target(norm_sce, scuttle::logNormCounts(filtered_sce)),
+  targets::tar_target(reduced_sce, scater::runPCA(norm_sce, ncomponents = 30)),
+  targets::tar_target(markers, scran::findMarkers(reduced_sce, groups = reduced_sce$cluster)),
+  targets::tar_target(serialized, saveRDS(reduced_sce, "outputs/filtered-sce.rds")),
+  targets::tar_target(report, rmarkdown::render("reports/single-cell-summary.Rmd", output_dir = "outputs"))
+)`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/project.yml', 'inputs/samples.csv'],
+    writes: [],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('captures a multi-sample spatial registration and figure pipeline', async () => {
+  const source = `from pathlib import Path
+import json
+import pandas as pd
+import torch
+import scanpy as sc
+
+root = Path("inputs")
+cfg = json.loads((root / "params.json").read_text())
+sample_sheet = pd.read_csv(root / "samples.csv")
+out = Path("results")
+out.mkdir(exist_ok=True)
+embeddings = []
+for row in sample_sheet.itertuples():
+    source = sc.read_h5ad(root / row.expression_h5ad)
+    image = torch.load(root / row.image_tensor, weights_only=True)
+    coords = pd.read_csv(root / row.coordinates_csv)
+    source.obsm["spatial"] = coords[["x", "y"]].to_numpy()
+    source.obsm["image_features"] = image.numpy()
+    source.write_h5ad(out / f"{row.sample_id}.registered.h5ad")
+    embeddings.append(pd.DataFrame(source.obsm["image_features"]))
+combined = pd.concat(embeddings, ignore_index=True)
+combined.to_parquet(out / "registered-embeddings.parquet")
+combined.to_csv(out / "figure-data.csv", index=False)
+(out / "run-manifest.json").write_text(json.dumps({"parameters": cfg, "samples": len(embeddings)}))`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/params.json', 'inputs/samples.csv'],
+    writes: [
+      'results/figure-data.csv',
+      'results/registered-embeddings.parquet',
+      'results/run-manifest.json'
+    ],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it('preserves uncertainty for a dynamic proteomics QC pipeline', async () => {
+  const source = `from pathlib import Path
+import pandas as pd
+from pyteomics import mzml
+
+root = Path("inputs")
+out = Path("outputs")
+out.mkdir(exist_ok=True)
+records = []
+for raw_path in sorted((root / "mzml").glob("*.mzML")):
+    tic = 0.0; ms2 = 0
+    with mzml.read(str(raw_path)) as reader:
+        for spectrum in reader:
+            tic += float(spectrum.get("intensity array", []).sum())
+            ms2 += int(spectrum.get("ms level", 1) == 2)
+    records.append({"sample_id": raw_path.stem, "tic": tic, "ms2_spectra": ms2})
+qc = pd.DataFrame(records).merge(pd.read_csv(root / "sample-metadata.csv"), on="sample_id")
+qc.to_csv(out / "proteomics-qc.csv", index=False)
+qc.to_parquet(out / "proteomics-qc.parquet")
+qc.describe(include="all").to_json(out / "proteomics-qc-summary.json")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/sample-metadata.csv'],
+    writes: [
+      'outputs/proteomics-qc-summary.json',
+      'outputs/proteomics-qc.csv',
+      'outputs/proteomics-qc.parquet'
+    ],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})

--- a/src/main/notebook/source-file-access-analysis.dataframe-mutation.test.ts
+++ b/src/main/notebook/source-file-access-analysis.dataframe-mutation.test.ts
@@ -1,0 +1,53 @@
+import { expect, it } from 'vitest'
+
+import { analyzePythonNotebookSource } from './dependency-analysis-python'
+import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+
+it.each(['risk', 'to_csv'])(
+  'retains file writers after assigning a DataFrame column named %s',
+  async (column) => {
+    const result = await analyzeNotebookSourceFileAccess(
+      'python',
+      `import pandas as pd
+cohort = pd.read_csv("inputs/cohort.csv")
+cohort["${column}"] = 1
+cohort.to_csv("outputs/cohort.csv", index=False)
+pd.DataFrame({"score": [1]}).to_csv("outputs/scores.csv", index=False)`
+    )
+    expect(result).toMatchObject({
+      reads: ['inputs/cohort.csv'],
+      writes: ['outputs/cohort.csv', 'outputs/scores.csv'],
+      writeState: 'complete'
+    })
+  }
+)
+
+it.each([
+  'cohort.to_csv = replacement',
+  'alias = cohort\nalias.to_csv = replacement',
+  'pd.DataFrame.to_csv = replacement'
+])('keeps a replaced DataFrame writer uncertain: %s', async (replacement) => {
+  const result = await analyzeNotebookSourceFileAccess(
+    'python',
+    `import pandas as pd
+cohort = pd.read_csv("inputs/cohort.csv")
+${replacement}
+cohort.to_csv("outputs/not-a-proven-write.csv")`
+  )
+  expect(result.writes).not.toContain('outputs/not-a-proven-write.csv')
+  expect(result.externalState).toBe('partial')
+})
+
+it('retains the column mutation and writer identities across cells', async () => {
+  const prepared = await analyzePythonNotebookSource(`import pandas as pd
+cohort = pd.read_csv("inputs/cohort.csv")
+cohort["risk"] = 1`)
+  expect(prepared.facts.mutatedNames).toContain('cohort')
+  expect(prepared.fileAccess?.context?.pythonTaintedNamespaces ?? []).not.toContain('pandas')
+  const result = await analyzeNotebookSourceFileAccess(
+    'python',
+    'cohort.to_csv("outputs/cohort.csv", index=False)',
+    prepared.fileAccess?.context
+  )
+  expect(result.writes).toEqual(['outputs/cohort.csv'])
+})

--- a/src/main/notebook/source-file-access-analysis.deferred-tasks.test.ts
+++ b/src/main/notebook/source-file-access-analysis.deferred-tasks.test.ts
@@ -1,0 +1,192 @@
+import { expect, it } from 'vitest'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { NotebookRunRecord } from '../../shared/notebook'
+import { NotebookDependencyAnalyzer } from './dependency-analysis'
+import { analyzeRNotebookSource } from './dependency-analysis-r'
+import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+
+it.each([
+  'targets::tar_target(result, saveRDS(cohort, "results/model.rds"))',
+  'targets::tar_target(command = saveRDS(cohort, "results/model.rds"), result)',
+  'targets::tar_target(result, { path <- "wrong.csv"; saveRDS(cohort, "results/model.rds") })'
+])('does not promote a deferred write into produced-file evidence: %s', async (definition) => {
+  const source = `path <- "inputs/cohort.csv"
+${definition}
+cohort <- read.csv(path)
+previous <- readRDS("results/model.rds")`
+  const access = await analyzeNotebookSourceFileAccess('r', source)
+  expect(access).toMatchObject({
+    reads: ['inputs/cohort.csv', 'results/model.rds'],
+    writes: [],
+    externalState: 'partial'
+  })
+  const { facts } = await analyzeRNotebookSource(source)
+  expect(facts.priorUsedNames).not.toContain('cohort')
+})
+
+it('retains eager options while ignoring the deferred command and branch pattern', async () => {
+  const access = await analyzeNotebookSourceFileAccess(
+    'r',
+    `targets::tar_target(
+  name = stage,
+  command = readRDS("inputs/deferred.rds"),
+  pattern = map(readRDS("inputs/deferred-pattern.rds")),
+  resources = readRDS("inputs/resources.rds"),
+  description = { writeLines("prepared", "results/setup.txt"); "stage" }
+)`
+  )
+  expect(access.reads).toEqual(['inputs/resources.rds'])
+  expect(access.writes).toEqual(['results/setup.txt'])
+})
+
+it('does not apply task quotation semantics to a different namespace', async () => {
+  const access = await analyzeNotebookSourceFileAccess(
+    'r',
+    'other::tar_target(stage, readRDS("inputs/eager.rds"))'
+  )
+  expect(access.reads).toContain('inputs/eager.rds')
+  expect(access.externalState).toBe('partial')
+})
+
+it('keeps scheduler execution uncertain after creating a task definition', async () => {
+  const access = await analyzeNotebookSourceFileAccess(
+    'r',
+    `targets::tar_target(stage, saveRDS(cohort, "results/model.rds"))
+targets::tar_make()`
+  )
+  expect(access).toMatchObject({ writes: [], writeState: 'partial', externalState: 'partial' })
+})
+
+it('preserves uncertainty for tidy injection within a deferred command', async () => {
+  const access = await analyzeNotebookSourceFileAccess(
+    'r',
+    'targets::tar_target(stage, !!readRDS("inputs/injected.rds"))'
+  )
+  expect(access.readState).toBe('partial')
+  expect(access.externalState).toBe('partial')
+})
+
+it('does not report a deferred output through an attached task constructor', async () => {
+  const access = await analyzeNotebookSourceFileAccess(
+    'r',
+    `library(targets)
+tar_target(stage, saveRDS(cohort, "results/deferred.rds"))`
+  )
+  expect(access.writes).toEqual([])
+})
+
+it('retains quotation through a constructor alias', async () => {
+  const access = await analyzeNotebookSourceFileAccess(
+    'r',
+    `library(targets)
+define_stage <- tar_target
+define_stage(stage, saveRDS(cohort, "results/deferred.rds"))`
+  )
+  expect(access.writes).toEqual([])
+  expect(access.writeState).toBe('partial')
+})
+
+it('retains eager cohort reporting around a deferred multi-stage omics model', async () => {
+  const source = `library(jsonlite)
+library(targets)
+cfg <- jsonlite::fromJSON("inputs/config.json")
+samples <- read.csv("inputs/sample-sheet.csv", stringsAsFactors = FALSE)
+for (sample in samples$id) {
+  raw <- read.csv(file.path("inputs", "omics", sample, "counts.csv"))
+  qc <- transform(raw,
+    pass = signal > cfg$threshold,
+    normalized = signal / median(signal, na.rm = TRUE))
+  dir.create("work", showWarnings = FALSE, recursive = TRUE)
+  write.csv(qc, file.path("work", paste0(sample, "-qc.csv")), row.names = FALSE)
+}
+fit <- lm(outcome ~ batch + treatment, data = samples)
+model_metrics <- as.data.frame(coef(summary(fit)))
+write.csv(model_metrics, "outputs/final-coefficients.csv")
+define_stage <- tar_target
+model_path <- "outputs/model.rds"
+list(
+  define_stage(counts, readRDS("work/merged-counts.rds")),
+  define_stage(features, {
+    system2("feature-tool", c("--input", "work/merged-counts.rds", "--output", "work/features.csv"))
+    read.csv("work/features.csv")
+  }),
+  define_stage(folds, split(samples, samples$fold)),
+  define_stage(models, lapply(folds, function(training) {
+    lm(outcome ~ batch + treatment, data = training)
+  })),
+  define_stage(model_artifact, {
+    model_path <- "outputs/replaced-model.rds"
+    saveRDS(models, "outputs/model.rds")
+  })
+)
+previous_model <- readRDS(model_path)
+comparison <- data.frame(previous = length(previous_model), current = length(coef(fit)))
+write.csv(comparison, "outputs/model-comparison.csv", row.names = FALSE)`
+  expect(await analyzeNotebookSourceFileAccess('r', source)).toMatchObject({
+    reads: ['inputs/config.json', 'inputs/sample-sheet.csv', 'outputs/model.rds'],
+    writes: ['outputs/final-coefficients.csv', 'outputs/model-comparison.csv'],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})
+
+it.each([
+  'library(targets); tar_target <- function(name, command) command; tar_target(stage, readRDS("inputs/eager.rds"))',
+  'library(targets); source("helpers.R"); tar_target(stage, readRDS("inputs/eager.rds"))',
+  'targets::tar_target_raw("stage", readRDS("inputs/eager.rds"))'
+])('does not hide evaluated arguments behind unproven quotation: %s', async (source) => {
+  const access = await analyzeNotebookSourceFileAccess('r', source)
+  expect(access.reads).toContain('inputs/eager.rds')
+})
+
+it('restores the constructor binding and its dependency across cells', async () => {
+  const scripts = ['library(targets)', 'tar_target(stage, saveRDS(cohort, "results/deferred.rds"))']
+  const runs: NotebookRunRecord[] = scripts.map((script, index) => ({
+    runId: `run-${index}`,
+    cellId: `run-${index}`,
+    source: 'agent',
+    kernelKind: 'r',
+    kernelEpochId: 'epoch',
+    environment: 'default-r',
+    script,
+    status: 'completed',
+    startedAt: index,
+    endedAt: index,
+    text: { stdout: '', stderr: '', traceback: '', plain: [] },
+    outputs: [],
+    workingFiles: []
+  }))
+  const root = await mkdtemp(join(tmpdir(), 'r-task-context-'))
+  try {
+    const analyzer = new NotebookDependencyAnalyzer({
+      storageRoot: root,
+      repository: { readSessionRuns: async () => runs }
+    })
+    const result = await analyzer.project({
+      projectId: 'project',
+      sessionId: 'session',
+      completedRun: runs[1]
+    })
+    const context = await analyzer.sourceFileAccessContext({
+      projectId: 'project',
+      sessionId: 'session',
+      currentRunId: 'run-1',
+      language: 'r',
+      environment: 'default-r',
+      kernelEpochId: 'epoch'
+    })
+    expect(result.stalenessByRunId['run-1']).toMatchObject({ state: 'unknown' })
+    const { facts } = await analyzeRNotebookSource(scripts[1], context)
+    expect(facts.priorUsedNames).toContain('tar_target')
+    expect(facts.priorUsedNames).not.toContain('cohort')
+    expect(await analyzeNotebookSourceFileAccess('r', scripts[1], context)).toMatchObject({
+      writes: [],
+      writeState: 'partial'
+    })
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+})

--- a/src/main/notebook/source-file-access-analysis.workflow-orchestration.test.ts
+++ b/src/main/notebook/source-file-access-analysis.workflow-orchestration.test.ts
@@ -1,0 +1,39 @@
+import { expect, it } from 'vitest'
+import { analyzeNotebookSourceFileAccess } from './source-file-access-analysis'
+
+it('captures a configuration-driven clinical workflow with dynamic cohort stages', async () => {
+  const source = `from pathlib import Path
+import json
+import subprocess
+import pandas as pd
+from lifelines import CoxPHFitter
+import joblib
+
+root = Path("inputs")
+config = json.loads((root / "workflow.json").read_text())
+cohorts = pd.read_csv(root / "cohorts.csv")
+results = Path("results")
+results.mkdir(exist_ok=True)
+models = []
+for cohort in cohorts.itertuples():
+    expression = root / cohort.expression_file
+    clinical = root / cohort.clinical_file
+    subprocess.run(["normalizer", "--input", str(expression), "--output", "work/normalized.tsv"], check=True)
+    frame = pd.read_csv("work/normalized.tsv", sep="\\t").merge(pd.read_csv(clinical), on="patient_id")
+    frame.to_parquet(results / f"{cohort.name}-features.parquet")
+    model = CoxPHFitter().fit(frame, duration_col=config["duration"], event_col=config["event"])
+    joblib.dump(model, results / f"{cohort.name}-cox.joblib")
+    models.append(model)
+summary = pd.DataFrame({"cohort": cohorts.name, "models": len(models)})
+summary.to_csv(results / "survival-summary.csv", index=False)
+(results / "run-manifest.json").write_text(json.dumps({"cohorts": len(models), "config": config}))
+Path("reports").mkdir(exist_ok=True)
+(Path("reports") / "survival.html").write_text("<html>report</html>")`
+  expect(await analyzeNotebookSourceFileAccess('python', source)).toMatchObject({
+    reads: ['inputs/cohorts.csv', 'inputs/workflow.json', 'work/normalized.tsv'],
+    writes: ['reports/survival.html', 'results/run-manifest.json', 'results/survival-summary.csv'],
+    readState: 'partial',
+    writeState: 'partial',
+    externalState: 'partial'
+  })
+})


### PR DESCRIPTION
## Problem
Complex clinical and omics workflows were underrepresented in reproducibility capture. Deferred R task definitions could be mistaken for executed file effects, while multi-stage Python and R workflows needed broader lineage coverage.

## Proposed change
Expand R and Python input, output and dependency lineage across clinical and omics workflows. Correct scientific API argument mapping, preserve constructor and wrapper binding provenance, and retain uncertainty for dynamic paths, directory datasets, companion files and mixed-effect wrappers. Project-saving calls retain input uncertainty for referenced Arrow files. Project construction records both scalar and collection Arrow inputs.

## Scope and compatibility
The analyzer revision advances once from tree-sitter-in-process-103 to tree-sitter-in-process-104, as approved by the maintainer. Existing cached analysis is invalidated through the existing revision/checksum mechanism and refreshed on demand. The analyzer format version remains 1. No database migration, persisted serialization format, enum, UI, IPC or runtime execution behavior changes are introduced. Historical provenance format remains readable; this PR adds no bulk rewrite of historical evidence.

## Acceptance criteria and validation
Validation of the final changes:

- Source-file access, dependency analysis and input-resource behavior, including stale cached-analysis refresh, plus artifact analysis-revision and snapshot-decoder consumers: targeted Vitest run across 94 files after the final analyzer edit; 3,545 passed and 64 skipped. No analyzer code changed afterward.
- npm run lint, changed-file Prettier and git diff --check passed.
- Local Node typecheck remains blocked by the reused dependency installation's older sandbox declarations. There are no diagnostics in the changed files. Exact-head CI remains authoritative for clean-install typechecks and cross-platform validation.
- Session package export/import, read-only history, persistence restarts and cleanup: `npx playwright test e2e/session-package.spec.ts --grep "exports a Session package" --retries=0 --repeat-each=3` passed all three macOS runs after the final E2E edit. The E2E build also passed. Windows exact-head CI remains required.
- No full local npm test run. Renderer code is unchanged; cross-platform selected CI lanes validate the final PR diff.
- No biological packages or external datasets were installed or downloaded.

The Session package E2E follow-up waits for the final generated turn to finish before restarting and gives archive inspection the existing 60-second package-operation budget, with 240 seconds for the complete journey. Graceful-close enforcement and all original behavioral assertions remain enabled.

## Review focus
Review deferred-command quotation boundaries, constructor identity and namespace replacement, named/positional scientific file arguments, conservative uncertainty states, and cache invalidation. Single-path wrapper summaries intentionally exclude mixed-effect ArchR operations rather than claiming complete file coverage; exact paths inside those wrappers remain a limitation.


