### PR TITLE
refactor(ipc): isolate upload surface wiring

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -1022,12 +1022,28 @@
       "fallbackCapability": "main_runtime"
     },
     "ipc_surfaces": {
-      "ownerPaths": ["src/main/ipc-surfaces/adapter.ts", "src/main/ipc-surfaces/core.ts"],
-      "interfacePaths": ["src/main/ipc-surfaces/adapter.ts", "src/main/ipc-surfaces/core.ts"],
+      "ownerPaths": [
+        "src/main/ipc-surfaces/adapter.ts",
+        "src/main/ipc-surfaces/core.ts",
+        "src/main/ipc-surfaces/uploads.ts"
+      ],
+      "interfacePaths": [
+        "src/main/ipc-surfaces/adapter.ts",
+        "src/main/ipc-surfaces/core.ts",
+        "src/main/ipc-surfaces/uploads.ts"
+      ],
       "consumerModules": [],
       "testFiles": {
-        "owner": ["src/main/ipc-surfaces/adapter.test.ts", "src/main/ipc-surfaces/core.test.ts"],
+        "owner": [
+          "src/main/ipc-surfaces/adapter.test.ts",
+          "src/main/ipc-surfaces/core.test.ts",
+          "src/main/ipc-surfaces/uploads.test.ts"
+        ],
         "contract": [
+          "src/main/uploads/ipc.test.ts",
+          "src/main/uploads/command-owner.test.ts",
+          "src/main/renderer-broadcast.test.ts",
+          "src/main/application-events.test.ts",
           "src/main/ipc-handler-registry.test.ts",
           "src/main/caller-lifecycle.test.ts",
           "src/main/runtime-electron-wiring.test.ts",

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -50,6 +50,20 @@ const dependencyBlock = compact(
 )
 
 describe('production application command wiring', () => {
+  it('keeps the upload owner and notification surface in its original installation phase', () => {
+    const uploadSurface = compact(readSource('src/main/ipc-surfaces/uploads.ts'))
+    expect(uploadSurface).toContain("import { registerUploadIpcHandlers } from '../uploads/ipc'")
+    expect(uploadSurface).toContain('registerUploadIpcHandlers(owner, {')
+    expect(
+      between(
+        ipcSource,
+        'surfaceAdapters = afterAcpAdapters',
+        "declareElectronAdapter('notebook-input-preview'"
+      )
+    ).toContain('surfaceAdapters.push(createUploadElectronSurface(uploadCommandOwner))')
+    expect(occurrences(ipcSource, 'createUploadElectronSurface(uploadCommandOwner)')).toBe(1)
+  })
+
   it('includes active reproducibility kernels in the Session export admission gate', () => {
     expect(compact(ipcSource)).toContain(
       'const notebookLifecycle = withReproducibilityNotebookLifecycle( notebookService, () => artifactReproducibilityAttemptOwnerRef.current )'
@@ -140,7 +154,7 @@ describe('production application command wiring', () => {
       ['logsCommandOwner', 'registerLogsIpcHandlers(logsCommandOwner)', 'logs: logsCommandOwner'],
       [
         'uploadCommandOwner',
-        'registerUploadIpcHandlers(uploadCommandOwner, {',
+        'surfaceAdapters.push(createUploadElectronSurface(uploadCommandOwner))',
         'uploads: uploadCommandOwner'
       ],
       [

--- a/src/main/ipc-surfaces/uploads.test.ts
+++ b/src/main/ipc-surfaces/uploads.test.ts
@@ -1,0 +1,196 @@
+import { EventEmitter } from 'node:events'
+import { resolve } from 'node:path'
+import type { IpcMain, IpcMainInvokeEvent } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+
+const native = vi.hoisted(() => ({
+  handlers: new Map<string, Parameters<IpcMain['handle']>[1]>(),
+  failAt: undefined as string | undefined,
+  windows: [
+    { isDestroyed: () => false, webContents: { send: vi.fn() } },
+    { isDestroyed: () => false, webContents: { send: vi.fn() } }
+  ]
+}))
+
+// Exercise the real registrar, registry, event hub and Electron broadcast projection.
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: Parameters<IpcMain['handle']>[1]) => {
+      if (native.failAt === channel) throw new Error(`install failed: ${channel}`)
+      if (native.handlers.has(channel)) throw new Error(`duplicate channel: ${channel}`)
+      native.handlers.set(channel, handler)
+    },
+    removeHandler: (channel: string) => native.handlers.delete(channel)
+  },
+  BrowserWindow: { getAllWindows: () => native.windows }
+}))
+
+import { ApplicationEventHub } from '../application-events'
+import { disposeIpcHandlerRegistry, ipcMainHandle } from '../ipc-handler-registry'
+import { installRendererBroadcastEventHub } from '../renderer-broadcast'
+import type { UploadCommandOwner } from '../uploads/command-owner'
+import type { UploadedAttachment } from '../../shared/uploads'
+import { createUploadElectronSurface } from './uploads'
+
+const caller = (): {
+  sender: EventEmitter & { id: number; send: ReturnType<typeof vi.fn> }
+  event: IpcMainInvokeEvent
+} => {
+  const sender = Object.assign(new EventEmitter(), { id: 42, send: vi.fn() })
+  return { sender, event: { sender } as unknown as IpcMainInvokeEvent }
+}
+const attachment: UploadedAttachment = {
+  id: 'file',
+  sessionId: 'standalone-uploads',
+  name: 'data.csv',
+  originalName: 'data.csv',
+  path: resolve('managed', 'data.csv'),
+  size: 3
+}
+const fixture = (): {
+  owner: UploadCommandOwner
+  stageLocalPath: Mock<UploadCommandOwner['stageLocalPath']>
+  beginTransfer: Mock<UploadCommandOwner['beginTransfer']>
+  pending: ReturnType<typeof Promise.withResolvers<UploadedAttachment>>
+} => {
+  const pending = Promise.withResolvers<UploadedAttachment>()
+  const stageLocalPath = vi.fn<UploadCommandOwner['stageLocalPath']>(() => pending.promise)
+  const beginTransfer = vi.fn<UploadCommandOwner['beginTransfer']>()
+  // Supply only exercised methods. Production must use this owner, not construct a fallback.
+  const owner = { stageLocalPath, beginTransfer } as unknown as UploadCommandOwner
+  return { owner, stageLocalPath, beginTransfer, pending }
+}
+let hub: ApplicationEventHub
+let uninstallHub: () => void
+
+beforeEach(() => {
+  hub = new ApplicationEventHub()
+  uninstallHub = installRendererBroadcastEventHub(hub)
+  native.windows.forEach((window) => window.webContents.send.mockClear())
+})
+afterEach(() => {
+  uninstallHub()
+  hub.dispose()
+  disposeIpcHandlerRegistry()
+  native.failAt = undefined
+  expect(native.handlers.size).toBe(0)
+})
+
+describe('upload Electron production surface', () => {
+  it('lazily installs ten channels and idempotently removes only its own handlers', async () => {
+    const surface = createUploadElectronSurface(fixture().owner)
+    expect(surface.name).toBe('uploads')
+    expect(native.handlers.size).toBe(0)
+    ipcMainHandle('test:external', () => undefined)
+    const installation = await surface.install()
+    expect([...native.handlers.keys()].filter((channel) => channel.startsWith('uploads:'))).toEqual(
+      [
+        'uploads:stage-local-file',
+        'uploads:claim-local-file',
+        'uploads:stage-local-path',
+        'uploads:begin-transfer',
+        'uploads:append-transfer',
+        'uploads:transfer-status',
+        'uploads:finish-transfer',
+        'uploads:abort-transfer',
+        'uploads:delete',
+        'uploads:read-preview'
+      ]
+    )
+    await installation.uninstall()
+    await installation.uninstall()
+    expect([...native.handlers.keys()]).toEqual(['test:external'])
+    await (await surface.install()).uninstall()
+    expect([...native.handlers.keys()]).toEqual(['test:external'])
+  })
+
+  it.each([undefined, 'project-1'])(
+    'publishes a Files refresh only after saving for project %s',
+    async (projectId) => {
+      const { owner, stageLocalPath, pending } = fixture()
+      await createUploadElectronSurface(owner).install()
+      const { event, sender } = caller()
+      const request = {
+        transferId: 'transfer',
+        name: 'data.csv',
+        sourcePath: resolve('data.csv'),
+        projectId
+      }
+      const received = vi.fn()
+      hub.subscribe(received)
+      const result = native.handlers.get('uploads:stage-local-path')!(event, request)
+      const [invocation, progressTarget] = stageLocalPath.mock.calls[0]
+      expect(invocation.args[0]).toBe(request)
+      expect(invocation.callerContext.lifecycleClientId).toBe('electron:42')
+      expect(invocation.callerLease.isCurrent()).toBe(true)
+      const progress = { transferId: 'transfer', name: 'data.csv', receivedBytes: 1, totalBytes: 3 }
+      progressTarget!.report(progress)
+      expect(sender.send).toHaveBeenCalledExactlyOnceWith('uploads:transfer-progress', progress)
+      expect(received).not.toHaveBeenCalled()
+      native.windows.forEach((window) => expect(window.webContents.send).not.toHaveBeenCalled())
+
+      pending.resolve(attachment)
+      await expect(result).resolves.toBe(attachment)
+      const payload = {
+        projectId: projectId ?? 'default-project',
+        sessionId: 'standalone-uploads',
+        sources: ['upload'],
+        kind: 'upsert'
+      }
+      expect(received).toHaveBeenCalledOnce()
+      expect(received).toHaveBeenCalledWith(
+        expect.objectContaining({ channel: 'project-files:changed', payload })
+      )
+      native.windows.forEach((window) =>
+        expect(window.webContents.send).toHaveBeenCalledExactlyOnceWith(
+          'project-files:changed',
+          payload
+        )
+      )
+      expect(sender.send).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('propagates publication failures without sending a Files refresh', async () => {
+    const { owner, pending } = fixture()
+    await createUploadElectronSurface(owner).install()
+    const received = vi.fn()
+    hub.subscribe(received)
+    const result = native.handlers.get('uploads:stage-local-path')!(caller().event, {})
+    const failure = new Error('upload publication failed')
+    const rejected = expect(result).rejects.toBe(failure)
+    pending.reject(failure)
+    await rejected
+    expect(received).not.toHaveBeenCalled()
+    native.windows.forEach((window) => expect(window.webContents.send).not.toHaveBeenCalled())
+  })
+
+  it('rolls back a partial upload installation without removing an earlier surface', async () => {
+    ipcMainHandle('test:external', () => undefined)
+    native.failAt = 'uploads:stage-local-path'
+    const surface = createUploadElectronSurface(fixture().owner)
+    expect(() => surface.install()).toThrow('install failed: uploads:stage-local-path')
+    expect([...native.handlers.keys()]).toEqual(['test:external'])
+    native.failAt = undefined
+    await (await surface.install()).uninstall()
+    expect([...native.handlers.keys()]).toEqual(['test:external'])
+  })
+
+  it('passes the registry lease to the owner and revokes it on navigation and registry disposal', async () => {
+    const { owner, beginTransfer } = fixture()
+    await createUploadElectronSurface(owner).install()
+    const { sender, event } = caller()
+    await native.handlers.get('uploads:begin-transfer')!(event, { transferId: 'first' })
+    const first = beginTransfer.mock.calls[0][0].callerLease
+    sender.emit('did-start-navigation', { isMainFrame: true, isSameDocument: false })
+    expect(first.signal.aborted).toBe(true)
+    expect(first.isCurrent()).toBe(false)
+    await native.handlers.get('uploads:begin-transfer')!(event, { transferId: 'second' })
+    const second = beginTransfer.mock.calls[1][0].callerLease
+    expect(second).not.toBe(first)
+    expect(second.isCurrent()).toBe(true)
+    disposeIpcHandlerRegistry()
+    expect(second.signal.aborted).toBe(true)
+    expect(second.isCurrent()).toBe(false)
+  })
+})

--- a/src/main/ipc-surfaces/uploads.ts
+++ b/src/main/ipc-surfaces/uploads.ts
@@ -1,0 +1,22 @@
+import { broadcastToRenderers } from '../renderer-broadcast'
+import type { NamedElectronSurfaceAdapter } from '../runtime-electron-wiring'
+import type { UploadCommandOwner } from '../uploads/command-owner'
+import { registerUploadIpcHandlers } from '../uploads/ipc'
+import { createElectronSurfaceAdapter } from './adapter'
+
+export const createUploadElectronSurface = (
+  owner: UploadCommandOwner
+): NamedElectronSurfaceAdapter =>
+  createElectronSurfaceAdapter('uploads', () =>
+    registerUploadIpcHandlers(owner, {
+      // Standalone "Save as artifact" uploads have no session mutation to piggyback on, so the
+      // Files panel only learns about them through this broadcast.
+      onStandaloneUploadSaved: (projectId, sessionId) =>
+        broadcastToRenderers('project-files:changed', {
+          projectId,
+          sessionId,
+          sources: ['upload'],
+          kind: 'upsert'
+        })
+    })
+  )

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -468,7 +468,8 @@ import {
 } from './update/strategy'
 import type { UpdateBlocker } from '../shared/update'
 import { startUpdateScheduler } from './update/scheduler'
-import { createDefaultUploadRepository, registerUploadIpcHandlers } from './uploads/ipc'
+import { createDefaultUploadRepository } from './uploads/ipc'
+import { createUploadElectronSurface } from './ipc-surfaces/uploads'
 import { createUploadCommandOwner } from './uploads/command-owner'
 import { ContentRepository } from './storage/content-repository'
 import { broadcastToRenderers, installRendererBroadcastEventHub } from './renderer-broadcast'
@@ -4674,19 +4675,7 @@ const createApplicationModules = async (
         receiptExporter.importEnvironmentLock(sender, request)
     })
   })
-  declareElectronAdapter('uploads', () =>
-    registerUploadIpcHandlers(uploadCommandOwner, {
-      // Standalone "Save as artifact" uploads have no session mutation to piggyback on, so the
-      // Files panel only learns about them through this broadcast.
-      onStandaloneUploadSaved: (projectId, sessionId) =>
-        broadcastToRenderers('project-files:changed', {
-          projectId,
-          sessionId,
-          sources: ['upload'],
-          kind: 'upsert'
-        })
-    })
-  )
+  surfaceAdapters.push(createUploadElectronSurface(uploadCommandOwner))
   declareElectronAdapter('notebook-input-preview', () => {
     ipcMainHandle('notebook:read-input-preview', (_event, request) =>
       notebookInputRegistry.readPreview(request)


### PR DESCRIPTION
## Problem

Upload IPC installation and the standalone Files refresh publication are still coupled to the large `ipc.ts` composition root. Registrar tests exercise a supplied callback, leaving the production notification wiring without a focused behavioral test.

## Proposed change

Continue the reviewed surface extraction from #2499. Move the existing upload registration and `project-files:changed` publication into an owner-only `createUploadElectronSurface`, reusing the scoped adapter factory. Keep the same shared upload owner and the same position in `afterAcp`.

The surface statically imports the real registrar and broadcaster. Its tests exercise the real registry, event hub and renderer projection with Electron mocked and a controlled business owner. The root wiring guard retains shared-owner identity and installation-phase checks.

## Scope and non-goals

- No channel/payload, progress-routing, cancellation, owner-construction or installation-order changes.
- Historical compatibility: no migration or compatibility-policy change.
- New fields, states or enum values: none.
- Persistence: no schema, format, path or write-order changes.
- UI and interaction: unchanged.
- This is a behavior-preserving refactor, not a claimed defect fix. The pre-change upload/wiring baseline passed 39 tests; no failing production scenario is being claimed.
- The full composition root and non-Electron command paths remain outside this extraction. No new general catalog, framework or runtime registry is introduced.

## Acceptance criteria and validation

Final local evidence (after the last material edit):

| Behavior | Command | Result |
| --- | --- | --- |
| Upload installation/uninstall, partial rollback, owner/lease forwarding; progress stays with caller; Files refresh follows successful publication only | `npm run test:module -- ipc_surfaces` | 22 files, 231 tests passed |
| Existing upload cancellation and command-owner contracts, event hub/broadcast, core surfaces, startup/runtime and representative command consumers | Same explained module plan | Included in the 231 tests above |
| Module ownership and test selection/classifier validity | `npm test -- scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts scripts/ci/classify-pr-changes.test.ts` | 3 files, 113 tests passed |
| Node and sandbox types | `npm run typecheck:node` | Passed, including sandbox |
| Lint | `npm run lint` | Passed |
| Formatting and whitespace | Prettier check on all five changed files; `git diff --check` | Passed |

Per the maintainer's explicit instruction, no complete local `npm test` run was performed. The manifest adds the new surface to the existing module and its tests; it does not narrow the CI fallback for `ipc.ts`. Exact-head PR CI and independent review remain required before considering verification complete.

The root CodeGraph index informed pre-change owner/lifecycle analysis. The fresh worktree has no independent index, so final graph-query retrieval improvement is not asserted; direct imports and calls are checked by the wiring guard and TypeScript. New upload behavior tests mock the business owner; existing upload owner/IPC contracts cover the underlying cancellation and publication behavior. No Electron E2E or platform lane was run locally because no native API, filesystem operation, UI, or platform path logic changed.

## Review focus

Check unchanged upload adapter placement and shared owner identity; verify that the notification options were moved unchanged and that the test impact set covers the final diff. The benefit is local ownership and behavioral testing of upload transport notification wiring, not a broad reduction in composition-root size.
