### PR TITLE
fix(session-persistence): roll back failed first-save allocations

### DIFF
--- a/src/main/session-persistence/auxiliary-turn-usage.test.ts
+++ b/src/main/session-persistence/auxiliary-turn-usage.test.ts
@@ -34,7 +34,7 @@ beforeEach(async () => {
   await migrateApplicationDatabase(client)
   await client.project.create({ data: { id: 'project', name: 'Project' } })
   projection = new SessionProjectionRepository(async () => client)
-  const session = await projection.prepareSave({
+  const { session: session } = await projection.prepareSave({
     id: 'session',
     projectId: 'project',
     title: 'Session',

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -1,4 +1,4 @@
-import { lstat, mkdtemp, readFile, rename, rm, truncate, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, mkdtemp, readFile, rename, rm, truncate, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -398,8 +398,8 @@ describe('Session projection', () => {
     })
     const repository = new SessionProjectionRepository(async () => client!)
 
-    const first = await repository.prepareSave(session('session-1', 100))
-    const second = await repository.prepareSave(session('session-2', 200))
+    const { session: first } = await repository.prepareSave(session('session-1', 100))
+    const { session: second } = await repository.prepareSave(session('session-2', 200))
     expect([first.number, second.number]).toEqual([1, 2])
 
     await repository.commitSave(first)
@@ -461,7 +461,7 @@ describe('Session projection', () => {
       data: { id: 'project-1', name: 'Project', createdAt: new Date(50) }
     })
     const repository = new SessionProjectionRepository(async () => client!)
-    const projected = await repository.prepareSave(session('auxiliary', 100))
+    const { session: projected } = await repository.prepareSave(session('auxiliary', 100))
     await repository.commitSave(projected)
     const recorder = new SessionAuxiliaryTurnUsageRecorder(async () => client!)
     const record = {
@@ -831,7 +831,7 @@ describe('Session projection', () => {
     })
     const repository = new SessionProjectionRepository(async () => client!)
 
-    const first = await repository.prepareSave(session('session-1'))
+    const { session: first } = await repository.prepareSave(session('session-1'))
     await repository.commitSave(first)
     await repository.commitDelete(first.projectId, first.id)
 
@@ -863,7 +863,7 @@ describe('Session projection', () => {
     await repository.markPending(first.projectId, first.id)
     await expect(repository.commitReconciliation(first)).resolves.toBeUndefined()
     await expect(repository.pending()).resolves.toEqual([])
-    const second = await repository.prepareSave(session('session-2'))
+    const { session: second } = await repository.prepareSave(session('session-2'))
     expect(second.number).toBe(2)
     const primaryKey = await client.$queryRaw<Array<{ name: string; pk: bigint }>>`
       PRAGMA table_info("Session")
@@ -891,7 +891,7 @@ describe('Session projection', () => {
       ]
     })
     const repository = new SessionProjectionRepository(async () => client!)
-    const owned = await repository.prepareSave({
+    const { session: owned } = await repository.prepareSave({
       ...session('session-1'),
       projectId: 'project-2'
     })
@@ -929,7 +929,7 @@ describe('Session projection', () => {
       data: { id: 'project-1', name: 'Project', createdAt: new Date(50) }
     })
     const sessions = new SessionProjectionRepository(async () => client!)
-    const saved = await sessions.prepareSave(session('session-1'))
+    const { session: saved } = await sessions.prepareSave(session('session-1'))
     await sessions.commitSave(saved)
 
     await new ProjectRepository(async () => client!).delete('project-1')
@@ -1027,6 +1027,229 @@ describe('Session projection', () => {
     await expect(repository.loadSession('project-1', 'session-1')).resolves.toMatchObject({
       title: 'Newer concurrent title'
     })
+  })
+
+  it('allows retry of a first save after recovery of a failed JSON publication', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-first-save-recovery-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const repository = new SessionRepository(storageRoot, {}, projection)
+    await repository.ensureSessionProjection(() => repository.loadAll())
+
+    // Introduce the filesystem failure at the existing projection boundary, after admission checks
+    // and the real SQLite reservation, but before the first JSON publication.
+    const sessionsDirectory = join(storageRoot, 'sessions')
+    const projectDirectory = join(sessionsDirectory, 'project-1')
+    await mkdir(sessionsDirectory, { recursive: true })
+    const prepareSave = projection.prepareSave.bind(projection)
+    vi.spyOn(projection, 'prepareSave').mockImplementationOnce(async (incoming) => {
+      const prepared = await prepareSave(incoming)
+      await expect(projection.pending()).resolves.toEqual([
+        { projectId: 'project-1', sessionId: 'session-1', operation: 'save' }
+      ])
+      await writeFile(projectDirectory, 'temporary directory obstacle')
+      return prepared
+    })
+    await expect(repository.saveSession(session('session-1'), 0)).rejects.toThrow()
+    await rm(projectDirectory)
+    await expect(repository.loadSession('project-1', 'session-1')).resolves.toBeUndefined()
+
+    // Restart the storage owners and connection: no previous in-memory revision or scheduler survives.
+    await client.$disconnect()
+    client = createProjectDbClient(storageRoot)
+    const restartedProjection = new SessionProjectionRepository(async () => client!)
+    const restarted = new SessionRepository(storageRoot, {}, restartedProjection)
+    await restarted.ensureSessionProjection(() => restarted.loadAll())
+    await expect(restartedProjection.pending()).resolves.toEqual([])
+    await expect(restartedProjection.list()).resolves.toEqual([])
+
+    // No user deletion occurred. Retrying the unsaved draft must remain possible.
+    await expect(restarted.saveSession(session('session-1'), 0)).resolves.toMatchObject({
+      id: 'session-1',
+      revision: 1
+    })
+  })
+
+  it.each([false, true])(
+    'recovers JSON authority after projection commit failure (existing Session: %s)',
+    async (existing) => {
+      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-commit-recovery-'))
+      client = createProjectDbClient(storageRoot)
+      await migrateApplicationDatabase(client)
+      await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+      const projection = new SessionProjectionRepository(async () => client!)
+      const repository = new SessionRepository(storageRoot, {}, projection)
+      await repository.ensureSessionProjection(() => repository.loadAll())
+      const original = session('session-1')
+      const saved = existing ? await repository.saveSession(original, 0) : original
+      const failure = new Error('injected SQLite commit failure')
+      vi.spyOn(projection, 'commitSave').mockRejectedValueOnce(failure)
+      await expect(
+        repository.saveSession({ ...saved, title: 'Durable new title' }, saved.revision ?? 0)
+      ).rejects.toBe(failure)
+      await expect(projection.pending()).resolves.toEqual([
+        { projectId: 'project-1', sessionId: 'session-1', operation: 'save' }
+      ])
+      await expect(repository.loadSession('project-1', 'session-1')).resolves.toMatchObject({
+        title: 'Durable new title',
+        revision: (saved.revision ?? 0) + 1
+      })
+
+      await client.$disconnect()
+      client = createProjectDbClient(storageRoot)
+      const restartedProjection = new SessionProjectionRepository(async () => client!)
+      const restarted = new SessionRepository(storageRoot, {}, restartedProjection)
+      await restarted.ensureSessionProjection(() => restarted.loadAll())
+      await expect(restartedProjection.pending()).resolves.toEqual([])
+      await expect(restartedProjection.list()).resolves.toEqual([
+        expect.objectContaining({ id: 'session-1', title: 'Durable new title' })
+      ])
+      await expect(restarted.loadSession('project-1', 'session-1')).resolves.toMatchObject({
+        title: 'Durable new title'
+      })
+    }
+  )
+
+  it.each([
+    { existing: false, publication: 'absent' },
+    { existing: true, publication: 'absent' },
+    { existing: false, publication: 'temporary' },
+    { existing: false, publication: 'published' }
+  ] as const)(
+    'preserves the correct retry authority after rename failure ($existing, $publication)',
+    async ({ existing, publication }) => {
+      storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-rename-recovery-'))
+      client = createProjectDbClient(storageRoot)
+      await migrateApplicationDatabase(client)
+      await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+      const projection = new SessionProjectionRepository(async () => client!)
+      const files = new SessionRepository(storageRoot, {}, projection)
+      await files.ensureSessionProjection(() => files.loadAll())
+      const original = existing
+        ? await files.saveSession(session('session-1'))
+        : session('session-1')
+      const failure = new Error('injected Session rename failure')
+      let temporaryPath: string | undefined
+      const failing = new SessionRepository(
+        storageRoot,
+        {
+          renameFile: async (source, destination) => {
+            temporaryPath = source
+            if (publication === 'published') await rename(source, destination)
+            throw failure
+          },
+          remove: async (path, options) => {
+            if (publication === 'temporary') throw new Error('temporary cleanup failed')
+            await rm(path, options)
+          }
+        },
+        projection
+      )
+
+      // Trusted Main writes omit expectedRevision; they must get the same compensation as renderer writes.
+      await expect(failing.saveSession({ ...original, title: 'New title' })).rejects.toBe(failure)
+      const rolledBack = !existing && publication === 'absent'
+      await expect(projection.pending()).resolves.toHaveLength(rolledBack ? 0 : 1)
+      if (rolledBack) {
+        await expect(client.session.findUnique({ where: { id: original.id } })).resolves.toBeNull()
+        const retried = await files.saveSession(original, 0)
+        expect(retried.number).toBe(2)
+        expect(retried.revision).toBe(1)
+      } else {
+        await expect(
+          client.session.findUnique({ where: { id: original.id } })
+        ).resolves.toMatchObject({
+          deletedAtMs: null
+        })
+        if (publication === 'temporary') {
+          // A failed temporary cleanup is unresolved authority, not permission to discard its index.
+          // Automatic pending replay of a temp-only Session is a separate recovery contract.
+          expect(JSON.parse(await readFile(temporaryPath!, 'utf8')).session.title).toBe('New title')
+          return
+        }
+        await files.ensureSessionProjection(() => files.loadAll())
+        await expect(files.loadSession(original.projectId, original.id)).resolves.toMatchObject({
+          title: publication === 'absent' ? original.title : 'New title'
+        })
+        await expect(projection.pending()).resolves.toEqual([])
+      }
+    }
+  )
+
+  it('retains both errors and pending evidence when allocation compensation fails', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-compensation-failure-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const failure = new Error('injected Session rename failure')
+    const repository = new SessionRepository(
+      storageRoot,
+      {
+        renameFile: async () => {
+          await client!.$executeRawUnsafe('PRAGMA query_only = ON')
+          throw failure
+        }
+      },
+      projection
+    )
+    await repository.ensureSessionProjection(() => repository.loadAll())
+
+    const rejected = await repository
+      .saveSession(session('session-1'), 0)
+      .catch((error: unknown) => error)
+    await client.$executeRawUnsafe('PRAGMA query_only = OFF')
+    expect(rejected).toBeInstanceOf(AggregateError)
+    expect(rejected).toMatchObject({ cause: failure, errors: [failure, expect.any(Error)] })
+    await expect(projection.pending()).resolves.toEqual([
+      { projectId: 'project-1', sessionId: 'session-1', operation: 'save' }
+    ])
+    await expect(client.session.findUnique({ where: { id: 'session-1' } })).resolves.toMatchObject({
+      deletedAtMs: null
+    })
+    // The original draft can still retry before a catalog replay, without pretending the first save succeeded.
+    const retrying = new SessionRepository(storageRoot, {}, projection)
+    await expect(retrying.saveSession(session('session-1'), 0)).resolves.toMatchObject({
+      revision: 1
+    })
+  })
+
+  it('does not discard a committed deletion with a stale allocation receipt', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-receipt-delete-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const prepared = await projection.prepareSave(session('session-1'))
+    await projection.commitDelete('project-1', 'session-1')
+    await expect(projection.abortUnpublishedSave(prepared)).rejects.toThrow(
+      'pending operation has changed'
+    )
+    await expect(projection.prepareSave(session('session-1'))).rejects.toThrow('deleted Session')
+    await expect(client.session.findUnique({ where: { id: 'session-1' } })).resolves.toMatchObject({
+      deletedAtMs: expect.anything()
+    })
+  })
+
+  it('does not cascade-delete published facts through an old allocation receipt', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-receipt-facts-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const prepared = await projection.prepareSave(session('session-1'))
+    await projection.commitSave(prepared.session)
+    await projection.markPending('project-1', 'session-1')
+    await expect(projection.abortUnpublishedSave(prepared)).rejects.toThrow(
+      'allocation that has changed'
+    )
+    await expect(projection.list()).resolves.toHaveLength(1)
+    await expect(projection.usage()).resolves.toMatchObject({
+      usageEvents: [expect.objectContaining({ inputTokens: 10 })]
+    })
+    await expect(projection.pending()).resolves.toHaveLength(1)
   })
 
   it('resumes an individually deleted Session after a crash before JSON removal', async () => {

--- a/src/main/session-persistence/projection.test.ts
+++ b/src/main/session-persistence/projection.test.ts
@@ -1216,6 +1216,52 @@ describe('Session projection', () => {
     })
   })
 
+  it('preserves auxiliary usage recorded before a failed first publication', async () => {
+    storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-auxiliary-usage-'))
+    client = createProjectDbClient(storageRoot)
+    await migrateApplicationDatabase(client)
+    await client.project.create({ data: { id: 'project-1', name: 'Project' } })
+    const projection = new SessionProjectionRepository(async () => client!)
+    const recorder = new SessionAuxiliaryTurnUsageRecorder(async () => client!)
+    const failure = new Error('injected Session rename failure')
+    const usageEvent = { timestamp: 120, inputTokens: 5, cacheTokens: 2, outputTokens: 4 }
+    const repository = new SessionRepository(
+      storageRoot,
+      {
+        renameFile: async () => {
+          await recorder.record({
+            projectId: 'project-1',
+            sessionId: 'session-1',
+            eventId: 'side-stop-1',
+            source: 'side-chat',
+            frameworkId: 'codebuddy',
+            completedAtMs: usageEvent.timestamp,
+            usage: usageEvent
+          })
+          await expect(projection.usage()).resolves.toMatchObject({ usageEvents: [usageEvent] })
+          throw failure
+        }
+      },
+      projection
+    )
+    await repository.ensureSessionProjection(() => repository.loadAll())
+    const draft = { ...session('session-1'), messages: [] }
+
+    const rejected = await repository.saveSession(draft, 0).catch((error: unknown) => error)
+    // Durable usage must remain visible with its original owner even though no JSON was published.
+    await expect(projection.usage()).resolves.toMatchObject({ usageEvents: [usageEvent] })
+    expect(rejected).toMatchObject({ cause: failure, errors: [failure, expect.any(Error)] })
+    await expect(projection.pending()).resolves.toHaveLength(1)
+    await expect(client.session.findUnique({ where: { id: draft.id } })).resolves.toMatchObject({
+      number: 1,
+      deletedAtMs: null
+    })
+    const retrying = new SessionRepository(storageRoot, {}, projection)
+    await expect(retrying.saveSession(draft, 0)).resolves.toMatchObject({ number: 1, revision: 1 })
+    await expect(projection.usage()).resolves.toMatchObject({ usageEvents: [usageEvent] })
+    await expect(projection.pending()).resolves.toEqual([])
+  })
+
   it('does not discard a committed deletion with a stale allocation receipt', async () => {
     storageRoot = await mkdtemp(join(tmpdir(), 'open-science-save-receipt-delete-'))
     client = createProjectDbClient(storageRoot)

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -675,6 +675,14 @@ export class SessionProjectionRepository {
       if (pending?.projectId !== session.projectId || pending.operation !== 'save') {
         throw new Error('Cannot discard a Session allocation whose pending operation has changed.')
       }
+      // Auxiliary usage has no Session foreign key; preserve its owner in the same transaction.
+      const auxiliaryUsage = await tx.sessionAuxiliaryTurnUsage.findFirst({
+        where: { sessionId: session.id },
+        select: { eventId: true }
+      })
+      if (auxiliaryUsage) {
+        throw new Error('Cannot discard a Session allocation that has changed.')
+      }
       const removed = await tx.session.deleteMany({
         where: {
           id: session.id,

--- a/src/main/session-persistence/projection.ts
+++ b/src/main/session-persistence/projection.ts
@@ -26,6 +26,12 @@ const PROJECTION_VERSION = 5
 const SESSION_NUMBER_SEQUENCE_ID = 'global'
 const MAX_SAFE_INTEGER_BIGINT = BigInt(Number.MAX_SAFE_INTEGER)
 const MAX_SQLITE_INT = 2_147_483_647
+
+// An in-process allocation receipt, never part of Session JSON or the database schema.
+export type PreparedSessionSave = {
+  session: PersistedChatSession
+  created: boolean
+}
 const PERSISTED_SESSION_STATUSES: ReadonlySet<string> = new Set([
   'idle',
   'running',
@@ -599,11 +605,11 @@ export class SessionProjectionRepository {
     return client.session.findMany({ select: { id: true, number: true } })
   }
 
-  async prepareSave(session: PersistedChatSession): Promise<PersistedChatSession> {
+  async prepareSave(session: PersistedChatSession): Promise<PreparedSessionSave> {
     const client = await this.client()
     const projection = buildSessionProjection(session)
     assertProjectionStorageShape(projection)
-    const number = await runProjectionTransaction(client, async (tx) => {
+    const allocation = await runProjectionTransaction(client, async (tx) => {
       const project = await tx.project.findFirst({
         where: { id: session.projectId, deletedAt: null },
         select: { id: true }
@@ -620,7 +626,7 @@ export class SessionProjectionRepository {
         create: { sessionId: session.id, projectId: session.projectId, operation: 'save' },
         update: { projectId: session.projectId, operation: 'save', markedAt: new Date() }
       })
-      if (existing) return existing.number
+      if (existing) return { number: existing.number, created: false }
       const preferredNumber = session.number
       let number: number
       if (preferredNumber !== undefined) {
@@ -648,9 +654,44 @@ export class SessionProjectionRepository {
         number = sequence.nextNumber - 1
       }
       const created = await tx.session.create({ data: sessionData(projection, number) })
-      return created.number
+      return { number: created.number, created: true }
     })
-    return session.number === number ? session : { ...session, number }
+    return {
+      session:
+        session.number === allocation.number ? session : { ...session, number: allocation.number },
+      created: allocation.created
+    }
+  }
+
+  // The Repository must first prove that this failed first publication left no JSON authority,
+  // including recoverable temporary files. Never reuse its number or remove an existing tombstone.
+  async abortUnpublishedSave({ session, created }: PreparedSessionSave): Promise<void> {
+    if (!created) return
+    const client = await this.client()
+    await runProjectionTransaction(client, async (tx) => {
+      const pending = await tx.pendingSessionReconciliation.findUnique({
+        where: { sessionId: session.id }
+      })
+      if (pending?.projectId !== session.projectId || pending.operation !== 'save') {
+        throw new Error('Cannot discard a Session allocation whose pending operation has changed.')
+      }
+      const removed = await tx.session.deleteMany({
+        where: {
+          id: session.id,
+          projectId: session.projectId,
+          number: session.number,
+          revision: BigInt(session.revision ?? 0),
+          deletedAtMs: null,
+          turnUsage: { none: {} },
+          runs: { none: {} },
+          artifactRefs: { none: {} }
+        }
+      })
+      if (removed.count !== 1) {
+        throw new Error('Cannot discard a Session allocation that has changed.')
+      }
+      await tx.pendingSessionReconciliation.deleteMany({ where: { sessionId: session.id } })
+    })
   }
 
   async commitSave(session: PersistedChatSession): Promise<void> {

--- a/src/main/session-persistence/repository.ts
+++ b/src/main/session-persistence/repository.ts
@@ -993,7 +993,9 @@ class SessionRepository {
     ) {
       throw new Error('Session expected revision must be a non-negative integer.')
     }
-    await this.assertExistingSessionWithinLimit(this.sessionFilePath(session.projectId, session.id))
+    const hadPrimaryAuthority = await this.assertExistingSessionWithinLimit(
+      this.sessionFilePath(session.projectId, session.id)
+    )
     if (expectedRevision !== undefined) {
       // Both checks own the same serialized save lane. Reuse this operation's authority read;
       // the next save must load again so revision and readonly checks never use a stale cache.
@@ -1029,29 +1031,46 @@ class SessionRepository {
     if (this.projection && this.projectionWritesSuspended) {
       assertSessionProjectionStorageShape(session)
     }
-    const projectedSession =
+    const preparedProjection =
       this.projection && !this.projectionWritesSuspended
         ? await this.projection.prepareSave(session)
-        : session
+        : undefined
     const durableSession: PersistedChatSession = {
-      ...projectedSession,
+      ...(preparedProjection?.session ?? session),
       revision: nextRevision
     }
     // prepareSave only assigns the authoritative number. Reuse the normalized graph instead
     // of materializing it again; retain the final byte check before writing authority.
-    let preparedWrite = unprojectedWrite
-    if (unprojectedWrite.document.session.number !== durableSession.number) {
-      const document = {
-        ...unprojectedWrite.document,
-        session: { ...unprojectedWrite.document.session, number: durableSession.number }
+    try {
+      let preparedWrite = unprojectedWrite
+      if (unprojectedWrite.document.session.number !== durableSession.number) {
+        const document = {
+          ...unprojectedWrite.document,
+          session: { ...unprojectedWrite.document.session, number: durableSession.number }
+        }
+        preparedWrite = {
+          ...unprojectedWrite,
+          document,
+          contents: this.serializeJsonForWrite(document, this.dependencies.maxSessionBytes)
+        }
       }
-      preparedWrite = {
-        ...unprojectedWrite,
-        document,
-        contents: this.serializeJsonForWrite(document, this.dependencies.maxSessionBytes)
+      await this.writeSession(durableSession, preparedWrite)
+    } catch (error) {
+      if (preparedProjection?.created && !hadPrimaryAuthority) {
+        try {
+          if (await this.hasNoSessionAuthorityFiles(session.projectId, session.id)) {
+            await this.projection!.abortUnpublishedSave(preparedProjection)
+          }
+        } catch (compensationError) {
+          throw new AggregateError(
+            [error, compensationError],
+            'Session publication and allocation cleanup failed.',
+            { cause: error }
+          )
+        }
       }
+      throw error
     }
-    await this.writeSession(durableSession, preparedWrite)
     if (this.projectionWritesSuspended) {
       this.suspendedProjectionSessionWrites.set(key, {
         projectId: session.projectId,
@@ -1341,13 +1360,27 @@ class SessionRepository {
     await this.atomicWriteContents(filePath, contents)
   }
 
-  private async assertExistingSessionWithinLimit(filePath: string): Promise<void> {
+  private async assertExistingSessionWithinLimit(filePath: string): Promise<boolean> {
     try {
       if ((await lstat(filePath)).size > this.dependencies.maxSessionBytes) {
         throw new SessionSizeLimitError(this.dependencies.maxSessionBytes)
       }
+      return true
     } catch (error) {
-      if (isMissingFileError(error)) return
+      if (isMissingFileError(error)) return false
+      throw error
+    }
+  }
+
+  private async hasNoSessionAuthorityFiles(projectId: string, sessionId: string): Promise<boolean> {
+    try {
+      const entries = await this.dependencies.readDirectoryEntries(this.projectDir(projectId))
+      const primary = `${assertSafeSegment(sessionId)}.json`
+      // Retain evidence even when only a temporary, backup, or quarantined file remains.
+      return !entries.some(({ name }) => name === primary || name.startsWith(`${primary}.`))
+    } catch (error) {
+      if (isMissingFileError(error) || (error as NodeJS.ErrnoException).code === 'ENOTDIR')
+        return true
       throw error
     }
   }

--- a/src/main/session-persistence/usage-regressions.test.ts
+++ b/src/main/session-persistence/usage-regressions.test.ts
@@ -108,7 +108,7 @@ const save = async (id: string): Promise<PersistedChatSession> => {
       )
     )
   )
-  const prepared = await repository.prepareSave(input)
+  const { session: prepared } = await repository.prepareSave(input)
   await repository.commitSave(prepared)
   return prepared
 }
@@ -122,7 +122,7 @@ describe('usage through real store, Session codec, and SQLite', () => {
   it('does not count imported source usage as local execution', async () => {
     run('source')
     const source = await save('source')
-    const imported = await repository.prepareSave({
+    const { session: imported } = await repository.prepareSave({
       ...structuredClone(source),
       id: 'imported',
       number: undefined,
@@ -226,7 +226,7 @@ describe('usage through real store, Session codec, and SQLite', () => {
     await save('nested')
     expect(await summary()).toMatchObject({ totalSessions: 3, totalRuns: 2, totalTokens: 30 })
     // Equal message/call IDs in an independent Session remain independent execution identities.
-    const independent = await repository.prepareSave({
+    const { session: independent } = await repository.prepareSave({
       ...source,
       id: 'independent',
       number: undefined


### PR DESCRIPTION
## Problem

A first Session save can allocate its SQLite projection and pending save before JSON publication fails. Later catalog recovery sees no JSON and turns that allocation into a deletion tombstone. Retrying the original, never-published draft then fails with `Cannot save a deleted Session`.

## Proposed change

Return an internal allocation receipt from `prepareSave`. On failed publication, compensate only a newly created projection whose primary JSON was absent at admission and whose directory contains no primary, temporary, backup or quarantine evidence. Remove the unchanged allocation and pending save in one SQLite transaction. Preserve tombstones, published child facts, independently recorded auxiliary usage and the number sequence; retain both errors if compensation fails. JSON-success/projection-failure recovery is unchanged.

The public Session Repository/IPC return contract remains unchanged. The three projection test consumers unwrap the internal receipt.

## Scope and non-goals

- Persistence behavior changes; no database columns, JSON fields, migrations, business enum values, UI or provider protocol changes. The receipt is transient.
- No bulk repair of historical tombstones. No generic transaction framework or append-log migration.
- Crash before compensation, failed compensation, and temp-only pending replay remain separate recovery concerns. A probe found that existing pending replay can tombstone a temp-only first save; this patch retains that file/pending evidence at the failed-save boundary and does not claim to fix the subsequent replay.

## Acceptance criteria and validation

The real-filesystem/real-SQLite regression failed repeatedly on unchanged production code, including immediately before implementation, at the retry promise with the reported deleted-Session error. It now passes. New controls cover trusted writes, existing authority, temporary retention, errors after rename, projection commit failures, failed compensation, tombstones and published facts.

An additional real-SQLite regression recorded auxiliary usage through the existing rename boundary before failing first publication. Before the guard, it failed twice because the usage projection became empty. It now verifies that usage stays visible, the owner and number remain intact, and the draft retries successfully.

Local checks after the last material edit:

| Behavior | Project-owned check | Result |
| --- | --- | --- |
| Repository, projection, durable JSON and usage contracts | `npm test -- src/main/session-persistence/projection.test.ts src/main/session-persistence/repository.test.ts src/main/session-persistence/repository-queue.test.ts src/main/session-persistence/auxiliary-turn-usage.test.ts src/main/session-persistence/usage-regressions.test.ts src/main/storage/durable-json-file.test.ts` | 174 passed |
| Main ownership, hydration, deletion and IPC | `npm run test:module -- session_persistence` | 653 passed |
| Project deletion, renderer flush and merge consumers | `npm test -- src/main/projects/deletion-coordinator.test.ts src/main/session-persistence/deletion-integration.test.ts src/main/session-persistence/renderer-flush.test.ts src/renderer/src/lib/session-persistence/session-persistence.test.ts src/renderer/src/stores/session-store.test.ts` | 434 passed |
| Main types | `npm run typecheck:node` | Passed, including sandbox package |
| Style | `npm run lint`; Prettier and `git diff --check` | Passed |

CodeGraph traces the root-checkout Repository/projection relationship; worktree references confirm Repository is the sole production `prepareSave` consumer. Its private receipt remains inside this boundary. The affected-plan classifier requests full CI because changed projection files/test consumers lack module ownership entries (the exact-head plan first flags auxiliary-turn-usage.test.ts). Per maintainer instruction, no full local suite was run; exact-head CI and independent review remain required. Tests use portable temporary paths but do not simulate OS power loss or exercise live providers/multiple windows. No renderer/interface change requires a new UI screenshot.

## Review focus

Please check the evidence required before compensating and the conditional transaction's non-resurrection guarantees. In particular, missing authority after a crash is not treated as proof of first publication.

Prior art: VS Code's [chat write confirmation](https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/chat/common/model/objectMutationLog.ts) distinguishes prepared from confirmed state for retries. Its storage model differs; this patch does not adopt its log format.
