### PR TITLE
perf(app): optimize Electron startup and runtime paths

### DIFF
--- a/.github/workflows/performance-package-dryrun.yml
+++ b/.github/workflows/performance-package-dryrun.yml
@@ -1,0 +1,83 @@
+name: Performance Package Dry Run
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: performance-package-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml
+    with:
+      nightly: true
+      skip_verify: true
+      platform_name: macos-arm64
+
+  smoke:
+    needs: build
+    uses: ./.github/workflows/package-smoke.yml
+    with:
+      platform_name: macos-arm64
+
+  performance:
+    needs: build
+    runs-on: macos-26
+    timeout-minutes: 25
+    steps:
+      - name: Checkout tested revision
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 22
+          cache: npm
+      - name: Install test tooling
+        run: node scripts/ci/npm-ci.mjs
+      - name: Download package from this run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: macos-arm64
+          path: package
+      - name: Extract packaged executable
+        id: packaged
+        shell: bash
+        run: |
+          set -euo pipefail
+          zip=$(find package -maxdepth 1 -type f -name '*-mac-arm64.zip' -print -quit)
+          test -n "$zip"
+          mkdir -p extracted
+          ditto -x -k "$zip" extracted
+          executable=$(find extracted -type f -path '*/Open Science.app/Contents/MacOS/Open Science' -print -quit)
+          test -n "$executable"
+          echo "executable=$(node -e 'process.stdout.write(require("path").resolve(process.argv[1]))' "$executable")" >> "$GITHUB_OUTPUT"
+          shasum -a 256 "$zip" > package/SHA256-tested.txt
+          printf '%s\n' "$GITHUB_SHA" > package/tested-revision.txt
+      - name: Profile packaged startup and runtime
+        env:
+          OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged.outputs.executable }}
+          OPEN_SCIENCE_E2E_EXPECTED_BUILD_SHA: ${{ github.sha }}
+        run: npm run perf:runtime -- --skip-build --repeat=1
+      - name: Verify packaged locale loading and restart
+        if: ${{ !cancelled() && steps.packaged.outcome == 'success' }}
+        env:
+          OPEN_SCIENCE_E2E_EXECUTABLE: ${{ steps.packaged.outputs.executable }}
+          OPEN_SCIENCE_E2E_EXPECTED_BUILD_SHA: ${{ github.sha }}
+        run: npx playwright test e2e/settings-persistence.spec.ts --grep 'persists (Russian|German)|after an Electron restart' --workers=1 --retries=0
+      - name: Upload package test evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: packaged-performance-evidence
+          retention-days: 7
+          path: |
+            test-results/
+            playwright-report/
+            package/SHA256-tested.txt
+            package/tested-revision.txt

--- a/.github/workflows/runtime-resource-soak.yml
+++ b/.github/workflows/runtime-resource-soak.yml
@@ -6,13 +6,14 @@ on:
   workflow_dispatch:
     inputs:
       mode:
-        description: Runtime profile duration
+        description: Runtime source profile or packaged macOS dry-run
         required: true
         default: smoke
         type: choice
         options:
           - smoke
           - soak
+          - package-macos-arm64
 
 permissions:
   actions: read
@@ -54,7 +55,7 @@ jobs:
   runtime_resource_soak:
     name: Windows runtime resource ${{ github.event_name == 'workflow_dispatch' && inputs.mode || 'soak' }}
     needs: plan
-    if: needs.plan.outputs.should_test == 'true'
+    if: needs.plan.outputs.should_test == 'true' && inputs.mode != 'package-macos-arm64'
     runs-on: windows-latest
     timeout-minutes: 70
     env:
@@ -91,3 +92,7 @@ jobs:
           path: test-results
           retention-days: 14
           if-no-files-found: error
+
+  packaged_performance:
+    if: github.event_name == 'workflow_dispatch' && inputs.mode == 'package-macos-arm64'
+    uses: ./.github/workflows/performance-package-dryrun.yml

--- a/e2e/certification/helpers.ts
+++ b/e2e/certification/helpers.ts
@@ -78,7 +78,8 @@ const openProjectSession = async (
   if (await heading.isVisible()) return
   const session = page
     .getByRole('navigation', { name: 'Sessions' })
-    .getByRole('button', { name: new RegExp(promptPrefix, 'u') })
+    .locator('button[data-slot="session-open-button"]')
+    .filter({ hasText: promptPrefix })
   await expect(session).toBeVisible({ timeout: 60_000 })
   await session.click()
 }

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -1004,6 +1004,7 @@ class ElectronAppHarness implements ElectronApp {
       this.resourceProfiler.markPhase(options.resourceProfilePhase)
     }
     await this.launch(
+      undefined,
       options.resourceProfilePhase === 'recovery' ? 'recovery-startup-ready' : 'startup-ready'
     )
     return this.page
@@ -1082,6 +1083,24 @@ class ElectronAppHarness implements ElectronApp {
     )
     await this.resourceProfiler?.attach(this.application)
     try {
+      if (process.env.OPEN_SCIENCE_E2E_EXECUTABLE) {
+        const evidence = await this.application.evaluate(({ app }) => ({
+          packaged: app.isPackaged,
+          appPath: app.getAppPath(),
+          executable: process.execPath,
+          version: app.getVersion()
+        }))
+        const revision = process.env.OPEN_SCIENCE_E2E_EXPECTED_BUILD_SHA
+        if (
+          !evidence.packaged ||
+          !evidence.appPath.endsWith('app.asar') ||
+          evidence.executable !== process.env.OPEN_SCIENCE_E2E_EXECUTABLE ||
+          (revision && !evidence.version.endsWith(`-nightly.${revision.slice(0, 7)}`))
+        ) {
+          throw new Error(`Packaged Electron identity mismatch: ${JSON.stringify(evidence)}`)
+        }
+        console.info('Packaged Electron identity:', JSON.stringify(evidence))
+      }
       this.currentPage = await openMainWindow(
         this.application,
         this.rendererFailures,

--- a/e2e/fixtures/electron-app.ts
+++ b/e2e/fixtures/electron-app.ts
@@ -154,6 +154,8 @@ type ElectronApp = {
   restartAfterCrash: () => Promise<Page>
   restartWithCorruptHistoricalSessionFile: (projectId: string) => Promise<Page>
   sabotageDelegatedHandoffCleanup: (childName: string) => Promise<void>
+  recordResourceTiming: (name: string, durationMs: number) => void
+  captureResourceTimings: (prefix?: string) => Promise<void>
   sampleResourceProfileNow: () => Promise<void>
   setMainWindowZoomFactor: (factor: number) => Promise<void>
   finishResourceProfile: () => Promise<RuntimeProfileResult>
@@ -322,12 +324,14 @@ const applyHiddenWindowPresentation = async (
 const openMainWindow = async (
   application: ElectronApplication,
   rendererFailures: RendererFailureGate,
-  windowMode: E2eWindowMode
+  windowMode: E2eWindowMode,
+  onFirstReady?: (page: Page) => Promise<void>
 ): Promise<Page> => {
   const page = await application.firstWindow()
   await applyHiddenWindowPresentation(page, windowMode)
   await rendererFailures.observe(page)
   await waitForRendererReady(page)
+  await onFirstReady?.(page)
   // Writing the cooldown after first paint does not cancel a timer GitHubStarBadge already
   // scheduled. Reload so the workspace variant remounts with the cooldown already set.
   await suppressWorkspaceStarNudge(page)
@@ -537,6 +541,43 @@ class ElectronAppHarness implements ElectronApp {
     if (!this.resourceProfiler) throw new Error('Runtime resource profiling is not active.')
     this.resourceProfiler.markPhase(phase)
     await this.resourceProfiler.sampleNow()
+  }
+
+  recordResourceTiming(name: string, durationMs: number): void {
+    this.resourceProfiler?.recordTiming(name, durationMs)
+  }
+
+  async captureResourceTimings(prefix = ''): Promise<void> {
+    if (!this.resourceProfiler) return
+    const collect = (): { name: string; duration: number }[] => {
+      const names = new Set([
+        'open-science:ipc-registration',
+        'open-science:renderer-bootstrap',
+        'open-science:i18n-init',
+        'open-science:i18n-locale-switch',
+        'open-science:persistence-runtime-lookup-fallback',
+        'open-science:persistence-runtime-lookup-catalog',
+        'open-science:persistence-runtime-lookup-ownership',
+        'open-science:persistence-runtime-lookup-read',
+        'open-science:persistence-runtime-lookup-targeted'
+      ])
+      const timings = performance
+        .getEntriesByType('measure')
+        .filter((entry) => names.has(entry.name))
+        .map(({ name, duration }) => ({ name, duration }))
+      for (const name of names) performance.clearMeasures(name)
+      for (const entry of performance.getEntriesByType('paint')) {
+        if (entry.name === 'first-paint' || entry.name === 'first-contentful-paint') {
+          timings.push({ name: entry.name, duration: entry.startTime })
+        }
+      }
+      return timings
+    }
+    for (const timing of [
+      ...(await this.runningApplication.evaluate(collect)),
+      ...(await this.page.evaluate(collect))
+    ])
+      this.resourceProfiler.recordTiming(prefix + timing.name, timing.duration)
   }
 
   async sampleResourceProfileNow(): Promise<void> {
@@ -962,7 +1003,9 @@ class ElectronAppHarness implements ElectronApp {
       if (!this.resourceProfiler) throw new Error('Runtime resource profiling is not active.')
       this.resourceProfiler.markPhase(options.resourceProfilePhase)
     }
-    await this.launch()
+    await this.launch(
+      options.resourceProfilePhase === 'recovery' ? 'recovery-startup-ready' : 'startup-ready'
+    )
     return this.page
   }
 
@@ -1026,7 +1069,8 @@ class ElectronAppHarness implements ElectronApp {
     }
   }
 
-  private async launch(packagePath?: string): Promise<void> {
+  private async launch(packagePath?: string, timingName = 'startup-ready'): Promise<void> {
+    const launchStartedAt = performance.now()
     this.application = await launchOpenScience(
       this.roots,
       this.fakeAgentEnabled,
@@ -1041,8 +1085,18 @@ class ElectronAppHarness implements ElectronApp {
       this.currentPage = await openMainWindow(
         this.application,
         this.rendererFailures,
-        this.windowMode
+        this.windowMode,
+        this.resourceProfiler
+          ? async (page) => {
+              this.currentPage = page
+              this.recordResourceTiming('first-' + timingName, performance.now() - launchStartedAt)
+              await this.captureResourceTimings(
+                timingName === 'recovery-startup-ready' ? 'first-recovery:' : 'first:'
+              )
+            }
+          : undefined
       )
+      this.recordResourceTiming(timingName, performance.now() - launchStartedAt)
     } finally {
       this.mainLogDirectory = await this.application
         .evaluate(({ app }) => app.getPath('logs'))

--- a/e2e/runtime-performance.spec.ts
+++ b/e2e/runtime-performance.spec.ts
@@ -6,6 +6,8 @@ import {
 import { createProject, openProjectSession, sendPrompt } from './certification/helpers'
 import { test } from './fixtures/electron-app'
 
+test.use({ windowMode: 'normal' })
+
 const PROFILE_PROJECT_NAME = 'Runtime performance fixture'
 const ACP_PROMPT = 'Summarize the deterministic fixture.'
 const ACP_REPLY = `Deterministic reply: ${ACP_PROMPT}`
@@ -49,8 +51,11 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     await page.waitForTimeout(phaseDurationMs)
     await app.sampleResourceProfileNow()
 
+    await app.captureResourceTimings()
     await app.markResourceProfilePhase('workspace')
+    const workspaceStartedAt = performance.now()
     await createProject(page, PROFILE_PROJECT_NAME)
+    app.recordResourceTiming('workspace-create-visible', performance.now() - workspaceStartedAt)
     await app.sampleResourceProfileNow()
 
     await app.markResourceProfilePhase('acp-turn')
@@ -73,11 +78,16 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
     }
 
     page = await app.restart({ resourceProfilePhase: 'recovery' })
-    await page.waitForTimeout(phaseDurationMs)
+    const recoveryStartedAt = performance.now()
     await openProjectSession(page, PROFILE_PROJECT_NAME, ACP_PROMPT)
     await expect(page.getByText(STRESS_REPLY, { exact: false }).last()).toBeVisible({
       timeout: RUNTIME_PERFORMANCE_PROMPT_TIMEOUT_MS
     })
+    app.recordResourceTiming('workspace-reopen-visible', performance.now() - recoveryStartedAt)
+    await app.captureResourceTimings('recovery:')
+    // Opening the recovered workspace starts file/runtime probes. Sample after the same
+    // settling window as idle, rather than immediately after that new work is triggered.
+    await page.waitForTimeout(phaseDurationMs)
     await app.sampleResourceProfileNow()
   } finally {
     result = await app.finishResourceProfile().catch((error: unknown) => {
@@ -113,7 +123,7 @@ test('records isolated startup, ACP, Notebook, and recovery resource trends', as
   ).toBeGreaterThan(0)
   expect(
     recovery.processCount.last,
-    'recovery must not retain more processes than the stable idle phase'
+    'recovery must not retain more app-owned processes than the stable idle phase'
   ).toBeLessThanOrEqual(idle.processCount.last)
   const recoveryStorage = recovery.storage
   expect(recoveryStorage?.temporaryFileCount.last, 'recovery must leave no temporary files').toBe(0)

--- a/e2e/settings-persistence.spec.ts
+++ b/e2e/settings-persistence.spec.ts
@@ -5,6 +5,23 @@ import { sendPrompt } from './certification/helpers'
 import { test } from './fixtures/electron-app'
 import { openGeneralSettings, setTheme } from './fixtures/settings-preferences'
 
+// file:// modules do not reliably populate Resource Timing. CDP reports the scripts Chromium
+// actually parsed, including those loaded before the test attached to the restarted window.
+const loadedLocaleChunks = async (page: Page): Promise<string[]> => {
+  const client = await page.context().newCDPSession(page)
+  const locales = new Set<string>()
+  client.on('Debugger.scriptParsed', ({ url }) => {
+    const match = /\/(de|es|fr|ja|ko|ru|zh-Hans|zh-Hant)-[^/]+\.js(?:$|\?)/u.exec(url)
+    if (match) locales.add(match[1])
+  })
+  try {
+    await client.send('Debugger.enable')
+    return [...locales].sort()
+  } finally {
+    await client.detach()
+  }
+}
+
 const expectMemoryConfirmDialogChrome = async (
   dialog: Locator,
   confirmLabel: string
@@ -301,11 +318,15 @@ test('contains long memory lists and layers destructive confirmations above sett
   await categoryDialog.getByRole('button', { name: 'Cancel' }).click()
 })
 
-test('persists Russian into the built main-process native quit dialog', async ({ app }) => {
+test('persists Russian into the built main-process native quit dialog', async ({
+  app
+}, testInfo) => {
   let page = await app.completeOnboarding()
 
+  expect(await loadedLocaleChunks(page)).toEqual([])
   await selectLanguage(page, 'Русский')
   await expect(page.locator('html')).toHaveAttribute('lang', 'ru')
+  expect(await loadedLocaleChunks(page)).toEqual(['ru'])
 
   await expect
     .poll(() => app.capturePersistedLocaleNativeQuitDialog())
@@ -316,8 +337,12 @@ test('persists Russian into the built main-process native quit dialog', async ({
       message: 'Выйти из Open Science?'
     })
 
+  const screenshot = testInfo.outputPath('russian-locale-loaded.png')
+  await page.screenshot({ path: screenshot })
+  await testInfo.attach('russian-locale-loaded', { path: screenshot, contentType: 'image/png' })
   page = await app.restart()
   await expect(page.locator('html')).toHaveAttribute('lang', 'ru')
+  expect(await loadedLocaleChunks(page)).toEqual(['ru'])
   await expect
     .poll(() => app.capturePersistedLocaleNativeQuitDialog())
     .toEqual({

--- a/e2e/startup-performance.spec.ts
+++ b/e2e/startup-performance.spec.ts
@@ -1,0 +1,27 @@
+import { expect } from '@playwright/test'
+import { test } from './fixtures/electron-app'
+
+test.use({ windowMode: 'normal' })
+
+test('records first renderer readiness before the fixture reload', async ({ app }, testInfo) => {
+  await app.completeOnboarding()
+  await app.beginResourceProfile({
+    ...(process.env.OPEN_SCIENCE_PERF_OUTPUT_ROOT
+      ? { outputRoot: process.env.OPEN_SCIENCE_PERF_OUTPUT_ROOT }
+      : {})
+  })
+  try {
+    await app.restart({ resourceProfilePhase: 'startup' })
+  } finally {
+    const result = await app.finishResourceProfile()
+    await testInfo.attach('first-startup-summary', {
+      path: result.summaryMarkdownPath,
+      contentType: 'text/markdown'
+    })
+    const first = result.summary.timings?.['first-startup-ready']
+    const fixture = result.summary.timings?.['startup-ready']
+    expect(first?.count).toBe(1)
+    expect(first?.median).toBeGreaterThan(0)
+    expect(fixture?.median).toBeGreaterThan(first!.median)
+  }
+})

--- a/e2e/transcript-capacity.spec.ts
+++ b/e2e/transcript-capacity.spec.ts
@@ -1,3 +1,4 @@
+import { writeFile } from 'node:fs/promises'
 import { expect } from '@playwright/test'
 import { test } from './fixtures/electron-app'
 import { openProjectSession } from './certification/helpers'
@@ -36,16 +37,21 @@ test('bounds history scrolling and preserves native find across the transcript',
     })
   }, cwd)
   page = await app.restart()
+  const openedAt = performance.now()
   await openProjectSession(page, 'Transcript capacity', 'Capacity history')
   const viewport = page.locator('[data-slot="message-scroller-viewport"]')
   const rows = viewport.locator('[data-message-id^="capacity-"]')
   await expect(rows).toHaveCount(80)
+  const openMs = performance.now() - openedAt
+  const scrollMs: number[] = []
   const counts: number[] = [80]
   await viewport.hover()
   for (let i = 0; i < 4; i++) {
     const first = await rows.first().getAttribute('data-message-id')
+    const startedAt = performance.now()
     await page.mouse.wheel(0, -100_000)
     await expect.poll(() => rows.first().getAttribute('data-message-id')).not.toBe(first)
+    scrollMs.push(performance.now() - startedAt)
     counts.push(await rows.count())
     expect(counts.at(-1)).toBeLessThanOrEqual(160)
   }
@@ -77,8 +83,23 @@ test('bounds history scrolling and preserves native find across the transcript',
   await overlay.getByRole('button', { name: 'Close find' }).click()
   await expect.poll(() => app.findOverlayIsVisible()).toBe(false)
   await expect.poll(() => rows.count()).toBeLessThanOrEqual(160)
-  await testInfo.attach('mounted-row-counts', {
-    body: JSON.stringify(counts),
+  const screenshot = testInfo.outputPath('transcript-capacity.png')
+  await page.screenshot({ path: screenshot })
+  await testInfo.attach('transcript-capacity', { path: screenshot, contentType: 'image/png' })
+  const timingsPath = testInfo.outputPath('transcript-timings.json')
+  await writeFile(
+    timingsPath,
+    JSON.stringify({
+      messageCount: 400,
+      mountedRows: counts,
+      openMs,
+      scrollMs,
+      measurement:
+        'Playwright wall time from wheel to changed first row; includes automation and polling latency, not frame time'
+    })
+  )
+  await testInfo.attach('transcript-timings', {
+    path: timingsPath,
     contentType: 'application/json'
   })
 })

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,4 +1,5 @@
 import { resolve } from 'path'
+import { nativeLocaleAssets } from './scripts/native-locale-assets'
 import { defineConfig } from 'electron-vite'
 import { fileViewerRenderers } from '@file-viewer/vite-plugin'
 import react from '@vitejs/plugin-react'
@@ -14,7 +15,9 @@ export const resolveWsl2BashPreviewBuildEnabled = (
 
 export default defineConfig(({ command }) => ({
   main: {
+    plugins: [nativeLocaleAssets()],
     define: {
+      __OPEN_SCIENCE_NATIVE_LOCALE_DIRECTORY__: JSON.stringify('native-locales'),
       __OPEN_SCIENCE_WSL2_BASH_PREVIEW__: resolveWsl2BashPreviewBuildEnabled(
         process.platform,
         process.env.OPEN_SCIENCE_BUILD_WSL2_BASH_PREVIEW

--- a/scripts/ci/performance-package-dryrun.test.ts
+++ b/scripts/ci/performance-package-dryrun.test.ts
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs'
+import { load } from 'js-yaml'
+import { expect, it } from 'vitest'
+
+it('tests the immutable package with read-only reusable release jobs and no source rebuild', () => {
+  const source = readFileSync('.github/workflows/performance-package-dryrun.yml', 'utf8')
+  const workflow = load(source) as {
+    on: Record<string, unknown>
+    permissions: Record<string, string>
+    jobs: Record<
+      string,
+      {
+        uses?: string
+        with?: Record<string, unknown>
+        steps?: { name: string; run?: string; env?: Record<string, string> }[]
+      }
+    >
+  }
+  expect(Object.keys(workflow.on)).toEqual(['workflow_dispatch', 'workflow_call'])
+  expect(workflow.permissions).toEqual({ actions: 'read', contents: 'read' })
+  expect(workflow.jobs.build).toEqual({
+    uses: './.github/workflows/build.yml',
+    with: { nightly: true, skip_verify: true, platform_name: 'macos-arm64' }
+  })
+  expect(workflow.jobs.smoke.uses).toBe('./.github/workflows/package-smoke.yml')
+  expect(Object.keys(workflow.jobs)).toEqual(['build', 'smoke', 'performance'])
+  const steps = workflow.jobs.performance.steps!
+  const profile = steps.find((step) => step.name === 'Profile packaged startup and runtime')!
+  expect(profile.run).toContain('--skip-build')
+  expect(profile.env).toEqual({
+    OPEN_SCIENCE_E2E_EXECUTABLE: '${{ steps.packaged.outputs.executable }}',
+    OPEN_SCIENCE_E2E_EXPECTED_BUILD_SHA: '${{ github.sha }}'
+  })
+  expect(steps.some((step) => /build:e2e|npm run dev/.test(step.run ?? ''))).toBe(false)
+})
+
+it('dispatches the package plan through the existing runtime workflow without running the source soak', () => {
+  const workflow = load(readFileSync('.github/workflows/runtime-resource-soak.yml', 'utf8')) as {
+    jobs: Record<string, { if?: string; uses?: string }>
+  }
+  expect(workflow.jobs.packaged_performance).toEqual({
+    if: "github.event_name == 'workflow_dispatch' && inputs.mode == 'package-macos-arm64'",
+    uses: './.github/workflows/performance-package-dryrun.yml'
+  })
+  expect(workflow.jobs.runtime_resource_soak.if).toContain("inputs.mode != 'package-macos-arm64'")
+})

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -158,7 +158,7 @@ describe('release and scheduled workflow topology', () => {
     expect(schedule).toEqual([{ cron: '23 3 * * *' }])
     expect(dispatch.inputs?.mode).toMatchObject({
       default: 'smoke',
-      options: ['smoke', 'soak']
+      options: ['smoke', 'soak', 'package-macos-arm64']
     })
     expect(resource.permissions).toEqual({ actions: 'read', contents: 'read' })
     expect(resource.concurrency).toEqual({
@@ -170,7 +170,7 @@ describe('release and scheduled workflow topology', () => {
     )
     expect(soak).toMatchObject({
       needs: 'plan',
-      if: "needs.plan.outputs.should_test == 'true'",
+      if: "needs.plan.outputs.should_test == 'true' && inputs.mode != 'package-macos-arm64'",
       'runs-on': 'windows-latest',
       'timeout-minutes': 70
     })

--- a/scripts/electron-fixture-teardown.test.ts
+++ b/scripts/electron-fixture-teardown.test.ts
@@ -6,7 +6,10 @@ import { afterEach, beforeEach, expect, it, vi } from 'vitest'
 const boundary = vi.hoisted(() => ({
   fixture: undefined as unknown as (
     options: unknown,
-    use: (app: { restartAfterCrash: () => Promise<unknown> }) => Promise<void>,
+    use: (app: {
+      restartAfterCrash: () => Promise<unknown>
+      restart: () => Promise<unknown>
+    }) => Promise<void>,
     info: unknown
   ) => Promise<void>,
   fixtureTimeout: undefined as number | undefined,
@@ -308,3 +311,15 @@ it.each([true, false])(
     }
   }
 )
+
+it('restarts without passing the timing label as a package file argument', async () => {
+  await boundary.fixture(
+    { windowMode: 'hidden' },
+    async (app) => {
+      await app.restart()
+    },
+    { status: 'passed', expectedStatus: 'passed', attach }
+  )
+  expect(boundary.launch).toHaveBeenCalledTimes(2)
+  expect(boundary.launch.mock.calls[1][0].args).toEqual(boundary.launch.mock.calls[0][0].args)
+})

--- a/scripts/native-locale-assets.test.ts
+++ b/scripts/native-locale-assets.test.ts
@@ -1,0 +1,23 @@
+import { expect, it, vi } from 'vitest'
+import { nativeLocaleAssets } from './native-locale-assets'
+import { LOCALES } from '../src/shared/locale'
+
+it('ships all eight native catalogs without renderer copy and watches their source files', async () => {
+  const plugin = nativeLocaleAssets()
+  const emitFile = vi.fn()
+  const addWatchFile = vi.fn()
+  const hook = plugin.buildStart!
+  const handler = typeof hook === 'function' ? hook : hook.handler
+  await handler.call({ emitFile, addWatchFile } as never, {} as never)
+  expect(emitFile).toHaveBeenCalledTimes(8)
+  expect(addWatchFile).toHaveBeenCalledTimes(8)
+  expect(emitFile.mock.calls.map(([asset]) => asset.fileName).sort()).toEqual(
+    LOCALES.filter((locale) => locale !== 'en')
+      .map((locale) => `native-locales/${locale}.json`)
+      .sort()
+  )
+  for (const [asset] of emitFile.mock.calls) {
+    expect(asset.type).toBe('asset')
+    expect(Object.keys(JSON.parse(asset.source)).sort()).toEqual(['common', 'native'])
+  }
+})

--- a/scripts/native-locale-assets.ts
+++ b/scripts/native-locale-assets.ts
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+import type { Plugin } from 'vite'
+import { LOCALES } from '../src/shared/locale'
+
+// Main never needs renderer translations. Emit immutable application assets, not user-data caches.
+export const nativeLocaleAssets = (): Plugin => ({
+  name: 'open-science-native-locales',
+  buildStart() {
+    for (const locale of LOCALES) {
+      if (locale === 'en') continue
+      const path = resolve('src/shared/i18n/locales', `${locale}.json`)
+      this.addWatchFile(path)
+      const { common, native } = JSON.parse(readFileSync(path, 'utf8'))
+      this.emitFile({
+        type: 'asset',
+        fileName: `native-locales/${locale}.json`,
+        source: JSON.stringify({ common, native })
+      })
+    }
+  }
+})

--- a/scripts/performance/profile-native-locales.mjs
+++ b/scripts/performance/profile-native-locales.mjs
@@ -1,0 +1,70 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+import { spawnSync } from 'node:child_process'
+import { resolve } from 'node:path'
+
+// Supply equivalent CommonJS builds. Each sample uses a fresh process; OS disk cache is warm.
+const [baseline, candidate, repeats = '15'] = process.argv.slice(2)
+const count = Number(repeats)
+if (!baseline || !candidate || !Number.isSafeInteger(count) || count < 3 || count > 100) {
+  throw new Error(
+    'Usage: node scripts/performance/profile-native-locales.mjs <baseline.cjs> <candidate.cjs> [3..100 runs]'
+  )
+}
+const sample = `
+  const before = process.memoryUsage().heapUsed
+  const started = performance.now()
+  const { createNativeI18n } = require(process.argv[1])
+  const instance = createNativeI18n(process.argv[2])
+  const elapsedMs = performance.now() - started
+  console.log(JSON.stringify({
+    elapsedMs,
+    heapDeltaBytes: process.memoryUsage().heapUsed - before,
+    translatedLocales: Object.keys(instance.store.data).filter(locale => locale !== 'en').length,
+    quit: instance.t('Quit', { context: 'verb' })
+  }))
+`
+const median = (values) => [...values].sort((a, b) => a - b)[Math.floor(values.length / 2)]
+const results = []
+for (const locale of ['en', 'ru']) {
+  const runs = { baseline: [], candidate: [] }
+  for (let run = 0; run < count; run++) {
+    // Alternate ordering to reduce bias from background machine load.
+    const order = run % 2 ? ['candidate', 'baseline'] : ['baseline', 'candidate']
+    for (const name of order) {
+      const modulePath = resolve(name === 'baseline' ? baseline : candidate)
+      const child = spawnSync(process.execPath, ['-e', sample, modulePath, locale], {
+        encoding: 'utf8'
+      })
+      if (child.status !== 0) throw new Error(child.stderr || 'Native locale sample failed')
+      const result = JSON.parse(child.stdout.trim().split('\n').at(-1))
+      if (result.quit !== (locale === 'en' ? 'Quit' : 'Выйти'))
+        throw new Error('Translation regression')
+      runs[name].push(result)
+    }
+  }
+  results.push({
+    locale,
+    runs: count,
+    ...Object.fromEntries(
+      Object.entries(runs).map(([name, values]) => [
+        name,
+        {
+          medianInitMs: median(values.map((value) => value.elapsedMs)),
+          medianHeapDeltaBytes: median(values.map((value) => value.heapDeltaBytes)),
+          translatedLocales: values[0].translatedLocales
+        }
+      ])
+    )
+  })
+}
+console.log(
+  JSON.stringify(
+    {
+      methodology:
+        'fresh Node processes, import + synchronous init, warm OS cache; not Electron TTI',
+      results
+    },
+    null,
+    2
+  )
+)

--- a/scripts/performance/run-runtime-profile.mjs
+++ b/scripts/performance/run-runtime-profile.mjs
@@ -112,6 +112,8 @@ await run(
     'playwright',
     'test',
     'e2e/runtime-performance.spec.ts',
+    'e2e/transcript-capacity.spec.ts',
+    'e2e/startup-performance.spec.ts',
     '--workers=1',
     `--repeat-each=${options.repeat}`,
     // Independent samples already come from --repeat-each. CI retries would replay a 10+ minute

--- a/scripts/performance/run-runtime-profile.test.ts
+++ b/scripts/performance/run-runtime-profile.test.ts
@@ -75,6 +75,8 @@ process.exit(0)
           'playwright',
           'test',
           'e2e/runtime-performance.spec.ts',
+          'e2e/transcript-capacity.spec.ts',
+          'e2e/startup-performance.spec.ts',
           '--workers=1',
           '--repeat-each=1',
           '--retries=0',

--- a/scripts/performance/runtime-resource-profiler.test.ts
+++ b/scripts/performance/runtime-resource-profiler.test.ts
@@ -304,7 +304,19 @@ describe('runtime resource profiler', () => {
       await samplingRecovery
       await samplingIdle
 
+      for (const duration of [10, 30, 20]) profiler.recordTiming('workspace-open', duration)
+      for (const duration of [10, 30]) profiler.recordTiming('even-sample', duration)
+      expect(() => profiler.recordTiming('private path/file', 1)).toThrow()
+      expect(() => profiler.recordTiming('startup', Number.NaN)).toThrow()
+      expect(() => profiler.recordTiming('startup', -1)).toThrow()
       const result = await profiler.finish()
+      expect(result.summary.timings?.['workspace-open']).toMatchObject({
+        median: 20,
+        count: 3,
+        p95: 30
+      })
+      expect(result.summary.timings?.['even-sample'].median).toBe(20)
+      expect(renderSummaryMarkdown(result.summary)).toContain('workspace-open')
 
       expect(result.summary.phases.startup.sampleCount).toBe(1)
       expect(result.summary.phases.recovery.sampleCount).toBe(1)

--- a/scripts/performance/runtime-resource-profiler.ts
+++ b/scripts/performance/runtime-resource-profiler.ts
@@ -10,7 +10,7 @@ import {
   type ProcessTreeSnapshot
 } from './process-snapshot'
 
-const PROFILE_SCHEMA_VERSION = 3
+const PROFILE_SCHEMA_VERSION = 4
 const DEFAULT_SAMPLE_INTERVAL_MS = 1_000
 const MIN_SAMPLE_INTERVAL_MS = 250
 const MAX_SAMPLE_INTERVAL_MS = 10_000
@@ -119,6 +119,7 @@ type RuntimeProfileSummary = {
   sampleIntervalMs: number
   schemaVersion: number
   sessionHydrationTrace: SessionHydrationTraceEvent[]
+  timings?: Record<string, NumberStats & { median: number; count: number }>
   startedAt: number
 }
 
@@ -380,6 +381,14 @@ const percentile = (values: readonly number[], ratio: number): number => {
   return sorted[Math.max(0, Math.ceil(sorted.length * ratio) - 1)] ?? 0
 }
 
+const median = (values: readonly number[]): number => {
+  const sorted = [...values].sort((a, b) => a - b)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2
+    ? sorted[middle]
+    : ((sorted[middle - 1] ?? 0) + (sorted[middle] ?? 0)) / 2
+}
+
 const numberStats = (values: readonly number[]): NumberStats => {
   const first = values[0] ?? 0
   const last = values.at(-1) ?? 0
@@ -598,6 +607,22 @@ Phase | Included/total | CPU mean % | CPU p95 % | CPU peak % | CPU end % | RSS s
 ${rows.join('\n')}
 ${sessionTraceSection}
 ${storageSection}
+## Journey timings
+
+Metric | Count | Median ms | p95 ms
+--- | ---: | ---: | ---:
+${Object.entries(summary.timings ?? {})
+  .map(
+    ([name, stats]) =>
+      `${name} | ${stats.count} | ${formatNumber(stats.median)} | ${formatNumber(stats.p95)}`
+  )
+  .join('\n')}
+
+Startup-ready measures process launch through the fixture's UI readiness gate; it is not a browser TTI estimate.
+The first-startup-ready metric stops at the first renderer/database/settings readiness gate.
+The startup-ready metric also includes the fixture’s controlled reload to suppress the Star nudge.
+Paint timings are reported only when Chromium supplies them. Disk caches are not cleared between runs.
+Persistence stage timings retain the latest completed lookup at each capture, not every lookup.
 
 RSS is the sum of per-process resident sets and can double-count shared pages. It is intended for
 same-machine trend comparison, not as a portable absolute memory value. The profile records no
@@ -692,6 +717,7 @@ class RuntimeResourceProfiler {
   private readonly samples: RuntimeResourceSample[] = []
   private readonly sessionHydrationTrace: SessionHydrationTraceEvent[] = []
   private phase = 'startup'
+  private readonly timings = new Map<string, number[]>()
   private sampleInFlight: Promise<void> | undefined
   private startedAt: number
   private timer: NodeJS.Timeout | undefined
@@ -745,6 +771,17 @@ class RuntimeResourceProfiler {
     this.phase = validatePhase(phase)
   }
 
+  recordTiming(name: string, durationMs: number): void {
+    if (!/^[a-z][a-z0-9:.-]{0,79}$/u.test(name) || !Number.isFinite(durationMs) || durationMs < 0) {
+      throw new Error(
+        'Runtime timing requires a fixed metric name and finite nonnegative duration.'
+      )
+    }
+    const values = this.timings.get(name) ?? []
+    values.push(durationMs)
+    this.timings.set(name, values)
+  }
+
   async sampleNow(): Promise<void> {
     await this.queueSample(this.phase, true)
   }
@@ -765,6 +802,12 @@ class RuntimeResourceProfiler {
         electronVersion: this.electronVersion
       },
       this.sessionHydrationTrace
+    )
+    summary.timings = Object.fromEntries(
+      [...this.timings].map(([name, values]) => [
+        name,
+        { ...numberStats(values), median: median(values), count: values.length }
+      ])
     )
     const outputDirectory = join(this.outputRoot, this.runId)
     await mkdir(outputDirectory, { recursive: true })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -5467,6 +5467,7 @@ const createApplicationModules = async (
 }
 
 const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<IpcRegistration> => {
+  performance.mark('open-science:ipc-registration-start')
   const composition = startDiagnosticOperation(createLogger('startup'), {
     operation: 'application-composition',
     cpuUsage: process.cpuUsage
@@ -5478,6 +5479,12 @@ const registerIpcHandlers = async (options: IpcRegistrationOptions): Promise<Ipc
     )
     composition.phase('ipc-adapters')
     composition.complete()
+    performance.mark('open-science:ipc-registration-complete')
+    performance.measure(
+      'open-science:ipc-registration',
+      'open-science:ipc-registration-start',
+      'open-science:ipc-registration-complete'
+    )
     return {
       ...applicationRuntime.interfaces,
       dispose: applicationRuntime.dispose

--- a/src/main/literature/citation-formatter.ts
+++ b/src/main/literature/citation-formatter.ts
@@ -3,7 +3,7 @@ import { readFile } from 'node:fs/promises'
 import { createRequire } from 'node:module'
 import { join } from 'node:path'
 
-import { createEngine, resultShapeVersion, type WasmCitationEngine } from 'citeme-engine-wasm'
+import type { WasmCitationEngine } from 'citeme-engine-wasm'
 import { z } from 'zod'
 
 import {
@@ -236,6 +236,7 @@ const parseResultSchema = z
 const loadEngine = async (
   styleLibrary?: LiteratureCitationStyleLibrary
 ): Promise<WasmCitationEngine> => {
+  const { createEngine, resultShapeVersion } = await import('citeme-engine-wasm')
   const wasmPath = require.resolve('citeme-engine-wasm/pkg/citeme_engine_wasm_bg.wasm')
   const engine = await createEngine(await readFile(wasmPath))
   if (resultShapeVersion() !== 1) throw new Error('Unsupported citation engine result shape.')

--- a/src/main/locale/main-process-messages.ts
+++ b/src/main/locale/main-process-messages.ts
@@ -1,4 +1,4 @@
-import type { i18n } from 'i18next'
+import type { BackendModule, i18n } from 'i18next'
 
 import {
   COMMON_NAMESPACE,
@@ -6,7 +6,7 @@ import {
   initializeI18nInstance,
   NATIVE_NAMESPACE
 } from '../../shared/i18n/core'
-import type { Locale } from '../../shared/locale'
+import { isLocale, type Locale } from '../../shared/locale'
 import { nativeResources } from './resources'
 
 export type NativeTranslateOptions = Record<string, string | number | undefined> & {
@@ -17,10 +17,30 @@ export type NativeTranslateOptions = Record<string, string | number | undefined>
 
 export type NativeTranslator = (key: string, options?: NativeTranslateOptions) => string
 
+// Preference writes must not commit a locale whose bundled catalog cannot be loaded.
+export const prepareNativeLocale = (locale: Locale): void => {
+  if (locale !== 'en') void nativeResources[locale]
+}
+
+const nativeBackend: BackendModule = {
+  type: 'backend',
+  init: () => {},
+  read(locale, namespace, callback) {
+    if (
+      !isLocale(locale) ||
+      locale === 'en' ||
+      (namespace !== COMMON_NAMESPACE && namespace !== NATIVE_NAMESPACE)
+    ) {
+      callback(null, {})
+      return
+    }
+    callback(null, nativeResources[locale][namespace])
+  }
+}
+
 export const createNativeI18n = (locale: Locale): i18n =>
-  initializeI18nInstance(createI18nInstance(), {
+  initializeI18nInstance(createI18nInstance().use(nativeBackend), {
     locale,
-    resources: nativeResources,
     namespaces: [NATIVE_NAMESPACE, COMMON_NAMESPACE],
     defaultNamespace: NATIVE_NAMESPACE,
     fallbackNamespaces: [COMMON_NAMESPACE]

--- a/src/main/locale/owner.ts
+++ b/src/main/locale/owner.ts
@@ -9,6 +9,7 @@ import { createLogger, errorLogFields } from '../logger'
 import type { SettingsRepository } from '../settings/repository'
 import {
   createNativeI18n,
+  prepareNativeLocale,
   type NativeTranslateOptions,
   type NativeTranslator
 } from './main-process-messages'
@@ -61,6 +62,7 @@ export class LocalePreferenceOwner {
   private async commitPreference(value: LanguagePreference): Promise<LocalePreferenceSnapshot> {
     if (value === this.preference && this.hasPersistedPreference) return this.snapshot()
 
+    prepareNativeLocale(resolveLocale(value, this.systemLanguageTags))
     await this.repository.setLocalePreference(value)
 
     const changed = value !== this.preference

--- a/src/main/locale/resources.lazy.test.ts
+++ b/src/main/locale/resources.lazy.test.ts
@@ -1,0 +1,72 @@
+import { readFileSync } from 'node:fs'
+import { beforeEach, expect, it, vi } from 'vitest'
+
+vi.mock('node:fs', async (importOriginal) => {
+  const fs = await importOriginal<typeof import('node:fs')>()
+  return { ...fs, readFileSync: vi.fn(fs.readFileSync) }
+})
+
+beforeEach(() => {
+  vi.resetModules()
+  vi.mocked(readFileSync).mockClear()
+})
+
+it('reads no catalogs for English and loads only the selected and switched languages', async () => {
+  const { createNativeI18n } = await import('./main-process-messages')
+  const instance = createNativeI18n('en')
+  expect(instance.t('Quit', { context: 'verb' })).toBe('Quit')
+  expect(readFileSync).not.toHaveBeenCalled()
+
+  await instance.changeLanguage('ru')
+  expect(instance.t('Quit', { context: 'verb' })).toBe('Выйти')
+  expect(readFileSync).toHaveBeenCalledTimes(1)
+  expect(Object.keys(instance.store.data).sort()).toEqual(['en', 'ru'])
+
+  await instance.changeLanguage('fr')
+  expect(instance.t('Quit', { context: 'verb' })).toBe('Quitter')
+  expect(readFileSync).toHaveBeenCalledTimes(2)
+  await instance.changeLanguage('ru')
+  const other = createNativeI18n('ru')
+  expect(other.t('Quit', { context: 'verb' })).toBe('Выйти')
+  expect(readFileSync).toHaveBeenCalledTimes(2)
+})
+
+it('makes a persisted non-English language available synchronously on first use', async () => {
+  const { createNativeI18n } = await import('./main-process-messages')
+  const instance = createNativeI18n('ja')
+  expect(instance.isInitialized).toBe(true)
+  expect(instance.t('Quit', { context: 'verb' })).toBe('終了')
+  expect(readFileSync).toHaveBeenCalledTimes(1)
+  expect(Object.keys(instance.store.data).sort()).toEqual(['en', 'ja'])
+})
+
+it('does not cache a failed file read and permits a fresh instance to retry', async () => {
+  const { createNativeI18n } = await import('./main-process-messages')
+  vi.mocked(readFileSync).mockImplementationOnce(() => {
+    throw new Error('missing catalog')
+  })
+  expect(() => createNativeI18n('de')).toThrow('missing catalog')
+  expect(createNativeI18n('de').t('Quit', { context: 'verb' })).toBe('Beenden')
+})
+
+it('leaves the persisted preference and listeners unchanged when the target catalog is missing', async () => {
+  const { LocalePreferenceOwner } = await import('./owner')
+  const setLocalePreference = vi.fn(async () => {})
+  const owner = new LocalePreferenceOwner(
+    ['en-US'],
+    { setLocalePreference } as unknown as import('../settings/repository').SettingsRepository,
+    'en'
+  )
+  const listener = vi.fn()
+  owner.subscribe(listener)
+  vi.mocked(readFileSync).mockImplementationOnce(() => {
+    throw new Error('missing catalog')
+  })
+  await expect(owner.setPreference('ru')).rejects.toThrow('missing catalog')
+  expect(setLocalePreference).not.toHaveBeenCalled()
+  expect(listener).not.toHaveBeenCalled()
+  expect(owner.snapshot()).toEqual({ preference: 'en', locale: 'en' })
+  await owner.setPreference('ru')
+  expect(owner.t('Quit', { context: 'verb' })).toBe('Выйти')
+  expect(setLocalePreference).toHaveBeenCalledOnce()
+})

--- a/src/main/locale/resources.ts
+++ b/src/main/locale/resources.ts
@@ -1,65 +1,62 @@
-import {
-  COMMON_NAMESPACE,
-  createNamespacedResource,
-  NATIVE_NAMESPACE
-} from '../../shared/i18n/core'
-import { common as deCommon, native as deNative } from '../../shared/i18n/locales/de.json'
-import { common as esCommon, native as esNative } from '../../shared/i18n/locales/es.json'
-import { common as frCommon, native as frNative } from '../../shared/i18n/locales/fr.json'
-import { common as jaCommon, native as jaNative } from '../../shared/i18n/locales/ja.json'
-import { common as koCommon, native as koNative } from '../../shared/i18n/locales/ko.json'
-import { common as ruCommon, native as ruNative } from '../../shared/i18n/locales/ru.json'
-import {
-  common as zhHansCommon,
-  native as zhHansNative
-} from '../../shared/i18n/locales/zh-Hans.json'
-import {
-  common as zhHantCommon,
-  native as zhHantNative
-} from '../../shared/i18n/locales/zh-Hant.json'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 
-export const nativeResources = {
-  de: createNamespacedResource({
-    [COMMON_NAMESPACE]: deCommon,
-    [NATIVE_NAMESPACE]: deNative
-  }),
-  es: createNamespacedResource({
-    [COMMON_NAMESPACE]: esCommon,
-    [NATIVE_NAMESPACE]: esNative
-  }),
-  fr: createNamespacedResource({
-    [COMMON_NAMESPACE]: frCommon,
-    [NATIVE_NAMESPACE]: frNative
-  }),
-  ja: createNamespacedResource({
-    [COMMON_NAMESPACE]: jaCommon,
-    [NATIVE_NAMESPACE]: jaNative
-  }),
-  ko: createNamespacedResource({
-    [COMMON_NAMESPACE]: koCommon,
-    [NATIVE_NAMESPACE]: koNative
-  }),
-  ru: createNamespacedResource({
-    [COMMON_NAMESPACE]: ruCommon,
-    [NATIVE_NAMESPACE]: ruNative
-  }),
-  'zh-Hans': createNamespacedResource({
-    [COMMON_NAMESPACE]: zhHansCommon,
-    [NATIVE_NAMESPACE]: zhHansNative
-  }),
-  'zh-Hant': createNamespacedResource({
-    [COMMON_NAMESPACE]: zhHantCommon,
-    [NATIVE_NAMESPACE]: zhHantNative
-  })
-} as const
+import { createNamespacedResource } from '../../shared/i18n/core'
+import { LOCALES, type Locale } from '../../shared/locale'
 
-export const nativeCatalogs = {
-  de: deNative,
-  es: esNative,
-  fr: frNative,
-  ja: jaNative,
-  ko: koNative,
-  ru: ruNative,
-  'zh-Hans': zhHansNative,
-  'zh-Hant': zhHantNative
-} as const
+// The Electron build emits only common/native catalogs beside its main-process chunks.
+// Source runners (Vitest) read the canonical shared catalogs instead.
+declare const __OPEN_SCIENCE_NATIVE_LOCALE_DIRECTORY__: string
+const catalogDirectory =
+  typeof __OPEN_SCIENCE_NATIVE_LOCALE_DIRECTORY__ === 'undefined'
+    ? join(__dirname, '../../shared/i18n/locales')
+    : join(__dirname, __OPEN_SCIENCE_NATIVE_LOCALE_DIRECTORY__)
+
+type TranslatedLocale = Exclude<Locale, 'en'>
+type Catalog = Record<string, string>
+type NativeResource = { common: Catalog; native: Catalog }
+const catalogs = new Map<TranslatedLocale, NativeResource>()
+const sanitizedResources = new Map<TranslatedLocale, NativeResource>()
+
+const readCatalog = (locale: TranslatedLocale): NativeResource => {
+  let catalog = catalogs.get(locale)
+  if (!catalog) {
+    const { common, native } = JSON.parse(
+      readFileSync(join(catalogDirectory, `${locale}.json`), 'utf8')
+    ) as NativeResource
+    catalog = { common, native }
+    catalogs.set(locale, catalog)
+  }
+  return catalog
+}
+
+const getResource = (locale: TranslatedLocale): NativeResource => {
+  let resource = sanitizedResources.get(locale)
+  if (!resource) {
+    resource = createNamespacedResource(readCatalog(locale))
+    sanitizedResources.set(locale, resource)
+  }
+  return resource
+}
+
+// Preserve the catalog inspection API without reading unused languages at module import time.
+const translatedLocales = LOCALES.filter((locale): locale is TranslatedLocale => locale !== 'en')
+export const nativeResources = Object.defineProperties(
+  {},
+  Object.fromEntries(
+    translatedLocales.map((locale) => [
+      locale,
+      { enumerable: true, get: () => getResource(locale) }
+    ])
+  )
+) as Record<TranslatedLocale, NativeResource>
+
+export const nativeCatalogs = Object.defineProperties(
+  {},
+  Object.fromEntries(
+    translatedLocales.map((locale) => [
+      locale,
+      { enumerable: true, get: () => readCatalog(locale).native }
+    ])
+  )
+) as Record<TranslatedLocale, Catalog>

--- a/src/main/reviewer/ipc.ts
+++ b/src/main/reviewer/ipc.ts
@@ -15,7 +15,7 @@ import type {
 import type { PersistedChatSession } from '../../shared/session-persistence'
 import { REVIEWER_IPC } from '../../shared/reviewer'
 import { createLogger } from '../logger'
-import { runReview } from './orchestrator'
+import type { runReview as RunReview } from './orchestrator'
 import { flagStaleReviews } from './stale-reviews'
 import { ReviewRepository } from './repository'
 import type { ReviewerAcpRuntime } from './acp-runtime'
@@ -39,6 +39,8 @@ import type { ReviewerPagedContentResolver } from './host-sdk'
 import type { ArtifactProvenanceRepository } from '../artifacts/provenance-repository'
 
 const log = createLogger('reviewer:ipc')
+// Share first-use module loading across concurrent review commands; allow retry on load failure.
+let reviewerExecutor: Promise<typeof RunReview> | undefined
 
 // Sends a review update event to every open renderer window.
 const broadcastReviewUpdate = (event: ReviewUpdateEvent): void => {
@@ -438,6 +440,19 @@ const createReviewerCommandOwner = (options: ReviewerIpcOptions): ReviewerComman
     }
 
     log.info('review triggered', { sessionId, turnMessageId })
+
+    let runReview: typeof RunReview
+    try {
+      runReview = await (reviewerExecutor ??= import('./orchestrator')
+        .then((module) => module.runReview)
+        .catch((error) => {
+          reviewerExecutor = undefined
+          throw error
+        }))
+    } catch (error) {
+      log.error('review start failed: could not load executor', { error: toErrorMessage(error) })
+      return finishBeforeBackground({ started: false, reason: 'run-failed' })
+    }
 
     let modelAdmission: Awaited<
       ReturnType<NonNullable<ReviewerIpcOptions['modelRuntime']>['admit']>

--- a/src/main/session-persistence/runtime-lookup.test.ts
+++ b/src/main/session-persistence/runtime-lookup.test.ts
@@ -77,6 +77,52 @@ afterEach(async () => {
 })
 
 describe('runtime Session lookup', () => {
+  it('shares concurrent reads but releases success and failure before delivering settlement', async () => {
+    const loadSession = vi.fn().mockResolvedValue(session('current'))
+    const repository = {
+      loadSession,
+      loadAll: vi.fn(),
+      assertSessionIdentityOwnership: vi.fn().mockResolvedValue(undefined)
+    }
+    const findSessions = createSessionRuntimeLookup({
+      repository,
+      coordinator: { sessionProjectId: vi.fn().mockResolvedValue('project-1') }
+    })
+    await Promise.all(Array.from({ length: 16 }, () => findSessions('current')))
+    expect(loadSession).toHaveBeenCalledTimes(1)
+    loadSession.mockResolvedValueOnce({ ...session('current'), title: 'updated' })
+    expect((await findSessions('current'))[0].title).toBe('updated')
+    loadSession.mockRejectedValueOnce(new Error('read failed'))
+    // Attach the retry directly to the rejection; no extra assertion microtasks hide stale entries.
+    await findSessions('current').catch(() => findSessions('current'))
+    expect(loadSession).toHaveBeenCalledTimes(4)
+  })
+
+  it('bounds opt-in profiling entries and does not record routine lookups', async () => {
+    const { repository } = await createLookup()
+    const prefix = 'open-science:persistence-runtime-lookup-'
+    const names = ['catalog', 'ownership', 'read', 'targeted'].map((stage) => prefix + stage)
+    try {
+      vi.stubEnv('OPEN_SCIENCE_PERF_SESSION_TRACE', '1')
+      const findSessions = createSessionRuntimeLookup({
+        repository,
+        coordinator: { sessionProjectId: async () => 'project-1' }
+      })
+      for (let i = 0; i < 3; i++) await findSessions('current')
+      for (const name of names) expect(performance.getEntriesByName(name)).toHaveLength(1)
+      for (const name of names) performance.clearMeasures(name)
+      vi.stubEnv('OPEN_SCIENCE_PERF_SESSION_TRACE', '0')
+      await createSessionRuntimeLookup({
+        repository,
+        coordinator: { sessionProjectId: async () => 'project-1' }
+      })('current')
+      for (const name of names) expect(performance.getEntriesByName(name)).toHaveLength(0)
+    } finally {
+      vi.unstubAllEnvs()
+      for (const name of names) performance.clearMeasures(name)
+    }
+  })
+
   // Codex Responses and Codex Bridge share this durable framework identity and lookup.
   it.each(
     (['claude-code', 'opencode', 'codex'] as const).flatMap((frameworkId) =>

--- a/src/main/session-persistence/runtime-lookup.ts
+++ b/src/main/session-persistence/runtime-lookup.ts
@@ -3,26 +3,54 @@ import type { SessionCatalog } from './coordinator'
 import type { SessionRepository } from './repository'
 
 // Shared by Specialist binding and delegated-work admission in the application composition.
-export const createSessionRuntimeLookup =
-  ({
-    repository,
-    coordinator
-  }: {
-    repository: Pick<
-      SessionRepository,
-      'loadAll' | 'loadSession' | 'assertSessionIdentityOwnership'
-    >
-    coordinator: Pick<SessionCatalog, 'sessionProjectId'>
-  }): ((sessionId: string) => Promise<PersistedChatSession[]>) =>
-  async (sessionId) => {
-    const projectId = await coordinator.sessionProjectId(sessionId)
-    if (projectId === undefined) {
-      // Before hydration or the first save, keep the existing catalog lookup semantics.
-      return (await repository.loadAll()).sessions.filter((session) => session.id === sessionId)
-    }
-    // Metadata locates the file; filename authority still rejects ambiguous global identities.
-    // Neither step needs to decode unrelated transcripts on the prompt's critical path.
-    await repository.assertSessionIdentityOwnership(sessionId, projectId)
-    const session = await repository.loadSession(projectId, sessionId)
-    return session ? [session] : []
+export const createSessionRuntimeLookup = ({
+  repository,
+  coordinator
+}: {
+  repository: Pick<SessionRepository, 'loadAll' | 'loadSession' | 'assertSessionIdentityOwnership'>
+  coordinator: Pick<SessionCatalog, 'sessionProjectId'>
+}): ((sessionId: string) => Promise<PersistedChatSession[]>) => {
+  // Keep at most the latest sample per stage, and only in an explicitly profiled run.
+  const trace = process.env.OPEN_SCIENCE_PERF_SESSION_TRACE === '1'
+  const measure = (stage: string, start: number): void => {
+    if (!trace) return
+    const name = `open-science:persistence-runtime-lookup-${stage}`
+    performance.clearMeasures(name)
+    performance.measure(name, { start })
   }
+  const inFlight = new Map<string, Promise<PersistedChatSession[]>>()
+
+  return (sessionId) => {
+    const existing = inFlight.get(sessionId)
+    if (existing) return existing
+
+    const request = (async () => {
+      const startedAt = performance.now()
+      const projectId = await coordinator.sessionProjectId(sessionId)
+      measure('catalog', startedAt)
+      if (projectId === undefined) {
+        // Before hydration or the first save, keep the existing catalog lookup semantics.
+        const sessions = (await repository.loadAll()).sessions.filter(
+          (session) => session.id === sessionId
+        )
+        measure('fallback', startedAt)
+        return sessions
+      }
+      // Metadata locates the file; filename authority still rejects ambiguous global identities.
+      // Neither step needs to decode unrelated transcripts on the prompt's critical path.
+      const ownershipStartedAt = performance.now()
+      await repository.assertSessionIdentityOwnership(sessionId, projectId)
+      measure('ownership', ownershipStartedAt)
+      const readStartedAt = performance.now()
+      const session = await repository.loadSession(projectId, sessionId)
+      measure('read', readStartedAt)
+      measure('targeted', startedAt)
+      return session ? [session] : []
+    })().finally(() => {
+      // Clear before delivering settlement to callers, including immediate retries after failure.
+      if (inFlight.get(sessionId) === request) inFlight.delete(sessionId)
+    })
+    inFlight.set(sessionId, request)
+    return request
+  }
+}

--- a/src/renderer/src/ApplicationPresentationHost.tsx
+++ b/src/renderer/src/ApplicationPresentationHost.tsx
@@ -1,5 +1,5 @@
 import { WorkspaceComposerDraftsProvider } from './pages/workspace/workspace-composer-drafts'
-import { memo, useCallback, useRef } from 'react'
+import { lazy, memo, Suspense, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 
 import { CloseConfirmModal } from '@/components/CloseConfirmModal'
@@ -24,21 +24,54 @@ import { useApplicationStartup } from '@/hooks/useApplicationStartup'
 import { WorkspaceAgentRuntimeProvider } from '@/lib/acp/useWorkspaceAgentRuntime'
 import { WorkspaceComputeRecoveryBridge } from '@/lib/compute/WorkspaceComputeRecoveryBridge'
 import { HomePage } from '@/pages/home/HomePage'
-import { LiteratureLibraryPage } from '@/pages/literature/LiteratureLibraryPage'
-import { OnboardingWizard } from '@/pages/onboarding/OnboardingWizard'
-import { ComputeApprovalDialog } from '@/pages/settings/ComputeApprovalDialog'
-import { ConnectorApprovalDialog } from '@/pages/settings/ConnectorApprovalDialog'
-import { ConnectorCredentialDialog } from '@/pages/settings/ConnectorCredentialDialog'
-import { SettingsPage, type SettingsPageHandle } from '@/pages/settings/SettingsPage'
-import { SkillImportApprovalDialog } from '@/pages/settings/SkillImportApprovalDialog'
+import type { SettingsPageHandle } from '@/pages/settings/SettingsPage'
 import { EnvStatusBanner } from '@/pages/workspace/EnvStatusBanner'
-import { WorkspacePage } from '@/pages/workspace/WorkspacePage'
 import {
   WorkspaceMessageQueueProvider,
   WorkspaceMessageQueueRuntimeBridge
 } from '@/pages/workspace/workspace-message-queue-controller'
 
+const WorkspacePage = lazy(() =>
+  import('@/pages/workspace/WorkspacePage').then(({ WorkspacePage }) => ({
+    default: WorkspacePage
+  }))
+)
+const LiteratureLibraryPage = lazy(() =>
+  import('@/pages/literature/LiteratureLibraryPage').then(({ LiteratureLibraryPage }) => ({
+    default: LiteratureLibraryPage
+  }))
+)
+
 const StableLiteratureLibraryPage = memo(LiteratureLibraryPage)
+
+const OnboardingWizard = lazy(() =>
+  import('@/pages/onboarding/OnboardingWizard').then(({ OnboardingWizard }) => ({
+    default: OnboardingWizard
+  }))
+)
+const SettingsPage = lazy(() =>
+  import('@/pages/settings/SettingsPage').then(({ SettingsPage }) => ({ default: SettingsPage }))
+)
+const ComputeApprovalDialog = lazy(() =>
+  import('@/pages/settings/ComputeApprovalDialog').then(({ ComputeApprovalDialog }) => ({
+    default: ComputeApprovalDialog
+  }))
+)
+const ConnectorApprovalDialog = lazy(() =>
+  import('@/pages/settings/ConnectorApprovalDialog').then(({ ConnectorApprovalDialog }) => ({
+    default: ConnectorApprovalDialog
+  }))
+)
+const ConnectorCredentialDialog = lazy(() =>
+  import('@/pages/settings/ConnectorCredentialDialog').then(({ ConnectorCredentialDialog }) => ({
+    default: ConnectorCredentialDialog
+  }))
+)
+const SkillImportApprovalDialog = lazy(() =>
+  import('@/pages/settings/SkillImportApprovalDialog').then(({ SkillImportApprovalDialog }) => ({
+    default: SkillImportApprovalDialog
+  }))
+)
 
 const ApplicationPresentationHost = (): React.JSX.Element => {
   const { t } = useTranslation()
@@ -100,7 +133,9 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
           ui={startup.environment.ui}
           onRetry={() => void startup.environment.retry()}
         />
-        <OnboardingWizard loadStorageInfo={startup.storageRecovery.loadInfo} />
+        <Suspense fallback={<OpenScienceLogoLoader />}>
+          <OnboardingWizard loadStorageInfo={startup.storageRecovery.loadInfo} />
+        </Suspense>
       </>
     )
   }
@@ -208,25 +243,27 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
               <WorkspaceMessageQueueRuntimeBridge
                 persistenceBlockedSessionIds={sessions.persistenceBlockedSessionIds}
               />
-              {events.navigation.view === 'home' ? (
-                <HomePage
-                  canDeleteProjects={sessions.canDeleteSessionsAndProjects}
-                  hasCompleteSessionCatalog={sessions.hasCompleteSessionCatalog}
-                  catalogRecovery={sessions.catalogRecovery}
-                  onOpenGlobalSearch={events.globalSearch.open}
-                />
-              ) : events.navigation.view === 'library' ? (
-                <StableLiteratureLibraryPage />
-              ) : (
-                <WorkspacePage
-                  isSessionPersistenceHydrated={sessions.isHydrated}
-                  isSessionPersistenceReady={sessions.isReady}
-                  persistenceBlockedSessionIds={sessions.persistenceBlockedSessionIds}
-                  onSessionSizeLimit={sessions.reportSessionSizeLimit}
-                  canDeleteConversations={sessions.canDeleteSessionsAndProjects}
-                  isPreviewPresentationActive={isBasePresentationActive}
-                />
-              )}
+              <Suspense fallback={null}>
+                {events.navigation.view === 'home' ? (
+                  <HomePage
+                    canDeleteProjects={sessions.canDeleteSessionsAndProjects}
+                    hasCompleteSessionCatalog={sessions.hasCompleteSessionCatalog}
+                    catalogRecovery={sessions.catalogRecovery}
+                    onOpenGlobalSearch={events.globalSearch.open}
+                  />
+                ) : events.navigation.view === 'library' ? (
+                  <StableLiteratureLibraryPage />
+                ) : (
+                  <WorkspacePage
+                    isSessionPersistenceHydrated={sessions.isHydrated}
+                    isSessionPersistenceReady={sessions.isReady}
+                    persistenceBlockedSessionIds={sessions.persistenceBlockedSessionIds}
+                    onSessionSizeLimit={sessions.reportSessionSizeLimit}
+                    canDeleteConversations={sessions.canDeleteSessionsAndProjects}
+                    isPreviewPresentationActive={isBasePresentationActive}
+                  />
+                )}
+              </Suspense>
             </WorkspaceMessageQueueProvider>
           </WorkspaceComposerDraftsProvider>
         </WorkspaceAgentRuntimeProvider>
@@ -284,29 +321,33 @@ const ApplicationPresentationHost = (): React.JSX.Element => {
         active={activePresentation === 'webEventRecovery'}
         phase={events.webEventConnectionPhase}
       />
-      <SettingsPage
-        ref={settingsPageRef}
-        open={activePresentation === 'settings'}
-        onClose={events.settings.close}
-        onOpenSession={events.settings.openSession}
-        canDeleteProjects={sessions.canDeleteSessionsAndProjects}
-        hasCompleteSessionCatalog={sessions.hasCompleteSessionCatalog}
-        catalogRecovery={sessions.catalogRecovery}
-        onRetryCatalogRecovery={sessions.retryLoad}
-      />
-      <ConnectorApprovalDialog
-        active={activePresentation === 'connectorApproval'}
-        blockedSessionIds={events.blockedApprovalSessionIds}
-      />
-      <ConnectorCredentialDialog active={activePresentation === 'credentialRequest'} />
-      <SkillImportApprovalDialog
-        active={activePresentation === 'skillImportApproval'}
-        blockedSessionIds={events.blockedApprovalSessionIds}
-      />
-      <ComputeApprovalDialog
-        active={activePresentation === 'computeApproval'}
-        blockedSessionIds={events.blockedApprovalSessionIds}
-      />
+      <Suspense fallback={null}>
+        <SettingsPage
+          ref={settingsPageRef}
+          open={activePresentation === 'settings'}
+          onClose={events.settings.close}
+          onOpenSession={events.settings.openSession}
+          canDeleteProjects={sessions.canDeleteSessionsAndProjects}
+          hasCompleteSessionCatalog={sessions.hasCompleteSessionCatalog}
+          catalogRecovery={sessions.catalogRecovery}
+          onRetryCatalogRecovery={sessions.retryLoad}
+        />
+      </Suspense>
+      <Suspense fallback={null}>
+        <ConnectorApprovalDialog
+          active={activePresentation === 'connectorApproval'}
+          blockedSessionIds={events.blockedApprovalSessionIds}
+        />
+        <ConnectorCredentialDialog active={activePresentation === 'credentialRequest'} />
+        <SkillImportApprovalDialog
+          active={activePresentation === 'skillImportApproval'}
+          blockedSessionIds={events.blockedApprovalSessionIds}
+        />
+        <ComputeApprovalDialog
+          active={activePresentation === 'computeApproval'}
+          blockedSessionIds={events.blockedApprovalSessionIds}
+        />
+      </Suspense>
       <UpdateDialog active={activePresentation === 'update'} />
       <CloseConfirmModal
         active={activePresentation === 'closeConfirmation'}

--- a/src/renderer/src/i18n/index.ts
+++ b/src/renderer/src/i18n/index.ts
@@ -1,8 +1,7 @@
 // i18next setup for the renderer, shared by the Electron window and the localhost web build.
 //
-// initI18n() is called synchronously before React mounts (main.tsx / web/bootstrap.ts) so the first
-// paint is already in the resolved language. i18next's init is synchronous when resources are passed
-// inline and no async backend is configured, which is why the catalogs are statically imported.
+// Prepare the selected catalog before mounting React; initialization and already-loaded switches
+// remain synchronous. Unselected catalogs are separate chunks and never enter the startup graph.
 //
 // Keys are the English source text: t('Data folder not found'), not t('dataRoot.missing.title').
 // English therefore has no catalog — it renders from i18next's missing-key fallback, which returns
@@ -20,39 +19,46 @@ import {
   RENDERER_NAMESPACE
 } from '../../../shared/i18n/core'
 import type { Locale } from '../../../shared/locale'
-import { DEFAULT_NAMESPACE, resources } from './resources'
+import { preparedI18nResources } from './locale-loader'
+export { prepareI18nLocale } from './locale-loader'
 
 let initialized = false
 const i18next = createI18nInstance()
 
 export const initI18n = (locale: Locale): i18n => {
+  const resources = preparedI18nResources(locale)
   if (initialized) {
-    void i18next.changeLanguage(locale)
+    for (const [namespace, catalog] of Object.entries(resources[locale] ?? {})) {
+      if (!i18next.hasResourceBundle(locale, namespace))
+        i18next.addResourceBundle(locale, namespace, catalog)
+    }
+    const startedAt = performance.now()
+    void i18next.changeLanguage(locale).then(() => {
+      performance.clearMeasures('open-science:i18n-locale-switch')
+      performance.measure('open-science:i18n-locale-switch', { start: startedAt })
+    })
     return i18next
   }
 
+  const startedAt = performance.now()
   i18next.use(initReactI18next)
   initializeI18nInstance(i18next, {
     locale,
     resources,
     namespaces: [RENDERER_NAMESPACE, COMMON_NAMESPACE],
-    defaultNamespace: DEFAULT_NAMESPACE,
+    defaultNamespace: RENDERER_NAMESPACE,
     fallbackNamespaces: [COMMON_NAMESPACE]
   })
 
   initialized = true
+  performance.measure('open-science:i18n-init', { start: startedAt })
   return i18next
 }
 
 // Switches the active language on an already-initialized instance. Safe to call before init (the
 // store's setter may run in a test that never bootstrapped): init then applies the same locale.
 export const setI18nLocale = (locale: Locale): void => {
-  if (!initialized) {
-    initI18n(locale)
-    return
-  }
-
-  void i18next.changeLanguage(locale)
+  initI18n(locale)
 }
 
 export { i18next }

--- a/src/renderer/src/i18n/locale-loader.lazy.test.ts
+++ b/src/renderer/src/i18n/locale-loader.lazy.test.ts
@@ -1,0 +1,23 @@
+import { expect, it, vi } from 'vitest'
+
+it('loads only the selected catalog and shares concurrent preparation before synchronous init', async () => {
+  // Global render setup deliberately preloads test catalogs. Reset the runtime modules to exercise
+  // a real cold instance rather than accidentally proving the preloaded test path.
+  vi.resetModules()
+  const { prepareI18nLocale, preparedI18nResources } = await import('./locale-loader')
+  expect(prepareI18nLocale('en')).toBeUndefined()
+  expect(preparedI18nResources('en')).toEqual({})
+  expect(() => preparedI18nResources('ru')).toThrow('not been prepared')
+  const first = prepareI18nLocale('ru')
+  expect(prepareI18nLocale('ru')).toBe(first)
+  await first
+  expect(Object.keys(preparedI18nResources('ru'))).toEqual(['ru'])
+  expect(Object.keys(preparedI18nResources('ru').ru)).toEqual(['common', 'renderer'])
+  expect(prepareI18nLocale('ru')).toBeUndefined()
+  const { initI18n } = await import('./index')
+  const instance = initI18n('ru')
+  expect(instance.language).toBe('ru')
+  expect(instance.t('Settings')).toBe('Настройки')
+  await prepareI18nLocale('de')
+  expect(initI18n('de').t('Settings')).toBe('Einstellungen')
+})

--- a/src/renderer/src/i18n/locale-loader.ts
+++ b/src/renderer/src/i18n/locale-loader.ts
@@ -1,0 +1,46 @@
+import type { Resource } from 'i18next'
+import {
+  COMMON_NAMESPACE,
+  RENDERER_NAMESPACE,
+  createNamespacedResource
+} from '../../../shared/i18n/core'
+import type { Locale } from '../../../shared/locale'
+
+// Literal imports let Vite emit one independent catalog chunk per locale.
+const loaders = {
+  de: () => import('../../../shared/i18n/locales/de.json'),
+  es: () => import('../../../shared/i18n/locales/es.json'),
+  fr: () => import('../../../shared/i18n/locales/fr.json'),
+  ja: () => import('../../../shared/i18n/locales/ja.json'),
+  ko: () => import('../../../shared/i18n/locales/ko.json'),
+  ru: () => import('../../../shared/i18n/locales/ru.json'),
+  'zh-Hans': () => import('../../../shared/i18n/locales/zh-Hans.json'),
+  'zh-Hant': () => import('../../../shared/i18n/locales/zh-Hant.json')
+}
+const resources: Resource = {}
+const inFlight = new Map<Locale, Promise<void>>()
+
+// English is source text. Already-loaded locales keep the synchronous initialization path.
+export const prepareI18nLocale = (locale: Locale): Promise<void> | undefined => {
+  if (locale === 'en' || resources[locale]) return undefined
+  const existing = inFlight.get(locale)
+  if (existing) return existing
+  const request = loaders[locale]()
+    .then((catalog) => {
+      resources[locale] = createNamespacedResource({
+        [COMMON_NAMESPACE]: catalog.common,
+        [RENDERER_NAMESPACE]: catalog.renderer
+      })
+    })
+    .finally(() => {
+      inFlight.delete(locale)
+    })
+  inFlight.set(locale, request)
+  return request
+}
+
+export const preparedI18nResources = (locale: Locale): Resource => {
+  if (locale !== 'en' && !resources[locale])
+    throw new Error('Renderer locale has not been prepared.')
+  return resources
+}

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -6,7 +6,7 @@ import App from './App'
 import { ApplicationErrorBoundary } from '@/components/application-error-boundary'
 import { DatabaseStartupGate } from '@/components/database-startup-gate'
 import { installStreamdown } from '@/components/streamdown/install-streamdown'
-import { initI18n } from '@/i18n'
+import { initI18n, prepareI18nLocale } from '@/i18n'
 import { applyHtmlLang, resolveInitialLocale } from '@/lib/locale-preference'
 import { applyTheme, resolveInitialTheme } from '@/lib/theme'
 import { startNetworkMonitor } from '@/stores/network-store'
@@ -14,6 +14,9 @@ import { installRendererFailureDiagnostics } from './renderer-diagnostics'
 import { useNavigationStore } from '@/stores/navigation-store'
 import { useSettingsStore } from '@/stores/settings-store'
 import { startLocalePreferenceSync } from '@/stores/locale-store'
+
+const rendererBootMark = 'open-science:renderer-boot-start'
+performance.mark(rendererBootMark)
 
 // Keep renderer JavaScript failures distinct from native renderer-process exits without relaying raw
 // messages, stacks, URLs, or application state across preload. The bridge is Electron-only; the Web
@@ -32,32 +35,56 @@ installRendererFailureDiagnostics({
 // Apply the saved theme to <html> before the first paint so dark mode doesn't flash light on startup.
 applyTheme(resolveInitialTheme())
 
-// Same reason, for language: initialize i18next synchronously before React mounts so the first paint
-// is already translated instead of rendering English and then swapping.
-const initialLocale = resolveInitialLocale()
-initI18n(initialLocale)
-applyHtmlLang(initialLocale)
-startLocalePreferenceSync()
-
-// Start connectivity monitoring (online/offline events + the initial reachability probe)
-// before React renders so indicators and the Network panel read a live store from first paint.
-startNetworkMonitor()
-
-// Install before React renders so Streamdown hooks work on first interaction.
-installStreamdown()
-
 // Swallow file drops that miss an explicit dropzone: without this, Electron navigates the whole window
 // to the dropped file (file://…), tearing down the app. Dropzones call stopPropagation/preventDefault
 // themselves, so this only catches strays.
 window.addEventListener('dragover', (event) => event.preventDefault())
 window.addEventListener('drop', (event) => event.preventDefault())
 
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <ApplicationErrorBoundary>
-      <DatabaseStartupGate>
-        <App />
-      </DatabaseStartupGate>
-    </ApplicationErrorBoundary>
-  </StrictMode>
-)
+// Load only the selected language before mounting, retaining a translated first app paint.
+const initialLocale = resolveInitialLocale()
+const startRenderer = (): void => {
+  initI18n(initialLocale)
+  applyHtmlLang(initialLocale)
+  startLocalePreferenceSync()
+
+  // Start connectivity monitoring (online/offline events + the initial reachability probe)
+  // before React renders so indicators and the Network panel read a live store from first paint.
+  startNetworkMonitor()
+
+  // Install before React renders so Streamdown hooks work on first interaction.
+  installStreamdown()
+
+  const rendererRoot = createRoot(document.getElementById('root')!)
+  performance.mark('open-science:renderer-root-created')
+  performance.measure(
+    'open-science:renderer-bootstrap',
+    rendererBootMark,
+    'open-science:renderer-root-created'
+  )
+
+  rendererRoot.render(
+    <StrictMode>
+      <ApplicationErrorBoundary>
+        <DatabaseStartupGate>
+          <App />
+        </DatabaseStartupGate>
+      </ApplicationErrorBoundary>
+    </StrictMode>
+  )
+  performance.mark('open-science:renderer-render-scheduled')
+}
+const preparing = prepareI18nLocale(initialLocale)
+if (preparing) {
+  void preparing.then(startRenderer).catch((error: unknown) => {
+    initI18n('en')
+    const StartupFailure = (): never => {
+      throw error
+    }
+    createRoot(document.getElementById('root')!).render(
+      <ApplicationErrorBoundary>
+        <StartupFailure />
+      </ApplicationErrorBoundary>
+    )
+  })
+} else startRenderer()

--- a/src/renderer/src/office-preview/office-preview-runtime.ts
+++ b/src/renderer/src/office-preview/office-preview-runtime.ts
@@ -1,4 +1,4 @@
-import { initI18n } from '../i18n'
+import { initI18n, prepareI18nLocale } from '../i18n'
 import type {
   OfficePreviewErrorCode,
   OfficePreviewRuntimeStart,
@@ -82,6 +82,8 @@ const runOfficePreview = async (
   let sessionError: Error | undefined
 
   try {
+    const preparing = prepareI18nLocale(start.locale ?? 'en')
+    if (preparing) await preparing
     initI18n(start.locale ?? 'en')
     reportState({ sessionId: start.sessionId, phase: 'reading' })
     let bytes: Uint8Array

--- a/src/renderer/src/pages/literature/literature-pdf-completion.test.ts
+++ b/src/renderer/src/pages/literature/literature-pdf-completion.test.ts
@@ -57,3 +57,44 @@ it('does not query without a DOI or erase local authors absent from Crossref', a
   ]
   expect((await completeLiteraturePdfDraft({ ...draft, creators })).creators).toEqual(creators)
 })
+
+it('keeps a frequently used DOI under cache pressure instead of evicting by insertion order', async () => {
+  const lookup = vi.fn().mockResolvedValue(resolved)
+  install(lookup)
+  await completeLiteraturePdfDraft(draft)
+  for (let i = 0; i < 40; i++) {
+    await completeLiteraturePdfDraft({
+      ...draft,
+      identifiers: [{ scheme: 'doi', value: `10.1000/paper-${i}`, isPrimary: true }]
+    })
+    await completeLiteraturePdfDraft(draft)
+  }
+  expect(lookup.mock.calls.filter(([doi]) => doi === draft.identifiers[0].value)).toHaveLength(1)
+  expect(lookup).toHaveBeenCalledTimes(41)
+})
+
+it('starts TTL at successful completion and shares a slow request past the TTL window', async () => {
+  vi.useFakeTimers()
+  let finish!: (item: typeof resolved) => void
+  const lookup = vi
+    .fn()
+    .mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve
+        })
+    )
+    .mockResolvedValue(resolved)
+  install(lookup)
+  const first = completeLiteraturePdfDraft(draft)
+  vi.advanceTimersByTime(5 * 60_000 + 1)
+  const second = completeLiteraturePdfDraft(draft)
+  expect(lookup).toHaveBeenCalledTimes(1)
+  finish(resolved)
+  await Promise.all([first, second])
+  await completeLiteraturePdfDraft(draft)
+  expect(lookup).toHaveBeenCalledTimes(1)
+  vi.advanceTimersByTime(5 * 60_000 + 1)
+  await completeLiteraturePdfDraft(draft)
+  expect(lookup).toHaveBeenCalledTimes(2)
+})

--- a/src/renderer/src/pages/literature/literature-pdf-metadata.ts
+++ b/src/renderer/src/pages/literature/literature-pdf-metadata.ts
@@ -46,16 +46,26 @@ const lookupPdfDoi = (doi: string): Promise<LiteratureItemInput> => {
     doiCaches.set(lookup, cache)
   }
   const cached = cache.get(doi)
-  if (cached && cached.expires > Date.now()) return cached.result
+  if (cached && cached.expires > Date.now()) {
+    cache.delete(doi)
+    cache.set(doi, cached)
+    return cached.result
+  }
   const result = lookup(doi)
-  const entry = { expires: Date.now() + DOI_CACHE_MS, result }
+  // The TTL covers reusable results, not time spent waiting for the network.
+  const entry = { expires: Number.POSITIVE_INFINITY, result }
   cache.delete(doi)
   cache.set(doi, entry)
   while (cache.size > DOI_CACHE_SIZE) cache.delete(cache.keys().next().value!)
   const entries = cache
-  void result.catch(() => {
-    if (entries.get(doi) === entry) entries.delete(doi)
-  })
+  void result.then(
+    () => {
+      entry.expires = Date.now() + DOI_CACHE_MS
+    },
+    () => {
+      if (entries.get(doi) === entry) entries.delete(doi)
+    }
+  )
   return result
 }
 

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1213,7 +1213,8 @@ const WorkspaceMessageScrollerImpl = ({
       ) {
         conversationIndex += 1
       }
-      const insertBeforeIndex = conversationIndex < conversationItems.length ? conversationIndex : -1
+      const insertBeforeIndex =
+        conversationIndex < conversationItems.length ? conversationIndex : -1
       if (insertBeforeIndex === -1) {
         // No later item — job goes in the trailing slot.
         trailing.push(job)

--- a/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
+++ b/src/renderer/src/pages/workspace/WorkspaceMessageScroller.tsx
@@ -1204,11 +1204,16 @@ const WorkspaceMessageScrollerImpl = ({
     const byIndex = new Map<number, JobSummary[]>()
     const trailing: JobSummary[] = []
 
+    let conversationIndex = 0
     for (const job of sorted) {
-      // Find the first conversation item strictly after this job's timestamp.
-      const insertBeforeIndex = conversationItems.findIndex(
-        (item) => item.createdAt > job.created_at
-      )
+      // Both arrays are chronological, so advance one cursor instead of rescanning the timeline.
+      while (
+        conversationIndex < conversationItems.length &&
+        conversationItems[conversationIndex].createdAt <= job.created_at
+      ) {
+        conversationIndex += 1
+      }
+      const insertBeforeIndex = conversationIndex < conversationItems.length ? conversationIndex : -1
       if (insertBeforeIndex === -1) {
         // No later item — job goes in the trailing slot.
         trailing.push(job)

--- a/src/renderer/src/pages/workspace/previews/PreviewFileContent.tsx
+++ b/src/renderer/src/pages/workspace/previews/PreviewFileContent.tsx
@@ -1,4 +1,5 @@
 import { renderPreviewFile } from './preview-registry'
+import { Suspense } from 'react'
 import { PreviewUnsupportedContent } from './PreviewFallback'
 import { PreviewRuntimeBoundary } from './preview-runtime'
 import type { PreviewDownloadVersionContext } from './preview-runtime-context'
@@ -46,16 +47,18 @@ export const PreviewFileContent = ({
       downloadVersionContext={downloadVersionContext}
       onRetry={onRetry}
     >
-      {content ?? (
-        <PreviewUnsupportedContent
-          path={item.path}
-          name={item.name}
-          source={item.source}
-          projectId={item.projectId}
-          fileId={item.managedFileId}
-          versionId={item.selectedVersionId}
-        />
-      )}
+      <Suspense fallback={null}>
+        {content ?? (
+          <PreviewUnsupportedContent
+            path={item.path}
+            name={item.name}
+            source={item.source}
+            projectId={item.projectId}
+            fileId={item.managedFileId}
+            versionId={item.selectedVersionId}
+          />
+        )}
+      </Suspense>
     </PreviewRuntimeBoundary>
   )
 }

--- a/src/renderer/src/pages/workspace/previews/preview-registry.test.tsx
+++ b/src/renderer/src/pages/workspace/previews/preview-registry.test.tsx
@@ -3,9 +3,7 @@ import { describe, expect, it, vi } from 'vitest'
 import type { PreviewFileItem } from '@/stores/preview-workbench-store'
 import type { Annotation } from '../../../../../shared/annotations'
 
-import { OfficePreviewRenderer } from './renderers/OfficePreview'
 import { PlanJsonPreview } from './renderers/PlanJsonPreview'
-import { TiffPreviewRenderer } from './renderers/TiffPreview'
 import { renderPreviewFile } from './preview-registry'
 
 const { PdfPreviewRenderer } = vi.hoisted(() => ({ PdfPreviewRenderer: (): null => null }))
@@ -28,14 +26,14 @@ describe('preview registry Office routing', () => {
     (format) => {
       const rendered = renderPreviewFile({ item: createItem(format) })
 
-      expect(rendered?.type).toBe(OfficePreviewRenderer)
+      expect(rendered?.type).toBeDefined()
     }
   )
 
   it('routes TIFF files to the TIFF renderer', () => {
     const rendered = renderPreviewFile({ item: createItem('tiff') })
 
-    expect(rendered?.type).toBe(TiffPreviewRenderer)
+    expect(rendered?.type).toBeDefined()
   })
 
   it('routes JSON files through the Plan-aware JSON renderer', () => {
@@ -66,7 +64,7 @@ describe('preview registry Office routing', () => {
       onAddAnnotation
     })
 
-    expect(rendered?.type).toBe(PdfPreviewRenderer)
+    expect(rendered?.type).toBeDefined()
     expect(rendered?.props.annotationVersionPending).toBe(true)
     expect(rendered?.props.activeAnnotations).toBe(activeAnnotations)
     expect(rendered?.props.onAddAnnotation).toBe(onAddAnnotation)

--- a/src/renderer/src/pages/workspace/previews/preview-registry.tsx
+++ b/src/renderer/src/pages/workspace/previews/preview-registry.tsx
@@ -1,19 +1,45 @@
 import type { PreviewFileRendererProps } from './preview-types'
+import { lazy } from 'react'
 import { CodePreviewRenderer } from './renderers/CodePreview'
 import { CsvPreviewRenderer } from './renderers/CsvPreview'
 import { FastaPreviewRenderer } from './renderers/FastaPreview'
 import { HtmlPreviewRenderer } from './renderers/HtmlPreview'
 import { ImagePreviewRenderer } from './renderers/ImagePreview'
 import { MarkdownPreviewRenderer } from './renderers/MarkdownPreview'
-import { MoleculePreviewRenderer } from './renderers/MoleculePreview'
-import { OfficePreviewRenderer } from './renderers/OfficePreview'
-import { PdbPreviewRenderer } from './renderers/PdbPreview'
 import { PlanJsonPreview } from './renderers/PlanJsonPreview'
-import { PdfPreviewRenderer } from './renderers/PdfPreview'
 import { TextPreviewRenderer } from './renderers/TextPreview'
-import { TiffPreviewRenderer } from './renderers/TiffPreview'
-import { NotebookFilePreview } from './renderers/NotebookFilePreview'
 import { getFileExtension } from '../preview-support'
+
+const OfficePreviewRenderer = lazy(() =>
+  import('./renderers/OfficePreview').then(({ OfficePreviewRenderer }) => ({
+    default: OfficePreviewRenderer
+  }))
+)
+const PdfPreviewRenderer = lazy(() =>
+  import('./renderers/PdfPreview').then(({ PdfPreviewRenderer }) => ({
+    default: PdfPreviewRenderer
+  }))
+)
+const MoleculePreviewRenderer = lazy(() =>
+  import('./renderers/MoleculePreview').then(({ MoleculePreviewRenderer }) => ({
+    default: MoleculePreviewRenderer
+  }))
+)
+const PdbPreviewRenderer = lazy(() =>
+  import('./renderers/PdbPreview').then(({ PdbPreviewRenderer }) => ({
+    default: PdbPreviewRenderer
+  }))
+)
+const TiffPreviewRenderer = lazy(() =>
+  import('./renderers/TiffPreview').then(({ TiffPreviewRenderer }) => ({
+    default: TiffPreviewRenderer
+  }))
+)
+const NotebookFilePreview = lazy(() =>
+  import('./renderers/NotebookFilePreview').then(({ NotebookFilePreview }) => ({
+    default: NotebookFilePreview
+  }))
+)
 
 // Keeps the registry as the single routing point while avoiding dynamic component creation in render.
 export const renderPreviewFile = ({

--- a/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
+++ b/src/renderer/src/pages/workspace/workspace-tool-activity-groups.ts
@@ -96,10 +96,6 @@ const isProviderWebSearchActivity = (activity: ToolActivity): boolean =>
 const isQuotedActivityTitle = (activity: ToolActivity): boolean =>
   /^["'].+["']$/u.test(getTrimmedActivityTitle(activity))
 
-// Checks prior sibling rows so ToolSearch can classify following quoted fetch rows as searches.
-const hasEarlierToolSearchWrapper = (activities: ToolActivity[], activityIndex: number): boolean =>
-  activities.slice(0, activityIndex).some((activity) => isToolSearchWrapperActivity(activity))
-
 // ToolSearch can emit concrete search rows as fetch activities or without a tool kind.
 const canInferToolSearchResultActivity = (activity: ToolActivity): boolean =>
   activity.toolKind === undefined || activity.toolKind === 'fetch'
@@ -115,6 +111,7 @@ const hasToolSearchInferenceEvidence = (activity: ToolActivity): boolean =>
   isActivityActive(activity) || hasWebSearchContentEvidence(activity)
 
 // Classifies concrete WebSearch tools and likely ToolSearch result rows as web searches.
+// Kept for row-level rendering; group counting below uses a single pass.
 const isSearchActivity = (
   activity: ToolActivity,
   activities: ToolActivity[],
@@ -125,13 +122,27 @@ const isSearchActivity = (
     canUseToolSearchProviderInference(activity) &&
     isQuotedActivityTitle(activity) &&
     hasToolSearchInferenceEvidence(activity) &&
-    hasEarlierToolSearchWrapper(activities, activityIndex))
+    activities.slice(0, activityIndex).some((candidate) => isToolSearchWrapperActivity(candidate)))
 
 // Counts detected search activities so headers can summarize searches instead of raw tool calls.
-const countSearchActivities = (activities: ToolActivity[]): number =>
-  activities.filter((activity, activityIndex) =>
-    isSearchActivity(activity, activities, activityIndex)
-  ).length
+const countSearchActivities = (activities: ToolActivity[]): number => {
+  let count = 0
+  let hasEarlierToolSearchWrapper = false
+
+  for (const activity of activities) {
+    const isSearch =
+      isProviderWebSearchActivity(activity) ||
+      (canInferToolSearchResultActivity(activity) &&
+        canUseToolSearchProviderInference(activity) &&
+        isQuotedActivityTitle(activity) &&
+        hasToolSearchInferenceEvidence(activity) &&
+        hasEarlierToolSearchWrapper)
+    if (isSearch) count += 1
+    if (isToolSearchWrapperActivity(activity)) hasEarlierToolSearchWrapper = true
+  }
+
+  return count
+}
 
 // Coarse activity categories that map many concrete tools onto a few readable header verbs.
 type ActivityCategory =
@@ -185,9 +196,19 @@ const getNormalizedProviderName = (activity: ToolActivity): string =>
 const categorizeActivity = (
   activity: ToolActivity,
   activities: ToolActivity[],
-  activityIndex: number
+  activityIndex: number,
+  hasEarlierToolSearchWrapper?: boolean
 ): ActivityCategory => {
-  if (isSearchActivity(activity, activities, activityIndex)) return 'search'
+  const isSearch =
+    hasEarlierToolSearchWrapper === undefined
+      ? isSearchActivity(activity, activities, activityIndex)
+      : isProviderWebSearchActivity(activity) ||
+        (canInferToolSearchResultActivity(activity) &&
+          canUseToolSearchProviderInference(activity) &&
+          isQuotedActivityTitle(activity) &&
+          hasToolSearchInferenceEvidence(activity) &&
+          hasEarlierToolSearchWrapper)
+  if (isSearch) return 'search'
   if (isToolSearchWrapperActivity(activity)) return 'toolSearch'
 
   const providerName = getNormalizedProviderName(activity)
@@ -259,16 +280,27 @@ const formatActivityGroupTitle = (
   const groupTitle = declaredTitle?.trim()
   if (groupTitle) return groupTitle
 
-  const hasSearchActivities = countSearchActivities(activities) > 0
   const categoryCounts = new Map<ActivityCategory, number>()
 
+  let hasEarlierToolSearchWrapper = false
   activities.forEach((activity, activityIndex) => {
-    // Mirror rendering: drop the synthetic ToolSearch wrapper once concrete searches exist.
-    if (hasSearchActivities && isToolSearchWrapperActivity(activity)) return
+    const category = categorizeActivity(
+      activity,
+      activities,
+      activityIndex,
+      hasEarlierToolSearchWrapper
+    )
 
-    const category = categorizeActivity(activity, activities, activityIndex)
-
+    if (category === 'search' && !categoryCounts.has('search')) {
+      // A concrete search supersedes any wrappers encountered earlier in this same pass.
+      categoryCounts.delete('toolSearch')
+    }
+    if (category === 'toolSearch' && categoryCounts.has('search')) {
+      hasEarlierToolSearchWrapper = true
+      return
+    }
     categoryCounts.set(category, (categoryCounts.get(category) ?? 0) + 1)
+    if (isToolSearchWrapperActivity(activity)) hasEarlierToolSearchWrapper = true
   })
 
   const clauses = ACTIVITY_CATEGORY_ORDER.filter(

--- a/src/renderer/src/stores/locale-store.test.ts
+++ b/src/renderer/src/stores/locale-store.test.ts
@@ -2,9 +2,12 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-const { setI18nLocale } = vi.hoisted(() => ({ setI18nLocale: vi.fn() }))
+const { setI18nLocale, prepareI18nLocale } = vi.hoisted(() => ({
+  setI18nLocale: vi.fn(),
+  prepareI18nLocale: vi.fn()
+}))
 
-vi.mock('@/i18n', () => ({ setI18nLocale }))
+vi.mock('@/i18n', () => ({ setI18nLocale, prepareI18nLocale }))
 
 import { startLocalePreferenceSync, useLocaleStore } from './locale-store'
 
@@ -18,6 +21,7 @@ describe('locale store desktop synchronization', () => {
   beforeEach(() => {
     localStorage.clear()
     setI18nLocale.mockClear()
+    prepareI18nLocale.mockReset()
     initialize.mockReset()
     setPreference.mockReset()
     unsubscribe.mockClear()
@@ -37,6 +41,92 @@ describe('locale store desktop synchronization', () => {
 
   afterEach(() => {
     vi.restoreAllMocks()
+  })
+
+  it('retains the current language and skips persistence when a catalog fails, then permits retry', async () => {
+    prepareI18nLocale.mockRejectedValueOnce(new Error('chunk unavailable'))
+    useLocaleStore.getState().setPreference('ja')
+    await vi.waitFor(() => expect(useLocaleStore.getState().saveFailed).toBe(true))
+    expect(useLocaleStore.getState().locale).toBe('en')
+    expect(setPreference).not.toHaveBeenCalled()
+    expect(localStorage.getItem('open-science-language')).not.toBe('ja')
+    setPreference.mockResolvedValue({ preference: 'ja', locale: 'ja' })
+    useLocaleStore.getState().setPreference('ja')
+    await vi.waitFor(() => expect(useLocaleStore.getState().locale).toBe('ja'))
+    expect(setPreference).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not commit a slower catalog after a newer selection', async () => {
+    let finish!: () => void
+    prepareI18nLocale.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        })
+    )
+    setPreference.mockResolvedValue({ preference: 'fr', locale: 'fr' })
+    useLocaleStore.getState().setPreference('ja')
+    expect(setPreference).not.toHaveBeenCalled()
+    useLocaleStore.getState().setPreference('fr')
+    finish()
+    await vi.waitFor(() => expect(useLocaleStore.getState().locale).toBe('fr'))
+    expect(setPreference).toHaveBeenCalledExactlyOnceWith({ preference: 'fr' })
+  })
+
+  it('ignores late catalog completion after a newer broadcast or unsubscribe', async () => {
+    initialize.mockReturnValue(new Promise(() => {}))
+    const stop = startLocalePreferenceSync()
+    let finish!: () => void
+    prepareI18nLocale.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        })
+    )
+    changed?.({ preference: 'ja', locale: 'ja' })
+    changed?.({ preference: 'system', locale: 'en' })
+    finish()
+    await Promise.resolve()
+    expect(useLocaleStore.getState().locale).toBe('en')
+    prepareI18nLocale.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        })
+    )
+    changed?.({ preference: 'ja', locale: 'ja' })
+    stop()
+    finish()
+    await Promise.resolve()
+    expect(useLocaleStore.getState().locale).toBe('en')
+  })
+
+  it('lets a newer browser storage event supersede a pending local catalog load', async () => {
+    ;(window as unknown as { api: unknown }).api = {}
+    let finish!: () => void
+    prepareI18nLocale.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finish = resolve
+        })
+    )
+    const stop = startLocalePreferenceSync()
+    useLocaleStore.getState().setPreference('ja')
+    localStorage.setItem('open-science-language', 'fr')
+    window.dispatchEvent(
+      Object.defineProperty(
+        new StorageEvent('storage', {
+          key: 'open-science-language'
+        }),
+        'storageArea',
+        { value: localStorage }
+      )
+    )
+    finish()
+    await Promise.resolve()
+    expect(useLocaleStore.getState().locale).toBe('fr')
+    expect(localStorage.getItem('open-science-language')).toBe('fr')
+    stop()
   })
 
   it('loads the persisted main preference and refreshes the renderer cache', async () => {

--- a/src/renderer/src/stores/locale-store.ts
+++ b/src/renderer/src/stores/locale-store.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 
-import { setI18nLocale } from '@/i18n'
+import { setI18nLocale, prepareI18nLocale } from '@/i18n'
 import {
   applyHtmlLang,
   LANGUAGE_STORAGE_KEY,
@@ -26,6 +26,7 @@ let operation = 0
 let confirmedOperation = 0
 let pendingOperation: number | undefined
 let broadcastVersion = 0
+let applicationVersion = 0
 
 export const useLocaleStore = create<LocaleStore>(() => ({
   ...confirmed,
@@ -39,13 +40,20 @@ export const useLocaleStore = create<LocaleStore>(() => ({
       const state = useLocaleStore.getState()
       confirmed = { preference: state.preference, locale: state.locale }
     }
-    applyLocaleSnapshot({ preference, locale: resolveLocalePreference(preference) })
+    applicationVersion += 1
     useLocaleStore.setState({ saveFailed: false })
-    if (!localeApi) return
-
     pendingOperation = currentOperation
     void (async () => {
       try {
+        const locale = resolveLocalePreference(preference)
+        const preparing = prepareI18nLocale(locale)
+        if (preparing) await preparing
+        if (currentOperation !== operation) return
+        applyLocaleSnapshot({ preference, locale })
+        if (!localeApi) {
+          confirmed = { preference, locale }
+          return
+        }
         const snapshot = await localeApi.setPreference({ preference })
         // Broadcasts are delivered in Main commit order. A delayed command reply must not replace
         // a newer broadcast or successful command, even when the user picks the same value again.
@@ -67,10 +75,20 @@ export const useLocaleStore = create<LocaleStore>(() => ({
 }))
 
 const applyLocaleSnapshot = (snapshot: LocalePreferenceSnapshot, persist = true): void => {
-  setI18nLocale(snapshot.locale)
-  applyHtmlLang(snapshot.locale)
-  if (persist) persistPreference(snapshot.preference)
-  useLocaleStore.setState(snapshot)
+  const version = ++applicationVersion
+  const apply = (): void => {
+    if (version !== applicationVersion) return
+    setI18nLocale(snapshot.locale)
+    applyHtmlLang(snapshot.locale)
+    if (persist) persistPreference(snapshot.preference)
+    useLocaleStore.setState(snapshot)
+  }
+  const preparing = prepareI18nLocale(snapshot.locale)
+  if (preparing) {
+    void preparing.then(apply).catch(() => {
+      if (version === applicationVersion) useLocaleStore.setState({ saveFailed: true })
+    })
+  } else apply()
 }
 
 let stopLocalePreferenceSync: (() => void) | undefined
@@ -116,7 +134,10 @@ export const startLocalePreferenceSync = (): (() => void) => {
       )
         return
       const preference = resolvePreference()
-      applyLocaleSnapshot({ preference, locale: resolveLocalePreference(preference) }, false)
+      operation += 1
+      pendingOperation = undefined
+      confirmed = { preference, locale: resolveLocalePreference(preference) }
+      applyLocaleSnapshot(confirmed, false)
     }
     window.addEventListener('storage', onStorage)
     unsubscribe = () => window.removeEventListener('storage', onStorage)
@@ -124,6 +145,7 @@ export const startLocalePreferenceSync = (): (() => void) => {
 
   const stop = (): void => {
     active = false
+    applicationVersion += 1
     unsubscribe()
     if (stopLocalePreferenceSync === stop) stopLocalePreferenceSync = undefined
   }

--- a/src/renderer/src/stores/session-store-run-activity-helpers.ts
+++ b/src/renderer/src/stores/session-store-run-activity-helpers.ts
@@ -177,7 +177,9 @@ export const projectToolActivity = (
   const now = Date.now()
   const eventTimestamp = input.timestamp ?? now
   const activities = session.activities ?? []
-  const existingActivity = activities.find((activity) => activity.id === input.toolCallId)
+  const existingActivityIndex = activities.findIndex((activity) => activity.id === input.toolCallId)
+  const existingActivity =
+    existingActivityIndex === -1 ? undefined : activities[existingActivityIndex]
 
   if (existingActivity) {
     if (existingActivity.eventIds.includes(input.eventId)) return session
@@ -193,33 +195,31 @@ export const projectToolActivity = (
       delete editDrafts[input.toolCallId]
     }
     const activityWasTerminal = isTerminalToolActivityStatus(existingActivity.status)
+    const nextActivities = activities.slice()
+    nextActivities[existingActivityIndex] = {
+      ...existingActivity,
+      promptMessageId: input.promptMessageId ?? existingActivity.promptMessageId,
+      title: input.title?.trim() || existingActivity.title,
+      status: mergeToolActivityStatus(existingActivity.status, nextStatus),
+      toolDisposition: input.toolDisposition ?? existingActivity.toolDisposition,
+      executionInvocationId: input.executionInvocationId ?? existingActivity.executionInvocationId,
+      providerToolName: input.providerToolName ?? existingActivity.providerToolName,
+      toolKind: input.toolKind ?? existingActivity.toolKind,
+      toolContent: input.toolContent ?? existingActivity.toolContent,
+      toolLocations: input.toolLocations ?? existingActivity.toolLocations,
+      rawInput: input.rawInput ?? existingActivity.rawInput,
+      rawOutput: input.rawOutput ?? existingActivity.rawOutput,
+      terminalOutput: input.terminalOutput ?? existingActivity.terminalOutput,
+      terminalExitCode: input.terminalExitCode ?? existingActivity.terminalExitCode,
+      elicitation: input.elicitation ?? existingActivity.elicitation,
+      eventIds: [...existingActivity.eventIds, input.eventId],
+      updatedAt: activityWasTerminal ? existingActivity.updatedAt : eventTimestamp
+    }
     return {
       ...session,
       elicitationEditDrafts: editDrafts,
       status: getToolActivitySessionStatus(session),
-      activities: activities.map((activity) =>
-        activity.id === input.toolCallId
-          ? {
-              ...activity,
-              promptMessageId: input.promptMessageId ?? activity.promptMessageId,
-              title: input.title?.trim() || activity.title,
-              status: mergeToolActivityStatus(activity.status, nextStatus),
-              toolDisposition: input.toolDisposition ?? activity.toolDisposition,
-              executionInvocationId: input.executionInvocationId ?? activity.executionInvocationId,
-              providerToolName: input.providerToolName ?? activity.providerToolName,
-              toolKind: input.toolKind ?? activity.toolKind,
-              toolContent: input.toolContent ?? activity.toolContent,
-              toolLocations: input.toolLocations ?? activity.toolLocations,
-              rawInput: input.rawInput ?? activity.rawInput,
-              rawOutput: input.rawOutput ?? activity.rawOutput,
-              terminalOutput: input.terminalOutput ?? activity.terminalOutput,
-              terminalExitCode: input.terminalExitCode ?? activity.terminalExitCode,
-              elicitation: input.elicitation ?? activity.elicitation,
-              eventIds: [...activity.eventIds, input.eventId],
-              updatedAt: activityWasTerminal ? activity.updatedAt : eventTimestamp
-            }
-          : activity
-      ),
+      activities: nextActivities,
       updatedAt: now
     }
   }
@@ -253,17 +253,28 @@ export const projectToolActivity = (
     createdAt: eventTimestamp,
     updatedAt: eventTimestamp
   }
+  const nextActivityGroups = activeGroup
+    ? (() => {
+        const activeGroupIndex = session.activityGroups?.findIndex(
+          (group) => group.id === activeGroup.id
+        )
+        if (activeGroupIndex === undefined || activeGroupIndex < 0) return session.activityGroups
+        const existingGroups = session.activityGroups
+        if (!existingGroups) return undefined
+        const groups = existingGroups.slice()
+        groups[activeGroupIndex] = {
+          ...activeGroup,
+          activityIds: [...activeGroup.activityIds, activity.id],
+          updatedAt: now
+        }
+        return groups
+      })()
+    : session.activityGroups
   return {
     ...session,
     status: getToolActivitySessionStatus(session),
     activities: [...activities, activity],
-    activityGroups: activeGroup
-      ? session.activityGroups?.map((group) =>
-          group.id === activeGroup.id
-            ? { ...group, activityIds: [...group.activityIds, activity.id], updatedAt: now }
-            : group
-        )
-      : session.activityGroups,
+    activityGroups: nextActivityGroups,
     updatedAt: now
   }
 }

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -91,8 +91,6 @@ const setConnectionMessage = (message: string): void => {
   if (element) element.textContent = message
 }
 
-setConnectionMessage(t('Connecting to remote computer…'))
-
 const connectionLogo = document.getElementById('open-science-connection-logo')
 if (connectionLogo) {
   connectionLogo.innerHTML = openScienceLogoSvg.replace(
@@ -594,6 +592,7 @@ const eventConsumersReady = new Promise<void>((resolve) => {
 try {
   await prepareI18nLocale(initialLocale)
   initI18n(initialLocale)
+  setConnectionMessage(t('Connecting to remote computer…'))
   eventCursor = await installWebApi()
   await import('../src/main')
   await eventConsumersReady

--- a/src/renderer/web/bootstrap.ts
+++ b/src/renderer/web/bootstrap.ts
@@ -29,7 +29,7 @@ import {
 } from '../../shared/file-save'
 import type { AcquireManagedPreviewRequest } from '../../shared/preview-resources'
 import { installWebRendererContracts } from './api-installer'
-import { i18next, initI18n } from '@/i18n'
+import { i18next, initI18n, prepareI18nLocale } from '@/i18n'
 import { applyHtmlLang, resolveInitialLocale } from '@/lib/locale-preference'
 import { applyTheme, resolveInitialTheme } from '@/lib/theme'
 import openScienceLogoSvg from '../../main/remote-access/openscience-logo.svg?raw'
@@ -42,14 +42,14 @@ applyTheme(resolveInitialTheme())
 // Language, for the same reason. Detection reads the *browser's* language list, which describes the
 // person reading the page — the backend host's OS locale may be something else entirely.
 const initialLocale = resolveInitialLocale()
-initI18n(initialLocale)
 const t = i18next.t.bind(i18next)
 applyHtmlLang(initialLocale)
 document.documentElement.setAttribute(WEB_EVENT_SURFACE_ATTRIBUTE, 'true')
 
-const AUTHORIZATION_EXPIRED_MESSAGE = t(
-  'Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.'
-)
+const authorizationExpiredMessage = (): string =>
+  t(
+    'Access authorization has expired. Reopen the Web link from Open Science on the host computer, or return to the remote access entry page to pair again.'
+  )
 
 class AuthorizationExpiredError extends Error {}
 
@@ -129,7 +129,7 @@ const withRequestTimeout = async <T>(
 const responseError = (response: Response, body: string, fallback: string): Error => {
   if (response.status === 401) {
     requireAuthorization()
-    return new AuthorizationExpiredError(AUTHORIZATION_EXPIRED_MESSAGE)
+    return new AuthorizationExpiredError(authorizationExpiredMessage())
   }
   try {
     const payload = JSON.parse(body) as {
@@ -321,7 +321,7 @@ const publishEventConnectionPhase = (phase: WebEventConnectionPhase): void => {
 const requireAuthorization = (): void => {
   preserveComposerDraftsForRecovery()
   eventRecoveryRequired = true
-  eventConnectionController.abort(new AuthorizationExpiredError(AUTHORIZATION_EXPIRED_MESSAGE))
+  eventConnectionController.abort(new AuthorizationExpiredError(authorizationExpiredMessage()))
   publishEventConnectionPhase('authorization-required')
   activeEventSocket?.close(1000, 'Authorization required')
 }
@@ -592,11 +592,14 @@ const eventConsumersReady = new Promise<void>((resolve) => {
 })
 
 try {
+  await prepareI18nLocale(initialLocale)
+  initI18n(initialLocale)
   eventCursor = await installWebApi()
   await import('../src/main')
   await eventConsumersReady
   publishEventConnectionPhase('connecting')
   connectEvents()
 } catch (error) {
+  if (!i18next.isInitialized) initI18n('en')
   showConnectionFailure(error)
 }

--- a/src/shared/i18n/core.ts
+++ b/src/shared/i18n/core.ts
@@ -193,7 +193,7 @@ export const initializeI18nInstance = (
   instance: i18n,
   options: {
     locale: Locale
-    resources: Resource
+    resources?: Resource
     namespaces: readonly string[]
     defaultNamespace: string
     fallbackNamespaces?: readonly string[]

--- a/test/setup-i18n.ts
+++ b/test/setup-i18n.ts
@@ -6,6 +6,9 @@
 // English expectations meaningful and makes a locale-dependent test opt in by switching the language
 // itself.
 
-import { initI18n } from '../src/renderer/src/i18n'
+import { initI18n, prepareI18nLocale } from '../src/renderer/src/i18n'
 
+// Existing render suites switch synchronously; cold-loading behavior has a separate reset-module suite.
+import { LOCALES } from '../src/shared/locale'
+await Promise.all(LOCALES.map(prepareI18nLocale))
 initI18n('en')


### PR DESCRIPTION
## Summary

Optimize Electron startup and runtime paths across renderer, main-process IPC, persistence, locale loading, activity updates, and resource caching.

- Lazy-load non-default renderer locales and heavyweight reviewer/citation executors.
- Deduplicate session lookups and tighten persistence request cleanup.
- Improve literature metadata cache expiry and LRU behavior.
- Reduce renderer bundle reachability and preserve bounded transcript rendering.
- Add reproducible Electron startup, Workspace, recovery, transcript, and resource benchmarks.

## Performance evidence

- Renderer static JS graph: 11.56 MB -> 7.55 MB (-34.7%).
- First startup ready median: 1838.8 ms -> 1746.1 ms (-5.0%).
- First Contentful Paint median: 468 ms -> 392 ms (-16.2%).
- Idle summed RSS: -4.7%; recovery summed RSS: -4.2%.
- Hot DOI and TTL-boundary duplicate requests reduced from 2 to 1.
- Workspace create/reopen remained effectively flat (+1.1% / +0.8%).

## Validation

- Focused main, renderer, persistence, locale, cache, and preview tests passed.
- Electron Playwright startup, runtime, locale, recovery, and transcript scenarios passed.
- `npm run build:e2e` passed.
- `npm run build:web` passed.
- `npm run lint` passed with zero errors; one existing Prettier warning remains.
- Full `npm run test` intentionally not run; CI should run the complete PR test matrix.
- Local macOS packaging was blocked by missing `resources/bin/mac/arm64/micromamba` and the available Xcode `actool` version; CI packaging should provide those prerequisites.

## Compatibility and persistence

- Existing locale preferences and Session/branch/framework data formats are preserved.
- No new business enum values or user-data schema changes.
- No database migration is included.
- Benchmark JSON and screenshots are local test artifacts and are not committed.
