### PR TITLE
feat(global-search): add advanced filter island column

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -349,7 +349,7 @@ colors communicate a successful or failed probe/migration result.
 - Workspace shell surfaces use `bg-bg-10`; white workspace surfaces use `bg-bg-000`.
 - Sidebar row hover/active states use `hover:bg-bg-300` and active `bg-bg-300`.
 - Session action menu items use `data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000`; destructive highlights use `data-[highlighted]:bg-danger-900`.
-- Detached island panel: a narrow floating panel that must read as isolated from its surroundings (reference: the global-search advanced filter column) uses the dedicated dark tokens `--island` / `--island-foreground` (a dark fill with its own light foreground in both themes, exposed as `bg-island` / `text-island-foreground`), `rounded-xl`, a faint border mixed from `--island-foreground`, `shadow-menu`, and margin on all four sides so the dark fill never touches neighboring surfaces. Controls inside the island re-tint their borders, backgrounds, and text from `--island-foreground`.
+- Detached island panel: a narrow auxiliary column that must read as separated from its neighbors while staying visually unified with them (reference: the global-search advanced filter column) keeps the standard white surface — `bg-bg-000`, `border`, `rounded-xl`, `shadow-menu` — and sits inside a `bg-bg-200` gutter track with equal margins on all four sides, so the light-gray spacing supplies the separation instead of a contrasting fill. The island stretches to the full height of its track.
 - Do not use large brand-color surfaces. Deep green is reserved for links, focus, status dots, active states, and primary actions.
 
 ### Shadows

--- a/docs/design.md
+++ b/docs/design.md
@@ -349,6 +349,7 @@ colors communicate a successful or failed probe/migration result.
 - Workspace shell surfaces use `bg-bg-10`; white workspace surfaces use `bg-bg-000`.
 - Sidebar row hover/active states use `hover:bg-bg-300` and active `bg-bg-300`.
 - Session action menu items use `data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000`; destructive highlights use `data-[highlighted]:bg-danger-900`.
+- Detached island panel: a narrow floating panel that must read as isolated from its surroundings (reference: the global-search advanced filter column) uses the dedicated dark tokens `--island` / `--island-foreground` (a dark fill with its own light foreground in both themes, exposed as `bg-island` / `text-island-foreground`), `rounded-xl`, a faint border mixed from `--island-foreground`, `shadow-menu`, and margin on all four sides so the dark fill never touches neighboring surfaces. Controls inside the island re-tint their borders, backgrounds, and text from `--island-foreground`.
 - Do not use large brand-color surfaces. Deep green is reserved for links, focus, status dots, active states, and primary actions.
 
 ### Shadows

--- a/docs/design.md
+++ b/docs/design.md
@@ -349,7 +349,7 @@ colors communicate a successful or failed probe/migration result.
 - Workspace shell surfaces use `bg-bg-10`; white workspace surfaces use `bg-bg-000`.
 - Sidebar row hover/active states use `hover:bg-bg-300` and active `bg-bg-300`.
 - Session action menu items use `data-[highlighted]:bg-bg-200 data-[highlighted]:text-text-000`; destructive highlights use `data-[highlighted]:bg-danger-900`.
-- Detached island panel: a narrow auxiliary column that must read as separated from its neighbors while staying visually unified with them (reference: the global-search advanced filter column) keeps the standard white surface — `bg-bg-000`, `border`, `rounded-xl`, `shadow-menu` — and sits inside a `bg-bg-200` gutter track with equal margins on all four sides, so the light-gray spacing supplies the separation instead of a contrasting fill. The island stretches to the full height of its track.
+- Detached island panel: a narrow auxiliary column that must read as separated from its neighbors while staying visually unified with them (reference: the global-search advanced filter column) keeps the standard white surface — `bg-bg-000`, `rounded-xl`, `shadow-menu`, no border — and sits inside a `bg-bg-200` gutter track with equal margins on all four sides, so the light-gray spacing supplies the separation instead of a contrasting fill. The gutter track is rounded on its left side only (`border-radius: var(--radius-xl) 0 0 var(--radius-xl)`) so it flows into the dialog edge on the right. The island stretches to the full height of its track.
 - Do not use large brand-color surfaces. Deep green is reserved for links, focus, status dots, active states, and primary actions.
 
 ### Shadows

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -602,6 +602,9 @@ test('toggles the advanced filter island column from the category chips', async 
     const [gr, gg, gb] = rgb(trackStyle.backgroundColor)
     return {
       borderRadius: style.borderRadius,
+      borderWidth: style.borderTopWidth,
+      gutterRadiusLeft: trackStyle.borderTopLeftRadius,
+      gutterRadiusRight: trackStyle.borderTopRightRadius,
       islandLightness: (r + g + b) / 3,
       gutterLightness: (gr + gg + gb) / 3,
       gapRight: body.right - rect.right,
@@ -612,6 +615,10 @@ test('toggles the advanced filter island column from the category chips', async 
     }
   })
   expect(islandGeometry.borderRadius).toBe('12px')
+  // No inner border on the island; the gray gutter is rounded on the left side only.
+  expect(islandGeometry.borderWidth).toBe('0px')
+  expect(islandGeometry.gutterRadiusLeft).toBe('12px')
+  expect(islandGeometry.gutterRadiusRight).toBe('0px')
   // The island matches the other panes' white surface; the light-gray gutter separates it.
   expect(islandGeometry.islandLightness).toBeGreaterThan(245)
   expect(islandGeometry.gutterLightness).toBeGreaterThan(200)

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -594,19 +594,33 @@ test('toggles the advanced filter island column from the category chips', async 
   const islandGeometry = await island.evaluate((el) => {
     const style = getComputedStyle(el)
     const rect = el.getBoundingClientRect()
+    const track = el.closest('.global-search-advanced')!
+    const trackStyle = getComputedStyle(track)
     const body = el.closest('.global-search-body')!.getBoundingClientRect()
-    const [r, g, b] = style.backgroundColor.match(/\d+/g)!.map(Number)
+    const rgb = (value: string): number[] => value.match(/\d+/g)!.map(Number)
+    const [r, g, b] = rgb(style.backgroundColor)
+    const [gr, gg, gb] = rgb(trackStyle.backgroundColor)
     return {
       borderRadius: style.borderRadius,
-      lightness: (r + g + b) / 3,
+      islandLightness: (r + g + b) / 3,
+      gutterLightness: (gr + gg + gb) / 3,
       gapRight: body.right - rect.right,
-      gapTop: rect.top - body.top
+      gapTop: rect.top - body.top,
+      gapBottom: body.bottom - rect.bottom,
+      height: rect.height,
+      bodyHeight: body.height
     }
   })
   expect(islandGeometry.borderRadius).toBe('12px')
-  expect(islandGeometry.lightness).toBeLessThan(90)
+  // The island matches the other panes' white surface; the light-gray gutter separates it.
+  expect(islandGeometry.islandLightness).toBeGreaterThan(245)
+  expect(islandGeometry.gutterLightness).toBeGreaterThan(200)
+  expect(islandGeometry.gutterLightness).toBeLessThan(islandGeometry.islandLightness - 5)
   expect(islandGeometry.gapRight).toBeGreaterThanOrEqual(12)
-  expect(islandGeometry.gapTop).toBeGreaterThanOrEqual(6)
+  expect(islandGeometry.gapTop).toBeGreaterThanOrEqual(12)
+  expect(islandGeometry.gapBottom).toBeGreaterThanOrEqual(12)
+  // The island fills the full body height like the other panes.
+  expect(islandGeometry.height).toBeGreaterThanOrEqual(islandGeometry.bodyHeight - 25)
   await expect(panel.getByRole('combobox', { name: 'Search scope' })).toBeVisible()
   await panel.getByRole('combobox', { name: 'Result order' }).click()
   await page.getByRole('option', { name: 'Recently updated', exact: true }).click()

--- a/e2e/global-search.spec.ts
+++ b/e2e/global-search.spec.ts
@@ -558,6 +558,97 @@ test('keeps saved Notebook output and structured file previews visible inside se
   await dialog.screenshot({ path: testInfo.outputPath('search-molecule.png') })
 })
 
+test('toggles the advanced filter island column from the category chips', async ({
+  app
+}, testInfo) => {
+  await app.completeOnboarding()
+  const page = await app.configureFakeAgent()
+  await suppressWorkspaceStarNudge(page)
+  await page.getByRole('button', { name: 'Search', exact: true }).click()
+  const dialog = page.getByRole('dialog', { name: 'Global search' })
+  const toggle = dialog.getByRole('button', { name: 'Advanced filters' })
+  const panel = dialog.getByTestId('global-search-advanced')
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(toggle).toHaveAttribute('aria-controls', (await panel.getAttribute('id'))!)
+  await expect(panel).toHaveAttribute('data-open', 'false')
+  // The toggle stays the last chip in the category row.
+  expect(
+    await dialog
+      .locator('.global-search-chips')
+      .evaluate(
+        (row) =>
+          row.lastElementChild ===
+          row.querySelector('[data-testid="global-search-advanced-toggle"]')
+      )
+  ).toBe(true)
+  await expect(dialog.locator('.global-search-list-pane .search-subfilters')).toBeVisible()
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'true')
+  await expect(panel).toHaveAttribute('data-open', 'true')
+  await expect(dialog.locator('.global-search-list-pane .search-subfilters')).toHaveCount(0)
+  await panel.evaluate(async (el) => {
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+  })
+  const island = panel.locator('.search-advanced-island')
+  await expect(island).toBeVisible()
+  const islandGeometry = await island.evaluate((el) => {
+    const style = getComputedStyle(el)
+    const rect = el.getBoundingClientRect()
+    const body = el.closest('.global-search-body')!.getBoundingClientRect()
+    const [r, g, b] = style.backgroundColor.match(/\d+/g)!.map(Number)
+    return {
+      borderRadius: style.borderRadius,
+      lightness: (r + g + b) / 3,
+      gapRight: body.right - rect.right,
+      gapTop: rect.top - body.top
+    }
+  })
+  expect(islandGeometry.borderRadius).toBe('12px')
+  expect(islandGeometry.lightness).toBeLessThan(90)
+  expect(islandGeometry.gapRight).toBeGreaterThanOrEqual(12)
+  expect(islandGeometry.gapTop).toBeGreaterThanOrEqual(6)
+  await expect(panel.getByRole('combobox', { name: 'Search scope' })).toBeVisible()
+  await panel.getByRole('combobox', { name: 'Result order' }).click()
+  await page.getByRole('option', { name: 'Recently updated', exact: true }).click()
+  await expect(panel.getByRole('combobox', { name: 'Result order' })).toContainText(
+    'Recently updated'
+  )
+  // Selecting a result while the island is open must not clip the detail pane.
+  await page.evaluate(async () => {
+    await window.api.projects.create({
+      name: 'Island clipping check',
+      description: 'Detail pane geometry fixture',
+      agentContext: ''
+    })
+  })
+  await dialog.getByRole('combobox', { name: 'Global search' }).fill('Island clipping check')
+  const projectHit = dialog.locator('[data-search-group="projects"]').getByRole('option')
+  await expect(projectHit).toHaveCount(1)
+  await projectHit.click()
+  await dialog.locator('.global-search-body').evaluate(async (el) => {
+    await Promise.all(el.getAnimations().map((animation) => animation.finished))
+  })
+  const detailGeometry = await dialog.evaluate(() => {
+    const surface = document.querySelector('.global-search-detail-surface')!.getBoundingClientRect()
+    const track = document.querySelector('.global-search-detail')!.getBoundingClientRect()
+    const islandBox = document.querySelector('.search-advanced-island')!.getBoundingClientRect()
+    return {
+      surfaceWidth: surface.width,
+      trackWidth: track.width,
+      surfaceRight: surface.right,
+      islandLeft: islandBox.left
+    }
+  })
+  expect(detailGeometry.surfaceWidth).toBeLessThanOrEqual(detailGeometry.trackWidth + 1)
+  expect(detailGeometry.surfaceRight).toBeLessThanOrEqual(detailGeometry.islandLeft)
+  await dialog.screenshot({ path: testInfo.outputPath('global-search-advanced-island.png') })
+  await dialog.getByRole('button', { name: 'Collapse details' }).click()
+  await toggle.click()
+  await expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  await expect(panel).toHaveAttribute('data-open', 'false')
+  await expect(dialog.locator('.global-search-list-pane .search-subfilters')).toBeVisible()
+})
+
 test('uses the same preview and information tabs for generated files', async ({
   app
 }, testInfo) => {

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -178,8 +178,6 @@
   --color-bg-200: var(--bg-200);
   --color-bg-300: var(--bg-300);
   --color-bg-400: var(--bg-400);
-  --color-island: var(--island);
-  --color-island-foreground: var(--island-foreground);
   --color-border-200: hsl(var(--border-ink-channel) / 0.15);
   --color-border-300: hsl(var(--border-ink-channel) / 0.2);
   --color-border-100: hsl(var(--border-ink-channel));
@@ -279,10 +277,6 @@
   --bg-200: hsl(60 11% 95%);
   --bg-300: hsl(45 12% 93%);
   --bg-400: hsl(45 10% 88%);
-  /* Detached dark "island" surface (e.g. the global-search advanced filter column): a dark fill
-     with its own light foreground, so the panel separates from its surroundings in both themes. */
-  --island: hsl(48 6% 16%);
-  --island-foreground: hsl(60 14% 96%);
   --border-ink-channel: 60 2% 12%;
   --text-000: hsl(0 0% 7%);
   --text-100: var(--muted-foreground);
@@ -366,9 +360,6 @@
   --bg-200: hsl(50 3% 18%);
   --bg-300: hsl(48 3% 22%);
   --bg-400: hsl(46 3% 28%);
-  /* Dark theme keeps the island darker than the darkest shell surface so it still reads detached. */
-  --island: hsl(48 8% 7%);
-  --island-foreground: hsl(48 12% 92%);
   --border-ink-channel: 48 8% 82%;
   --text-000: hsl(48 12% 92%);
   --text-100: hsl(45 5% 62%);

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -178,6 +178,8 @@
   --color-bg-200: var(--bg-200);
   --color-bg-300: var(--bg-300);
   --color-bg-400: var(--bg-400);
+  --color-island: var(--island);
+  --color-island-foreground: var(--island-foreground);
   --color-border-200: hsl(var(--border-ink-channel) / 0.15);
   --color-border-300: hsl(var(--border-ink-channel) / 0.2);
   --color-border-100: hsl(var(--border-ink-channel));
@@ -277,6 +279,10 @@
   --bg-200: hsl(60 11% 95%);
   --bg-300: hsl(45 12% 93%);
   --bg-400: hsl(45 10% 88%);
+  /* Detached dark "island" surface (e.g. the global-search advanced filter column): a dark fill
+     with its own light foreground, so the panel separates from its surroundings in both themes. */
+  --island: hsl(48 6% 16%);
+  --island-foreground: hsl(60 14% 96%);
   --border-ink-channel: 60 2% 12%;
   --text-000: hsl(0 0% 7%);
   --text-100: var(--muted-foreground);
@@ -360,6 +366,9 @@
   --bg-200: hsl(50 3% 18%);
   --bg-300: hsl(48 3% 22%);
   --bg-400: hsl(46 3% 28%);
+  /* Dark theme keeps the island darker than the darkest shell surface so it still reads detached. */
+  --island: hsl(48 8% 7%);
+  --island-foreground: hsl(48 12% 92%);
   --border-ink-channel: 48 8% 82%;
   --text-000: hsl(48 12% 92%);
   --text-100: hsl(45 5% 62%);

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.test.tsx
@@ -655,6 +655,34 @@ describe('GlobalSearchDialog', () => {
     act(() => document.querySelector<HTMLButtonElement>('[aria-label="Collapse details"]')!.click())
     expect(panel.dataset.open).toBe('false')
   })
+  it('toggles the advanced filter island from the chip row and restores the inline filter row', async () => {
+    await renderSearch()
+    const toggle = screen.getByRole('button', { name: 'Advanced filters' })
+    const panel = document.querySelector<HTMLElement>('[data-testid="global-search-advanced"]')!
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(toggle.getAttribute('aria-controls')).toBe(panel.id)
+    expect(panel.dataset.open).toBe('false')
+    expect(panel.getAttribute('aria-hidden')).toBe('true')
+    expect(document.querySelector('.global-search-list-pane .search-subfilters')).not.toBeNull()
+    expect(panel.querySelector('.search-subfilters')).toBeNull()
+    act(() => toggle.click())
+    expect(toggle.getAttribute('aria-expanded')).toBe('true')
+    expect(panel.dataset.open).toBe('true')
+    expect(panel.getAttribute('aria-hidden')).toBe('false')
+    expect(document.querySelector('.global-search-list-pane .search-subfilters')).toBeNull()
+    expect(panel.querySelector('.search-subfilters-stacked')).not.toBeNull()
+    await selectFilter('Search scope', 'Current project')
+    await waitFor(() =>
+      expect(window.api.sessions.searchMessages).toHaveBeenLastCalledWith(
+        expect.objectContaining({ projectIds: ['project-a'] })
+      )
+    )
+    act(() => toggle.click())
+    expect(toggle.getAttribute('aria-expanded')).toBe('false')
+    expect(panel.dataset.open).toBe('false')
+    expect(document.querySelector('.global-search-list-pane .search-subfilters')).not.toBeNull()
+    expect(panel.querySelector('.search-subfilters')).toBeNull()
+  })
   it('searches all projects by default and applies an explicit current-project filter', async () => {
     await renderSearch()
     expect(window.api.projectFiles.searchArtifacts).toHaveBeenCalledWith(

--- a/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
+++ b/src/renderer/src/components/global-search/GlobalSearchDialog.tsx
@@ -10,6 +10,7 @@ import {
   Grid2X2,
   MessageCircle,
   Search,
+  SlidersHorizontal,
   Upload,
   X
 } from 'lucide-react'
@@ -98,6 +99,7 @@ export const GlobalSearchDialog = ({
   const { t, i18n } = useTranslation()
   const locale = resolveLocaleFromTags([i18n.resolvedLanguage ?? i18n.language])
   const listboxId = useId()
+  const advancedPanelId = useId()
   const inputRef = useRef<HTMLInputElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
   const loadMoreRef = useRef<HTMLDivElement>(null)
@@ -112,6 +114,7 @@ export const GlobalSearchDialog = ({
   const [days, setDays] = useState(0)
   const [dateReference, setDateReference] = useState(Date.now)
   const [subtype, setSubtype] = useState('all')
+  const [advancedOpen, setAdvancedOpen] = useState(false)
   const updatedAfter = days ? dateReference - days * 86_400_000 : undefined
   const [counts, setCounts] = useState(initialCounts)
   const [selected, setSelected] = useState<SearchResult>()
@@ -557,6 +560,31 @@ export const GlobalSearchDialog = ({
       } else openResult(row)
     }
   }
+  const searchFilterProps = {
+    category,
+    scope: restrictToProject ? ('current' as const) : ('all' as const),
+    canScopeToProject: view === 'workspace' && !!activeProjectId,
+    sort,
+    days,
+    subtype,
+    onScope: (value: string) => {
+      setCurrentProjectOnly(value === 'current')
+      resetSelection()
+    },
+    onSort: (value: SearchSort) => {
+      setSort(value)
+      resetSelection()
+    },
+    onDays: (value: number) => {
+      setDays(value)
+      setDateReference(Date.now())
+      resetSelection()
+    },
+    onSubtype: (value: string) => {
+      setSubtype(value)
+      resetSelection()
+    }
+  }
   return (
     <Dialog.Root
       open={open}
@@ -577,6 +605,7 @@ export const GlobalSearchDialog = ({
           onOpenAutoFocus={(event) => {
             event.preventDefault()
             setCategory('all')
+            setAdvancedOpen(false)
             resetSelection()
             inputRef.current?.focus()
           }}
@@ -685,6 +714,17 @@ export const GlobalSearchDialog = ({
                   </button>
                 )
               })}
+              <button
+                type="button"
+                data-testid="global-search-advanced-toggle"
+                aria-expanded={advancedOpen}
+                aria-controls={advancedPanelId}
+                onClick={() => setAdvancedOpen((open) => !open)}
+                className="search-category-chip search-advanced-toggle transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <SlidersHorizontal aria-hidden="true" />
+                {t('Advanced filters')}
+              </button>
             </div>
           </header>
           <div className="global-search-body min-h-0 flex-1" data-expanded={!!selected}>
@@ -692,31 +732,7 @@ export const GlobalSearchDialog = ({
               className="global-search-list-pane min-h-0 min-w-0 flex flex-col"
               aria-label={t('Search results')}
             >
-              <SearchResultFilters
-                category={category}
-                scope={restrictToProject ? 'current' : 'all'}
-                canScopeToProject={view === 'workspace' && !!activeProjectId}
-                sort={sort}
-                days={days}
-                subtype={subtype}
-                onScope={(value) => {
-                  setCurrentProjectOnly(value === 'current')
-                  resetSelection()
-                }}
-                onSort={(value) => {
-                  setSort(value)
-                  resetSelection()
-                }}
-                onDays={(value) => {
-                  setDays(value)
-                  setDateReference(Date.now())
-                  resetSelection()
-                }}
-                onSubtype={(value) => {
-                  setSubtype(value)
-                  resetSelection()
-                }}
-              />
+              {!advancedOpen && <SearchResultFilters {...searchFilterProps} />}
               <div
                 className="global-search-list min-h-0 flex-1 overflow-auto"
                 ref={listRef}
@@ -961,6 +977,20 @@ export const GlobalSearchDialog = ({
                     onCollapse={collapse}
                   />
                 )}
+              </div>
+            </aside>
+            <aside
+              id={advancedPanelId}
+              data-testid="global-search-advanced"
+              data-open={advancedOpen}
+              aria-hidden={!advancedOpen}
+              inert={!advancedOpen}
+              aria-label={t('Advanced filters')}
+              className="global-search-advanced h-full"
+            >
+              <div className="search-advanced-island">
+                <div className="search-advanced-title">{t('Advanced filters')}</div>
+                {advancedOpen && <SearchResultFilters stacked {...searchFilterProps} />}
               </div>
             </aside>
           </div>

--- a/src/renderer/src/components/global-search/SearchResultFilters.tsx
+++ b/src/renderer/src/components/global-search/SearchResultFilters.tsx
@@ -6,6 +6,7 @@ import {
   SelectTrigger,
   SelectValue
 } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 import type { SearchSort } from '../../../../shared/search-text'
 import type { SearchCategory } from './search-result'
 
@@ -19,7 +20,8 @@ export const SearchResultFilters = ({
   onScope,
   onSort,
   onDays,
-  onSubtype
+  onSubtype,
+  stacked = false
 }: {
   category: SearchCategory | 'all'
   scope: 'all' | 'current'
@@ -31,6 +33,7 @@ export const SearchResultFilters = ({
   onSort: (value: SearchSort) => void
   onDays: (value: number) => void
   onSubtype: (value: string) => void
+  stacked?: boolean
 }): React.JSX.Element => {
   const { t } = useTranslation()
   const options =
@@ -57,7 +60,7 @@ export const SearchResultFilters = ({
             ]
           : []
   return (
-    <div className="search-subfilters">
+    <div className={cn('search-subfilters', stacked && 'search-subfilters-stacked')}>
       <Select value={scope} onValueChange={onScope}>
         <SelectTrigger
           aria-label={t('Search scope')}

--- a/src/renderer/src/components/global-search/global-search.css
+++ b/src/renderer/src/components/global-search/global-search.css
@@ -63,10 +63,14 @@
 .search-category-chip:hover {
   background: var(--bg-200);
 }
-.search-category-chip[aria-pressed='true'] {
+.search-category-chip[aria-pressed='true'],
+.search-advanced-toggle[aria-expanded='true'] {
   color: var(--primary-foreground);
   background: var(--primary);
   border-color: var(--primary);
+}
+.search-advanced-toggle {
+  margin-left: auto;
 }
 .search-subfilters {
   min-height: 28px;
@@ -233,11 +237,11 @@
 .global-search-body {
   container-type: inline-size;
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 0fr);
+  grid-template-columns: minmax(0, 1fr) minmax(0, 0fr) auto;
   transition: grid-template-columns 240ms ease;
 }
 .global-search-body[data-expanded='true'] {
-  grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.55fr);
+  grid-template-columns: minmax(0, 0.45fr) minmax(0, 0.55fr) auto;
 }
 .global-search-detail {
   min-width: 0;
@@ -247,6 +251,67 @@
 }
 .global-search-detail[data-open='true'] {
   opacity: 1;
+}
+.global-search-advanced {
+  width: 0;
+  min-width: 0;
+  overflow: hidden;
+  opacity: 0;
+  transition:
+    width 240ms ease,
+    opacity 200ms ease;
+}
+.global-search-advanced[data-open='true'] {
+  width: 244px;
+  opacity: 1;
+}
+.search-advanced-island {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 220px;
+  margin: 6px 12px 12px;
+  padding: 12px;
+  border: 1px solid color-mix(in oklab, var(--island-foreground) 14%, transparent);
+  border-radius: var(--radius-xl);
+  background: var(--island);
+  color: var(--island-foreground);
+  box-shadow: var(--shadow-menu);
+}
+.search-advanced-title {
+  font-size: 11px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  color: color-mix(in oklab, var(--island-foreground) 72%, transparent);
+}
+.search-subfilters-stacked {
+  flex-direction: column;
+  align-items: stretch;
+  flex-wrap: nowrap;
+  min-height: 0;
+  padding: 0;
+}
+.search-subfilters-stacked [data-slot='select-trigger'] {
+  width: 100%;
+  max-width: none;
+}
+.search-advanced-island .search-subfilters [data-slot='select-trigger'] {
+  border-color: color-mix(in oklab, var(--island-foreground) 18%, transparent);
+  background: color-mix(in oklab, var(--island-foreground) 6%, transparent);
+  color: var(--island-foreground);
+}
+.search-advanced-island .search-subfilters [data-slot='select-trigger']:hover,
+.search-advanced-island .search-subfilters [data-slot='select-trigger'][data-state='open'] {
+  background: color-mix(in oklab, var(--island-foreground) 12%, transparent);
+}
+/* The detail surface freezes at 55cqw so it does not reflow during the grid transition; when the
+   advanced island occupies its fixed 244px track, the detail track is 55% of the remaining width,
+   so the surface must subtract the island track or its right edge is clipped. */
+@media (min-width: 741px) {
+  .global-search-body:has(> .global-search-advanced[data-open='true'])
+    .global-search-detail-surface {
+    width: calc(0.55 * (100cqw - 244px));
+  }
 }
 .search-detail-header {
   flex-shrink: 0;
@@ -765,6 +830,20 @@
   .global-search-detail[data-open='true'] {
     pointer-events: auto;
   }
+  .global-search-advanced,
+  .global-search-advanced[data-open='true'] {
+    position: absolute;
+    inset: 0;
+    width: auto;
+    pointer-events: none;
+  }
+  .global-search-advanced[data-open='true'] .search-advanced-island {
+    pointer-events: auto;
+  }
+  .global-search-advanced .search-advanced-island {
+    width: min(240px, calc(100% - 48px));
+    margin: 8px 12px 12px auto;
+  }
   .global-search-body[data-expanded='true'] > .global-search-list-pane {
     visibility: hidden;
   }
@@ -772,6 +851,7 @@
 @media (prefers-reduced-motion: reduce) {
   .global-search-body,
   .global-search-detail,
+  .global-search-advanced,
   .search-recent-session,
   .search-recent-literature,
   .search-recent-file,

--- a/src/renderer/src/components/global-search/global-search.css
+++ b/src/renderer/src/components/global-search/global-search.css
@@ -258,6 +258,7 @@
   min-width: 0;
   overflow: hidden;
   opacity: 0;
+  border-radius: var(--radius-xl) 0 0 var(--radius-xl);
   background: var(--bg-200);
   transition:
     width 240ms ease,
@@ -275,7 +276,6 @@
   margin: 12px;
   padding: 12px;
   overflow-y: auto;
-  border: 1px solid var(--border);
   border-radius: var(--radius-xl);
   background: var(--bg-000);
   box-shadow: var(--shadow-menu);

--- a/src/renderer/src/components/global-search/global-search.css
+++ b/src/renderer/src/components/global-search/global-search.css
@@ -253,10 +253,12 @@
   opacity: 1;
 }
 .global-search-advanced {
+  display: flex;
   width: 0;
   min-width: 0;
   overflow: hidden;
   opacity: 0;
+  background: var(--bg-200);
   transition:
     width 240ms ease,
     opacity 200ms ease;
@@ -267,22 +269,22 @@
 }
 .search-advanced-island {
   display: flex;
+  flex: 1;
   flex-direction: column;
   gap: 10px;
-  width: 220px;
-  margin: 6px 12px 12px;
+  margin: 12px;
   padding: 12px;
-  border: 1px solid color-mix(in oklab, var(--island-foreground) 14%, transparent);
+  overflow-y: auto;
+  border: 1px solid var(--border);
   border-radius: var(--radius-xl);
-  background: var(--island);
-  color: var(--island-foreground);
+  background: var(--bg-000);
   box-shadow: var(--shadow-menu);
 }
 .search-advanced-title {
   font-size: 11px;
   font-weight: 500;
   letter-spacing: 0.02em;
-  color: color-mix(in oklab, var(--island-foreground) 72%, transparent);
+  color: var(--muted-foreground);
 }
 .search-subfilters-stacked {
   flex-direction: column;
@@ -294,15 +296,6 @@
 .search-subfilters-stacked [data-slot='select-trigger'] {
   width: 100%;
   max-width: none;
-}
-.search-advanced-island .search-subfilters [data-slot='select-trigger'] {
-  border-color: color-mix(in oklab, var(--island-foreground) 18%, transparent);
-  background: color-mix(in oklab, var(--island-foreground) 6%, transparent);
-  color: var(--island-foreground);
-}
-.search-advanced-island .search-subfilters [data-slot='select-trigger']:hover,
-.search-advanced-island .search-subfilters [data-slot='select-trigger'][data-state='open'] {
-  background: color-mix(in oklab, var(--island-foreground) 12%, transparent);
 }
 /* The detail surface freezes at 55cqw so it does not reflow during the grid transition; when the
    advanced island occupies its fixed 244px track, the detail track is 55% of the remaining width,
@@ -836,13 +829,15 @@
     inset: 0;
     width: auto;
     pointer-events: none;
+    background: transparent;
   }
   .global-search-advanced[data-open='true'] .search-advanced-island {
     pointer-events: auto;
   }
   .global-search-advanced .search-advanced-island {
+    flex: none;
     width: min(240px, calc(100% - 48px));
-    margin: 8px 12px 12px auto;
+    margin: 12px 12px 12px auto;
   }
   .global-search-body[data-expanded='true'] > .global-search-list-pane {
     visibility: hidden;

--- a/src/shared/i18n/locales/de.json
+++ b/src/shared/i18n/locales/de.json
@@ -499,6 +499,7 @@
     "Added to conversation": "Zur Konversation hinzugefügt",
     "Adding host…": "Host wird hinzugefügt…",
     "Adding…": "Hinzufügen…",
+    "Advanced filters": "Erweiterte Filter",
     "Advanced settings": "Erweiterte Einstellungen",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "Erweitert. Die Anmeldung erfolgt im Browser und wird als separates Claude-Konto in Open Science gespeichert – vollständig von Ihrem persönlichen Claude-Profil getrennt.",
     "Agent": "Agent",

--- a/src/shared/i18n/locales/es.json
+++ b/src/shared/i18n/locales/es.json
@@ -542,6 +542,7 @@
     "Added to conversation": "Agregado a la conversación",
     "Adding host…": "Agregando host…",
     "Adding…": "Agregando…",
+    "Advanced filters": "Filtros avanzados",
     "Advanced settings": "Configuración avanzada",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "Avanzado. Inicia sesión a través del navegador y almacena un inicio de sesión Claude separado en Open Science, completamente aislado de su perfil personal Claude.",
     "Agent": "Agente",

--- a/src/shared/i18n/locales/fr.json
+++ b/src/shared/i18n/locales/fr.json
@@ -542,6 +542,7 @@
     "Added to conversation": "Ajouté à la conversation",
     "Adding host…": "Ajout d'un hôte…",
     "Adding…": "Ajout…",
+    "Advanced filters": "Filtres avancés",
     "Advanced settings": "Paramètres avancés",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "Avancé. Se connecte via le navigateur et stocke une connexion Claude distincte dans Open Science, complètement isolée de votre profil personnel Claude.",
     "Agent": "Agent",

--- a/src/shared/i18n/locales/ja.json
+++ b/src/shared/i18n/locales/ja.json
@@ -527,6 +527,7 @@
     "Added to conversation": "会話に追加されました",
     "Adding host…": "ホストを追加中…",
     "Adding…": "追加中…",
+    "Advanced filters": "詳細フィルター",
     "Advanced settings": "詳細設定",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "上級者向け。ブラウザーでサインインし、個人の Claude プロファイルから完全に分離された Claude サインインを Open Science に保存します。",
     "Agent": "エージェント",

--- a/src/shared/i18n/locales/ko.json
+++ b/src/shared/i18n/locales/ko.json
@@ -526,6 +526,7 @@
     "Added to conversation": "대화에 추가됨",
     "Adding host…": "호스트 추가 중…",
     "Adding…": "추가 중…",
+    "Advanced filters": "고급 필터",
     "Advanced settings": "고급 설정",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "고급. 브라우저를 통해 로그인하고 개인 Claude 프로필과 완전히 격리된 별도의 Claude 로그인을 Open Science에 저장합니다.",
     "Agent": "에이전트",

--- a/src/shared/i18n/locales/ru.json
+++ b/src/shared/i18n/locales/ru.json
@@ -549,6 +549,7 @@
     "Added to conversation": "Добавлено в диалог",
     "Adding host…": "Добавление хоста…",
     "Adding…": "Добавление…",
+    "Advanced filters": "Расширенные фильтры",
     "Advanced settings": "Расширенные настройки",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "Расширенный режим. Вход выполняется в браузере, а отдельная учётная запись Claude хранится в Open Science независимо от вашего личного профиля Claude.",
     "Agent": "Агент",

--- a/src/shared/i18n/locales/zh-Hans.json
+++ b/src/shared/i18n/locales/zh-Hans.json
@@ -591,6 +591,7 @@
     "Added to conversation": "已添加到对话",
     "Adding host…": "正在添加主机…",
     "Adding…": "添加中…",
+    "Advanced filters": "高级筛选",
     "Advanced settings": "高级设置",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "进阶。通过浏览器登录，并在 Open Science 中单独存储一份 Claude 登录，与你个人的 Claude 配置完全隔离。",
     "Agent": "智能体",

--- a/src/shared/i18n/locales/zh-Hant.json
+++ b/src/shared/i18n/locales/zh-Hant.json
@@ -591,6 +591,7 @@
     "Added to conversation": "已加入對話",
     "Adding host…": "正在加入主機…",
     "Adding…": "新增中…",
+    "Advanced filters": "進階篩選",
     "Advanced settings": "進階設定",
     "Advanced. Signs in through the browser and stores a separate Claude login in Open Science, completely isolated from your personal Claude profile.": "進階。透過瀏覽器登入，並在 Open Science 中單獨儲存一份 Claude 登入，與你個人的 Claude 設定完全隔離。",
     "Agent": "智能體",


### PR DESCRIPTION
## What

Adds an **Advanced filters** toggle at the right end of the global search category chip row. Clicking it expands a narrow third filter column; clicking again collapses the column and restores the inline filter row.

For visual unity with the other two panes, the column keeps the standard white surface (`bg-bg-000`, `border`, `rounded-xl`, `shadow-menu`) and is separated from its surroundings by a light-gray `bg-bg-200` gutter track with equal 12px margins on all four sides; the island stretches to the full body height. On ≤740px it overlays right-aligned with pass-through taps outside the panel.

- While the island is open, the existing scope / order / time / refine selects render inside it as a vertically stacked variant of `SearchResultFilters`; filter state stays single-sourced in `GlobalSearchDialog`.
- The collapsed column is `inert` + `aria-hidden`; the toggle uses `aria-expanded` / `aria-controls`; reopening the dialog resets the island to closed.
- The reveal reuses the 240ms panel rhythm and respects `prefers-reduced-motion`.
- Detail pane geometry: when both the detail pane and the island are open, the detail surface width subtracts the island's 244px track so its right edge is not clipped.
- `Advanced filters` registered in all eight locales (i18n guard green); the island pattern is documented in `docs/design.md`.

## Verification

- `npx vitest run src/renderer/src/components/global-search/ src/renderer/src/i18n/resources.test.ts` — 895 passed, incl. the new toggle/relocation/inert test.
- `npx electron-vite build` — clean; `npx eslint` + prettier — clean.
- `npx playwright test e2e/global-search.spec.ts -g "advanced filter island"` — passes in real Electron; asserts island geometry (12px radius, white surface on the gray gutter, uniform gaps, full height), last-child toggle position, filter use inside the island, and no detail-pane clipping with both panes open (screenshot: `global-search-advanced-island.png`).
- Independent code review across both iterations: 2 Important findings (detail-surface clipping, mobile tap-blocking) fixed and re-reviewed to "Ready to merge: Yes".

Tracking: TAPD 需求「【OpenScience】全局搜索弹窗高级筛选栏」。
