### PR TITLE
refactor(ipc): isolate notification surface wiring

### DIFF
--- a/scripts/ci/module-impact.json
+++ b/scripts/ci/module-impact.json
@@ -1025,21 +1025,28 @@
       "ownerPaths": [
         "src/main/ipc-surfaces/adapter.ts",
         "src/main/ipc-surfaces/core.ts",
-        "src/main/ipc-surfaces/uploads.ts"
+        "src/main/ipc-surfaces/uploads.ts",
+        "src/main/ipc-surfaces/notifications.ts"
       ],
       "interfacePaths": [
         "src/main/ipc-surfaces/adapter.ts",
         "src/main/ipc-surfaces/core.ts",
-        "src/main/ipc-surfaces/uploads.ts"
+        "src/main/ipc-surfaces/uploads.ts",
+        "src/main/ipc-surfaces/notifications.ts"
       ],
       "consumerModules": [],
       "testFiles": {
         "owner": [
           "src/main/ipc-surfaces/adapter.test.ts",
           "src/main/ipc-surfaces/core.test.ts",
-          "src/main/ipc-surfaces/uploads.test.ts"
+          "src/main/ipc-surfaces/uploads.test.ts",
+          "src/main/ipc-surfaces/notifications.test.ts"
         ],
         "contract": [
+          "src/main/notifications/notification-inbox-ipc.test.ts",
+          "src/main/notifications/electron-wiring.test.ts",
+          "src/main/notifications/task-notifications.test.ts",
+          "src/main/notifications/notification-inbox-controller.test.ts",
           "src/main/uploads/ipc.test.ts",
           "src/main/uploads/command-owner.test.ts",
           "src/main/renderer-broadcast.test.ts",

--- a/src/main/application-command-wiring.test.ts
+++ b/src/main/application-command-wiring.test.ts
@@ -34,13 +34,7 @@ const webAdapterSources = [
 const legacyAdapterBlock = compact(
   between(ipcSource, "declareElectronAdapter('desktop-utilities'", 'const electronSenderFor')
 )
-const notificationAdapterBlock = compact(
-  between(
-    ipcSource,
-    "declareElectronAdapter('task-notifications'",
-    'const connectorApplication = await modules.add('
-  )
-)
+const notificationAdapterBlock = compact(readSource('src/main/ipc-surfaces/notifications.ts'))
 const dependencyBlock = compact(
   between(
     ipcSource,
@@ -264,9 +258,28 @@ describe('production application command wiring', () => {
   })
 
   it('installs every notification inbox request on the Electron adapter', () => {
-    expect(notificationAdapterBlock).toContain(
-      'registerNotificationInboxIpcAdapter(notificationInbox)'
+    expect(
+      compact(
+        between(
+          ipcSource,
+          'let surfaceAdapters = beforeComputeAdapters',
+          'surfaceAdapters = beforeAcpAdapters'
+        )
+      )
+    ).toContain(
+      'surfaceAdapters.push( createNotificationElectronSurface( notificationInbox, taskNotifications, taskNotificationDeliveryDeps ) )'
     )
+    expect(occurrences(ipcSource, 'createNotificationElectronSurface(')).toBe(1)
+    expect(notificationAdapterBlock).toContain(
+      "import { registerNotificationInboxIpcAdapter, type NotificationInboxIpcOwner } from '../notifications/notification-inbox-ipc'"
+    )
+    expect(notificationAdapterBlock).toContain('registerNotificationInboxIpcAdapter(inbox)')
+    expect(notificationAdapterBlock).toContain('taskNotifications.peekPendingOpenSession()')
+    expect(notificationAdapterBlock).toContain(
+      'taskNotifications.takePendingOpenSession(expectedToken)'
+    )
+    expect(notificationAdapterBlock).toContain('getTaskNotificationAvailability(delivery)')
+    expect(notificationAdapterBlock).toContain('showTestTaskNotification(delivery)')
     expect(notificationIpcSource).toContain("ipcMainHandle('notifications:get-snapshot'")
     expect(notificationIpcSource).toContain("ipcMainHandle('notifications:mark-read'")
     expect(notificationIpcSource).toContain("ipcMainHandle('notifications:mark-all-read'")

--- a/src/main/ipc-surfaces/notifications.test.ts
+++ b/src/main/ipc-surfaces/notifications.test.ts
@@ -1,0 +1,187 @@
+import { EventEmitter } from 'node:events'
+import type { IpcMain, IpcMainInvokeEvent, Notification } from 'electron'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const native = vi.hoisted(() => ({
+  handlers: new Map<string, Parameters<IpcMain['handle']>[1]>(),
+  failAt: undefined as string | undefined
+}))
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: (channel: string, handler: Parameters<IpcMain['handle']>[1]) => {
+      if (native.failAt === channel) throw new Error(`install failed: ${channel}`)
+      if (native.handlers.has(channel)) throw new Error(`duplicate channel: ${channel}`)
+      native.handlers.set(channel, handler)
+    },
+    removeHandler: (channel: string) => native.handlers.delete(channel)
+  }
+}))
+
+import { disposeIpcHandlerRegistry, ipcMainHandle } from '../ipc-handler-registry'
+import type { BuildTaskNotificationShowDeps } from '../notifications/electron-wiring'
+import type { NotificationInboxIpcOwner } from '../notifications/notification-inbox-ipc'
+import { TaskNotificationService } from '../notifications/task-notifications'
+import { createNotificationElectronSurface } from './notifications'
+
+class FakeNotification extends EventEmitter {
+  static isSupported = vi.fn(() => true)
+  static constructed: FakeNotification[] = []
+  constructor(readonly options: { title?: string; body?: string }) {
+    super()
+    FakeNotification.constructed.push(this)
+  }
+  show(): void {
+    this.emit('show')
+  }
+}
+
+const fixture = (): {
+  inbox: NotificationInboxIpcOwner
+  tasks: TaskNotificationService
+  delivery: BuildTaskNotificationShowDeps
+} => ({
+  inbox: {
+    getSnapshot: vi.fn(async () => ({ revision: 1, latestSequence: 0, unreadCount: 0, items: [] })),
+    markRead: vi.fn(async () => undefined),
+    markAllRead: vi.fn(async () => undefined),
+    markSessionCompletionsRead: vi.fn(async () => undefined)
+  },
+  tasks: new TaskNotificationService({
+    isEnabled: async () => true,
+    isAppFocused: () => false,
+    show: vi.fn(),
+    translate: (key) => key
+  }),
+  delivery: {
+    notificationCtor: FakeNotification as unknown as typeof Notification,
+    liveNotifications: new Set(),
+    log: { info: vi.fn(), warn: vi.fn() },
+    headless: false
+  }
+})
+const invoke = (channel: string, request?: unknown): unknown =>
+  native.handlers.get(channel)!({ sender: { id: 42 } } as IpcMainInvokeEvent, request)
+
+beforeEach(() => {
+  FakeNotification.isSupported.mockReset().mockReturnValue(true)
+  FakeNotification.constructed = []
+})
+afterEach(() => {
+  disposeIpcHandlerRegistry()
+  native.failAt = undefined
+  expect(native.handlers.size).toBe(0)
+})
+
+describe('notification Electron production surface', () => {
+  it('lazily installs eight channels, routes to the supplied inbox and uninstalls only its channels', async () => {
+    const { inbox, tasks, delivery } = fixture()
+    const surface = createNotificationElectronSurface(inbox, tasks, delivery)
+    expect(surface.name).toBe('task-notifications')
+    expect(native.handlers.size).toBe(0)
+    ipcMainHandle('test:external', () => undefined)
+    const installed = await surface.install()
+    expect([...native.handlers.keys()]).toEqual([
+      'test:external',
+      'notifications:get-snapshot',
+      'notifications:mark-read',
+      'notifications:mark-all-read',
+      'notifications:mark-session-completions-read',
+      'notifications:get-desktop-availability',
+      'notifications:send-test',
+      'notifications:peek-pending-open-session',
+      'notifications:take-pending-open-session'
+    ])
+    await expect(invoke('notifications:get-snapshot')).resolves.toEqual({
+      revision: 1,
+      latestSequence: 0,
+      unreadCount: 0,
+      items: []
+    })
+    await invoke('notifications:mark-read', { ids: ['message'] })
+    await invoke('notifications:mark-all-read', { throughSequence: 7 })
+    await invoke('notifications:mark-session-completions-read', { sessionIds: ['session'] })
+    expect(inbox.markRead).toHaveBeenCalledExactlyOnceWith(['message'])
+    expect(inbox.markAllRead).toHaveBeenCalledExactlyOnceWith(7)
+    expect(inbox.markSessionCompletionsRead).toHaveBeenCalledExactlyOnceWith(['session'])
+    expect(() => invoke('notifications:mark-read', { ids: [1] })).toThrow(
+      'Invalid notifications:mark-read request.'
+    )
+    expect(inbox.markRead).toHaveBeenCalledOnce()
+    await installed.uninstall()
+    await installed.uninstall()
+    expect([...native.handlers.keys()]).toEqual(['test:external'])
+  })
+
+  it('uses the supplied native delivery dependencies for availability and test delivery', async () => {
+    const { inbox, tasks, delivery } = fixture()
+    delivery.translate = (key) => `translated: ${key}`
+    await createNotificationElectronSurface(inbox, tasks, delivery).install()
+    expect(invoke('notifications:get-desktop-availability')).toBe('supported')
+    await expect(invoke('notifications:send-test')).resolves.toBe('shown')
+    expect(FakeNotification.constructed).toHaveLength(1)
+    expect(FakeNotification.constructed[0].options.title).toBe('translated: Test notification')
+    expect(
+      delivery.liveNotifications.has(FakeNotification.constructed[0] as unknown as Notification)
+    ).toBe(true)
+    FakeNotification.constructed[0].emit('close')
+    expect(delivery.liveNotifications.size).toBe(0)
+  })
+
+  it.each(['headless', 'unsupported'] as const)(
+    'preserves the %s desktop gate through IPC',
+    async (mode) => {
+      const { inbox, tasks, delivery } = fixture()
+      delivery.headless = mode === 'headless'
+      FakeNotification.isSupported.mockReturnValue(mode !== 'unsupported')
+      await createNotificationElectronSurface(inbox, tasks, delivery).install()
+      expect(invoke('notifications:get-desktop-availability')).toBe('unavailable')
+      await expect(invoke('notifications:send-test')).resolves.toBe('unavailable')
+      expect(FakeNotification.constructed).toHaveLength(0)
+      if (mode === 'headless') expect(FakeNotification.isSupported).not.toHaveBeenCalled()
+    }
+  )
+
+  it('validates take tokens and preserves a newer target against an older IPC request', async () => {
+    const { inbox, tasks, delivery } = fixture()
+    await createNotificationElectronSurface(inbox, tasks, delivery).install()
+    tasks.setPendingOpenSession('first')
+    const first = tasks.peekPendingOpenSession()!
+    expect(invoke('notifications:peek-pending-open-session')).toBe(first)
+    const take = vi.spyOn(tasks, 'takePendingOpenSession')
+    for (const token of [
+      undefined,
+      null,
+      '1',
+      0,
+      -1,
+      1.5,
+      NaN,
+      Infinity,
+      Number.MAX_SAFE_INTEGER + 1
+    ]) {
+      expect(invoke('notifications:take-pending-open-session', token)).toBeNull()
+    }
+    expect(take).not.toHaveBeenCalled()
+    tasks.setPendingOpenSession('second')
+    const second = tasks.peekPendingOpenSession()!
+    expect(invoke('notifications:take-pending-open-session', first.token)).toBeNull()
+    expect(invoke('notifications:peek-pending-open-session')).toBe(second)
+    expect(invoke('notifications:take-pending-open-session', second.token)).toBe(second)
+    expect(invoke('notifications:peek-pending-open-session')).toBeNull()
+  })
+
+  it.each(['notifications:mark-all-read', 'notifications:send-test'])(
+    'rolls back partial registration at %s and permits a clean retry',
+    async (channel) => {
+      const { inbox, tasks, delivery } = fixture()
+      ipcMainHandle('test:external', () => undefined)
+      const surface = createNotificationElectronSurface(inbox, tasks, delivery)
+      native.failAt = channel
+      expect(() => surface.install()).toThrow(`install failed: ${channel}`)
+      expect([...native.handlers.keys()]).toEqual(['test:external'])
+      native.failAt = undefined
+      await (await surface.install()).uninstall()
+      expect([...native.handlers.keys()]).toEqual(['test:external'])
+    }
+  )
+})

--- a/src/main/ipc-surfaces/notifications.ts
+++ b/src/main/ipc-surfaces/notifications.ts
@@ -1,0 +1,39 @@
+import { ipcMainHandle } from '../ipc-handler-registry'
+import {
+  getTaskNotificationAvailability,
+  showTestTaskNotification,
+  type BuildTaskNotificationShowDeps
+} from '../notifications/electron-wiring'
+import {
+  registerNotificationInboxIpcAdapter,
+  type NotificationInboxIpcOwner
+} from '../notifications/notification-inbox-ipc'
+import type { TaskNotificationService } from '../notifications/task-notifications'
+import type { NamedElectronSurfaceAdapter } from '../runtime-electron-wiring'
+import { createElectronSurfaceAdapter } from './adapter'
+
+export const createNotificationElectronSurface = (
+  inbox: NotificationInboxIpcOwner,
+  taskNotifications: Pick<
+    TaskNotificationService,
+    'peekPendingOpenSession' | 'takePendingOpenSession'
+  >,
+  delivery: BuildTaskNotificationShowDeps
+): NamedElectronSurfaceAdapter =>
+  createElectronSurfaceAdapter('task-notifications', () => {
+    registerNotificationInboxIpcAdapter(inbox)
+    ipcMainHandle('notifications:get-desktop-availability', () =>
+      getTaskNotificationAvailability(delivery)
+    )
+    ipcMainHandle('notifications:send-test', () => showTestTaskNotification(delivery))
+    // Peek after hydration, then consume only the inspected target. An older IPC round trip
+    // must not clear a newer click target; the shared task owner checks token identity.
+    ipcMainHandle('notifications:peek-pending-open-session', () =>
+      taskNotifications.peekPendingOpenSession()
+    )
+    ipcMainHandle('notifications:take-pending-open-session', (_event, expectedToken: unknown) =>
+      typeof expectedToken === 'number' && Number.isSafeInteger(expectedToken) && expectedToken > 0
+        ? taskNotifications.takePendingOpenSession(expectedToken)
+        : null
+    )
+  })

--- a/src/main/ipc.ts
+++ b/src/main/ipc.ts
@@ -169,16 +169,14 @@ import { registerWindowIpcHandlers } from './window-ipc'
 import { registerWindowFindIpcHandlers } from './window-find-ipc'
 import { TaskNotificationService } from './notifications/task-notifications'
 import { createNotificationInboxController } from './notifications/notification-inbox-controller'
-import { registerNotificationInboxIpcAdapter } from './notifications/notification-inbox-ipc'
+import { createNotificationElectronSurface } from './ipc-surfaces/notifications'
 import { NotificationInboxDbRepository } from './notifications/notification-inbox-repository'
 import { bindNotificationInboxDeletionRuntime } from './notifications/notification-inbox-runtime'
 import {
   buildSkillImportApprovalBroadcast,
   buildConnectorApprovalBroadcast,
   buildConnectorCredentialRequestBroadcast,
-  buildTaskNotificationShow,
-  getTaskNotificationAvailability,
-  showTestTaskNotification
+  buildTaskNotificationShow
 } from './notifications/electron-wiring'
 import { createLogger, diagnosticErrorFields, errorLogFields } from './logger'
 import { startDiagnosticOperation, type DiagnosticOperation } from './diagnostics/operation'
@@ -2320,26 +2318,13 @@ const createApplicationModules = async (
     onInboxError: (error) =>
       notificationsLog.warn('message center recording failed', errorLogFields(error))
   })
-  // The renderer peeks once sessions are hydrated, then conditionally consumes the same target.
-  // This lets partial recovery open an already-loaded conversation while retaining an omitted one
-  // for retry, without an older IPC round trip clearing a newer click target.
-  declareElectronAdapter('task-notifications', () => {
-    registerNotificationInboxIpcAdapter(notificationInbox)
-    ipcMainHandle('notifications:get-desktop-availability', () =>
-      getTaskNotificationAvailability(taskNotificationDeliveryDeps)
+  surfaceAdapters.push(
+    createNotificationElectronSurface(
+      notificationInbox,
+      taskNotifications,
+      taskNotificationDeliveryDeps
     )
-    ipcMainHandle('notifications:send-test', () =>
-      showTestTaskNotification(taskNotificationDeliveryDeps)
-    )
-    ipcMainHandle('notifications:peek-pending-open-session', () =>
-      taskNotifications.peekPendingOpenSession()
-    )
-    ipcMainHandle('notifications:take-pending-open-session', (_event, expectedToken: unknown) =>
-      typeof expectedToken === 'number' && Number.isSafeInteger(expectedToken) && expectedToken > 0
-        ? taskNotifications.takePendingOpenSession(expectedToken)
-        : null
-    )
-  })
+  )
   // The connector application owns MCP, connector/skill approval, runtime projection, and service
   // construction. Late-bound local tools remain composition-root dependencies and are passed in.
   const moleculePreviewHandler = createMoleculePreviewHandler({


### PR DESCRIPTION
## Problem

The notification surface still combines four inbox registrations with desktop availability, test delivery and pending-session click handling inline in `ipc.ts`. Its individual owners have tests, but the complete production installation group is guarded only by source checks.

## Proposed change

Continue the reviewed scoped surface pattern from #2499 and #2501. Move the existing eight-channel registration into `createNotificationElectronSurface`, with static imports of the inbox registrar and desktop delivery helpers. Keep the same task-notifications name, beforeCompute position, inbox/task owners and native delivery dependencies.

Production-surface tests use the real registry, inbox registrar, native delivery helpers and task service. Only Electron and its Notification constructor are replaced; a controlled inbox owner supplies the exercised methods.

## Scope and non-goals

- No changes to IPC channels/payloads, token validation, notification delivery or owner construction.
- Historical compatibility: no migration or compatibility-policy changes.
- New fields, states or enum values: none.
- Persistence: no changes to inbox rows, schema, read markers, retention or write ordering.
- UI and interaction: unchanged.
- No framework/ACP translation, event production, subscription or Web/Task command changes.
- This is a behavior-preserving refactor, not a claimed defect fix. The untouched baseline passed 124 tests in five notification/wiring files.

The benefit is one queryable installation boundary and focused integration tests, with future notification IPC edits outside the composition root. The rest of owner construction remains in `ipc.ts`; this does not claim a runtime performance improvement.

## Acceptance criteria and validation

Final local evidence, after the last material edit:

| Behavior | Command | Result |
| --- | --- | --- |
| Eight-channel installation, partial rollback, idempotent uninstall/retry; inbox dispatch/validation; native delivery/headless gates; pending-session token handling | `npm run test:module -- ipc_surfaces` | 27 files, 346 tests passed |
| Existing notification owner/controller/helper contracts, core/upload surfaces, runtime/startup disposal and representative application-command consumers | Same explained module plan | Included in the 346 tests above |
| Ownership manifest, module plan selection and classifier validation | `npm test -- scripts/ci/validate-module-impact.test.ts scripts/ci/module-test-impact.test.ts scripts/ci/classify-pr-changes.test.ts` | 3 files, 113 tests passed |
| Node and sandbox types | `npm run typecheck:node` | Passed, including sandbox |
| Lint | `npm run lint` | Passed |
| Formatting and whitespace | Prettier check on the five changed files; `git diff --check` | Passed |

No full local `npm test` was run, per the maintainer's explicit instruction. The module manifest adds the new surface and its test impact set; CI fallback selection for the mixed composition root remains intact. Exact-head PR CI and independent review remain required before considering verification complete.

The updated root CodeGraph index supplied pre-change caller/callee analysis. The fresh worktree has no independent index, so post-edit retrieval measurements are not claimed; the final static routing is guarded by the production wiring test and TypeScript. Native platform delivery is mocked in the new tests and covered at the existing helper boundary. No OS E2E, renderer typecheck or persistence migration test was run locally because those implementations and interfaces are unchanged.

## Review focus

Confirm the same inbox/task/delivery objects are passed at the original beforeCompute position, the positive-safe-integer token guard is unchanged, and partial failures remove both the inbox channels and later notification channels without touching earlier installations. Check the evidence mapping against the final diff.
