### PR TITLE
fix(ipc): remove handlers when registry is disposed

### DIFF
--- a/src/main/ipc-handler-registry.test.ts
+++ b/src/main/ipc-handler-registry.test.ts
@@ -248,6 +248,20 @@ describe('createIpcHandlerRegistry', () => {
     expect(removeHandler).toHaveBeenCalledWith('test:partial')
   })
 
+  it('removes all registered handlers when the registry is disposed', () => {
+    const removeHandler = vi.fn()
+    const registry = createIpcHandlerRegistry({ handle: vi.fn(), removeHandler } as never)
+
+    registry.ipcMainHandle('test:first', vi.fn())
+    registry.ipcMainHandle('test:second', vi.fn())
+
+    registry.dispose()
+
+    expect(removeHandler).toHaveBeenCalledTimes(2)
+    expect(removeHandler).toHaveBeenCalledWith('test:first')
+    expect(removeHandler).toHaveBeenCalledWith('test:second')
+  })
+
   it('records a rejected native handler once without retaining its payload', async () => {
     const nativeHandlers = new Map<string, (...args: unknown[]) => unknown>()
     const handle = vi.fn((channel: string, handler: (...args: unknown[]) => unknown) => {

--- a/src/main/ipc-handler-registry.ts
+++ b/src/main/ipc-handler-registry.ts
@@ -201,6 +201,7 @@ const createIpcHandlerRegistry = (
     dispose: () => {
       activeCallerLeaseEpoch.registry.dispose()
       activeCallerLeaseEpoch.disposed = true
+      removeChannels([...registeredChannels])
     }
   }
 }


### PR DESCRIPTION
## Problem
Disposing the IPC handler registry invalidated caller leases but left registered Electron handlers installed. Startup rollback, runtime recomposition, and shutdown therefore lacked a complete handler cleanup guarantee.

## Change
- Remove every channel still tracked by the registry during `dispose()`.
- Add a regression test covering multiple registered channels.

## Validation
- `npx vitest run src/main/ipc-handler-registry.test.ts src/main/application-runtime.test.ts src/main/runtime-electron-wiring.test.ts src/main/index-startup-failure.test.ts src/main/app-lifecycle.test.ts`
- 5 files passed, 121 tests passed
- `git diff --check`
