### PR TITLE
refactor(ipc): split core electron surfaces

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -1020,6 +1020,35 @@
       },
       "capabilityOverlays": ["windows_sensitive"],
       "fallbackCapability": "main_runtime"
+    },
+    "ipc_surfaces": {
+      "ownerPaths": ["src/main/ipc-surfaces/adapter.ts", "src/main/ipc-surfaces/core.ts"],
+      "interfacePaths": ["src/main/ipc-surfaces/adapter.ts", "src/main/ipc-surfaces/core.ts"],
+      "consumerModules": [],
+      "testFiles": {
+        "owner": ["src/main/ipc-surfaces/adapter.test.ts", "src/main/ipc-surfaces/core.test.ts"],
+        "contract": [
+          "src/main/ipc-handler-registry.test.ts",
+          "src/main/caller-lifecycle.test.ts",
+          "src/main/runtime-electron-wiring.test.ts",
+          "src/main/application-command-wiring.test.ts",
+          "src/main/permission-grants/ipc.test.ts",
+          "src/main/project-files/ipc.test.ts",
+          "src/main/managed-file-versions/ipc.test.ts",
+          "src/main/local-fs/ipc.test.ts",
+          "src/main/projects/ipc.test.ts",
+          "src/main/lifecycle-broadcast.test.ts"
+        ],
+        "consumer": [
+          "src/main/application-runtime.test.ts",
+          "src/main/index-startup-failure.test.ts",
+          "src/main/application-command-composition.test.ts",
+          "src/main/application-command-electron-adapter.test.ts",
+          "src/main/runtime-state-ownership.architecture.test.ts"
+        ]
+      },
+      "capabilityOverlays": [],
+      "fallbackCapability": "main_runtime"
     }
   }
 }

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -18,6 +18,7 @@ const between = (source: string, start: string, end: string): string => {
 }
 
 const ipcSource = readSource('src/main/ipc.ts')
+const coreSurfaceSource = compact(readSource('src/main/ipc-surfaces/core.ts'))
 const indexSource = readSource('src/main/index.ts')
 const runtimeSource = readSource('src/main/application-runtime.ts')
 const compositionSource = readSource('src/main/application-command-composition.ts')
@@ -114,21 +115,11 @@ describe('production application command wiring', () => {
         'managedPreview: managedPreviewOwners'
       ],
       [
-        'projectFilesHandlers',
-        'projectDeletionCoordinator, projectFilesHandlers )',
-        'projectFiles: projectFilesHandlers'
-      ],
-      [
         'sessionPersistenceHandlers',
         'reviewRepository, sessionPersistenceHandlers, async (session)',
         '...sessionPersistenceHandlers'
       ],
       ['artifactHandlers', 'artifactHandlers )', 'artifacts: artifactHandlers'],
-      [
-        'permissionGrantProjection',
-        'registerPermissionGrantIpcAdapter(permissionGrantProjection)',
-        'permissionGrants: permissionGrantProjection'
-      ],
       ['storageCommandOwner', 'storageCommandOwner )', 'storage: storageCommandOwner'],
       [
         'reviewerCommandOwner',
@@ -183,7 +174,28 @@ describe('production application command wiring', () => {
     expect(ipcSource).not.toContain("ipcMainHandle('sessions:export-package'")
     expect(ipcSource).not.toContain("ipcMainHandle('sessions:import-package'")
     expect(ipcSource).not.toContain('registerProjectIpcHandlers')
-    expect(legacyAdapterBlock).toContain('registerPreviewStateIpcHandlers(previewStateRepository)')
+    // Keep checking the shared owner identities at the composition root. The extracted module's
+    // actual registration/dispatch is covered by ipc-surfaces/core.test.ts.
+    const coreDependencies = compact(
+      between(ipcSource, '...createCoreElectronSurfaces({', '// Compute IPC handlers')
+    )
+    expect(occurrences(ipcSource, 'createCoreElectronSurfaces(')).toBe(1)
+    expect(coreDependencies).toContain('permissionGrantProjection,')
+    expect(coreDependencies).toContain(
+      'projectFiles: [ projectFilesRepository, sessionPersistenceCoordinator, projectDeletionCoordinator, projectFilesHandlers ]'
+    )
+    expect(coreDependencies).toContain('previewStateRepository')
+    expect(dependencyBlock).toContain('permissionGrants: permissionGrantProjection')
+    expect(dependencyBlock).toContain('projectFiles: projectFilesHandlers')
+    expect(coreSurfaceSource).toContain(
+      'registerPermissionGrantIpcAdapter(dependencies.permissionGrantProjection)'
+    )
+    expect(coreSurfaceSource).toContain(
+      'registerProjectFilesIpcHandlers(...dependencies.projectFiles)'
+    )
+    expect(coreSurfaceSource).toContain(
+      'registerPreviewStateIpcHandlers(dependencies.previewStateRepository)'
+    )
 
     expect(compact(ipcSource)).toContain(
       'electronAdapters: { beforeCompute: beforeComputeAdapters, compute: { handlers: computeIpcModule.handlers, enabledHosts: sessionEnabledComputeHostsOwner },'

--- a/src/main/ipc-surfaces/adapter.test.ts
+++ b/src/main/ipc-surfaces/adapter.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, expect, it, vi } from 'vitest'
+
+const native = vi.hoisted(() => ({ channels: new Set<string>() }))
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string) => {
+      if (native.channels.has(channel)) throw new Error(`duplicate channel: ${channel}`)
+      native.channels.add(channel)
+    },
+    removeHandler: (channel: string) => native.channels.delete(channel)
+  }
+}))
+
+import { createElectronSurfaceAdapter } from './adapter'
+import { disposeIpcHandlerRegistry, ipcMainHandle } from '../ipc-handler-registry'
+
+afterEach(() => disposeIpcHandlerRegistry())
+
+it('removes channels even when auxiliary cleanup fails and runs cleanup only once', async () => {
+  const failure = new Error('auxiliary cleanup failed')
+  const cleanup = vi.fn(() => {
+    throw failure
+  })
+  const adapter = createElectronSurfaceAdapter('test', () => {
+    ipcMainHandle('test:owned', () => undefined)
+    return cleanup
+  })
+  expect(native.channels.size).toBe(0)
+  const installation = await adapter.install()
+  expect(() => installation.uninstall()).toThrow(failure)
+  expect(native.channels.size).toBe(0)
+  await installation.uninstall()
+  expect(cleanup).toHaveBeenCalledOnce()
+})
+
+it('preserves an earlier surface when a duplicate registration aborts a later surface', async () => {
+  const earlier = await createElectronSurfaceAdapter('earlier', () => {
+    ipcMainHandle('test:shared', () => undefined)
+  }).install()
+  const later = createElectronSurfaceAdapter('later', () => {
+    ipcMainHandle('test:partial', () => undefined)
+    ipcMainHandle('test:shared', () => undefined)
+  })
+  expect(() => later.install()).toThrow('duplicate channel: test:shared')
+  expect([...native.channels]).toEqual(['test:shared'])
+  await earlier.uninstall()
+  expect(native.channels.size).toBe(0)
+})

--- a/src/main/ipc-surfaces/adapter.ts
+++ b/src/main/ipc-surfaces/adapter.ts
@@ -1,0 +1,21 @@
+import { createIpcHandlerInstallationScope } from '../ipc-handler-registry'
+import type { NamedElectronSurfaceAdapter } from '../runtime-electron-wiring'
+
+// Installation is synchronous: a failed registrar must roll back its partial channel set before
+// the runtime wiring uninstalls earlier surfaces. The returned handle owns successful installation.
+export const createElectronSurfaceAdapter = (
+  name: string,
+  register: () => void | (() => void)
+): NamedElectronSurfaceAdapter => ({
+  name,
+  install: () => {
+    const scope = createIpcHandlerInstallationScope()
+    try {
+      const cleanup = register()
+      return scope.complete(typeof cleanup === 'function' ? cleanup : undefined)
+    } catch (error) {
+      scope.rollback()
+      throw error
+    }
+  }
+})

--- a/src/main/ipc-surfaces/core.test.ts
+++ b/src/main/ipc-surfaces/core.test.ts
@@ -1,0 +1,159 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { IpcMain } from 'electron'
+
+const native = vi.hoisted(() => ({
+  handlers: new Map<string, Parameters<IpcMain['handle']>[1]>(),
+  failAt: undefined as string | undefined
+}))
+
+// Keep the real surface registrars, registry, runtime builder and phase installer. Only Electron
+// and the unrelated Compute/ACP transports are replaced; business owners are supplied below.
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: Parameters<IpcMain['handle']>[1]) => {
+      if (native.failAt === channel) throw new Error(`install failed: ${channel}`)
+      if (native.handlers.has(channel)) throw new Error(`duplicate channel: ${channel}`)
+      native.handlers.set(channel, handler)
+    },
+    removeHandler: (channel: string) => native.handlers.delete(channel)
+  }
+}))
+vi.mock('../compute/ipc', () => ({ installComputeIpcHandlers: () => ({ uninstall: vi.fn() }) }))
+vi.mock('../acp/ipc', () => ({ installAcpIpcHandlers: () => ({ uninstall: vi.fn() }) }))
+
+import { createCoreElectronSurfaces, type CoreElectronSurfaceDependencies } from './core'
+import { createElectronSurfaceAdapter } from './adapter'
+import { composeApplicationRuntimeWithAdapters } from '../application-runtime'
+import {
+  installElectronRuntimeAdapters,
+  type ElectronRuntimeAdapterInterfaces
+} from '../runtime-electron-wiring'
+import { disposeIpcHandlerRegistry, ipcMainHandle } from '../ipc-handler-registry'
+import { LIFECYCLE_CHANNELS } from '../../shared/lifecycle-events'
+
+const fixture = (): {
+  dependencies: CoreElectronSurfaceDependencies
+  owners: Record<string, ReturnType<typeof vi.fn>>
+} => {
+  const owners = {
+    permissions: vi.fn(async () => ({ grants: [] })),
+    projectFiles: vi.fn(async () => ({ entries: [] })),
+    versions: vi.fn(async () => ({ ok: true, value: {} })),
+    localFs: vi.fn(() => ({ roots: [] })),
+    preview: vi.fn(async () => null)
+  }
+  // Only these public owner methods are invoked; registrars must not construct fallback owners.
+  const dependencies = {
+    permissionGrantProjection: { list: owners.permissions },
+    projectFiles: [{}, {}, {}, { listFiles: owners.projectFiles }],
+    managedFileVersionHandlers: { inspect: owners.versions },
+    localFsService: { getRoots: owners.localFs },
+    previewStateRepository: { get: owners.preview }
+  } as unknown as CoreElectronSurfaceDependencies
+  return { dependencies, owners }
+}
+
+const compose = (
+  dependencies: CoreElectronSurfaceDependencies,
+  disposed: string[] = []
+): ReturnType<typeof composeApplicationRuntimeWithAdapters> =>
+  composeApplicationRuntimeWithAdapters(async (modules) => {
+    await modules.add(undefined, () => ({
+      capability: undefined,
+      dispose: () => {
+        expect(
+          [...native.handlers.keys()].filter((channel) => channel !== 'test:external')
+        ).toEqual([])
+        disposed.push('first')
+      }
+    }))
+    await modules.add(undefined, () => ({
+      capability: undefined,
+      dispose: () => {
+        expect(
+          [...native.handlers.keys()].filter((channel) => channel !== 'test:external')
+        ).toEqual([])
+        disposed.push('second')
+      }
+    }))
+    return {
+      electronAdapters: {
+        beforeCompute: [],
+        beforeAcp: [],
+        compute: {} as ElectronRuntimeAdapterInterfaces['compute'],
+        acp: {} as ElectronRuntimeAdapterInterfaces['acp'],
+        afterAcp: createCoreElectronSurfaces(dependencies)
+      }
+    }
+  }, installElectronRuntimeAdapters)
+
+afterEach(() => {
+  native.failAt = undefined
+  disposeIpcHandlerRegistry()
+  expect(native.handlers.size).toBe(0)
+})
+
+describe('core Electron production composition', () => {
+  it('defers installation, dispatches through supplied owners, and removes only its channels', async () => {
+    const { dependencies, owners } = fixture()
+    const surfaces = createCoreElectronSurfaces(dependencies)
+    expect(surfaces.map(({ name }) => name)).toEqual([
+      'permission-grants',
+      'project-files',
+      'managed-file-versions',
+      'local-fs',
+      'preview-state',
+      'lifecycle'
+    ])
+    expect(native.handlers.size).toBe(0)
+    const external = await createElectronSurfaceAdapter('external', () =>
+      ipcMainHandle('test:external', () => 'external')
+    ).install()
+    const disposed: string[] = []
+    const runtime = await compose(dependencies, disposed)
+    expect(native.handlers.size).toBe(31) // 30 production channels plus the independently owned one.
+    const event = { sender: { id: 42 } } as Parameters<Parameters<IpcMain['handle']>[1]>[0]
+    const request = { projectId: 'project', fileId: 'file' }
+    for (const channel of [
+      'permissions:list',
+      'project-files:list-files',
+      'managed-file-versions:inspect',
+      'local-fs:get-roots'
+    ]) {
+      await native.handlers.get(channel)!(event, request)
+    }
+    await native.handlers.get('preview:load')!(event, request)
+    expect(native.handlers.get(LIFECYCLE_CHANNELS.clientId)!(event)).toBe('electron:42')
+    expect(owners.permissions).toHaveBeenCalledOnce()
+    expect(owners.projectFiles).toHaveBeenCalledWith(request)
+    expect(owners.versions).toHaveBeenCalledWith(request)
+    expect(owners.localFs).toHaveBeenCalledOnce()
+    expect(owners.preview).toHaveBeenCalledWith('project')
+
+    await runtime.dispose()
+    await runtime.dispose()
+    expect(disposed).toEqual(['second', 'first'])
+    expect([...native.handlers.keys()]).toEqual(['test:external'])
+    await external.uninstall()
+  })
+
+  it.each([
+    'permissions:revoke',
+    'project-files:resolve-file',
+    'managed-file-versions:cancel-diff',
+    'local-fs:read-preview',
+    'preview:save',
+    LIFECYCLE_CHANNELS.clientId
+  ])(
+    'rolls back partial %s installation and earlier surfaces before releasing owners',
+    async (channel) => {
+      native.failAt = channel
+      const disposed: string[] = []
+      await expect(compose(fixture().dependencies, disposed)).rejects.toThrow(
+        `install failed: ${channel}`
+      )
+      expect(native.handlers.size).toBe(0)
+      expect(disposed).toEqual(['second', 'first'])
+    }
+  )
+})

--- a/src/main/ipc-surfaces/core.ts
+++ b/src/main/ipc-surfaces/core.ts
@@ -1,0 +1,39 @@
+import { registerPermissionGrantIpcAdapter } from '../permission-grants/ipc'
+import { registerLocalFsIpcHandlers } from '../local-fs/ipc'
+import { registerManagedFileVersionIpcHandlers } from '../managed-file-versions/ipc'
+import { registerPreviewStateIpcHandlers } from '../projects/ipc'
+import { registerProjectFilesIpcHandlers } from '../project-files/ipc'
+import { registerLifecycleIpcHandlers } from '../lifecycle-broadcast'
+import type { NamedElectronSurfaceAdapter } from '../runtime-electron-wiring'
+import { createElectronSurfaceAdapter } from './adapter'
+
+export type CoreElectronSurfaceDependencies = Readonly<{
+  permissionGrantProjection: Parameters<typeof registerPermissionGrantIpcAdapter>[0]
+  projectFiles: Required<Parameters<typeof registerProjectFilesIpcHandlers>>
+  managedFileVersionHandlers: Parameters<typeof registerManagedFileVersionIpcHandlers>[0]
+  localFsService: NonNullable<Parameters<typeof registerLocalFsIpcHandlers>[0]>
+  previewStateRepository: Parameters<typeof registerPreviewStateIpcHandlers>[0]
+}>
+
+// Own only transport installation. The composition root supplies the same constructed owners used
+// by application commands; declaration does not install channels or construct another owner.
+export const createCoreElectronSurfaces = (
+  dependencies: CoreElectronSurfaceDependencies
+): NamedElectronSurfaceAdapter[] => [
+  createElectronSurfaceAdapter('permission-grants', () =>
+    registerPermissionGrantIpcAdapter(dependencies.permissionGrantProjection)
+  ),
+  createElectronSurfaceAdapter('project-files', () =>
+    registerProjectFilesIpcHandlers(...dependencies.projectFiles)
+  ),
+  createElectronSurfaceAdapter('managed-file-versions', () =>
+    registerManagedFileVersionIpcHandlers(dependencies.managedFileVersionHandlers)
+  ),
+  createElectronSurfaceAdapter('local-fs', () =>
+    registerLocalFsIpcHandlers(dependencies.localFsService)
+  ),
+  createElectronSurfaceAdapter('preview-state', () =>
+    registerPreviewStateIpcHandlers(dependencies.previewStateRepository)
+  ),
+  createElectronSurfaceAdapter('lifecycle', registerLifecycleIpcHandlers)
+]

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -17,7 +17,7 @@ import {
   type WebContents
 } from 'electron'
 
-import { createIpcHandlerInstallationScope, ipcMainHandle } from './ipc-handler-registry'
+import { ipcMainHandle } from './ipc-handler-registry'
 import {
   APPLICATION_MODULE_DISPOSAL_BUDGET_MS,
   composeApplicationRuntimeWithAdapters,
@@ -157,7 +157,6 @@ import {
   UPDATE_SHUTDOWN_BUDGET_MS,
   type ShutdownStepOutcome
 } from './lifecycle-shutdown'
-import { registerLifecycleIpcHandlers } from './lifecycle-broadcast'
 import {
   createWebSessionPersistenceFlush,
   rendererSessionPersistenceFlushBlocksShutdown,
@@ -258,8 +257,7 @@ import {
 import {
   createDefaultPreviewStateRepository,
   createDefaultProjectRepository,
-  createProjectHandlers,
-  registerPreviewStateIpcHandlers
+  createProjectHandlers
 } from './projects/ipc'
 import {
   createReviewerCommandOwner,
@@ -285,12 +283,9 @@ import {
   registerConversationExportIpcHandler
 } from './session-persistence/conversation-export'
 import { SessionProjectionDiagnostics } from './session-persistence/projection-diagnostics'
-import { createProjectFilesHandlers, registerProjectFilesIpcHandlers } from './project-files/ipc'
+import { createProjectFilesHandlers } from './project-files/ipc'
 import { createManagedFileIndexRepository } from './project-files/repository'
-import {
-  createManagedFileVersionHandlers,
-  registerManagedFileVersionIpcHandlers
-} from './managed-file-versions/ipc'
+import { createManagedFileVersionHandlers } from './managed-file-versions/ipc'
 import { ManagedFileVersionService } from './managed-file-versions/service'
 import {
   ProjectDeletionCoordinator,
@@ -302,7 +297,6 @@ import { getProjectDbClient } from './projects/prisma-client'
 import { seedDefaultPermissionGrants } from './permission-grants/defaults'
 import { createPermissionGrantRegistry } from './permission-grants/registry'
 import { isPermissionGrantScopeLive } from './permission-grants/scope-liveness'
-import { registerPermissionGrantIpcAdapter } from './permission-grants/ipc'
 import { createPermissionGrantProjectionController } from './permission-grants/projection-controller'
 import {
   reconcilePendingCustomServerDeletions,
@@ -334,7 +328,8 @@ import { SessionDeletionOwner } from './session-deletion/owner'
 import { buildSessionDetailsUserPrompt, createSessionDetailsOwner } from './session-details/owner'
 import { tryDecryptKey } from './settings/crypto'
 import { SETTINGS_INSTALL_LOG_CHANNEL, registerSettingsIpcHandlers } from './settings/ipc'
-import { registerLocalFsIpcHandlers } from './local-fs/ipc'
+import { createCoreElectronSurfaces } from './ipc-surfaces/core'
+import { createElectronSurfaceAdapter } from './ipc-surfaces/adapter'
 import { GrantedLocalRootsRepository } from './local-fs/granted-roots-repository'
 import { LocalFsService } from './local-fs/service'
 import { SettingsService } from './settings/service'
@@ -579,19 +574,7 @@ const createApplicationModules = async (
   const afterAcpAdapters: NamedElectronSurfaceAdapter[] = []
   let surfaceAdapters = beforeComputeAdapters
   const declareElectronAdapter = (name: string, install: () => void | (() => void)): void => {
-    surfaceAdapters.push({
-      name,
-      install: () => {
-        const scope = createIpcHandlerInstallationScope()
-        try {
-          const cleanup = install()
-          return scope.complete(typeof cleanup === 'function' ? cleanup : undefined)
-        } catch (error) {
-          scope.rollback()
-          throw error
-        }
-      }
-    })
+    surfaceAdapters.push(createElectronSurfaceAdapter(name, install))
   }
   const applicationEvents = await modules.add(
     installRendererBroadcastEventHub,
@@ -4831,26 +4814,20 @@ const createApplicationModules = async (
     removePackageQuitGuard()
     await sessionPackageDesktop.close()
   }
-  declareElectronAdapter('permission-grants', () =>
-    registerPermissionGrantIpcAdapter(permissionGrantProjection)
+  surfaceAdapters.push(
+    ...createCoreElectronSurfaces({
+      permissionGrantProjection,
+      projectFiles: [
+        projectFilesRepository,
+        sessionPersistenceCoordinator,
+        projectDeletionCoordinator,
+        projectFilesHandlers
+      ],
+      managedFileVersionHandlers,
+      localFsService,
+      previewStateRepository
+    })
   )
-  declareElectronAdapter('project-files', () =>
-    registerProjectFilesIpcHandlers(
-      projectFilesRepository,
-      sessionPersistenceCoordinator,
-      projectDeletionCoordinator,
-      projectFilesHandlers
-    )
-  )
-  declareElectronAdapter('managed-file-versions', () =>
-    registerManagedFileVersionIpcHandlers(managedFileVersionHandlers)
-  )
-  // Backs the "This computer" browser; shares localFsService with the managed-preview resolver.
-  declareElectronAdapter('local-fs', () => registerLocalFsIpcHandlers(localFsService))
-  declareElectronAdapter('preview-state', () =>
-    registerPreviewStateIpcHandlers(previewStateRepository)
-  )
-  declareElectronAdapter('lifecycle', () => registerLifecycleIpcHandlers())
   // Compute IPC handlers are registered earlier (before the notebook RPC server) so computeService
   // can be injected into the RPC server for the computeCall route. See above.
   // Wire the reviewer backend into the app lifecycle: installs ipcMainHandle('reviewer:run', ...)


### PR DESCRIPTION
## Problem
Electron surface registration still lived in the large `ipc.ts` composition root. The initial extraction forwarded registrar callbacks from that file, leaving the hotspot and indirect call edges largely intact. It also left a source-based owner-sharing check pointing at the old registration block, which failed in CI.

## Proposed change
- Move static imports and ordered registration for six core surfaces into `ipc-surfaces/core.ts`. `ipc.ts` now supplies already-constructed capabilities only; no registrar callbacks or fallback owners cross that boundary.
- Extract the existing synchronous installation-scope wrapper into `ipc-surfaces/adapter.ts`. Preserve partial-install rollback, successful uninstall, and cleanup semantics.
- Replace callback-only tests with real core registrars + IPC registry + runtime/phase composition over a fake Electron transport. Cover dispatch through the supplied owners, partial registration failure in each of six surfaces, cleanup before owner disposal, duplicate isolation, and cleanup failure.
- Update the root owner-sharing guard and declare an `ipc_surfaces` module test plan with owner/contract/consumer layers. CI fallback routing is unchanged.

## Scope and non-goals
Permission grants, Project Files, managed file versions, local filesystem, preview state and lifecycle remain in the same `afterAcp` order. `registerIpcHandlers` remains the facade. This is one extraction slice, not a complete production-root harness or a complete IPC catalog.

No historical data compatibility work, new status/enum values, persistence/schema changes, or UI/interaction changes. No provider protocol or execution-framework behavior changes; Compute/ACP transports are mocked in the new core harness and retain their existing tests.

## Acceptance criteria and validation
Checks below ran after the final material edit. Independent read-only review found no actionable issues and confirmed the behavior/check mapping.

| Behavior / contract | Command / evidence | Result |
| --- | --- | --- |
| Owner registration, dispatch, rollback, disposal, root wiring and consumers | `npm run test:module -- ipc_surfaces` | 17 files / 168 tests passed |
| Test-plan manifest, module planner and CI classifier | `npx vitest run scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts scripts/ci/classify-pr-changes.test.ts` | 3 files / 113 tests passed |
| Node interfaces and sandbox types | `npm run typecheck:node` | passed |
| Changed TS files | ESLint and Prettier check | passed |
| Patch whitespace | `git diff --check` | passed |
| Structural retrieval | worktree-local CodeGraph sync/explore | direct core-to-registrar calls visible |

The previous owner-sharing test failed twice with the same missing-registration assertion before correction and passes now. A rollback mutation probe (temporarily omitting `scope.rollback()`) caused five core tests to fail on leaked channels; restoring production code made all seven core cases pass.

No local full suite was run per request. Full portable/platform verification remains on this PR's CI. Local tests cover the six extracted registrars and runtime consumers; they do not execute the entire application root or every platform-native operation. Existing domain contract tests cover the individual channel behavior.

## Review focus
Check owner identity, the unchanged installation phase/order, and that a partial surface failure leaves no registered channels before runtime owners are disposed. Future edits to these surface registrations should stay inside the extracted module unless their capability requirements change.
