### PR TITLE
fix(cli): install the Debian command with the application

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,6 +16,7 @@ on:
           - full
           - runtime-source
           - macos-x64
+          - linux-cli
 
 # Build and publication preparation run without write access. Only the separate workflow_run
 # publisher receives contents:write, and it never checks out or executes the triggering revision.
@@ -24,7 +25,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: nightly-build
+  group: nightly-build${{ inputs.dry_run == 'linux-cli' && '-linux-cli' || '' }}
   cancel-in-progress: true
 
 jobs:
@@ -55,16 +56,17 @@ jobs:
     with:
       nightly: true
       # A manual `macos-x64` dispatch runs only the Intel packaging job (the heap-sensitive Vite
-      # renderer build) and skips verify. Smoke, certification, and publish stay skipped below.
-      skip_verify: ${{ inputs.dry_run == 'macos-x64' }}
-      platform_name: ${{ inputs.dry_run == 'macos-x64' && 'macos-x64' || '' }}
+      # renderer build) and skips verify. The linux-cli dry-run builds and smoke-tests Linux only;
+      # unrelated certification and publication preparation stay skipped.
+      skip_verify: ${{ inputs.dry_run == 'macos-x64' || inputs.dry_run == 'linux-cli' }}
+      platform_name: ${{ inputs.dry_run == 'macos-x64' && 'macos-x64' || inputs.dry_run == 'linux-cli' && 'linux-x64' || '' }}
 
   # Scheduled coverage remains advisory during burn-in and is deliberately absent from prepare.needs.
   # A manual `runtime-source` dispatch runs this exact reusable job as a blocking focused dry-run while
   # build/package/publish preparation stay skipped.
   runtime-certification:
     needs: plan
-    if: needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'macos-x64'
+    if: needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'macos-x64' && inputs.dry_run != 'linux-cli'
     uses: ./.github/workflows/runtime-certification.yml
     with:
       allow_failure: ${{ github.event_name != 'workflow_dispatch' }}
@@ -73,11 +75,14 @@ jobs:
     needs: build
     if: inputs.dry_run != 'macos-x64'
     uses: ./.github/workflows/package-smoke.yml
+    with:
+      platform_name: ${{ inputs.dry_run == 'linux-cli' && 'linux-x64' || '' }}
 
   # Run advisory desktop behavior checks inside the same read-only Nightly run. Failures remain
   # visible and independently rerunnable, but do not gate preparation or publication.
   regression:
     needs: [build, package-smoke]
+    if: inputs.dry_run != 'linux-cli'
     uses: ./.github/workflows/desktop-regression.yml
     with:
       allow_failure: true
@@ -88,7 +93,7 @@ jobs:
   prepare:
     name: Prepare nightly publish artifact
     needs: [plan, build, package-smoke]
-    if: needs.build.result == 'success' && needs.package-smoke.result == 'success'
+    if: needs.build.result == 'success' && needs.package-smoke.result == 'success' && inputs.dry_run != 'linux-cli'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -114,8 +114,9 @@ jobs:
         shell: bash
         run: |
           npx vitest run scripts/deb-cli-launcher.test.ts
-          sudo apt-get install --yes ./dist/*.deb
           trap 'sudo apt-get remove --yes open-science || true' EXIT
+          sudo "$(command -v node)" scripts/deb-package-lifecycle-smoke.mjs ./dist/*.deb
+          sudo apt-get install --yes ./dist/*.deb
           xvfb-run -a node scripts/linux-package-smoke.mjs \
             --artifact-dir dist \
             --installed-executable "/opt/Open Science/open-science" \

--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -113,11 +113,13 @@ jobs:
         timeout-minutes: 10
         shell: bash
         run: |
+          npx vitest run scripts/deb-cli-launcher.test.ts
           sudo apt-get install --yes ./dist/*.deb
           trap 'sudo apt-get remove --yes open-science || true' EXIT
           xvfb-run -a node scripts/linux-package-smoke.mjs \
             --artifact-dir dist \
-            --installed-executable /usr/bin/open-science
+            --installed-executable "/opt/Open Science/open-science" \
+            --installed-cli /usr/bin/open-science
 
       - name: Record platform certification evidence
         if: ${{ !inputs.install_only }}

--- a/build/deb-after-install.tpl
+++ b/build/deb-after-install.tpl
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Keep the package-owned Electron path stable for desktop entries and existing user launchers.
+# Only the Debian alternatives entry changes from the desktop executable to the bundled CLI.
+cli_link='/usr/bin/${executable}'
+cli_target='/opt/${sanitizedProductName}/resources/open-science-cli'
+legacy_target='/opt/${sanitizedProductName}/${executable}'
+
+# Never replace an unmanaged file/symlink or repurpose another alternatives link group.
+if [ -e "$cli_link" ] || [ -L "$cli_link" ]; then
+  if [ ! -L "$cli_link" ] || [ "$(readlink "$cli_link")" != '/etc/alternatives/${executable}' ]; then
+    echo "Open Science cannot register its CLI: $cli_link is not an alternatives-managed link." >&2
+    exit 1
+  fi
+fi
+alternative_state=$(LC_ALL=C update-alternatives --query '${executable}' 2>/dev/null) || alternative_state=
+if [ -n "$alternative_state" ] && ! printf '%s\n' "$alternative_state" | grep -Fxq "Link: $cli_link"; then
+  echo 'Open Science cannot repurpose an unrelated alternatives link group.' >&2
+  exit 1
+fi
+update-alternatives --install "$cli_link" '${executable}' "$cli_target" 100 || exit "$?"
+# Register the replacement before removing the exact legacy candidate. Unrelated manual choices stay.
+if printf '%s\n' "$alternative_state" | grep -Fxq "Alternative: $legacy_target"; then
+  update-alternatives --remove '${executable}' "$legacy_target" || exit "$?"
+fi
+
+# Check if user namespaces are supported by the kernel and working with a quick test:
+if ! { [[ -L /proc/self/ns/user ]] && unshare --user true; }; then
+    # Use SUID chrome-sandbox only on systems without user namespaces:
+    chmod 4755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+else
+    chmod 0755 '/opt/${sanitizedProductName}/chrome-sandbox' || true
+fi
+
+if hash update-mime-database 2>/dev/null; then
+    update-mime-database /usr/share/mime || true
+fi
+
+if hash update-desktop-database 2>/dev/null; then
+    update-desktop-database /usr/share/applications || true
+fi
+
+# Install apparmor profile. (Ubuntu 24+)
+# First check if the version of AppArmor running on the device supports our profile.
+# This is in order to keep backwards compatibility with Ubuntu 22.04 which does not support abi/4.0.
+# In that case, we just skip installing the profile since the app runs fine without it on 22.04.
+#
+# Those apparmor_parser flags are akin to performing a dry run of loading a profile.
+# https://wiki.debian.org/AppArmor/HowToUse#Dumping_profiles
+#
+# Unfortunately, at the moment AppArmor doesn't have a good story for backwards compatibility.
+# https://askubuntu.com/questions/1517272/writing-a-backwards-compatible-apparmor-profile
+if apparmor_status --enabled > /dev/null 2>&1; then
+  APPARMOR_PROFILE_SOURCE='/opt/${sanitizedProductName}/resources/apparmor-profile'
+  APPARMOR_PROFILE_TARGET='/etc/apparmor.d/${executable}'
+  if apparmor_parser --skip-kernel-load --debug "$APPARMOR_PROFILE_SOURCE" > /dev/null 2>&1; then
+    cp -f "$APPARMOR_PROFILE_SOURCE" "$APPARMOR_PROFILE_TARGET"
+
+    # Updating the current AppArmor profile is not possible and probably not meaningful in a chroot'ed environment.
+    # Use cases are for example environments where images for clients are maintained.
+    # There, AppArmor might correctly be installed, but live updating makes no sense.
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      # Extra flags taken from dh_apparmor:
+      # > By using '-W -T' we ensure that any abstraction updates are also pulled in.
+      # https://wiki.debian.org/AppArmor/Contribute/FirstTimeProfileImport
+      apparmor_parser --replace --write-cache --skip-read-cache "$APPARMOR_PROFILE_TARGET"
+    fi
+  else
+    echo "Skipping the installation of the AppArmor profile as this version of AppArmor does not seem to support the bundled profile"
+  fi
+fi

--- a/build/deb-after-install.tpl
+++ b/build/deb-after-install.tpl
@@ -17,6 +17,22 @@ if [ -n "$alternative_state" ] && ! printf '%s\n' "$alternative_state" | grep -F
   echo 'Open Science cannot repurpose an unrelated alternatives link group.' >&2
   exit 1
 fi
+# Protect a manually replaced alternatives link too, not only the public command.
+alternative_link='/etc/alternatives/${executable}'
+if [ -e "$alternative_link" ] || [ -L "$alternative_link" ]; then
+  if [ ! -L "$alternative_link" ]; then
+    echo "Open Science cannot modify an unmanaged $alternative_link." >&2
+    exit 1
+  fi
+  selected_target=$(readlink "$alternative_link")
+  if [ "$selected_target" != '/opt/${sanitizedProductName}/resources/open-science-cli' ] &&
+     [ "$selected_target" != '/opt/${sanitizedProductName}/${executable}' ] &&
+     ! printf '%s\n' "$alternative_state" | grep -Fxq "Alternative: $selected_target"; then
+    echo "Open Science cannot modify an unregistered target at $alternative_link." >&2
+    exit 1
+  fi
+fi
+
 update-alternatives --install "$cli_link" '${executable}' "$cli_target" 100 || exit "$?"
 # Register the replacement before removing the exact legacy candidate. Unrelated manual choices stay.
 if printf '%s\n' "$alternative_state" | grep -Fxq "Alternative: $legacy_target"; then

--- a/build/deb-after-remove.tpl
+++ b/build/deb-after-remove.tpl
@@ -19,6 +19,22 @@ if [ -n "$alternative_state" ] && ! printf '%s\n' "$alternative_state" | grep -F
   exit 1
 fi
 
+# Protect a manually replaced alternatives link too, not only the public command.
+alternative_link='/etc/alternatives/${executable}'
+if [ -e "$alternative_link" ] || [ -L "$alternative_link" ]; then
+  if [ ! -L "$alternative_link" ]; then
+    echo "Open Science cannot modify an unmanaged $alternative_link." >&2
+    exit 1
+  fi
+  selected_target=$(readlink "$alternative_link")
+  if [ "$selected_target" != '/opt/${sanitizedProductName}/resources/open-science-cli' ] &&
+     [ "$selected_target" != '/opt/${sanitizedProductName}/${executable}' ] &&
+     ! printf '%s\n' "$alternative_state" | grep -Fxq "Alternative: $selected_target"; then
+    echo "Open Science cannot modify an unregistered target at $alternative_link." >&2
+    exit 1
+  fi
+fi
+
 # Debian records the exact candidate. Do not remove the group or any other installation's entry.
 update-alternatives --remove '${executable}' '/opt/${sanitizedProductName}/resources/open-science-cli' || exit "$?"
 

--- a/build/deb-after-remove.tpl
+++ b/build/deb-after-remove.tpl
@@ -1,0 +1,40 @@
+#!/bin/bash
+# FPM can invoke postrm during upgrades; the replacement package owns the live registration.
+case "$1" in
+  remove|purge) ;;
+  *) exit 0 ;;
+esac
+
+# Fail closed if another program replaced the generic link after installation.
+cli_link='/usr/bin/${executable}'
+if [ -e "$cli_link" ] || [ -L "$cli_link" ]; then
+  if [ ! -L "$cli_link" ] || [ "$(readlink "$cli_link")" != '/etc/alternatives/${executable}' ]; then
+    echo "Open Science cannot unregister its CLI: $cli_link was replaced by an unmanaged entry." >&2
+    exit 1
+  fi
+fi
+alternative_state=$(LC_ALL=C update-alternatives --query '${executable}' 2>/dev/null) || alternative_state=
+if [ -n "$alternative_state" ] && ! printf '%s\n' "$alternative_state" | grep -Fxq "Link: $cli_link"; then
+  echo 'Open Science cannot modify an unrelated alternatives link group.' >&2
+  exit 1
+fi
+
+# Debian records the exact candidate. Do not remove the group or any other installation's entry.
+update-alternatives --remove '${executable}' '/opt/${sanitizedProductName}/resources/open-science-cli' || exit "$?"
+
+APPARMOR_PROFILE_DEST='/etc/apparmor.d/${executable}'
+
+# Remove and unload apparmor profile.
+if [ -f "$APPARMOR_PROFILE_DEST" ]; then
+  # Unload the profile from the running kernel before deleting the file so the
+  # policy is not left enforced until the next reboot.  Mirror the chroot guard
+  # used in the after-install script — live AppArmor operations are not
+  # meaningful inside a chroot.
+  # https://wiki.debian.org/AppArmor/HowToUse
+  if apparmor_status --enabled > /dev/null 2>&1; then
+    if ! { [ -x '/usr/bin/ischroot' ] && /usr/bin/ischroot; } && hash apparmor_parser 2>/dev/null; then
+      apparmor_parser --remove "$APPARMOR_PROFILE_DEST" || true
+    fi
+  fi
+  rm -f "$APPARMOR_PROFILE_DEST"
+fi

--- a/build/deb-cli-launcher
+++ b/build/deb-cli-launcher
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Debian package-owned CLI entry. The desktop executable keeps its existing path.
+set -eu
+launcher=$(readlink -f "$0")
+app_dir=$(dirname "$(dirname "$launcher")")
+export OPEN_SCIENCE_APP_PATH="$app_dir/open-science"
+export ELECTRON_RUN_AS_NODE=1
+exec "$OPEN_SCIENCE_APP_PATH" "$app_dir/resources/cli/index.mjs" "$@"

--- a/cli/lifecycle.test.ts
+++ b/cli/lifecycle.test.ts
@@ -421,24 +421,37 @@ describe('headless startup', () => {
     expect(() =>
       parseCliArgs(['start', '--credential-store=file', '--credential-store', 'os'])
     ).toThrow()
-    expect(buildAppLaunchArgs(['app-root'], { credentialStore: 'file' }, 44100)).toEqual([
-      'app-root',
-      '--credential-store=file',
-      '--open-science-headless',
-      '--serve=44100'
-    ])
+    expect(
+      buildAppLaunchArgs(['app-root'], { credentialStore: 'file' }, 44100, { platform: 'darwin' })
+    ).toEqual(['app-root', '--credential-store=file', '--open-science-headless', '--serve=44100'])
     expect(buildAppLaunchArgs([], {}, 44100).join(' ')).not.toContain('credential-store')
   })
 
   it('places the no-sandbox runtime switch before the development app path', () => {
-    expect(buildAppLaunchArgs(['app-root'], { noSandbox: true }, 44100)).toEqual([
-      '--no-sandbox',
-      'app-root',
-      '--open-science-headless',
-      '--serve=44100'
-    ])
+    expect(
+      buildAppLaunchArgs(['app-root'], { noSandbox: true }, 44100, { platform: 'darwin' })
+    ).toEqual(['--no-sandbox', 'app-root', '--open-science-headless', '--serve=44100'])
     expect(buildAppLaunchArgs(['app-root'], {}, 44100)).not.toContain('--no-sandbox')
   })
+
+  it.each([
+    ['linux', {}, true],
+    ['linux', { DISPLAY: ':0' }, false],
+    ['linux', { WAYLAND_DISPLAY: 'wayland-0' }, false],
+    ['darwin', {}, false],
+    ['win32', {}, false]
+  ] as const)(
+    'selects display-free Ozone only for Linux without a display: %s %j',
+    (platform, env, expected) => {
+      const args = buildAppLaunchArgs(['app-root'], {}, 44100, { platform, env })
+      expect(args.includes('--ozone-platform=headless')).toBe(expected)
+      expect(args).not.toContain('--no-sandbox')
+      expect(args).not.toContain('--headless')
+      expect(args).toContain('--open-science-headless')
+      if (expected)
+        expect(args.indexOf('--ozone-platform=headless')).toBeLessThan(args.indexOf('app-root'))
+    }
+  )
 
   it('stops waiting as soon as the packaged app exits', async () => {
     const child = new EventEmitter()

--- a/cli/locate-app.test.ts
+++ b/cli/locate-app.test.ts
@@ -2,9 +2,15 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { locateApp } from './locate-app.mjs'
+import * as fs from 'node:fs/promises'
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>()
+  return { ...actual, access: vi.fn(actual.access) }
+})
 
 describe('locateApp', () => {
   let dir: string
@@ -14,6 +20,8 @@ describe('locateApp', () => {
   })
 
   afterEach(async () => {
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
     await rm(dir, { recursive: true, force: true })
   })
 
@@ -31,6 +39,21 @@ describe('locateApp', () => {
     const app = await locateApp({ env: { OPEN_SCIENCE_APP_PATH: exe } })
     expect(app.command).toBe(exe)
     expect(app.packaged).toBe(true)
+  })
+
+  it('prefers the Debian Electron executable over the system CLI wrapper', async () => {
+    vi.stubGlobal('process', { ...process, platform: 'linux' })
+    const candidates = new Set(['/opt/Open Science/open-science', '/usr/bin/open-science'])
+    vi.mocked(fs.access).mockImplementation(async (path) => {
+      if (!candidates.has(String(path))) throw new Error('ENOENT')
+    })
+    const app = await locateApp({ env: {} })
+    expect(app).toMatchObject({
+      command: '/opt/Open Science/open-science',
+      args: [],
+      packaged: true
+    })
+    vi.mocked(fs.access).mockRestore()
   })
 
   it('throws a helpful error when the explicit path does not exist', async () => {

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -179,9 +179,14 @@ linux:
     # looks for it there via process.resourcesPath).
     - from: resources/bin/linux/${arch}/micromamba
       to: micromamba
+    # Debian registers this CLI entry; AppImage retains its explicit user launcher workflow.
+    - from: build/deb-cli-launcher
+      to: open-science-cli
 appImage:
   artifactName: aipoch-${name}-${version}-linux-${arch}.${ext}
 deb:
+  afterInstall: build/deb-after-install.tpl
+  afterRemove: build/deb-after-remove.tpl
   artifactName: aipoch-${name}_${version}_${arch}.${ext}
   depends:
     - libgtk-3-0

--- a/packages/open-science/CLI.md
+++ b/packages/open-science/CLI.md
@@ -5,7 +5,26 @@ requiring browser interaction.
 
 ## Installation
 
-### From the installed application
+### From a Debian package (including WSL)
+
+Installing the `.deb` package registers `/usr/bin/open-science` automatically. No separate
+Node.js, desktop Settings interaction, or `cli install` command is needed:
+
+```bash
+sudo apt install ./open-science.deb  # Use the downloaded package's actual filename.
+open-science init
+open-science start --no-open
+open-science url
+```
+
+The desktop shortcut continues to launch the application directly. Debian maintains the CLI entry
+through upgrades and removal. Upgrades migrate only the old package-owned system alternative;
+existing user launchers and unrelated manually selected alternatives are preserved. The installer
+reports a conflict instead of overwriting an unmanaged `/usr/bin/open-science` file or symlink.
+The Settings and `cli install`/`cli uninstall` controls manage the optional user launcher, not the
+Debian-owned system entry; remove the Debian package to remove that entry.
+
+### From other application packages
 
 Open **Settings > General > Command line tool** in Open Science and choose **Install command**. This
 adds an `open-science` launcher to your PATH (`~/.local/bin` on macOS and Linux, or a per-user
@@ -173,7 +192,8 @@ profile. Doctor reports readiness, not a live third-party authorization or resea
 include the submitted secret or raw upstream error. Bootstrap/launcher writes require an
 authenticated local connection and are not exposed as research-agent tools.
 
-Install the PATH launcher with `open-science cli install --json`. Before a launcher exists, invoke
+For packages without an automatically registered command, install the optional user PATH launcher
+with `cli install --json`. Before a launcher exists, invoke
 the bundled CLI by absolute path using the application's Electron executable in Node mode (for
 example on macOS):
 

--- a/packages/open-science/cli.mjs
+++ b/packages/open-science/cli.mjs
@@ -746,8 +746,17 @@ const readLogTail = async (logPath) => {
 
 export const openLaunchLog = (logPath) => openSync(logPath, 'w')
 
-export const buildAppLaunchArgs = (appArgs, options, port) => [
+export const buildAppLaunchArgs = (
+  appArgs,
+  options,
+  port,
+  { platform = process.platform, env = process.env } = {}
+) => [
   ...(options.noSandbox ? ['--no-sandbox'] : []),
+  // No-window mode alone still initializes X11. Select Ozone's display-free backend on servers.
+  ...(platform === 'linux' && !env.DISPLAY && !env.WAYLAND_DISPLAY
+    ? ['--ozone-platform=headless']
+    : []),
   ...appArgs,
   ...(options.credentialStore ? [`--credential-store=${options.credentialStore}`] : []),
   // `--open-science-headless` instead of `--headless`: Chromium consumes `--headless` and renders

--- a/packages/open-science/locate-app.mjs
+++ b/packages/open-science/locate-app.mjs
@@ -51,7 +51,8 @@ const defaultInstalledCandidates = (env = process.env) => {
       Boolean
     )
   }
-  return ['/usr/bin/open-science', '/usr/local/bin/open-science']
+  // Debian's public command is a CLI wrapper, not the Electron executable.
+  return ['/opt/Open Science/open-science', '/usr/bin/open-science', '/usr/local/bin/open-science']
 }
 
 const locateDevelopmentApp = async () => {

--- a/scripts/ci/release-workflows.test.ts
+++ b/scripts/ci/release-workflows.test.ts
@@ -207,7 +207,7 @@ describe('release and scheduled workflow topology', () => {
     expect(nightly.on).toHaveProperty('workflow_dispatch')
     expect(nightly.permissions).toEqual({ actions: 'read', contents: 'read' })
     expect(nightly.concurrency).toEqual({
-      group: 'nightly-build',
+      group: "nightly-build${{ inputs.dry_run == 'linux-cli' && '-linux-cli' || '' }}",
       'cancel-in-progress': true
     })
     expect(nightly.jobs.build).toMatchObject({
@@ -216,8 +216,9 @@ describe('release and scheduled workflow topology', () => {
       uses: './.github/workflows/build.yml',
       with: {
         nightly: true,
-        skip_verify: "${{ inputs.dry_run == 'macos-x64' }}",
-        platform_name: "${{ inputs.dry_run == 'macos-x64' && 'macos-x64' || '' }}"
+        skip_verify: "${{ inputs.dry_run == 'macos-x64' || inputs.dry_run == 'linux-cli' }}",
+        platform_name:
+          "${{ inputs.dry_run == 'macos-x64' && 'macos-x64' || inputs.dry_run == 'linux-cli' && 'linux-x64' || '' }}"
       }
     })
     expect(step(nightly.jobs.plan, 'Compare main with the rolling nightly tag').run).toContain(
@@ -229,13 +230,17 @@ describe('release and scheduled workflow topology', () => {
     }
     expect(dispatch.inputs?.dry_run).toMatchObject({
       default: 'full',
-      options: ['full', 'runtime-source', 'macos-x64']
+      options: ['full', 'runtime-source', 'macos-x64', 'linux-cli']
     })
     expect(nightly.jobs['package-smoke'].if).toBe("inputs.dry_run != 'macos-x64'")
+    expect(nightly.jobs['package-smoke'].with).toEqual({
+      platform_name: "${{ inputs.dry_run == 'linux-cli' && 'linux-x64' || '' }}"
+    })
+    expect(nightly.jobs.regression.if).toBe("inputs.dry_run != 'linux-cli'")
     expect(nightly.jobs['runtime-certification'].if).toContain("inputs.dry_run != 'macos-x64'")
     expect(prepare).toMatchObject({
       needs: ['plan', 'build', 'package-smoke'],
-      if: "needs.build.result == 'success' && needs.package-smoke.result == 'success'",
+      if: "needs.build.result == 'success' && needs.package-smoke.result == 'success' && inputs.dry_run != 'linux-cli'",
       'runs-on': 'ubuntu-latest'
     })
     expect(step(prepare, 'Aggregate release certification evidence').run).toContain(

--- a/scripts/ci/runtime-certification-workflow.test.ts
+++ b/scripts/ci/runtime-certification-workflow.test.ts
@@ -156,12 +156,12 @@ describe('runtime certification workflow', () => {
 
     expect(dispatch.inputs?.dry_run).toMatchObject({
       default: 'full',
-      options: ['full', 'runtime-source', 'macos-x64']
+      options: ['full', 'runtime-source', 'macos-x64', 'linux-cli']
     })
     expect(nightly.jobs.build.if).toContain("inputs.dry_run != 'runtime-source'")
     expect(runtime).toMatchObject({
       needs: 'plan',
-      if: "needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'macos-x64'",
+      if: "needs.plan.outputs.should_build == 'true' && inputs.dry_run != 'macos-x64' && inputs.dry_run != 'linux-cli'",
       uses: './.github/workflows/runtime-certification.yml',
       with: { allow_failure: "${{ github.event_name != 'workflow_dispatch' }}" }
     })

--- a/scripts/deb-cli-launcher.test.ts
+++ b/scripts/deb-cli-launcher.test.ts
@@ -1,0 +1,203 @@
+import { spawnSync, type SpawnSyncReturns } from 'node:child_process'
+import { chmod, copyFile, mkdir, mkdtemp, realpath, rm, symlink, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+const roots: string[] = []
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })))
+})
+
+// Exercise the POSIX wrapper locally as well as on its Linux target.
+describe.skipIf(process.platform === 'win32')('Debian CLI launcher', () => {
+  it('runs the bundled CLI through Electron Node mode and preserves arguments and exit status', async () => {
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'deb-cli-')))
+    roots.push(root)
+    const app = join(root, "Open Science ' 数据")
+    const resources = join(app, 'resources')
+    const bin = join(root, 'bin')
+    await mkdir(resources, { recursive: true })
+    await mkdir(bin)
+    await copyFile(resolve('build/deb-cli-launcher'), join(resources, 'open-science-cli'))
+    await chmod(join(resources, 'open-science-cli'), 0o755)
+    const executable = join(app, 'open-science')
+    await writeFile(
+      executable,
+      '#!/bin/sh\nprintf "%s\\n" "$ELECTRON_RUN_AS_NODE" "$OPEN_SCIENCE_APP_PATH" "$@"\nexit 23\n',
+      { mode: 0o755 }
+    )
+    const command = join(bin, 'open-science')
+    await symlink(join(resources, 'open-science-cli'), command)
+    const result = spawnSync(command, ['run', '--prompt', 'spaces; $(never-run) "quoted"', ''], {
+      encoding: 'utf8',
+      env: { ...process.env, OPEN_SCIENCE_APP_PATH: '/wrong/application', DISPLAY: '' }
+    })
+    expect(result.error).toBeUndefined()
+    expect(result.status).toBe(23)
+    expect(result.stderr).toBe('')
+    expect(result.stdout.split('\n')).toEqual([
+      '1',
+      executable,
+      join(resources, 'cli/index.mjs'),
+      'run',
+      '--prompt',
+      'spaces; $(never-run) "quoted"',
+      '',
+      ''
+    ])
+  })
+})
+
+// Preserve electron-builder's platform setup while replacing only command registration.
+describe('Debian packaging contract', () => {
+  it('keeps the upstream sandbox, MIME and AppArmor setup and installs a separate CLI entry', async () => {
+    const { readFile } = await import('node:fs/promises')
+    const { load } = await import('js-yaml')
+    const config = load(await readFile('electron-builder.yml', 'utf8')) as {
+      deb: { afterInstall: string; afterRemove: string }
+      linux: { executableName?: string; extraResources: { from: string; to: string }[] }
+    }
+    expect(config.deb.afterInstall).toBe('build/deb-after-install.tpl')
+    expect(config.deb.afterRemove).toBe('build/deb-after-remove.tpl')
+    expect(config.linux.executableName).toBeUndefined()
+    expect(config.linux.extraResources).toContainEqual({
+      from: 'build/deb-cli-launcher',
+      to: 'open-science-cli'
+    })
+    for (const [filename, marker] of [
+      ['after-install.tpl', '# Check if user namespaces'],
+      ['after-remove.tpl', 'APPARMOR_PROFILE_DEST=']
+    ]) {
+      const upstream = await readFile(
+        `node_modules/app-builder-lib/templates/linux/${filename}`,
+        'utf8'
+      )
+      const owned = await readFile(`build/deb-${filename}`, 'utf8')
+      expect(owned.slice(owned.indexOf(marker)).trim()).toBe(
+        upstream.slice(upstream.indexOf(marker)).trim()
+      )
+    }
+  })
+})
+
+describe.skipIf(process.platform !== 'linux')('Debian alternatives lifecycle', () => {
+  const fixture = async (): Promise<{
+    root: string
+    target: string
+    legacy: string
+    command: string
+    run: (args: string[]) => SpawnSyncReturns<string>
+    hook: (kind: string, argument: string) => SpawnSyncReturns<string>
+  }> => {
+    const { readFile } = await import('node:fs/promises')
+    const root = await realpath(await mkdtemp(join(tmpdir(), 'deb-alternatives-')))
+    roots.push(root)
+    const bin = join(root, 'bin')
+    const alternatives = join(root, 'etc/alternatives')
+    const admin = join(root, 'var/lib/dpkg/alternatives')
+    const resources = join(root, 'opt/Open Science/resources')
+    for (const dir of [bin, alternatives, admin, resources, join(root, 'usr/bin')]) {
+      await mkdir(dir, { recursive: true })
+    }
+    const legacy = join(root, 'opt/Open Science/open-science')
+    const target = join(resources, 'open-science-cli')
+    const command = join(root, 'usr/bin/open-science')
+    await writeFile(legacy, 'legacy')
+    await writeFile(target, 'cli')
+    await writeFile(join(root, 'opt/Open Science/chrome-sandbox'), '')
+    await writeFile(
+      join(bin, 'update-alternatives'),
+      `#!/bin/sh\nexec /usr/bin/update-alternatives --altdir '${alternatives}' --admindir '${admin}' "$@"\n`,
+      { mode: 0o755 }
+    )
+    for (const [name, status] of [
+      ['apparmor_status', 1],
+      ['update-mime-database', 0],
+      ['update-desktop-database', 0],
+      ['unshare', 0]
+    ]) {
+      await writeFile(join(bin, String(name)), `#!/bin/sh\nexit ${status}\n`, { mode: 0o755 })
+    }
+    const env = { ...process.env, PATH: `${bin}:/usr/bin:/bin`, LC_ALL: 'C' }
+    const run = (args: string[]): SpawnSyncReturns<string> =>
+      spawnSync(join(bin, 'update-alternatives'), args, { env, encoding: 'utf8' })
+    const scripts: Record<string, string> = {}
+    for (const kind of ['install', 'remove']) {
+      const text = (await readFile(`build/deb-after-${kind}.tpl`, 'utf8'))
+        .replaceAll('${executable}', 'open-science')
+        .replaceAll('${sanitizedProductName}', 'Open Science')
+        .replaceAll('/usr/bin/', `${root}/usr/bin/`)
+        .replaceAll('/etc/alternatives/', `${alternatives}/`)
+        .replaceAll('/opt/', `${root}/opt/`)
+        .replaceAll('/etc/apparmor.d/', `${root}/etc/apparmor.d/`)
+      scripts[kind] = join(root, kind)
+      await writeFile(scripts[kind], text)
+    }
+    const hook = (kind: string, argument: string): SpawnSyncReturns<string> =>
+      spawnSync('/bin/bash', [scripts[kind], argument], { env, encoding: 'utf8' })
+    return { root, target, legacy, command, run, hook }
+  }
+
+  it('supports fresh install, reinstall, upgrade postrm, remove and repeated purge', async () => {
+    const f = await fixture()
+    for (let i = 0; i < 2; i++) {
+      expect(f.hook('install', 'configure').status).toBe(0)
+      expect(await realpath(f.command)).toBe(f.target)
+    }
+    expect(f.hook('remove', 'upgrade').status).toBe(0)
+    expect(await realpath(f.command)).toBe(f.target)
+    await rm(f.target) // dpkg removes payload before postrm.
+    expect(f.hook('remove', 'remove').status).toBe(0)
+    await expect(realpath(f.command)).rejects.toThrow()
+    expect(f.hook('remove', 'purge').status).toBe(0)
+  })
+
+  it.each(['auto', 'manual'])('migrates only the legacy %s alternative', async (mode) => {
+    const f = await fixture()
+    expect(f.run(['--install', f.command, 'open-science', f.legacy, '100']).status).toBe(0)
+    if (mode === 'manual') expect(f.run(['--set', 'open-science', f.legacy]).status).toBe(0)
+    expect(f.hook('install', 'configure').status).toBe(0)
+    expect(await realpath(f.command)).toBe(f.target)
+    const query = f.run(['--query', 'open-science']).stdout
+    expect(query).not.toContain(`Alternative: ${f.legacy}\n`)
+  })
+
+  it('preserves another manually selected alternative through install and uninstall', async () => {
+    const f = await fixture()
+    const other = join(f.root, 'another-cli')
+    await writeFile(other, 'user choice')
+    expect(f.run(['--install', f.command, 'open-science', f.legacy, '100']).status).toBe(0)
+    expect(f.run(['--install', f.command, 'open-science', other, '200']).status).toBe(0)
+    expect(f.run(['--set', 'open-science', other]).status).toBe(0)
+    expect(f.hook('install', 'configure').status).toBe(0)
+    expect(await realpath(f.command)).toBe(other)
+    expect(f.hook('remove', 'remove').status).toBe(0)
+    expect(await realpath(f.command)).toBe(other)
+  })
+
+  it('fails closed when an unmanaged symlink replaces the command before uninstall', async () => {
+    const f = await fixture()
+    expect(f.hook('install', 'configure').status).toBe(0)
+    await rm(f.command)
+    await symlink(f.legacy, f.command)
+    await rm(f.target)
+    for (const phase of ['remove', 'purge']) {
+      expect(f.hook('remove', phase).status).toBe(1)
+      expect(await realpath(f.command)).toBe(f.legacy)
+    }
+  })
+
+  it.each(['file', 'symlink'])('refuses to replace an unmanaged %s', async (kind) => {
+    const f = await fixture()
+    if (kind === 'file') await writeFile(f.command, 'user command')
+    else await symlink(f.legacy, f.command)
+    const { lstat, readFile, readlink } = await import('node:fs/promises')
+    const before = await lstat(f.command)
+    expect(f.hook('install', 'configure').status).toBe(1)
+    expect((await lstat(f.command)).ino).toBe(before.ino)
+    if (kind === 'file') expect(await readFile(f.command, 'utf8')).toBe('user command')
+    else expect(await readlink(f.command)).toBe(f.legacy)
+  })
+})

--- a/scripts/deb-cli-launcher.test.ts
+++ b/scripts/deb-cli-launcher.test.ts
@@ -85,6 +85,7 @@ describe('Debian packaging contract', () => {
 describe.skipIf(process.platform !== 'linux')('Debian alternatives lifecycle', () => {
   const fixture = async (): Promise<{
     root: string
+    alternativeLink: string
     target: string
     legacy: string
     command: string
@@ -137,7 +138,15 @@ describe.skipIf(process.platform !== 'linux')('Debian alternatives lifecycle', (
     }
     const hook = (kind: string, argument: string): SpawnSyncReturns<string> =>
       spawnSync('/bin/bash', [scripts[kind], argument], { env, encoding: 'utf8' })
-    return { root, target, legacy, command, run, hook }
+    return {
+      root,
+      alternativeLink: join(alternatives, 'open-science'),
+      target,
+      legacy,
+      command,
+      run,
+      hook
+    }
   }
 
   it('supports fresh install, reinstall, upgrade postrm, remove and repeated purge', async () => {
@@ -187,6 +196,18 @@ describe.skipIf(process.platform !== 'linux')('Debian alternatives lifecycle', (
       expect(f.hook('remove', phase).status).toBe(1)
       expect(await realpath(f.command)).toBe(f.legacy)
     }
+  })
+
+  it('preserves an unregistered replacement of the alternatives link itself', async () => {
+    const f = await fixture()
+    expect(f.hook('install', 'configure').status).toBe(0)
+    const other = join(f.root, 'unregistered-cli')
+    await writeFile(other, 'user command')
+    await rm(f.alternativeLink)
+    await symlink(other, f.alternativeLink)
+    expect(f.hook('install', 'configure').status).toBe(1)
+    expect(f.hook('remove', 'remove').status).toBe(1)
+    expect(await realpath(f.command)).toBe(other)
   })
 
   it.each(['file', 'symlink'])('refuses to replace an unmanaged %s', async (kind) => {

--- a/scripts/deb-package-lifecycle-smoke.mjs
+++ b/scripts/deb-package-lifecycle-smoke.mjs
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/explicit-function-return-type */
+
+// Run on a disposable Linux certification runner before installing the real application.
+// Use the built package's actual FPM control scripts, not merely the source templates.
+import { execFileSync } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, lstat, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const run = (command, args) =>
+  execFileSync(command, args, { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] })
+const command = '/usr/bin/open-science'
+const appRoot = '/opt/Open Science'
+const legacyTarget = `${appRoot}/open-science`
+const cliTarget = `${appRoot}/resources/open-science-cli`
+
+const main = async (deb) => {
+  if (process.platform !== 'linux' || process.getuid() !== 0) {
+    throw new Error('Debian lifecycle certification requires root on a disposable Linux runner.')
+  }
+  // Never use this harness to replace an already installed application or user command.
+  const status = (() => {
+    try {
+      return run('dpkg-query', ['-W', '-f=${db:Status-Status}', 'open-science']).trim()
+    } catch {
+      return 'not-installed'
+    }
+  })()
+  if (status === 'installed') {
+    throw new Error('Run Debian lifecycle certification before installing Open Science.')
+  }
+  for (const path of [command, appRoot]) {
+    if (
+      await lstat(path).then(
+        () => true,
+        () => false
+      )
+    ) {
+      throw new Error(`Refusing to replace an existing certification target: ${path}`)
+    }
+  }
+  const root = await mkdtemp(join(tmpdir(), 'deb-lifecycle-'))
+  try {
+    const control = join(root, 'actual-control')
+    run('dpkg-deb', ['--control', deb, control])
+    const generated = {}
+    for (const name of ['postinst', 'postrm'])
+      generated[name] = await readFile(join(control, name), 'utf8')
+    if (!generated.postinst.includes(cliTarget) || !generated.postrm.includes(cliTarget)) {
+      throw new Error('The built Debian control scripts did not include the CLI lifecycle hooks.')
+    }
+    const fixture = async (version, legacy) => {
+      const tree = join(root, version)
+      await mkdir(join(tree, 'DEBIAN'), { recursive: true })
+      await mkdir(join(tree, 'opt/Open Science/resources'), { recursive: true })
+      await writeFile(
+        join(tree, 'DEBIAN/control'),
+        `Package: open-science\nVersion: ${version}\nArchitecture: all\nMaintainer: AIPOCH\nDescription: Debian CLI lifecycle certification fixture\n`
+      )
+      for (const name of ['postinst', 'postrm']) {
+        const text = legacy
+          ? (
+              await readFile(
+                resolve(
+                  `node_modules/app-builder-lib/templates/linux/${name === 'postinst' ? 'after-install' : 'after-remove'}.tpl`
+                ),
+                'utf8'
+              )
+            )
+              .replaceAll('${executable}', 'open-science')
+              .replaceAll('${sanitizedProductName}', 'Open Science')
+          : generated[name]
+        const path = join(tree, 'DEBIAN', name)
+        await writeFile(path, text)
+        await chmod(path, 0o755)
+      }
+      for (const file of ['open-science', 'resources/open-science-cli', 'chrome-sandbox']) {
+        await writeFile(join(tree, 'opt/Open Science', file), '#!/bin/sh\nexit 0\n', {
+          mode: 0o755
+        })
+      }
+      const output = join(root, `${version}.deb`)
+      run('dpkg-deb', ['--build', '--root-owner-group', tree, output])
+      return output
+    }
+    const oldPackage = await fixture('0.0.1', true)
+    const newPackage = await fixture('0.0.2', false)
+    for (const mode of ['auto', 'manual']) {
+      run('dpkg', ['--install', oldPackage])
+      if ((await realpath(command)) !== legacyTarget)
+        throw new Error('Legacy fixture did not expose Electron.')
+      if (mode === 'manual') run('update-alternatives', ['--set', 'open-science', legacyTarget])
+      run('dpkg', ['--install', newPackage])
+      if ((await realpath(command)) !== cliTarget)
+        throw new Error(`Debian ${mode} upgrade did not expose the CLI.`)
+      run('dpkg', ['--install', newPackage])
+      if ((await realpath(command)) !== cliTarget) throw new Error('Debian reinstall lost the CLI.')
+      run('dpkg', ['--remove', 'open-science'])
+      if (
+        await realpath(command).then(
+          () => true,
+          () => false
+        )
+      )
+        throw new Error('Debian removal left a live command.')
+      run('dpkg', ['--purge', 'open-science'])
+      console.log(
+        `Debian generated hooks: ${mode} legacy upgrade, reinstall, remove and purge passed.`
+      )
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
+  main(process.argv[2]).catch((error) => {
+    console.error(error)
+    process.exitCode = 1
+  })
+}

--- a/scripts/electron-builder-config.test.ts
+++ b/scripts/electron-builder-config.test.ts
@@ -46,7 +46,10 @@ describe('electron-builder native image processing', () => {
       to: 'notebook-network-sandbox/wsl2/manifest.json'
     })
     expect(config.mac?.extraResources).toHaveLength(1)
-    expect(config.linux?.extraResources).toHaveLength(1)
+    expect(config.linux?.extraResources).toEqual([
+      { from: 'resources/bin/linux/${arch}/micromamba', to: 'micromamba' },
+      { from: 'build/deb-cli-launcher', to: 'open-science-cli' }
+    ])
   })
 })
 

--- a/scripts/linux-package-smoke.mjs
+++ b/scripts/linux-package-smoke.mjs
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 
 import { spawn } from 'node:child_process'
-import { access, chmod, mkdtemp, readdir, realpath, rm } from 'node:fs/promises'
+import { access, chmod, mkdir, mkdtemp, readFile, readdir, realpath, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
 import { pathToFileURL } from 'node:url'
@@ -209,6 +209,87 @@ const smokeExecutable = async ({
   return sqliteVersions
 }
 
+// Exercise the installed public command with an empty user profile and no display server.
+// Tokens are inspected in memory only; certification output must never print them.
+const smokeInstalledCli = async ({ executable, expectedVersion, root, env }) => {
+  const cliEnv = {
+    ...env,
+    HOME: join(root, 'cli home 数据'),
+    XDG_CONFIG_HOME: join(root, 'cli config 数据')
+  }
+  for (const name of [
+    'DISPLAY',
+    'WAYLAND_DISPLAY',
+    'OPEN_SCIENCE_APP_PATH',
+    'ELECTRON_RUN_AS_NODE',
+    'OPEN_SCIENCE_CONFIG_ROOT',
+    'OPEN_SCIENCE_STORAGE_ROOT',
+    'OPEN_SCIENCE_E2E_STORAGE_ROOT'
+  ]) {
+    delete cliEnv[name]
+  }
+  await mkdir(cliEnv.HOME, { recursive: true })
+  const invoke = (args) => runProcess(executable, args, { env: cliEnv })
+  const initialized = JSON.parse((await invoke(['init', '--json'])).stdout)
+  if (initialized.configRoot !== join(cliEnv.HOME, '.open-science')) {
+    throw new Error('Installed CLI did not initialize the isolated production profile.')
+  }
+  try {
+    const started = await invoke([
+      'start',
+      '--no-open',
+      '--port',
+      '44109',
+      '--credential-store=file'
+    ])
+    const statePath = join(initialized.configRoot, 'web-service.json')
+    const firstState = JSON.parse(await readFile(statePath, 'utf8'))
+    const reused = await invoke(['start', '--no-open'])
+    const secondState = JSON.parse(await readFile(statePath, 'utf8'))
+    if (firstState.pid !== secondState.pid || firstState.port !== 44109) {
+      throw new Error('Installed CLI failed daemon reuse or custom-port selection.')
+    }
+    const browserUrl = new URL((await invoke(['url'])).stdout.trim())
+    const token = browserUrl.searchParams.get('token')
+    if (browserUrl.hostname !== '127.0.0.1' || browserUrl.port !== '44109' || !token) {
+      throw new Error('Installed CLI did not return an authenticated loopback URL.')
+    }
+    const response = await fetch(new URL('/api/bootstrap', browserUrl), {
+      headers: { authorization: `Bearer ${token}` },
+      signal: AbortSignal.timeout(15_000)
+    })
+    const bootstrap = await response.json()
+    if (
+      !response.ok ||
+      bootstrap.appVersion !== expectedVersion ||
+      bootstrap.platform !== 'linux'
+    ) {
+      throw new Error('Installed CLI started an unexpected or unhealthy application.')
+    }
+    const logs = await readFile(join(initialized.configRoot, 'cli-daemon.log'), 'utf8')
+    if (
+      [started.stdout, started.stderr, reused.stdout, reused.stderr, logs].some((text) =>
+        text.includes(token)
+      )
+    ) {
+      throw new Error('A CLI startup output or daemon log disclosed the browser token.')
+    }
+    console.log(
+      'Installed CLI: init, headless start, custom port, daemon reuse and authenticated URL passed (token redacted).'
+    )
+  } finally {
+    await invoke(['stop'])
+  }
+  const stoppedUrl = await invoke(['url']).then(
+    () => false,
+    () => true
+  )
+  if (!stoppedUrl) throw new Error('The URL command succeeded after the daemon was stopped.')
+  console.log(
+    'Installed CLI: stop and unavailable URL passed; no desktop or display server was used.'
+  )
+}
+
 const parseArguments = (argv) => {
   const valueFor = (name) => {
     const index = argv.indexOf(name)
@@ -216,6 +297,7 @@ const parseArguments = (argv) => {
   }
   const artifactDirectory = valueFor('--artifact-dir')
   const installedExecutable = valueFor('--installed-executable')
+  const installedCli = valueFor('--installed-cli')
   if (!artifactDirectory || !installedExecutable) {
     throw new Error(
       'Usage: --artifact-dir <path> --installed-executable <path-to-installed-open-science>'
@@ -223,7 +305,8 @@ const parseArguments = (argv) => {
   }
   return {
     artifactDirectory: resolve(artifactDirectory),
-    installedExecutable: resolve(installedExecutable)
+    installedExecutable: resolve(installedExecutable),
+    installedCli: resolve(installedCli ?? '/usr/bin/open-science')
   }
 }
 
@@ -244,6 +327,12 @@ const main = async () => {
   ]
 
   try {
+    await smokeInstalledCli({
+      executable: options.installedCli,
+      expectedVersion,
+      root,
+      env: baseEnv
+    })
     const sqliteVersions = []
     const debProfiles = launchProfiles('deb')
     await seedLegacyDatabase(debProfiles[0].storageRoot)
@@ -304,5 +393,6 @@ export {
   findResourceRoot,
   packagedResourcePaths,
   parseArguments,
-  parsePackagedAppEndpoint
+  parsePackagedAppEndpoint,
+  smokeInstalledCli
 }

--- a/scripts/linux-package-smoke.mjs
+++ b/scripts/linux-package-smoke.mjs
@@ -234,6 +234,7 @@ const smokeInstalledCli = async ({ executable, expectedVersion, root, env }) => 
   if (initialized.configRoot !== join(cliEnv.HOME, '.open-science')) {
     throw new Error('Installed CLI did not initialize the isolated production profile.')
   }
+  let failure
   try {
     const started = await invoke([
       'start',
@@ -277,8 +278,23 @@ const smokeInstalledCli = async ({ executable, expectedVersion, root, env }) => 
     console.log(
       'Installed CLI: init, headless start, custom port, daemon reuse and authenticated URL passed (token redacted).'
     )
+  } catch (error) {
+    failure = error
   } finally {
-    await invoke(['stop'])
+    try {
+      await invoke(['stop'])
+    } catch (error) {
+      failure ??= error
+    }
+  }
+  if (failure) {
+    const token = await readFile(join(initialized.configRoot, 'web-token'), 'utf8')
+      .then((text) => text.trim())
+      .catch(() => '')
+    const logs = await readFile(join(initialized.configRoot, 'cli-daemon.log'), 'utf8')
+      .catch(() => '(daemon log unavailable)')
+    const diagnostic = `${failure.message}\n${logs}`
+    throw new Error(token ? diagnostic.replaceAll(token, '<REDACTED>') : diagnostic)
   }
   const stoppedUrl = await invoke(['url']).then(
     () => false,

--- a/scripts/linux-package-smoke.mjs
+++ b/scripts/linux-package-smoke.mjs
@@ -291,8 +291,9 @@ const smokeInstalledCli = async ({ executable, expectedVersion, root, env }) => 
     const token = await readFile(join(initialized.configRoot, 'web-token'), 'utf8')
       .then((text) => text.trim())
       .catch(() => '')
-    const logs = await readFile(join(initialized.configRoot, 'cli-daemon.log'), 'utf8')
-      .catch(() => '(daemon log unavailable)')
+    const logs = await readFile(join(initialized.configRoot, 'cli-daemon.log'), 'utf8').catch(
+      () => '(daemon log unavailable)'
+    )
     const diagnostic = `${failure.message}\n${logs}`
     throw new Error(token ? diagnostic.replaceAll(token, '<REDACTED>') : diagnostic)
   }

--- a/src/main/tray.test.ts
+++ b/src/main/tray.test.ts
@@ -165,11 +165,40 @@ describe('createAppTray', () => {
     emptyPaths = []
     // Default the shared cases to a non-darwin platform (full-color icon path).
     setPlatform('linux')
+    vi.stubEnv('DISPLAY', ':99')
+    vi.stubEnv('WAYLAND_DISPLAY', undefined)
   })
 
   afterEach(() => {
     setPlatform(originalPlatform)
+    vi.unstubAllEnvs()
   })
+
+  it.each([
+    ['linux', undefined, undefined, false],
+    ['linux', ':99', undefined, true],
+    ['linux', undefined, 'wayland-0', true],
+    ['darwin', undefined, undefined, true],
+    ['win32', undefined, undefined, true]
+  ])(
+    'handles tray availability on %s with X11=%s and Wayland=%s',
+    (platform, x11, wayland, available) => {
+      setPlatform(platform)
+      vi.stubEnv('DISPLAY', x11)
+      vi.stubEnv('WAYLAND_DISPLAY', wayland)
+      const tray = createAppTray({
+        iconPath: '/icons/tray.png',
+        onShow: vi.fn(),
+        onHide: vi.fn(),
+        onQuit: vi.fn()
+      })
+      expect(Boolean(tray)).toBe(available)
+      if (!available) {
+        expect(lastTray).toBeUndefined()
+        expect(createdFromPaths).toEqual([])
+      }
+    }
+  )
 
   it('builds a tray with tooltip and a Show/Hide/Quit context menu', () => {
     const tray = createAppTray({

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -105,6 +105,10 @@ const createAppTray = (opts: {
   onCopyWebUrl?: () => void | Promise<void>
   translate?: NativeTranslator
 }): Tray | undefined => {
+  // GTK tray initialization can abort the process without a display, outside JS error handling.
+  if (process.platform === 'linux' && !process.env.DISPLAY && !process.env.WAYLAND_DISPLAY) {
+    return undefined
+  }
   try {
     // macOS gets a monochrome template glyph that follows the menu-bar appearance; other platforms use
     // the full-color icon. An empty image is tolerated so the tray still appears with a blank glyph.


### PR DESCRIPTION
## Problem

Installing the Debian application exposes the desktop executable as `open-science`, leaving users on servers or WSL without a directly usable CLI. Related: #1405.

## Proposed change

Install a package-owned CLI wrapper through Debian alternatives, preserving the internal Electron executable and desktop shortcut. Only migrate the exact legacy package candidate; preserve unrelated manual alternatives and reject unmanaged command conflicts. Upgrade removal leaves the new entry intact, while uninstall removes only the package candidate.

On Linux without DISPLAY or WAYLAND_DISPLAY, select Ozone headless and skip native tray creation. Real package testing exposed both the default X11 requirement and a subsequent GTK tray crash; these fixes allow the existing `start --no-open` and `url` workflow without a display server.

## Scope and non-goals

Debian system CLI registration only; other package formats retain their existing launcher installation flow. No new `web` command, business enum, database migration, or renderer change. OS persistence consists of package-owned files and alternatives registration. Existing home-directory launchers are untouched. WSL uses the Debian path, but no Windows-host WSL session was available for direct certification.

## Acceptance criteria and validation

The packaged implementation was last changed at f0b260953. Final commit 662e9eb67 only replaces an obsolete resource-count test with explicit micromamba/CLI resource assertions; the native artifact evidence remains applicable:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| CLI discovery, lifecycle, launcher, consumers, tray and app lifecycle | 21 explicitly selected Vitest files across `cli/`, `packages/open-science/`, `src/main/cli-install/`, `src/main/tray.test.ts`, `src/main/app-lifecycle.test.ts` and packaging/workflow guards | 461 passed, 16 platform skips locally |
| Final packaging config assertion | `npx vitest run scripts/electron-builder-config.test.ts scripts/deb-cli-launcher.test.ts` at 662e9eb67 | 20 passed, 8 Linux-only skips locally; changed-test ESLint passed |
| Real POSIX wrapper, alternatives ownership/conflicts | `npx vitest run scripts/deb-cli-launcher.test.ts` on native Ubuntu | 10 passed |
| Generated FPM control scripts: legacy auto/manual upgrade, reinstall, remove, purge | `scripts/deb-package-lifecycle-smoke.mjs` with real dpkg | Passed |
| Installed CLI: init, no-display start, custom port, daemon reuse, authenticated URL, token-free output, stop, URL unavailable after stop | `scripts/linux-package-smoke.mjs --installed-cli /usr/bin/open-science` | Passed without DISPLAY/WAYLAND_DISPLAY or a sandbox bypass |
| Existing Debian/AppImage resource and database certification | Original paths in `scripts/linux-package-smoke.mjs` | Passed |
| Changed production types and style | Node/sandbox typecheck and changed-file ESLint | Passed; full repository checks also passed before the final tray-only increment |

[Final-head native Linux build and certification](https://github.com/aipoch/open-science/actions/runs/34728962211) passed. Full portable tests and Windows/macOS regression lanes are delegated to PR Gate as requested; their final status is shown in checks. Linux is required for package hooks and GTK/Ozone, while macOS/Windows lanes guard the shared CLI and tray consumers. Direct WSL-on-Windows certification remains uncovered.

## Review focus

Alternatives ownership and upgrade ordering; preserving the desktop executable; display-free startup without weakening sandboxing. Independent reviews covered the final ownership guards, tray change and failure diagnostics and found no remaining actionable issues. Native CLI success logs provide interaction evidence; there is no renderer layout change.

## Existing main failures

PR Gate checks the merged tree. At main bc85f2645, independent of this PR, `VITEST_PORTABLE_CI=1 npx vitest run scripts/ci/e2e-execution-ownership.test.ts src/renderer/src/pages/workspace/previews/PreviewFileContent.test.tsx` reproduces six failures (43 passed): missing startup-performance E2E ownership and synchronous preview expectations after lazy loading. The original 2c64d3370 baseline passes all 49 tests. These block complete CI and are being handled separately from the verified CLI implementation. No merge will occur while required checks fail.
